### PR TITLE
Proposed updates to VCF Feature

### DIFF
--- a/packages/jbrowse-web/src/plugins/VcfTabixAdapter/VcfFeature.ts
+++ b/packages/jbrowse-web/src/plugins/VcfTabixAdapter/VcfFeature.ts
@@ -70,7 +70,6 @@ export default class VCFFeature implements Feature {
       ...Object.keys(this.variant),
       'samples',
     ]
-    if (!t.includes('SAMPLES')) t.push('SAMPLES')
     return t
   }
 
@@ -233,6 +232,11 @@ export default class VCFFeature implements Feature {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(): any {
-    return { uniqueId: this._id, ...this.data, ...this.variant }
+    return {
+      uniqueId: this._id,
+      ...this.data,
+      ...this.variant,
+      samples: this.variant.SAMPLES,
+    }
   }
 }

--- a/packages/jbrowse-web/src/plugins/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
+++ b/packages/jbrowse-web/src/plugins/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
@@ -9,555 +9,239 @@ Array [
 exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
 Array [
   Object {
-    "AC1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele count (no HWE assumption)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+    "ALT": Array [
+      "C",
+    ],
+    "CHROM": "ctgA",
+    "FILTER": null,
+    "ID": null,
+    "INFO": Object {
+      "AC1": Array [
         2,
       ],
-    },
-    "AF1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele frequency (assuming HWE)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "AF1": Array [
         1,
       ],
-    },
-    "DP": Object {
-      "meta": Object {
-        "Description": "Raw read depth",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP": Array [
         3,
       ],
-    },
-    "DP4": Object {
-      "meta": Object {
-        "Description": "# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases",
-        "Number": 4,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP4": Array [
         0,
         0,
         3,
         0,
       ],
-    },
-    "FQ": Object {
-      "meta": Object {
-        "Description": "Phred probability of all samples being the same",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "FQ": Array [
         -36,
       ],
-    },
-    "MQ": Object {
-      "meta": Object {
-        "Description": "Root-mean-square mapping quality of covering reads",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "MQ": Array [
         37,
       ],
-    },
-    "VDB": Object {
-      "meta": Object {
-        "Description": "Variant Distance Bias",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "VDB": Array [
         0.0186,
       ],
     },
+    "POS": 277,
+    "QUAL": 10.4,
+    "REF": "T",
     "aliases": undefined,
-    "alternative_alleles": Object {
-      "meta": Object {
-        "description": "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples",
-      },
-      "values": Array [
-        "C",
-      ],
-    },
     "description": "SNV T -> C",
     "end": 277,
-    "filters": Object {
-      "meta": Object {
-        "description": "List of filters that this site has not passed, or PASS if it has passed all filters",
-        "filters": Object {
-          "PASS": Object {
-            "Description": "Passed all filters",
-          },
-        },
-      },
-      "values": null,
-    },
     "name": undefined,
     "refName": "ctgA",
-    "reference_allele": "T",
-    "score": 10.4,
     "start": 276,
     "type": "SNV",
     "uniqueId": "vcf-2560",
   },
   Object {
-    "AC1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele count (no HWE assumption)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+    "ALT": Array [
+      "C",
+    ],
+    "CHROM": "ctgA",
+    "FILTER": null,
+    "ID": null,
+    "INFO": Object {
+      "AC1": Array [
         2,
       ],
-    },
-    "AF1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele frequency (assuming HWE)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "AF1": Array [
         1,
       ],
-    },
-    "DP": Object {
-      "meta": Object {
-        "Description": "Raw read depth",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP": Array [
         23,
       ],
-    },
-    "DP4": Object {
-      "meta": Object {
-        "Description": "# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases",
-        "Number": 4,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP4": Array [
         0,
         1,
         8,
         14,
       ],
-    },
-    "FQ": Object {
-      "meta": Object {
-        "Description": "Phred probability of all samples being the same",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "FQ": Array [
         -73,
       ],
-    },
-    "MQ": Object {
-      "meta": Object {
-        "Description": "Root-mean-square mapping quality of covering reads",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "MQ": Array [
         37,
       ],
-    },
-    "PV4": Object {
-      "meta": Object {
-        "Description": "P-values for strand bias, baseQ bias, mapQ bias and tail distance bias",
-        "Number": 4,
-        "Type": "Float",
-      },
-      "values": Array [
+      "PV4": Array [
         1,
         1,
         0.42,
         1,
       ],
-    },
-    "VDB": Object {
-      "meta": Object {
-        "Description": "Variant Distance Bias",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "VDB": Array [
         0.0308,
       ],
     },
+    "POS": 1694,
+    "QUAL": 107,
+    "REF": "T",
     "aliases": undefined,
-    "alternative_alleles": Object {
-      "meta": Object {
-        "description": "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples",
-      },
-      "values": Array [
-        "C",
-      ],
-    },
     "description": "SNV T -> C",
     "end": 1694,
-    "filters": Object {
-      "meta": Object {
-        "description": "List of filters that this site has not passed, or PASS if it has passed all filters",
-        "filters": Object {
-          "PASS": Object {
-            "Description": "Passed all filters",
-          },
-        },
-      },
-      "values": null,
-    },
     "name": undefined,
     "refName": "ctgA",
-    "reference_allele": "T",
-    "score": 107,
     "start": 1693,
     "type": "SNV",
     "uniqueId": "vcf-2658",
   },
   Object {
-    "AC1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele count (no HWE assumption)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+    "ALT": Array [
+      "G",
+    ],
+    "CHROM": "ctgA",
+    "FILTER": null,
+    "ID": null,
+    "INFO": Object {
+      "AC1": Array [
         1,
       ],
-    },
-    "AF1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele frequency (assuming HWE)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "AF1": Array [
         0.5,
       ],
-    },
-    "DP": Object {
-      "meta": Object {
-        "Description": "Raw read depth",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP": Array [
         22,
       ],
-    },
-    "DP4": Object {
-      "meta": Object {
-        "Description": "# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases",
-        "Number": 4,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP4": Array [
         6,
         5,
         3,
         8,
       ],
-    },
-    "FQ": Object {
-      "meta": Object {
-        "Description": "Phred probability of all samples being the same",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "FQ": Array [
         45.3,
       ],
-    },
-    "MQ": Object {
-      "meta": Object {
-        "Description": "Root-mean-square mapping quality of covering reads",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "MQ": Array [
         37,
       ],
-    },
-    "PV4": Object {
-      "meta": Object {
-        "Description": "P-values for strand bias, baseQ bias, mapQ bias and tail distance bias",
-        "Number": 4,
-        "Type": "Float",
-      },
-      "values": Array [
+      "PV4": Array [
         0.39,
         1,
         1,
         1,
       ],
-    },
-    "VDB": Object {
-      "meta": Object {
-        "Description": "Variant Distance Bias",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "VDB": Array [
         0.0253,
       ],
     },
+    "POS": 2644,
+    "QUAL": 44,
+    "REF": "T",
     "aliases": undefined,
-    "alternative_alleles": Object {
-      "meta": Object {
-        "description": "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples",
-      },
-      "values": Array [
-        "G",
-      ],
-    },
     "description": "SNV T -> G",
     "end": 2644,
-    "filters": Object {
-      "meta": Object {
-        "description": "List of filters that this site has not passed, or PASS if it has passed all filters",
-        "filters": Object {
-          "PASS": Object {
-            "Description": "Passed all filters",
-          },
-        },
-      },
-      "values": null,
-    },
     "name": undefined,
     "refName": "ctgA",
-    "reference_allele": "T",
-    "score": 44,
     "start": 2643,
     "type": "SNV",
     "uniqueId": "vcf-2775",
   },
   Object {
-    "AC1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele count (no HWE assumption)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+    "ALT": Array [
+      "A",
+    ],
+    "CHROM": "ctgA",
+    "FILTER": null,
+    "ID": null,
+    "INFO": Object {
+      "AC1": Array [
         2,
       ],
-    },
-    "AF1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele frequency (assuming HWE)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "AF1": Array [
         1,
       ],
-    },
-    "DP": Object {
-      "meta": Object {
-        "Description": "Raw read depth",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP": Array [
         19,
       ],
-    },
-    "DP4": Object {
-      "meta": Object {
-        "Description": "# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases",
-        "Number": 4,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP4": Array [
         0,
         0,
         8,
         11,
       ],
-    },
-    "FQ": Object {
-      "meta": Object {
-        "Description": "Phred probability of all samples being the same",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "FQ": Array [
         -84,
       ],
-    },
-    "MQ": Object {
-      "meta": Object {
-        "Description": "Root-mean-square mapping quality of covering reads",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "MQ": Array [
         36,
       ],
-    },
-    "VDB": Object {
-      "meta": Object {
-        "Description": "Variant Distance Bias",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "VDB": Array [
         0.0384,
       ],
     },
+    "POS": 3213,
+    "QUAL": 124,
+    "REF": "T",
     "aliases": undefined,
-    "alternative_alleles": Object {
-      "meta": Object {
-        "description": "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples",
-      },
-      "values": Array [
-        "A",
-      ],
-    },
     "description": "SNV T -> A",
     "end": 3213,
-    "filters": Object {
-      "meta": Object {
-        "description": "List of filters that this site has not passed, or PASS if it has passed all filters",
-        "filters": Object {
-          "PASS": Object {
-            "Description": "Passed all filters",
-          },
-        },
-      },
-      "values": null,
-    },
     "name": undefined,
     "refName": "ctgA",
-    "reference_allele": "T",
-    "score": 124,
     "start": 3212,
     "type": "SNV",
     "uniqueId": "vcf-2892",
   },
   Object {
-    "AC1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele count (no HWE assumption)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+    "ALT": Array [
+      "ct",
+    ],
+    "CHROM": "ctgA",
+    "FILTER": null,
+    "ID": null,
+    "INFO": Object {
+      "AC1": Array [
         2,
       ],
-    },
-    "AF1": Object {
-      "meta": Object {
-        "Description": "Max-likelihood estimate of the first ALT allele frequency (assuming HWE)",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "AF1": Array [
         1,
       ],
-    },
-    "DP": Object {
-      "meta": Object {
-        "Description": "Raw read depth",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP": Array [
         15,
       ],
-    },
-    "DP4": Object {
-      "meta": Object {
-        "Description": "# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases",
-        "Number": 4,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "DP4": Array [
         0,
         0,
         5,
         6,
       ],
-    },
-    "FQ": Object {
-      "meta": Object {
-        "Description": "Phred probability of all samples being the same",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "FQ": Array [
         -67.5,
       ],
-    },
-    "INDEL": Object {
-      "meta": Object {
-        "Description": "Indicates that the variant is an INDEL.",
-        "Number": 0,
-        "Type": "Flag",
-      },
-      "values": null,
-    },
-    "MQ": Object {
-      "meta": Object {
-        "Description": "Root-mean-square mapping quality of covering reads",
-        "Number": 1,
-        "Type": "Integer",
-      },
-      "values": Array [
+      "INDEL": null,
+      "MQ": Array [
         37,
       ],
-    },
-    "VDB": Object {
-      "meta": Object {
-        "Description": "Variant Distance Bias",
-        "Number": 1,
-        "Type": "Float",
-      },
-      "values": Array [
+      "VDB": Array [
         0.0384,
       ],
     },
+    "POS": 3858,
+    "QUAL": 160,
+    "REF": "ctt",
     "aliases": undefined,
-    "alternative_alleles": Object {
-      "meta": Object {
-        "description": "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples",
-      },
-      "values": Array [
-        "ct",
-      ],
-    },
     "description": "deletion ctt -> ct",
     "end": 3860,
-    "filters": Object {
-      "meta": Object {
-        "description": "List of filters that this site has not passed, or PASS if it has passed all filters",
-        "filters": Object {
-          "PASS": Object {
-            "Description": "Passed all filters",
-          },
-        },
-      },
-      "values": null,
-    },
     "name": undefined,
     "refName": "ctgA",
-    "reference_allele": "ctt",
-    "score": 160,
     "start": 3857,
     "type": "deletion",
     "uniqueId": "vcf-2994",

--- a/packages/jbrowse-web/src/plugins/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
+++ b/packages/jbrowse-web/src/plugins/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
@@ -49,6 +49,21 @@ Array [
     "end": 277,
     "name": undefined,
     "refName": "ctgA",
+    "samples": Object {
+      "sample_data/raw/volvox/volvox-sorted.bam": Object {
+        "GQ": Array [
+          13,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+        "PL": Array [
+          42,
+          9,
+          0,
+        ],
+      },
+    },
     "start": 276,
     "type": "SNV",
     "uniqueId": "vcf-2560",
@@ -100,6 +115,21 @@ Array [
     "end": 1694,
     "name": undefined,
     "refName": "ctgA",
+    "samples": Object {
+      "sample_data/raw/volvox/volvox-sorted.bam": Object {
+        "GQ": Array [
+          89,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+        "PL": Array [
+          140,
+          46,
+          0,
+        ],
+      },
+    },
     "start": 1693,
     "type": "SNV",
     "uniqueId": "vcf-2658",
@@ -151,6 +181,21 @@ Array [
     "end": 2644,
     "name": undefined,
     "refName": "ctgA",
+    "samples": Object {
+      "sample_data/raw/volvox/volvox-sorted.bam": Object {
+        "GQ": Array [
+          75,
+        ],
+        "GT": Array [
+          "0/1",
+        ],
+        "PL": Array [
+          74,
+          0,
+          77,
+        ],
+      },
+    },
     "start": 2643,
     "type": "SNV",
     "uniqueId": "vcf-2775",
@@ -196,6 +241,21 @@ Array [
     "end": 3213,
     "name": undefined,
     "refName": "ctgA",
+    "samples": Object {
+      "sample_data/raw/volvox/volvox-sorted.bam": Object {
+        "GQ": Array [
+          99,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+        "PL": Array [
+          157,
+          57,
+          0,
+        ],
+      },
+    },
     "start": 3212,
     "type": "SNV",
     "uniqueId": "vcf-2892",
@@ -242,6 +302,21 @@ Array [
     "end": 3860,
     "name": undefined,
     "refName": "ctgA",
+    "samples": Object {
+      "sample_data/raw/volvox/volvox-sorted.bam": Object {
+        "GQ": Array [
+          63,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+        "PL": Array [
+          201,
+          33,
+          0,
+        ],
+      },
+    },
     "start": 3857,
     "type": "deletion",
     "uniqueId": "vcf-2994",


### PR DESCRIPTION
When I re-did JB1's VcfFeature after the create of vcf-js, I had to keep a lot of things compatible with the old VCF features. Since we're not bound by that in JB2, I'd like to propose some changes:

- Just assume what's in `get()` is the correct case, don't mess with `toLowerCase()` at all.
- Get rid of references to "genotypes", since really it's actually sample-specific data that can contain a lot more than just genotypes
- Just have `get()` access the variant information as-is. Only store in `data` things that are derived from the variant info (like SO terms).
- Don't copy INFO fields into `data`. This has the danger of overriding other fields and I think can be a bit confusing.

Here's what's available via `get()`:
```js
console.log(feature.tags())
// ["refName", "start", "end", "description", "type", "name", "aliases", "CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "samples", "SAMPLES"]
```
(I aliased "samples" to "SAMPLES" since "SAMPLES" isn't actually a VCF field like "ALT", "QUAL", etc. are.)

This makes it so metadata like "description" aren't in the feature data itself, but they can still be easily accessed by doing e.g. `feature.parser.getMetadata('INFO', 'DP')`

Hopefully these changes make the relationship between the feature and the underlying VCF data more clear. Thoughts?