### PR TITLE
Show error on unsupported browsers

### DIFF
--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -4,10 +4,27 @@ import ReactDOM from 'react-dom'
 import JBrowse from './JBrowse'
 import * as serviceWorker from './serviceWorker'
 
-// this is the main process, so start and register our service worker and web workers
-serviceWorker.register()
+let app = <JBrowse config={{ uri: 'test_data/config.json' }} />
 
-ReactDOM.render(
-  <JBrowse config={{ uri: 'test_data/config.json' }} />,
-  document.getElementById('root'),
-)
+// TODO: get rid of user agent detection
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+if (window.chrome)
+  // this is the main process, so start and register our service worker and web workers
+  serviceWorker.register()
+else
+  app = (
+    <div>
+      <h1>This browser is not supported</h1>
+      <p>
+        JBrowse 2 is still in development and doesn't support all modern
+        browsers yet. Browsers that do currently work include:
+      </p>
+      <ul>
+        <li>Chrome</li>
+        <li>Chromium</li>
+        <li>Opera</li>
+      </ul>
+    </div>
+  )
+
+ReactDOM.render(app, document.getElementById('root'))


### PR DESCRIPTION
This is very basic and just checks `window.chrome`, which should allow chromium-based browsers like Chrome, Chromium, Opera, etc. (I tested on Opera and jbrowse-web appears to work fine).

Since this is just a temporary measure, I think it should be ok.

resolves #21 