### PR TITLE
Modify scroll behavior for circular view

### DIFF
--- a/packages/circular-view/src/CircularView/components/CircularView.js
+++ b/packages/circular-view/src/CircularView/components/CircularView.js
@@ -175,7 +175,7 @@ export default pluginManager => {
         <div
           className={classes.scroller}
           style={{
-            width: `${model.width}px`,
+            width: '100%',
             height: `${model.height}px`,
           }}
           onScroll={model.onScroll}

--- a/packages/circular-view/src/CircularView/models/CircularView.js
+++ b/packages/circular-view/src/CircularView/models/CircularView.js
@@ -181,8 +181,23 @@ export default pluginManager => {
       },
 
       onScroll(event) {
-        self.scrollX = event.currentTarget.scrollLeft
-        self.scrollY = event.currentTarget.scrollTop
+        const {
+          scrollLeft,
+          clientHeight,
+          scrollHeight,
+          scrollTop,
+        } = event.currentTarget
+
+        self.scrollX = scrollLeft
+        const n = scrollTop
+        const max = scrollHeight - clientHeight
+        const session = getSession(self)
+        if (n > 0 && n < max) {
+          session.shouldntScroll = true
+        } else {
+          session.shouldntScroll = false
+        }
+        self.scrollY = scrollTop
       },
 
       closeView() {


### PR DESCRIPTION
This adds the concept of "shouldntScroll" to the circular view. It makes it so that the app view does not scroll while any scrolling is happening in the circular view panel. It also makes the width 100% for the circular view which causes it to naturally display the scrollbar because previously it is missing (the manual setting of the width makes it go behind the drawer widget)