### PR TITLE
LGV header

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -123,15 +123,12 @@ export function parseLocString(
   let refName
   let assemblyName
   let rest
-  if (ret.length == 3) {
-    assemblyName = ret[0]
-    refName = ret[1]
-    rest = ret[2]
-  } else if (ret.length == 2) {
-    refName = ret[0]
-    rest = ret[1]
-  } else if (ret.length == 1) {
-    rest = ret[0]
+  if (ret.length === 3) {
+    ;[assemblyName, refName, rest] = ret
+  } else if (ret.length === 2) {
+    ;[refName, rest] = ret
+  } else if (ret.length === 1) {
+    ;[rest] = ret
   }
   if (rest) {
     const [start, end] = rest.split('..')

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -128,7 +128,7 @@ export function parseLocString(
   } else if (ret.length === 2) {
     ;[refName, rest] = ret
   } else if (ret.length === 1) {
-    ;[rest] = ret
+    ;[refName] = ret
   }
   if (rest) {
     const [start, end] = rest.split('..')

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -176,6 +176,20 @@ export function iterMap<T, U>(
   return results
 }
 
+export function generateLocString(
+  r: {
+    refName: string
+    start: number
+    end: number
+  },
+  tied: boolean,
+): string {
+  if (tied) {
+    return r.refName
+  }
+  return `${r.refName}:${r.start}..${r.end}`
+}
+
 /**
  * properly check if the given AbortSignal is aborted.
  * per the standard, if the signal reads as aborted,

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -111,6 +111,40 @@ export function assembleLocString(region: IRegion | INoAssemblyRegion): string {
   return `${refName}:${start + 1}-${end}`
 }
 
+export function parseLocString(
+  locstring: string,
+): {
+  assemblyName?: string
+  refName?: string
+  start?: number
+  end?: number
+} {
+  const ret = locstring.split(':')
+  let refName
+  let assemblyName
+  let rest
+  if (ret.length == 3) {
+    assemblyName = ret[0]
+    refName = ret[1]
+    rest = ret[2]
+  } else if (ret.length == 2) {
+    refName = ret[0]
+    rest = ret[1]
+  } else if (ret.length == 1) {
+    rest = ret[0]
+  }
+  if (rest) {
+    const [start, end] = rest.split('..')
+    if (start !== undefined && end !== undefined) {
+      return { assemblyName, refName, start: +start, end: +end }
+    }
+    if (start !== undefined) {
+      return { assemblyName, refName, start: +start }
+    }
+  }
+  return { assemblyName, refName }
+}
+
 /**
  * Ensure that a number is at least min and at most max.
  *
@@ -177,17 +211,18 @@ export function iterMap<T, U>(
 }
 
 export function generateLocString(
-  r: {
-    refName: string
-    start: number
-    end: number
-  },
+  r: IRegion,
   tied: boolean,
+  includeAssemblyName: boolean,
 ): string {
   if (tied) {
     return r.refName
   }
-  return `${r.refName}:${r.start}..${r.end}`
+  let s = ''
+  if (includeAssemblyName && r.assemblyName) {
+    s = `${r.assemblyName}:`
+  }
+  return `${s}${r.refName}:${r.start}..${r.end}`
 }
 
 /**

--- a/packages/jbrowse-web/public/test_data/config_intergration_test_displayed_region_list.json
+++ b/packages/jbrowse-web/public/test_data/config_intergration_test_displayed_region_list.json
@@ -1,0 +1,1292 @@
+{
+  "datasets": [
+    {
+      "configId": "C1c60gOB4",
+      "name": "volvox",
+      "assembly": {
+        "configId": "8oWn_kpVRo",
+        "name": "volvox",
+        "aliases": [
+          "vvx"
+        ],
+        "sequence": {
+          "configId": "volvox_refseq_track",
+          "type": "ReferenceSequenceTrack",
+          "adapter": {
+            "configId": "Rzzq0j7cBQ",
+            "type": "TwoBitAdapter",
+            "twoBitLocation": {
+              "uri": "/test_data/volvox.2bit"
+            }
+          },
+          "rendering": {
+            "configId": "bD6rgA1_Ww",
+            "type": "DivSequenceRenderer"
+          }
+        },
+        "refNameAliases": {
+          "configId": "5rcBDyVD6r",
+          "adapter": {
+            "configId": "Pvc34PLyvv",
+            "type": "FromConfigAdapter",
+            "features": [
+              {
+                "refName": "ctgA",
+                "uniqueId": "alias1",
+                "aliases": [
+                  "A",
+                  "contigA"
+                ]
+              },
+              {
+                "refName": "ctgB",
+                "uniqueId": "alias2",
+                "aliases": [
+                  "B",
+                  "contigB"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "tracks": [
+        {
+          "configId": "FDN0zpD_B6",
+          "type": "DynamicTrack",
+          "name": "Lollipop track",
+          "category": [
+            "Miscellaneous"
+          ],
+          "adapter": {
+            "configId": "KdPxlEm9QN",
+            "type": "FromConfigAdapter",
+            "features": [
+              {
+                "uniqueId": "one",
+                "refName": "ctgA",
+                "start": 190,
+                "end": 191,
+                "type": "foo",
+                "score": 200,
+                "name": "Boris"
+              },
+              {
+                "uniqueId": "two",
+                "refName": "ctgA",
+                "start": 191,
+                "end": 192,
+                "type": "bar",
+                "score": 20,
+                "name": "Theresa"
+              },
+              {
+                "uniqueId": "three",
+                "refName": "ctgA",
+                "start": 210,
+                "end": 211,
+                "type": "baz",
+                "score": 300,
+                "name": "Nigel"
+              },
+              {
+                "uniqueId": "four",
+                "refName": "ctgA",
+                "start": 220,
+                "end": 221,
+                "score": 2,
+                "type": "quux",
+                "name": "Geoffray"
+              }
+            ]
+          },
+          "renderer": {
+            "configId": "qNOcBblcYe",
+            "type": "LollipopRenderer"
+          }
+        },
+        {
+          "configId": "OOv_Iwf5no",
+          "type": "AlignmentsTrack",
+          "name": "volvox-long reads",
+          "category": [
+            "Alignments"
+          ],
+          "adapter": {
+            "configId": "_m5epcAGu6",
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "/test_data/volvox-long-reads.fastq.sorted.bam"
+            },
+            "index": {
+              "configId": "-bETsJYDd9",
+              "location": {
+                "uri": "/test_data/volvox-long-reads.fastq.sorted.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "cfV-sEuwTS",
+            "PileupRenderer": {
+              "configId": "Syc-_K0qM5",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "Ain_GttdTR",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "JbwBsHdbnP"
+              }
+            }
+          }
+        },
+        {
+          "configId": "volvox_bam",
+          "type": "AlignmentsTrack",
+          "name": "volvox-sorted red/blue",
+          "category": [
+            "Alignments"
+          ],
+          "adapter": {
+            "configId": "PphRAaR1y4_",
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "/test_data/volvox-sorted.bam"
+            },
+            "index": {
+              "configId": "PB2zR_KB-RN",
+              "location": {
+                "uri": "/test_data/volvox-sorted.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "NGINUnvvMqj",
+            "PileupRenderer": {
+              "configId": "oO78CJInOtk",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "1am8PdZjPfJ",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "cH9mZmuv1Fq"
+              }
+            }
+          }
+        },
+        {
+          "configId": "TBggZ1Rwy_p",
+          "type": "VariantTrack",
+          "name": "volvox filtered vcf",
+          "category": [
+            "Variants"
+          ],
+          "adapter": {
+            "configId": "bzyhJPlur4p",
+            "type": "VcfTabixAdapter",
+            "vcfGzLocation": {
+              "uri": "/test_data/volvox.filtered.vcf.gz"
+            },
+            "index": {
+              "configId": "5c3arnyCBht",
+              "location": {
+                "uri": "/test_data/volvox.filtered.vcf.gz.tbi"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "HtjPFEcXEfe",
+            "PileupRenderer": {
+              "configId": "7T0cius845q",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "Kl-C1CPbPUE",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "egu03dn9JAj"
+              }
+            }
+          }
+        },
+        {
+          "configId": "bigbed_genes",
+          "type": "BasicTrack",
+          "name": "BigBed genes",
+          "category": [
+            "Miscellaneous"
+          ],
+          "adapter": {
+            "configId": "JxEowEEheuJ",
+            "type": "BigBedAdapter",
+            "bigBedLocation": {
+              "uri": "/test_data/volvox.bb"
+            }
+          },
+          "renderer": {
+            "configId": "sJ2wkCzLE0V",
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "configId": "qOXCMCGvVIh"
+            }
+          }
+        },
+        {
+          "configId": "gp2w9yFU-MS",
+          "type": "FilteringTrack",
+          "name": "Filter track",
+          "category": [
+            "Miscellaneous"
+          ],
+          "adapter": {
+            "configId": "BXP519m7XD1",
+            "type": "FromConfigAdapter",
+            "features": [
+              {
+                "uniqueId": "one",
+                "refName": "ctgA",
+                "start": 100,
+                "end": 101,
+                "type": "foo",
+                "name": "Boris",
+                "note": "note for boris"
+              },
+              {
+                "uniqueId": "two",
+                "refName": "ctgA",
+                "start": 110,
+                "end": 111,
+                "type": "bar",
+                "name": "Theresa",
+                "note": "note for theresa"
+              },
+              {
+                "uniqueId": "three",
+                "refName": "ctgA",
+                "start": 120,
+                "end": 121,
+                "type": "baz",
+                "name": "Nigel",
+                "note": "note for nigel"
+              },
+              {
+                "uniqueId": "four",
+                "refName": "ctgA",
+                "start": 130,
+                "end": 131,
+                "type": "quux",
+                "name": "Geoffray",
+                "note": "note for geoffray"
+              }
+            ]
+          },
+          "renderer": {
+            "configId": "rIiWfqGDR2e",
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "configId": "Q2RhRL_R9Uc"
+            }
+          },
+          "filterAttributes": [
+            "type",
+            "start",
+            "end"
+          ]
+        },
+        {
+          "configId": "EA_0Jp4oPKg",
+          "type": "BasicTrack",
+          "name": "NCList genes",
+          "category": [
+            "Miscellaneous"
+          ],
+          "adapter": {
+            "configId": "nm8UCY3U92c",
+            "type": "NCListAdapter",
+            "rootUrlTemplate": "/test_data/volvox_genes_nclist/{refseq}/trackData.json"
+          },
+          "renderer": {
+            "configId": "HuIa2_kFIDY",
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "configId": "qRT9PpIQv0U"
+            }
+          }
+        },
+        {
+          "configId": "LrM3WWJR0tj",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray",
+          "category": [
+            "BigWig",
+            "Line"
+          ],
+          "adapter": {
+            "configId": "DB-sDX31tgH",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray.bw"
+            }
+          },
+          "defaultRendering": "line",
+          "renderers": {
+            "configId": "J6w-gKGWCU6",
+            "DensityRenderer": {
+              "configId": "baW5RG40D_U",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "n8SJdzGDf8y",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "fMLjaOxPONU",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "VUyE25kYsQo",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray",
+          "category": [
+            "BigWig",
+            "Density"
+          ],
+          "adapter": {
+            "configId": "ex8Em3Ozuno",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray.bw"
+            }
+          },
+          "defaultRendering": "density",
+          "renderers": {
+            "configId": "UEDdYEgdKdZ",
+            "DensityRenderer": {
+              "configId": "CbulhYGNzxO",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "qJTOyZsX3Se",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "vAu2hO7WUMq",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "24eGIUSM86l",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray",
+          "category": [
+            "BigWig",
+            "XYPlot"
+          ],
+          "adapter": {
+            "configId": "26uNqVISq5X",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray.bw"
+            }
+          },
+          "renderers": {
+            "configId": "UHh4zfs8_3p",
+            "DensityRenderer": {
+              "configId": "22nXUsvX0lp",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "BBE3UhdC0lY",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "06FZ33dngGC",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "oMVFQozR9NO",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray - negative",
+          "category": [
+            "BigWig",
+            "Density"
+          ],
+          "adapter": {
+            "configId": "M_yb4o2pnJQ",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray_negative.bw"
+            }
+          },
+          "defaultRendering": "density",
+          "renderers": {
+            "configId": "zn4amagA7Sn",
+            "DensityRenderer": {
+              "configId": "i0nXW3sOUyw",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "ill8FKNk39c",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "qAjokjmfxsT",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "1at1sLO1Gsl",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray - negative",
+          "category": [
+            "BigWig",
+            "XYPlot"
+          ],
+          "adapter": {
+            "configId": "mvznsyIjAbx",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray_negative.bw"
+            }
+          },
+          "renderers": {
+            "configId": "9uGraHzzooZ",
+            "DensityRenderer": {
+              "configId": "KLYbOiwHHXW",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "3W_yji6qKA-",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "urS9x7n3bvj",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "FKQP7kvWcgO",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray with +/- values",
+          "category": [
+            "BigWig",
+            "Line"
+          ],
+          "adapter": {
+            "configId": "deTs4XSQOI6",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray_posneg.bw"
+            }
+          },
+          "defaultRendering": "line",
+          "renderers": {
+            "configId": "948zZcpQx92",
+            "DensityRenderer": {
+              "configId": "BGpnqrXfHSp",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "MNlwaajEFRD",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "jr6nU5Eyl34",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "jdYHuGnpAc_",
+          "type": "WiggleTrack",
+          "name": "Volvox microarray with +/- values",
+          "category": [
+            "BigWig",
+            "XYPlot"
+          ],
+          "adapter": {
+            "configId": "cRHHbdsiAPC",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox_microarray_posneg.bw"
+            }
+          },
+          "renderers": {
+            "configId": "xYfs1FnzFzf",
+            "DensityRenderer": {
+              "configId": "ulZyLBGC1EV",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "t4RVxTGhGvm",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "d2CSXQM3nYO",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "p7FU-K6WqS_",
+          "type": "WiggleTrack",
+          "name": "Volvox - BAM coverage",
+          "category": [
+            "BigWig",
+            "Line"
+          ],
+          "adapter": {
+            "configId": "tti4u-USnnP",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox-sorted.bam.coverage.bw"
+            }
+          },
+          "defaultRendering": "line",
+          "renderers": {
+            "configId": "xKSmDn4GuKz",
+            "DensityRenderer": {
+              "configId": "bt3NVEPJgjS",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "jr1uPz9XF3d",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "aMVo9_keTfm",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "pOOtg9wxcUC",
+          "type": "WiggleTrack",
+          "name": "Volvox - BAM coverage",
+          "category": [
+            "BigWig"
+          ],
+          "adapter": {
+            "configId": "LqumLPc7aJg",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "/test_data/volvox-sorted.bam.coverage.bw"
+            }
+          },
+          "renderers": {
+            "configId": "-VoVmJv7sG2",
+            "DensityRenderer": {
+              "configId": "83c1U3n8QWf",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "7kdSqURZrMf",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "TqEQ6lglNRk",
+              "type": "LinePlotRenderer"
+            }
+          }
+        }
+      ],
+      "connections": [
+        {
+          "configId": "pyz7l1IaODm",
+          "type": "UCSCTrackHubConnection",
+          "name": "Volvox UCSC TrackHub",
+          "hubTxtLocation": {
+            "uri": "https://jbrowse.org/volvoxhub/hub.txt"
+          }
+        },
+        {
+          "configId": "yRhZxX1BTm4",
+          "type": "JBrowse1Connection",
+          "name": "Volvox JBrowse 1 Data",
+          "dataDirLocation": {
+            "uri": "https://jbrowse.org/code/JBrowse-1.16.4/sample_data/json/volvox/"
+          }
+        }
+      ]
+    },
+    {
+      "configId": "GbR-gJfAC9M",
+      "name": "Homo sapiens",
+      "assembly": {
+        "configId": "LxT4lkflYm1",
+        "name": "hg19",
+        "aliases": [
+          "GRCh37"
+        ],
+        "sequence": {
+          "configId": "Pd8Wh30ei9R",
+          "type": "ReferenceSequenceTrack",
+          "adapter": {
+            "configId": "YK3RiyLKJq4",
+            "type": "IndexedFastaAdapter",
+            "fastaLocation": {
+              "uri": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"
+            },
+            "faiLocation": {
+              "uri": "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai"
+            }
+          },
+          "rendering": {
+            "configId": "_Ta2aorot0V",
+            "type": "DivSequenceRenderer"
+          }
+        },
+        "refNameAliases": {
+          "configId": "Zur8oMv8w07",
+          "adapter": {
+            "configId": "681v51gSgQL",
+            "type": "FromConfigAdapter",
+            "features": [
+              {
+                "refName": "chr1",
+                "uniqueId": "hg19_alias1",
+                "aliases": [
+                  "1"
+                ]
+              },
+              {
+                "refName": "chr2",
+                "uniqueId": "hg19_alias2",
+                "aliases": [
+                  "2"
+                ]
+              },
+              {
+                "refName": "chr3",
+                "uniqueId": "hg19_alias3",
+                "aliases": [
+                  "3"
+                ]
+              },
+              {
+                "refName": "chr4",
+                "uniqueId": "hg19_alias4",
+                "aliases": [
+                  "4"
+                ]
+              },
+              {
+                "refName": "chr5",
+                "uniqueId": "hg19_alias5",
+                "aliases": [
+                  "5"
+                ]
+              },
+              {
+                "refName": "chr6",
+                "uniqueId": "hg19_alias6",
+                "aliases": [
+                  "6"
+                ]
+              },
+              {
+                "refName": "chr7",
+                "uniqueId": "hg19_alias7",
+                "aliases": [
+                  "7"
+                ]
+              },
+              {
+                "refName": "chr8",
+                "uniqueId": "hg19_alias8",
+                "aliases": [
+                  "8"
+                ]
+              },
+              {
+                "refName": "chr9",
+                "uniqueId": "hg19_alias9",
+                "aliases": [
+                  "9"
+                ]
+              },
+              {
+                "refName": "chr10",
+                "uniqueId": "hg19_alias10",
+                "aliases": [
+                  "10"
+                ]
+              },
+              {
+                "refName": "chr11",
+                "uniqueId": "hg19_alias11",
+                "aliases": [
+                  "11"
+                ]
+              },
+              {
+                "refName": "chr12",
+                "uniqueId": "hg19_alias12",
+                "aliases": [
+                  "12"
+                ]
+              },
+              {
+                "refName": "chr13",
+                "uniqueId": "hg19_alias13",
+                "aliases": [
+                  "13"
+                ]
+              },
+              {
+                "refName": "chr14",
+                "uniqueId": "hg19_alias14",
+                "aliases": [
+                  "14"
+                ]
+              },
+              {
+                "refName": "chr15",
+                "uniqueId": "hg19_alias15",
+                "aliases": [
+                  "15"
+                ]
+              },
+              {
+                "refName": "chr16",
+                "uniqueId": "hg19_alias16",
+                "aliases": [
+                  "16"
+                ]
+              },
+              {
+                "refName": "chr17",
+                "uniqueId": "hg19_alias17",
+                "aliases": [
+                  "17"
+                ]
+              },
+              {
+                "refName": "chr18",
+                "uniqueId": "hg19_alias18",
+                "aliases": [
+                  "18"
+                ]
+              },
+              {
+                "refName": "chr19",
+                "uniqueId": "hg19_alias19",
+                "aliases": [
+                  "19"
+                ]
+              },
+              {
+                "refName": "chr20",
+                "uniqueId": "hg19_alias20",
+                "aliases": [
+                  "20"
+                ]
+              },
+              {
+                "refName": "chr21",
+                "uniqueId": "hg19_alias21",
+                "aliases": [
+                  "21"
+                ]
+              },
+              {
+                "refName": "chr22",
+                "uniqueId": "hg19_alias22",
+                "aliases": [
+                  "22"
+                ]
+              },
+              {
+                "refName": "chrX",
+                "uniqueId": "hg19_aliasX",
+                "aliases": [
+                  "X"
+                ]
+              },
+              {
+                "refName": "chrY",
+                "uniqueId": "hg19_aliasY",
+                "aliases": [
+                  "Y"
+                ]
+              },
+              {
+                "refName": "chrM",
+                "uniqueId": "hg19_aliasMT",
+                "aliases": [
+                  "MT"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "tracks": [
+        {
+          "configId": "XWkHTtv9ui5",
+          "type": "AlignmentsTrack",
+          "name": "HG002.hs37d5.11kb",
+          "category": [
+            "PacBio",
+            "BAM"
+          ],
+          "adapter": {
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/m64011_181218_235052.8M.HG002.hs37d5.11kb.bam"
+            },
+            "index": {
+              "location": {
+                "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/m64011_181218_235052.8M.HG002.hs37d5.11kb.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "PileupRenderer": {
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "type": "SvgFeatureRenderer",
+              "labels": {}
+            }
+          }
+        },
+        {
+          "type": "AlignmentsTrack",
+          "name": "NA12878 Exome",
+          "category": [
+            "1000 genomes"
+          ],
+          "adapter": {
+            "configId": "OTDepV9NVQj",
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/NA12878/exome_alignment/NA12878.mapped.ILLUMINA.bwa.CEU.exome.20121211.bam"
+            },
+            "index": {
+              "configId": "cS35TbI08yD",
+              "location": {
+                "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/NA12878/exome_alignment/NA12878.mapped.ILLUMINA.bwa.CEU.exome.20121211.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "YiOyYnupJa8",
+            "PileupRenderer": {
+              "configId": "Lhb2lIWJnTd",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "s8YU2XWWehv",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "743qj43cJrD"
+              }
+            }
+          }
+        },
+        {
+          "configId": "ZI7-sp11jGI",
+          "type": "AlignmentsTrack",
+          "configId": "chm1_pacbio",
+          "category": [
+            "PacBio",
+            "BAM"
+          ],
+          "name": "CHM1 pacbio",
+          "adapter": {
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "https://s3.amazonaws.com/1000genomes/phase3/integrated_sv_map/supporting/CHM1/pacbio/data/aligned_reads.bam"
+            },
+            "index": {
+              "location": {
+                "uri": "https://s3.amazonaws.com/1000genomes/phase3/integrated_sv_map/supporting/CHM1/pacbio/data/aligned_reads.bam.bai"
+              }
+            }
+          }
+        },
+        {
+          "type": "AlignmentsTrack",
+          "name": "HG00096 Illumina high coverage",
+          "category": [
+            "1000 genomes"
+          ],
+          "adapter": {
+            "configId": "EwF71672lBA",
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/HG00096/high_coverage_alignment/HG00096.wgs.ILLUMINA.bwa.GBR.high_cov_pcr_free.20140203.bam"
+            },
+            "index": {
+              "configId": "OR-n1OqwE3X",
+              "location": {
+                "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/HG00096/high_coverage_alignment/HG00096.wgs.ILLUMINA.bwa.GBR.high_cov_pcr_free.20140203.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "wa7xGT9bmhU",
+            "PileupRenderer": {
+              "configId": "6OSKh0L8UMC",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "ZM4tP6_Qbcw",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "NG04oARDu88"
+              }
+            }
+          }
+        },
+        {
+          "configId": "rJxR1X2T0yu",
+          "type": "AlignmentsTrack",
+          "name": "HG00096 Illumina low coverage",
+          "category": [
+            "1000 genomes"
+          ],
+          "adapter": {
+            "configId": "BWBdaUrgsOP",
+            "type": "BamAdapter",
+            "bamLocation": {
+              "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/HG00096/alignment/HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam"
+            },
+            "index": {
+              "configId": "Wo7_uXtLj-L",
+              "location": {
+                "uri": "https://s3.amazonaws.com/1000genomes/phase3/data/HG00096/alignment/HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam.bai"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "l6ri1CJuYRh",
+            "PileupRenderer": {
+              "configId": "mjcRxahq0QK",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "SiP2Xpddy3_",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "8OxyEW_afFb"
+              }
+            }
+          }
+        },
+        {
+          "configId": "wiggle_global_autoscale",
+          "type": "WiggleTrack",
+          "name": "Encode global autoscale",
+          "category": [
+            "ENCODE bigWigs"
+          ],
+          "adapter": {
+            "configId": "8L8nA9qpjRe",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "https://www.encodeproject.org/files/ENCFF303QSJ/@@download/ENCFF303QSJ.bigWig"
+            }
+          },
+          "renderers": {
+            "configId": "Q6WzvBzOnbL",
+            "DensityRenderer": {
+              "configId": "j7Hr8HSBoh_",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "YtuFWYpGQlt",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "YYY_eV2iQ7S",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "wiggle_local_autoscale",
+          "type": "WiggleTrack",
+          "name": "Encode local autoscale",
+          "category": [
+            "ENCODE bigWigs"
+          ],
+          "autoscale": "local",
+          "adapter": {
+            "configId": "vARzwjicxgq",
+            "type": "BigWigAdapter",
+            "bigWigLocation": {
+              "uri": "https://www.encodeproject.org/files/ENCFF303QSJ/@@download/ENCFF303QSJ.bigWig"
+            }
+          },
+          "renderers": {
+            "configId": "Hu3KQHJ-RLX",
+            "DensityRenderer": {
+              "configId": "Nrh4xydmujo",
+              "type": "DensityRenderer"
+            },
+            "XYPlotRenderer": {
+              "configId": "QRAw8coHW1i",
+              "type": "XYPlotRenderer"
+            },
+            "LinePlotRenderer": {
+              "configId": "aazgDbgS8qm",
+              "type": "LinePlotRenderer"
+            }
+          }
+        },
+        {
+          "configId": "nclist_genes",
+          "type": "BasicTrack",
+          "name": "Gencode v19",
+          "category": [
+            "Genes"
+          ],
+          "adapter": {
+            "configId": "XyQjQg8RPJH",
+            "type": "NCListAdapter",
+            "rootUrlTemplate": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/gencode/{refseq}/trackData.json"
+          },
+          "renderer": {
+            "configId": "xtVjXoyixlj",
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "configId": "qCayxx8Rgb6"
+            }
+          }
+        },
+        {
+          "configId": "bigbed_peaks",
+          "type": "BasicTrack",
+          "name": "Encode peaks",
+          "category": [
+            "ENCODE bigWigs"
+          ],
+          "adapter": {
+            "configId": "wCI0N1qJgMe",
+            "type": "BigBedAdapter",
+            "bigBedLocation": {
+              "uri": "https://www.encodeproject.org/files/ENCFF082DRX/@@download/ENCFF082DRX.bigBed"
+            }
+          },
+          "renderer": {
+            "configId": "lqGk6Jefctk",
+            "type": "PileupRenderer"
+          }
+        },
+        {
+          "configId": "UppxfMGl81V",
+          "type": "VariantTrack",
+          "name": "InDels",
+          "category": [
+            "Variants"
+          ],
+          "adapter": {
+            "configId": "5cVzXc0r4sO",
+            "type": "VcfTabixAdapter",
+            "vcfGzLocation": {
+              "uri": "https://1000genomes.s3.amazonaws.com/phase1/analysis_results/consensus_call_sets/indels/ALL.wgs.VQSR_V2_GLs_polarized.20101123.indels.low_coverage.genotypes.vcf.gz"
+            },
+            "index": {
+              "configId": "bmWtGbNWnlD",
+              "location": {
+                "uri": "https://1000genomes.s3.amazonaws.com/phase1/analysis_results/consensus_call_sets/indels/ALL.wgs.VQSR_V2_GLs_polarized.20101123.indels.low_coverage.genotypes.vcf.gz.tbi"
+              }
+            }
+          },
+          "renderers": {
+            "configId": "GXEKwN52kO0",
+            "PileupRenderer": {
+              "configId": "Oz9nuyem1z2",
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "configId": "7wSZSPLj8Kn",
+              "type": "SvgFeatureRenderer",
+              "labels": {
+                "configId": "TFb1J4Uz4gH"
+              }
+            }
+          }
+        },
+        {
+          "type": "VariantTrack",
+          "name": "hs37d5.HG002-SequelII-CCS",
+          "category": [
+            "PacBio",
+            "VCF"
+          ],
+          "adapter": {
+            "type": "VcfTabixAdapter",
+            "vcfGzLocation": {
+              "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/hs37d5.HG002-SequelII-CCS.sv.vcf.gz"
+            },
+            "index": {
+              "location": {
+                "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/hs37d5.HG002-SequelII-CCS.sv.vcf.gz.tbi"
+              }
+            }
+          },
+          "renderers": {
+            "PileupRenderer": {
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "type": "SvgFeatureRenderer",
+              "labels": {}
+            }
+          }
+        },
+        {
+          "type": "VariantTrack",
+          "name": "chm.full.37d5.vcf.gz",
+          "category": [
+            "PacBio",
+            "VCF"
+          ],
+          "adapter": {
+            "type": "VcfTabixAdapter",
+            "vcfGzLocation": {
+              "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/chm.full.37d5.vcf.gz"
+            },
+            "index": {
+              "location": {
+                "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/chm.full.37d5.vcf.gz.tbi"
+              }
+            }
+          },
+          "renderers": {
+            "PileupRenderer": {
+              "type": "PileupRenderer"
+            },
+            "SvgFeatureRenderer": {
+              "type": "SvgFeatureRenderer",
+              "labels": {}
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "configuration": {
+    "configId": "WBBdhiJUQdj",
+    "rpc": {
+      "configId": "A8raoinDhoH"
+    }
+  },
+  "savedSessions": [
+    {
+      "name": "Human Example (hg19)",
+      "width": 1192,
+      "drawerWidth": 384,
+      "views": [
+        {
+          "id": "Cma34s8JJ",
+          "type": "LinearGenomeView",
+          "offsetPx": 0,
+          "bpPerPx": 1,
+          "displayedRegions": [
+            {
+              "refName": "chr1",
+              "start": 0,
+              "end": 1000,
+              "assemblyName": "hg19"
+            },
+            {
+              "refName": "chr1",
+              "start": 10000,
+              "end": 11000,
+              "assemblyName": "hg19"
+            }
+          ],
+          "reversed": false,
+          "tracks": [
+            {
+              "id": "8fmNOg8Mt",
+              "type": "WiggleTrack",
+              "height": 100,
+              "configuration": "wiggle_global_autoscale",
+              "selectedRendering": ""
+            },
+            {
+              "id": "PbHbhnr6Vn",
+              "type": "WiggleTrack",
+              "height": 100,
+              "configuration": "wiggle_local_autoscale",
+              "selectedRendering": ""
+            },
+            {
+              "id": "co9dWzCnSq",
+              "type": "BasicTrack",
+              "height": 100,
+              "configuration": "bigbed_peaks"
+            }
+          ],
+          "controlsWidth": 120,
+          "width": 1192,
+          "hideControls": false,
+          "trackSelectorType": "hierarchical",
+          "minimumBlockWidth": 20
+        }
+      ],
+      "drawerWidgets": {
+        "hierarchicalTrackSelector": {
+          "id": "KiRG5qjrcS",
+          "type": "HierarchicalTrackSelectorDrawerWidget",
+          "collapsed": {},
+          "filterText": "",
+          "view": "Cma34s8JJ"
+        }
+      },
+      "activeDrawerWidgets": {},
+      "menuBars": [
+        {
+          "id": "aU_iMpOUx4",
+          "type": "MainMenuBar",
+          "menus": [
+            {
+              "name": "Admin",
+              "menuItems": [
+                {
+                  "name": "Export configuration",
+                  "icon": "cloud_download",
+                  "callback": "exportConfiguration"
+                },
+                {
+                  "name": "Import configuration",
+                  "icon": "cloud_upload",
+                  "callback": "importConfiguration"
+                }
+              ]
+            },
+            {
+              "name": "Help",
+              "menuItems": [
+                {
+                  "name": "About",
+                  "icon": "info",
+                  "callback": "openAbout"
+                },
+                {
+                  "name": "Help",
+                  "icon": "help",
+                  "callback": "openHelp"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "connections": {}
+    }
+  ]
+}

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -291,9 +291,6 @@ describe('test configuration editor', () => {
     // Note: a series of like 5 or 6 waitForDomChange calls
     // on container also works instead of timeout
     await timeout(1000)
-    setTimeout(() => {
-      throw new Error('crazy')
-    }, 100)
     const ret = await waitForElement(() => byId('vcf-2560'))
     expect(ret).toMatchSnapshot()
   })

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -291,6 +291,9 @@ describe('test configuration editor', () => {
     // Note: a series of like 5 or 6 waitForDomChange calls
     // on container also works instead of timeout
     await timeout(1000)
+    setTimeout(() => {
+      throw new Error('crazy')
+    }, 100)
     const ret = await waitForElement(() => byId('vcf-2560'))
     expect(ret).toMatchSnapshot()
   })

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -138,6 +138,29 @@ describe('valid file tests', () => {
     expect(end - start).toEqual(150)
   })
 
+  it('click and drag to rubberband', async () => {
+    const state = rootModel.create({ jbrowse: config })
+    const { getByTestId } = render(<JBrowse initialState={state} />)
+    const track = await waitForElement(() =>
+      getByTestId('rubberband_container'),
+    )
+
+    expect(state.session.views[0].bpPerPx).toEqual(0.05)
+    fireEvent.mouseDown(track, { clientX: 100, clientY: 0 })
+    fireEvent.mouseMove(track, { clientX: 250, clientY: 0 })
+    fireEvent.mouseUp(track, { clientX: 250, clientY: 0 })
+    expect(state.session.views[0].bpPerPx).toEqual(0.03125)
+  })
+
+  it('click and zoom in and back out', async () => {
+    const state = rootModel.create({ jbrowse: config })
+    const { getByTestId: byId } = render(<JBrowse initialState={state} />)
+    const before = state.session.views[0].bpPerPx
+    fireEvent.click(await waitForElement(() => byId('zoom_in')))
+    fireEvent.click(await waitForElement(() => byId('zoom_out')))
+    expect(state.session.views[0].bpPerPx).toEqual(before)
+  })
+
   it('opens track selector', async () => {
     const state = rootModel.create({ jbrowse: config })
     const { getByTestId } = render(<JBrowse initialState={state} />)

--- a/packages/linear-genome-view/package.json
+++ b/packages/linear-genome-view/package.json
@@ -9,13 +9,14 @@
   "author": "Robert Buels",
   "license": "MIT",
   "dependencies": {
+    "@material-ui/icons": "^4.2.1",
     "classnames": "^2.2.6"
   },
   "peerDependencies": {
     "@gmod/jbrowse-core": "^2.0.0",
     "@material-ui/core": "^4.0.0",
-    "@material-ui/styles": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.20",
+    "@material-ui/styles": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.10.2",

--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -311,38 +311,40 @@ Array [
 `;
 
 exports[`reverse block calculation 1 1`] = `
-Array [
-  Object {
-    "assemblyName": undefined,
-    "end": 10000,
-    "isLeftEndOfDisplayedRegion": true,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:9201-10000",
-    "offsetPx": 0,
-    "parentRegion": Object {
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "assemblyName": undefined,
       "end": 10000,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:9201-10000",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 9200,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 9200,
-    "widthPx": 800,
-  },
-  Object {
-    "assemblyName": undefined,
-    "end": 9200,
-    "isLeftEndOfDisplayedRegion": false,
-    "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:8401-9200",
-    "offsetPx": 800,
-    "parentRegion": Object {
-      "end": 10000,
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 9200,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:8401-9200",
+      "offsetPx": 800,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
       "refName": "ctgA",
-      "start": 0,
+      "start": 8400,
+      "widthPx": 800,
     },
-    "refName": "ctgA",
-    "start": 8400,
-    "widthPx": 800,
-  },
-]
+  ],
+}
 `;

--- a/packages/linear-genome-view/src/BasicTrack/util/blockTypes.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/blockTypes.js
@@ -1,6 +1,10 @@
 export class BlockSet {
   blocks = []
 
+  constructor(blocks = []) {
+    this.blocks = blocks
+  }
+
   push(block) {
     if (block instanceof ElidedBlock) {
       if (this.blocks.length) {

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
@@ -2,16 +2,18 @@ import { assembleLocString } from '@gmod/jbrowse-core/util'
 import { BlockSet, ContentBlock, ElidedBlock } from './blockTypes'
 
 export function calculateBlocksReversed(self, extra = 0) {
-  return calculateBlocksForward(self, extra).map(fwdBlock => {
-    const { parentRegion } = fwdBlock
-    const revBlock = {
-      ...fwdBlock,
-      start: parentRegion.end - fwdBlock.end,
-      end: parentRegion.end - fwdBlock.start,
-    }
-    revBlock.key = assembleLocString(revBlock)
-    return revBlock
-  })
+  return new BlockSet(
+    calculateBlocksForward(self, extra).map(fwdBlock => {
+      const { parentRegion } = fwdBlock
+      const revBlock = new ContentBlock({
+        ...fwdBlock,
+        start: parentRegion.end - fwdBlock.end,
+        end: parentRegion.end - fwdBlock.start,
+      })
+      revBlock.key = assembleLocString(revBlock)
+      return revBlock
+    }),
+  )
 }
 
 export function calculateBlocksForward(self, extra = 0) {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -10,8 +10,6 @@ import {
   MenuItem,
   makeStyles,
 } from '@material-ui/core'
-import MoreVertIcon from '@material-ui/icons/MoreVert'
-import SearchIcon from '@material-ui/icons/Search'
 import { clamp, getSession } from '@gmod/jbrowse-core/util'
 
 import classnames from 'classnames'
@@ -163,7 +161,7 @@ function LongMenu(props) {
         className={className}
         onClick={handleClick}
       >
-        <MoreVertIcon />
+        <Icon>more_vert</Icon>
       </IconButton>
       <Menu
         id="long-menu"
@@ -247,7 +245,7 @@ function Search(props) {
           placeholder="Enter locstring"
         />
         <IconButton className={classes.iconButton} aria-label="search">
-          <SearchIcon />
+          <Icon>search</Icon>
         </IconButton>
       </form>
     </Paper>
@@ -262,8 +260,14 @@ function Header({ model, header, setHeader }) {
   const navTo = locstring => {
     const [refSeq, rest = ''] = locstring.split(':')
     const [start, end] = rest.split('..')
-    if (refSeq !== undefined && start !== undefined && end !== undefined) {
-      model.navTo({ refSeq, start, end })
+    if (refSeq !== undefined) {
+      if (start !== undefined && end !== undefined) {
+        model.navTo({ refSeq, start: +start, end: +end })
+      } else if (start !== undefined) {
+        model.navTo({ refSeq, start: +start })
+      } else {
+        model.navTo({ refSeq })
+      }
     }
   }
   return (

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -309,11 +309,6 @@ function LinearGenomeView(props) {
     gridTemplateColumns: `[controls] ${controlsWidth}px [blocks] auto`,
   }
 
-  const searchFeatures = model.activateSearch
-  const showAllRegions = () => {}
-  const setFlip = () => {}
-  const showTrackSelector = model.activateTrackSelector
-
   return (
     <div className={classes.root}>
       <div
@@ -341,18 +336,17 @@ function LinearGenomeView(props) {
                   {
                     title: 'Show track selector',
                     key: 'track_selector',
-                    callback: showTrackSelector,
+                    callback: model.activateTrackSelector,
                   },
-                  { title: 'Horizontal flip', key: 'flip', callback: setFlip },
+                  {
+                    title: 'Horizontal flip',
+                    key: 'flip',
+                    callback: model.flipCurrentView,
+                  },
                   {
                     title: 'Show all regions',
                     key: 'showall',
-                    callback: showAllRegions,
-                  },
-                  {
-                    title: 'Search features',
-                    key: 'search_features',
-                    callback: searchFeatures,
+                    callback: model.showAllRegions,
                   },
                   {
                     title: header ? 'Hide header' : 'Show header',

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -206,15 +206,19 @@ function TextFieldOrTypography({ onChange, value = '' }) {
   const classes = useStyles()
   const [name, setName] = useState(value)
   const [edit, setEdit] = useState(false)
+  const submit = event => {
+    setEdit(false)
+    onChange(name)
+    event.preventDefault()
+  }
   return edit ? (
-    <TextField
-      value={name}
-      onChange={event => setName(event.target.value)}
-      onBlur={() => {
-        setEdit(false)
-        onChange(name)
-      }}
-    />
+    <form onSubmit={submit}>
+      <TextField
+        value={name}
+        onChange={event => setName(event.target.value)}
+        onBlur={submit}
+      />
+    </form>
   ) : (
     <Typography className={classes.viewName} onClick={() => setEdit(true)}>
       {name}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -84,6 +84,12 @@ const useStyles = makeStyles(theme => ({
   hovered: {
     border: '1px solid grey',
   },
+  input: {
+    width: 300,
+    error: {
+      backgroundColor: 'red',
+    },
+  },
   ...buttonStyles(theme),
 }))
 
@@ -255,10 +261,10 @@ TextFieldOrTypography.propTypes = {
   model: PropTypes.objectOrObservableObject.isRequired,
 }
 
-function Search(props) {
-  const { onSubmit } = props
+function Search({ onSubmit, error }) {
   const [value, setValue] = useState(null)
   const classes = useStyles()
+  const placeholder = 'Enter location (e.g. chr1:1000..5000)'
 
   return (
     <Paper className={classes.searchRoot}>
@@ -270,10 +276,15 @@ function Search(props) {
       >
         <InputBase
           className={classes.input}
+          error={!!error}
           onChange={event => setValue(event.target.value)}
-          placeholder="Enter locstring"
+          placeholder={placeholder}
         />
-        <IconButton className={classes.iconButton} aria-label="search">
+        <IconButton
+          onClick={() => onSubmit(value)}
+          className={classes.iconButton}
+          aria-label="search"
+        >
           <Icon>search</Icon>
         </IconButton>
       </form>
@@ -282,6 +293,7 @@ function Search(props) {
 }
 Search.propTypes = {
   onSubmit: ReactPropTypes.func.isRequired,
+  error: ReactPropTypes.string, // eslint-disable-line react/require-default-props
 }
 
 function RefSeqDropdown({ model, onSubmit }) {
@@ -315,8 +327,11 @@ RefSeqDropdown.propTypes = {
 
 function Header({ model, header, setHeader }) {
   const classes = useStyles()
+  const [error, setError] = useState()
   const navTo = locstring => {
-    model.navTo(parseLocString(locstring))
+    if (!model.navTo(parseLocString(locstring))) {
+      setError(`Unable to find ${locstring}`)
+    }
   }
   return (
     <div className={classes.headerBar}>
@@ -326,7 +341,7 @@ function Header({ model, header, setHeader }) {
       <TextFieldOrTypography model={model} />
       <div className={classes.spacer} />
 
-      <Search onSubmit={navTo} />
+      <Search onSubmit={navTo} error={error} />
       <RefSeqDropdown onSubmit={navTo} model={model} />
 
       <ZoomControls model={model} />

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.js
@@ -308,7 +308,8 @@ function RefSeqDropdown({ model, onSubmit }) {
   )
 }
 
-Header.propTypes = {
+RefSeqDropdown.propTypes = {
+  onSubmit: ReactPropTypes.func.isRequired,
   model: PropTypes.objectOrObservableObject.isRequired,
 }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Rubberband.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Rubberband.js
@@ -108,6 +108,7 @@ class Rubberband extends Component {
     }
     return (
       <div
+        data-testid="rubberband_container"
         className={classes.rubberBandContainer}
         onMouseDown={this.onMouseDown}
         role="presentation"

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.js
@@ -22,6 +22,7 @@ function ZoomControls(props) {
   return (
     <div className={classes.container}>
       <IconButton
+        data-testid="zoom_out"
         onClick={() => {
           model.zoomTo(model.bpPerPx * 2)
         }}
@@ -36,6 +37,7 @@ function ZoomControls(props) {
         onChange={(event, value) => model.zoomTo(2 ** -value)}
       />
       <IconButton
+        data-testid="zoom_in"
         onClick={() => {
           model.zoomTo(model.bpPerPx / 2)
         }}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.js
@@ -18,9 +18,9 @@ const styles = {
 }
 
 function ZoomControls(props) {
-  const { classes, model, controlsHeight } = props
+  const { classes, model } = props
   return (
-    <div className={classes.container} style={{ height: controlsHeight }}>
+    <div className={classes.container}>
       <IconButton
         onClick={() => {
           model.zoomTo(model.bpPerPx * 2)
@@ -49,7 +49,6 @@ function ZoomControls(props) {
 ZoomControls.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   model: MobxPropTypes.observableObject.isRequired,
-  controlsHeight: PropTypes.number.isRequired,
 }
 
 export default withStyles(styles)(observer(ZoomControls))

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -137,6 +137,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_out"
           tabindex="0"
           type="button"
         >
@@ -180,6 +181,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         </span>
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_in"
           tabindex="0"
           type="button"
         >
@@ -208,6 +210,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
     />
     <div
       class="Rubberband-rubberBandContainer-165"
+      data-testid="rubberband_container"
       role="presentation"
     >
       <div
@@ -432,6 +435,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_out"
           tabindex="0"
           type="button"
         >
@@ -475,6 +479,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </span>
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_in"
           tabindex="0"
           type="button"
         >
@@ -503,6 +508,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
     />
     <div
       class="Rubberband-rubberBandContainer-165"
+      data-testid="rubberband_container"
       role="presentation"
     >
       <div
@@ -929,6 +935,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_out"
           tabindex="0"
           type="button"
         >
@@ -972,6 +979,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         </span>
         <button
           class="MuiButtonBase-root MuiIconButton-root"
+          data-testid="zoom_in"
           tabindex="0"
           type="button"
         >
@@ -1000,6 +1008,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
     />
     <div
       class="Rubberband-rubberBandContainer-165"
+      data-testid="rubberband_container"
       role="presentation"
     >
       <div

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -12,7 +12,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         title="close this view"
         type="button"
@@ -35,24 +35,19 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         type="button"
       >
         <span
           class="MuiIconButton-label"
         >
-          <svg
+          <span
             aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
+            class="material-icons MuiIcon-root"
           >
-            <path
-              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-            />
-          </svg>
+            more_vert
+          </span>
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -84,24 +79,19 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
             tabindex="0"
             type="button"
           >
             <span
               class="MuiIconButton-label"
             >
-              <svg
+              <span
                 aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                role="presentation"
-                viewBox="0 0 24 24"
+                class="material-icons MuiIcon-root"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
+                search
+              </span>
             </span>
             <span
               class="MuiTouchRipple-root"
@@ -142,7 +132,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         </svg>
       </div>
       <div
-        class="ZoomControls-container-141"
+        class="ZoomControls-container-142"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -164,7 +154,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-142"
+          class="MuiSlider-root ZoomControls-slider-143"
         >
           <span
             class="MuiSlider-rail"
@@ -216,11 +206,11 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-163"
+      class="Rubberband-rubberBandContainer-164"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-164"
+        class="ScaleBar-scaleBar-165"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       />
     </div>
@@ -229,7 +219,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
         tabindex="0"
         title="close this track"
         type="button"
@@ -249,7 +239,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -271,32 +261,32 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-205"
+      class="TrackRenderingContainer-trackRenderingContainer-206"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-206"
+        class="Track-track-207"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-207"
+          class="TrackBlocks-trackBlocks-208"
           data-testid="Block"
         />
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-210"
+      class="TrackResizeHandle-dragHandle-211"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -316,7 +306,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         title="close this view"
         type="button"
@@ -339,24 +329,19 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         type="button"
       >
         <span
           class="MuiIconButton-label"
         >
-          <svg
+          <span
             aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
+            class="material-icons MuiIcon-root"
           >
-            <path
-              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-            />
-          </svg>
+            more_vert
+          </span>
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -388,24 +373,19 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
             tabindex="0"
             type="button"
           >
             <span
               class="MuiIconButton-label"
             >
-              <svg
+              <span
                 aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                role="presentation"
-                viewBox="0 0 24 24"
+                class="material-icons MuiIcon-root"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
+                search
+              </span>
             </span>
             <span
               class="MuiTouchRipple-root"
@@ -446,7 +426,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </svg>
       </div>
       <div
-        class="ZoomControls-container-141"
+        class="ZoomControls-container-142"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -468,7 +448,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-142"
+          class="MuiSlider-root ZoomControls-slider-143"
         >
           <span
             class="MuiSlider-rail"
@@ -520,15 +500,15 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-163"
+      class="Rubberband-rubberBandContainer-164"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-164"
+        class="ScaleBar-scaleBar-165"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       >
         <div
-          class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
+          class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
           style="left: 0px; width: 100px;"
         >
           <svg
@@ -536,7 +516,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             width="100"
           >
             <line
-              class="Ruler-majorTick-215"
+              class="Ruler-majorTick-216"
               data-bp="-1"
               stroke="#555"
               stroke-width="1"
@@ -546,7 +526,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="Ruler-minorTick-216"
+              class="Ruler-minorTick-217"
               data-bp="19"
               stroke="#999"
               stroke-width="1"
@@ -556,7 +536,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-216"
+              class="Ruler-minorTick-217"
               data-bp="39"
               stroke="#999"
               stroke-width="1"
@@ -566,7 +546,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-216"
+              class="Ruler-minorTick-217"
               data-bp="59"
               stroke="#999"
               stroke-width="1"
@@ -576,7 +556,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-216"
+              class="Ruler-minorTick-217"
               data-bp="79"
               stroke="#999"
               stroke-width="1"
@@ -586,7 +566,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-majorTick-215"
+              class="Ruler-majorTick-216"
               data-bp="99"
               stroke="#555"
               stroke-width="1"
@@ -596,7 +576,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="Ruler-minorTick-216"
+              class="Ruler-minorTick-217"
               data-bp="119"
               stroke="#999"
               stroke-width="1"
@@ -606,7 +586,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <text
-              class="Ruler-majorTickLabel-214"
+              class="Ruler-majorTickLabel-215"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="-4"
@@ -615,7 +595,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               0
             </text>
             <text
-              class="Ruler-majorTickLabel-214"
+              class="Ruler-majorTickLabel-215"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="96"
@@ -626,7 +606,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </svg>
         </div>
         <div
-          class="ScaleBar-refLabel-165"
+          class="ScaleBar-refLabel-166"
         >
           ctgA
         </div>
@@ -637,7 +617,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
         tabindex="0"
         title="close this track"
         type="button"
@@ -657,7 +637,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -679,34 +659,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-205"
+      class="TrackRenderingContainer-trackRenderingContainer-206"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-206"
+        class="Track-track-207"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-207"
+          class="TrackBlocks-trackBlocks-208"
           data-testid="Block"
         >
           <div
-            class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
+            class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-221"
+              class="Component-blockMessage-222"
             >
               region assembly does not match track assembly
             </div>
@@ -715,7 +695,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-210"
+      class="TrackResizeHandle-dragHandle-211"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -724,7 +704,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: track-bar; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
         tabindex="0"
         title="close this track"
         type="button"
@@ -744,7 +724,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -766,34 +746,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
       >
         Bar Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-205"
+      class="TrackRenderingContainer-trackRenderingContainer-206"
       role="presentation"
       style="grid-row: track-bar; grid-column: blocks;"
     >
       <div
-        class="Track-track-206"
+        class="Track-track-207"
         data-testid="track-testConfig2"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-207"
+          class="TrackBlocks-trackBlocks-208"
           data-testid="Block"
         >
           <div
-            class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
+            class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-221"
+              class="Component-blockMessage-222"
             >
               region assembly does not match track assembly
             </div>
@@ -802,7 +782,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-210"
+      class="TrackResizeHandle-dragHandle-211"
       role="presentation"
       style="grid-row: resize-bar; grid-column: span 2;"
     />
@@ -822,7 +802,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         title="close this view"
         type="button"
@@ -845,24 +825,19 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
         tabindex="0"
         type="button"
       >
         <span
           class="MuiIconButton-label"
         >
-          <svg
+          <span
             aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
+            class="material-icons MuiIcon-root"
           >
-            <path
-              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-            />
-          </svg>
+            more_vert
+          </span>
         </span>
         <span
           class="MuiTouchRipple-root"
@@ -894,24 +869,19 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
             tabindex="0"
             type="button"
           >
             <span
               class="MuiIconButton-label"
             >
-              <svg
+              <span
                 aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                role="presentation"
-                viewBox="0 0 24 24"
+                class="material-icons MuiIcon-root"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
+                search
+              </span>
             </span>
             <span
               class="MuiTouchRipple-root"
@@ -952,7 +922,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         </svg>
       </div>
       <div
-        class="ZoomControls-container-141"
+        class="ZoomControls-container-142"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -974,7 +944,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-142"
+          class="MuiSlider-root ZoomControls-slider-143"
         >
           <span
             class="MuiSlider-rail"
@@ -1026,11 +996,11 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-163"
+      class="Rubberband-rubberBandContainer-164"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-164"
+        class="ScaleBar-scaleBar-165"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       />
     </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -6,14 +6,13 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
 >
   <div
     class="makeStyles-linearGenomeView-2"
-    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-controls-3 makeStyles-viewControls-4"
-      style="grid-row: scale-bar;"
+      class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
         title="close this view"
         type="button"
@@ -33,44 +32,117 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
-        data_testid="track_select"
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
-        title="select tracks"
         type="button"
-        value="track_select"
       >
         <span
-          class="MuiToggleButton-label"
+          class="MuiIconButton-label"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
           >
-            line_style
-          </span>
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
         </span>
         <span
           class="MuiTouchRipple-root"
         />
       </button>
-    </div>
-    <div
-      class="Rubberband-rubberBandContainer-37"
-      role="presentation"
-    >
       <div
-        class="ScaleBar-scaleBar-38"
-        style="height: 32px;"
+        class="makeStyles-emphasis-9"
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-11 MuiTypography-body1"
+        />
+      </div>
+      <div
+        class="makeStyles-spacer-7"
       />
-    </div>
-    <div
-      class="makeStyles-zoomControls-6"
-      style="right: 4px; z-index: 1000;"
-    >
       <div
-        class="ZoomControls-container-40"
-        style="height: 32px;"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-10 MuiPaper-rounded"
+      >
+        <form>
+          <div
+            class="MuiInputBase-root"
+          >
+            <input
+              class="MuiInputBase-input"
+              placeholder="Enter locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline"
+      >
+        <div
+          aria-haspopup="true"
+          aria-pressed="false"
+          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input MuiInputBase-inputSelect"
+          id="select-refseq"
+          role="button"
+          tabindex="0"
+        >
+          <span>
+            ​
+          </span>
+        </div>
+        <input
+          name="refseq"
+          type="hidden"
+          value="Select refSeq"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+      <div
+        class="ZoomControls-container-141"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -92,7 +164,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-41"
+          class="MuiSlider-root ZoomControls-slider-142"
         >
           <span
             class="MuiSlider-rail"
@@ -135,13 +207,29 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           />
         </button>
       </div>
+      <div
+        class="makeStyles-spacer-7"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    />
+    <div
+      class="Rubberband-rubberBandContainer-163"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-164"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      />
     </div>
     <div
       class="makeStyles-controls-3 makeStyles-trackControls-5"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-73"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
         tabindex="0"
         title="close this track"
         type="button"
@@ -161,7 +249,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-74 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -183,32 +271,32 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-71 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-72 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-105"
+      class="TrackRenderingContainer-trackRenderingContainer-205"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-106"
+        class="Track-track-206"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-107"
+          class="TrackBlocks-trackBlocks-207"
           data-testid="Block"
         />
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-110"
+      class="TrackResizeHandle-dragHandle-210"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -222,14 +310,13 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
 >
   <div
     class="makeStyles-linearGenomeView-2"
-    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-controls-3 makeStyles-viewControls-4"
-      style="grid-row: scale-bar;"
+      class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
         title="close this view"
         type="button"
@@ -249,148 +336,117 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
-        data_testid="track_select"
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
-        title="select tracks"
         type="button"
-        value="track_select"
       >
         <span
-          class="MuiToggleButton-label"
+          class="MuiIconButton-label"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
           >
-            line_style
-          </span>
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
         </span>
         <span
           class="MuiTouchRipple-root"
         />
       </button>
-    </div>
-    <div
-      class="Rubberband-rubberBandContainer-37"
-      role="presentation"
-    >
       <div
-        class="ScaleBar-scaleBar-38"
-        style="height: 32px;"
+        class="makeStyles-emphasis-9"
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-11 MuiTypography-body1"
+        />
+      </div>
+      <div
+        class="makeStyles-spacer-7"
+      />
+      <div
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-10 MuiPaper-rounded"
+      >
+        <form>
+          <div
+            class="MuiInputBase-root"
+          >
+            <input
+              class="MuiInputBase-input"
+              placeholder="Enter locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline"
       >
         <div
-          class="Block-block-111 Block-leftBorder-112 Block-rightBorder-113"
-          style="left: 0px; width: 100px;"
+          aria-haspopup="true"
+          aria-pressed="false"
+          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input MuiInputBase-inputSelect"
+          id="select-refseq"
+          role="button"
+          tabindex="0"
         >
-          <svg
-            height="32"
-            width="100"
-          >
-            <line
-              class="Ruler-majorTick-115"
-              data-bp="-1"
-              stroke="#555"
-              stroke-width="1"
-              x1="-1"
-              x2="-1"
-              y1="0"
-              y2="6"
-            />
-            <line
-              class="Ruler-minorTick-116"
-              data-bp="19"
-              stroke="#999"
-              stroke-width="1"
-              x1="19"
-              x2="19"
-              y1="0"
-              y2="4"
-            />
-            <line
-              class="Ruler-minorTick-116"
-              data-bp="39"
-              stroke="#999"
-              stroke-width="1"
-              x1="39"
-              x2="39"
-              y1="0"
-              y2="4"
-            />
-            <line
-              class="Ruler-minorTick-116"
-              data-bp="59"
-              stroke="#999"
-              stroke-width="1"
-              x1="59"
-              x2="59"
-              y1="0"
-              y2="4"
-            />
-            <line
-              class="Ruler-minorTick-116"
-              data-bp="79"
-              stroke="#999"
-              stroke-width="1"
-              x1="79"
-              x2="79"
-              y1="0"
-              y2="4"
-            />
-            <line
-              class="Ruler-majorTick-115"
-              data-bp="99"
-              stroke="#555"
-              stroke-width="1"
-              x1="99"
-              x2="99"
-              y1="0"
-              y2="6"
-            />
-            <line
-              class="Ruler-minorTick-116"
-              data-bp="119"
-              stroke="#999"
-              stroke-width="1"
-              x1="119"
-              x2="119"
-              y1="0"
-              y2="4"
-            />
-            <text
-              class="Ruler-majorTickLabel-114"
-              dominant-baseline="hanging"
-              style="font-size: 11px;"
-              x="-4"
-              y="7"
-            >
-              0
-            </text>
-            <text
-              class="Ruler-majorTickLabel-114"
-              dominant-baseline="hanging"
-              style="font-size: 11px;"
-              x="96"
-              y="7"
-            >
-              100
-            </text>
-          </svg>
+          <span>
+            ​
+          </span>
         </div>
-        <div
-          class="ScaleBar-refLabel-39"
+        <input
+          name="refseq"
+          type="hidden"
+          value="Select refSeq"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
         >
-          ctgA
-        </div>
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
       </div>
-    </div>
-    <div
-      class="makeStyles-zoomControls-6"
-      style="right: 4px; z-index: 1000;"
-    >
       <div
-        class="ZoomControls-container-40"
-        style="height: 32px;"
+        class="ZoomControls-container-141"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -412,7 +468,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-41"
+          class="MuiSlider-root ZoomControls-slider-142"
         >
           <span
             class="MuiSlider-rail"
@@ -455,13 +511,133 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
         </button>
       </div>
+      <div
+        class="makeStyles-spacer-7"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    />
+    <div
+      class="Rubberband-rubberBandContainer-163"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-164"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      >
+        <div
+          class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
+          style="left: 0px; width: 100px;"
+        >
+          <svg
+            height="32"
+            width="100"
+          >
+            <line
+              class="Ruler-majorTick-215"
+              data-bp="-1"
+              stroke="#555"
+              stroke-width="1"
+              x1="-1"
+              x2="-1"
+              y1="0"
+              y2="6"
+            />
+            <line
+              class="Ruler-minorTick-216"
+              data-bp="19"
+              stroke="#999"
+              stroke-width="1"
+              x1="19"
+              x2="19"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-216"
+              data-bp="39"
+              stroke="#999"
+              stroke-width="1"
+              x1="39"
+              x2="39"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-216"
+              data-bp="59"
+              stroke="#999"
+              stroke-width="1"
+              x1="59"
+              x2="59"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-216"
+              data-bp="79"
+              stroke="#999"
+              stroke-width="1"
+              x1="79"
+              x2="79"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-majorTick-215"
+              data-bp="99"
+              stroke="#555"
+              stroke-width="1"
+              x1="99"
+              x2="99"
+              y1="0"
+              y2="6"
+            />
+            <line
+              class="Ruler-minorTick-216"
+              data-bp="119"
+              stroke="#999"
+              stroke-width="1"
+              x1="119"
+              x2="119"
+              y1="0"
+              y2="4"
+            />
+            <text
+              class="Ruler-majorTickLabel-214"
+              dominant-baseline="hanging"
+              style="font-size: 11px;"
+              x="-4"
+              y="7"
+            >
+              0
+            </text>
+            <text
+              class="Ruler-majorTickLabel-214"
+              dominant-baseline="hanging"
+              style="font-size: 11px;"
+              x="96"
+              y="7"
+            >
+              100
+            </text>
+          </svg>
+        </div>
+        <div
+          class="ScaleBar-refLabel-165"
+        >
+          ctgA
+        </div>
+      </div>
     </div>
     <div
       class="makeStyles-controls-3 makeStyles-trackControls-5"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-73"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
         tabindex="0"
         title="close this track"
         type="button"
@@ -481,7 +657,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-74 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -503,34 +679,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-71 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-72 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-105"
+      class="TrackRenderingContainer-trackRenderingContainer-205"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-106"
+        class="Track-track-206"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-107"
+          class="TrackBlocks-trackBlocks-207"
           data-testid="Block"
         >
           <div
-            class="Block-block-111 Block-leftBorder-112 Block-rightBorder-113"
+            class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-121"
+              class="Component-blockMessage-221"
             >
               region assembly does not match track assembly
             </div>
@@ -539,7 +715,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-110"
+      class="TrackResizeHandle-dragHandle-210"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -548,7 +724,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: track-bar; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-73"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-197"
         tabindex="0"
         title="close this track"
         type="button"
@@ -568,7 +744,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-74 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-198 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -590,34 +766,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-71 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-195 MuiTypography-body1"
       >
         Bar Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-72 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-196 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-105"
+      class="TrackRenderingContainer-trackRenderingContainer-205"
       role="presentation"
       style="grid-row: track-bar; grid-column: blocks;"
     >
       <div
-        class="Track-track-106"
+        class="Track-track-206"
         data-testid="track-testConfig2"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-107"
+          class="TrackBlocks-trackBlocks-207"
           data-testid="Block"
         >
           <div
-            class="Block-block-111 Block-leftBorder-112 Block-rightBorder-113"
+            class="Block-block-211 Block-leftBorder-212 Block-rightBorder-213"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-121"
+              class="Component-blockMessage-221"
             >
               region assembly does not match track assembly
             </div>
@@ -626,7 +802,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-110"
+      class="TrackResizeHandle-dragHandle-210"
       role="presentation"
       style="grid-row: resize-bar; grid-column: span 2;"
     />
@@ -640,14 +816,13 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
 >
   <div
     class="makeStyles-linearGenomeView-2"
-    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
+    style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-controls-3 makeStyles-viewControls-4"
-      style="grid-row: scale-bar;"
+      class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
         title="close this view"
         type="button"
@@ -667,44 +842,117 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
-        data_testid="track_select"
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
         tabindex="0"
-        title="select tracks"
         type="button"
-        value="track_select"
       >
         <span
-          class="MuiToggleButton-label"
+          class="MuiIconButton-label"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
           >
-            line_style
-          </span>
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
         </span>
         <span
           class="MuiTouchRipple-root"
         />
       </button>
-    </div>
-    <div
-      class="Rubberband-rubberBandContainer-37"
-      role="presentation"
-    >
       <div
-        class="ScaleBar-scaleBar-38"
-        style="height: 32px;"
+        class="makeStyles-emphasis-9"
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-11 MuiTypography-body1"
+        />
+      </div>
+      <div
+        class="makeStyles-spacer-7"
       />
-    </div>
-    <div
-      class="makeStyles-zoomControls-6"
-      style="right: 4px; z-index: 1000;"
-    >
       <div
-        class="ZoomControls-container-40"
-        style="height: 32px;"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-10 MuiPaper-rounded"
+      >
+        <form>
+          <div
+            class="MuiInputBase-root"
+          >
+            <input
+              class="MuiInputBase-input"
+              placeholder="Enter locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-13"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline"
+      >
+        <div
+          aria-haspopup="true"
+          aria-pressed="false"
+          class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input MuiInputBase-inputSelect"
+          id="select-refseq"
+          role="button"
+          tabindex="0"
+        >
+          <span>
+            ​
+          </span>
+        </div>
+        <input
+          name="refseq"
+          type="hidden"
+          value="Select refSeq"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSelect-icon"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+      <div
+        class="ZoomControls-container-141"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -726,7 +974,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-41"
+          class="MuiSlider-root ZoomControls-slider-142"
         >
           <span
             class="MuiSlider-rail"
@@ -769,6 +1017,22 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           />
         </button>
       </div>
+      <div
+        class="makeStyles-spacer-7"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    />
+    <div
+      class="Rubberband-rubberBandContainer-163"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-164"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      />
     </div>
   </div>
 </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -12,7 +12,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         title="close this view"
         type="button"
@@ -35,7 +35,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         type="button"
       >
@@ -68,18 +68,19 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       >
         <form>
           <div
-            class="MuiInputBase-root"
+            class="MuiInputBase-root makeStyles-input-14"
           >
             <input
+              aria-invalid="false"
               class="MuiInputBase-input"
-              placeholder="Enter locstring"
+              placeholder="Enter location (e.g. chr1:1000..5000)"
               type="text"
               value=""
             />
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
             tabindex="0"
             type="button"
           >
@@ -132,7 +133,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         </svg>
       </div>
       <div
-        class="ZoomControls-container-142"
+        class="ZoomControls-container-143"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -154,7 +155,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-143"
+          class="MuiSlider-root ZoomControls-slider-144"
         >
           <span
             class="MuiSlider-rail"
@@ -206,11 +207,11 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-164"
+      class="Rubberband-rubberBandContainer-165"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-165"
+        class="ScaleBar-scaleBar-166"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       />
     </div>
@@ -219,7 +220,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-199"
         tabindex="0"
         title="close this track"
         type="button"
@@ -239,7 +240,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-200 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -261,32 +262,32 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-197 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-198 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-206"
+      class="TrackRenderingContainer-trackRenderingContainer-207"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-207"
+        class="Track-track-208"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-208"
+          class="TrackBlocks-trackBlocks-209"
           data-testid="Block"
         />
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-211"
+      class="TrackResizeHandle-dragHandle-212"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -306,7 +307,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         title="close this view"
         type="button"
@@ -329,7 +330,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         type="button"
       >
@@ -362,18 +363,19 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       >
         <form>
           <div
-            class="MuiInputBase-root"
+            class="MuiInputBase-root makeStyles-input-14"
           >
             <input
+              aria-invalid="false"
               class="MuiInputBase-input"
-              placeholder="Enter locstring"
+              placeholder="Enter location (e.g. chr1:1000..5000)"
               type="text"
               value=""
             />
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
             tabindex="0"
             type="button"
           >
@@ -426,7 +428,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </svg>
       </div>
       <div
-        class="ZoomControls-container-142"
+        class="ZoomControls-container-143"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -448,7 +450,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-143"
+          class="MuiSlider-root ZoomControls-slider-144"
         >
           <span
             class="MuiSlider-rail"
@@ -500,15 +502,15 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-164"
+      class="Rubberband-rubberBandContainer-165"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-165"
+        class="ScaleBar-scaleBar-166"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       >
         <div
-          class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
+          class="Block-block-213 Block-leftBorder-214 Block-rightBorder-215"
           style="left: 0px; width: 100px;"
         >
           <svg
@@ -516,7 +518,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             width="100"
           >
             <line
-              class="Ruler-majorTick-216"
+              class="Ruler-majorTick-217"
               data-bp="-1"
               stroke="#555"
               stroke-width="1"
@@ -526,7 +528,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="Ruler-minorTick-217"
+              class="Ruler-minorTick-218"
               data-bp="19"
               stroke="#999"
               stroke-width="1"
@@ -536,7 +538,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-217"
+              class="Ruler-minorTick-218"
               data-bp="39"
               stroke="#999"
               stroke-width="1"
@@ -546,7 +548,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-217"
+              class="Ruler-minorTick-218"
               data-bp="59"
               stroke="#999"
               stroke-width="1"
@@ -556,7 +558,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-minorTick-217"
+              class="Ruler-minorTick-218"
               data-bp="79"
               stroke="#999"
               stroke-width="1"
@@ -566,7 +568,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="Ruler-majorTick-216"
+              class="Ruler-majorTick-217"
               data-bp="99"
               stroke="#555"
               stroke-width="1"
@@ -576,7 +578,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="Ruler-minorTick-217"
+              class="Ruler-minorTick-218"
               data-bp="119"
               stroke="#999"
               stroke-width="1"
@@ -586,7 +588,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <text
-              class="Ruler-majorTickLabel-215"
+              class="Ruler-majorTickLabel-216"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="-4"
@@ -595,7 +597,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               0
             </text>
             <text
-              class="Ruler-majorTickLabel-215"
+              class="Ruler-majorTickLabel-216"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="96"
@@ -606,7 +608,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </svg>
         </div>
         <div
-          class="ScaleBar-refLabel-166"
+          class="ScaleBar-refLabel-167"
         >
           ctgA
         </div>
@@ -617,7 +619,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-199"
         tabindex="0"
         title="close this track"
         type="button"
@@ -637,7 +639,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-200 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -659,34 +661,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-197 MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-198 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-206"
+      class="TrackRenderingContainer-trackRenderingContainer-207"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="Track-track-207"
+        class="Track-track-208"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-208"
+          class="TrackBlocks-trackBlocks-209"
           data-testid="Block"
         >
           <div
-            class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
+            class="Block-block-213 Block-leftBorder-214 Block-rightBorder-215"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-222"
+              class="Component-blockMessage-223"
             >
               region assembly does not match track assembly
             </div>
@@ -695,7 +697,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-211"
+      class="TrackResizeHandle-dragHandle-212"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2;"
     />
@@ -704,7 +706,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       style="grid-row: track-bar; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-198"
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-199"
         tabindex="0"
         title="close this track"
         type="button"
@@ -724,7 +726,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-199 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-200 MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -746,34 +748,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root TrackControls-trackName-196 MuiTypography-body1"
+        class="MuiTypography-root TrackControls-trackName-197 MuiTypography-body1"
       >
         Bar Track
       </p>
       <span
-        class="MuiTypography-root TrackControls-trackDescription-197 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root TrackControls-trackDescription-198 MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-206"
+      class="TrackRenderingContainer-trackRenderingContainer-207"
       role="presentation"
       style="grid-row: track-bar; grid-column: blocks;"
     >
       <div
-        class="Track-track-207"
+        class="Track-track-208"
         data-testid="track-testConfig2"
         role="presentation"
       >
         <div
-          class="TrackBlocks-trackBlocks-208"
+          class="TrackBlocks-trackBlocks-209"
           data-testid="Block"
         >
           <div
-            class="Block-block-212 Block-leftBorder-213 Block-rightBorder-214"
+            class="Block-block-213 Block-leftBorder-214 Block-rightBorder-215"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="Component-blockMessage-222"
+              class="Component-blockMessage-223"
             >
               region assembly does not match track assembly
             </div>
@@ -782,7 +784,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="TrackResizeHandle-dragHandle-211"
+      class="TrackResizeHandle-dragHandle-212"
       role="presentation"
       style="grid-row: resize-bar; grid-column: span 2;"
     />
@@ -802,7 +804,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       class="makeStyles-headerBar-6"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         title="close this view"
         type="button"
@@ -825,7 +827,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
         tabindex="0"
         type="button"
       >
@@ -858,18 +860,19 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       >
         <form>
           <div
-            class="MuiInputBase-root"
+            class="MuiInputBase-root makeStyles-input-14"
           >
             <input
+              aria-invalid="false"
               class="MuiInputBase-input"
-              placeholder="Enter locstring"
+              placeholder="Enter location (e.g. chr1:1000..5000)"
               type="text"
               value=""
             />
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-14"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
             tabindex="0"
             type="button"
           >
@@ -922,7 +925,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         </svg>
       </div>
       <div
-        class="ZoomControls-container-142"
+        class="ZoomControls-container-143"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -944,7 +947,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           />
         </button>
         <span
-          class="MuiSlider-root ZoomControls-slider-143"
+          class="MuiSlider-root ZoomControls-slider-144"
         >
           <span
             class="MuiSlider-rail"
@@ -996,11 +999,11 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-164"
+      class="Rubberband-rubberBandContainer-165"
       role="presentation"
     >
       <div
-        class="ScaleBar-scaleBar-165"
+        class="ScaleBar-scaleBar-166"
         style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
       />
     </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap.orig
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap.orig
@@ -1,0 +1,1156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinearGenomeView genome view component renders one track, no blocks 1`] = `
+<div
+  class="makeStyles-root-1"
+>
+  <div
+<<<<<<< HEAD
+    class="makeStyles-linearGenomeView-2"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+        tabindex="0"
+        title="close this view"
+        type="button"
+=======
+    class="makeStyles-linearGenomeView-3"
+    style="display: grid; position: relative; grid-template-rows: [header] auto [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-headerBar-7"
+    >
+      <div
+        class="makeStyles-emphasis-10"
+>>>>>>> Add a header bar for searching with linear genome view
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-12 MuiTypography-body1"
+        />
+<<<<<<< HEAD
+      </button>
+      <button
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
+        data_testid="track_select"
+        tabindex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+=======
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+      <div
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-11 MuiPaper-rounded"
+>>>>>>> Add a header bar for searching with linear genome view
+      >
+        <form
+          id="myform"
+        >
+          <div
+            class="MuiInputBase-root"
+          >
+<<<<<<< HEAD
+            line_style
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="Rubberband-rubberBandContainer-37"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-38"
+        style="height: 32px;"
+      />
+    </div>
+    <div
+      class="makeStyles-zoomControls-6"
+      style="right: 4px; z-index: 1000;"
+    >
+=======
+            <input
+              aria-label="search google maps"
+              class="MuiInputBase-input"
+              placeholder="Search feature or locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+>>>>>>> Add a header bar for searching with linear genome view
+      <div
+        class="ZoomControls-container-109"
+      >
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <span
+          class="MuiSlider-root ZoomControls-slider-110"
+        >
+          <span
+            class="MuiSlider-rail"
+          />
+          <span
+            class="MuiSlider-track"
+          />
+          <input
+            type="hidden"
+            value="5.643856189774724"
+          />
+          <span
+            aria-orientation="horizontal"
+            aria-valuemax="5.643856189774724"
+            aria-valuemin="5.643856189774724"
+            aria-valuenow="5.643856189774724"
+            class="MuiSlider-thumb"
+            data-index="0"
+            role="slider"
+            tabindex="0"
+          />
+        </span>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-4 makeStyles-viewControls-5"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+        tabindex="0"
+        title="close this view"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="Rubberband-rubberBandContainer-143"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-144"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      />
+    </div>
+    <div
+<<<<<<< HEAD
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
+=======
+      class="makeStyles-controls-4 makeStyles-trackControls-6"
+>>>>>>> Add a header bar for searching with linear genome view
+      style="grid-row: track-foo; grid-column: controls;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-177"
+        tabindex="0"
+        title="close this track"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-178 MuiToggleButton-sizeSmall"
+        style="min-width: 0;"
+        tabindex="0"
+        title="configure track"
+        type="button"
+        value="configure"
+      >
+        <span
+          class="MuiToggleButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <p
+        class="MuiTypography-root TrackControls-trackName-175 MuiTypography-body1"
+      >
+        Foo Track
+      </p>
+      <span
+        class="MuiTypography-root TrackControls-trackDescription-176 MuiTypography-caption MuiTypography-colorTextSecondary"
+      />
+    </div>
+    <div
+      class="TrackRenderingContainer-trackRenderingContainer-185"
+      role="presentation"
+      style="grid-row: track-foo; grid-column: blocks;"
+    >
+      <div
+        class="Track-track-186"
+        data-testid="track-testConfig"
+        role="presentation"
+      >
+        <div
+          class="TrackBlocks-trackBlocks-187"
+          data-testid="Block"
+        />
+      </div>
+    </div>
+    <div
+      class="TrackResizeHandle-dragHandle-190"
+      role="presentation"
+      style="grid-row: resize-foo; grid-column: span 2;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LinearGenomeView genome view component renders two tracks, two regions 1`] = `
+<div
+  class="makeStyles-root-1"
+>
+  <div
+<<<<<<< HEAD
+    class="makeStyles-linearGenomeView-2"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+=======
+    class="makeStyles-linearGenomeView-3"
+    style="display: grid; position: relative; grid-template-rows: [header] auto [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-headerBar-7"
+    >
+      <div
+        class="makeStyles-emphasis-10"
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-12 MuiTypography-body1"
+        />
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+      <div
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-11 MuiPaper-rounded"
+      >
+        <form
+          id="myform"
+        >
+          <div
+            class="MuiInputBase-root"
+          >
+            <input
+              aria-label="search google maps"
+              class="MuiInputBase-input"
+              placeholder="Search feature or locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+      <div
+        class="ZoomControls-container-109"
+      >
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <span
+          class="MuiSlider-root ZoomControls-slider-110"
+        >
+          <span
+            class="MuiSlider-rail"
+          />
+          <span
+            class="MuiSlider-track"
+          />
+          <input
+            type="hidden"
+            value="5.643856189774724"
+          />
+          <span
+            aria-orientation="horizontal"
+            aria-valuemax="5.643856189774724"
+            aria-valuemin="5.643856189774724"
+            aria-valuenow="5.643856189774724"
+            class="MuiSlider-thumb"
+            data-index="0"
+            role="slider"
+            tabindex="0"
+          />
+        </span>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-4 makeStyles-viewControls-5"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+>>>>>>> Add a header bar for searching with linear genome view
+        tabindex="0"
+        title="close this view"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+<<<<<<< HEAD
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
+        data_testid="track_select"
+=======
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+>>>>>>> Add a header bar for searching with linear genome view
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="Rubberband-rubberBandContainer-143"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-144"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      >
+        <div
+          class="Block-block-191 Block-leftBorder-192 Block-rightBorder-193"
+          style="left: 0px; width: 100px;"
+        >
+          <svg
+            height="32"
+            width="100"
+          >
+            <line
+              class="Ruler-majorTick-195"
+              data-bp="-1"
+              stroke="#555"
+              stroke-width="1"
+              x1="-1"
+              x2="-1"
+              y1="0"
+              y2="6"
+            />
+            <line
+              class="Ruler-minorTick-196"
+              data-bp="19"
+              stroke="#999"
+              stroke-width="1"
+              x1="19"
+              x2="19"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-196"
+              data-bp="39"
+              stroke="#999"
+              stroke-width="1"
+              x1="39"
+              x2="39"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-196"
+              data-bp="59"
+              stroke="#999"
+              stroke-width="1"
+              x1="59"
+              x2="59"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-minorTick-196"
+              data-bp="79"
+              stroke="#999"
+              stroke-width="1"
+              x1="79"
+              x2="79"
+              y1="0"
+              y2="4"
+            />
+            <line
+              class="Ruler-majorTick-195"
+              data-bp="99"
+              stroke="#555"
+              stroke-width="1"
+              x1="99"
+              x2="99"
+              y1="0"
+              y2="6"
+            />
+            <line
+              class="Ruler-minorTick-196"
+              data-bp="119"
+              stroke="#999"
+              stroke-width="1"
+              x1="119"
+              x2="119"
+              y1="0"
+              y2="4"
+            />
+            <text
+              class="Ruler-majorTickLabel-194"
+              dominant-baseline="hanging"
+              style="font-size: 11px;"
+              x="-4"
+              y="7"
+            >
+              0
+            </text>
+            <text
+              class="Ruler-majorTickLabel-194"
+              dominant-baseline="hanging"
+              style="font-size: 11px;"
+              x="96"
+              y="7"
+            >
+              100
+            </text>
+          </svg>
+        </div>
+        <div
+          class="ScaleBar-refLabel-145"
+        >
+          ctgA
+        </div>
+      </div>
+    </div>
+    <div
+<<<<<<< HEAD
+      class="makeStyles-zoomControls-6"
+      style="right: 4px; z-index: 1000;"
+    >
+      <div
+        class="ZoomControls-container-40"
+        style="height: 32px;"
+      >
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <span
+          class="MuiSlider-root ZoomControls-slider-41"
+        >
+          <span
+            class="MuiSlider-rail"
+          />
+          <span
+            class="MuiSlider-track"
+          />
+          <input
+            type="hidden"
+            value="5.643856189774724"
+          />
+          <span
+            aria-orientation="horizontal"
+            aria-valuemax="5.643856189774724"
+            aria-valuemin="5.643856189774724"
+            aria-valuenow="5.643856189774724"
+            class="MuiSlider-thumb"
+            data-index="0"
+            role="slider"
+            tabindex="0"
+          />
+        </span>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
+=======
+      class="makeStyles-controls-4 makeStyles-trackControls-6"
+>>>>>>> Add a header bar for searching with linear genome view
+      style="grid-row: track-foo; grid-column: controls;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-177"
+        tabindex="0"
+        title="close this track"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-178 MuiToggleButton-sizeSmall"
+        style="min-width: 0;"
+        tabindex="0"
+        title="configure track"
+        type="button"
+        value="configure"
+      >
+        <span
+          class="MuiToggleButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <p
+        class="MuiTypography-root TrackControls-trackName-175 MuiTypography-body1"
+      >
+        Foo Track
+      </p>
+      <span
+        class="MuiTypography-root TrackControls-trackDescription-176 MuiTypography-caption MuiTypography-colorTextSecondary"
+      />
+    </div>
+    <div
+      class="TrackRenderingContainer-trackRenderingContainer-185"
+      role="presentation"
+      style="grid-row: track-foo; grid-column: blocks;"
+    >
+      <div
+        class="Track-track-186"
+        data-testid="track-testConfig"
+        role="presentation"
+      >
+        <div
+          class="TrackBlocks-trackBlocks-187"
+          data-testid="Block"
+        >
+          <div
+            class="Block-block-191 Block-leftBorder-192 Block-rightBorder-193"
+            style="left: 0px; width: 100px;"
+          >
+            <div
+              class="Component-blockMessage-201"
+            >
+              region assembly does not match track assembly
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="TrackResizeHandle-dragHandle-190"
+      role="presentation"
+      style="grid-row: resize-foo; grid-column: span 2;"
+    />
+    <div
+<<<<<<< HEAD
+      class="makeStyles-controls-3 makeStyles-trackControls-5"
+=======
+      class="makeStyles-controls-4 makeStyles-trackControls-6"
+>>>>>>> Add a header bar for searching with linear genome view
+      style="grid-row: track-bar; grid-column: controls;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root TrackControls-iconButton-177"
+        tabindex="0"
+        title="close this track"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiToggleButton-root TrackControls-toggleButton-178 MuiToggleButton-sizeSmall"
+        style="min-width: 0;"
+        tabindex="0"
+        title="configure track"
+        type="button"
+        value="configure"
+      >
+        <span
+          class="MuiToggleButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            settings
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <p
+        class="MuiTypography-root TrackControls-trackName-175 MuiTypography-body1"
+      >
+        Bar Track
+      </p>
+      <span
+        class="MuiTypography-root TrackControls-trackDescription-176 MuiTypography-caption MuiTypography-colorTextSecondary"
+      />
+    </div>
+    <div
+      class="TrackRenderingContainer-trackRenderingContainer-185"
+      role="presentation"
+      style="grid-row: track-bar; grid-column: blocks;"
+    >
+      <div
+        class="Track-track-186"
+        data-testid="track-testConfig2"
+        role="presentation"
+      >
+        <div
+          class="TrackBlocks-trackBlocks-187"
+          data-testid="Block"
+        >
+          <div
+            class="Block-block-191 Block-leftBorder-192 Block-rightBorder-193"
+            style="left: 0px; width: 100px;"
+          >
+            <div
+              class="Component-blockMessage-201"
+            >
+              region assembly does not match track assembly
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="TrackResizeHandle-dragHandle-190"
+      role="presentation"
+      style="grid-row: resize-bar; grid-column: span 2;"
+    />
+  </div>
+</div>
+`;
+
+exports[`LinearGenomeView genome view component renders with an empty model 1`] = `
+<div
+  class="makeStyles-root-1"
+>
+  <div
+<<<<<<< HEAD
+    class="makeStyles-linearGenomeView-2"
+    style="display: grid; position: relative; grid-template-rows: [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-7"
+        tabindex="0"
+        title="close this view"
+        type="button"
+=======
+    class="makeStyles-linearGenomeView-3"
+    style="display: grid; position: relative; grid-template-rows: [header] auto [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
+  >
+    <div
+      class="makeStyles-headerBar-7"
+    >
+      <div
+        class="makeStyles-emphasis-10"
+>>>>>>> Add a header bar for searching with linear genome view
+      >
+        <p
+          class="MuiTypography-root makeStyles-viewName-12 MuiTypography-body1"
+        />
+<<<<<<< HEAD
+      </button>
+      <button
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-8"
+        data_testid="track_select"
+        tabindex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+=======
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+      <div
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-11 MuiPaper-rounded"
+>>>>>>> Add a header bar for searching with linear genome view
+      >
+        <form
+          id="myform"
+        >
+          <div
+            class="MuiInputBase-root"
+          >
+<<<<<<< HEAD
+            line_style
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="Rubberband-rubberBandContainer-37"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-38"
+        style="height: 32px;"
+      />
+    </div>
+    <div
+      class="makeStyles-zoomControls-6"
+      style="right: 4px; z-index: 1000;"
+    >
+=======
+            <input
+              aria-label="search google maps"
+              class="MuiInputBase-input"
+              placeholder="Search feature or locstring"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </form>
+      </div>
+>>>>>>> Add a header bar for searching with linear genome view
+      <div
+        class="ZoomControls-container-109"
+      >
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_out
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <span
+          class="MuiSlider-root ZoomControls-slider-110"
+        >
+          <span
+            class="MuiSlider-rail"
+          />
+          <span
+            class="MuiSlider-track"
+          />
+          <input
+            type="hidden"
+            value="5.643856189774724"
+          />
+          <span
+            aria-orientation="horizontal"
+            aria-valuemax="5.643856189774724"
+            aria-valuemin="5.643856189774724"
+            aria-valuenow="5.643856189774724"
+            class="MuiSlider-thumb"
+            data-index="0"
+            role="slider"
+            tabindex="0"
+          />
+        </span>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <span
+              aria-hidden="true"
+              class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+            >
+              zoom_in
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="makeStyles-spacer-8"
+      />
+    </div>
+    <div
+      class="makeStyles-controls-4 makeStyles-viewControls-5"
+      style="grid-row: scale-bar;"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+        tabindex="0"
+        title="close this view"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-label="more"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-2"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="Rubberband-rubberBandContainer-143"
+      role="presentation"
+    >
+      <div
+        class="ScaleBar-scaleBar-144"
+        style="grid-column: blocks; grid-row: scale-bar; height: 32px;"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -180,19 +180,6 @@ export function stateModelFactory(pluginManager) {
         self.displayRegionsFromAssemblyName = assemblyName
       },
 
-      activateSearch() {
-        const session = getSession(self)
-        const search = session.addDrawerWidget(
-          'SearchDrawerWidget',
-          'searchAndNav',
-          {
-            target: self,
-          },
-        )
-        search.setTarget(self)
-        session.showDrawerWidget(search)
-      },
-
       activateTrackSelector() {
         if (self.trackSelectorType === 'hierarchical') {
           const session = getSession(self)
@@ -253,6 +240,12 @@ export function stateModelFactory(pluginManager) {
 
       navTo({ refSeq, start, end }) {
         const index = self.getIndex(refSeq)
+        if (start === undefined) {
+          start = self.displayedRegions[index].start // eslint-disable-line
+        }
+        if (end === undefined) {
+          end = self.displayedRegions[index].end //eslint-disable-line
+        }
         self.moveTo({ index, offset: start }, { index, offset: end })
       },
 
@@ -329,7 +322,7 @@ export function stateModelFactory(pluginManager) {
       },
 
       showAllRegions() {
-        self.bpPerPx = self.maxBpPerPx
+        self.bpPerPx = self.totalBp / self.viewingRegionWidth
         self.offsetPx = 0
       },
     }))

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -135,7 +135,7 @@ export function stateModelFactory(pluginManager) {
 
       horizontallyFlip() {
         self.reversed = !self.reversed
-        self.displayedRegions = self.displayedRegions.reverse()
+        self.displayedRegions = self.displayedRegions.slice().reverse()
         self.offsetPx = self.totalBp / self.bpPerPx - self.offsetPx - self.width
       },
 

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -33,6 +33,10 @@ const validBpPerPx = [
   100000,
   200000,
   500000,
+  1000000,
+  2000000,
+  5000000,
+  10000000,
 ]
 
 function constrainBpPerPx(newBpPerPx) {
@@ -113,6 +117,9 @@ export function stateModelFactory(pluginManager) {
           horizontallyFlipped: self.horizontallyFlipped,
         }
       },
+      getIndex(refSeq) {
+        return self.displayedRegions.findIndex(r => r.refName === refSeq)
+      },
     }))
     .actions(self => ({
       setWidth(newWidth) {
@@ -166,6 +173,19 @@ export function stateModelFactory(pluginManager) {
 
       setDisplayedRegionsFromAssemblyName(assemblyName) {
         self.displayRegionsFromAssemblyName = assemblyName
+      },
+
+      activateSearch() {
+        const session = getSession(self)
+        const search = session.addDrawerWidget(
+          'SearchDrawerWidget',
+          'searchAndNav',
+          {
+            target: self,
+          },
+        )
+        search.setTarget(self)
+        session.showDrawerWidget(search)
       },
 
       activateTrackSelector() {
@@ -224,6 +244,11 @@ export function stateModelFactory(pluginManager) {
           offset: Math.round(bp - bpSoFar),
           index: self.displayedRegions.length - 1,
         }
+      },
+
+      navTo({ refSeq, start, end }) {
+        const index = self.getIndex(refSeq)
+        self.moveTo({ index, offset: start }, { index, offset: end })
       },
 
       /**

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -242,6 +242,14 @@ export function stateModelFactory(pluginManager) {
         }
       },
 
+      /*
+       * navTo navigates to a simple refName:start..end type object as input
+       * can handle if there are multiple displayedRegions from same chr
+       * only navigates to a locstring if it is entirely within a displayedRegion
+       *
+       * @param {refName,start,end} is a proposed location to navigate to
+       * returns true if navigation was successful, false if not
+       */
       navTo({ refName, start, end }) {
         let s = start
         let e = end
@@ -265,7 +273,9 @@ export function stateModelFactory(pluginManager) {
             { index, offset: s - f.start },
             { index, offset: e - f.start },
           )
+          return true
         }
+        return false
       },
 
       /**

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -76,14 +76,19 @@ export function stateModelFactory(pluginManager) {
       get viewingRegionWidth() {
         return self.width - self.controlsWidth
       },
-      get maxBpPerPx() {
-        const displayWidth = self.viewingRegionWidth
+
+      get totalBp() {
         let totalbp = 0
         self.displayedRegions.forEach(region => {
           totalbp += region.end - region.start
         })
-        return constrainBpPerPx(totalbp / displayWidth)
+        return totalbp
       },
+
+      get maxBpPerPx() {
+        return constrainBpPerPx(self.totalBp / self.viewingRegionWidth)
+      },
+
       get minBpPerPx() {
         return constrainBpPerPx(0)
       },
@@ -321,6 +326,11 @@ export function stateModelFactory(pluginManager) {
       setNewView(bpPerPx, offsetPx) {
         self.bpPerPx = bpPerPx
         self.offsetPx = offsetPx
+      },
+
+      showAllRegions() {
+        self.bpPerPx = self.maxBpPerPx
+        self.offsetPx = 0
       },
     }))
 }

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -133,6 +133,7 @@ export function stateModelFactory(pluginManager) {
 
       horizontallyFlip() {
         self.reversed = !self.reversed
+        self.displayedRegions = self.displayedRegions.reverse()
       },
 
       showTrack(configuration, initialSnapshot = {}) {

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -240,13 +240,15 @@ export function stateModelFactory(pluginManager) {
 
       navTo({ refSeq, start, end }) {
         const index = self.getIndex(refSeq)
-        if (start === undefined) {
-          start = self.displayedRegions[index].start // eslint-disable-line
+        if (index !== -1) {
+          if (start === undefined) {
+            start = self.displayedRegions[index].start // eslint-disable-line
+          }
+          if (end === undefined) {
+            end = self.displayedRegions[index].end //eslint-disable-line
+          }
+          self.moveTo({ index, offset: start }, { index, offset: end })
         }
-        if (end === undefined) {
-          end = self.displayedRegions[index].end //eslint-disable-line
-        }
-        self.moveTo({ index, offset: start }, { index, offset: end })
       },
 
       /**

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -56,6 +56,7 @@ export function stateModelFactory(pluginManager) {
       bpPerPx: 1,
       displayedRegions: types.array(Region),
       displayRegionsFromAssemblyName: types.maybe(types.string),
+      displayName: types.maybe(types.string),
       reversed: false,
       // we use an array for the tracks because the tracks are displayed in a specific
       // order that we need to keep.
@@ -122,13 +123,14 @@ export function stateModelFactory(pluginManager) {
           horizontallyFlipped: self.horizontallyFlipped,
         }
       },
-      getIndex(refSeq) {
-        return self.displayedRegions.findIndex(r => r.refName === refSeq)
-      },
     }))
     .actions(self => ({
       setWidth(newWidth) {
         self.width = newWidth
+      },
+
+      setDisplayName(name) {
+        self.displayName = name
       },
 
       horizontallyFlip() {
@@ -241,15 +243,25 @@ export function stateModelFactory(pluginManager) {
       },
 
       navTo({ refSeq, start, end }) {
-        const index = self.getIndex(refSeq)
+        let s = start
+        let e = end
+        const index = self.displayedRegions.findIndex(r => {
+          if (refSeq == r.refName) {
+            if (s === undefined) {
+              s = r.start
+            }
+            if (e === undefined) {
+              e = r.end
+            }
+            if (s >= r.start && e <= r.end) {
+              return true
+            }
+          }
+          return false
+        })
+        console.log('here', index)
         if (index !== -1) {
-          if (start === undefined) {
-            start = self.displayedRegions[index].start // eslint-disable-line
-          }
-          if (end === undefined) {
-            end = self.displayedRegions[index].end //eslint-disable-line
-          }
-          self.moveTo({ index, offset: start }, { index, offset: end })
+          self.moveTo({ index, offset: s }, { index, offset: e })
         }
       },
 

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -246,7 +246,7 @@ export function stateModelFactory(pluginManager) {
         let s = start
         let e = end
         const index = self.displayedRegions.findIndex(r => {
-          if (refName == r.refName) {
+          if (refName === r.refName) {
             if (s === undefined) {
               s = r.start
             }
@@ -259,7 +259,6 @@ export function stateModelFactory(pluginManager) {
           }
           return false
         })
-        console.log('here', index)
         const f = self.displayedRegions[index]
         if (index !== -1) {
           self.moveTo(

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -242,11 +242,11 @@ export function stateModelFactory(pluginManager) {
         }
       },
 
-      navTo({ refSeq, start, end }) {
+      navTo({ refName, start, end }) {
         let s = start
         let e = end
         const index = self.displayedRegions.findIndex(r => {
-          if (refSeq == r.refName) {
+          if (refName == r.refName) {
             if (s === undefined) {
               s = r.start
             }
@@ -260,8 +260,12 @@ export function stateModelFactory(pluginManager) {
           return false
         })
         console.log('here', index)
+        const f = self.displayedRegions[index]
         if (index !== -1) {
-          self.moveTo({ index, offset: s }, { index, offset: e })
+          self.moveTo(
+            { index, offset: s - f.start },
+            { index, offset: e - f.start },
+          )
         }
       },
 

--- a/packages/linear-genome-view/src/LinearGenomeView/index.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.js
@@ -134,6 +134,7 @@ export function stateModelFactory(pluginManager) {
       horizontallyFlip() {
         self.reversed = !self.reversed
         self.displayedRegions = self.displayedRegions.reverse()
+        self.offsetPx = self.totalBp / self.bpPerPx - self.offsetPx - self.width
       },
 
       showTrack(configuration, initialSnapshot = {}) {

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.js
@@ -144,6 +144,43 @@ test('can instantiate a model that has multiple displayed regions', () => {
   expect(model.bpPerPx).toEqual(2.5)
 })
 
+test('can instantiate a model that tests navTo/moveTo', () => {
+  const name = types
+    .model({
+      name: 'testSession',
+      view: types.maybe(LinearGenomeModel),
+      configuration: types.map(types.string),
+    })
+    .actions(self => ({
+      setView(view) {
+        self.view = view
+        return view
+      },
+    }))
+    .create({
+      config: {},
+    })
+
+  const model = name.setView(
+    LinearGenomeModel.create({
+      type: 'LinearGenomeView',
+      tracks: [{ name: 'foo track', type: 'AlignmentsTrack' }],
+      controlsWidth: 0,
+      configuration: {},
+    }),
+  )
+  model.setDisplayedRegions([
+    { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
+    { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgB' },
+  ])
+  expect(model.maxBpPerPx).toEqual(20)
+
+  model.navTo({ refName: 'ctgA', start: 0, end: 100 })
+  expect(model.bpPerPx).toEqual(100 / 800)
+  model.navTo({ refName: 'ctgA', start: 0, end: 20000 })
+  expect(model.bpPerPx).toEqual(100 / 800) // did nothing
+})
+
 test('can instantiate a model that >2 regions', () => {
   const name = types
     .model({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,13 @@
     react-transition-group "^4.0.0"
     warning "^4.0.1"
 
+"@material-ui/icons@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.2.1.tgz#fe2f1c4f60c24256d244a69d86d0c00e8ed4037e"
+  integrity sha512-FvSD5lUBJ66frI4l4AYAPy2CH14Zs2Dgm0o3oOMr33BdQtOAjCgbdOcvPBeaD1w6OQl31uNW3CKOE8xfPNxvUQ==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+
 "@material-ui/lab@^4.0.0-alpha.0":
   version "4.0.0-alpha.18"
   resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.18.tgz#e1b8f51d177190f8431b1d07da9f78f560727ac8"


### PR DESCRIPTION
This is a preview of what a header for the Linear genome view could possibly look like

It does these things

* restores ability to horizontally flip the view
* has a vertical ... menu format
* allows itself to show/hide the header
* has ability to view the entire set of displayed regions from a zoomed-out point of view

Some of my proposed features including locstring input and refseq name dropdown are in some sense very problematic with our arbitrary notion of displayed regions. Therefore, these features may have to be removed, or linked to only show when the displayedRegions are tied to the assembly.

![localhost_3000_ (3)](https://user-images.githubusercontent.com/6511937/62497971-9d6d7e00-b7ab-11e9-87ec-449ed0355f72.png)

Marked as a draft



