### PR TITLE
render cancellation

### DIFF
--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.js
@@ -4,6 +4,7 @@ import { openLocation } from '../../util/io'
 import BaseAdapter from '../../BaseAdapter'
 import BamSlightlyLazyFeature from './BamSlightlyLazyFeature'
 import { ObservableCreate } from '../../util/rxjs'
+import { checkAbortSignal } from '../../util'
 
 export default class BamAdapter extends BaseAdapter {
   static capabilities = ['getFeatures', 'getRefNames']
@@ -65,12 +66,16 @@ export default class BamAdapter extends BaseAdapter {
    * want to verify that the store has features for the given reference sequence
    * before fetching.
    * @param {Region} param
+   * @param {AbortSignal} [signal] optional signalling object for aborting the fetch
    * @returns {Observable[Feature]} Observable of Feature objects in the region
    */
-  getFeatures({ refName, start, end }) {
+  getFeatures({ refName, start, end }, signal) {
     return ObservableCreate(async observer => {
       await this.setup()
-      const records = await this.bam.getRecordsForRange(refName, start, end)
+      const records = await this.bam.getRecordsForRange(refName, start, end, {
+        signal,
+      })
+      checkAbortSignal(signal)
       records.forEach(record => {
         observer.next(this.bamRecordToFeature(record))
       })

--- a/packages/jbrowse-web/src/rpc/remoteAbortSignals.js
+++ b/packages/jbrowse-web/src/rpc/remoteAbortSignals.js
@@ -1,0 +1,65 @@
+/* ---------------- for the RPC client ----------------- */
+
+let abortSignalCounter = 0
+const abortSignalIds = new WeakMap() // map of abortsignal => numerical ID
+
+/**
+ * assign an ID to the given abort signal and return a plain object representation
+ * @param {AbortSignal} signal the signal to serialize
+ * @param {function} callfunc function used to call a remote method, will be called like callfunc('signalAbort', signalId)
+ */
+export function serializeAbortSignal(signal, callfunc) {
+  if (!abortSignalIds.has(signal)) {
+    abortSignalCounter += 1
+    abortSignalIds.set(signal, abortSignalCounter)
+    signal.addEventListener('abort', () => {
+      callfunc('signalAbort', abortSignalIds.get(signal))
+    })
+  }
+  return { abortSignalId: abortSignalIds.get(signal) }
+}
+
+/* ---------------- for the RPC server ----------------- */
+
+/**
+ * test whether a given object
+ * @param {object} thing the thing to test
+ * @returns {boolean} true if the thing is a remote abort signal
+ */
+export function isRemoteAbortSignal(thing) {
+  return thing && typeof thing.abortSignalId === 'number'
+}
+
+// the server side keeps a set of surrogate abort controllers that can be
+// aborted based on ID
+const surrogateAbortControllers = new Map() // numerical ID => surrogate abort controller
+
+/**
+ * deserialize the result of serializeAbortSignal into an AbortSignal
+ *
+ * @param {RemoteAbortSignal} signal
+ * @returns {AbortSignal} an abort signal that corresponds to the given ID
+ */
+export function deserializeAbortSignal({ abortSignalId }) {
+  if (!surrogateAbortControllers.has(abortSignalId)) {
+    surrogateAbortControllers.set(abortSignalId, new AbortController())
+  }
+  return surrogateAbortControllers.get(abortSignalId).signal
+}
+
+/**
+ * fire an abort signal from a remote abort signal ID
+ *
+ * @param {number} abortSignalId
+ */
+export function remoteAbort(abortSignalId) {
+  if (surrogateAbortControllers.has(abortSignalId)) {
+    surrogateAbortControllers.get(abortSignalId).abort()
+  }
+}
+
+export function remoteAbortRpcHandler() {
+  return {
+    signalAbort: remoteAbort,
+  }
+}

--- a/packages/jbrowse-web/src/util/index.js
+++ b/packages/jbrowse-web/src/util/index.js
@@ -44,6 +44,51 @@ export function iterMap(iterable, func, sizeHint) {
   return results
 }
 
+/**
+ * properly check if the given AbortSignal is aborted.
+ * per the standard, if the signal reads as aborted,
+ * this function throws either a DOMException AbortError, or a regular error
+ * with a `code` attribute set to `ERR_ABORTED`.
+ *
+ * for convenience, passing `undefined` is a no-op
+ *
+ * @param {AbortSignal} [signal]
+ * @returns nothing
+ */
+export function checkAbortSignal(signal) {
+  if (!signal) return
+
+  if (!(signal instanceof AbortSignal)) {
+    throw new TypeError('must pass an AbortSignal')
+  }
+
+  if (signal.aborted) {
+    if (typeof DOMException !== 'undefined')
+      throw new DOMException('aborted', 'AbortError')
+    else {
+      const e = new Error('aborted')
+      e.code = 'ERR_ABORTED'
+      throw e
+    }
+  }
+}
+
+/**
+ * check if the given exception was caused by an operation being intentionally aborted
+ * @param {Error} exception
+ * @returns {boolean}
+ */
+export function isAbortException(exception) {
+  return (
+    // DOMException
+    exception.name === 'AbortError' ||
+    // standard-ish non-DOM abort exception
+    exception.code === 'ERR_ABORTED' ||
+    // stringified DOMException
+    exception.message === 'AbortError: aborted'
+  )
+}
+
 export const inDevelopment =
   typeof process === 'object' &&
   process.env &&

--- a/packages/jbrowse-web/src/util/io/rangeFetcher.js
+++ b/packages/jbrowse-web/src/util/io/rangeFetcher.js
@@ -117,24 +117,26 @@ class GloballyCachedFilehandle {
     this.url = url
   }
 
-  async read(buffer, offset = 0, length, position) {
+  async read(buffer, offset = 0, length, position, abortSignal) {
     let data
     if (length === undefined && offset === 0) {
       data = await this.readFile()
     } else {
-      data = (await globalCache.getRange(this.url, position, length)).buffer
+      data = (await globalCache.getRange(this.url, position, length, {
+        signal: abortSignal,
+      })).buffer
     }
     data.copy(buffer, offset)
     return data.length
   }
 
-  async readFile() {
-    const res = await getfetch(this.url)
+  async readFile(abortSignal) {
+    const res = await getfetch(this.url, { signal: abortSignal })
     return Buffer.from(await res.arrayBuffer())
   }
 
-  stat() {
-    return globalCache.stat(this.url)
+  stat(abortSignal) {
+    return globalCache.stat(this.url, { signal: abortSignal })
   }
 
   toString() {


### PR DESCRIPTION
Adds AbortController-based cancellation to much of the rendering machinery. Passes AbortSignals to data backends, which can pay attention to them if they want.

resolves #155 