### PR TITLE
A couple repo-level updates

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "npmClient": "yarn"
 }

--- a/packages/jbrowse-web/.editorconfig
+++ b/packages/jbrowse-web/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/jbrowse-web/.eslintrc.json
+++ b/packages/jbrowse-web/.eslintrc.json
@@ -1,47 +1,55 @@
 {
-    "parser": "babel-eslint",
-    "extends": [
-        "airbnb",
-        "prettier",
-        "prettier/react"
-    ],
-    "plugins": [ "prettier"],
-    "env": {
-        "browser": true
+  "parser": "babel-eslint",
+  "extends": [
+    "airbnb",
+    "prettier",
+    "prettier/react"
+  ],
+  "plugins": [
+    "prettier"
+  ],
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "react/jsx-filename-extension": 0,
+    "react/prefer-stateless-function": "warn",
+    "no-use-before-define": 0,
+    "no-param-reassign": 0,
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "semi": false,
+        "trailingComma": "all"
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": [
+        "src/*.worker.js"
+      ],
+      "globals": {
+        "self": true
+      },
+      "rules": {
+        "no-restricted-globals": 0
+      }
     },
-    "rules": {
-        "react/jsx-filename-extension": 0,
-        "react/prefer-stateless-function": "warn",
-        "no-use-before-define": 0,
-        "no-param-reassign": 0,
-        "prettier/prettier": [
-            "error",
-            {
-              "singleQuote": true,
-              "semi": false,
-              "trailingComma": "all"
-            }
-          ]
-    },
-    "overrides": [
-        {
-          "files": [ "src/*.worker.js" ],
-          "globals": { "self": true },
-          "rules": {
-              "no-restricted-globals": 0
-          }
-        },
-        {
-            "files": [ "src/*.test.js" ],
-            "env": {
-                "jest": true
-            },
-            "globals": {
-                "document": true
-            },
-            "rules": {
-                "no-restricted-globals": 0
-            }
-          }          
-      ]
+    {
+      "files": [
+        "src/*.test.js"
+      ],
+      "env": {
+        "jest": true
+      },
+      "globals": {
+        "document": true
+      },
+      "rules": {
+        "no-restricted-globals": 0
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This updates a couple housekeeping items:
* Specifies yarn as the NPM client so `lerna bootstap` uses that instead of NPM (and stops trying to create the package-lock.json file)
* Make .eslintrc.json look a little nicer
* Add an .editorconfig file