### PR TITLE
Specify view config ID in snapshot

### DIFF
--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -15,7 +15,7 @@ jbrowse.addWorkers(workerGroups)
 // add the initial configuration
 jbrowse.configure({
   views: {
-    LinearGenomeView: {},
+    LinearGenomeView: { _configId: 'LinearGenomeView' },
   },
   tracks: [
     {


### PR DESCRIPTION
@rbuels putting this in a PR since I'm not sure how we want to handle this. I found that if you do this:
```js
jbrowse.configure({
  views: {
    LinearGenomeView: {},
  },
})
```
and then run `getSnapshot(MODEL.configuration.views)` you can see that the state is
```json
{
   "LinearGenomeView":{
      "_configId":"mk6EmWpndk"
   }
}
```
This sometimes causes an error that says: `Uncaught Error: [mobx-state-tree] A map of objects containing an identifier should always store the object under their own identifier. Trying to store key 'mk6EmWpndk', but expected: 'LinearGenomeView'`. You can fix this by manually specifying the `_configId` like I did in this PR. However, it seems like we would want it to automatically take care of that so we don't have to worry about specifying the `_configId` every time a view is configured. I tried to put a check in `ConfigurationSchema()` from `configurationSchema.js` to see if the config was for a view and then set the `_configId` to the view name instead of a random ID, but I couldn't figure out a way to tell from there whether the config was for a view or not. If you know a good way of doing that, that would probably be a better way of fixing the problem than this PR.

Note, if you just run `jbrowse.configure()` and then run `model.addView('LinearGenomeView')`, it doesn't have any problems since `addView` explicitly sets the `_configId` to the view name.