### PR TITLE
Mock testing lib render

### DIFF
--- a/packages/__mocks__/@testing-library/react.js
+++ b/packages/__mocks__/@testing-library/react.js
@@ -1,4 +1,4 @@
-import { StylesProvider, createGenerateClassName } from '@material-ui/styles'
+import { StylesProvider } from '@material-ui/styles'
 import React from 'react'
 
 const react = jest.requireActual('@testing-library/react')

--- a/packages/__mocks__/@testing-library/react.js
+++ b/packages/__mocks__/@testing-library/react.js
@@ -1,0 +1,15 @@
+import { StylesProvider, createGenerateClassName } from '@material-ui/styles'
+import React from 'react'
+
+const react = jest.requireActual('@testing-library/react')
+const generateClassName = (rule, styleSheet) =>
+  `${styleSheet.options.classNamePrefix}-${rule.key}`
+const render = args => {
+  return react.render(
+    <StylesProvider generateClassName={generateClassName}>
+      {args}
+    </StylesProvider>,
+  )
+}
+
+module.exports = { ...react, render }

--- a/packages/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/packages/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`open up a drawer widget 1`] = `
 <div
-  class="MuiPaper-root MuiPaper-elevation1 makeStyles-root-1 MuiPaper-rounded"
+  class="MuiPaper-root MuiPaper-elevation1 makeStyles-root MuiPaper-rounded"
   data-testid="alignment-side-drawer"
 >
   <div
     class="MuiPaper-root MuiPaper-elevation1 MuiCard-root MuiPaper-rounded"
   >
     <div
-      class="MuiCardHeader-root makeStyles-header-5"
+      class="MuiCardHeader-root makeStyles-header"
     >
       <div
         class="MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiCardHeader-title makeStyles-title-6 MuiTypography-h5 MuiTypography-displayBlock"
+          class="MuiTypography-root MuiCardHeader-title makeStyles-title MuiTypography-h5 MuiTypography-displayBlock"
         >
           Primary data
         </span>
@@ -26,48 +26,48 @@ exports[`open up a drawer widget 1`] = `
     >
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           Position
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           ctgA:3..102
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           Name
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           ctgA_3_555_0:0:0_2:0:0_102d
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           Length
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           100
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           Type
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           match
         </div>
@@ -81,13 +81,13 @@ exports[`open up a drawer widget 1`] = `
     class="MuiPaper-root MuiPaper-elevation1 MuiCard-root MuiPaper-rounded"
   >
     <div
-      class="MuiCardHeader-root makeStyles-header-5"
+      class="MuiCardHeader-root makeStyles-header"
     >
       <div
         class="MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiCardHeader-title makeStyles-title-6 MuiTypography-h5 MuiTypography-displayBlock"
+          class="MuiTypography-root MuiCardHeader-title makeStyles-title MuiTypography-h5 MuiTypography-displayBlock"
         >
           Attributes
         </span>
@@ -98,96 +98,96 @@ exports[`open up a drawer widget 1`] = `
     >
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           seq
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           score
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           37
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           qual
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           MQ
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           37
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           CIGAR
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           100M
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           length_on_ref
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           100
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           template_length
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           0
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           seq_length
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           100
         </div>
@@ -201,13 +201,13 @@ exports[`open up a drawer widget 1`] = `
     class="MuiPaper-root MuiPaper-elevation1 MuiCard-root MuiPaper-rounded"
   >
     <div
-      class="MuiCardHeader-root makeStyles-header-5"
+      class="MuiCardHeader-root makeStyles-header"
     >
       <div
         class="MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiCardHeader-title makeStyles-title-6 MuiTypography-h5 MuiTypography-displayBlock"
+          class="MuiTypography-root MuiCardHeader-title makeStyles-title MuiTypography-h5 MuiTypography-displayBlock"
         >
           Flags
         </span>
@@ -218,60 +218,60 @@ exports[`open up a drawer widget 1`] = `
     >
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           unmapped
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           false
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           qc_failed
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           false
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           duplicate
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           false
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           secondary_alignment
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           false
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           supplementary_alignment
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           false
         </div>

--- a/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2,14 +2,14 @@
 
 exports[`ConfigurationEditor drawer widget renders all the different types of built-in slots 1`] = `
 <div
-  class="makeStyles-root-118"
+  class="makeStyles-root"
   data-testid="configEditor"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -38,7 +38,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -63,10 +63,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <fieldset
         class="MuiFormControl-root"
@@ -80,13 +80,13 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-246 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-247 Mui-checked MuiIconButton-colorSecondary"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <div
-                  class="PrivateRadioButtonIcon-root-250 PrivateRadioButtonIcon-checked-252"
+                  class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
                 >
                   <svg
                     aria-hidden="true"
@@ -101,7 +101,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-251"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                     focusable="false"
                     role="presentation"
                     viewBox="0 0 24 24"
@@ -113,7 +113,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                 </div>
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input-249"
+                  class="PrivateSwitchBase-input"
                   type="radio"
                   value="uri"
                 />
@@ -129,18 +129,18 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
             </span>
           </label>
           <label
-            class="MuiFormControlLabel-root Mui-disabled"
+            class="MuiFormControlLabel-root MuiFormControlLabel-disabled"
           >
             <span
               aria-disabled="true"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-246 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled-248 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled MuiRadio-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
               tabindex="-1"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <div
-                  class="PrivateRadioButtonIcon-root-250"
+                  class="PrivateRadioButtonIcon-root"
                 >
                   <svg
                     aria-hidden="true"
@@ -155,7 +155,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                   </svg>
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-251"
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                     focusable="false"
                     role="presentation"
                     viewBox="0 0 24 24"
@@ -166,7 +166,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                   </svg>
                 </div>
                 <input
-                  class="PrivateSwitchBase-input-249"
+                  class="PrivateSwitchBase-input"
                   disabled=""
                   type="radio"
                   value="localPath"
@@ -174,7 +174,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
               </span>
             </span>
             <span
-              class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+              class="MuiTypography-root MuiFormControlLabel-label MuiFormControlLabel-disabled MuiTypography-body1"
             >
               Local File
             </span>
@@ -208,7 +208,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -233,10 +233,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
@@ -348,7 +348,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                 class="MuiInputAdornment-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-disabled MuiButtonBase-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -376,7 +376,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -401,10 +401,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
@@ -412,7 +412,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
         stringArrayMapTest
       </label>
       <div
-        class="MuiPaper-root MuiPaper-elevation8 MuiCard-root makeStyles-card-314 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation8 MuiCard-root makeStyles-card MuiPaper-rounded"
       >
         <div
           class="MuiCardHeader-root"
@@ -558,7 +558,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                     class="MuiInputAdornment-root"
                   >
                     <button
-                      class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-disabled MuiButtonBase-disabled"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -587,7 +587,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
         </div>
       </div>
       <div
-        class="MuiPaper-root MuiPaper-elevation8 MuiCard-root makeStyles-card-314 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation8 MuiCard-root makeStyles-card MuiPaper-rounded"
       >
         <div
           class="MuiCardHeader-root"
@@ -612,7 +612,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
                   class="MuiInputAdornment-root"
                 >
                   <button
-                    class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-disabled MuiButtonBase-disabled"
                     disabled=""
                     tabindex="-1"
                     type="button"
@@ -641,7 +641,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -666,10 +666,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root"
@@ -698,7 +698,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -723,10 +723,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root"
@@ -755,7 +755,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -780,10 +780,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -813,7 +813,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -838,10 +838,10 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-120 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-121"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root"
@@ -851,7 +851,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
         >
           <span
             aria-disabled="false"
-            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-246 MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked-247 Mui-checked MuiIconButton-colorSecondary"
+            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
           >
             <span
               class="MuiIconButton-label"
@@ -869,7 +869,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
               </svg>
               <input
                 checked=""
-                class="PrivateSwitchBase-input-249"
+                class="PrivateSwitchBase-input"
                 data-indeterminate="false"
                 type="checkbox"
                 value=""
@@ -893,7 +893,7 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-122"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -922,14 +922,14 @@ exports[`ConfigurationEditor drawer widget renders all the different types of bu
 
 exports[`ConfigurationEditor drawer widget renders with defaults of the AlignmentsTrack schema 1`] = `
 <div
-  class="makeStyles-root-339"
+  class="makeStyles-root"
   data-testid="configEditor"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-342"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -958,7 +958,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-343"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -983,10 +983,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-342"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1015,7 +1015,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-343"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -1040,10 +1040,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-342"
+      class="makeStyles-paperContent"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
@@ -1073,7 +1073,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 class="MuiInputAdornment-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-disabled MuiButtonBase-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -1101,7 +1101,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
       </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-343"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -1131,13 +1131,13 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
     adapter
   </label>
   <div
-    class="makeStyles-subSchemaContainer-340"
+    class="makeStyles-subSchemaContainer"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+      class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
     >
       <div
-        class="makeStyles-paperContent-342"
+        class="makeStyles-paperContent"
       >
         <div
           class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1187,10 +1187,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
       class="MuiFormGroup-root"
     >
       <div
-        class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
       >
         <div
-          class="makeStyles-paperContent-342"
+          class="makeStyles-paperContent"
         >
           <fieldset
             class="MuiFormControl-root"
@@ -1204,13 +1204,13 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               >
                 <span
                   aria-disabled="false"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-508 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-509 Mui-checked MuiIconButton-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <div
-                      class="PrivateRadioButtonIcon-root-512 PrivateRadioButtonIcon-checked-514"
+                      class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
                     >
                       <svg
                         aria-hidden="true"
@@ -1225,7 +1225,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       </svg>
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-513"
+                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -1237,7 +1237,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                     </div>
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input-511"
+                      class="PrivateSwitchBase-input"
                       type="radio"
                       value="uri"
                     />
@@ -1253,18 +1253,18 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 </span>
               </label>
               <label
-                class="MuiFormControlLabel-root Mui-disabled"
+                class="MuiFormControlLabel-root MuiFormControlLabel-disabled"
               >
                 <span
                   aria-disabled="true"
-                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-508 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled-510 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled MuiRadio-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
                   tabindex="-1"
                 >
                   <span
                     class="MuiIconButton-label"
                   >
                     <div
-                      class="PrivateRadioButtonIcon-root-512"
+                      class="PrivateRadioButtonIcon-root"
                     >
                       <svg
                         aria-hidden="true"
@@ -1279,7 +1279,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       </svg>
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-513"
+                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -1290,7 +1290,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       </svg>
                     </div>
                     <input
-                      class="PrivateSwitchBase-input-511"
+                      class="PrivateSwitchBase-input"
                       disabled=""
                       type="radio"
                       value="localPath"
@@ -1298,7 +1298,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+                  class="MuiTypography-root MuiFormControlLabel-label MuiFormControlLabel-disabled MuiTypography-body1"
                 >
                   Local File
                 </span>
@@ -1328,7 +1328,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
           </div>
         </div>
         <div
-          class="makeStyles-slotModeSwitch-343"
+          class="makeStyles-slotModeSwitch"
         >
           <button
             class="MuiButtonBase-root MuiIconButton-root"
@@ -1358,16 +1358,16 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
         index
       </label>
       <div
-        class="makeStyles-subSchemaContainer-340"
+        class="makeStyles-subSchemaContainer"
       >
         <div
           class="MuiFormGroup-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1409,7 +1409,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -1434,10 +1434,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <fieldset
                 class="MuiFormControl-root"
@@ -1451,13 +1451,13 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   >
                     <span
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-508 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-509 Mui-checked MuiIconButton-colorSecondary"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
                     >
                       <span
                         class="MuiIconButton-label"
                       >
                         <div
-                          class="PrivateRadioButtonIcon-root-512 PrivateRadioButtonIcon-checked-514"
+                          class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
                         >
                           <svg
                             aria-hidden="true"
@@ -1472,7 +1472,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-513"
+                            class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                             focusable="false"
                             role="presentation"
                             viewBox="0 0 24 24"
@@ -1484,7 +1484,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                         </div>
                         <input
                           checked=""
-                          class="PrivateSwitchBase-input-511"
+                          class="PrivateSwitchBase-input"
                           type="radio"
                           value="uri"
                         />
@@ -1500,18 +1500,18 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                     </span>
                   </label>
                   <label
-                    class="MuiFormControlLabel-root Mui-disabled"
+                    class="MuiFormControlLabel-root MuiFormControlLabel-disabled"
                   >
                     <span
                       aria-disabled="true"
-                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-508 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled-510 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled MuiRadio-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
                       tabindex="-1"
                     >
                       <span
                         class="MuiIconButton-label"
                       >
                         <div
-                          class="PrivateRadioButtonIcon-root-512"
+                          class="PrivateRadioButtonIcon-root"
                         >
                           <svg
                             aria-hidden="true"
@@ -1526,7 +1526,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-513"
+                            class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                             focusable="false"
                             role="presentation"
                             viewBox="0 0 24 24"
@@ -1537,7 +1537,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                           </svg>
                         </div>
                         <input
-                          class="PrivateSwitchBase-input-511"
+                          class="PrivateSwitchBase-input"
                           disabled=""
                           type="radio"
                           value="localPath"
@@ -1545,7 +1545,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       </span>
                     </span>
                     <span
-                      class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+                      class="MuiTypography-root MuiFormControlLabel-label MuiFormControlLabel-disabled MuiTypography-body1"
                     >
                       Local File
                     </span>
@@ -1575,7 +1575,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -1604,10 +1604,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-342"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -1649,7 +1649,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-343"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -1679,7 +1679,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
     renderers
   </label>
   <div
-    class="makeStyles-subSchemaContainer-340"
+    class="makeStyles-subSchemaContainer"
   >
     <div
       class="MuiFormGroup-root"
@@ -1690,16 +1690,16 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
         PileupRenderer
       </label>
       <div
-        class="makeStyles-subSchemaContainer-340"
+        class="makeStyles-subSchemaContainer"
       >
         <div
           class="MuiFormGroup-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root"
@@ -1712,7 +1712,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   alignmentColor
                 </label>
                 <div
-                  class="makeStyles-callbackEditor-545"
+                  class="makeStyles-callbackEditor"
                   style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
                 >
                   <textarea
@@ -1899,7 +1899,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -1929,10 +1929,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -1961,7 +1961,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -1986,10 +1986,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -2018,7 +2018,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2050,16 +2050,16 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
         SvgFeatureRenderer
       </label>
       <div
-        class="makeStyles-subSchemaContainer-340"
+        class="makeStyles-subSchemaContainer"
       >
         <div
           class="MuiFormGroup-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2089,7 +2089,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2114,10 +2114,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2147,7 +2147,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2172,10 +2172,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2205,7 +2205,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2230,10 +2230,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -2262,7 +2262,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2292,16 +2292,16 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             labels
           </label>
           <div
-            class="makeStyles-subSchemaContainer-340"
+            class="makeStyles-subSchemaContainer"
           >
             <div
               class="MuiFormGroup-root"
             >
               <div
-                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
               >
                 <div
-                  class="makeStyles-paperContent-342"
+                  class="makeStyles-paperContent"
                 >
                   <div
                     class="MuiFormControl-root"
@@ -2314,7 +2314,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       name
                     </label>
                     <div
-                      class="makeStyles-callbackEditor-545"
+                      class="makeStyles-callbackEditor"
                       style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
                     >
                       <textarea
@@ -2470,7 +2470,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch-343"
+                  class="makeStyles-slotModeSwitch"
                 >
                   <button
                     class="MuiButtonBase-root MuiIconButton-root"
@@ -2500,10 +2500,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
               >
                 <div
-                  class="makeStyles-paperContent-342"
+                  class="makeStyles-paperContent"
                 >
                   <div
                     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2533,7 +2533,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch-343"
+                  class="makeStyles-slotModeSwitch"
                 >
                   <button
                     class="MuiButtonBase-root MuiIconButton-root"
@@ -2558,10 +2558,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
               >
                 <div
-                  class="makeStyles-paperContent-342"
+                  class="makeStyles-paperContent"
                 >
                   <div
                     class="MuiFormControl-root"
@@ -2574,7 +2574,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                       description
                     </label>
                     <div
-                      class="makeStyles-callbackEditor-545"
+                      class="makeStyles-callbackEditor"
                       style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
                     >
                       <textarea
@@ -2698,7 +2698,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch-343"
+                  class="makeStyles-slotModeSwitch"
                 >
                   <button
                     class="MuiButtonBase-root MuiIconButton-root"
@@ -2728,10 +2728,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
               >
                 <div
-                  class="makeStyles-paperContent-342"
+                  class="makeStyles-paperContent"
                 >
                   <div
                     class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2761,7 +2761,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch-343"
+                  class="makeStyles-slotModeSwitch"
                 >
                   <button
                     class="MuiButtonBase-root MuiIconButton-root"
@@ -2786,10 +2786,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
               >
                 <div
-                  class="makeStyles-paperContent-342"
+                  class="makeStyles-paperContent"
                 >
                   <div
                     class="MuiFormControl-root MuiTextField-root"
@@ -2818,7 +2818,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch-343"
+                  class="makeStyles-slotModeSwitch"
                 >
                   <button
                     class="MuiButtonBase-root MuiIconButton-root"
@@ -2845,10 +2845,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -2877,7 +2877,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2902,10 +2902,10 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
             </div>
           </div>
           <div
-            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-341 MuiPaper-rounded"
+            class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
           >
             <div
-              class="makeStyles-paperContent-342"
+              class="makeStyles-paperContent"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -2934,7 +2934,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
               </div>
             </div>
             <div
-              class="makeStyles-slotModeSwitch-343"
+              class="makeStyles-slotModeSwitch"
             >
               <button
                 class="MuiButtonBase-root MuiIconButton-root"
@@ -2967,14 +2967,14 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the Alignmen
 
 exports[`ConfigurationEditor drawer widget renders with just the required model elements 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
   data-testid="configEditor"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-3 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <div
-      class="makeStyles-paperContent-4"
+      class="makeStyles-paperContent"
     >
       <div
         class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
@@ -2999,7 +2999,7 @@ exports[`ConfigurationEditor drawer widget renders with just the required model 
       </div>
     </div>
     <div
-      class="makeStyles-slotModeSwitch-5"
+      class="makeStyles-slotModeSwitch"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"

--- a/packages/data-management/src/AddConnectionDrawerWidget/components/__snapshots__/AddConnectionDrawerWidget.test.js.snap
+++ b/packages/data-management/src/AddConnectionDrawerWidget/components/__snapshots__/AddConnectionDrawerWidget.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<AddConnectionDrawerWidget /> renders 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation0 MuiStepper-root MuiStepper-vertical makeStyles-stepper-2"
+    class="MuiPaper-root MuiPaper-elevation0 MuiStepper-root MuiStepper-vertical makeStyles-stepper"
   >
     <div
       class="MuiStep-root MuiStep-vertical"
@@ -151,10 +151,10 @@ exports[`<AddConnectionDrawerWidget /> renders 1`] = `
                 </div>
               </form>
               <div
-                class="makeStyles-actionsContainer-4"
+                class="makeStyles-actionsContainer"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root makeStyles-button-3 MuiButton-text Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root makeStyles-button MuiButton-text MuiButton-disabled MuiButtonBase-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -166,7 +166,7 @@ exports[`<AddConnectionDrawerWidget /> renders 1`] = `
                   </span>
                 </button>
                 <button
-                  class="MuiButtonBase-root MuiButton-root makeStyles-button-3 MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root makeStyles-button MuiButton-contained MuiButton-containedPrimary MuiButton-disabled MuiButtonBase-disabled"
                   data-testid="addConnectionNext"
                   disabled=""
                   tabindex="-1"
@@ -185,7 +185,7 @@ exports[`<AddConnectionDrawerWidget /> renders 1`] = `
       </div>
     </div>
     <div
-      class="MuiStepConnector-root MuiStepConnector-vertical Mui-disabled"
+      class="MuiStepConnector-root MuiStepConnector-vertical MuiStepConnector-disabled"
     >
       <span
         class="MuiStepConnector-line MuiStepConnector-lineVertical"
@@ -195,7 +195,7 @@ exports[`<AddConnectionDrawerWidget /> renders 1`] = `
       class="MuiStep-root MuiStep-vertical"
     >
       <span
-        class="MuiStepLabel-root MuiStepLabel-vertical Mui-disabled"
+        class="MuiStepLabel-root MuiStepLabel-vertical MuiStepLabel-disabled"
       >
         <span
           class="MuiStepLabel-iconContainer"

--- a/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/AddTrackDrawerWidget.test.js.snap
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/AddTrackDrawerWidget.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<AddTrackDrawerWidget /> renders 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation0 MuiStepper-root MuiStepper-vertical makeStyles-stepper-2"
+    class="MuiPaper-root MuiPaper-elevation0 MuiStepper-root MuiStepper-vertical makeStyles-stepper"
   >
     <div
       class="MuiStep-root MuiStep-vertical"
@@ -63,7 +63,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
               class="MuiCollapse-wrapperInner"
             >
               <div
-                class="makeStyles-root-105"
+                class="makeStyles-root"
               >
                 <fieldset
                   class="MuiFormControl-root"
@@ -78,13 +78,13 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-124 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-125 Mui-checked MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <div
-                            class="PrivateRadioButtonIcon-root-140 PrivateRadioButtonIcon-checked-142"
+                            class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
                           >
                             <svg
                               aria-hidden="true"
@@ -99,7 +99,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-141"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                               focusable="false"
                               role="presentation"
                               viewBox="0 0 24 24"
@@ -111,7 +111,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                           </div>
                           <input
                             checked=""
-                            class="PrivateSwitchBase-input-127"
+                            class="PrivateSwitchBase-input"
                             data-testid="addTrackFromFileRadio"
                             type="radio"
                             value="fromFile"
@@ -132,13 +132,13 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-124 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
                       >
                         <span
                           class="MuiIconButton-label"
                         >
                           <div
-                            class="PrivateRadioButtonIcon-root-140"
+                            class="PrivateRadioButtonIcon-root"
                           >
                             <svg
                               aria-hidden="true"
@@ -153,7 +153,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-141"
+                              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                               focusable="false"
                               role="presentation"
                               viewBox="0 0 24 24"
@@ -164,7 +164,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                             </svg>
                           </div>
                           <input
-                            class="PrivateSwitchBase-input-127"
+                            class="PrivateSwitchBase-input"
                             data-testid="addTrackFromConfigRadio"
                             type="radio"
                             value="fromConfig"
@@ -183,7 +183,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                   </div>
                 </fieldset>
                 <div
-                  class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-106 MuiPaper-rounded"
+                  class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
                 >
                   <fieldset
                     class="MuiFormControl-root"
@@ -197,13 +197,13 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                       >
                         <span
                           aria-disabled="false"
-                          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-124 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-125 Mui-checked MuiIconButton-colorSecondary"
+                          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
                         >
                           <span
                             class="MuiIconButton-label"
                           >
                             <div
-                              class="PrivateRadioButtonIcon-root-140 PrivateRadioButtonIcon-checked-142"
+                              class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
                             >
                               <svg
                                 aria-hidden="true"
@@ -218,7 +218,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-141"
+                                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                                 focusable="false"
                                 role="presentation"
                                 viewBox="0 0 24 24"
@@ -230,7 +230,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                             </div>
                             <input
                               checked=""
-                              class="PrivateSwitchBase-input-127"
+                              class="PrivateSwitchBase-input"
                               type="radio"
                               value="uri"
                             />
@@ -246,18 +246,18 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                         </span>
                       </label>
                       <label
-                        class="MuiFormControlLabel-root Mui-disabled"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-disabled"
                       >
                         <span
                           aria-disabled="true"
-                          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-124 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled-126 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+                          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled MuiRadio-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
                           tabindex="-1"
                         >
                           <span
                             class="MuiIconButton-label"
                           >
                             <div
-                              class="PrivateRadioButtonIcon-root-140"
+                              class="PrivateRadioButtonIcon-root"
                             >
                               <svg
                                 aria-hidden="true"
@@ -272,7 +272,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                               </svg>
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-141"
+                                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                                 focusable="false"
                                 role="presentation"
                                 viewBox="0 0 24 24"
@@ -283,7 +283,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                               </svg>
                             </div>
                             <input
-                              class="PrivateSwitchBase-input-127"
+                              class="PrivateSwitchBase-input"
                               disabled=""
                               type="radio"
                               value="localPath"
@@ -291,7 +291,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                           </span>
                         </span>
                         <span
-                          class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+                          class="MuiTypography-root MuiFormControlLabel-label MuiFormControlLabel-disabled MuiTypography-body1"
                         >
                           Local File
                         </span>
@@ -322,10 +322,10 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                 </div>
               </div>
               <div
-                class="makeStyles-actionsContainer-4"
+                class="makeStyles-actionsContainer"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root makeStyles-button-3 MuiButton-text Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root makeStyles-button MuiButton-text MuiButton-disabled MuiButtonBase-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -337,7 +337,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
                   </span>
                 </button>
                 <button
-                  class="MuiButtonBase-root MuiButton-root makeStyles-button-3 MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root makeStyles-button MuiButton-contained MuiButton-containedPrimary MuiButton-disabled MuiButtonBase-disabled"
                   data-testid="addTrackNextButton"
                   disabled=""
                   tabindex="-1"
@@ -356,7 +356,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
       </div>
     </div>
     <div
-      class="MuiStepConnector-root MuiStepConnector-vertical Mui-disabled"
+      class="MuiStepConnector-root MuiStepConnector-vertical MuiStepConnector-disabled"
     >
       <span
         class="MuiStepConnector-line MuiStepConnector-lineVertical"
@@ -366,7 +366,7 @@ exports[`<AddTrackDrawerWidget /> renders 1`] = `
       class="MuiStep-root MuiStep-vertical"
     >
       <span
-        class="MuiStepLabel-root MuiStepLabel-vertical Mui-disabled"
+        class="MuiStepLabel-root MuiStepLabel-vertical MuiStepLabel-disabled"
       >
         <span
           class="MuiStepLabel-iconContainer"

--- a/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/ConfirmTrack.test.js.snap
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/ConfirmTrack.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<ConfirmTrack /> mounts with config 1`] = `
 <p
-  class="MuiTypography-root makeStyles-spacing-337 MuiTypography-body1"
+  class="MuiTypography-root makeStyles-spacing MuiTypography-body1"
 >
   Using adapter 
   <code>
@@ -19,7 +19,7 @@ exports[`<ConfirmTrack /> mounts with config 1`] = `
 
 exports[`<ConfirmTrack /> mounts with localPath 1`] = `
 <p
-  class="MuiTypography-root makeStyles-spacing-225 MuiTypography-body1"
+  class="MuiTypography-root makeStyles-spacing MuiTypography-body1"
 >
   Using adapter 
   <code>
@@ -36,7 +36,7 @@ exports[`<ConfirmTrack /> mounts with localPath 1`] = `
 
 exports[`<ConfirmTrack /> mounts with uri 1`] = `
 <p
-  class="MuiTypography-root makeStyles-spacing-113 MuiTypography-body1"
+  class="MuiTypography-root makeStyles-spacing MuiTypography-body1"
 >
   Using adapter 
   <code>
@@ -53,7 +53,7 @@ exports[`<ConfirmTrack /> mounts with uri 1`] = `
 
 exports[`<ConfirmTrack /> renders 1`] = `
 <p
-  class="MuiTypography-root makeStyles-spacing-1 MuiTypography-body1"
+  class="MuiTypography-root makeStyles-spacing MuiTypography-body1"
 >
   Using adapter 
   <code>

--- a/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TrackSourceSelect /> renders 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
 >
   <fieldset
     class="MuiFormControl-root"
@@ -17,13 +17,13 @@ exports[`<TrackSourceSelect /> renders 1`] = `
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-20 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-21 Mui-checked MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
           >
             <div
-              class="PrivateRadioButtonIcon-root-36 PrivateRadioButtonIcon-checked-38"
+              class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
             >
               <svg
                 aria-hidden="true"
@@ -38,7 +38,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-37"
+                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                 focusable="false"
                 role="presentation"
                 viewBox="0 0 24 24"
@@ -50,7 +50,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
             </div>
             <input
               checked=""
-              class="PrivateSwitchBase-input-23"
+              class="PrivateSwitchBase-input"
               data-testid="addTrackFromFileRadio"
               type="radio"
               value="fromFile"
@@ -71,13 +71,13 @@ exports[`<TrackSourceSelect /> renders 1`] = `
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-20 MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
           >
             <div
-              class="PrivateRadioButtonIcon-root-36"
+              class="PrivateRadioButtonIcon-root"
             >
               <svg
                 aria-hidden="true"
@@ -92,7 +92,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-37"
+                class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                 focusable="false"
                 role="presentation"
                 viewBox="0 0 24 24"
@@ -103,7 +103,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
               </svg>
             </div>
             <input
-              class="PrivateSwitchBase-input-23"
+              class="PrivateSwitchBase-input"
               data-testid="addTrackFromConfigRadio"
               type="radio"
               value="fromConfig"
@@ -122,7 +122,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
     </div>
   </fieldset>
   <div
-    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper-2 MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 makeStyles-paper MuiPaper-rounded"
   >
     <fieldset
       class="MuiFormControl-root"
@@ -136,13 +136,13 @@ exports[`<TrackSourceSelect /> renders 1`] = `
         >
           <span
             aria-disabled="false"
-            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-20 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked-21 Mui-checked MuiIconButton-colorSecondary"
+            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-checked MuiRadio-checked MuiIconButton-colorSecondary"
           >
             <span
               class="MuiIconButton-label"
             >
               <div
-                class="PrivateRadioButtonIcon-root-36 PrivateRadioButtonIcon-checked-38"
+                class="PrivateRadioButtonIcon-root PrivateRadioButtonIcon-checked"
               >
                 <svg
                   aria-hidden="true"
@@ -157,7 +157,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
                 </svg>
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-37"
+                  class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -169,7 +169,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
               </div>
               <input
                 checked=""
-                class="PrivateSwitchBase-input-23"
+                class="PrivateSwitchBase-input"
                 type="radio"
                 value="uri"
               />
@@ -185,18 +185,18 @@ exports[`<TrackSourceSelect /> renders 1`] = `
           </span>
         </label>
         <label
-          class="MuiFormControlLabel-root Mui-disabled"
+          class="MuiFormControlLabel-root MuiFormControlLabel-disabled"
         >
           <span
             aria-disabled="true"
-            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-20 MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled-22 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorSecondary PrivateSwitchBase-disabled MuiRadio-disabled MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
             tabindex="-1"
           >
             <span
               class="MuiIconButton-label"
             >
               <div
-                class="PrivateRadioButtonIcon-root-36"
+                class="PrivateRadioButtonIcon-root"
               >
                 <svg
                   aria-hidden="true"
@@ -211,7 +211,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
                 </svg>
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-37"
+                  class="MuiSvgIcon-root PrivateRadioButtonIcon-layer"
                   focusable="false"
                   role="presentation"
                   viewBox="0 0 24 24"
@@ -222,7 +222,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
                 </svg>
               </div>
               <input
-                class="PrivateSwitchBase-input-23"
+                class="PrivateSwitchBase-input"
                 disabled=""
                 type="radio"
                 value="localPath"
@@ -230,7 +230,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
             </span>
           </span>
           <span
-            class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+            class="MuiTypography-root MuiFormControlLabel-label MuiFormControlLabel-disabled MuiTypography-body1"
           >
             Local File
           </span>

--- a/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -4,11 +4,11 @@ exports[`HierarchicalTrackSelector drawer widget renders nothing with no dataset
 
 exports[`HierarchicalTrackSelector drawer widget renders with a couple of categorized tracks 1`] = `
 <div
-  class="makeStyles-root-191"
+  class="makeStyles-root"
   data-testid="hierarchical_track_selector"
 >
   <div
-    class="MuiFormControl-root MuiTextField-root makeStyles-searchBox-192 MuiFormControl-fullWidth"
+    class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
   >
     <label
       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -55,16 +55,16 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
     class="MuiFormGroup-root"
   >
     <div
-      class="makeStyles-track-283"
+      class="makeStyles-track"
       style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel-281"
+        class="MuiFormControlLabel-root makeStyles-formControlLabel"
         title="The reference sequence for volvox"
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-305 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-282 MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
@@ -81,7 +81,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
               />
             </svg>
             <input
-              class="PrivateSwitchBase-input-308"
+              class="PrivateSwitchBase-input"
               data-indeterminate="false"
               data-testid="htsTrackEntry-sequenceConfigId"
               type="checkbox"
@@ -99,7 +99,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
         </span>
       </label>
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-284"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
         tabindex="0"
         type="button"
       >
@@ -120,24 +120,24 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
     </div>
   </div>
   <hr
-    class="MuiDivider-root makeStyles-divider-278"
+    class="MuiDivider-root makeStyles-divider"
   />
   <div
     class="MuiFormGroup-root"
   />
   <div
-    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root Mui-expanded MuiExpansionPanel-rounded MuiPaper-rounded"
+    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-expanded MuiExpansionPanel-rounded MuiPaper-rounded"
     style="margin-top: 4px;"
   >
     <div
       aria-disabled="false"
       aria-expanded="true"
-      class="MuiButtonBase-root MuiExpansionPanelSummary-root makeStyles-root-355 Mui-expanded makeStyles-expanded-356"
+      class="MuiButtonBase-root MuiExpansionPanelSummary-root makeStyles-root MuiExpansionPanelSummary-expanded makeStyles-expanded"
       role="button"
       tabindex="0"
     >
       <div
-        class="MuiExpansionPanelSummary-content makeStyles-content-354 Mui-expanded makeStyles-expanded-356"
+        class="MuiExpansionPanelSummary-content makeStyles-content MuiExpansionPanelSummary-expanded makeStyles-expanded"
       >
         <span
           class="MuiTypography-root MuiTypography-button"
@@ -148,7 +148,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
       <div
         aria-disabled="false"
         aria-hidden="true"
-        class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon Mui-expanded makeStyles-expanded-356 MuiIconButton-edgeEnd"
+        class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiExpansionPanelSummary-expanded makeStyles-expanded MuiIconButton-edgeEnd"
         role="button"
         tabindex="-1"
       >
@@ -181,22 +181,22 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
             role="region"
           >
             <div
-              class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails-353"
+              class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
             >
               <div
                 class="MuiFormGroup-root"
               >
                 <div
-                  class="makeStyles-track-283"
+                  class="makeStyles-track"
                   style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
                 >
                   <label
-                    class="MuiFormControlLabel-root makeStyles-formControlLabel-281"
+                    class="MuiFormControlLabel-root makeStyles-formControlLabel"
                     title=""
                   >
                     <span
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-305 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-282 PrivateSwitchBase-checked-306 Mui-checked MuiIconButton-colorSecondary"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
                     >
                       <span
                         class="MuiIconButton-label"
@@ -214,7 +214,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                         </svg>
                         <input
                           checked=""
-                          class="PrivateSwitchBase-input-308"
+                          class="PrivateSwitchBase-input"
                           data-indeterminate="false"
                           data-testid="htsTrackEntry-fooC"
                           type="checkbox"
@@ -232,7 +232,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                     </span>
                   </label>
                   <button
-                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-284"
+                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
                     tabindex="0"
                     type="button"
                   >
@@ -253,18 +253,18 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root Mui-expanded MuiExpansionPanel-rounded MuiPaper-rounded"
+                class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-expanded MuiExpansionPanel-rounded MuiPaper-rounded"
                 style="margin-top: 4px;"
               >
                 <div
                   aria-disabled="false"
                   aria-expanded="true"
-                  class="MuiButtonBase-root MuiExpansionPanelSummary-root makeStyles-root-355 Mui-expanded makeStyles-expanded-356"
+                  class="MuiButtonBase-root MuiExpansionPanelSummary-root makeStyles-root MuiExpansionPanelSummary-expanded makeStyles-expanded"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiExpansionPanelSummary-content makeStyles-content-354 Mui-expanded makeStyles-expanded-356"
+                    class="MuiExpansionPanelSummary-content makeStyles-content MuiExpansionPanelSummary-expanded makeStyles-expanded"
                   >
                     <span
                       class="MuiTypography-root MuiTypography-button"
@@ -275,7 +275,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon Mui-expanded makeStyles-expanded-356 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiExpansionPanelSummary-expanded makeStyles-expanded MuiIconButton-edgeEnd"
                     role="button"
                     tabindex="-1"
                   >
@@ -308,22 +308,22 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                         role="region"
                       >
                         <div
-                          class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails-353"
+                          class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
                         >
                           <div
                             class="MuiFormGroup-root"
                           >
                             <div
-                              class="makeStyles-track-283"
+                              class="makeStyles-track"
                               style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
                             >
                               <label
-                                class="MuiFormControlLabel-root makeStyles-formControlLabel-281"
+                                class="MuiFormControlLabel-root makeStyles-formControlLabel"
                                 title=""
                               >
                                 <span
                                   aria-disabled="false"
-                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-305 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-282 PrivateSwitchBase-checked-306 Mui-checked MuiIconButton-colorSecondary"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -341,7 +341,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                                     </svg>
                                     <input
                                       checked=""
-                                      class="PrivateSwitchBase-input-308"
+                                      class="PrivateSwitchBase-input"
                                       data-indeterminate="false"
                                       data-testid="htsTrackEntry-barC"
                                       type="checkbox"
@@ -359,7 +359,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
                                 </span>
                               </label>
                               <button
-                                class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-284"
+                                class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
                                 tabindex="0"
                                 type="button"
                               >
@@ -395,7 +395,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
     class="MuiFormGroup-root"
   />
   <button
-    class="MuiButtonBase-root MuiFab-root makeStyles-fab-193 MuiFab-secondary"
+    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
     tabindex="0"
     type="button"
   >
@@ -418,11 +418,11 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of catego
 
 exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncategorized tracks 1`] = `
 <div
-  class="makeStyles-root-6"
+  class="makeStyles-root"
   data-testid="hierarchical_track_selector"
 >
   <div
-    class="MuiFormControl-root MuiTextField-root makeStyles-searchBox-7 MuiFormControl-fullWidth"
+    class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
   >
     <label
       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -469,16 +469,16 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
     class="MuiFormGroup-root"
   >
     <div
-      class="makeStyles-track-98"
+      class="makeStyles-track"
       style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel-96"
+        class="MuiFormControlLabel-root makeStyles-formControlLabel"
         title="The reference sequence for volMyt1"
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-120 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-97 MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
@@ -495,7 +495,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
               />
             </svg>
             <input
-              class="PrivateSwitchBase-input-123"
+              class="PrivateSwitchBase-input"
               data-indeterminate="false"
               data-testid="htsTrackEntry-sequenceConfigId"
               type="checkbox"
@@ -513,7 +513,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
         </span>
       </label>
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-99"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
         tabindex="0"
         type="button"
       >
@@ -534,22 +534,22 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
     </div>
   </div>
   <hr
-    class="MuiDivider-root makeStyles-divider-93"
+    class="MuiDivider-root makeStyles-divider"
   />
   <div
     class="MuiFormGroup-root"
   >
     <div
-      class="makeStyles-track-98"
+      class="makeStyles-track"
       style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel-96"
+        class="MuiFormControlLabel-root makeStyles-formControlLabel"
         title=""
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-120 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-97 PrivateSwitchBase-checked-121 Mui-checked MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
@@ -567,7 +567,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
             </svg>
             <input
               checked=""
-              class="PrivateSwitchBase-input-123"
+              class="PrivateSwitchBase-input"
               data-indeterminate="false"
               data-testid="htsTrackEntry-fooC"
               type="checkbox"
@@ -585,7 +585,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
         </span>
       </label>
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-99"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
         tabindex="0"
         type="button"
       >
@@ -605,16 +605,16 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
       </button>
     </div>
     <div
-      class="makeStyles-track-98"
+      class="makeStyles-track"
       style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel-96"
+        class="MuiFormControlLabel-root makeStyles-formControlLabel"
         title=""
       >
         <span
           aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-120 MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox-97 PrivateSwitchBase-checked-121 Mui-checked MuiIconButton-colorSecondary"
+          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
         >
           <span
             class="MuiIconButton-label"
@@ -632,7 +632,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
             </svg>
             <input
               checked=""
-              class="PrivateSwitchBase-input-123"
+              class="PrivateSwitchBase-input"
               data-indeterminate="false"
               data-testid="htsTrackEntry-barC"
               type="checkbox"
@@ -650,7 +650,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
         </span>
       </label>
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton-99"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton"
         tabindex="0"
         type="button"
       >
@@ -674,7 +674,7 @@ exports[`HierarchicalTrackSelector drawer widget renders with a couple of uncate
     class="MuiFormGroup-root"
   />
   <button
-    class="MuiButtonBase-root MuiFab-root makeStyles-fab-8 MuiFab-secondary"
+    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
     tabindex="0"
     type="button"
   >

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -2,17 +2,17 @@
 
 exports[`LinearGenomeView genome view component renders one track, no blocks 1`] = `
 <div
-  class="makeStyles-root-198"
+  class="makeStyles-root"
 >
   <div
-    class="makeStyles-linearGenomeView-199"
+    class="makeStyles-linearGenomeView"
     style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto [track-foo] 20px [resize-foo] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-headerBar-203"
+      class="makeStyles-headerBar"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-212"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this view"
         type="button"
@@ -35,7 +35,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-212"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         type="button"
       >
@@ -54,21 +54,21 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <div
-        class="makeStyles-emphasis-206"
+        class="makeStyles-emphasis"
       >
         <p
-          class="MuiTypography-root makeStyles-viewName-208 MuiTypography-body1"
+          class="MuiTypography-root makeStyles-viewName MuiTypography-body1"
         />
       </div>
       <div
-        class="makeStyles-spacer-204"
+        class="makeStyles-spacer"
       />
       <div
-        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-207 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot MuiPaper-rounded"
       >
         <form>
           <div
-            class="MuiInputBase-root makeStyles-input-211"
+            class="MuiInputBase-root makeStyles-input"
           >
             <input
               aria-invalid="false"
@@ -80,7 +80,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-212"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
             tabindex="0"
             type="button"
           >
@@ -132,7 +132,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         </svg>
       </div>
       <div
-        class="makeStyles-container-341"
+        class="makeStyles-container"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -155,7 +155,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
           />
         </button>
         <span
-          class="MuiSlider-root makeStyles-slider-342"
+          class="MuiSlider-root makeStyles-slider"
         >
           <span
             class="MuiSlider-rail"
@@ -200,28 +200,28 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         </button>
       </div>
       <div
-        class="makeStyles-spacer-204"
+        class="makeStyles-spacer"
       />
     </div>
     <div
-      class="makeStyles-controls-200 makeStyles-viewControls-201"
+      class="makeStyles-controls makeStyles-viewControls"
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-363"
+      class="Rubberband-rubberBandContainer"
       data-testid="rubberband_container"
       role="presentation"
     >
       <div
-        class="makeStyles-scaleBar-364"
+        class="makeStyles-scaleBar"
       />
     </div>
     <div
-      class="makeStyles-controls-200 makeStyles-trackControls-202"
+      class="makeStyles-controls makeStyles-trackControls"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-368"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this track"
         type="button"
@@ -241,7 +241,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-369 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -263,32 +263,32 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <p
-        class="MuiTypography-root makeStyles-trackName-366 MuiTypography-body1"
+        class="MuiTypography-root makeStyles-trackName MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root makeStyles-trackDescription-367 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root makeStyles-trackDescription MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-376"
+      class="TrackRenderingContainer-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="makeStyles-track-377"
+        class="makeStyles-track"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="makeStyles-trackBlocks-378"
+          class="makeStyles-trackBlocks"
           data-testid="Block"
         />
       </div>
     </div>
     <div
-      class="makeStyles-horizontalHandle-381"
+      class="makeStyles-horizontalHandle"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2; background: rgb(204, 204, 204); box-sizing: border-box; border-top: 1px solid #fafafa;"
     />
@@ -298,17 +298,17 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
 
 exports[`LinearGenomeView genome view component renders two tracks, two regions 1`] = `
 <div
-  class="makeStyles-root-412"
+  class="makeStyles-root"
 >
   <div
-    class="makeStyles-linearGenomeView-413"
+    class="makeStyles-linearGenomeView"
     style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto [track-foo] 20px [resize-foo] 3px [track-bar] 20px [resize-bar] 3px; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-headerBar-417"
+      class="makeStyles-headerBar"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-426"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this view"
         type="button"
@@ -331,7 +331,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-426"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         type="button"
       >
@@ -350,21 +350,21 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <div
-        class="makeStyles-emphasis-420"
+        class="makeStyles-emphasis"
       >
         <p
-          class="MuiTypography-root makeStyles-viewName-422 MuiTypography-body1"
+          class="MuiTypography-root makeStyles-viewName MuiTypography-body1"
         />
       </div>
       <div
-        class="makeStyles-spacer-418"
+        class="makeStyles-spacer"
       />
       <div
-        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-421 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot MuiPaper-rounded"
       >
         <form>
           <div
-            class="MuiInputBase-root makeStyles-input-425"
+            class="MuiInputBase-root makeStyles-input"
           >
             <input
               aria-invalid="false"
@@ -376,7 +376,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-426"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
             tabindex="0"
             type="button"
           >
@@ -428,7 +428,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </svg>
       </div>
       <div
-        class="makeStyles-container-555"
+        class="makeStyles-container"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -451,7 +451,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           />
         </button>
         <span
-          class="MuiSlider-root makeStyles-slider-556"
+          class="MuiSlider-root makeStyles-slider"
         >
           <span
             class="MuiSlider-rail"
@@ -496,23 +496,23 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </button>
       </div>
       <div
-        class="makeStyles-spacer-418"
+        class="makeStyles-spacer"
       />
     </div>
     <div
-      class="makeStyles-controls-414 makeStyles-viewControls-415"
+      class="makeStyles-controls makeStyles-viewControls"
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-577"
+      class="Rubberband-rubberBandContainer"
       data-testid="rubberband_container"
       role="presentation"
     >
       <div
-        class="makeStyles-scaleBar-578"
+        class="makeStyles-scaleBar"
       >
         <div
-          class="makeStyles-block-580 makeStyles-leftBorder-581 makeStyles-rightBorder-582"
+          class="makeStyles-block makeStyles-leftBorder makeStyles-rightBorder"
           style="left: 0px; width: 100px;"
         >
           <svg
@@ -520,7 +520,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             width="100"
           >
             <line
-              class="makeStyles-majorTick-584"
+              class="makeStyles-majorTick"
               data-bp="-1"
               stroke="#555"
               stroke-width="1"
@@ -530,7 +530,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="makeStyles-minorTick-585"
+              class="makeStyles-minorTick"
               data-bp="19"
               stroke="#999"
               stroke-width="1"
@@ -540,7 +540,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="makeStyles-minorTick-585"
+              class="makeStyles-minorTick"
               data-bp="39"
               stroke="#999"
               stroke-width="1"
@@ -550,7 +550,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="makeStyles-minorTick-585"
+              class="makeStyles-minorTick"
               data-bp="59"
               stroke="#999"
               stroke-width="1"
@@ -560,7 +560,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="makeStyles-minorTick-585"
+              class="makeStyles-minorTick"
               data-bp="79"
               stroke="#999"
               stroke-width="1"
@@ -570,7 +570,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <line
-              class="makeStyles-majorTick-584"
+              class="makeStyles-majorTick"
               data-bp="99"
               stroke="#555"
               stroke-width="1"
@@ -580,7 +580,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="6"
             />
             <line
-              class="makeStyles-minorTick-585"
+              class="makeStyles-minorTick"
               data-bp="119"
               stroke="#999"
               stroke-width="1"
@@ -590,7 +590,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               y2="4"
             />
             <text
-              class="makeStyles-majorTickLabel-583"
+              class="makeStyles-majorTickLabel"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="-4"
@@ -599,7 +599,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
               0
             </text>
             <text
-              class="makeStyles-majorTickLabel-583"
+              class="makeStyles-majorTickLabel"
               dominant-baseline="hanging"
               style="font-size: 11px;"
               x="96"
@@ -610,18 +610,18 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </svg>
         </div>
         <div
-          class="makeStyles-refLabel-579"
+          class="makeStyles-refLabel"
         >
           ctgA
         </div>
       </div>
     </div>
     <div
-      class="makeStyles-controls-414 makeStyles-trackControls-416"
+      class="makeStyles-controls makeStyles-trackControls"
       style="grid-row: track-foo; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-590"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this track"
         type="button"
@@ -641,7 +641,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-591 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -663,34 +663,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root makeStyles-trackName-588 MuiTypography-body1"
+        class="MuiTypography-root makeStyles-trackName MuiTypography-body1"
       >
         Foo Track
       </p>
       <span
-        class="MuiTypography-root makeStyles-trackDescription-589 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root makeStyles-trackDescription MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-598"
+      class="TrackRenderingContainer-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
       <div
-        class="makeStyles-track-599"
+        class="makeStyles-track"
         data-testid="track-testConfig"
         role="presentation"
       >
         <div
-          class="makeStyles-trackBlocks-600"
+          class="makeStyles-trackBlocks"
           data-testid="Block"
         >
           <div
-            class="makeStyles-block-580 makeStyles-leftBorder-581 makeStyles-rightBorder-582"
+            class="makeStyles-block makeStyles-leftBorder makeStyles-rightBorder"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="makeStyles-blockMessage-605"
+              class="makeStyles-blockMessage"
             >
               region assembly does not match track assembly
             </div>
@@ -699,16 +699,16 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="makeStyles-horizontalHandle-606"
+      class="makeStyles-horizontalHandle"
       role="presentation"
       style="grid-row: resize-foo; grid-column: span 2; background: rgb(204, 204, 204); box-sizing: border-box; border-top: 1px solid #fafafa;"
     />
     <div
-      class="makeStyles-controls-414 makeStyles-trackControls-416"
+      class="makeStyles-controls makeStyles-trackControls"
       style="grid-row: track-bar; grid-column: controls;"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-590"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this track"
         type="button"
@@ -728,7 +728,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton-591 MuiToggleButton-sizeSmall"
+        class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton MuiToggleButton-sizeSmall"
         style="min-width: 0;"
         tabindex="0"
         title="configure track"
@@ -750,34 +750,34 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         />
       </button>
       <p
-        class="MuiTypography-root makeStyles-trackName-588 MuiTypography-body1"
+        class="MuiTypography-root makeStyles-trackName MuiTypography-body1"
       >
         Bar Track
       </p>
       <span
-        class="MuiTypography-root makeStyles-trackDescription-589 MuiTypography-caption MuiTypography-colorTextSecondary"
+        class="MuiTypography-root makeStyles-trackDescription MuiTypography-caption MuiTypography-colorTextSecondary"
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer-598"
+      class="TrackRenderingContainer-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-bar; grid-column: blocks;"
     >
       <div
-        class="makeStyles-track-599"
+        class="makeStyles-track"
         data-testid="track-testConfig2"
         role="presentation"
       >
         <div
-          class="makeStyles-trackBlocks-600"
+          class="makeStyles-trackBlocks"
           data-testid="Block"
         >
           <div
-            class="makeStyles-block-580 makeStyles-leftBorder-581 makeStyles-rightBorder-582"
+            class="makeStyles-block makeStyles-leftBorder makeStyles-rightBorder"
             style="left: 0px; width: 100px;"
           >
             <div
-              class="makeStyles-blockMessage-605"
+              class="makeStyles-blockMessage"
             >
               region assembly does not match track assembly
             </div>
@@ -786,7 +786,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       </div>
     </div>
     <div
-      class="makeStyles-horizontalHandle-606"
+      class="makeStyles-horizontalHandle"
       role="presentation"
       style="grid-row: resize-bar; grid-column: span 2; background: rgb(204, 204, 204); box-sizing: border-box; border-top: 1px solid #fafafa;"
     />
@@ -796,17 +796,17 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
 
 exports[`LinearGenomeView genome view component renders with an empty model 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
 >
   <div
-    class="makeStyles-linearGenomeView-2"
+    class="makeStyles-linearGenomeView"
     style="display: grid; position: relative; grid-template-rows: [header] auto  [scale-bar] auto; grid-template-columns: [controls] 100px [blocks] auto;"
   >
     <div
-      class="makeStyles-headerBar-6"
+      class="makeStyles-headerBar"
     >
       <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         title="close this view"
         type="button"
@@ -829,7 +829,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
         tabindex="0"
         type="button"
       >
@@ -848,21 +848,21 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         />
       </button>
       <div
-        class="makeStyles-emphasis-9"
+        class="makeStyles-emphasis"
       >
         <p
-          class="MuiTypography-root makeStyles-viewName-11 MuiTypography-body1"
+          class="MuiTypography-root makeStyles-viewName MuiTypography-body1"
         />
       </div>
       <div
-        class="makeStyles-spacer-7"
+        class="makeStyles-spacer"
       />
       <div
-        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot-10 MuiPaper-rounded"
+        class="MuiPaper-root MuiPaper-elevation1 makeStyles-searchRoot MuiPaper-rounded"
       >
         <form>
           <div
-            class="MuiInputBase-root makeStyles-input-14"
+            class="MuiInputBase-root makeStyles-input"
           >
             <input
               aria-invalid="false"
@@ -874,7 +874,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           </div>
           <button
             aria-label="search"
-            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-15"
+            class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton"
             tabindex="0"
             type="button"
           >
@@ -926,7 +926,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         </svg>
       </div>
       <div
-        class="makeStyles-container-144"
+        class="makeStyles-container"
       >
         <button
           class="MuiButtonBase-root MuiIconButton-root"
@@ -949,7 +949,7 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
           />
         </button>
         <span
-          class="MuiSlider-root makeStyles-slider-145"
+          class="MuiSlider-root makeStyles-slider"
         >
           <span
             class="MuiSlider-rail"
@@ -994,20 +994,20 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
         </button>
       </div>
       <div
-        class="makeStyles-spacer-7"
+        class="makeStyles-spacer"
       />
     </div>
     <div
-      class="makeStyles-controls-3 makeStyles-viewControls-4"
+      class="makeStyles-controls makeStyles-viewControls"
       style="grid-row: scale-bar;"
     />
     <div
-      class="Rubberband-rubberBandContainer-166"
+      class="Rubberband-rubberBandContainer"
       data-testid="rubberband_container"
       role="presentation"
     >
       <div
-        class="makeStyles-scaleBar-167"
+        class="makeStyles-scaleBar"
       />
     </div>
   </div>

--- a/packages/menus/src/MainMenuBar/components/__snapshots__/DropDownMenu.test.js.snap
+++ b/packages/menus/src/MainMenuBar/components/__snapshots__/DropDownMenu.test.js.snap
@@ -35,7 +35,7 @@ exports[`<DropDownMenu /> opens a menu and selects a menu item 1`] = `
 
 exports[`<DropDownMenu /> renders 1`] = `
 <div
-  class="makeStyles-root-1"
+  class="makeStyles-root"
 >
   <button
     aria-haspopup="true"

--- a/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
+++ b/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<MainMenuBar /> renders 1`] = `
 <header
-  class="MuiPaper-root MuiPaper-elevation4 MuiAppBar-root MuiAppBar-positionStatic makeStyles-root-1 MuiAppBar-colorPrimary"
+  class="MuiPaper-root MuiPaper-elevation4 MuiAppBar-root MuiAppBar-positionStatic makeStyles-root MuiAppBar-colorPrimary"
 >
   <div
     class="MuiToolbar-root MuiToolbar-dense MuiToolbar-gutters"
   >
     <div
-      class="makeStyles-root-45"
+      class="makeStyles-root"
     >
       <button
         aria-haspopup="true"
@@ -35,7 +35,7 @@ exports[`<MainMenuBar /> renders 1`] = `
       </button>
     </div>
     <div
-      class="makeStyles-root-45"
+      class="makeStyles-root"
     >
       <button
         aria-haspopup="true"
@@ -62,7 +62,7 @@ exports[`<MainMenuBar /> renders 1`] = `
       </button>
     </div>
     <div
-      class="makeStyles-grow-2"
+      class="makeStyles-grow"
     />
     <p
       class="MuiTypography-root MuiTypography-body1"
@@ -70,7 +70,7 @@ exports[`<MainMenuBar /> renders 1`] = `
       testSession
     </p>
     <div
-      class="makeStyles-grow-2"
+      class="makeStyles-grow"
     >
       <button
         class="MuiButtonBase-root MuiIconButton-root"
@@ -82,7 +82,7 @@ exports[`<MainMenuBar /> renders 1`] = `
         >
           <span
             aria-hidden="true"
-            class="material-icons MuiIcon-root makeStyles-icon-4"
+            class="material-icons MuiIcon-root makeStyles-icon"
           >
             edit
           </span>

--- a/packages/menus/src/SessionManager/components/__snapshots__/SessionManager.test.js.snap
+++ b/packages/menus/src/SessionManager/components/__snapshots__/SessionManager.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<SessionManager /> renders 1`] = `
 <div
-  class="MuiPaper-root MuiPaper-elevation1 makeStyles-root-1 MuiPaper-rounded"
+  class="MuiPaper-root MuiPaper-elevation1 makeStyles-root MuiPaper-rounded"
 >
   <ul
     class="MuiList-root MuiList-padding MuiList-subheader"
@@ -17,7 +17,7 @@ exports[`<SessionManager /> renders 1`] = `
     >
       <div
         aria-disabled="true"
-        class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters Mui-disabled MuiListItem-button MuiListItem-secondaryAction Mui-disabled"
+        class="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-disabled MuiListItem-button MuiListItem-secondaryAction MuiButtonBase-disabled"
         role="button"
         tabindex="-1"
       >
@@ -51,7 +51,7 @@ exports[`<SessionManager /> renders 1`] = `
       >
         <button
           aria-label="Delete"
-          class="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-edgeEnd Mui-disabled"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-disabled MuiIconButton-edgeEnd MuiButtonBase-disabled"
           disabled=""
           tabindex="-1"
           type="button"

--- a/packages/variants/src/VariantFeatureDrawerWidget/__snapshots__/VariantFeatureDrawerWidget.test.js.snap
+++ b/packages/variants/src/VariantFeatureDrawerWidget/__snapshots__/VariantFeatureDrawerWidget.test.js.snap
@@ -9,13 +9,13 @@ exports[`VariantTrack drawer widget renders with just the required model element
     class="MuiPaper-root MuiPaper-elevation1 MuiCard-root MuiPaper-rounded"
   >
     <div
-      class="MuiCardHeader-root makeStyles-header-5"
+      class="MuiCardHeader-root makeStyles-header"
     >
       <div
         class="MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiCardHeader-title makeStyles-title-6 MuiTypography-h5 MuiTypography-displayBlock"
+          class="MuiTypography-root MuiCardHeader-title makeStyles-title MuiTypography-h5 MuiTypography-displayBlock"
         >
           Primary data
         </span>
@@ -26,12 +26,12 @@ exports[`VariantTrack drawer widget renders with just the required model element
     >
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           Position
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           ctgA:NaN..undefined
         </div>
@@ -46,13 +46,13 @@ exports[`VariantTrack drawer widget renders with just the required model element
     class="MuiPaper-root MuiPaper-elevation1 MuiCard-root MuiPaper-rounded"
   >
     <div
-      class="MuiCardHeader-root makeStyles-header-5"
+      class="MuiCardHeader-root makeStyles-header"
     >
       <div
         class="MuiCardHeader-content"
       >
         <span
-          class="MuiTypography-root MuiCardHeader-title makeStyles-title-6 MuiTypography-h5 MuiTypography-displayBlock"
+          class="MuiTypography-root MuiCardHeader-title makeStyles-title MuiTypography-h5 MuiTypography-displayBlock"
         >
           Attributes
         </span>
@@ -63,48 +63,48 @@ exports[`VariantTrack drawer widget renders with just the required model element
     >
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           MQ
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           5
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           REF
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           A
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           ALT
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           C
         </div>
       </div>
       <div>
         <div
-          class="makeStyles-fieldName-3"
+          class="makeStyles-fieldName"
         >
           QUAL
         </div>
         <div
-          class="makeStyles-fieldValue-4"
+          class="makeStyles-fieldValue"
         >
           10.4
         </div>


### PR DESCRIPTION
This creates a mock for @testing-library/react in packages/__mocks__/@testing-library/react.js that wraps all calls to render() in the <StylesProvider> with a generateClassName function to removes the numerical suffix

Fixes #500 