### PR TITLE
Regularize assembly and sequence names

### DIFF
--- a/packages/jbrowse-web/src/BaseAdapter.js
+++ b/packages/jbrowse-web/src/BaseAdapter.js
@@ -1,0 +1,147 @@
+import { Observable } from 'rxjs'
+
+/**
+ * Base class for adapters to extend. Provides utilities for reference sequence
+ * name normalization and defines some methods that subclasses must implement.
+ * @property {string} assemblyName - The name of the assembly given in the
+ * config or the normalized name if it was an alias defined in the root config
+ * @property {string[]} assemblyAliases - An array of other possible names for this
+ * assembly
+ * @property {object} seqNameAliases - An object with keys that are possible
+ * sequence names for that assembly and values that are arrays of other possible
+ * names for that sequence
+ */
+export default class BaseAdapter {
+  constructor(config, rootConfig) {
+    if (new.target === BaseAdapter) {
+      throw new TypeError(
+        'Cannot create BaseAdapter instances directly, use a subclass',
+      )
+    }
+    const { assemblyName } = config
+    this.assemblyName = assemblyName
+    this.assemblyAliases = []
+    this.seqNameAliases = {}
+    const assemblies = rootConfig.assemblies || {}
+    if (assemblies[assemblyName]) {
+      this.assemblyAliases = assemblies[assemblyName].aliases
+      this.seqNameAliases = assemblies[assemblyName].seqNameAliases
+    } else
+      Object.keys(assemblies).forEach(assembly => {
+        if (assemblies[assembly].aliases.includes(assemblyName)) {
+          this.assemblyName = assembly
+          this.assemblyAliases = assemblies[assembly].aliases
+          this.seqNameAliases = assemblies[assembly].seqNameAliases
+        }
+      })
+  }
+
+  /**
+   * Subclasses should override this method. Method signature here for reference.
+   * @returns {string[]} Observable of Feature objects in the region
+   */
+  async loadData() {
+    throw new Error('This method should be overridden by the subclass')
+    // Subclass method should look something like this:
+    // this.metadata = await this.store.getMetadata()
+    // const { seqNames } = this.metadata
+    // return seqNames
+  }
+
+  /**
+   * Subclasses should override this method. Method signature here for reference.
+   * @param {Region} param
+   * @param {string} region.assemblyName Name of the assembly
+   * @param {string} region.refName Name of the reference sequence
+   * @param {int} region.start Start of the reference sequence
+   * @param {int} region.end End of the reference sequence
+   * @returns {Observable[Feature]} Observable of Feature objects in the region
+   */
+  // eslint-disable-next-line no-unused-vars
+  async getFeaturesInRegion({ assembly, refName, start, end }) {
+    throw new Error('This method should be overridden by the subclass')
+    // Subclass method should look something like this:
+    // return Observable.create(observer => {
+    //   const records = getRecords(assembly, refName, start, end)
+    //   records.forEach(record => {
+    //     observer.next(this.recordToFeature(record))
+    //   })
+    //   observer.complete()
+    // })
+  }
+
+  /**
+   * Subclasses should override this method. Method signature here for reference.
+   *
+   * called to provide a hint that data tied to a certain region
+   * will not be needed for the forseeable future and can be purged
+   * from caches, etc
+   * @param {Region} region
+   */
+  // eslint-disable-next-line no-unused-vars
+  freeResources(region) {
+    throw new Error('This method should be overridden by the subclass')
+  }
+
+  async regularizeAndGetFeaturesInRegion(region) {
+    const { assemblyName } = region
+    let { refName } = region
+    const refSeqs = await this.loadData()
+    this.loadRefSeqs(refSeqs)
+    if (!this.hasDataForRefSeq({ assemblyName, refName })) {
+      return Observable.create(observer => {
+        observer.complete()
+      })
+    }
+    refName = this.seqNameMap.get(refName) || refName
+    return this.getFeaturesInRegion(Object.assign(region, { refName }))
+  }
+
+  /**
+   * Generates the alias map for the provided sequence names.
+   * @param {string[]} refSeqs An array of the reference sequences in the file
+   */
+  loadRefSeqs(refSeqs) {
+    this.seqNameMap = new Map()
+    refSeqs.forEach(seqName => {
+      this.seqNameMap.set(seqName, seqName)
+      if (this.seqNameAliases[seqName]) {
+        this.seqNameAliases[seqName].forEach(seqNameAlias => {
+          this.seqNameMap.set(seqNameAlias, seqName)
+        })
+      } else
+        Object.keys(this.seqNameAliases).forEach(configSeqName => {
+          if (this.seqNameAliases[configSeqName].includes(seqName)) {
+            this.seqNameMap.set(configSeqName, seqName)
+            this.seqNameAliases[configSeqName].forEach(seqNameAlias => {
+              this.seqNameMap.set(seqNameAlias, seqName)
+            })
+          }
+        })
+    })
+  }
+
+  /**
+   * Check if the store has data for the given reference name. Also checks the
+   * assembly name if one was specified in the initial adapter config.
+   * @param {Region} region A sequence region
+   * @param {string} region.assemblyName Name of the assembly
+   * @param {string} region.refName Name of the reference sequence
+   */
+  hasDataForRefSeq({ assemblyName, refName }) {
+    if (!this.seqNameMap)
+      throw new Error(
+        '"loadRefSeqs" must be called before "hasDataForRefSeq" can be called',
+      )
+    if (
+      this.assemblyName &&
+      !(
+        this.assemblyName === assemblyName ||
+        this.assemblyAliases.includes(assemblyName)
+      )
+    )
+      return false
+    if (this.seqNameMap.get(refName)) return true
+    return false
+  }
+}

--- a/packages/jbrowse-web/src/BaseAdapter.js
+++ b/packages/jbrowse-web/src/BaseAdapter.js
@@ -41,7 +41,7 @@ export default class BaseAdapter {
    * @returns {string[]} Observable of Feature objects in the region
    */
   async loadData() {
-    throw new Error('This method should be overridden by the subclass')
+    throw new Error('loadData should be overridden by the subclass')
     // Subclass method should look something like this:
     // this.metadata = await this.store.getMetadata()
     // const { seqNames } = this.metadata
@@ -59,7 +59,7 @@ export default class BaseAdapter {
    */
   // eslint-disable-next-line no-unused-vars
   async getFeaturesInRegion({ assembly, refName, start, end }) {
-    throw new Error('This method should be overridden by the subclass')
+    throw new Error('getFeaturesInRegion should be overridden by the subclass')
     // Subclass method should look something like this:
     // return Observable.create(observer => {
     //   const records = getRecords(assembly, refName, start, end)
@@ -80,7 +80,7 @@ export default class BaseAdapter {
    */
   // eslint-disable-next-line no-unused-vars
   freeResources(region) {
-    throw new Error('This method should be overridden by the subclass')
+    throw new Error('freeResources should be overridden by the subclass')
   }
 
   async regularizeAndGetFeaturesInRegion(region) {

--- a/packages/jbrowse-web/src/BaseAdapter.test.js
+++ b/packages/jbrowse-web/src/BaseAdapter.test.js
@@ -1,0 +1,320 @@
+import { Observable } from 'rxjs'
+import { toArray } from 'rxjs/operators'
+import BaseAdapter from './BaseAdapter'
+
+describe('base data adapter', () => {
+  it('throws if instantiated directly', () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new BaseAdapter({}, {})
+    }).toThrow(/Cannot create BaseAdapter instances directly/)
+  })
+
+  it('throws if loadData() is not overridden by the subclass', async () => {
+    class Adapter extends BaseAdapter {
+      async getFeaturesInRegion() {
+        return Observable.create(observer => {
+          observer.next({
+            id: 'testFeature',
+            start: 100,
+            end: 200,
+          })
+          observer.complete()
+        })
+      }
+    }
+    const adapter = new Adapter({ assemblyName: 'volvox' }, {})
+    await expect(
+      adapter.regularizeAndGetFeaturesInRegion({
+        assemblyName: 'volvox',
+        refName: 'ctgA',
+        start: 0,
+        end: 20000,
+      }),
+    ).rejects.toThrow(/loadData should be overridden by the subclass/)
+  })
+
+  it('throws if getFeaturesInRegion() is not overridden by the subclass', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+    }
+    const adapter = new Adapter({ assemblyName: 'volvox' }, {})
+    await expect(
+      adapter.regularizeAndGetFeaturesInRegion({
+        assemblyName: 'volvox',
+        refName: 'ctgA',
+        start: 0,
+        end: 20000,
+      }),
+    ).rejects.toThrow(
+      /getFeaturesInRegion should be overridden by the subclass/,
+    )
+  })
+
+  it('throws if freeResources() is not overridden by the subclass', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+    }
+    const adapter = new Adapter({ assemblyName: 'volvox' }, {})
+    expect(() => adapter.freeResources()).toThrow(
+      /freeResources should be overridden by the subclass/,
+    )
+  })
+
+  it('throws if hasDataForRefSeq is called before loadRefSeqs', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+    }
+    const adapter = new Adapter({ assemblyName: 'volvox' }, {})
+    expect(() =>
+      adapter.hasDataForRefSeq({ assemblyName: 'volvox', refName: 'ctgA' }),
+    ).toThrow(
+      /"loadRefSeqs" must be called before "hasDataForRefSeq" can be called/,
+    )
+  })
+
+  it('retrieves features', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+
+      async getFeaturesInRegion() {
+        return Observable.create(observer => {
+          observer.next({
+            id: 'testFeature',
+            start: 100,
+            end: 200,
+          })
+          observer.complete()
+        })
+      }
+    }
+    const adapter = new Adapter({ assemblyName: 'volvox' }, {})
+    const features = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'volvox',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray = await features.pipe(toArray()).toPromise()
+    expect(featuresArray).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "end": 200,
+    "id": "testFeature",
+    "start": 100,
+  },
+]
+`)
+    const features2 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'volvox',
+      refName: 'ctgC',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray2 = await features2.pipe(toArray()).toPromise()
+    expect(featuresArray2).toMatchInlineSnapshot(`Array []`)
+  })
+
+  it('regularizes an assembly name in a query', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+
+      async getFeaturesInRegion() {
+        return Observable.create(observer => {
+          observer.next({
+            id: 'testFeature',
+            start: 100,
+            end: 200,
+          })
+          observer.complete()
+        })
+      }
+    }
+    const adapter = new Adapter(
+      { assemblyName: 'volvox' },
+      {
+        assemblies: {
+          volvox: {
+            aliases: ['vvx'],
+            seqNameAliases: {
+              A: ['ctgA', 'contigA'],
+              B: ['ctgB', 'contigB'],
+            },
+          },
+        },
+      },
+    )
+    const features = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'wrongAssemblyName',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray = await features.pipe(toArray()).toPromise()
+    expect(featuresArray).toMatchInlineSnapshot(`Array []`)
+    const features2 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray2 = await features2.pipe(toArray()).toPromise()
+    expect(featuresArray2).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "end": 200,
+    "id": "testFeature",
+    "start": 100,
+  },
+]
+`)
+  })
+
+  it('regularizes an assembly name in its configuration', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['ctgA', 'ctgB']
+      }
+
+      async getFeaturesInRegion() {
+        return Observable.create(observer => {
+          observer.next({
+            id: 'testFeature',
+            start: 100,
+            end: 200,
+          })
+          observer.complete()
+        })
+      }
+    }
+    const adapter = new Adapter(
+      { assemblyName: 'vvx' },
+      {
+        assemblies: {
+          volvox: {
+            aliases: ['vvx'],
+            seqNameAliases: {
+              A: ['ctgA', 'contigA'],
+              B: ['ctgB', 'contigB'],
+            },
+          },
+        },
+      },
+    )
+    const features = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'volvox',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray = await features.pipe(toArray()).toPromise()
+    const features2 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray2 = await features2.pipe(toArray()).toPromise()
+    expect(featuresArray).toEqual(featuresArray2)
+  })
+
+  it('regularizes a reference name in a query', async () => {
+    class Adapter extends BaseAdapter {
+      async loadData() {
+        return ['A', 'ctgB']
+      }
+
+      async getFeaturesInRegion(region) {
+        return Observable.create(observer => {
+          const { refName } = region
+          let feature = {}
+          if (refName === 'A')
+            feature = {
+              id: 'testFeature',
+              start: 100,
+              end: 200,
+            }
+          else if (refName === 'ctgB')
+            feature = {
+              id: 'testFeature',
+              start: 300,
+              end: 400,
+            }
+          else throw new Error('unrecognized refName')
+          observer.next(feature)
+          observer.complete()
+        })
+      }
+    }
+    const adapter = new Adapter(
+      { assemblyName: 'volvox' },
+      {
+        assemblies: {
+          volvox: {
+            aliases: ['vvx'],
+            seqNameAliases: {
+              A: ['ctgA', 'contigA'],
+              B: ['ctgB', 'contigB'],
+            },
+          },
+        },
+      },
+    )
+    const features = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'volvox',
+      refName: 'A',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray = await features.pipe(toArray()).toPromise()
+    const features2 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'ctgA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray2 = await features2.pipe(toArray()).toPromise()
+    const features3 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'contigA',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray3 = await features3.pipe(toArray()).toPromise()
+    expect(featuresArray).toEqual(featuresArray2)
+    expect(featuresArray).toEqual(featuresArray3)
+    const features4 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'volvox',
+      refName: 'B',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray4 = await features4.pipe(toArray()).toPromise()
+    const features5 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'ctgB',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray5 = await features5.pipe(toArray()).toPromise()
+    const features6 = await adapter.regularizeAndGetFeaturesInRegion({
+      assemblyName: 'vvx',
+      refName: 'contigB',
+      start: 0,
+      end: 20000,
+    })
+    const featuresArray6 = await features6.pipe(toArray()).toPromise()
+    expect(featuresArray4).toEqual(featuresArray5)
+    expect(featuresArray4).toEqual(featuresArray6)
+  })
+})

--- a/packages/jbrowse-web/src/configuration/configurationSchema.js
+++ b/packages/jbrowse-web/src/configuration/configurationSchema.js
@@ -88,14 +88,13 @@ export function ConfigurationSchema(
   }
 
   // now assemble the MST model of the configuration schema
-  const modelDefinition = { configId: ElementId }
-  if (options.singleton) {
-    modelDefinition.configId = types.optional(
-      types.refinement(types.identifier, t => t === modelName),
-      modelName,
-    )
-  } else {
-    modelDefinition.configId = ElementId
+  const modelDefinition = {
+    configId: options.singleton
+      ? types.optional(
+          types.refinement(types.identifier, t => t === modelName),
+          modelName,
+        )
+      : ElementId,
   }
 
   if (options.explicitlyTyped) modelDefinition.type = types.literal(modelName)

--- a/packages/jbrowse-web/src/configuration/configurationSlot.js
+++ b/packages/jbrowse-web/src/configuration/configurationSlot.js
@@ -9,6 +9,7 @@ function isValidColorString(/* str */) {
 }
 const typeModels = {
   stringArray: types.array(types.string),
+  stringArrayMap: types.map(types.array(types.string)),
   boolean: types.boolean,
   color: types.refinement('Color', types.string, isValidColorString),
   integer: types.integer,

--- a/packages/jbrowse-web/src/configuration/index.js
+++ b/packages/jbrowse-web/src/configuration/index.js
@@ -3,7 +3,7 @@ import {
   getPropertyMembers,
   getSnapshot,
 } from 'mobx-state-tree'
-import { isObservableArray, isObservableObject } from 'mobx'
+import { isObservableArray, isObservableObject, isObservableMap } from 'mobx'
 
 import {
   ConfigurationSchema,
@@ -28,8 +28,12 @@ function getModelConfig(tree) {
       keys.forEach(key => {
         config[key] = getModelConfig(tree[key])
       })
-    } else if (isObservableArray(tree)) {
-      config = tree.map(getModelConfig)
+    } else if (isObservableArray(tree)) config = tree.map(getModelConfig)
+    else if (isObservableMap(tree)) {
+      config = {}
+      tree.forEach((value, key) => {
+        config[key] = getModelConfig(value)
+      })
     }
 
     return config
@@ -48,6 +52,7 @@ function getConf(model, slotName, args) {
  * read the configuration variable at the given path
  */
 function readConfObject(confObject, slotPath, args) {
+  if (!slotPath) return getSnapshot(confObject)
   if (typeof slotPath === 'string') {
     const slot = confObject[slotPath]
     if (!slot) {

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -25,6 +25,7 @@ jbrowse.configure({
       adapter: {
         type: 'TwoBitAdapter',
         twoBitLocation: { uri: '/test_data/volvox.2bit' },
+        assemblyName: 'volvox',
       },
     },
     {
@@ -35,6 +36,7 @@ jbrowse.configure({
         type: 'BamAdapter',
         bamLocation: { uri: '/test_data/volvox-sorted.bam' },
         index: { location: { uri: '/test_data/volvox-sorted.bam.bai' } },
+        assemblyName: 'volvox',
       },
     },
     {
@@ -45,6 +47,7 @@ jbrowse.configure({
         type: 'BamAdapter',
         bamLocation: { uri: '/test_data/volvox-sorted.bam' },
         index: { location: { uri: '/test_data/volvox-sorted.bam.bai' } },
+        assemblyName: 'vvx',
       },
       renderers: { PileupRenderer: { alignmentColor: 'green' } },
     },
@@ -84,8 +87,8 @@ model.menuBars[0].addMenu({
 const firstView = model.addView('LinearGenomeView')
 firstView.displayRegions([
   {
-    assemblyName: 'nope',
-    refName: 'ctgA',
+    assemblyName: 'vvx',
+    refName: 'contigA',
     start: 0,
     end: 50000,
   },

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -49,6 +49,15 @@ jbrowse.configure({
       renderers: { PileupRenderer: { alignmentColor: 'green' } },
     },
   ],
+  assemblies: {
+    volvox: {
+      aliases: ['vvx'],
+      seqNameAliases: {
+        A: ['ctgA', 'contigA'],
+        B: ['ctgB', 'contigB'],
+      },
+    },
+  },
 })
 
 // poke some things for testing (this stuff will eventually be removed)
@@ -75,12 +84,12 @@ model.menuBars[0].addMenu({
 const firstView = model.addView('LinearGenomeView')
 firstView.displayRegions([
   {
-    assembly: 'volvox',
+    assemblyName: 'nope',
     refName: 'ctgA',
     start: 0,
     end: 50000,
   },
-  { assembly: 'volvox', refName: 'ctgB', start: 0, end: 300 },
+  { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 300 },
 ])
 
 firstView.zoomTo(0.06) // bpPerPx
@@ -91,9 +100,9 @@ firstView.showTrack(model.configuration.tracks[2], { height: 200 })
 const secondView = model.addView('LinearGenomeView')
 secondView.showTrack(model.configuration.tracks[1], { height: 100 })
 secondView.displayRegions([
-  { assembly: 'volvox', refName: 'ctgA', start: 0, end: 1000 },
+  { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 1000 },
   {
-    assembly: 'volvox',
+    assemblyName: 'volvox',
     refName: 'ctgB',
     start: 0,
     end: 2000,

--- a/packages/jbrowse-web/src/mst-types.js
+++ b/packages/jbrowse-web/src/mst-types.js
@@ -34,17 +34,16 @@ export const Region = types
     get locString() {
       return assembleLocString(self)
     },
-    get assembly() {
-      const rootModel = getRoot(self)
-      let assembly = rootModel.configuration.assemblies.get(self.assemblyName)
-      if (!assembly) {
-        rootModel.configuration.assemblies.forEach((value, key) => {
-          if (readConfObject(value, 'aliases').includes(self.assemblyName))
-            assembly = rootModel.configuration.assemblies.get(key)
-        })
-      }
-      return assembly || self.assemblyName
-    },
+    // get assembly() {
+    //   const rootModel = getRoot(self)
+    //   let assembly = rootModel.configuration.assemblies.get(self.assemblyName)
+    //   if (!assembly)
+    //     rootModel.configuration.assemblies.forEach((value, key) => {
+    //       if (readConfObject(value, 'aliases').includes(self.assemblyName))
+    //         assembly = rootModel.configuration.assemblies.get(key)
+    //     })
+    //   return assembly || { aliases: [], seqNameAliases: {} }
+    // },
   }))
 
 export const BlockState = types.model('BlockState', {

--- a/packages/jbrowse-web/src/mst-types.js
+++ b/packages/jbrowse-web/src/mst-types.js
@@ -1,10 +1,9 @@
 import shortid from 'shortid'
-import { types, getRoot } from 'mobx-state-tree'
+import { types } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 import { PropTypes as MxPropTypes } from 'mobx-react'
 
 import { assembleLocString } from './util'
-import { readConfObject } from './configuration'
 
 export const ElementId = types.optional(types.identifier, shortid.generate)
 
@@ -34,16 +33,6 @@ export const Region = types
     get locString() {
       return assembleLocString(self)
     },
-    // get assembly() {
-    //   const rootModel = getRoot(self)
-    //   let assembly = rootModel.configuration.assemblies.get(self.assemblyName)
-    //   if (!assembly)
-    //     rootModel.configuration.assemblies.forEach((value, key) => {
-    //       if (readConfObject(value, 'aliases').includes(self.assemblyName))
-    //         assembly = rootModel.configuration.assemblies.get(key)
-    //     })
-    //   return assembly || { aliases: [], seqNameAliases: {} }
-    // },
   }))
 
 export const BlockState = types.model('BlockState', {

--- a/packages/jbrowse-web/src/plugins/AlignmentsTrack/model/alignmentsTrack.js
+++ b/packages/jbrowse-web/src/plugins/AlignmentsTrack/model/alignmentsTrack.js
@@ -1,4 +1,4 @@
-import { types, getSnapshot, getParent, getRoot } from 'mobx-state-tree'
+import { types, getParent, getRoot } from 'mobx-state-tree'
 
 import { ConfigurationReference, getConf } from '../../../configuration'
 
@@ -127,31 +127,6 @@ export default (pluginManager, configSchema) =>
               featureMaps.push(block.data.features)
           }
           return new CompositeMap(featureMaps)
-        },
-
-        /**
-         * the PluggableElementType for the currently defined adapter
-         */
-        get adapterType() {
-          const adapterConfig = getConf(self, 'adapter')
-          if (!adapterConfig)
-            throw new Error(
-              `no adapter configuration provided for ${self.type}`,
-            )
-          const adapterType = pluginManager.getAdapterType(adapterConfig.type)
-          if (!adapterType)
-            throw new Error(`unknown adapter type ${adapterConfig.type}`)
-          return adapterType
-        },
-
-        /**
-         * the Adapter that this track uses to fetch data
-         */
-        get adapter() {
-          const adapter = new self.adapterType.AdapterClass(
-            getSnapshot(self.configuration.adapter),
-          )
-          return adapter
         },
       })),
   )

--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
@@ -55,6 +55,7 @@ export default class BamAdapter extends BaseAdapter {
 
   /**
    * Fetch features for a certain region
+   * You probably actually want to use regularizeAndGetFeaturesInRegion()
    * @param {Region} param
    * @returns {Observable[Feature]} Observable of Feature objects in the region
    */

--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
@@ -29,8 +29,8 @@ export default class BamAdapter {
       .then(header => this.loadSamHeader(header))
   }
 
-  async hasDataForRefSeq({ assembly, refName }) {
-    if (this.assemblyName !== assembly) return false
+  async hasDataForRefSeq({ assemblyName, refName }) {
+    if (this.assemblyName !== assemblyName) return false
     await this.gotBamHeader
     return this.samHeader.refSeqNameToId[refName] !== undefined
   }

--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.test.js
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.test.js
@@ -15,7 +15,7 @@ test('adapter can fetch features from volvox.bam', async () => {
   })
 
   const features = adapter.getFeaturesInRegion({
-    assembly: 'volvox',
+    assemblyName: 'volvox',
     refName: 'ctgA',
     start: 0,
     end: 20000,
@@ -31,6 +31,6 @@ test('adapter can fetch features from volvox.bam', async () => {
   expect(await adapter.refIdToName(1)).toBe(undefined)
 
   expect(
-    await adapter.hasDataForRefSeq({ assembly: 'volvox', refName: 'ctgA' }),
+    await adapter.hasDataForRefSeq({ assemblyName: 'volvox', refName: 'ctgA' }),
   ).toBe(true)
 })

--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.test.js
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.test.js
@@ -3,18 +3,21 @@ import { toArray } from 'rxjs/operators'
 import Adapter from './BamAdapter'
 
 test('adapter can fetch features from volvox.bam', async () => {
-  const adapter = new Adapter({
-    assemblyName: 'volvox',
-    bamLocation: { path: require.resolve('./test_data/volvox-sorted.bam') },
-    index: {
-      location: {
-        path: require.resolve('./test_data/volvox-sorted.bam.bai'),
+  const adapter = new Adapter(
+    {
+      assemblyName: 'volvox',
+      bamLocation: { path: require.resolve('./test_data/volvox-sorted.bam') },
+      index: {
+        location: {
+          path: require.resolve('./test_data/volvox-sorted.bam.bai'),
+        },
+        indexType: 'BAI',
       },
-      indexType: 'BAI',
     },
-  })
+    {},
+  )
 
-  const features = adapter.getFeaturesInRegion({
+  const features = await adapter.regularizeAndGetFeaturesInRegion({
     assemblyName: 'volvox',
     refName: 'ctgA',
     start: 0,

--- a/packages/jbrowse-web/src/plugins/DivSequenceRenderer/components/DivSequenceRendering.test.js
+++ b/packages/jbrowse-web/src/plugins/DivSequenceRenderer/components/DivSequenceRendering.test.js
@@ -11,7 +11,7 @@ test('no features', () => {
     <Rendering
       width={500}
       height={500}
-      region={{ assembly: 'toaster', refName: 'zonk', start: 0, end: 300 }}
+      region={{ assemblyName: 'toaster', refName: 'zonk', start: 0, end: 300 }}
       layout={new PrecomputedLayout({ rectangles: {}, totalHeight: 20 })}
       config={DivRenderingConfigSchema.create()}
       bpPerPx={3}
@@ -27,7 +27,7 @@ test('one feature', () => {
     <Rendering
       width={500}
       height={500}
-      region={{ assembly: 'toaster', refName: 'zonk', start: 0, end: 1000 }}
+      region={{ assemblyName: 'toaster', refName: 'zonk', start: 0, end: 1000 }}
       layout={new GranularRectLayout({ pitchX: 1, pitchY: 1 })}
       features={
         new Map([['one', new SimpleFeature({ id: 'one', start: 1, end: 3 })]])

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.test.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/LinearGenomeView.test.js
@@ -65,8 +65,8 @@ describe('LinearGenomeView genome view component', () => {
         offsetPx: 0,
         bpPerPx: 1,
         displayedRegions: [
-          { assembly: 'volvox', refName: 'ctgA', start: 0, end: 100 },
-          { assembly: 'volvox', refName: 'ctgB', start: 1000, end: 200 },
+          { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+          { assemblyName: 'volvox', refName: 'ctgB', start: 1000, end: 200 },
         ],
         tracks: [
           {

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/__snapshots__/calculateBlocks.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/__snapshots__/calculateBlocks.test.js.snap
@@ -3,14 +3,14 @@
 exports[`block calculation can calculate some blocks 1 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 800,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:1-800",
     "offsetPx": 0,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,
@@ -20,14 +20,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 1600,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:801-1600",
     "offsetPx": 800,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,
@@ -42,14 +42,14 @@ Array [
 exports[`block calculation can calculate some blocks 2 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 100,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": true,
     "key": "volvox:ctgA:1-100",
     "offsetPx": 0,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 100,
       "refName": "ctgA",
       "start": 0,
@@ -59,14 +59,14 @@ Array [
     "widthPx": 100,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 200,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": true,
     "key": "volvox:ctgB:101-200",
     "offsetPx": 200,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 200,
       "refName": "ctgB",
       "start": 100,
@@ -81,14 +81,14 @@ Array [
 exports[`block calculation can calculate some blocks 5 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 5600,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:4801-5600",
     "offsetPx": 4800,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,
@@ -98,14 +98,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 6400,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:5601-6400",
     "offsetPx": 5600,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,
@@ -120,14 +120,14 @@ Array [
 exports[`block calculation can calculate some blocks 6 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 200,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": true,
     "key": "volvox:ctgA:1-200",
     "offsetPx": 0,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 200,
       "refName": "ctgA",
       "start": 0,
@@ -137,14 +137,14 @@ Array [
     "widthPx": 200,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 800,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgB:1-800",
     "offsetPx": 200,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 1000,
       "refName": "ctgB",
       "start": 0,
@@ -159,14 +159,14 @@ Array [
 exports[`block calculation can calculate some blocks 7 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 800,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgB:1-800",
     "offsetPx": 200,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 1000,
       "refName": "ctgB",
       "start": 0,
@@ -176,14 +176,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 1000,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": true,
     "key": "volvox:ctgB:801-1000",
     "offsetPx": 1000,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 1000,
       "refName": "ctgB",
       "start": 0,
@@ -198,14 +198,14 @@ Array [
 exports[`block calculation can calculate some blocks 8 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 1600,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgB:801-1600",
     "offsetPx": 1000,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000000,
       "refName": "ctgB",
       "start": 0,
@@ -215,14 +215,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 2400,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgB:1601-2400",
     "offsetPx": 1800,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000000,
       "refName": "ctgB",
       "start": 0,
@@ -237,14 +237,14 @@ Array [
 exports[`block calculation can calculate some blocks 9 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 3200,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:1601-3200",
     "offsetPx": 800,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 50000,
       "refName": "ctgA",
       "start": 0,
@@ -254,14 +254,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 4800,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:3201-4800",
     "offsetPx": 1600,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 50000,
       "refName": "ctgA",
       "start": 0,
@@ -276,14 +276,14 @@ Array [
 exports[`reverse block calculation 1 1`] = `
 Array [
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 10000,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:9201-10000",
     "offsetPx": 0,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,
@@ -293,14 +293,14 @@ Array [
     "widthPx": 800,
   },
   Object {
-    "assembly": "volvox",
+    "assemblyName": "volvox",
     "end": 9200,
     "isLeftEndOfDisplayedRegion": false,
     "isRightEndOfDisplayedRegion": false,
     "key": "volvox:ctgA:8401-9200",
     "offsetPx": 800,
     "parentRegion": Object {
-      "assembly": "volvox",
+      "assemblyName": "volvox",
       "end": 10000,
       "refName": "ctgA",
       "start": 0,

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/baseTrack.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/baseTrack.js
@@ -120,6 +120,7 @@ const BaseTrack = types
     get adapter() {
       const adapter = new self.adapterType.AdapterClass(
         getSnapshot(self.configuration.adapter),
+        getSnapshot(getRoot(self).configuration),
       )
       return adapter
     },

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/calculateBlocks.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/calculateBlocks.js
@@ -48,7 +48,7 @@ export function calculateBlocksForward(self) {
       blockNum += 1
     ) {
       const newBlock = {
-        assembly: region.assembly,
+        assemblyName: region.assemblyName,
         refName: region.refName,
         start: region.start + blockNum * blockSizeBp,
         end: Math.min(region.end, region.start + (blockNum + 1) * blockSizeBp),

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/calculateBlocks.test.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/calculateBlocks.test.js
@@ -10,7 +10,7 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 0,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
       ],
     })
     expect(blocks).toMatchSnapshot()
@@ -22,8 +22,8 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 30,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 100 },
-        { assembly: 'volvox', refName: 'ctgB', start: 100, end: 200 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 100, end: 200 },
       ],
     })
     expect(blocks).toMatchSnapshot()
@@ -35,8 +35,8 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 1000,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 100 },
-        { assembly: 'volvox', refName: 'ctgB', start: 100, end: 200 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 100, end: 200 },
       ],
     })
     expect(blocks).toEqual([])
@@ -49,8 +49,8 @@ describe('block calculation', () => {
         width: 800,
         offsetPx: -1000,
         displayedRegions: [
-          { assembly: 'volvox', refName: 'ctgA', start: 0, end: 100 },
-          { assembly: 'volvox', refName: 'ctgB', start: 100, end: 200 },
+          { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+          { assemblyName: 'volvox', refName: 'ctgB', start: 100, end: 200 },
         ],
       },
       {
@@ -66,8 +66,8 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 5000,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
-        { assembly: 'volvox', refName: 'ctgB', start: 100, end: 10000 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 100, end: 10000 },
       ],
     })
     expect(blocks).toMatchSnapshot()
@@ -80,12 +80,12 @@ describe('block calculation', () => {
       offsetPx: 0,
       displayedRegions: [
         {
-          assembly: 'volvox',
+          assemblyName: 'volvox',
           refName: 'ctgA',
           start: 0,
           end: 200,
         },
-        { assembly: 'volvox', refName: 'ctgB', start: 0, end: 1000 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 1000 },
       ],
     })
     expect(blocks).toMatchSnapshot()
@@ -97,8 +97,8 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 801,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 200 },
-        { assembly: 'volvox', refName: 'ctgB', start: 0, end: 1000 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 200 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 1000 },
       ],
     })
     expect(blocks).toMatchSnapshot()
@@ -110,8 +110,8 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 1600,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 200 },
-        { assembly: 'volvox', refName: 'ctgB', start: 0, end: 10000000 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 200 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 10000000 },
       ],
       configuration: 'fakeReference',
     })
@@ -125,12 +125,12 @@ describe('block calculation', () => {
       bpPerPx: 2,
       displayedRegions: [
         {
-          assembly: 'volvox',
+          assemblyName: 'volvox',
           refName: 'ctgA',
           start: 0,
           end: 50000,
         },
-        { assembly: 'volvox', refName: 'ctgB', start: 0, end: 300 },
+        { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 300 },
       ],
       configuration: 'fakeReference',
     })
@@ -145,7 +145,7 @@ describe('reverse block calculation', () => {
       width: 800,
       offsetPx: 0,
       displayedRegions: [
-        { assembly: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
+        { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 10000 },
       ],
     })
     expect(blocks).toMatchSnapshot()

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/serverSideRenderedBlock.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/serverSideRenderedBlock.js
@@ -26,6 +26,7 @@ function renderBlockData(self) {
       region: self.region,
       adapterType: track.adapterType.name,
       adapterConfig: getConf(track, 'adapter'),
+      rootConfig: getConf(root),
       rendererType: rendererType.name,
       renderProps,
       sessionId: track.id,

--- a/packages/jbrowse-web/src/plugins/PileupRenderer/components/PileupRendering.test.js
+++ b/packages/jbrowse-web/src/plugins/PileupRenderer/components/PileupRendering.test.js
@@ -10,7 +10,7 @@ test('one', () => {
     <PileupRendering
       width={500}
       height={500}
-      region={{ assembly: 'toaster', refName: 'zonk', start: 1, end: 3 }}
+      region={{ assemblyName: 'toaster', refName: 'zonk', start: 1, end: 3 }}
       layout={new PrecomputedLayout({ rectangles: {}, totalHeight: 20 })}
       bpPerPx={3}
     />,

--- a/packages/jbrowse-web/src/plugins/PileupRenderer/components/__snapshots__/PileupRendering.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/PileupRenderer/components/__snapshots__/PileupRendering.test.js.snap
@@ -21,7 +21,7 @@ exports[`one 1`] = `
     }
     region={
       Object {
-        "assembly": "toaster",
+        "assemblyName": "toaster",
         "end": 3,
         "refName": "zonk",
         "start": 1,

--- a/packages/jbrowse-web/src/plugins/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
+++ b/packages/jbrowse-web/src/plugins/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
@@ -11,7 +11,7 @@ test('no features', () => {
     <Rendering
       width={500}
       height={500}
-      region={{ assembly: 'toaster', refName: 'zonk', start: 0, end: 300 }}
+      region={{ assemblyName: 'toaster', refName: 'zonk', start: 0, end: 300 }}
       layout={new PrecomputedLayout({ rectangles: {}, totalHeight: 20 })}
       config={{}}
       bpPerPx={3}
@@ -27,7 +27,7 @@ test('one feature', () => {
     <Rendering
       width={500}
       height={500}
-      region={{ assembly: 'toaster', refName: 'zonk', start: 0, end: 1000 }}
+      region={{ assemblyName: 'toaster', refName: 'zonk', start: 0, end: 1000 }}
       layout={new GranularRectLayout({ pitchX: 1, pitchY: 1 })}
       features={
         new Map([['one', new SimpleFeature({ id: 'one', start: 1, end: 3 })]])

--- a/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.js
+++ b/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.js
@@ -3,10 +3,12 @@ import { Observable } from 'rxjs'
 import { TwoBitFile } from '@gmod/twobit'
 
 import { openLocation } from '../../util'
+import BaseAdapter from '../../BaseAdapter'
 import SimpleFeature from '../../util/simpleFeature'
 
-export default class TwoBitAdapter {
-  constructor(config) {
+export default class TwoBitAdapter extends BaseAdapter {
+  constructor(config, rootConfig) {
+    super(config, rootConfig)
     const { twoBitLocation, assemblyName } = config
     const twoBitOpts = {
       filehandle: openLocation(twoBitLocation),
@@ -14,7 +16,11 @@ export default class TwoBitAdapter {
 
     this.assemblyName = assemblyName
     this.twobit = new TwoBitFile(twoBitOpts)
-    this.gotTwoBitHeader = this.twobit.getHeader()
+  }
+
+  async loadData() {
+    const seqNames = await this.twobit.getSequenceNames()
+    return seqNames
   }
 
   /**
@@ -22,10 +28,8 @@ export default class TwoBitAdapter {
    * @param {Region} param
    * @returns {Observable[Feature]} Observable of Feature objects in the region
    */
-  getFeaturesInRegion({ /* assembly, */ refName, start, end }) {
-    // TODO
+  async getFeaturesInRegion({ refName, start, end }) {
     return Observable.create(async observer => {
-      await this.gotTwoBitHeader
       const seq = await this.twobit.getSequence(refName, start, end)
       observer.next(
         new SimpleFeature({

--- a/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.test.js
+++ b/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.test.js
@@ -3,12 +3,15 @@ import { toArray } from 'rxjs/operators'
 import Adapter from './TwoBitAdapter'
 
 test('adapter can fetch features from volvox.2bit', async () => {
-  const adapter = new Adapter({
-    assemblyName: 'volvox',
-    twoBitLocation: { path: require.resolve('./test_data/volvox.2bit') },
-  })
+  const adapter = new Adapter(
+    {
+      assemblyName: 'volvox',
+      twoBitLocation: { path: require.resolve('./test_data/volvox.2bit') },
+    },
+    {},
+  )
 
-  const features = adapter.getFeaturesInRegion({
+  const features = await adapter.regularizeAndGetFeaturesInRegion({
     assemblyName: 'volvox',
     refName: 'ctgA',
     start: 0,

--- a/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.test.js
+++ b/packages/jbrowse-web/src/plugins/TwoBitAdapter/TwoBitAdapter.test.js
@@ -9,7 +9,7 @@ test('adapter can fetch features from volvox.2bit', async () => {
   })
 
   const features = adapter.getFeaturesInRegion({
-    assembly: 'volvox',
+    assemblyName: 'volvox',
     refName: 'ctgA',
     start: 0,
     end: 20000,

--- a/packages/jbrowse-web/src/render.worker.js
+++ b/packages/jbrowse-web/src/render.worker.js
@@ -45,7 +45,15 @@ export function freeResources(pluginManager, specification) {
  */
 export async function renderRegion(
   pluginManager,
-  { region, sessionId, adapterType, adapterConfig, rendererType, renderProps },
+  {
+    region,
+    sessionId,
+    adapterType,
+    adapterConfig,
+    rootConfig,
+    rendererType,
+    renderProps,
+  },
 ) {
   if (!sessionId) throw new Error('must pass a unique session id')
 
@@ -54,6 +62,7 @@ export async function renderRegion(
     sessionId,
     adapterType,
     adapterConfig,
+    rootConfig,
   )
 
   const RendererType = pluginManager.getRendererType(rendererType)

--- a/packages/jbrowse-web/src/render.worker.test.js
+++ b/packages/jbrowse-web/src/render.worker.test.js
@@ -20,6 +20,7 @@ const baseprops = {
       },
     },
   },
+  rootConfig: {},
   renderProps: { bpPerPx: 1 },
 }
 

--- a/packages/jbrowse-web/src/render.worker.test.js
+++ b/packages/jbrowse-web/src/render.worker.test.js
@@ -4,7 +4,7 @@ import { renderRegion, freeResources } from './render.worker'
 const jbrowse = new JBrowse().configure()
 
 const baseprops = {
-  region: { assembly: 'volvox', refName: 'ctgA', start: 0, end: 800 },
+  region: { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 800 },
   sessionId: 'knickers the cow',
   adapterType: 'BamAdapter',
   adapterConfig: {
@@ -55,7 +55,7 @@ test('can render a single region with SvgFeatures + BamAdapter', async () => {
   const testprops = {
     ...baseprops,
     rendererType: 'SvgFeatureRenderer',
-    region: { assembly: 'volvox', refName: 'ctgA', start: 0, end: 300 },
+    region: { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 300 },
   }
 
   const result = await renderRegion(jbrowse.pluginManager, testprops)

--- a/packages/jbrowse-web/src/renderers/boxRenderer.js
+++ b/packages/jbrowse-web/src/renderers/boxRenderer.js
@@ -63,7 +63,7 @@ export default class BoxRenderer extends ServerSideRenderer {
     const { region } = args
     const session = this.getWorkerSession(args)
     const subLayout = session.layout.getSublayout(
-      `${region.assembly}:${region.refName}`,
+      `${region.assemblyName}:${region.refName}`,
     )
     args.layout = subLayout
   }

--- a/packages/jbrowse-web/src/renderers/serverSideRenderer.js
+++ b/packages/jbrowse-web/src/renderers/serverSideRenderer.js
@@ -80,8 +80,10 @@ export default class ServerSideRenderer extends RendererType {
     this.deserializeArgsInWorker(args)
     const { dataAdapter, region } = args
     const features = new Map()
-    await dataAdapter
-      .getFeaturesInRegion(region)
+    const featureObservable = await dataAdapter.regularizeAndGetFeaturesInRegion(
+      region,
+    )
+    await featureObservable
       .pipe(tap(feature => features.set(feature.id(), feature)))
       .toPromise()
 

--- a/packages/jbrowse-web/src/rootModel.js
+++ b/packages/jbrowse-web/src/rootModel.js
@@ -2,6 +2,19 @@ import { types, getRoot, getType } from 'mobx-state-tree'
 import { ConfigurationSchema } from './configuration'
 import { isConfigurationModel } from './configuration/configurationSchema'
 
+const Assembly = ConfigurationSchema('Assembly', {
+  aliases: {
+    type: 'stringArray',
+    defaultValue: [],
+    description: 'A list of aliases of the assembly',
+  },
+  seqNameAliases: {
+    type: 'stringArrayMap',
+    defaultValue: {},
+    description: 'A map of seq -> Array(altSeqName)',
+  },
+})
+
 export default app => {
   const { pluginManager } = app
   const minViewsWidth = 150
@@ -30,6 +43,9 @@ export default app => {
           // track configuration is an array of track config schemas. multiple instances of
           // a track can exist that use the same configuration
           tracks: types.array(pluginManager.pluggableConfigSchemaType('track')),
+
+          // let's try some assemblies
+          assemblies: types.map(Assembly),
         },
         {
           actions: self => ({

--- a/packages/jbrowse-web/src/util/index.js
+++ b/packages/jbrowse-web/src/util/index.js
@@ -7,8 +7,8 @@ if (!Object.fromEntries) {
   fromEntries.shim()
 }
 
-export function assembleLocString({ assembly, refName, start, end }) {
-  return `${assembly}:${refName}:${start + 1}-${end}`
+export function assembleLocString({ assemblyName, refName, start, end }) {
+  return `${assemblyName}:${refName}:${start + 1}-${end}`
 }
 
 export function openLocation(location) {

--- a/packages/jbrowse-web/src/util/workerDataAdapterCache.js
+++ b/packages/jbrowse-web/src/util/workerDataAdapterCache.js
@@ -36,6 +36,7 @@ export function getAdapter(
   sessionId,
   adapterType,
   adapterConfig,
+  rootConfig,
 ) {
   // cache the adapter object
   const cacheKey = adapterConfigCacheKey(adapterType, adapterConfig)
@@ -45,7 +46,7 @@ export function getAdapter(
       throw new Error(`unknown data adapter type ${adapterType}`)
     // console.log('new adapter', cacheKey)
     adapterCache[cacheKey] = {
-      adapter: new dataAdapterType.AdapterClass(adapterConfig),
+      adapter: new dataAdapterType.AdapterClass(adapterConfig, rootConfig),
       sessionIds: new Set([sessionId]),
     }
   }


### PR DESCRIPTION
This moves a lot of the data adapter functionality to a shared BaseAdapter class so that name regularization can all happen in a single place. Individual adapters will only have to provide an array of reference sequences names they use, and everything else will be handled by the base class. Each individual adapter should implement:

- `loadData` this is where any metadata loading, etc. should happen and should return a promise for an array of reference sequence names
- `getFeaturesInRegion` returns a promise for an Observable, same as before. Does not need to do anything with assemblyName, as that is handled in the base class
- `freeResources` not used in any of our adapters yet

I've updated the BamAdapter and TwoBitAdapter to use this model, so you can look at those for an example.

Resolves #51 