### PR TITLE
Remove Admin menu

### DIFF
--- a/packages/jbrowse-web/public/test_data/config.json
+++ b/packages/jbrowse-web/public/test_data/config.json
@@ -1369,26 +1369,18 @@
                   "callback": "function(session) {session.setDefaultSession();}"
                 },
                 {
-                  "name": "divider"
-                },
-                {
                   "name": "Open Session...",
                   "icon": "folder_open",
                   "callback": "function(session) {const drawerWidget = session.addDrawerWidget('SessionManager','sessionManager',);session.showDrawerWidget(drawerWidget);}"
                 },
                 {
-                  "name": "divider"
-                },
-                {
                   "name": "Duplicate Session",
                   "icon": "file_copy",
                   "callback": "function(session) {session.duplicateCurrentSession();}"
-                }
-              ]
-            },
-            {
-              "name": "Admin",
-              "menuItems": [
+                },
+                {
+                  "name": "divider"
+                },
                 {
                   "name": "Export configuration",
                   "icon": "cloud_download",


### PR DESCRIPTION
This proposes removing the admin menu, at least the way it is configured by default in the config.json. It doesn't make sense to me to provide this as an admin function.

I moved the functions to the file menu.

If it is not supposed to be available to end users at all, then I would suggest removing it completely.