### PR TITLE
Avoid writing to mst if the model isn't alive anymore

### DIFF
--- a/packages/core/rpc/RpcManager.js
+++ b/packages/core/rpc/RpcManager.js
@@ -1,4 +1,5 @@
 import { decorate, observable } from 'mobx'
+import { isStateTreeNode, isAlive } from 'mobx-state-tree'
 import { readConfObject } from '../configuration'
 
 import rpcConfigSchema from './configSchema'
@@ -73,8 +74,11 @@ class RpcManager {
         assemblyName,
         { signal },
       )
-      if (refNameMap.has(args[0].region.refName))
-        args[0].region.setRefName(refNameMap.get(args[0].region.refName))
+      if (!isStateTreeNode(args[0].region) || isAlive(args[0].region)) {
+        if (refNameMap.has(args[0].region.refName)) {
+          args[0].region.setRefName(refNameMap.get(args[0].region.refName))
+        }
+      }
     }
     return this.getDriverForCall(stateGroupName, functionName, args).call(
       this.pluginManager,

--- a/packages/core/rpc/RpcManager.js
+++ b/packages/core/rpc/RpcManager.js
@@ -69,14 +69,18 @@ class RpcManager {
   async call(stateGroupName, functionName, ...args) {
     const { assemblyName, signal } = args[0]
     if (assemblyName) {
+      const { region } = args[0]
+      const { refName } = region
       const refNameMap = await this.assemblyManager.getRefNameMapForAdapter(
         args[0].adapterConfig,
         assemblyName,
         { signal },
       )
-      if (!isStateTreeNode(args[0].region) || isAlive(args[0].region)) {
-        if (refNameMap.has(args[0].region.refName)) {
-          args[0].region.setRefName(refNameMap.get(args[0].region.refName))
+      if (refNameMap.has(refName)) {
+        if (isStateTreeNode(region) && isAlive(region)) {
+          region.setRefName(refNameMap.get(refName))
+        } else {
+          args[0].region.refName = refNameMap.get(refName)
         }
       }
     }


### PR DESCRIPTION
This proposes a fix to warnings like this in the tests

```
  console.warn node_modules/mobx-state-tree/dist/mobx-state-tree.js:3007                                                                                                                             [28/28]
    Error: [mobx-state-tree] You are trying to read or write to an object that is no longer part of a state tree. (Object type was 'AnonymousModel'). Either detach nodes first, or don't use objects after 
removing / replacing them in the tree.           
```

We check isAlive before updating the statetree, and also check whether it is a state tree at all because it appears some not state tree things can come through here.