### PR TITLE
Add a main menu bar

### DIFF
--- a/packages/generator-jbrowse/generators/app/index.test.js
+++ b/packages/generator-jbrowse/generators/app/index.test.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const assert = require('yeoman-assert')
 const helpers = require('yeoman-test')
 
@@ -12,37 +11,33 @@ describe('generator-jbrowse:app', () => {
 
   it('throws when not in the plugins directory', async () =>
     expect(
-      helpers.run(path.join(__dirname, '.')).withPrompts({
+      helpers.run(__dirname).withPrompts({
         correctDir: false,
         type: 'helloWorldMenuBar',
       }),
     ).rejects.toThrow(/Exiting now/))
 
-  it('creates a "Hello World" menu bar', () =>
-    helpers
-      .run(path.join(__dirname, '.'))
+  it('creates a "Hello World" menu bar', async () => {
+    await helpers
+      .run(__dirname)
       .withPrompts({ correctDir: true, type: 'helloWorldMenuBar' })
-      .then(() =>
-        assert.file([
-          'HelloWorldMenuBar/components/HelloWorld.js',
-          'HelloWorldMenuBar/index.js',
-          'HelloWorldMenuBar/model.js',
-        ]),
-      ))
+    assert.file([
+      'HelloWorldMenuBar/components/HelloWorld.js',
+      'HelloWorldMenuBar/index.js',
+      'HelloWorldMenuBar/model.js',
+    ])
+  })
 
-  it('creates a "Hello World" menu bar and drawer widget', () =>
-    helpers
-      .run(path.join(__dirname, '.'))
-      .withPrompts({
-        correctDir: true,
-        type: 'helloWorldMenuBarAndDrawerWidget',
-      })
-      .then(() =>
-        assert.file([
-          'HelloWorldMenuBarAndDrawerWidget/components/HelloWorldDrawerWidget.js',
-          'HelloWorldMenuBarAndDrawerWidget/components/HelloWorldMenuBar.js',
-          'HelloWorldMenuBarAndDrawerWidget/index.js',
-          'HelloWorldMenuBarAndDrawerWidget/model.js',
-        ]),
-      ))
+  it('creates a "Hello World" menu bar and drawer widget', async () => {
+    await helpers.run(__dirname).withPrompts({
+      correctDir: true,
+      type: 'helloWorldMenuBarAndDrawerWidget',
+    })
+    assert.file([
+      'HelloWorldMenuBarAndDrawerWidget/components/HelloWorldDrawerWidget.js',
+      'HelloWorldMenuBarAndDrawerWidget/components/HelloWorldMenuBar.js',
+      'HelloWorldMenuBarAndDrawerWidget/index.js',
+      'HelloWorldMenuBarAndDrawerWidget/model.js',
+    ])
+  })
 })

--- a/packages/jbrowse-web/src/JBrowse.js
+++ b/packages/jbrowse-web/src/JBrowse.js
@@ -6,12 +6,14 @@ import PluginManager from './PluginManager'
 
 import App from './ui/App'
 import RootModelFactory from './rootModel'
+import MainMenuBarPlugin from './plugins/MainMenuBar'
 import HierarchicalTrackSelectorDrawerWidgetPlugin from './plugins/HierarchicalTrackSelectorDrawerWidget'
 import BamAdapterPlugin from './plugins/BamAdapter'
 import AlignmentsTrackPlugin from './plugins/AlignmentsTrack'
 import LinearGenomeViewPlugin from './plugins/LinearGenomeView'
 
 const corePlugins = [
+  MainMenuBarPlugin,
   HierarchicalTrackSelectorDrawerWidgetPlugin,
   BamAdapterPlugin,
   LinearGenomeViewPlugin,

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -48,6 +48,20 @@ window.MODEL = model
 window.getSnapshot = getSnapshot
 window.resolveIdentifier = resolveIdentifier
 
+model.addMenuBar('MainMenuBar')
+model.menuBars[0].addMenu({
+  name: 'Another Menu',
+  menuItems: [
+    { name: 'Item 1' },
+    {
+      name: 'Item 2',
+      icon: 'code',
+      callback:
+        'function(model){console.log("You clicked Item 2");console.log(model)}',
+    },
+  ],
+})
+
 const firstView = model.addView('LinearGenomeView')
 firstView.displayRegions([
   {

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/components/AboutDrawerWidget.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/components/AboutDrawerWidget.js
@@ -1,0 +1,9 @@
+import Typography from '@material-ui/core/Typography'
+import { observer } from 'mobx-react'
+import React from 'react'
+
+function About() {
+  return <Typography variant="h6">About JBrowse:</Typography>
+}
+
+export default observer(About)

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/components/DropDownMenu.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/components/DropDownMenu.js
@@ -1,0 +1,128 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from '@material-ui/core/Button'
+import ClickAwayListener from '@material-ui/core/ClickAwayListener'
+import Grow from '@material-ui/core/Grow'
+import Icon from '@material-ui/core/Icon'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+import ListItemText from '@material-ui/core/ListItemText'
+import MenuItem from '@material-ui/core/MenuItem'
+import MenuList from '@material-ui/core/MenuList'
+import Paper from '@material-ui/core/Paper'
+import Popper from '@material-ui/core/Popper'
+import SvgIcon from '@material-ui/core/SvgIcon'
+import { withStyles } from '@material-ui/core/styles'
+
+import { values } from 'mobx'
+import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+
+function EmptyIcon(props) {
+  return (
+    <SvgIcon {...props}>
+      <path />
+    </SvgIcon>
+  )
+}
+
+const styles = {
+  root: {
+    display: 'flex',
+  },
+}
+
+@observer
+class DropDownMenu extends React.Component {
+  state = {
+    anchorEl: null,
+  }
+
+  handleToggle = event => {
+    const { anchorEl } = this.state
+    this.setState({ anchorEl: anchorEl ? null : event.currentTarget })
+  }
+
+  handleClose = (event, callback) => {
+    const { anchorEl } = this.state
+    const { model } = this.props
+    if (anchorEl.contains(event.target)) {
+      return
+    }
+    this.setState({ anchorEl: null })
+    if (callback) callback(model)
+  }
+
+  render() {
+    const { classes, menuTitle, menuItems } = this.props
+    const { anchorEl } = this.state
+
+    return (
+      <div className={classes.root}>
+        <Button
+          aria-owns={anchorEl ? 'menu-list-grow' : null}
+          aria-haspopup="true"
+          onClick={this.handleToggle}
+          color="inherit"
+        >
+          {menuTitle}
+          <Icon>arrow_drop_down</Icon>
+        </Button>
+        <Popper
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          placement="bottom-start"
+          transition
+          // disablePortal
+        >
+          {({ TransitionProps }) => (
+            <Grow
+              {...TransitionProps}
+              id="menu-list-grow"
+              style={{
+                transformOrigin: 'left top',
+              }}
+            >
+              <Paper>
+                <ClickAwayListener onClickAway={this.handleClose}>
+                  <MenuList>
+                    {values(menuItems).map(menuItem => (
+                      <MenuItem
+                        key={menuItem.name}
+                        onClick={event =>
+                          this.handleClose(event, menuItem.func)
+                        }
+                      >
+                        <ListItemIcon key={menuItem.name}>
+                          {menuItem.icon ? (
+                            <Icon>{menuItem.icon}</Icon>
+                          ) : (
+                            <EmptyIcon key={menuItem.name} />
+                          )}
+                        </ListItemIcon>
+                        <ListItemText inset primary={menuItem.name} />
+                      </MenuItem>
+                    ))}
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </div>
+    )
+  }
+}
+
+DropDownMenu.defaultProps = {
+  itemIcons: [],
+}
+
+DropDownMenu.propTypes = {
+  classes: PropTypes.shape({
+    root: PropTypes.shape.isRequired,
+  }).isRequired,
+  menuTitle: PropTypes.string.isRequired,
+  menuItems: MobxPropTypes.observableArray.isRequired,
+  model: MobxPropTypes.observableObject.isRequired,
+}
+
+export default withStyles(styles)(DropDownMenu)

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/components/HelpDrawerWidget.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/components/HelpDrawerWidget.js
@@ -1,0 +1,9 @@
+import Typography from '@material-ui/core/Typography'
+import { observer } from 'mobx-react'
+import React from 'react'
+
+function Help() {
+  return <Typography variant="h6">Here&apos;s some help:</Typography>
+}
+
+export default observer(Help)

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/components/MainMenuBar.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/components/MainMenuBar.js
@@ -1,0 +1,51 @@
+import AppBar from '@material-ui/core/AppBar'
+import { withStyles } from '@material-ui/core/styles'
+import Toolbar from '@material-ui/core/Toolbar'
+import Typography from '@material-ui/core/Typography'
+import { values } from 'mobx'
+import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import DropDownMenu from './DropDownMenu'
+
+const styles = {
+  root: {
+    flexGrow: 1,
+  },
+  grow: {
+    flexGrow: 1,
+  },
+}
+
+function MainMenuBar(props) {
+  const { classes, model } = props
+
+  return (
+    <AppBar className={classes.root} position="static">
+      <Toolbar variant="dense">
+        {values(model.menus).map(menu => (
+          <DropDownMenu
+            key={menu.name}
+            menuTitle={menu.name}
+            menuItems={menu.menuItems}
+            model={model}
+          />
+        ))}
+        <div className={classes.grow} />
+        <Typography variant="h6" color="inherit">
+          JBrowse
+        </Typography>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+MainMenuBar.propTypes = {
+  classes: PropTypes.shape({
+    grow: PropTypes.shape.isRequired,
+    root: PropTypes.shape.isRequired,
+  }).isRequired,
+  model: MobxPropTypes.observableObject.isRequired,
+}
+
+export default withStyles(styles)(observer(MainMenuBar))

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/index.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/index.js
@@ -1,0 +1,59 @@
+import { lazy } from 'react'
+import { ConfigurationSchema } from '../../configuration'
+import Plugin, { DrawerWidgetType, MenuBarType } from '../../Plugin'
+import {
+  AboutDrawerWidgetModel,
+  HelpDrawerWidgetModel,
+  MainMenuBarModel,
+} from './model'
+
+const MainMenuBarComponent = lazy(() => import('./components/MainMenuBar'))
+const AboutDrawerWidgetComponent = lazy(() =>
+  import('./components/AboutDrawerWidget'),
+)
+const HelpDrawerWidgetComponent = lazy(() =>
+  import('./components/HelpDrawerWidget'),
+)
+
+export default class MainMenuBar extends Plugin {
+  install(pluginManager) {
+    pluginManager.addMenuBarType(() => {
+      const stateModel = MainMenuBarModel
+
+      const configSchema = ConfigurationSchema('MainMenuBar', {})
+
+      return new MenuBarType({
+        name: 'MainMenuBar',
+        configSchema,
+        stateModel,
+        LazyReactComponent: MainMenuBarComponent,
+      })
+    })
+
+    pluginManager.addDrawerWidgetType(() => {
+      const stateModel = AboutDrawerWidgetModel
+
+      const configSchema = ConfigurationSchema('AboutDrawerWidget', {})
+
+      return new DrawerWidgetType({
+        name: 'AboutDrawerWidget',
+        configSchema,
+        stateModel,
+        LazyReactComponent: AboutDrawerWidgetComponent,
+      })
+    })
+
+    pluginManager.addDrawerWidgetType(() => {
+      const stateModel = HelpDrawerWidgetModel
+
+      const configSchema = ConfigurationSchema('HelpDrawerWidget', {})
+
+      return new DrawerWidgetType({
+        name: 'HelpDrawerWidget',
+        configSchema,
+        stateModel,
+        LazyReactComponent: HelpDrawerWidgetComponent,
+      })
+    })
+  }
+}

--- a/packages/jbrowse-web/src/plugins/MainMenuBar/model.js
+++ b/packages/jbrowse-web/src/plugins/MainMenuBar/model.js
@@ -1,0 +1,83 @@
+import { getRoot, types } from 'mobx-state-tree'
+import { ElementId } from '../../mst-types'
+import { stringToFunction } from '../../configuration/configurationSchema'
+
+const MenuItemModel = types
+  .model('MenuItemModel', {
+    name: types.string,
+    icon: types.optional(types.string, ''),
+    callback: types.optional(
+      types.string,
+      'function(model){console.log(model)}',
+    ),
+  })
+  .views(self => ({
+    get func() {
+      const action = this.getAction(self.callback)
+      if (action) return action
+      return stringToFunction(self.callback)
+    },
+  }))
+  .actions(self => ({
+    getAction(action) {
+      return this[action]
+    },
+    openAbout() {
+      const rootModel = getRoot(self)
+      if (!rootModel.drawerWidgets.get('aboutDrawerWidget'))
+        rootModel.addDrawerWidget('AboutDrawerWidget', 'aboutDrawerWidget')
+      rootModel.showDrawerWidget(
+        rootModel.drawerWidgets.get('aboutDrawerWidget'),
+      )
+    },
+    openHelp() {
+      const rootModel = getRoot(self)
+      if (!rootModel.drawerWidgets.get('helpDrawerWidget'))
+        rootModel.addDrawerWidget('HelpDrawerWidget', 'helpDrawerWidget')
+      rootModel.showDrawerWidget(
+        rootModel.drawerWidgets.get('helpDrawerWidget'),
+      )
+    },
+  }))
+
+const MenuModel = types
+  .model('MenuModel', {
+    name: types.string,
+    menuItems: types.array(MenuItemModel),
+  })
+  .actions(self => ({
+    addMenuItem({ name, icon = undefined, callback = undefined }) {
+      self.menuItems.push(MenuItemModel.create({ name, icon, callback }))
+    },
+  }))
+
+export const MainMenuBarModel = types
+  .model('MainMenuBarModel', {
+    id: ElementId,
+    type: types.literal('MainMenuBar'),
+    menus: types.array(MenuModel),
+  })
+  .actions(self => ({
+    afterCreate() {
+      this.addMenu({
+        name: 'Help',
+        menuItems: [
+          { name: 'About', icon: 'info', callback: 'openAbout' },
+          { name: 'Help', icon: 'help', callback: 'openHelp' },
+        ],
+      })
+    },
+    addMenu({ name, menuItems = [] }) {
+      self.menus.push(MenuModel.create({ name, menuItems }))
+    },
+  }))
+
+export const AboutDrawerWidgetModel = types.model('AboutDrawerWidget', {
+  id: ElementId,
+  type: types.literal('AboutDrawerWidget'),
+})
+
+export const HelpDrawerWidgetModel = types.model('HelpDrawerWidget', {
+  id: ElementId,
+  type: types.literal('HelpDrawerWidget'),
+})


### PR DESCRIPTION
This adds a main menu bar that includes two built-in entries ("Help" and "About") and can be extended to add other entries.

The built-in entries each include a drawer widget that they open when clicked.

Closes #5 