### PR TITLE
Fix sidescrolling smoothness

### DIFF
--- a/packages/data-management/package.json
+++ b/packages/data-management/package.json
@@ -9,8 +9,7 @@
   "author": "Garrett Stevens",
   "license": "MIT",
   "dependencies": {
-    "@gmod/ucsc-hub": "^0.1.2",
-    "request-idle-callback": "^1.0.2"
+    "@gmod/ucsc-hub": "^0.1.2"
   },
   "peerDependencies": {
     "@gmod/jbrowse-core": "^2.0.0",

--- a/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/Contents.js
+++ b/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/Contents.js
@@ -7,7 +7,6 @@ import { observer } from 'mobx-react-lite'
 import { getRoot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
-import { cancelIdleCallback, requestIdleCallback } from 'request-idle-callback'
 // eslint-disable-next-line import/no-cycle
 import Category from './Category'
 import TrackEntry from './TrackEntry'

--- a/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/HierarchicalTrackSelector.test.js
+++ b/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/HierarchicalTrackSelector.test.js
@@ -3,6 +3,9 @@ import { render } from 'react-testing-library'
 import { createTestEnv } from '@gmod/jbrowse-web/src/JBrowse'
 import HierarchicalTrackSelector from './HierarchicalTrackSelector'
 
+window.requestIdleCallback = cb => cb()
+window.cancelIdleCallback = () => {}
+
 describe('HierarchicalTrackSelector drawer widget', () => {
   it('renders with just the required model elements', async () => {
     const { rootModel } = await createTestEnv()

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -15,6 +15,7 @@ import config from '../test_data/config_integration_test.json'
 fetchMock.config.sendAsJson = false
 
 window.requestIdleCallback = cb => cb()
+window.cancelIdleCallback = () => {}
 
 const getFile = url => new LocalFile(require.resolve(`../${url}`))
 // fakes server responses from local file object with fetchMock

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -14,11 +14,6 @@ import config from '../test_data/config_integration_test.json'
 
 fetchMock.config.sendAsJson = false
 
-jest.mock('request-idle-callback', () => ({
-  requestIdleCallback: callback => callback(),
-  cancelIdleCallback: () => {},
-}))
-
 const getFile = url => new LocalFile(require.resolve(`../${url}`))
 // fakes server responses from local file object with fetchMock
 const readBuffer = async (url, args) => {

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -14,6 +14,8 @@ import config from '../test_data/config_integration_test.json'
 
 fetchMock.config.sendAsJson = false
 
+window.requestIdleCallback = cb => cb()
+
 const getFile = url => new LocalFile(require.resolve(`../${url}`))
 // fakes server responses from local file object with fetchMock
 const readBuffer = async (url, args) => {

--- a/packages/linear-genome-view/package.json
+++ b/packages/linear-genome-view/package.json
@@ -9,8 +9,7 @@
   "author": "Robert Buels",
   "license": "MIT",
   "dependencies": {
-    "classnames": "^2.2.6",
-    "request-idle-callback": "^1.0.2"
+    "classnames": "^2.2.6"
   },
   "peerDependencies": {
     "@gmod/jbrowse-core": "^2.0.0",

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
@@ -42,26 +42,20 @@ class ServerSideRenderedContent extends Component {
       domNode.firstChild.innerHTML = html
       // defer main-thread rendering and hydration for when
       // we have some free time. helps keep the framerate up.
-      requestIdleCallback(() => {
-        if (!isAlive(model) || !isAlive(region)) return
-        const serializedRegion = isStateTreeNode(region)
-          ? getSnapshot(region)
-          : region
-        const mainThreadRendering = React.createElement(
-          renderingComponent,
-          {
-            ...data,
-            region: serializedRegion,
-            ...renderProps,
-          },
-          null,
-        )
-        requestIdleCallback(() => {
-          if (!isAlive(model) || !isAlive(region)) return
-          hydrate(mainThreadRendering, domNode.firstChild)
-          this.hydrated = true
-        })
-      })
+      const serializedRegion = isStateTreeNode(region)
+        ? getSnapshot(region)
+        : region
+      const mainThreadRendering = React.createElement(
+        renderingComponent,
+        {
+          ...data,
+          region: serializedRegion,
+          ...renderProps,
+        },
+        null,
+      )
+      hydrate(mainThreadRendering, domNode.firstChild)
+      this.hydrated = true
     }
   }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
@@ -3,8 +3,6 @@ import { observer, PropTypes } from 'mobx-react'
 import { hydrate, unmountComponentAtNode } from 'react-dom'
 import { isAlive, isStateTreeNode, getSnapshot } from 'mobx-state-tree'
 
-import { requestIdleCallback } from 'request-idle-callback'
-
 /**
  * A block whose content is rendered outside of the main thread and hydrated by this
  * component.
@@ -42,20 +40,26 @@ class ServerSideRenderedContent extends Component {
       domNode.firstChild.innerHTML = html
       // defer main-thread rendering and hydration for when
       // we have some free time. helps keep the framerate up.
-      const serializedRegion = isStateTreeNode(region)
-        ? getSnapshot(region)
-        : region
-      const mainThreadRendering = React.createElement(
-        renderingComponent,
-        {
-          ...data,
-          region: serializedRegion,
-          ...renderProps,
+      requestIdleCallback(
+        () => {
+          if (!isAlive(model) || !isAlive(region)) return
+          const serializedRegion = isStateTreeNode(region)
+            ? getSnapshot(region)
+            : region
+          const mainThreadRendering = React.createElement(
+            renderingComponent,
+            {
+              ...data,
+              region: serializedRegion,
+              ...renderProps,
+            },
+            null,
+          )
+          hydrate(mainThreadRendering, domNode.firstChild)
+          this.hydrated = true
         },
-        null,
+        { timeout: 10 },
       )
-      hydrate(mainThreadRendering, domNode.firstChild)
-      this.hydrated = true
     }
   }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ServerSideRenderedContent.js
@@ -58,7 +58,7 @@ class ServerSideRenderedContent extends Component {
           hydrate(mainThreadRendering, domNode.firstChild)
           this.hydrated = true
         },
-        { timeout: 10 },
+        { timeout: 50 },
       )
     }
   }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/buttonStyles.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/buttonStyles.js
@@ -1,9 +1,9 @@
-export default theme =>  ({
+export default theme => ({
   iconButton: {
     padding: theme.spacing(0.5),
   },
   toggleButton: {
     height: theme.spacing(4),
     border: 'none',
-  }
+  },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -13016,11 +13016,6 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
-request-idle-callback@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/request-idle-callback/-/request-idle-callback-1.0.2.tgz#9bb41771b746209de8be0b1c3cde2161e420edd2"
-  integrity sha1-m7QXcbdGIJ3ovgscPN4hYeQg7dI=
-
 request-promise-core@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"


### PR DESCRIPTION
This proposes speeding up scrolling noted in #365 by using the timeout on requestIdleCallback, which I set to a very short value. This requires unpolyfilled requestIdleCallback due to the shim library not passing the options to the global.requestIdleCallback (see https://github.com/santiagogil/request-idle-callback/issues/2)

If a polyfill is strongly needed for a particular browser we can find a workaround.

I also removed the nested requestIdleCallback because I wasn't sure if it was aiding smoothness, but I could restore. Also, more speculative outside-the-viewport data rendering could make it perceived as smoother since the content would just be ready before you arrive there via scrolling