### PR TITLE
Fix vertical scrolling

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/components/Track.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/Track.js
@@ -54,7 +54,6 @@ class Track extends Component {
 
   wheel(event) {
     const { onHorizontalScroll, onVerticalScroll } = this.props
-    const delta = { x: 0, y: 0 }
     onHorizontalScroll(event.deltaX)
     onVerticalScroll(event.deltaY)
     event.preventDefault()

--- a/packages/linear-genome-view/src/BasicTrack/components/Track.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/Track.js
@@ -24,6 +24,7 @@ class Track extends Component {
     trackId: PropTypes.string.isRequired,
     children: PropTypes.node,
     onHorizontalScroll: PropTypes.func.isRequired,
+    onVerticalScroll: PropTypes.func.isRequired,
   }
 
   static defaultProps = { children: null }
@@ -52,21 +53,11 @@ class Track extends Component {
   }
 
   wheel(event) {
-    const { onHorizontalScroll } = this.props
+    const { onHorizontalScroll, onVerticalScroll } = this.props
     const delta = { x: 0, y: 0 }
-    delta.x =
-      Math.abs(event.deltaY) > Math.abs(2 * event.deltaX)
-        ? 0
-        : -event.deltaX * (1 + event.deltaMode * 50)
-    delta.y = event.deltaY * -10
-
-    delta.x = Math.round(delta.x)
-    delta.y = Math.round(delta.y)
-
-    if (delta.x) {
-      onHorizontalScroll(-delta.x)
-      event.preventDefault()
-    }
+    onHorizontalScroll(event.deltaX)
+    onVerticalScroll(event.deltaY)
+    event.preventDefault()
   }
 
   mouseMove(event) {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -50,9 +50,9 @@ const useStyles = makeStyles(theme => ({
   ...buttonStyles(theme),
 }))
 
-function TrackContainer({ model, track, key }) {
+const TrackContainer = observer(({ model, track }) => {
   const classes = useStyles()
-  const { id, staticBlocks, tracks, bpPerPx, controlsWidth, offsetPx } = model
+  const { bpPerPx, offsetPx } = model
   const [scrollTop, setScrollTop] = useState(0)
   return (
     <>
@@ -81,7 +81,9 @@ function TrackContainer({ model, track, key }) {
           blockState={{}}
           onHorizontalScroll={model.horizontalScroll}
           onVerticalScroll={value =>
-            setScrollTop(Math.min(Math.max(scrollTop + value, 0), track.height))
+            setScrollTop(
+              Math.min(Math.max(scrollTop + value, 0), track.height + 10),
+            )
           }
         />
       </TrackRenderingContainer>
@@ -92,9 +94,10 @@ function TrackContainer({ model, track, key }) {
       />
     </>
   )
-}
+})
 
 TrackContainer.propTypes = {
+  model: PropTypes.objectOrObservableObject.isRequired,
   track: ReactPropTypes.shape({}).isRequired,
 }
 
@@ -189,7 +192,7 @@ function LinearGenomeView(props) {
           <ZoomControls model={model} controlsHeight={scaleBarHeight} />
         </div>
         {tracks.map(track => (
-          <TrackContainer key={track.configId} model={model} track={track} />
+          <TrackContainer key={track.id} model={model} track={track} />
         ))}
       </div>
     </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -1,10 +1,10 @@
-import { Icon, IconButton, withStyles } from '@material-ui/core'
+import { Icon, IconButton, makeStyles } from '@material-ui/core'
 import { getSession } from '@gmod/jbrowse-core/util'
 import ToggleButton from '@material-ui/lab/ToggleButton'
 import classnames from 'classnames'
 import { observer, PropTypes } from 'mobx-react'
 import ReactPropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 
 import ScaleBar from './ScaleBar'
 import Rubberband from './Rubberband'
@@ -17,7 +17,7 @@ import buttonStyles from './buttonStyles'
 
 const dragHandleHeight = 3
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     position: 'relative',
     marginBottom: theme.spacing(1),
@@ -48,13 +48,62 @@ const styles = theme => ({
   },
 
   ...buttonStyles(theme),
-})
+}))
+
+function TrackContainer({ model, track, key }) {
+  const classes = useStyles()
+  const { id, staticBlocks, tracks, bpPerPx, controlsWidth, offsetPx } = model
+  const [scrollTop, setScrollTop] = useState(0)
+  return (
+    <>
+      <div
+        className={classnames(classes.controls, classes.trackControls)}
+        key={`controls:${track.id}`}
+        style={{ gridRow: `track-${track.id}`, gridColumn: 'controls' }}
+      >
+        <track.ControlsComponent
+          track={track}
+          key={track.id}
+          view={model}
+          onConfigureClick={track.activateConfigurationUI}
+        />
+      </div>
+      <TrackRenderingContainer
+        key={`track-rendering:${track.id}`}
+        trackId={track.id}
+        height={track.height}
+        scrollTop={scrollTop}
+      >
+        <track.RenderingComponent
+          model={track}
+          offsetPx={offsetPx}
+          bpPerPx={bpPerPx}
+          blockState={{}}
+          onHorizontalScroll={model.horizontalScroll}
+          onVerticalScroll={value =>
+            setScrollTop(Math.min(Math.max(scrollTop + value, 0), track.height))
+          }
+        />
+      </TrackRenderingContainer>
+      <TrackResizeHandle
+        key={`handle:${track.id}`}
+        trackId={track.id}
+        onVerticalDrag={model.resizeTrack}
+      />
+    </>
+  )
+}
+
+TrackContainer.propTypes = {
+  track: ReactPropTypes.shape({}).isRequired,
+}
 
 function LinearGenomeView(props) {
-  const scaleBarHeight = 32
-  const { classes, model } = props
-  const session = getSession(model)
+  const { model } = props
   const { id, staticBlocks, tracks, bpPerPx, controlsWidth, offsetPx } = model
+  const scaleBarHeight = 32
+  const session = getSession(model)
+  const classes = useStyles()
   /*
    * NOTE: offsetPx is the total offset in px of the viewing window into the
    * whole set of concatenated regions. this number is often quite large.
@@ -139,45 +188,15 @@ function LinearGenomeView(props) {
         >
           <ZoomControls model={model} controlsHeight={scaleBarHeight} />
         </div>
-        {tracks.map(track => [
-          <div
-            className={classnames(classes.controls, classes.trackControls)}
-            key={`controls:${track.id}`}
-            style={{ gridRow: `track-${track.id}`, gridColumn: 'controls' }}
-          >
-            <track.ControlsComponent
-              track={track}
-              key={track.id}
-              view={model}
-              onConfigureClick={track.activateConfigurationUI}
-            />
-          </div>,
-          <TrackRenderingContainer
-            key={`track-rendering:${track.id}`}
-            trackId={track.id}
-            height={track.height}
-          >
-            <track.RenderingComponent
-              model={track}
-              offsetPx={offsetPx}
-              bpPerPx={bpPerPx}
-              blockState={{}}
-              onHorizontalScroll={model.horizontalScroll}
-            />
-          </TrackRenderingContainer>,
-          <TrackResizeHandle
-            key={`handle:${track.id}`}
-            trackId={track.id}
-            onVerticalDrag={model.resizeTrack}
-          />,
-        ])}
+        {tracks.map(track => (
+          <TrackContainer key={track.configId} model={model} track={track} />
+        ))}
       </div>
     </div>
   )
 }
 LinearGenomeView.propTypes = {
-  classes: ReactPropTypes.objectOf(ReactPropTypes.string).isRequired,
   model: PropTypes.objectOrObservableObject.isRequired,
 }
 
-export default withStyles(styles)(observer(LinearGenomeView))
+export default observer(LinearGenomeView)

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React, { useRef } from 'react'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core'
@@ -6,7 +6,6 @@ import { withStyles } from '@material-ui/core'
 const styles = {
   trackRenderingContainer: {
     overflowY: 'auto',
-    overflowX: 'hidden',
     background: '#333',
     whiteSpace: 'nowrap',
   },
@@ -16,14 +15,19 @@ const styles = {
  * mostly does UI gestures: drag scrolling, etc
  */
 function TrackRenderingContainer(props) {
-  const { trackId, height, children, classes } = props
+  const { trackId, heightA, children, classes, scrollTop } = props
+  const nameRef = useRef()
+
+  if (nameRef.current) {
+    nameRef.current.scrollTop = scrollTop
+  }
   return (
     <div
       className={classes.trackRenderingContainer}
+      ref={nameRef}
       style={{
         gridRow: `track-${trackId}`,
         gridColumn: 'blocks',
-        height,
       }}
       role="presentation"
     >
@@ -34,7 +38,6 @@ function TrackRenderingContainer(props) {
 TrackRenderingContainer.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   trackId: PropTypes.string.isRequired,
-  height: PropTypes.number.isRequired,
   children: PropTypes.node,
 }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core'
@@ -6,6 +6,7 @@ import { withStyles } from '@material-ui/core'
 const styles = {
   trackRenderingContainer: {
     overflowY: 'auto',
+    overflowX: 'hidden',
     background: '#333',
     whiteSpace: 'nowrap',
   },
@@ -14,8 +15,12 @@ const styles = {
 /**
  * mostly does UI gestures: drag scrolling, etc
  */
-function TrackRenderingContainer(props) {
-  const { trackId, heightA, children, classes, scrollTop } = props
+function TrackRenderingContainer({
+  trackId,
+  children,
+  classes,
+  scrollTop = 0,
+}) {
   const nameRef = useRef()
 
   if (nameRef.current) {
@@ -36,13 +41,10 @@ function TrackRenderingContainer(props) {
   )
 }
 TrackRenderingContainer.propTypes = {
+  scrollTop: PropTypes.number,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   trackId: PropTypes.string.isRequired,
   children: PropTypes.node,
-}
-
-TrackRenderingContainer.defaultProps = {
-  children: undefined,
 }
 
 export default withStyles(styles)(observer(TrackRenderingContainer))

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`LinearGenomeView genome view component renders one track, no blocks 1`] = `
 <div
-  class="LinearGenomeView-root-1"
+  class="makeStyles-root-1"
 >
   <div
-    class="LinearGenomeView-linearGenomeView-2"
+    class="makeStyles-linearGenomeView-2"
     style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
       style="grid-row: scale-bar;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root LinearGenomeView-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
         tabindex="0"
         title="close this view"
         type="button"
@@ -33,7 +33,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root LinearGenomeView-toggleButton-8"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
         data_testid="track_select"
         tabindex="0"
         title="select tracks"
@@ -65,7 +65,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       />
     </div>
     <div
-      class="LinearGenomeView-zoomControls-6"
+      class="makeStyles-zoomControls-6"
       style="right: 4px; z-index: 1000;"
     >
       <div
@@ -137,7 +137,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       </div>
     </div>
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
@@ -194,7 +194,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-foo; grid-column: blocks; height: 20px;"
+      style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
         class="Track-track-106"
@@ -218,18 +218,18 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
 
 exports[`LinearGenomeView genome view component renders two tracks, two regions 1`] = `
 <div
-  class="LinearGenomeView-root-1"
+  class="makeStyles-root-1"
 >
   <div
-    class="LinearGenomeView-linearGenomeView-2"
+    class="makeStyles-linearGenomeView-2"
     style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
       style="grid-row: scale-bar;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root LinearGenomeView-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
         tabindex="0"
         title="close this view"
         type="button"
@@ -249,7 +249,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root LinearGenomeView-toggleButton-8"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
         data_testid="track_select"
         tabindex="0"
         title="select tracks"
@@ -385,7 +385,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="LinearGenomeView-zoomControls-6"
+      class="makeStyles-zoomControls-6"
       style="right: 4px; z-index: 1000;"
     >
       <div
@@ -457,7 +457,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
@@ -514,7 +514,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-foo; grid-column: blocks; height: 20px;"
+      style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
         class="Track-track-106"
@@ -544,7 +544,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: resize-foo; grid-column: span 2;"
     />
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-trackControls-5"
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
       style="grid-row: track-bar; grid-column: controls;"
     >
       <button
@@ -601,7 +601,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     <div
       class="TrackRenderingContainer-trackRenderingContainer-105"
       role="presentation"
-      style="grid-row: track-bar; grid-column: blocks; height: 20px;"
+      style="grid-row: track-bar; grid-column: blocks;"
     >
       <div
         class="Track-track-106"
@@ -636,18 +636,18 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
 
 exports[`LinearGenomeView genome view component renders with an empty model 1`] = `
 <div
-  class="LinearGenomeView-root-1"
+  class="makeStyles-root-1"
 >
   <div
-    class="LinearGenomeView-linearGenomeView-2"
+    class="makeStyles-linearGenomeView-2"
     style="display: grid; position: relative; grid-template-rows: [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="LinearGenomeView-controls-3 LinearGenomeView-viewControls-4"
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
       style="grid-row: scale-bar;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root LinearGenomeView-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
         tabindex="0"
         title="close this view"
         type="button"
@@ -667,7 +667,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root LinearGenomeView-toggleButton-8"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
         data_testid="track_select"
         tabindex="0"
         title="select tracks"
@@ -699,7 +699,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       />
     </div>
     <div
-      class="LinearGenomeView-zoomControls-6"
+      class="makeStyles-zoomControls-6"
       style="right: 4px; z-index: 1000;"
     >
       <div


### PR DESCRIPTION
This makes it so that scroll events are always get event.preventDefault()'d but they get propagated "appropriately" via callback props. The track rendering container handles the vertical scroll so it is propagated to there. A modularized "TrackContainer" containing current scroll state is extracted from inside the LinearGenomeView

Addresses #437 