### PR TITLE
Update to latest MST version (3.14.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "mini-css-extract-plugin": "^0.5.0",
         "mobx": "^5.0.0",
         "mobx-react": "^6.0.0",
-        "mobx-state-tree": "3.10.2",
+        "mobx-state-tree": "3.14.1",
         "node-sass": "^4.9.3",
         "open-cli": "^5.0.0",
         "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/packages/alignments/package.json
+++ b/packages/alignments/package.json
@@ -19,7 +19,7 @@
     "@material-ui/core": "^4.0.0",
     "@material-ui/styles": "^4.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "rxjs": "^6.0.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,7 +19,7 @@
     "@material-ui/core": "^4.0.0",
     "@material-ui/styles": "^4.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "rxjs": "^6.0.0"

--- a/packages/config/src/ConfigurationEditorDrawerWidget/components/SlotEditor.js
+++ b/packages/config/src/ConfigurationEditorDrawerWidget/components/SlotEditor.js
@@ -1,3 +1,8 @@
+import {
+  getPropertyType,
+  getSubType,
+  getUnionSubTypes,
+} from '@gmod/jbrowse-core/util/mst-reflection'
 import Card from '@material-ui/core/Card'
 import CardContent from '@material-ui/core/CardContent'
 import CardHeader from '@material-ui/core/CardHeader'
@@ -328,8 +333,10 @@ const booleanEditor = observer(({ slot }) => (
 ))
 
 const stringEnumEditor = observer(({ slot, slotSchema }) => {
-  const p = getPropertyMembers(slotSchema.type)
-  const choices = p.properties.value.type.types[1].types.map(t => t.value)
+  const p = getPropertyMembers(getSubType(slotSchema))
+  const choices = getUnionSubTypes(
+    getUnionSubTypes(getSubType(getPropertyType(p, 'value')))[1],
+  ).map(t => t.value)
 
   return (
     <TextField

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "@material-ui/core": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/data-management/package.json
+++ b/packages/data-management/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "^4.0.0",
     "@material-ui/styles": "^4.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0"
   }

--- a/packages/filtering/package.json
+++ b/packages/filtering/package.json
@@ -14,7 +14,7 @@
     "@material-ui/core": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0"
   }

--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -37,7 +37,7 @@
     "clsx": "^1.0.4",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.3",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "mst-middlewares": "3.10.2",
     "prop-types": "^15.7.2",
     "raf": "^3.4.1",

--- a/packages/jbrowse1/package.json
+++ b/packages/jbrowse1/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@gmod/jbrowse-core": "^2.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "rxjs": "^6.0.0"
   }
 }

--- a/packages/linear-genome-view/package.json
+++ b/packages/linear-genome-view/package.json
@@ -18,7 +18,7 @@
     "@material-ui/styles": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -18,7 +18,7 @@
     "@material-ui/styles": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0"
   }

--- a/packages/protein-widget/package.json
+++ b/packages/protein-widget/package.json
@@ -29,7 +29,7 @@
     "@material-ui/lab": "^4.0.0-alpha.0",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.3",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/sequence/package.json
+++ b/packages/sequence/package.json
@@ -16,7 +16,7 @@
     "@gmod/jbrowse-core": "^2.0.0",
     "@gmod/jbrowse-plugin-linear-genome-view": "^2.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "rxjs": "^6.0.0"

--- a/packages/trackhub-registry/package.json
+++ b/packages/trackhub-registry/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "^4.0.0",
     "@material-ui/styles": "^4.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0"
   }

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -19,7 +19,7 @@
     "@gmod/jbrowse-plugin-linear-genome-view": "^2.0.0",
     "@material-ui/core": "^4.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "rxjs": "^6.0.0"

--- a/packages/wiggle/package.json
+++ b/packages/wiggle/package.json
@@ -21,7 +21,7 @@
     "@gmod/jbrowse-plugin-linear-genome-view": "^2.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
-    "mobx-state-tree": "3.10.2",
+    "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": "^16.8.0",
     "rxjs": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10011,10 +10011,10 @@ mobx-react@^6.0.0, mobx-react@^6.0.3:
   dependencies:
     mobx-react-lite "1.4.0"
 
-mobx-state-tree@3.10.2:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-3.10.2.tgz#1cbb99a65e7e0a8f91e2c2be44d23de9b1c71afc"
-  integrity sha512-DCt05qayAaLEMldsNYicJiLUg5rFyEzivlD4oiy8HjTQ+M3aqRbgvz9kn0g1uR/5IT27jPMkAZO8MSICDGitDw==
+mobx-state-tree@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-3.14.1.tgz#0a523876b87817f5c8553a162e71b38044f0c9da"
+  integrity sha512-cmwO1jvYPgaJTGJtqId0Qod4cDqcJEWWCwSu/Uns7jFT+kWKzLFhzb9jxPub8YM3HSXg7HPGpKiLe970he9FOw==
 
 mobx@^5.0.0, mobx@^5.10.1:
   version "5.13.0"


### PR DESCRIPTION
Turns out there was only one place that wasn't using mst-reflection that caused the tests to fail. Updating it to use that instead of calling MST reserved properties directly fixed it.

resolves #193