### PR TITLE
Remove rootModel from PluginManager

### DIFF
--- a/packages/core/PluginManager.js
+++ b/packages/core/PluginManager.js
@@ -10,10 +10,6 @@ import MenuBarType from './pluggableElementTypes/MenuBarType'
 
 import { ConfigurationSchema } from './configuration'
 
-// TODO: remove this
-// eslint-disable-next-line monorepo/no-relative-import
-import rootConfig from '../jbrowse-web/src/rootConfig'
-
 // little helper class that keeps groups of callbacks that are
 // then run in a specified order by group
 class PhasedScheduler {
@@ -80,16 +76,10 @@ export default class PluginManager {
     this.addDrawerWidgetType = this.addElementType.bind(this, 'drawer widget')
     this.addMenuBarType = this.addElementType.bind(this, 'menu bar')
 
-    this.elementCreationSchedule.add('root', this.addRootConfig.bind(this))
-
     // add all the initial plugins
     initialPlugins.forEach((plugin) => {
       this.addPlugin(plugin)
     })
-  }
-
-  addRootConfig() {
-    this.rootConfig = rootConfig(this)
   }
 
   addPlugin(plugin) {

--- a/packages/core/PluginManager.js
+++ b/packages/core/PluginManager.js
@@ -44,7 +44,6 @@ export default class PluginManager {
     'adapter',
     'track',
     'view',
-    'root',
     'drawer widget',
     'menu bar',
   )

--- a/packages/jbrowse-web/src/plugins/IndexedFastaAdapter/BgzipFastaAdapter.js
+++ b/packages/jbrowse-web/src/plugins/IndexedFastaAdapter/BgzipFastaAdapter.js
@@ -4,8 +4,8 @@ import { openLocation } from '@gmod/jbrowse-core/util/io'
 import IndexedFasta from './IndexedFastaAdapter'
 
 export default class BgzipFastaAdapter extends IndexedFasta {
-  constructor(config, rootConfig) {
-    super(config, rootConfig)
+  constructor(config) {
+    super(config)
     const { fastaLocation, faiLocation, gziLocation } = config
     if (!fastaLocation) {
       throw new Error('must provide fastaLocation')

--- a/packages/jbrowse-web/src/plugins/IndexedFastaAdapter/BgzipFastaAdapter.test.js
+++ b/packages/jbrowse-web/src/plugins/IndexedFastaAdapter/BgzipFastaAdapter.test.js
@@ -5,12 +5,8 @@ import Adapter from './BgzipFastaAdapter'
 test('can use a indexed fasta with gzi', async () => {
   const adapter = new Adapter({
     fastaLocation: { localPath: require.resolve('./test_data/volvox.fa.gz') },
-    faiLocation: {
-      localPath: require.resolve('./test_data/volvox.fa.gz.fai'),
-    },
-    gziLocation: {
-      localPath: require.resolve('./test_data/volvox.fa.gz.gzi'),
-    },
+    faiLocation: { localPath: require.resolve('./test_data/volvox.fa.gz.fai') },
+    gziLocation: { localPath: require.resolve('./test_data/volvox.fa.gz.gzi') },
   })
 
   const features = await adapter.getFeatures({

--- a/packages/jbrowse-web/src/rootModel.js
+++ b/packages/jbrowse-web/src/rootModel.js
@@ -7,6 +7,7 @@ import { isConfigurationModel } from '@gmod/jbrowse-core/configuration/configura
 import RpcManager from '@gmod/jbrowse-core/rpc/RpcManager'
 import { openLocation } from '@gmod/jbrowse-core/util/io'
 import AssemblyManager from './managers/AssemblyManager'
+import rootConfig from './rootConfig'
 
 import * as rpcFuncs from './render'
 
@@ -36,7 +37,7 @@ export default (pluginManager, workerManager) => {
       menuBars: types.array(
         pluginManager.pluggableMstType('menu bar', 'stateModel'),
       ),
-      configuration: pluginManager.rootConfig,
+      configuration: rootConfig(pluginManager),
     })
     .volatile(self => {
       const rpcManager = new RpcManager(pluginManager, self.configuration.rpc, {


### PR DESCRIPTION
@rbuels I took out rootModel from PluginManager, and just tweaked a couple things and everything seems to still work. Luckily it was easier than I though.

I thought I remembered that the reason it was there in the first place was something to do with making the "configure track" button work on a ReferenceSequence track type (which is a sequence track but without the ability to edit the name, category, or description). I had to register it via some weird MST introspection in `packages/jbrowse-web/src/plugins/ConfigurationEditorDrawerWidget/model.js` which required the rootModel to be visible from the PluginManger (or something? I don't quite remember).

Whatever the case, though, the "configure track" button is working just fine for the ReferenceSequence track, so the original problem must have been fixed somewhere else.