### PR TITLE
Fix aborting on track close

### DIFF
--- a/packages/core/BaseAdapter.ts
+++ b/packages/core/BaseAdapter.ts
@@ -35,7 +35,7 @@ export default abstract class BaseAdapter {
    * NOTE: if an adapter is unable to get it's own list of ref names, return empty
    *
    */
-  public abstract async getRefNames(): Promise<string[]>
+  public abstract async getRefNames(opts: BaseOptions): Promise<string[]>
 
   /**
    * Subclasses should override this method. Method signature here for reference.
@@ -79,7 +79,7 @@ export default abstract class BaseAdapter {
     opts: BaseOptions = {},
   ): Observable<Feature> {
     return ObservableCreate(async (observer: Observer<Feature>) => {
-      const hasData = await this.hasDataForRefName(region.refName)
+      const hasData = await this.hasDataForRefName(region.refName, opts)
       checkAbortSignal(opts.signal)
       if (!hasData) {
         observer.complete()
@@ -96,8 +96,11 @@ export default abstract class BaseAdapter {
    * @returns {Promise<boolean>} Whether data source has data for the given
    * reference name
    */
-  public async hasDataForRefName(refName: string): Promise<boolean> {
-    const refNames = await this.getRefNames()
+  public async hasDataForRefName(
+    refName: string,
+    opts: BaseOptions = {},
+  ): Promise<boolean> {
+    const refNames = await this.getRefNames(opts)
     if (refNames.includes(refName)) return true
     return false
   }

--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "dependencies": {
-    "@gmod/bam": "^1.0.17",
+    "@gmod/bam": "^1.0.19",
     "@gmod/bbi": "^1.0.21",
     "@gmod/bed": "^2.0.0",
     "@gmod/indexedfasta": "^1.0.11",

--- a/packages/jbrowse-web/src/managers/AssemblyManager.js
+++ b/packages/jbrowse-web/src/managers/AssemblyManager.js
@@ -35,7 +35,7 @@ export default class AssemblyManager {
    * @returns {Promise<object>} Object like { refName1: ['alias1', 'alias2'],
    * refName2: ['alias3', 'alias4'] }
    */
-  async getRefNameAliases(assemblyName) {
+  async getRefNameAliases(assemblyName, opts) {
     const refNameAliases = {}
     for (const assemblyConfig of this.assemblyConfigs) {
       let assembly = assemblyConfig.get(assemblyName)
@@ -63,6 +63,7 @@ export default class AssemblyManager {
               'type',
             ]),
             adapterConfig: readConfObject(assembly.refNameAliases, 'adapter'),
+            signal: opts.signal,
           },
           { timeout: 1000000 },
         )
@@ -80,13 +81,13 @@ export default class AssemblyManager {
    * observable by mobx.
    * @param {trackConf} trackConf Configuration model of a track
    */
-  async addRefNameMapForTrack(trackConf) {
+  async addRefNameMapForTrack(trackConf, opts) {
     const refNameMap = new Map()
 
     const assemblyName = readConfObject(trackConf, 'assemblyName')
 
     if (assemblyName) {
-      const refNameAliases = await this.getRefNameAliases(assemblyName)
+      const refNameAliases = await this.getRefNameAliases(assemblyName, opts)
 
       const refNames = await this.rpcManager.call(
         readConfObject(trackConf, 'configId'),
@@ -95,6 +96,7 @@ export default class AssemblyManager {
           sessionId: assemblyName,
           adapterType: readConfObject(trackConf, ['adapter', 'type']),
           adapterConfig: readConfObject(trackConf, 'adapter'),
+          signal: opts.signal,
         },
         { timeout: 1000000 },
       )
@@ -158,10 +160,10 @@ export default class AssemblyManager {
    * @returns {Map} See `addRefNameMapForTrack` for example Map, or an empty
    * map if the track is not found.
    */
-  async getRefNameMapForTrack(trackConf) {
+  async getRefNameMapForTrack(trackConf, opts) {
     const configId = readConfObject(trackConf, 'configId')
     if (!this.refNameMaps.has(configId)) {
-      await this.addRefNameMapForTrack(trackConf)
+      await this.addRefNameMapForTrack(trackConf, opts)
     }
     return this.refNameMaps.get(configId)
   }

--- a/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.ts
+++ b/packages/jbrowse-web/src/plugins/BamAdapter/BamAdapter.ts
@@ -49,9 +49,9 @@ export default class BamAdapter extends BaseAdapter {
     this.bam = new BamFile(bamOpts)
   }
 
-  async setup(): Promise<void> {
+  async setup(opts: BaseOptions): Promise<void> {
     if (!this.samHeader) {
-      const samHeader = await this.bam.getHeader()
+      const samHeader = await this.bam.getHeader(opts.signal)
       this.samHeader = {}
 
       // use the @SQ lines in the header to figure out the
@@ -76,8 +76,9 @@ export default class BamAdapter extends BaseAdapter {
     }
   }
 
-  async getRefNames(): Promise<string[]> {
-    await this.setup()
+  async getRefNames(opts: BaseOptions): Promise<string[]> {
+    console.log('getRefNames', opts)
+    await this.setup(opts)
     return this.samHeader.idToName
   }
 

--- a/packages/jbrowse-web/src/plugins/FromConfigAdapter/FromConfigAdapter.js
+++ b/packages/jbrowse-web/src/plugins/FromConfigAdapter/FromConfigAdapter.js
@@ -88,7 +88,7 @@ export default class FromConfigAdapter extends BaseAdapter {
     return regions
   }
 
-  async getRefNameAliases() {
+  async getRefNameAliases(/* opts: { signal } unused */) {
     return Array.from(this.features.values()).map(featureArray => ({
       refName: featureArray[0].get('refName'),
       aliases: featureArray[0].get('aliases'),

--- a/packages/jbrowse-web/src/plugins/LinearGenomeView/models/blockBasedTrack.js
+++ b/packages/jbrowse-web/src/plugins/LinearGenomeView/models/blockBasedTrack.js
@@ -66,9 +66,13 @@ export default types.compose(
             let blockDefinitions = getContainingView(self)[self.blockType]
             try {
               const { assemblyManager } = getRoot(self)
+              const aborter = new AbortController()
+              const { signal } = aborter
+              self.setRefNamesLoading(aborter)
 
               const refNameMap = await assemblyManager.getRefNameMapForTrack(
                 self.configuration,
+                { signal },
               )
               if (!refNameMap) return
 
@@ -105,6 +109,15 @@ export default types.compose(
             region: block.toRegion(),
           }),
         )
+      },
+      setRefNamesLoading(abortSignal) {
+        if (
+          self.statsFetchInProgress &&
+          !self.statsFetchInProgress.signal.aborted
+        ) {
+          self.statsFetchInProgress.abort()
+        }
+        self.statsFetchInProgress = abortSignal
       },
 
       deleteBlock(key) {

--- a/packages/jbrowse-web/src/plugins/WiggleTrack/model.js
+++ b/packages/jbrowse-web/src/plugins/WiggleTrack/model.js
@@ -41,7 +41,7 @@ export default (pluginManager, configSchema) =>
                 const aborter = new AbortController()
                 const { signal } = aborter
                 let statsPromise
-                self.setLoading(aborter)
+                self.setStatsLoading(aborter)
 
                 if (autoscaleType === 'global') {
                   statsPromise = rpcManager.call(
@@ -89,7 +89,7 @@ export default (pluginManager, configSchema) =>
           self.stats.setStats(stats)
           self.ready = true
         },
-        setLoading(abortSignal) {
+        setStatsLoading(abortSignal) {
           if (
             self.statsFetchInProgress &&
             !self.statsFetchInProgress.signal.aborted

--- a/packages/jbrowse-web/src/rpcMethods.js
+++ b/packages/jbrowse-web/src/rpcMethods.js
@@ -73,7 +73,7 @@ export async function getRegions(
     adapterType,
     adapterConfig,
   )
-  return dataAdapter.getRegions()
+  return dataAdapter.getRegions({ signal })
 }
 
 export async function getRefNames(
@@ -90,20 +90,23 @@ export async function getRefNames(
     adapterType,
     adapterConfig,
   )
-  return dataAdapter.getRefNames()
+  return dataAdapter.getRefNames({ signal })
 }
 
 export async function getRefNameAliases(
   pluginManager,
-  { sessionId, adapterType, adapterConfig },
+  { sessionId, adapterType, signal, adapterConfig },
 ) {
+  if (isRemoteAbortSignal(signal)) {
+    signal = deserializeAbortSignal(signal)
+  }
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
     adapterType,
     adapterConfig,
   )
-  return dataAdapter.getRefNameAliases()
+  return dataAdapter.getRefNameAliases({ signal })
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,18 +1163,18 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
   integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
 
-"@gmod/bam@^1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.0.17.tgz#37677469009e5c89f8976643735d589b6da43ea6"
-  integrity sha512-IMSTKfot61V44dpAjwd7AbRG+Ko+YThy2QtFaf4ze0oVlWDxq9HTH61tyewCUkbJp8dTim1+9AfKsYtDt/xDRg==
+"@gmod/bam@^1.0.19":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.0.19.tgz#f3f0f34c11804ea7cb25611d6e8f8f4f7e806300"
+  integrity sha512-uLlbkSnGEqnuf+IhO63fMq4hvtOt+58q/r3Tr0B3oF3AI3SDjAufyfJ/aNS6X4VkwL4JhStVJKB75BXSoHGxig==
   dependencies:
     "@babel/runtime" "^7.4.3"
     "@gmod/bgzf-filehandle" "^1.2.3"
-    abortable-promise-cache "^1.0.0"
+    abortable-promise-cache "^1.0.1"
     buffer-crc32 "^0.2.13"
     cross-fetch "^3.0.2"
     es6-promisify "^6.0.1"
-    generic-filehandle "^1.0.7"
+    generic-filehandle "^1.0.9"
     long "^4.0.0"
     object.entries-ponyfill "^1.0.1"
     quick-lru "^2.0.0"
@@ -2720,7 +2720,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abortable-promise-cache@^1.0.0, abortable-promise-cache@^1.0.1:
+abortable-promise-cache@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.0.1.tgz#68638de7806444e0fc3f3c2c5d53b81fad1c4466"
   integrity sha512-Iu27BBSRe6jPrNhf5SjCyxJ0yb8fJ63H3CRoEVD+sJ2AvJsXppY5PVMvpFlB4si8K2cTFgjSgYNTELjm9ofwTQ==
@@ -6695,7 +6695,7 @@ gaze@^1.0.0:
   dependencies:
     globule "^1.0.0"
 
-generic-filehandle@^1.0.6, generic-filehandle@^1.0.7, generic-filehandle@^1.0.8:
+generic-filehandle@^1.0.6, generic-filehandle@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-1.0.8.tgz#7cdb026884a237cec28a44fdbd1bd6eb0b5b408c"
   integrity sha512-JlccwYLF2V+C7gbZB7/kXRP+t2KXVWI5GTjAB0NtMVx7AiOQ/5Sn/BfOjitQ/cM7QxjvBDdExlY0QrZHRTxg+g==


### PR DESCRIPTION
This is a WIP at time of writing

I am seeing that, for example, closing a BAM track before the BAI has loaded continues downloading

This involves various things in AssemblyManager which does getRefNames from the adapter, but this should ideally be tied to aborting.

Feedback welcome but so far not complete yet