### PR TITLE
Remove custom scrolling

### DIFF
--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -41,7 +41,6 @@
     "prop-types": "^15.7.2",
     "raf": "^3.4.1",
     "react": "^16.8.0",
-    "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.8.0",
     "react-sizeme": "^2.6.7",
     "rxjs": "6.5.2",

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react-lite'
 import ReactPropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 
+import { withSize } from 'react-sizeme'
 import Drawer from './Drawer'
 
 const styles = theme => ({
@@ -63,6 +64,7 @@ function App(props) {
   const {
     classes,
     session,
+    size,
     sessionNames,
     addSessionSnapshot,
     activateSession,
@@ -71,8 +73,8 @@ function App(props) {
   const { pluginManager } = session
 
   useEffect(() => {
-    session.updateWidth(window.innerWidth)
-  }, [session])
+    session.updateWidth(size.width)
+  }, [session, size.width])
 
   const { visibleDrawerWidget } = session
   let drawerComponent
@@ -209,4 +211,4 @@ App.propTypes = {
   activateSession: ReactPropTypes.func.isRequired,
 }
 
-export default withStyles(styles)(observer(App))
+export default withSize()(withStyles(styles)(observer(App)))

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -25,15 +25,9 @@ const styles = theme => ({
   },
   root: {
     height: '100vh',
-    display: 'flex',
-    overflow: 'hidden',
     background: '#808080',
   },
   menuBars: {},
-  menuBarsAndComponents: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
   components: {},
   drawerCloseButton: {
     float: 'right',
@@ -129,7 +123,7 @@ function App(props) {
 
   return (
     <div className={classes.root}>
-      <div className={classes.menuBarsAndComponents}>
+      <div>
         <div className={classes.menuBars}>
           {session.menuBars.map(menuBar => {
             const { LazyReactComponent } = pluginManager.getMenuBarType(
@@ -149,47 +143,42 @@ function App(props) {
             )
           })}
         </div>
-        <Scrollbars
-          className={classes.components}
-          style={{ width: session.width }}
-        >
-          {session.views.map(view => {
-            const { ReactComponent } = pluginManager.getViewType(view.type)
-            return (
-              <ReactComponent
-                key={`view-${view.id}`}
-                model={view}
-                session={session}
-                getTrackType={pluginManager.getTrackType}
-              />
-            )
-          })}
-          <div className={classes.developer}>
-            <h3>Developer tools</h3>
-            <button
-              type="button"
-              onClick={() => {
-                if (!session.datasets.length)
-                  throw new Error(`Must add a dataset before adding a view`)
-                session.addLinearGenomeViewOfDataset(
-                  readConfObject(session.datasets[0], 'name'),
-                )
-              }}
-            >
-              Add linear view
-            </button>
-            <select
-              onChange={event => activateSession(event.target.value)}
-              value={session.name}
-            >
-              {sessionNames.map(name => (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              ))}
-            </select>
-          </div>
-        </Scrollbars>
+        {session.views.map(view => {
+          const { ReactComponent } = pluginManager.getViewType(view.type)
+          return (
+            <ReactComponent
+              key={`view-${view.id}`}
+              model={view}
+              session={session}
+              getTrackType={pluginManager.getTrackType}
+            />
+          )
+        })}
+        <div className={classes.developer}>
+          <h3>Developer tools</h3>
+          <button
+            type="button"
+            onClick={() => {
+              if (!session.datasets.length)
+                throw new Error(`Must add a dataset before adding a view`)
+              session.addLinearGenomeViewOfDataset(
+                readConfObject(session.datasets[0], 'name'),
+              )
+            }}
+          >
+            Add linear view
+          </button>
+          <select
+            onChange={event => activateSession(event.target.value)}
+            value={session.name}
+          >
+            {sessionNames.map(name => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
       <Drawer
         session={session}

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -39,6 +39,7 @@ const styles = theme => ({
   components: {
     display: 'block',
     overflowY: 'auto',
+    height: '100%',
   },
   drawerCloseButton: {
     float: 'right',

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -24,10 +24,18 @@ const styles = theme => ({
   },
   root: {
     height: '100vh',
+    display: 'flex',
+    overflow: 'hidden',
     background: '#808080',
   },
   menuBars: {},
-  components: {},
+  menuBarsAndComponents: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  components: {
+    overflowY: 'auto',
+  },
   drawerCloseButton: {
     float: 'right',
   },
@@ -122,7 +130,7 @@ function App(props) {
 
   return (
     <div className={classes.root}>
-      <div>
+      <div className={classes.menuBarsAndComponents}>
         <div className={classes.menuBars}>
           {session.menuBars.map(menuBar => {
             const { LazyReactComponent } = pluginManager.getMenuBarType(
@@ -142,41 +150,43 @@ function App(props) {
             )
           })}
         </div>
-        {session.views.map(view => {
-          const { ReactComponent } = pluginManager.getViewType(view.type)
-          return (
-            <ReactComponent
-              key={`view-${view.id}`}
-              model={view}
-              session={session}
-              getTrackType={pluginManager.getTrackType}
-            />
-          )
-        })}
-        <div className={classes.developer}>
-          <h3>Developer tools</h3>
-          <button
-            type="button"
-            onClick={() => {
-              if (!session.datasets.length)
-                throw new Error(`Must add a dataset before adding a view`)
-              session.addLinearGenomeViewOfDataset(
-                readConfObject(session.datasets[0], 'name'),
-              )
-            }}
-          >
-            Add linear view
-          </button>
-          <select
-            onChange={event => activateSession(event.target.value)}
-            value={session.name}
-          >
-            {sessionNames.map(name => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </select>
+        <div className={classes.components}>
+          {session.views.map(view => {
+            const { ReactComponent } = pluginManager.getViewType(view.type)
+            return (
+              <ReactComponent
+                key={`view-${view.id}`}
+                model={view}
+                session={session}
+                getTrackType={pluginManager.getTrackType}
+              />
+            )
+          })}
+          <div className={classes.developer}>
+            <h3>Developer tools</h3>
+            <button
+              type="button"
+              onClick={() => {
+                if (!session.datasets.length)
+                  throw new Error(`Must add a dataset before adding a view`)
+                session.addLinearGenomeViewOfDataset(
+                  readConfObject(session.datasets[0], 'name'),
+                )
+              }}
+            >
+              Add linear view
+            </button>
+            <select
+              onChange={event => activateSession(event.target.value)}
+              value={session.name}
+            >
+              {sessionNames.map(name => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
       <Drawer

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -13,7 +13,6 @@ import { observer } from 'mobx-react-lite'
 import ReactPropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { withSize } from 'react-sizeme'
-import { Scrollbars } from 'react-custom-scrollbars'
 
 import Drawer from './Drawer'
 

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -12,7 +12,6 @@ import { PropTypes } from 'mobx-react'
 import { observer } from 'mobx-react-lite'
 import ReactPropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { withSize } from 'react-sizeme'
 
 import Drawer from './Drawer'
 
@@ -28,19 +27,21 @@ const styles = theme => ({
     overflow: 'hidden',
     background: '#808080',
   },
-  menuBars: {},
+  menuBars: {
+    display: 'block',
+  },
   menuBarsAndComponents: {
-    display: 'flex',
-    flexDirection: 'column',
+    flex: '1 100%',
+  },
+  defaultDrawer: {
+    flex: '1 100%',
   },
   components: {
+    display: 'block',
     overflowY: 'auto',
   },
   drawerCloseButton: {
     float: 'right',
-  },
-  defaultDrawer: {
-    margin: theme.spacing(1),
   },
   drawerToolbar: {
     paddingLeft: theme.spacing(2),
@@ -60,7 +61,6 @@ const styles = theme => ({
 function App(props) {
   const {
     classes,
-    size,
     session,
     sessionNames,
     addSessionSnapshot,
@@ -70,8 +70,8 @@ function App(props) {
   const { pluginManager } = session
 
   useEffect(() => {
-    session.updateWidth(size.width)
-  }, [session, size])
+    session.updateWidth(window.innerWidth)
+  }, [session])
 
   const { visibleDrawerWidget } = session
   let drawerComponent
@@ -83,7 +83,7 @@ function App(props) {
     } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
     drawerComponent = (
       <Slide direction="left" in>
-        <div>
+        <div className={classes.defaultDrawer}>
           <AppBar position="static">
             <Toolbar
               variant="dense"
@@ -208,4 +208,4 @@ App.propTypes = {
   activateSession: ReactPropTypes.func.isRequired,
 }
 
-export default withSize()(withStyles(styles)(observer(App)))
+export default withStyles(styles)(observer(App))

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -33,14 +33,14 @@ const styles = theme => ({
   },
   menuBarsAndComponents: {
     flex: '1 100%',
+    height: '100%',
+    overflowY: 'auto',
   },
   defaultDrawer: {
     flex: '1 100%',
   },
   components: {
     display: 'block',
-    overflowY: 'auto',
-    height: '100%',
   },
   drawerCloseButton: {
     float: 'right',
@@ -56,7 +56,7 @@ const styles = theme => ({
   },
   developer: {
     background: 'white',
-    padding: '0 10px 10px 10px',
+    display: 'block',
   },
 })
 

--- a/packages/jbrowse-web/src/ui/Drawer.js
+++ b/packages/jbrowse-web/src/ui/Drawer.js
@@ -48,7 +48,7 @@ class Drawer extends React.Component {
     return (
       <Slide in={open} direction="left" appear={this.mounted}>
         <Paper
-          style={{ width: session.drawerWidth }}
+          style={{ width: open ? session.drawerWidth : 0 }}
           className={classes.paper}
           elevation={16}
           square

--- a/packages/jbrowse-web/src/ui/Drawer.js
+++ b/packages/jbrowse-web/src/ui/Drawer.js
@@ -14,7 +14,6 @@ const styles = theme => ({
     height: '100%',
     flex: '1 0 auto',
     zIndex: theme.zIndex.drawer,
-    position: 'fixed',
     top: 0,
     outline: 'none',
     left: 'auto',

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -54,15 +54,7 @@ function LinearGenomeView(props) {
   const scaleBarHeight = 32
   const { classes, model } = props
   const session = getSession(model)
-  const {
-    id,
-    staticBlocks,
-    tracks,
-    bpPerPx,
-    width,
-    controlsWidth,
-    offsetPx,
-  } = model
+  const { id, staticBlocks, tracks, bpPerPx, controlsWidth, offsetPx } = model
   /*
    * NOTE: offsetPx is the total offset in px of the viewing window into the
    * whole set of concatenated regions. this number is often quite large.
@@ -71,8 +63,6 @@ function LinearGenomeView(props) {
     scaleBarHeight + tracks.reduce((a, b) => a + b.height + dragHandleHeight, 0)
   const style = {
     display: 'grid',
-    width: `${width}px`,
-    height: `${height}px`,
     position: 'relative',
     gridTemplateRows: `[scale-bar] auto ${tracks
       .map(
@@ -139,7 +129,6 @@ function LinearGenomeView(props) {
             blocks={staticBlocks}
             offsetPx={offsetPx}
             horizontallyFlipped={model.horizontallyFlipped}
-            width={model.viewingRegionWidth}
           />
         </Rubberband>
 
@@ -168,7 +157,6 @@ function LinearGenomeView(props) {
           <TrackRenderingContainer
             key={`track-rendering:${track.id}`}
             trackId={track.id}
-            width={model.viewingRegionWidth}
             height={track.height}
           >
             <track.RenderingComponent

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.js
@@ -44,12 +44,10 @@ function ScaleBar({
   blocks,
   offsetPx,
   bpPerPx,
-  width,
   horizontallyFlipped,
 }) {
   const finalStyle = Object.assign({}, style, {
     height: `${height}px`,
-    width: `${width}px`,
   })
 
   const blockContainingLeftEndOfView = findBlockContainingLeftSideOfView(
@@ -104,7 +102,6 @@ ScaleBar.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   style: PropTypes.objectOf(PropTypes.any),
   height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
   blocks: PropTypes.shape({
     map: PropTypes.func.isRequired,
     getBlocks: PropTypes.func.isRequired,

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -16,14 +16,13 @@ const styles = {
  * mostly does UI gestures: drag scrolling, etc
  */
 function TrackRenderingContainer(props) {
-  const { trackId, width, height, children, classes } = props
+  const { trackId, height, children, classes } = props
   return (
     <div
       className={classes.trackRenderingContainer}
       style={{
         gridRow: `track-${trackId}`,
         gridColumn: 'blocks',
-        width,
         height,
       }}
       role="presentation"
@@ -35,7 +34,6 @@ function TrackRenderingContainer(props) {
 TrackRenderingContainer.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   trackId: PropTypes.string.isRequired,
-  width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   children: PropTypes.node,
 }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -6,7 +6,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
 >
   <div
     class="LinearGenomeView-linearGenomeView-2"
-    style="display: grid; width: 512px; height: 55px; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
       class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
@@ -61,7 +61,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
     >
       <div
         class="ScaleBar-scaleBar-38"
-        style="height: 32px; width: 412px;"
+        style="height: 32px;"
       />
     </div>
     <div
@@ -194,7 +194,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-foo; grid-column: blocks; width: 412px; height: 20px;"
+      style="grid-row: track-foo; grid-column: blocks; height: 20px;"
     >
       <div
         class="Track-track-106"
@@ -222,7 +222,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
 >
   <div
     class="LinearGenomeView-linearGenomeView-2"
-    style="display: grid; width: 512px; height: 78px; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
       class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
@@ -277,7 +277,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     >
       <div
         class="ScaleBar-scaleBar-38"
-        style="height: 32px; width: 412px;"
+        style="height: 32px;"
       >
         <div
           class="Block-block-111 Block-leftBorder-112 Block-rightBorder-113"
@@ -514,7 +514,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-foo; grid-column: blocks; width: 412px; height: 20px;"
+      style="grid-row: track-foo; grid-column: blocks; height: 20px;"
     >
       <div
         class="Track-track-106"
@@ -601,7 +601,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-bar; grid-column: blocks; width: 412px; height: 20px;"
+      style="grid-row: track-bar; grid-column: blocks; height: 20px;"
     >
       <div
         class="Track-track-106"
@@ -640,7 +640,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
 >
   <div
     class="LinearGenomeView-linearGenomeView-2"
-    style="display: grid; width: 512px; height: 32px; position: relative; grid-template-rows: [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
       class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
@@ -695,7 +695,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
     >
       <div
         class="ScaleBar-scaleBar-38"
-        style="height: 32px; width: 412px;"
+        style="height: 32px;"
       />
     </div>
     <div

--- a/packages/menus/src/MainMenuBar/components/MainMenuBar.js
+++ b/packages/menus/src/MainMenuBar/components/MainMenuBar.js
@@ -37,11 +37,6 @@ function MainMenuBar(props) {
             session={session}
           />
         ))}
-        <div
-          style={{
-            width: session.activeDrawerWidgets.size ? session.drawerWidth : 0,
-          }}
-        />
       </Toolbar>
     </AppBar>
   )

--- a/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
+++ b/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
@@ -42,9 +42,6 @@ exports[`<MainMenuBar /> renders 1`] = `
         />
       </button>
     </div>
-    <div
-      style="width: 0px;"
-    />
   </div>
 </header>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,11 +2877,6 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.0.5, acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-add-px-to-style@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/add-px-to-style/-/add-px-to-style-1.0.0.tgz#d0c135441fa8014a8137904531096f67f28f263a"
-  integrity sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo=
-
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -5508,15 +5503,6 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-css@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/dom-css/-/dom-css-2.1.0.tgz#fdbc2d5a015d0a3e1872e11472bbd0e7b9e6a202"
-  integrity sha1-/bwtWgFdCj4YcuEUcrvQ57nmogI=
-  dependencies:
-    add-px-to-style "1.0.0"
-    prefix-style "2.0.1"
-    to-camel-case "1.0.0"
 
 dom-helpers@^3.4.0:
   version "3.4.0"
@@ -11726,11 +11712,6 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.5,
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prefix-style@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/prefix-style/-/prefix-style-2.0.1.tgz#66bba9a870cfda308a5dc20e85e9120932c95a06"
-  integrity sha1-ZrupqHDP2jCKXcIOhekSCTLJWgY=
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -12021,7 +12002,7 @@ quick-lru@^4.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.0.tgz#a44d44010a776d787af65b1226566dd1ae7b9649"
   integrity sha512-5cS39FEMrySKt/8c66v10HrmoexP2iYOsJBhtbVrlAr6Cbuc6khFMN8CHJG87c+QsdxBABivfVscgk20I/rPDw==
 
-raf@3.4.1, raf@^3.1.0, raf@^3.4.1:
+raf@3.4.1, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -12103,15 +12084,6 @@ react-color@^2.17.3:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
-
-react-custom-scrollbars@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"
-  integrity sha1-gw/ZUCkn6X6KeMIIaBOJmyqLZts=
-  dependencies:
-    dom-css "^2.0.0"
-    prop-types "^15.5.10"
-    raf "^3.1.0"
 
 react-d3-axis@^0.1.2:
   version "0.1.2"
@@ -14154,22 +14126,10 @@ to-arraybuffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
-to-camel-case@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/to-camel-case/-/to-camel-case-1.0.0.tgz#1a56054b2f9d696298ce66a60897322b6f423e46"
-  integrity sha1-GlYFSy+daWKYzmamCJcyK29CPkY=
-  dependencies:
-    to-space-case "^1.0.0"
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
-
-to-no-case@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/to-no-case/-/to-no-case-1.0.2.tgz#c722907164ef6b178132c8e69930212d1b4aa16a"
-  integrity sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -14195,13 +14155,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-to-space-case@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/to-space-case/-/to-space-case-1.0.0.tgz#b052daafb1b2b29dc770cea0163e5ec0ebc9fc17"
-  integrity sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=
-  dependencies:
-    to-no-case "^1.0.0"
 
 to-through@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This proposes to remove the fake scrolling that existed in jbrowse-web

The react-custom-scrollbars is removed along with the flexbox containment

This gives an outer scrollbar addressing concerns of #299  (note, it is outer, to the right of the drawer widget)

If there is a strong reason to keep everything in a container then maybe this will not pass but I think that using the native scroll is basically preferable