### PR TITLE
Update and pin react-simple-code-editor

### DIFF
--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -33,7 +33,7 @@
     "react": "^16.6.3",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.5.2",
-    "react-simple-code-editor": "^0.8.0",
+    "react-simple-code-editor": "0.9.3",
     "react-sizeme": "^2.5.2",
     "react-test-renderer": "^16.7.0",
     "request-idle-callback": "^1.0.2",

--- a/packages/jbrowse-web/src/plugins/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2239,6 +2239,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   style={
                     Object {
                       "boxSizing": "border-box",
+                      "overflow": "hidden",
                       "padding": 0,
                       "position": "relative",
                       "textAlign": "left",
@@ -2251,7 +2252,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                     autoCapitalize="off"
                     autoComplete="off"
                     autoCorrect="off"
-                    className="npm__react-simple-code-editor__textarea "
+                    className="npm__react-simple-code-editor__textarea"
                     data-gramm={false}
                     onChange={[Function]}
                     onKeyDown={[Function]}
@@ -2310,6 +2311,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                     }
                     style={
                       Object {
+                        "background": "none",
                         "border": 0,
                         "boxSizing": "inherit",
                         "display": "inherit",
@@ -2337,9 +2339,9 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                     }
                   />
                   <style
-                    type="text/css"
-                  >
-                    
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "
 /**
  * Reset the text fill color so that placeholder is visible
  */
@@ -2348,20 +2350,28 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
 }
 
 /**
- * IE doesn't support '-webkit-text-fill-color'
- * So we use 'color: transparent' to make the text transparent on IE
- * Unlike other browsers, it doesn't affect caret color in IE
+ * Hack to apply on some CSS on IE10 and IE11
  */
-.npm__react-simple-code-editor__textarea-ie {
-  color: transparent !important;
-}
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  /**
+    * IE doesn't support '-webkit-text-fill-color'
+    * So we use 'color: transparent' to make the text transparent on IE
+    * Unlike other browsers, it doesn't affect caret color in IE
+    */
+  .npm__react-simple-code-editor__textarea {
+    color: transparent !important;
+  }
 
-.npm__react-simple-code-editor__textarea-ie::selection {
-  background-color: #accef7 !important;
-  color: transparent !important;
+  .npm__react-simple-code-editor__textarea::selection {
+    background-color: #accef7 !important;
+    color: transparent !important;
+  }
 }
-
-                  </style>
+",
+                      }
+                    }
+                    type="text/css"
+                  />
                 </div>
                 <p
                   className="MuiFormHelperText-root-110"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11191,10 +11191,10 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-simple-code-editor@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.8.0.tgz#c0c36df276c49d3d4410b8457f7a0a15396acbbf"
-  integrity sha512-H3HknuOqH2h8Kbg+vCUXf7YwDMC8UI0pEx2j5sODFVdX/RBeGX+w0vB+7LLrCh1qaQ1nTycyXXKWZifL3Dt0gg==
+react-simple-code-editor@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.3.tgz#12af0f85455eb1be1a86f15e325ec7861bc0db75"
+  integrity sha512-JexTKcpcOjArsXUDCWNoXgIdshoacJVSuf3LbdKG0tHw5ISREoh7wvNZlRRk2gncFRSixkkTI5E18svC966rYQ==
 
 react-sizeme@^2.5.2:
   version "2.5.2"


### PR DESCRIPTION
Updating this to the latest version and pinning to that version for the same reason `material-ui` is pinned: minor or patch version updates may break snapshots.