### PR TITLE
added support for different types of blocks

### DIFF
--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/ScaleBar.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/ScaleBar.js
@@ -1,7 +1,6 @@
 import { withStyles } from '@material-ui/core'
 import React from 'react'
 import PropTypes from 'prop-types'
-import { assembleLocString } from '@gmod/jbrowse-core/util'
 import Block from './Block'
 
 import Ruler from './Ruler'
@@ -28,7 +27,8 @@ const styles = (/* theme */) => ({
   },
 })
 
-function findBlockContainingLeftSideOfView(offsetPx, blocks) {
+function findBlockContainingLeftSideOfView(offsetPx, blockSet) {
+  const blocks = blockSet.getBlocks()
   for (let i = 0; i < blocks.length; i += 1) {
     const block = blocks[i]
     if (block.offsetPx <= offsetPx && block.offsetPx + block.widthPx > offsetPx)
@@ -60,7 +60,6 @@ function ScaleBar({
   return (
     <div style={finalStyle} className={classes.scaleBar}>
       {blocks.map(block => {
-        const locString = assembleLocString(block)
         return (
           <Block
             leftBorder={block.isLeftEndOfDisplayedRegion}
@@ -69,7 +68,7 @@ function ScaleBar({
             start={block.start}
             end={block.end}
             width={block.widthPx}
-            key={locString}
+            key={block.key}
             offset={block.offsetPx - offsetPx}
             bpPerPx={bpPerPx}
           >
@@ -102,7 +101,10 @@ ScaleBar.propTypes = {
   style: PropTypes.objectOf(PropTypes.any),
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
-  blocks: PropTypes.arrayOf(PropTypes.object),
+  blocks: PropTypes.shape({
+    map: PropTypes.func.isRequired,
+    getBlocks: PropTypes.func.isRequired,
+  }),
   bpPerPx: PropTypes.number.isRequired,
   offsetPx: PropTypes.number.isRequired,
   horizontallyFlipped: PropTypes.bool,

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/TrackBlocks.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/TrackBlocks.js
@@ -3,6 +3,7 @@ import { observer, PropTypes } from 'mobx-react'
 import ReactPropTypes from 'prop-types'
 import React from 'react'
 import Block from './Block'
+import { ContentBlock, ElidedBlock } from '../util/blockTypes'
 
 const styles = {
   trackBlocks: {
@@ -12,34 +13,66 @@ const styles = {
     background: '#404040',
     minHeight: '100%',
   },
+  elidedBlock: {
+    position: 'absolute',
+    minHeight: '100%',
+    boxSizing: 'border-box',
+    backgroundColor: '#999',
+    backgroundImage:
+      'repeating-linear-gradient(90deg, transparent, transparent 1px, rgba(255,255,255,.5) 1px, rgba(255,255,255,.5) 3px)',
+  },
 }
+
+const ElidedBlockMarker = withStyles(styles)(function ElidedBlockMarker({
+  classes,
+  width,
+  offset,
+}) {
+  return (
+    <div
+      className={classes.elidedBlock}
+      style={{ left: `${offset}px`, width: `${width}px` }}
+    />
+  )
+})
 
 function TrackBlocks({ classes, model, offsetPx, bpPerPx, blockState }) {
   const { blockDefinitions } = model
-
   return (
     <div className={classes.trackBlocks}>
       {blockDefinitions.map(block => {
-        const state = blockState.get(block.key)
-        return (
-          <Block
-            leftBorder={block.isLeftEndOfDisplayedRegion}
-            rightBorder={block.isRightEndOfDisplayedRegion}
-            start={block.start}
-            end={block.end}
-            refName={block.refName}
-            width={block.widthPx}
-            key={block.key}
-            offset={block.offsetPx - offsetPx}
-            bpPerPx={bpPerPx}
-          >
-            {state && state.reactComponent ? (
-              <state.reactComponent model={state} />
-            ) : (
-              ' '
-            )}
-          </Block>
-        )
+        if (block instanceof ContentBlock) {
+          const state = blockState.get(block.key)
+          return (
+            <Block
+              leftBorder={block.isLeftEndOfDisplayedRegion}
+              rightBorder={block.isRightEndOfDisplayedRegion}
+              start={block.start}
+              end={block.end}
+              refName={block.refName}
+              width={block.widthPx}
+              key={block.key}
+              offset={block.offsetPx - offsetPx}
+              bpPerPx={bpPerPx}
+            >
+              {state && state.reactComponent ? (
+                <state.reactComponent model={state} />
+              ) : (
+                ' '
+              )}
+            </Block>
+          )
+        }
+        if (block instanceof ElidedBlock) {
+          return (
+            <ElidedBlockMarker
+              key={block.key}
+              width={block.widthPx}
+              offset={block.offsetPx - offsetPx}
+            />
+          )
+        }
+        return null
       })}
     </div>
   )

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -410,7 +410,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-98"
+      className="TrackResizeHandle-dragHandle-99"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -837,7 +837,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-98"
+      className="TrackResizeHandle-dragHandle-99"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}
@@ -969,7 +969,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      className="TrackResizeHandle-dragHandle-98"
+      className="TrackResizeHandle-dragHandle-99"
       onMouseDown={[Function]}
       onMouseLeave={[Function]}
       onMouseMove={[Function]}

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/blockBasedTrack.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/blockBasedTrack.js
@@ -71,9 +71,11 @@ export default types.compose(
           if (!refNameMap) return
           self.setBlockDefinitions(
             blockDefinitions.map(blockDefinition => {
-              let { refName } = blockDefinition
-              refName = refNameMap.get(refName) || refName
-              return Object.assign({}, blockDefinition, { refName })
+              const { refName } = blockDefinition
+              if (refName && refNameMap.get(refName)) {
+                return blockDefinition.renameReference(refNameMap.get(refName))
+              }
+              return blockDefinition
             }),
           )
         })
@@ -89,7 +91,7 @@ export default types.compose(
           key,
           BlockState.create({
             key,
-            region: block,
+            region: block.toRegion(),
           }),
         )
       },

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/index.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/index.js
@@ -71,6 +71,7 @@ export default function LinearGenomeViewStateFactory(pluginManager) {
       configuration: LinearGenomeViewConfigSchema,
       // set this to true to hide the close, config, and tracksel buttons
       hideControls: false,
+      minimumBlockWidth: 12,
     })
     .views(self => ({
       get viewingRegionWidth() {

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -1,248 +1,262 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`block calculation can calculate some blocks 1 1`] = `
-Array [
-  Object {
-    "end": 800,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:1-800",
-    "offsetPx": 0,
-    "parentRegion": Object {
-      "end": 10000,
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "end": 800,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:1-800",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
       "start": 0,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 0,
-    "widthPx": 800,
-  },
-  Object {
-    "end": 1600,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:801-1600",
-    "offsetPx": 800,
-    "parentRegion": Object {
-      "end": 10000,
+    ContentBlock {
+      "end": 1600,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:801-1600",
+      "offsetPx": 800,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 800,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 800,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 2 1`] = `
-Array [
-  Object {
-    "end": 100,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": true,
-    "key": "ctgA:1-100",
-    "offsetPx": 0,
-    "parentRegion": Object {
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
       "end": 100,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:1-100",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 100,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
       "start": 0,
+      "widthPx": 100,
     },
-    "refName": "ctgA",
-    "start": 0,
-    "widthPx": 100,
-  },
-  Object {
-    "end": 200,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": true,
-    "key": "ctgB:101-200",
-    "offsetPx": 200,
-    "parentRegion": Object {
+    ContentBlock {
       "end": 200,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgB:101-200",
+      "offsetPx": 200,
+      "parentRegion": Object {
+        "end": 200,
+        "refName": "ctgB",
+        "start": 100,
+      },
       "refName": "ctgB",
       "start": 100,
+      "widthPx": 100,
     },
-    "refName": "ctgB",
-    "start": 100,
-    "widthPx": 100,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 5 1`] = `
-Array [
-  Object {
-    "end": 5600,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:4801-5600",
-    "offsetPx": 4800,
-    "parentRegion": Object {
-      "end": 10000,
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "end": 5600,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:4801-5600",
+      "offsetPx": 4800,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 4800,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 4800,
-    "widthPx": 800,
-  },
-  Object {
-    "end": 6400,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:5601-6400",
-    "offsetPx": 5600,
-    "parentRegion": Object {
-      "end": 10000,
+    ContentBlock {
+      "end": 6400,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:5601-6400",
+      "offsetPx": 5600,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 5600,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 5600,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 6 1`] = `
-Array [
-  Object {
-    "end": 200,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": true,
-    "key": "ctgA:1-200",
-    "offsetPx": 0,
-    "parentRegion": Object {
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
       "end": 200,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:1-200",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 200,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
       "start": 0,
+      "widthPx": 200,
     },
-    "refName": "ctgA",
-    "start": 0,
-    "widthPx": 200,
-  },
-  Object {
-    "end": 800,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgB:1-800",
-    "offsetPx": 200,
-    "parentRegion": Object {
-      "end": 1000,
+    ContentBlock {
+      "end": 800,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgB:1-800",
+      "offsetPx": 200,
+      "parentRegion": Object {
+        "end": 1000,
+        "refName": "ctgB",
+        "start": 0,
+      },
       "refName": "ctgB",
       "start": 0,
+      "widthPx": 800,
     },
-    "refName": "ctgB",
-    "start": 0,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 7 1`] = `
-Array [
-  Object {
-    "end": 800,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgB:1-800",
-    "offsetPx": 200,
-    "parentRegion": Object {
-      "end": 1000,
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "end": 800,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgB:1-800",
+      "offsetPx": 200,
+      "parentRegion": Object {
+        "end": 1000,
+        "refName": "ctgB",
+        "start": 0,
+      },
       "refName": "ctgB",
       "start": 0,
+      "widthPx": 800,
     },
-    "refName": "ctgB",
-    "start": 0,
-    "widthPx": 800,
-  },
-  Object {
-    "end": 1000,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": true,
-    "key": "ctgB:801-1000",
-    "offsetPx": 1000,
-    "parentRegion": Object {
+    ContentBlock {
       "end": 1000,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgB:801-1000",
+      "offsetPx": 1000,
+      "parentRegion": Object {
+        "end": 1000,
+        "refName": "ctgB",
+        "start": 0,
+      },
       "refName": "ctgB",
-      "start": 0,
+      "start": 800,
+      "widthPx": 200,
     },
-    "refName": "ctgB",
-    "start": 800,
-    "widthPx": 200,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 8 1`] = `
-Array [
-  Object {
-    "end": 1600,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgB:801-1600",
-    "offsetPx": 1000,
-    "parentRegion": Object {
-      "end": 10000000,
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "end": 1600,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgB:801-1600",
+      "offsetPx": 1000,
+      "parentRegion": Object {
+        "end": 10000000,
+        "refName": "ctgB",
+        "start": 0,
+      },
       "refName": "ctgB",
-      "start": 0,
+      "start": 800,
+      "widthPx": 800,
     },
-    "refName": "ctgB",
-    "start": 800,
-    "widthPx": 800,
-  },
-  Object {
-    "end": 2400,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgB:1601-2400",
-    "offsetPx": 1800,
-    "parentRegion": Object {
-      "end": 10000000,
+    ContentBlock {
+      "end": 2400,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgB:1601-2400",
+      "offsetPx": 1800,
+      "parentRegion": Object {
+        "end": 10000000,
+        "refName": "ctgB",
+        "start": 0,
+      },
       "refName": "ctgB",
-      "start": 0,
+      "start": 1600,
+      "widthPx": 800,
     },
-    "refName": "ctgB",
-    "start": 1600,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;
 
 exports[`block calculation can calculate some blocks 9 1`] = `
-Array [
-  Object {
-    "end": 3200,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:1601-3200",
-    "offsetPx": 800,
-    "parentRegion": Object {
-      "end": 50000,
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "end": 3200,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:1601-3200",
+      "offsetPx": 800,
+      "parentRegion": Object {
+        "end": 50000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 1600,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 1600,
-    "widthPx": 800,
-  },
-  Object {
-    "end": 4800,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:3201-4800",
-    "offsetPx": 1600,
-    "parentRegion": Object {
-      "end": 50000,
+    ContentBlock {
+      "end": 4800,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:3201-4800",
+      "offsetPx": 1600,
+      "parentRegion": Object {
+        "end": 50000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 3200,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 3200,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;
 
 exports[`reverse block calculation 1 1`] = `

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/util/blockTypes.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/util/blockTypes.js
@@ -1,0 +1,86 @@
+export class BlockSet {
+  blocks = []
+
+  push(block) {
+    if (block instanceof ElidedBlock) {
+      if (this.blocks.length) {
+        const lastBlock = this.blocks[this.blocks.length - 1]
+        if (lastBlock instanceof ElidedBlock) {
+          lastBlock.push(block)
+          return
+        }
+      }
+    }
+
+    this.blocks.push(block)
+  }
+
+  getBlocks() {
+    return this.blocks
+  }
+
+  map(func, thisarg) {
+    return this.blocks.map(func, thisarg)
+  }
+
+  forEach(func, thisarg) {
+    return this.blocks.forEach(func, thisarg)
+  }
+
+  get length() {
+    return this.blocks.length
+  }
+}
+
+class BaseBlock {
+  /**
+   * a block that should be shown as filled with data
+   */
+  constructor(data) {
+    Object.assign(this, data)
+  }
+
+  /**
+   * rename the reference sequence of this block and return a new one
+   *
+   * @param {string} refName
+   * @returns either a new block with a renamed reference sequence,
+   * or the same block, if the ref name is not actually different
+   */
+  renameReference(refName) {
+    if (this.refName && refName !== this.refName) {
+      return new ContentBlock({ ...this, refName })
+    }
+    return this
+  }
+
+  toRegion() {
+    return {
+      refName: this.refName,
+      start: this.start,
+      end: this.end,
+      assemblyName: this.assemblyName,
+    }
+  }
+}
+
+export class ContentBlock extends BaseBlock {}
+
+/**
+ * marker block representing one or more blocks that are
+ * too small to be shown at the current zoom level
+ */
+export class ElidedBlock extends BaseBlock {
+  elidedBlockCount = 1
+
+  push(otherBlock) {
+    this.elidedBlockCount += 1
+
+    if (otherBlock) {
+      this.refName = ''
+      this.start = 0
+      this.end = 0
+      this.widthPx += otherBlock.widthPx
+    }
+  }
+}

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/util/calculateDynamicBlocks.test.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/util/calculateDynamicBlocks.test.js
@@ -12,7 +12,7 @@ test('one', () => {
         bpPerPx: 1,
       },
       false,
-    ),
+    ).getBlocks(),
   ).toEqual([
     {
       end: 200,
@@ -37,7 +37,7 @@ test('two', () => {
         bpPerPx: 1,
       },
       true,
-    ),
+    ).getBlocks(),
   ).toEqual([
     {
       end: 50000,
@@ -62,7 +62,7 @@ test('three', () => {
         bpPerPx: 1,
       },
       true,
-    ),
+    ).getBlocks(),
   ).toEqual([
     {
       end: 50000,
@@ -87,7 +87,7 @@ test('four', () => {
         bpPerPx: 1,
       },
       false,
-    ),
+    ).getBlocks(),
   ).toEqual([
     {
       end: 250,
@@ -112,7 +112,7 @@ test('five', () => {
         bpPerPx: 0.05,
       },
       false,
-    ),
+    ).getBlocks(),
   ).toEqual([
     {
       end: 72.4,

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/util/calculateStaticBlocks.test.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/util/calculateStaticBlocks.test.js
@@ -28,7 +28,7 @@ describe('block calculation', () => {
   })
 
   it('can calculate some blocks 3', () => {
-    const blocks = calculateBlocksForward({
+    const blockSet = calculateBlocksForward({
       bpPerPx: 1,
       width: 800,
       offsetPx: 1000,
@@ -37,11 +37,11 @@ describe('block calculation', () => {
         { refName: 'ctgB', start: 100, end: 200 },
       ],
     })
-    expect(blocks).toEqual([])
+    expect(blockSet.getBlocks()).toEqual([])
   })
 
   it('can calculate some blocks 4', () => {
-    const blocks = calculateBlocksForward(
+    const blockSet = calculateBlocksForward(
       {
         bpPerPx: 1,
         width: 800,
@@ -55,7 +55,7 @@ describe('block calculation', () => {
         testEnv: true,
       },
     )
-    expect(blocks).toEqual([])
+    expect(blockSet.getBlocks()).toEqual([])
   })
 
   it('can calculate some blocks 5', () => {


### PR DESCRIPTION
Initially this just adds "elided" blocks, that represent one or more blocks that are too small to draw on their own and have been folded together.

This same mechanism can be expanded to draw things like breakpoint boundaries, joins, etc.

fixes #295