### PR TITLE
Modify how SimpleFeature.fromJSON is called to fix NCList features

### DIFF
--- a/packages/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
+++ b/packages/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
@@ -191,6 +191,7 @@ export default class implements Feature {
     plain.refName = this.get('refName')
     plain.name = this.get('name')
     plain.type = this.get('type')
+    plain.uniqueId = this.id()
     return plain
   }
 

--- a/packages/alignments/src/BamAdapter/__snapshots__/BamAdapter.test.js.snap
+++ b/packages/alignments/src/BamAdapter/__snapshots__/BamAdapter.test.js.snap
@@ -22,6 +22,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4782775,
     "unmapped": false,
   },
   Object {
@@ -44,6 +45,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4783043,
     "unmapped": false,
   },
   Object {
@@ -66,6 +68,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4783302,
     "unmapped": false,
   },
   Object {
@@ -88,6 +91,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4783568,
     "unmapped": false,
   },
   Object {
@@ -110,6 +114,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4783826,
     "unmapped": false,
   },
   Object {
@@ -132,6 +137,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4784088,
     "unmapped": false,
   },
   Object {
@@ -154,6 +160,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4784350,
     "unmapped": false,
   },
   Object {
@@ -176,6 +183,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4784611,
     "unmapped": false,
   },
   Object {
@@ -198,6 +206,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4784867,
     "unmapped": false,
   },
   Object {
@@ -220,6 +229,7 @@ Array [
     "supplementary_alignment": false,
     "template_length": 0,
     "type": "match",
+    "uniqueId": 4785127,
     "unmapped": false,
   },
 ]

--- a/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2352,7 +2352,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                           spellcheck="false"
                           style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-size: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
                         >
-                          function(feature) { return feature.get('name') || feature.id() }
+                          function(feature) { return feature.get('name') || feature.get('id') }
                         </textarea>
                         <pre
                           aria-hidden="true"
@@ -2431,12 +2431,17 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                           <span
                             class="token function"
                           >
-                            id
+                            get
                           </span>
                           <span
                             class="token punctuation"
                           >
                             (
+                          </span>
+                          <span
+                            class="token string"
+                          >
+                            'id'
                           </span>
                           <span
                             class="token punctuation"

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.js
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.js
@@ -36,7 +36,7 @@ export default class ServerSideRenderer extends RendererType {
     // deserialize some of the results that came back from the worker
     const featuresMap = new Map()
     result.features.forEach(j => {
-      const f = SimpleFeature.fromJSON(j)
+      const f = SimpleFeature.fromJSON({ data: j })
       featuresMap.set(String(f.id()), f)
     })
     result.features = featuresMap

--- a/packages/jbrowse-web/public/test_data/config_human.json
+++ b/packages/jbrowse-web/public/test_data/config_human.json
@@ -143,6 +143,19 @@
           }
         },
         {
+          "type": "BasicTrack",
+          "configId": "nclist_genes",
+          "name": "Gencode v19",
+          "category": ["Genes"],
+          "adapter": {
+            "type": "NCListAdapter",
+            "rootUrlTemplate": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/gencode/{refseq}/trackData.json"
+          },
+          "renderer": {
+            "type": "SvgFeatureRenderer"
+          }
+        },
+        {
           "configId": "bigbed_peaks",
           "type": "BasicTrack",
           "name": "Encode peaks",

--- a/packages/svg/src/SvgFeatureRenderer/configSchema.js
+++ b/packages/svg/src/SvgFeatureRenderer/configSchema.js
@@ -35,7 +35,7 @@ export default ConfigurationSchema(
         description:
           'the primary name of the feature to show, if space is available',
         defaultValue:
-          "function(feature) { return feature.get('name') || feature.id() }",
+          "function(feature) { return feature.get('name') || feature.get('id') }",
         functionSignature: ['feature'],
       },
       nameColor: {


### PR DESCRIPTION
This modifies how SimpleFeature.fromJSON is called, which helps fix issues we were seeing in #396 

The features being received are raw objects that contain a uniqueId

SimpleFeature actually expects the uniqueId to be inside of {data:{uniqueId:..., ...}} though

By placing the fromJSON call to expect the data to be in a "data" property the code works again. It reduces confusion about when a feature actually has an "id" as in column 9 of GFF

This also says that we do not display a feature name as feature.id(), since this is often autocomputed. We only display an "id" if it is from feature.get('id')