### PR TITLE
Fix feature not found in precomputed layout error

### DIFF
--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -123,8 +123,8 @@ function SvgFeatureRendering(props) {
 
     const topPx = layout.addRect(
       feature.id(),
-      start,
-      start + rootLayout.width * bpPerPx,
+      feature.get('start'),
+      feature.get('start') + rootLayout.width * bpPerPx,
       rootLayout.height,
     )
 


### PR DESCRIPTION
This makes the actual feature.get('start') coordinate get passed to the layout, because the layout is actually performed without horizontal flipping. Ref #468 