### PR TITLE
Fix scrolling the App pane

### DIFF
--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.js
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.js
@@ -183,7 +183,9 @@ class PileupRendering extends Component {
     const { offsetX, offsetY } = event.nativeEvent
     if (!(offsetX >= 0))
       throw new Error(
-        'invalid offsetX, does this browser provide offsetX and offsetY on mouse events?',
+        `invalid offsetX, does this browser provide offsetX and offsetY on mouse events? ${offsetX} ${String(
+          event,
+        )}`,
       )
 
     const { layout, bpPerPx, region, horizontallyFlipped } = this.props

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -144,7 +144,10 @@ function App(props) {
         className={classes.menuBarsAndComponents}
         ref={nameRef}
         onWheel={event => {
-          if (nameRef.current.scrollHeight > nameRef.current.clientHeight) {
+          if (
+            !session.shouldntScroll &&
+            nameRef.current.scrollHeight > nameRef.current.clientHeight
+          ) {
             setScrollTop(
               clamp(
                 scrollTop + event.deltaY,

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -144,8 +144,7 @@ function App(props) {
         className={classes.menuBarsAndComponents}
         ref={nameRef}
         onWheel={event => {
-          const max = nameRef.current.scrollHeight
-          if (max > nameRef.current.clientHeight) {
+          if (nameRef.current.scrollHeight > nameRef.current.clientHeight) {
             setScrollTop(
               clamp(
                 scrollTop + event.deltaY,

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -11,7 +11,8 @@ import Typography from '@material-ui/core/Typography'
 import { PropTypes } from 'mobx-react'
 import { observer } from 'mobx-react-lite'
 import ReactPropTypes from 'prop-types'
-import React, { useEffect } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
+import { clamp } from '@gmod/jbrowse-core/util'
 
 import { withSize } from 'react-sizeme'
 import Drawer from './Drawer'
@@ -71,6 +72,7 @@ function App(props) {
   } = props
 
   const { pluginManager } = session
+  const [scrollTop, setScrollTop] = useState(0)
 
   useEffect(() => {
     session.updateWidth(size.width)
@@ -130,10 +132,30 @@ function App(props) {
       </Slide>
     )
   }
+  const nameRef = useRef()
+
+  if (nameRef.current) {
+    nameRef.current.scrollTop = scrollTop
+  }
 
   return (
     <div className={classes.root}>
-      <div className={classes.menuBarsAndComponents}>
+      <div
+        className={classes.menuBarsAndComponents}
+        ref={nameRef}
+        onWheel={event => {
+          const max = nameRef.current.scrollHeight
+          if (max > nameRef.current.clientHeight) {
+            setScrollTop(
+              clamp(
+                scrollTop + event.deltaY,
+                0,
+                nameRef.current.scrollHeight - nameRef.current.clientHeight,
+              ),
+            )
+          }
+        }}
+      >
         <div className={classes.menuBars}>
           {session.menuBars.map(menuBar => {
             const { LazyReactComponent } = pluginManager.getMenuBarType(

--- a/packages/linear-genome-view/src/BasicTrack/components/Track.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/Track.js
@@ -24,7 +24,6 @@ class Track extends Component {
     trackId: PropTypes.string.isRequired,
     children: PropTypes.node,
     onHorizontalScroll: PropTypes.func.isRequired,
-    onVerticalScroll: PropTypes.func.isRequired,
   }
 
   static defaultProps = { children: null }
@@ -38,25 +37,10 @@ class Track extends Component {
     this.mouseDown = this.mouseDown.bind(this)
     this.mouseMove = this.mouseMove.bind(this)
     this.mouseLeave = this.mouseLeave.bind(this)
-    this.wheel = this.wheel.bind(this)
-  }
-
-  componentDidMount() {
-    if (this.mainNode.current)
-      this.mainNode.current.addEventListener('wheel', this.wheel, {
-        passive: false,
-      })
   }
 
   mouseDown(event) {
     this.setState({ mouseDragging: true, previousMouseX: event.clientX })
-  }
-
-  wheel(event) {
-    const { onHorizontalScroll, onVerticalScroll } = this.props
-    onHorizontalScroll(event.deltaX)
-    onVerticalScroll(event.deltaY)
-    event.preventDefault()
   }
 
   mouseMove(event) {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -1,5 +1,5 @@
 import { Icon, IconButton, makeStyles } from '@material-ui/core'
-import { getSession } from '@gmod/jbrowse-core/util'
+import { clamp, getSession } from '@gmod/jbrowse-core/util'
 import ToggleButton from '@material-ui/lab/ToggleButton'
 import classnames from 'classnames'
 import { observer, PropTypes } from 'mobx-react'
@@ -54,6 +54,7 @@ const TrackContainer = observer(({ model, track }) => {
   const classes = useStyles()
   const { bpPerPx, offsetPx } = model
   const [scrollTop, setScrollTop] = useState(0)
+  const session = getSession(model)
   return (
     <>
       <div
@@ -75,9 +76,13 @@ const TrackContainer = observer(({ model, track }) => {
         scrollTop={scrollTop}
         onHorizontalScroll={model.horizontalScroll}
         onVerticalScroll={value => {
-          setScrollTop(
-            Math.min(Math.max(scrollTop + value, 0), track.height + 10),
-          )
+          const n = scrollTop + value
+          if (n > 0 && n < track.height + 10) {
+            session.shouldntScroll = true
+            setScrollTop(clamp(n, 0, track.height + 10))
+          } else {
+            session.shouldntScroll = false
+          }
         }}
       >
         <track.RenderingComponent

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -73,6 +73,12 @@ const TrackContainer = observer(({ model, track }) => {
         trackId={track.id}
         height={track.height}
         scrollTop={scrollTop}
+        onHorizontalScroll={model.horizontalScroll}
+        onVerticalScroll={value => {
+          setScrollTop(
+            Math.min(Math.max(scrollTop + value, 0), track.height + 10),
+          )
+        }}
       >
         <track.RenderingComponent
           model={track}
@@ -80,11 +86,6 @@ const TrackContainer = observer(({ model, track }) => {
           bpPerPx={bpPerPx}
           blockState={{}}
           onHorizontalScroll={model.horizontalScroll}
-          onVerticalScroll={value =>
-            setScrollTop(
-              Math.min(Math.max(scrollTop + value, 0), track.height + 10),
-            )
-          }
         />
       </TrackRenderingContainer>
       <TrackResizeHandle

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -32,7 +32,8 @@ class TrackRenderingContainer extends Component {
 
   wheel(event) {
     const { onHorizontalScroll, onVerticalScroll } = this.props
-    onVerticalScroll(event.deltaY)
+    if (this.mainNode.current.scrollHeight > this.mainNode.current.clientHeight)
+      onVerticalScroll(event.deltaY)
     onHorizontalScroll(event.deltaX)
     event.preventDefault()
   }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/require-default-props */
-import React, { useRef } from 'react'
+import React, { Component } from 'react'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core'
@@ -16,36 +16,56 @@ const styles = {
 /**
  * mostly does UI gestures: drag scrolling, etc
  */
-function TrackRenderingContainer({
-  trackId,
-  children,
-  classes,
-  scrollTop = 0,
-}) {
-  const nameRef = useRef()
-
-  if (nameRef.current) {
-    nameRef.current.scrollTop = scrollTop
+class TrackRenderingContainer extends Component {
+  constructor(props) {
+    super(props)
+    this.mainNode = React.createRef()
+    this.wheel = this.wheel.bind(this)
   }
-  return (
-    <div
-      className={classes.trackRenderingContainer}
-      ref={nameRef}
-      style={{
-        gridRow: `track-${trackId}`,
-        gridColumn: 'blocks',
-      }}
-      role="presentation"
-    >
-      {children}
-    </div>
-  )
-}
-TrackRenderingContainer.propTypes = {
-  scrollTop: PropTypes.number,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-  trackId: PropTypes.string.isRequired,
-  children: PropTypes.node,
+
+  componentDidMount() {
+    if (this.mainNode.current)
+      this.mainNode.current.addEventListener('wheel', this.wheel, {
+        passive: false,
+      })
+  }
+
+  wheel(event) {
+    const { onHorizontalScroll, onVerticalScroll } = this.props
+    onVerticalScroll(event.deltaY)
+    onHorizontalScroll(event.deltaX)
+    event.preventDefault()
+  }
+
+  render() {
+    const { trackId, children, classes, scrollTop = 0 } = this.props
+
+    if (this.mainNode.current) {
+      this.mainNode.current.scrollTop = scrollTop
+    }
+    return (
+      <div
+        className={classes.trackRenderingContainer}
+        ref={this.mainNode}
+        style={{
+          gridRow: `track-${trackId}`,
+          gridColumn: 'blocks',
+        }}
+        role="presentation"
+      >
+        {children}
+      </div>
+    )
+  }
+
+  static propTypes = {
+    scrollTop: PropTypes.number,
+    classes: PropTypes.objectOf(PropTypes.string).isRequired,
+    trackId: PropTypes.string.isRequired,
+    children: PropTypes.node,
+    onHorizontalScroll: PropTypes.func.isRequired,
+    onVerticalScroll: PropTypes.func.isRequired,
+  }
 }
 
 export default withStyles(styles)(observer(TrackRenderingContainer))


### PR DESCRIPTION
This addresses #440 

Some app notes:

The preventDefault at the lower level appears to prevent scrolling at all levels

You can see this in a basic html script like this where scrolling in the inner div, which preventDefault's the wheel event, makes it so the outer one does not scroll (I think this is basically equivalent circumstances

```
<html>
	<body>
		<div id="out" style="background:green;width:200px;height:200px;padding:10px;overflow:auto">
			<div id="in" style="background:red;width:100px;height:500px;padding:10px;">
			</div>
		</div>
		<script>

		document.getElementById('out').addEventListener('wheel', function(event) {
			console.log('outer')
		}, {passive:false})

		document.getElementById('in').addEventListener('wheel', function(event) {
			console.log('in')
			event.preventDefault()
		},{passive:false})

		</script>
	</body>
</html>
```

The unfortunate aspect of this is that we have to manually scroll both the track and the app vertically. 

Note: most of the problems here can be sort of seen as coming back to this idea that the TrackRenderingContainer is horizontally scrollable but it just has overflowX: 'hidden'. It is difficult to disable scrolling without preventDefault but when that happens all vertical scrolling stops. 

This also addresses an unaddressed problem of #439 which was that if you did scrolling outside the track e.g. in the blank areas before or after a chromosome it could trigger horizontal scrolls that caused #437 so I moved the wheel listener to TrackRenderingContainer