### PR TITLE
Add a BUILT_TESTS flag for the fs.exists tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ cache:
 script:
     - set -e
     - yarn lint
+    - yarn test-ci
     - yarn tsc --noEmit
     - yarn build
-    - yarn test-ci
+    - BUILT_TESTS=1 yarn built-test-ci
     # - if .travis/build-condition.sh $TRAVIS_COMMIT_RANGE $PROJECT; then cd $PROJECT && . .travis.sh; else echo "$PROJECT is NOT being built"; fi
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "build": "NODE_ENV=production lerna run build",
         "lint": "eslint --ext .js,.ts .",
         "test-ci": "jest --ci --coverage",
+        "built-test-ci": "jest --ci packages/integration-tests",
         "test": "jest"
     },
     "devDependencies": {

--- a/packages/integration-tests/integration.test.js
+++ b/packages/integration-tests/integration.test.js
@@ -2,15 +2,17 @@
 /* eslint-disable global-require */
 const fs = require('fs')
 
-test('JBrowse Web built', () => {
-  expect(fs.existsSync('packages/jbrowse-web/build/index.html')).toBeTruthy()
-})
+if (process.env.BUILT_TESTS) {
+  test('JBrowse Web built', () => {
+    expect(fs.existsSync('packages/jbrowse-web/build/index.html')).toBeTruthy()
+  })
 
-test('Protein Widget built', () => {
-  expect(
-    fs.existsSync('packages/protein-widget/umd/jbrowse-protein-viewer.js'),
-  ).toBeTruthy()
-})
+  test('Protein Widget built', () => {
+    expect(
+      fs.existsSync('packages/protein-widget/umd/jbrowse-protein-viewer.js'),
+    ).toBeTruthy()
+  })
+}
 
 test('can import JBrowse Generator', () => {
   const generatorJbrowse = require('../generator-jbrowse')


### PR DESCRIPTION
This adds a BUILT_TESTS flag to the CI. This can allow tests to fail faster on CI. It doesn't necessarily give you a green light faster but it gives you a red light faster.