### PR TITLE
Try to fix UrlInput and test

### DIFF
--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -53,7 +53,7 @@
     "react-dom": "^16.9.0-alpha.0",
     "react-dropzone": "^10.1.0",
     "react-simple-code-editor": "0.9.3",
-    "react-sizeme": "^2.5.2",
+    "react-sizeme": "^2.6.7",
     "request-idle-callback": "^1.0.2",
     "rxjs": "^6.5.1",
     "sanitize-html": "^1.20.0",

--- a/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/DataHubDrawerWidget.test.js
+++ b/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/DataHubDrawerWidget.test.js
@@ -2,7 +2,7 @@ import {
   render,
   cleanup,
   fireEvent,
-  // waitForElement,
+  waitForElement,
 } from 'react-testing-library'
 import React from 'react'
 import { createTestEnv } from '../../../JBrowse'
@@ -10,13 +10,14 @@ import DataHubDrawerWidget from './DataHubDrawerWidget'
 
 describe('<DataHubDrawerWidget />', () => {
   let model
+  let rootModel
 
   beforeAll(async () => {
-    const { rootModel } = await createTestEnv({
+    ;({ rootModel } = await createTestEnv({
       configId: 'testing',
       defaultSession: {},
       rpc: { configId: 'testingRpc' },
-    })
+    }))
     rootModel.addDrawerWidget('DataHubDrawerWidget', 'dataHubDrawerWidget')
     model = rootModel.drawerWidgets.get('dataHubDrawerWidget')
   })
@@ -51,9 +52,11 @@ trackDb hg19/trackDb.txt
       )
     }
     jest.spyOn(global, 'fetch').mockImplementation(mockFetch)
-    const { getByTestId /* , getByText */ } = render(
+    const { getByTestId, getByText } = render(
       <DataHubDrawerWidget model={model} />,
     )
+
+    expect(rootModel.configuration.connections.length).toBe(0)
     fireEvent.click(getByTestId('ucsc'))
     fireEvent.click(getByTestId('dataHubNext-current'))
     fireEvent.click(getByTestId('ucscCustom'))
@@ -62,10 +65,10 @@ trackDb hg19/trackDb.txt
       target: { value: 'http://test.com/hub.txt' },
     })
     fireEvent.click(getByTestId('trackHubUrlInputValidate'))
-    // Next line doesn't work yet
-    // await waitForElement(() => getByText('Assemblies'))
-
-    // Do the rest of the UI actions to add the connection
+    await waitForElement(() => getByText('Assemblies'))
+    fireEvent.click(getByTestId('assemblyCheckbox_testAssembly'))
+    fireEvent.click(getByTestId('dataHubNext-current'))
+    expect(rootModel.configuration.connections.length).toBe(1)
   })
 
   xit('can handle Track Hub Registry hub', () => {})

--- a/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/GenomeSelector.js
+++ b/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/GenomeSelector.js
@@ -47,7 +47,7 @@ function GenomeSelector(props) {
         return
       }
       const responseText = await response.text()
-      let newGenomesFile = genomesFile
+      let newGenomesFile
       try {
         newGenomesFile = new GenomesFile(responseText)
       } catch (error) {
@@ -64,7 +64,7 @@ function GenomeSelector(props) {
     }
 
     getGenomesFile()
-  }, [genomesFile, hubTxt, hubUrl])
+  }, [hubTxt, hubUrl])
 
   function handleChange(event) {
     const assemblyName = event.target.value

--- a/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/GenomeSelector.js
+++ b/packages/jbrowse-web/src/plugins/DataHubManagerDrawerWidget/components/GenomeSelector.js
@@ -103,6 +103,9 @@ function GenomeSelector(props) {
                       checked={assemblyNames.includes(genomeName)}
                       onChange={handleChange}
                       value={genomeName}
+                      inputProps={{
+                        'data-testid': `assemblyCheckbox_${genomeName}`,
+                      }}
                     />
                   }
                   label={genomeName}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5621,7 +5621,7 @@ electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.124:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz#dbde0e95e64ebe322db0eca764d951f885a5aff2"
   integrity sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==
 
-element-resize-detector@^1.1.12:
+element-resize-detector@^1.1.15:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.15.tgz#48eba1a2eaa26969a4c998d972171128c971d8d2"
   integrity sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==
@@ -9214,11 +9214,6 @@ lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -9298,11 +9293,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
   dependencies:
     lodash._reinterpolate "~3.0.0"
-
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash.unescape@4.0.1:
   version "4.0.1"
@@ -12292,16 +12282,15 @@ react-simple-code-editor@0.9.3:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.3.tgz#12af0f85455eb1be1a86f15e325ec7861bc0db75"
   integrity sha512-JexTKcpcOjArsXUDCWNoXgIdshoacJVSuf3LbdKG0tHw5ISREoh7wvNZlRRk2gncFRSixkkTI5E18svC966rYQ==
 
-react-sizeme@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.5.2.tgz#e7041390cfb895ed15d896aa91d76e147e3b70b5"
-  integrity sha512-hYvcncV1FxVzPm2EhVwlOLf7Tk+k/ttO6rI7bfKUL/aL1gYzrY3DXJsdZ6nFaFgGSU/i8KC6gCoptOhBbRJpXQ==
+react-sizeme@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.7.tgz#231339ce8821ac2c26424c791e0027f89dae3e90"
+  integrity sha512-xCjPoBP5jmeW58TxIkcviMZqabZis7tTvDFWf0/Wa5XCgVWQTIe74NQBes2N1Kmp64GRLkpm60BaP0kk+v8aCQ==
   dependencies:
-    element-resize-detector "^1.1.12"
-    invariant "^2.2.2"
-    lodash.debounce "^4.0.8"
-    lodash.throttle "^4.1.1"
-    shallowequal "^1.0.2"
+    element-resize-detector "^1.1.15"
+    invariant "^2.2.4"
+    shallowequal "^1.1.0"
+    throttle-debounce "^2.1.0"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.3:
   version "16.8.6"
@@ -13325,7 +13314,7 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
-shallowequal@^1.0.2:
+shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -14181,6 +14170,11 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
+throttle-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 through2-filter@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
@cmdcolin this PR is into your react_16.9_upgrade branch. I think this fixes the warnings about updating state after unmount (in both the tests and the browser), but might be good to test on another machine to be sure. It also finishes the UrlInput test so that it actually does all the steps for adding a connection. The line `await waitForElement(() => getByText('Assemblies'))` didn't work before React 16.9, so hopefully that's a good sign that testing should be easier with your update.

Also includes an version bump for react-sizeme to avoid a deprecation warning in the tests.