### PR TITLE
Use "position: relative" on container to position zoom controls

### DIFF
--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.js
@@ -87,87 +87,97 @@ class LinearGenomeView extends Component {
     }
     // console.log(style)
     return (
-      <div
-        className={classes.linearGenomeView}
-        key={`view-${id}`}
-        style={style}
-      >
+      <div style={{ position: 'relative' }}>
         <div
-          className={classnames(classes.controls, classes.viewControls)}
-          style={{ gridRow: 'scale-bar' }}
+          className={classes.linearGenomeView}
+          key={`view-${id}`}
+          style={style}
         >
-          <IconButton
-            onClick={model.closeView}
-            style={{ padding: '4px' }}
-            title="close this view"
-          >
-            <Icon fontSize="small">close</Icon>
-          </IconButton>
-          <ConfigureToggleButton
-            model={model}
-            onClick={model.activateConfigurationUI}
-            title="configure view"
-            style={{}}
-            fontSize="small"
-          />
-          <ToggleButton
-            onClick={model.activateTrackSelector}
-            title="select tracks"
-            selected={
-              rootModel.task &&
-              rootModel.task.taskName === 'track_select' &&
-              rootModel.task.data === model
-            }
-            value="track_select"
-          >
-            <Icon fontSize="small">line_style</Icon>
-          </ToggleButton>
-        </div>
-        <ScaleBar
-          style={{ gridColumn: 'blocks', gridRow: 'scale-bar' }}
-          height={scaleBarHeight}
-          bpPerPx={bpPerPx}
-          blocks={blocks}
-          offsetPx={visibleBlocksOffsetPx}
-          horizontallyFlipped={model.horizontallyFlipped}
-          width={width - controlsWidth}
-        />
-        <div className={classes.zoomControls} style={{ left: width - 138 }}>
-          <ZoomControls model={model} controlsHeight={scaleBarHeight} />
-        </div>
-        {tracks.map(track => [
           <div
-            className={classnames(classes.controls, classes.trackControls)}
-            key={`controls:${track.id}`}
-            style={{ gridRow: `track-${track.id}`, gridColumn: 'controls' }}
+            className={classnames(classes.controls, classes.viewControls)}
+            style={{ gridRow: 'scale-bar' }}
           >
-            <track.ControlsComponent
-              track={track}
-              key={track.id}
-              view={model}
-              onConfigureClick={track.activateConfigurationUI}
+            <IconButton
+              onClick={model.closeView}
+              style={{ padding: '4px' }}
+              title="close this view"
+            >
+              <Icon fontSize="small">close</Icon>
+            </IconButton>
+            <ConfigureToggleButton
+              model={model}
+              onClick={model.activateConfigurationUI}
+              title="configure view"
+              style={{}}
+              fontSize="small"
             />
-          </div>,
-          <TrackRenderingContainer
-            key={`track-rendering:${track.id}`}
-            trackId={track.id}
+            <ToggleButton
+              onClick={model.activateTrackSelector}
+              title="select tracks"
+              selected={
+                rootModel.task &&
+                rootModel.task.taskName === 'track_select' &&
+                rootModel.task.data === model
+              }
+              value="track_select"
+            >
+              <Icon fontSize="small">line_style</Icon>
+            </ToggleButton>
+          </div>
+          <ScaleBar
+            style={{ gridColumn: 'blocks', gridRow: 'scale-bar' }}
+            height={scaleBarHeight}
+            bpPerPx={bpPerPx}
+            blocks={blocks}
+            offsetPx={visibleBlocksOffsetPx}
+            horizontallyFlipped={model.horizontallyFlipped}
             width={width - controlsWidth}
-            onHorizontalScroll={model.horizontalScroll}
+          />
+          <div
+            className={classes.zoomControls}
+            style={{
+              position: 'absolute',
+              right: '0px',
+              top: '0px',
+              zIndex: 999,
+            }}
           >
-            <track.RenderingComponent
-              model={track}
-              blockDefinitions={blocks}
-              offsetPx={visibleBlocksOffsetPx}
-              bpPerPx={bpPerPx}
-              blockState={{}}
-            />
-          </TrackRenderingContainer>,
-          <TrackResizeHandle
-            key={`handle:${track.id}`}
-            trackId={track.id}
-            onVerticalDrag={model.resizeTrack}
-          />,
-        ])}
+            <ZoomControls model={model} controlsHeight={scaleBarHeight} />
+          </div>
+          {tracks.map(track => [
+            <div
+              className={classnames(classes.controls, classes.trackControls)}
+              key={`controls:${track.id}`}
+              style={{ gridRow: `track-${track.id}`, gridColumn: 'controls' }}
+            >
+              <track.ControlsComponent
+                track={track}
+                key={track.id}
+                view={model}
+                onConfigureClick={track.activateConfigurationUI}
+              />
+            </div>,
+            <TrackRenderingContainer
+              key={`track-rendering:${track.id}`}
+              trackId={track.id}
+              width={width - controlsWidth}
+              onHorizontalScroll={model.horizontalScroll}
+            >
+              <track.RenderingComponent
+                model={track}
+                blockDefinitions={blocks}
+                offsetPx={visibleBlocksOffsetPx}
+                bpPerPx={bpPerPx}
+                blockState={{}}
+              />
+            </TrackRenderingContainer>,
+            <TrackResizeHandle
+              key={`handle:${track.id}`}
+              trackId={track.id}
+              onVerticalDrag={model.resizeTrack}
+            />,
+          ])}
+        </div>
       </div>
     )
   }

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.js
@@ -15,7 +15,10 @@ import ZoomControls from './ZoomControls'
 
 const dragHandleHeight = 3
 
-const styles = (/* theme */) => ({
+const styles = theme => ({
+  root: {
+    position: 'relative',
+  },
   linearGenomeView: {
     background: '#eee',
     // background: theme.palette.background.paper,
@@ -38,6 +41,12 @@ const styles = (/* theme */) => ({
   },
   zoomControls: {
     position: 'absolute',
+    right: theme.spacing.unit / 2,
+    top: '0px',
+    zIndex: 999,
+  },
+  iconButton: {
+    padding: theme.spacing.unit / 2,
   },
 })
 
@@ -87,7 +96,7 @@ class LinearGenomeView extends Component {
     }
     // console.log(style)
     return (
-      <div style={{ position: 'relative' }}>
+      <div className={classes.root}>
         <div
           className={classes.linearGenomeView}
           key={`view-${id}`}
@@ -99,7 +108,7 @@ class LinearGenomeView extends Component {
           >
             <IconButton
               onClick={model.closeView}
-              style={{ padding: '4px' }}
+              className={classes.iconButton}
               title="close this view"
             >
               <Icon fontSize="small">close</Icon>
@@ -133,15 +142,7 @@ class LinearGenomeView extends Component {
             horizontallyFlipped={model.horizontallyFlipped}
             width={width - controlsWidth}
           />
-          <div
-            className={classes.zoomControls}
-            style={{
-              position: 'absolute',
-              right: '0px',
-              top: '0px',
-              zIndex: 999,
-            }}
-          >
+          <div className={classes.zoomControls}>
             <ZoomControls model={model} controlsHeight={scaleBarHeight} />
           </div>
           {tracks.map(track => [

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -2,14 +2,10 @@
 
 exports[`LinearGenomeView genome view component renders one track, no blocks 1`] = `
 <div
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
+  className="LinearGenomeView-root-1"
 >
   <div
-    className="LinearGenomeView-linearGenomeView-1"
+    className="LinearGenomeView-linearGenomeView-2"
     style={
       Object {
         "display": "grid",
@@ -21,7 +17,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
     }
   >
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+      className="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
       style={
         Object {
           "gridRow": "scale-bar",
@@ -29,7 +25,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-14 MuiIconButton-root-8 LinearGenomeView-iconButton-7"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -42,31 +38,26 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        style={
-          Object {
-            "padding": "4px",
-          }
-        }
         tabIndex="0"
         title="close this view"
         type="button"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiIconButton-label-13"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             close
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         fontSize="small"
         onBlur={[Function]}
@@ -92,21 +83,21 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -125,22 +116,22 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         value="track_select"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             line_style
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
     </div>
     <div
-      className="ScaleBar-scaleBar-28"
+      className="ScaleBar-scaleBar-30"
       style={
         Object {
           "gridColumn": "blocks",
@@ -151,18 +142,10 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       }
     />
     <div
-      className="LinearGenomeView-zoomControls-5"
-      style={
-        Object {
-          "position": "absolute",
-          "right": "0px",
-          "top": "0px",
-          "zIndex": 999,
-        }
-      }
+      className="LinearGenomeView-zoomControls-6"
     >
       <div
-        className="ZoomControls-container-30"
+        className="ZoomControls-container-32"
         style={
           Object {
             "height": 32,
@@ -170,7 +153,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         }
       >
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -186,18 +169,18 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_out
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
         <div
@@ -205,7 +188,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           aria-valuemax={4.321928094887363}
           aria-valuemin={4.321928094887363}
           aria-valuenow={-0}
-          className="MuiSlider-root-32 ZoomControls-slider-31"
+          className="MuiSlider-root-34 ZoomControls-slider-33"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchMove={[Function]}
@@ -213,10 +196,10 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           role="slider"
         >
           <div
-            className="MuiSlider-container-33"
+            className="MuiSlider-container-35"
           >
             <div
-              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              className="MuiSlider-track-36 MuiSlider-trackBefore-37"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(0)",
@@ -224,7 +207,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
               }
             />
             <div
-              className="MuiSlider-thumbWrapper-37"
+              className="MuiSlider-thumbWrapper-39"
               style={
                 Object {
                   "transform": "translateX(0%)",
@@ -232,7 +215,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
               }
             >
               <button
-                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                className="MuiButtonBase-root-14 MuiSlider-thumb-40"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -249,7 +232,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
               />
             </div>
             <div
-              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              className="MuiSlider-track-36 MuiSlider-trackAfter-38"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(1)",
@@ -259,7 +242,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           </div>
         </div>
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -275,24 +258,24 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_in
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
       </div>
     </div>
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      className="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
       style={
         Object {
           "gridColumn": "controls",
@@ -301,7 +284,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -326,32 +309,32 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <p
-        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+        className="MuiTypography-root-57 MuiTypography-body1-66 TrackControls-trackName-55"
       >
         foo
       </p>
       <span
-        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+        className="MuiTypography-root-57 MuiTypography-caption-67 MuiTypography-colorTextSecondary-90 TrackControls-trackDescription-56"
       >
         
       </span>
     </div>
     <div
-      className="TrackRenderingContainer-trackRenderingContainer-90"
+      className="TrackRenderingContainer-trackRenderingContainer-92"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -375,7 +358,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-91"
+      className="TrackResizeHandle-dragHandle-93"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -394,14 +377,10 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
 
 exports[`LinearGenomeView genome view component renders two tracks, two regions 1`] = `
 <div
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
+  className="LinearGenomeView-root-1"
 >
   <div
-    className="LinearGenomeView-linearGenomeView-1"
+    className="LinearGenomeView-linearGenomeView-2"
     style={
       Object {
         "display": "grid",
@@ -413,7 +392,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     }
   >
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+      className="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
       style={
         Object {
           "gridRow": "scale-bar",
@@ -421,7 +400,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-14 MuiIconButton-root-8 LinearGenomeView-iconButton-7"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -434,31 +413,26 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        style={
-          Object {
-            "padding": "4px",
-          }
-        }
         tabIndex="0"
         title="close this view"
         type="button"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiIconButton-label-13"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             close
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         fontSize="small"
         onBlur={[Function]}
@@ -484,21 +458,21 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -517,22 +491,22 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         value="track_select"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             line_style
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
     </div>
     <div
-      className="ScaleBar-scaleBar-28"
+      className="ScaleBar-scaleBar-30"
       style={
         Object {
           "gridColumn": "blocks",
@@ -543,7 +517,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       }
     >
       <div
-        className="Block-block-92 Block-leftBorder-93 Block-rightBorder-94"
+        className="Block-block-94 Block-leftBorder-95 Block-rightBorder-96"
         style={
           Object {
             "left": "0px",
@@ -556,7 +530,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           width={100}
         >
           <line
-            className="Ruler-majorTick-96"
+            className="Ruler-majorTick-98"
             data-bp={-1}
             stroke="#555"
             strokeWidth={1}
@@ -566,7 +540,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={6}
           />
           <line
-            className="Ruler-minorTick-97"
+            className="Ruler-minorTick-99"
             data-bp={19}
             stroke="#999"
             strokeWidth={1}
@@ -576,7 +550,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={4}
           />
           <line
-            className="Ruler-minorTick-97"
+            className="Ruler-minorTick-99"
             data-bp={39}
             stroke="#999"
             strokeWidth={1}
@@ -586,7 +560,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={4}
           />
           <line
-            className="Ruler-minorTick-97"
+            className="Ruler-minorTick-99"
             data-bp={59}
             stroke="#999"
             strokeWidth={1}
@@ -596,7 +570,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={4}
           />
           <line
-            className="Ruler-minorTick-97"
+            className="Ruler-minorTick-99"
             data-bp={79}
             stroke="#999"
             strokeWidth={1}
@@ -606,7 +580,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={4}
           />
           <line
-            className="Ruler-majorTick-96"
+            className="Ruler-majorTick-98"
             data-bp={99}
             stroke="#555"
             strokeWidth={1}
@@ -616,7 +590,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             y2={6}
           />
           <line
-            className="Ruler-minorTick-97"
+            className="Ruler-minorTick-99"
             data-bp={119}
             stroke="#999"
             strokeWidth={1}
@@ -627,7 +601,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
           <text
             alignmentBaseline="hanging"
-            className="Ruler-majorTickLabel-95"
+            className="Ruler-majorTickLabel-97"
             style={
               Object {
                 "fontSize": "11px",
@@ -640,7 +614,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </text>
           <text
             alignmentBaseline="hanging"
-            className="Ruler-majorTickLabel-95"
+            className="Ruler-majorTickLabel-97"
             style={
               Object {
                 "fontSize": "11px",
@@ -654,24 +628,16 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </svg>
       </div>
       <div
-        className="ScaleBar-refLabel-29"
+        className="ScaleBar-refLabel-31"
       >
         ctgA
       </div>
     </div>
     <div
-      className="LinearGenomeView-zoomControls-5"
-      style={
-        Object {
-          "position": "absolute",
-          "right": "0px",
-          "top": "0px",
-          "zIndex": 999,
-        }
-      }
+      className="LinearGenomeView-zoomControls-6"
     >
       <div
-        className="ZoomControls-container-30"
+        className="ZoomControls-container-32"
         style={
           Object {
             "height": 32,
@@ -679,7 +645,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         }
       >
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -695,18 +661,18 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_out
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
         <div
@@ -714,7 +680,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           aria-valuemax={4.321928094887363}
           aria-valuemin={4.321928094887363}
           aria-valuenow={-0}
-          className="MuiSlider-root-32 ZoomControls-slider-31"
+          className="MuiSlider-root-34 ZoomControls-slider-33"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchMove={[Function]}
@@ -722,10 +688,10 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           role="slider"
         >
           <div
-            className="MuiSlider-container-33"
+            className="MuiSlider-container-35"
           >
             <div
-              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              className="MuiSlider-track-36 MuiSlider-trackBefore-37"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(0)",
@@ -733,7 +699,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               }
             />
             <div
-              className="MuiSlider-thumbWrapper-37"
+              className="MuiSlider-thumbWrapper-39"
               style={
                 Object {
                   "transform": "translateX(0%)",
@@ -741,7 +707,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               }
             >
               <button
-                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                className="MuiButtonBase-root-14 MuiSlider-thumb-40"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -758,7 +724,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               />
             </div>
             <div
-              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              className="MuiSlider-track-36 MuiSlider-trackAfter-38"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(1)",
@@ -768,7 +734,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </div>
         </div>
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -784,24 +750,24 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_in
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
       </div>
     </div>
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      className="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
       style={
         Object {
           "gridColumn": "controls",
@@ -810,7 +776,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -835,32 +801,32 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <p
-        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+        className="MuiTypography-root-57 MuiTypography-body1-66 TrackControls-trackName-55"
       >
         foo
       </p>
       <span
-        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+        className="MuiTypography-root-57 MuiTypography-caption-67 MuiTypography-colorTextSecondary-90 TrackControls-trackDescription-56"
       >
         
       </span>
     </div>
     <div
-      className="TrackRenderingContainer-trackRenderingContainer-90"
+      className="TrackRenderingContainer-trackRenderingContainer-92"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -884,7 +850,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-91"
+      className="TrackResizeHandle-dragHandle-93"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -898,7 +864,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       }
     />
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      className="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
       style={
         Object {
           "gridColumn": "controls",
@@ -907,7 +873,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -932,32 +898,32 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <p
-        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+        className="MuiTypography-root-57 MuiTypography-body1-66 TrackControls-trackName-55"
       >
         bar
       </p>
       <span
-        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+        className="MuiTypography-root-57 MuiTypography-caption-67 MuiTypography-colorTextSecondary-90 TrackControls-trackDescription-56"
       >
         
       </span>
     </div>
     <div
-      className="TrackRenderingContainer-trackRenderingContainer-90"
+      className="TrackRenderingContainer-trackRenderingContainer-92"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -981,7 +947,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-91"
+      className="TrackResizeHandle-dragHandle-93"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -1000,14 +966,10 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
 
 exports[`LinearGenomeView genome view component renders with an empty model 1`] = `
 <div
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
+  className="LinearGenomeView-root-1"
 >
   <div
-    className="LinearGenomeView-linearGenomeView-1"
+    className="LinearGenomeView-linearGenomeView-2"
     style={
       Object {
         "display": "grid",
@@ -1019,7 +981,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
     }
   >
     <div
-      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+      className="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
       style={
         Object {
           "gridRow": "scale-bar",
@@ -1027,7 +989,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       }
     >
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-14 MuiIconButton-root-8 LinearGenomeView-iconButton-7"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -1040,31 +1002,26 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        style={
-          Object {
-            "padding": "4px",
-          }
-        }
         tabIndex="0"
         title="close this view"
         type="button"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiIconButton-label-13"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             close
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         fontSize="small"
         onBlur={[Function]}
@@ -1090,21 +1047,21 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         value="configure"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             settings
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
       <button
-        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        className="MuiButtonBase-root-14 MuiToggleButton-root-26"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -1123,22 +1080,22 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         value="track_select"
       >
         <span
-          className="MuiToggleButton-label-27"
+          className="MuiToggleButton-label-29"
         >
           <span
             aria-hidden="true"
-            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+            className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
           >
             line_style
           </span>
         </span>
         <span
-          className="MuiTouchRipple-root-46"
+          className="MuiTouchRipple-root-48"
         />
       </button>
     </div>
     <div
-      className="ScaleBar-scaleBar-28"
+      className="ScaleBar-scaleBar-30"
       style={
         Object {
           "gridColumn": "blocks",
@@ -1149,18 +1106,10 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       }
     />
     <div
-      className="LinearGenomeView-zoomControls-5"
-      style={
-        Object {
-          "position": "absolute",
-          "right": "0px",
-          "top": "0px",
-          "zIndex": 999,
-        }
-      }
+      className="LinearGenomeView-zoomControls-6"
     >
       <div
-        className="ZoomControls-container-30"
+        className="ZoomControls-container-32"
         style={
           Object {
             "height": 32,
@@ -1168,7 +1117,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         }
       >
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -1184,18 +1133,18 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_out
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
         <div
@@ -1203,7 +1152,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           aria-valuemax={4.321928094887363}
           aria-valuemin={4.321928094887363}
           aria-valuenow={-0}
-          className="MuiSlider-root-32 ZoomControls-slider-31"
+          className="MuiSlider-root-34 ZoomControls-slider-33"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchMove={[Function]}
@@ -1211,10 +1160,10 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           role="slider"
         >
           <div
-            className="MuiSlider-container-33"
+            className="MuiSlider-container-35"
           >
             <div
-              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              className="MuiSlider-track-36 MuiSlider-trackBefore-37"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(0)",
@@ -1222,7 +1171,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
               }
             />
             <div
-              className="MuiSlider-thumbWrapper-37"
+              className="MuiSlider-thumbWrapper-39"
               style={
                 Object {
                   "transform": "translateX(0%)",
@@ -1230,7 +1179,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
               }
             >
               <button
-                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                className="MuiButtonBase-root-14 MuiSlider-thumb-40"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1247,7 +1196,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
               />
             </div>
             <div
-              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              className="MuiSlider-track-36 MuiSlider-trackAfter-38"
               style={
                 Object {
                   "transform": "translateY(-50%) scaleX(1)",
@@ -1257,7 +1206,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           </div>
         </div>
         <button
-          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -1273,18 +1222,18 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           type="button"
         >
           <span
-            className="MuiIconButton-label-11"
+            className="MuiIconButton-label-13"
           >
             <span
               aria-hidden="true"
-              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
               onClick={[Function]}
             >
               zoom_in
             </span>
           </span>
           <span
-            className="MuiTouchRipple-root-46"
+            className="MuiTouchRipple-root-48"
           />
         </button>
       </div>

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -2,160 +2,29 @@
 
 exports[`LinearGenomeView genome view component renders one track, no blocks 1`] = `
 <div
-  className="LinearGenomeView-linearGenomeView-1"
   style={
     Object {
-      "display": "grid",
-      "gridTemplateColumns": "[controls] 100px [blocks] auto",
-      "gridTemplateRows": "[scale-bar] auto [track-foo] 20px [resize-foo] 3px",
-      "height": "55px",
-      "width": "800px",
+      "position": "relative",
     }
   }
 >
   <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+    className="LinearGenomeView-linearGenomeView-1"
     style={
       Object {
-        "gridRow": "scale-bar",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiIconButton-root-6"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      style={
-        Object {
-          "padding": "4px",
-        }
-      }
-      tabIndex="0"
-      title="close this view"
-      type="button"
-    >
-      <span
-        className="MuiIconButton-label-11"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          close
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      fontSize="small"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
-      style={
-        Object {
-          "minWidth": 0,
-        }
-      }
-      tabIndex="0"
-      title="configure view"
-      type="button"
-      value="configure"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          settings
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      title="select tracks"
-      type="button"
-      value="track_select"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          line_style
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-  </div>
-  <div
-    className="ScaleBar-scaleBar-28"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "scale-bar",
-        "height": "32px",
-        "width": "700px",
-      }
-    }
-  />
-  <div
-    className="LinearGenomeView-zoomControls-5"
-    style={
-      Object {
-        "left": 662,
+        "display": "grid",
+        "gridTemplateColumns": "[controls] 100px [blocks] auto",
+        "gridTemplateRows": "[scale-bar] auto [track-foo] 20px [resize-foo] 3px",
+        "height": "55px",
+        "width": "800px",
       }
     }
   >
     <div
-      className="ZoomControls-container-30"
+      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
       style={
         Object {
-          "height": 32,
+          "gridRow": "scale-bar",
         }
       }
     >
@@ -173,7 +42,13 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        style={
+          Object {
+            "padding": "4px",
+          }
+        }
         tabIndex="0"
+        title="close this view"
         type="button"
       >
         <span
@@ -183,73 +58,250 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_out
+            close
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
-      <div
-        aria-orientation="horizontal"
-        aria-valuemax={4.321928094887363}
-        aria-valuemin={4.321928094887363}
-        aria-valuenow={-0}
-        className="MuiSlider-root-32 ZoomControls-slider-31"
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        fontSize="small"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
         onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
         onTouchMove={[Function]}
-        onTouchStartCapture={[Function]}
-        role="slider"
+        onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
+        tabIndex="0"
+        title="configure view"
+        type="button"
+        value="configure"
       >
+        <span
+          className="MuiToggleButton-label-27"
+        >
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+      >
+        <span
+          className="MuiToggleButton-label-27"
+        >
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            line_style
+          </span>
+        </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+    </div>
+    <div
+      className="ScaleBar-scaleBar-28"
+      style={
+        Object {
+          "gridColumn": "blocks",
+          "gridRow": "scale-bar",
+          "height": "32px",
+          "width": "700px",
+        }
+      }
+    />
+    <div
+      className="LinearGenomeView-zoomControls-5"
+      style={
+        Object {
+          "position": "absolute",
+          "right": "0px",
+          "top": "0px",
+          "zIndex": 999,
+        }
+      }
+    >
+      <div
+        className="ZoomControls-container-30"
+        style={
+          Object {
+            "height": 32,
+          }
+        }
+      >
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
         <div
-          className="MuiSlider-container-33"
+          aria-orientation="horizontal"
+          aria-valuemax={4.321928094887363}
+          aria-valuemin={4.321928094887363}
+          aria-valuenow={-0}
+          className="MuiSlider-root-32 ZoomControls-slider-31"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onTouchMove={[Function]}
+          onTouchStartCapture={[Function]}
+          role="slider"
         >
           <div
-            className="MuiSlider-track-34 MuiSlider-trackBefore-35"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(0)",
-              }
-            }
-          />
-          <div
-            className="MuiSlider-thumbWrapper-37"
-            style={
-              Object {
-                "transform": "translateX(0%)",
-              }
-            }
+            className="MuiSlider-container-33"
           >
-            <button
-              className="MuiButtonBase-root-12 MuiSlider-thumb-38"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              onTouchStartCapture={[Function]}
-              tabIndex="0"
-              type="button"
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(0)",
+                }
+              }
+            />
+            <div
+              className="MuiSlider-thumbWrapper-37"
+              style={
+                Object {
+                  "transform": "translateX(0%)",
+                }
+              }
+            >
+              <button
+                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                onTouchStartCapture={[Function]}
+                tabIndex="0"
+                type="button"
+              />
+            </div>
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(1)",
+                }
+              }
             />
           </div>
-          <div
-            className="MuiSlider-track-34 MuiSlider-trackAfter-36"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(1)",
-              }
-            }
-          />
         </div>
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
       </div>
+    </div>
+    <div
+      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      style={
+        Object {
+          "gridColumn": "controls",
+          "gridRow": "track-foo",
+        }
+      }
+    >
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -262,398 +314,109 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
         tabIndex="0"
+        title="configure track"
         type="button"
+        value="configure"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiToggleButton-label-27"
         >
           <span
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_in
+            settings
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
+      <p
+        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+      >
+        foo
+      </p>
+      <span
+        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+      >
+        
+      </span>
     </div>
-  </div>
-  <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
-    style={
-      Object {
-        "gridColumn": "controls",
-        "gridRow": "track-foo",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
+    <div
+      className="TrackRenderingContainer-trackRenderingContainer-90"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
+      onMouseMove={[Function]}
       onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
+      onWheel={[Function]}
+      role="presentation"
       style={
         Object {
-          "minWidth": 0,
+          "gridColumn": "blocks",
+          "gridRow": "track-foo",
+          "width": "700px",
         }
       }
-      tabIndex="0"
-      title="configure track"
-      type="button"
-      value="configure"
     >
-      <span
-        className="MuiToggleButton-label-27"
+      <div
+        className="TrackRenderingNotImplemented"
       >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          settings
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <p
-      className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
-    >
-      foo
-    </p>
-    <span
-      className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
-    >
-      
-    </span>
-  </div>
-  <div
-    className="TrackRenderingContainer-trackRenderingContainer-90"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    onWheel={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "track-foo",
-        "width": "700px",
-      }
-    }
-  >
-    <div
-      className="TrackRenderingNotImplemented"
-    >
-      Rendering not implemented for 
-      tester
-       tracks
+        Rendering not implemented for 
+        tester
+         tracks
+      </div>
     </div>
-  </div>
-  <div
-    className="TrackResizeHandle-dragHandle-91"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "span 2",
-        "gridRow": "resize-foo",
+    <div
+      className="TrackResizeHandle-dragHandle-91"
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      onMouseUp={[Function]}
+      role="presentation"
+      style={
+        Object {
+          "gridColumn": "span 2",
+          "gridRow": "resize-foo",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`LinearGenomeView genome view component renders two tracks, two regions 1`] = `
 <div
-  className="LinearGenomeView-linearGenomeView-1"
   style={
     Object {
-      "display": "grid",
-      "gridTemplateColumns": "[controls] 100px [blocks] auto",
-      "gridTemplateRows": "[scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px",
-      "height": "78px",
-      "width": "800px",
+      "position": "relative",
     }
   }
 >
   <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+    className="LinearGenomeView-linearGenomeView-1"
     style={
       Object {
-        "gridRow": "scale-bar",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiIconButton-root-6"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      style={
-        Object {
-          "padding": "4px",
-        }
-      }
-      tabIndex="0"
-      title="close this view"
-      type="button"
-    >
-      <span
-        className="MuiIconButton-label-11"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          close
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      fontSize="small"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
-      style={
-        Object {
-          "minWidth": 0,
-        }
-      }
-      tabIndex="0"
-      title="configure view"
-      type="button"
-      value="configure"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          settings
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      title="select tracks"
-      type="button"
-      value="track_select"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          line_style
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-  </div>
-  <div
-    className="ScaleBar-scaleBar-28"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "scale-bar",
-        "height": "32px",
-        "width": "700px",
+        "display": "grid",
+        "gridTemplateColumns": "[controls] 100px [blocks] auto",
+        "gridTemplateRows": "[scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px",
+        "height": "78px",
+        "width": "800px",
       }
     }
   >
     <div
-      className="Block-block-92 Block-leftBorder-93 Block-rightBorder-94"
+      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
       style={
         Object {
-          "left": "0px",
-          "width": "100px",
-        }
-      }
-    >
-      <svg
-        height={32}
-        width={100}
-      >
-        <line
-          className="Ruler-majorTick-96"
-          data-bp={-1}
-          stroke="#555"
-          strokeWidth={1}
-          x1={-1}
-          x2={-1}
-          y1={0}
-          y2={6}
-        />
-        <line
-          className="Ruler-minorTick-97"
-          data-bp={19}
-          stroke="#999"
-          strokeWidth={1}
-          x1={19}
-          x2={19}
-          y1={0}
-          y2={4}
-        />
-        <line
-          className="Ruler-minorTick-97"
-          data-bp={39}
-          stroke="#999"
-          strokeWidth={1}
-          x1={39}
-          x2={39}
-          y1={0}
-          y2={4}
-        />
-        <line
-          className="Ruler-minorTick-97"
-          data-bp={59}
-          stroke="#999"
-          strokeWidth={1}
-          x1={59}
-          x2={59}
-          y1={0}
-          y2={4}
-        />
-        <line
-          className="Ruler-minorTick-97"
-          data-bp={79}
-          stroke="#999"
-          strokeWidth={1}
-          x1={79}
-          x2={79}
-          y1={0}
-          y2={4}
-        />
-        <line
-          className="Ruler-majorTick-96"
-          data-bp={99}
-          stroke="#555"
-          strokeWidth={1}
-          x1={99}
-          x2={99}
-          y1={0}
-          y2={6}
-        />
-        <line
-          className="Ruler-minorTick-97"
-          data-bp={119}
-          stroke="#999"
-          strokeWidth={1}
-          x1={119}
-          x2={119}
-          y1={0}
-          y2={4}
-        />
-        <text
-          alignmentBaseline="hanging"
-          className="Ruler-majorTickLabel-95"
-          style={
-            Object {
-              "fontSize": "11px",
-            }
-          }
-          x={-4}
-          y={7}
-        >
-          0
-        </text>
-        <text
-          alignmentBaseline="hanging"
-          className="Ruler-majorTickLabel-95"
-          style={
-            Object {
-              "fontSize": "11px",
-            }
-          }
-          x={96}
-          y={7}
-        >
-          100
-        </text>
-      </svg>
-    </div>
-    <div
-      className="ScaleBar-refLabel-29"
-    >
-      ctgA
-    </div>
-  </div>
-  <div
-    className="LinearGenomeView-zoomControls-5"
-    style={
-      Object {
-        "left": 662,
-      }
-    }
-  >
-    <div
-      className="ZoomControls-container-30"
-      style={
-        Object {
-          "height": 32,
+          "gridRow": "scale-bar",
         }
       }
     >
@@ -671,7 +434,13 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        style={
+          Object {
+            "padding": "4px",
+          }
+        }
         tabIndex="0"
+        title="close this view"
         type="button"
       >
         <span
@@ -681,73 +450,367 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_out
+            close
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
-      <div
-        aria-orientation="horizontal"
-        aria-valuemax={4.321928094887363}
-        aria-valuemin={4.321928094887363}
-        aria-valuenow={-0}
-        className="MuiSlider-root-32 ZoomControls-slider-31"
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        fontSize="small"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
         onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
         onTouchMove={[Function]}
-        onTouchStartCapture={[Function]}
-        role="slider"
+        onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
+        tabIndex="0"
+        title="configure view"
+        type="button"
+        value="configure"
       >
+        <span
+          className="MuiToggleButton-label-27"
+        >
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+      >
+        <span
+          className="MuiToggleButton-label-27"
+        >
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            line_style
+          </span>
+        </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+    </div>
+    <div
+      className="ScaleBar-scaleBar-28"
+      style={
+        Object {
+          "gridColumn": "blocks",
+          "gridRow": "scale-bar",
+          "height": "32px",
+          "width": "700px",
+        }
+      }
+    >
+      <div
+        className="Block-block-92 Block-leftBorder-93 Block-rightBorder-94"
+        style={
+          Object {
+            "left": "0px",
+            "width": "100px",
+          }
+        }
+      >
+        <svg
+          height={32}
+          width={100}
+        >
+          <line
+            className="Ruler-majorTick-96"
+            data-bp={-1}
+            stroke="#555"
+            strokeWidth={1}
+            x1={-1}
+            x2={-1}
+            y1={0}
+            y2={6}
+          />
+          <line
+            className="Ruler-minorTick-97"
+            data-bp={19}
+            stroke="#999"
+            strokeWidth={1}
+            x1={19}
+            x2={19}
+            y1={0}
+            y2={4}
+          />
+          <line
+            className="Ruler-minorTick-97"
+            data-bp={39}
+            stroke="#999"
+            strokeWidth={1}
+            x1={39}
+            x2={39}
+            y1={0}
+            y2={4}
+          />
+          <line
+            className="Ruler-minorTick-97"
+            data-bp={59}
+            stroke="#999"
+            strokeWidth={1}
+            x1={59}
+            x2={59}
+            y1={0}
+            y2={4}
+          />
+          <line
+            className="Ruler-minorTick-97"
+            data-bp={79}
+            stroke="#999"
+            strokeWidth={1}
+            x1={79}
+            x2={79}
+            y1={0}
+            y2={4}
+          />
+          <line
+            className="Ruler-majorTick-96"
+            data-bp={99}
+            stroke="#555"
+            strokeWidth={1}
+            x1={99}
+            x2={99}
+            y1={0}
+            y2={6}
+          />
+          <line
+            className="Ruler-minorTick-97"
+            data-bp={119}
+            stroke="#999"
+            strokeWidth={1}
+            x1={119}
+            x2={119}
+            y1={0}
+            y2={4}
+          />
+          <text
+            alignmentBaseline="hanging"
+            className="Ruler-majorTickLabel-95"
+            style={
+              Object {
+                "fontSize": "11px",
+              }
+            }
+            x={-4}
+            y={7}
+          >
+            0
+          </text>
+          <text
+            alignmentBaseline="hanging"
+            className="Ruler-majorTickLabel-95"
+            style={
+              Object {
+                "fontSize": "11px",
+              }
+            }
+            x={96}
+            y={7}
+          >
+            100
+          </text>
+        </svg>
+      </div>
+      <div
+        className="ScaleBar-refLabel-29"
+      >
+        ctgA
+      </div>
+    </div>
+    <div
+      className="LinearGenomeView-zoomControls-5"
+      style={
+        Object {
+          "position": "absolute",
+          "right": "0px",
+          "top": "0px",
+          "zIndex": 999,
+        }
+      }
+    >
+      <div
+        className="ZoomControls-container-30"
+        style={
+          Object {
+            "height": 32,
+          }
+        }
+      >
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
         <div
-          className="MuiSlider-container-33"
+          aria-orientation="horizontal"
+          aria-valuemax={4.321928094887363}
+          aria-valuemin={4.321928094887363}
+          aria-valuenow={-0}
+          className="MuiSlider-root-32 ZoomControls-slider-31"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onTouchMove={[Function]}
+          onTouchStartCapture={[Function]}
+          role="slider"
         >
           <div
-            className="MuiSlider-track-34 MuiSlider-trackBefore-35"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(0)",
-              }
-            }
-          />
-          <div
-            className="MuiSlider-thumbWrapper-37"
-            style={
-              Object {
-                "transform": "translateX(0%)",
-              }
-            }
+            className="MuiSlider-container-33"
           >
-            <button
-              className="MuiButtonBase-root-12 MuiSlider-thumb-38"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              onTouchStartCapture={[Function]}
-              tabIndex="0"
-              type="button"
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(0)",
+                }
+              }
+            />
+            <div
+              className="MuiSlider-thumbWrapper-37"
+              style={
+                Object {
+                  "transform": "translateX(0%)",
+                }
+              }
+            >
+              <button
+                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                onTouchStartCapture={[Function]}
+                tabIndex="0"
+                type="button"
+              />
+            </div>
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(1)",
+                }
+              }
             />
           </div>
-          <div
-            className="MuiSlider-track-34 MuiSlider-trackAfter-36"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(1)",
-              }
-            }
-          />
         </div>
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
       </div>
+    </div>
+    <div
+      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      style={
+        Object {
+          "gridColumn": "controls",
+          "gridRow": "track-foo",
+        }
+      }
+    >
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -760,378 +823,206 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
         tabIndex="0"
+        title="configure track"
         type="button"
+        value="configure"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiToggleButton-label-27"
         >
           <span
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_in
+            settings
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
+      <p
+        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+      >
+        foo
+      </p>
+      <span
+        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+      >
+        
+      </span>
     </div>
-  </div>
-  <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
-    style={
-      Object {
-        "gridColumn": "controls",
-        "gridRow": "track-foo",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
+    <div
+      className="TrackRenderingContainer-trackRenderingContainer-90"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
+      onMouseMove={[Function]}
       onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
+      onWheel={[Function]}
+      role="presentation"
       style={
         Object {
-          "minWidth": 0,
+          "gridColumn": "blocks",
+          "gridRow": "track-foo",
+          "width": "700px",
         }
       }
-      tabIndex="0"
-      title="configure track"
-      type="button"
-      value="configure"
     >
-      <span
-        className="MuiToggleButton-label-27"
+      <div
+        className="TrackRenderingNotImplemented"
       >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          settings
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <p
-      className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
-    >
-      foo
-    </p>
-    <span
-      className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
-    >
-      
-    </span>
-  </div>
-  <div
-    className="TrackRenderingContainer-trackRenderingContainer-90"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    onWheel={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "track-foo",
-        "width": "700px",
-      }
-    }
-  >
-    <div
-      className="TrackRenderingNotImplemented"
-    >
-      Rendering not implemented for 
-      tester
-       tracks
+        Rendering not implemented for 
+        tester
+         tracks
+      </div>
     </div>
-  </div>
-  <div
-    className="TrackResizeHandle-dragHandle-91"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "span 2",
-        "gridRow": "resize-foo",
-      }
-    }
-  />
-  <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
-    style={
-      Object {
-        "gridColumn": "controls",
-        "gridRow": "track-bar",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
+    <div
+      className="TrackResizeHandle-dragHandle-91"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
+      onMouseMove={[Function]}
       onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
+      role="presentation"
       style={
         Object {
-          "minWidth": 0,
+          "gridColumn": "span 2",
+          "gridRow": "resize-foo",
         }
       }
-      tabIndex="0"
-      title="configure track"
-      type="button"
-      value="configure"
+    />
+    <div
+      className="LinearGenomeView-controls-2 LinearGenomeView-trackControls-4"
+      style={
+        Object {
+          "gridColumn": "controls",
+          "gridRow": "track-bar",
+        }
+      }
     >
-      <span
-        className="MuiToggleButton-label-27"
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
+        tabIndex="0"
+        title="configure track"
+        type="button"
+        value="configure"
       >
         <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          className="MuiToggleButton-label-27"
         >
-          settings
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            settings
+          </span>
         </span>
-      </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+      <p
+        className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
+      >
+        bar
+      </p>
       <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <p
-      className="MuiTypography-root-55 MuiTypography-body1-64 TrackControls-trackName-53"
-    >
-      bar
-    </p>
-    <span
-      className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
-    >
-      
-    </span>
-  </div>
-  <div
-    className="TrackRenderingContainer-trackRenderingContainer-90"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    onWheel={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "track-bar",
-        "width": "700px",
-      }
-    }
-  >
-    <div
-      className="TrackRenderingNotImplemented"
-    >
-      Rendering not implemented for 
-      tester
-       tracks
+        className="MuiTypography-root-55 MuiTypography-caption-65 MuiTypography-colorTextSecondary-88 TrackControls-trackDescription-54"
+      >
+        
+      </span>
     </div>
-  </div>
-  <div
-    className="TrackResizeHandle-dragHandle-91"
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseMove={[Function]}
-    onMouseUp={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "gridColumn": "span 2",
-        "gridRow": "resize-bar",
+    <div
+      className="TrackRenderingContainer-trackRenderingContainer-90"
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      onMouseUp={[Function]}
+      onWheel={[Function]}
+      role="presentation"
+      style={
+        Object {
+          "gridColumn": "blocks",
+          "gridRow": "track-bar",
+          "width": "700px",
+        }
       }
-    }
-  />
+    >
+      <div
+        className="TrackRenderingNotImplemented"
+      >
+        Rendering not implemented for 
+        tester
+         tracks
+      </div>
+    </div>
+    <div
+      className="TrackResizeHandle-dragHandle-91"
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      onMouseUp={[Function]}
+      role="presentation"
+      style={
+        Object {
+          "gridColumn": "span 2",
+          "gridRow": "resize-bar",
+        }
+      }
+    />
+  </div>
 </div>
 `;
 
 exports[`LinearGenomeView genome view component renders with an empty model 1`] = `
 <div
-  className="LinearGenomeView-linearGenomeView-1"
   style={
     Object {
-      "display": "grid",
-      "gridTemplateColumns": "[controls] 100px [blocks] auto",
-      "gridTemplateRows": "[scale-bar] auto ",
-      "height": "32px",
-      "width": "800px",
+      "position": "relative",
     }
   }
 >
   <div
-    className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
+    className="LinearGenomeView-linearGenomeView-1"
     style={
       Object {
-        "gridRow": "scale-bar",
-      }
-    }
-  >
-    <button
-      className="MuiButtonBase-root-12 MuiIconButton-root-6"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      style={
-        Object {
-          "padding": "4px",
-        }
-      }
-      tabIndex="0"
-      title="close this view"
-      type="button"
-    >
-      <span
-        className="MuiIconButton-label-11"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          close
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      fontSize="small"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      size="small"
-      style={
-        Object {
-          "minWidth": 0,
-        }
-      }
-      tabIndex="0"
-      title="configure view"
-      type="button"
-      value="configure"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          settings
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-    <button
-      className="MuiButtonBase-root-12 MuiToggleButton-root-24"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      title="select tracks"
-      type="button"
-      value="track_select"
-    >
-      <span
-        className="MuiToggleButton-label-27"
-      >
-        <span
-          aria-hidden="true"
-          className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
-        >
-          line_style
-        </span>
-      </span>
-      <span
-        className="MuiTouchRipple-root-46"
-      />
-    </button>
-  </div>
-  <div
-    className="ScaleBar-scaleBar-28"
-    style={
-      Object {
-        "gridColumn": "blocks",
-        "gridRow": "scale-bar",
+        "display": "grid",
+        "gridTemplateColumns": "[controls] 100px [blocks] auto",
+        "gridTemplateRows": "[scale-bar] auto ",
         "height": "32px",
-        "width": "700px",
-      }
-    }
-  />
-  <div
-    className="LinearGenomeView-zoomControls-5"
-    style={
-      Object {
-        "left": 662,
+        "width": "800px",
       }
     }
   >
     <div
-      className="ZoomControls-container-30"
+      className="LinearGenomeView-controls-2 LinearGenomeView-viewControls-3"
       style={
         Object {
-          "height": 32,
+          "gridRow": "scale-bar",
         }
       }
     >
@@ -1149,7 +1040,13 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        style={
+          Object {
+            "padding": "4px",
+          }
+        }
         tabIndex="0"
+        title="close this view"
         type="button"
       >
         <span
@@ -1159,73 +1056,55 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_out
+            close
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
-      <div
-        aria-orientation="horizontal"
-        aria-valuemax={4.321928094887363}
-        aria-valuemin={4.321928094887363}
-        aria-valuenow={-0}
-        className="MuiSlider-root-32 ZoomControls-slider-31"
-        onClick={[Function]}
-        onMouseDown={[Function]}
-        onTouchMove={[Function]}
-        onTouchStartCapture={[Function]}
-        role="slider"
-      >
-        <div
-          className="MuiSlider-container-33"
-        >
-          <div
-            className="MuiSlider-track-34 MuiSlider-trackBefore-35"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(0)",
-              }
-            }
-          />
-          <div
-            className="MuiSlider-thumbWrapper-37"
-            style={
-              Object {
-                "transform": "translateX(0%)",
-              }
-            }
-          >
-            <button
-              className="MuiButtonBase-root-12 MuiSlider-thumb-38"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              onTouchStartCapture={[Function]}
-              tabIndex="0"
-              type="button"
-            />
-          </div>
-          <div
-            className="MuiSlider-track-34 MuiSlider-trackAfter-36"
-            style={
-              Object {
-                "transform": "translateY(-50%) scaleX(1)",
-              }
-            }
-          />
-        </div>
-      </div>
       <button
-        className="MuiButtonBase-root-12 MuiIconButton-root-6"
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
+        disabled={false}
+        fontSize="small"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        size="small"
+        style={
+          Object {
+            "minWidth": 0,
+          }
+        }
+        tabIndex="0"
+        title="configure view"
+        type="button"
+        value="configure"
+      >
+        <span
+          className="MuiToggleButton-label-27"
+        >
+          <span
+            aria-hidden="true"
+            className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          className="MuiTouchRipple-root-46"
+        />
+      </button>
+      <button
+        className="MuiButtonBase-root-12 MuiToggleButton-root-24"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -1239,22 +1118,176 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         tabIndex="0"
+        title="select tracks"
         type="button"
+        value="track_select"
       >
         <span
-          className="MuiIconButton-label-11"
+          className="MuiToggleButton-label-27"
         >
           <span
             aria-hidden="true"
             className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
           >
-            zoom_in
+            line_style
           </span>
         </span>
         <span
           className="MuiTouchRipple-root-46"
         />
       </button>
+    </div>
+    <div
+      className="ScaleBar-scaleBar-28"
+      style={
+        Object {
+          "gridColumn": "blocks",
+          "gridRow": "scale-bar",
+          "height": "32px",
+          "width": "700px",
+        }
+      }
+    />
+    <div
+      className="LinearGenomeView-zoomControls-5"
+      style={
+        Object {
+          "position": "absolute",
+          "right": "0px",
+          "top": "0px",
+          "zIndex": 999,
+        }
+      }
+    >
+      <div
+        className="ZoomControls-container-30"
+        style={
+          Object {
+            "height": 32,
+          }
+        }
+      >
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
+        <div
+          aria-orientation="horizontal"
+          aria-valuemax={4.321928094887363}
+          aria-valuemin={4.321928094887363}
+          aria-valuenow={-0}
+          className="MuiSlider-root-32 ZoomControls-slider-31"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onTouchMove={[Function]}
+          onTouchStartCapture={[Function]}
+          role="slider"
+        >
+          <div
+            className="MuiSlider-container-33"
+          >
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackBefore-35"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(0)",
+                }
+              }
+            />
+            <div
+              className="MuiSlider-thumbWrapper-37"
+              style={
+                Object {
+                  "transform": "translateX(0%)",
+                }
+              }
+            >
+              <button
+                className="MuiButtonBase-root-12 MuiSlider-thumb-38"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                onTouchStartCapture={[Function]}
+                tabIndex="0"
+                type="button"
+              />
+            </div>
+            <div
+              className="MuiSlider-track-34 MuiSlider-trackAfter-36"
+              style={
+                Object {
+                  "transform": "translateY(-50%) scaleX(1)",
+                }
+              }
+            />
+          </div>
+        </div>
+        <button
+          className="MuiButtonBase-root-12 MuiIconButton-root-6"
+          disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex="0"
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label-11"
+          >
+            <span
+              aria-hidden="true"
+              className="material-icons MuiIcon-root-15 MuiIcon-fontSizeSmall-22"
+              onClick={[Function]}
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            className="MuiTouchRipple-root-46"
+          />
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -156,6 +156,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -174,7 +175,6 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_out
             </span>
@@ -245,6 +245,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -263,7 +264,6 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_in
             </span>
@@ -648,6 +648,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -666,7 +667,6 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_out
             </span>
@@ -737,6 +737,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -755,7 +756,6 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_in
             </span>
@@ -1120,6 +1120,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -1138,7 +1139,6 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_out
             </span>
@@ -1209,6 +1209,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           className="MuiButtonBase-root-14 MuiIconButton-root-8"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
@@ -1227,7 +1228,6 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
             <span
               aria-hidden="true"
               className="material-icons MuiIcon-root-17 MuiIcon-fontSizeSmall-24"
-              onClick={[Function]}
             >
               zoom_in
             </span>


### PR DESCRIPTION
I added a extra container element which aids in positioning the zoom controls

Fixes issue observed in #89 "The zoom icons for magnifying glass go behind track when it is scrolled down"


![screenshot-localhost-3000-2019 01 27-18-49-43](https://user-images.githubusercontent.com/6511937/51808649-972ea000-2264-11e9-95ab-d8dcca750ee1.png)


Reviewing this change with &w=1 removes whitespace changes