### PR TITLE
Wiggle remove scrollbar

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.js
@@ -11,7 +11,7 @@ const styles = {
     textAlign: 'left',
     width: '100%',
     background: '#404040',
-    minHeight: '100%',
+    height: '100%',
   },
   elidedBlock: {
     position: 'absolute',

--- a/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.js
@@ -11,7 +11,7 @@ const styles = {
     textAlign: 'left',
     width: '100%',
     background: '#404040',
-    height: '100%',
+    minHeight: '100%',
   },
   elidedBlock: {
     position: 'absolute',

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -59,8 +59,6 @@ function LinearGenomeView(props) {
    * NOTE: offsetPx is the total offset in px of the viewing window into the
    * whole set of concatenated regions. this number is often quite large.
    */
-  const height =
-    scaleBarHeight + tracks.reduce((a, b) => a + b.height + dragHandleHeight, 0)
   const style = {
     display: 'grid',
     position: 'relative',

--- a/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
+++ b/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
@@ -66,6 +66,7 @@ class WiggleRendering extends Component {
 
   render() {
     const { featureUnderMouse, offsetX } = this.state
+    const { height } = this.props
 
     const toP = s => parseFloat(s.toPrecision(6))
     const getFeatRepr = feature => {
@@ -100,7 +101,7 @@ class WiggleRendering extends Component {
         className="WiggleRendering"
         style={{
           overflow: 'hidden',
-          height: this.props.height,
+          height,
         }}
       >
         <PrerenderedCanvas {...this.props} />

--- a/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
+++ b/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
@@ -98,7 +98,11 @@ class WiggleRendering extends Component {
         role="presentation"
         onFocus={() => {}}
         className="WiggleRendering"
-        style={{ position: 'relative' }}
+        style={{
+          overflow: 'hidden',
+          height: this.props.height,
+          position: 'relative',
+        }}
       >
         <PrerenderedCanvas {...this.props} />
         {featureUnderMouse ? getMouseoverFlag(featureUnderMouse) : null}

--- a/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
+++ b/packages/wiggle/src/DensityRenderer/components/WiggleRendering.js
@@ -101,7 +101,6 @@ class WiggleRendering extends Component {
         style={{
           overflow: 'hidden',
           height: this.props.height,
-          position: 'relative',
         }}
       >
         <PrerenderedCanvas {...this.props} />

--- a/packages/wiggle/src/DensityRenderer/components/__snapshots__/WiggleRendering.test.js.snap
+++ b/packages/wiggle/src/DensityRenderer/components/__snapshots__/WiggleRendering.test.js.snap
@@ -4,7 +4,7 @@ exports[`one 1`] = `
 <div
   class="WiggleRendering"
   role="presentation"
-  style="position: relative;"
+  style="overflow: hidden; height: 500px; position: relative;"
 >
   <canvas
     data-testid="prerendered_canvas"

--- a/packages/wiggle/src/DensityRenderer/components/__snapshots__/WiggleRendering.test.js.snap
+++ b/packages/wiggle/src/DensityRenderer/components/__snapshots__/WiggleRendering.test.js.snap
@@ -4,7 +4,7 @@ exports[`one 1`] = `
 <div
   class="WiggleRendering"
   role="presentation"
-  style="overflow: hidden; height: 500px; position: relative;"
+  style="overflow: hidden; height: 500px;"
 >
   <canvas
     data-testid="prerendered_canvas"

--- a/packages/wiggle/src/WiggleTrack/components/WiggleTrackComponent.js
+++ b/packages/wiggle/src/WiggleTrack/components/WiggleTrackComponent.js
@@ -32,26 +32,22 @@ function WiggleTrackComponent(props) {
         ? axisProps.values.filter(s => powersOfTen.includes(s))
         : axisProps.values
     return (
-      <div
+      <svg
         style={{
           position: 'absolute',
           top: 0,
           left: 300,
-          pointerEvents: 'none',
-          zIndex: 100,
           width: 35,
-          height,
+          height: '100%',
         }}
       >
-        <svg style={{ height }}>
-          <Axis
-            {...axisProps}
-            values={values}
-            format={n => n}
-            style={{ orient: RIGHT }}
-          />
-        </svg>
-      </div>
+        <Axis
+          {...axisProps}
+          values={values}
+          format={n => n}
+          style={{ orient: RIGHT }}
+        />
+      </svg>
     )
   }
 

--- a/packages/wiggle/src/WiggleTrack/components/WiggleTrackComponent.js
+++ b/packages/wiggle/src/WiggleTrack/components/WiggleTrackComponent.js
@@ -37,7 +37,7 @@ function WiggleTrackComponent(props) {
           position: 'absolute',
           top: 0,
           left: 300,
-          width: 35,
+          pointerEvents: 'none',
           height: '100%',
         }}
       >


### PR DESCRIPTION
This proposes a fix for #347 

It requires changing some CSS at two locations (the WiggleRendering div and removing the wrapper div around the SVG)

I don't fully *get it* but this seems to work and is at least a fairly minimal change set