### PR TITLE
Re-initialize the layout if any of the height's don't match for PileupRenderer

### DIFF
--- a/packages/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/packages/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -101,19 +101,28 @@ export default class extends BoxRendererType {
     const getCoord = (coord: number): number =>
       bpToPx(coord, region, bpPerPx, horizontallyFlipped)
 
-    const layoutRecords = iterMap(
-      features.values(),
-      feature =>
-        this.layoutFeature(
-          feature,
-          layout,
-          config,
-          bpPerPx,
-          region,
-          horizontallyFlipped,
-        ),
-      features.size,
-    )
+    let layoutRecords
+
+    const getFeatureLayout = (): (LayoutRecord | null)[] =>
+      iterMap(
+        features.values(),
+        feature =>
+          this.layoutFeature(
+            feature,
+            layout,
+            config,
+            bpPerPx,
+            region,
+            horizontallyFlipped,
+          ),
+        features.size,
+      )
+    try {
+      layoutRecords = getFeatureLayout()
+    } catch (e) {
+      layout.reinitialize()
+      layoutRecords = getFeatureLayout()
+    }
 
     const width = (region.end - region.start) / bpPerPx
     const height = layout.getTotalHeight()

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -326,6 +326,12 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     this.pTotalHeight = 0 // total height, in units of bitmap squares (px/pitchY)
   }
 
+  reinitialize(): void {
+    this.bitmap = []
+    this.rectangles = {}
+    this.pTotalHeight = 0
+  }
+
   /**
    * @returns {Number} top position for the rect, or Null if laying
    *  out the rect would exceed maxHeight
@@ -340,6 +346,9 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     // if we have already laid it out, return its layout
     // console.log(`${this.id} add ${id}`)
     if (id in this.rectangles) {
+      if (this.rectangles[id].originalHeight !== height) {
+        throw new Error('we require a new layout')
+      }
       const storedRec = this.rectangles[id]
       if (storedRec.top === null) return null
 


### PR DESCRIPTION
This recreates the layout if we detect that the originalHeight doesn't match a new height being passed in

This fixes #107 in a way that works for the PileupRenderer, but it does not work for the SvgFeatureRenderer.

In the SvgFeatureRenderer case, the PrecomputedLayout is what ends up being called with modified height, and I couldn't really figure out how to wire it to the backend to properly re-render it again