### PR TITLE
Fix horizontal flip on displayed regions

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -310,46 +310,7 @@ Array [
 ]
 `;
 
-exports[`horizontally flipped displayed regions 1 1`] = `
-BlockSet {
-  "blocks": Array [
-    ContentBlock {
-      "assemblyName": undefined,
-      "end": 200,
-      "isLeftEndOfDisplayedRegion": true,
-      "isRightEndOfDisplayedRegion": true,
-      "key": "ctgA:101-200",
-      "offsetPx": 0,
-      "parentRegion": Object {
-        "end": 200,
-        "refName": "ctgA",
-        "start": 100,
-      },
-      "refName": "ctgA",
-      "start": 100,
-      "widthPx": 100,
-    },
-    ContentBlock {
-      "assemblyName": undefined,
-      "end": 600,
-      "isLeftEndOfDisplayedRegion": true,
-      "isRightEndOfDisplayedRegion": true,
-      "key": "ctgA:501-600",
-      "offsetPx": 100,
-      "parentRegion": Object {
-        "end": 600,
-        "refName": "ctgA",
-        "start": 500,
-      },
-      "refName": "ctgA",
-      "start": 500,
-      "widthPx": 100,
-    },
-  ],
-}
-`;
-
-exports[`horizontally flipped displayed regions with elided region and extra block 1 1`] = `
+exports[`horizontally flipped displayed regions with elided region 1`] = `
 BlockSet {
   "blocks": Array [
     ElidedBlock {
@@ -400,6 +361,45 @@ BlockSet {
       "refName": "ctgA",
       "start": 8400,
       "widthPx": 800,
+    },
+  ],
+}
+`;
+
+exports[`horizontally flipped displayed regions without elided region 1`] = `
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 200,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:101-200",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 200,
+        "refName": "ctgA",
+        "start": 100,
+      },
+      "refName": "ctgA",
+      "start": 100,
+      "widthPx": 100,
+    },
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 600,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:501-600",
+      "offsetPx": 100,
+      "parentRegion": Object {
+        "end": 600,
+        "refName": "ctgA",
+        "start": 500,
+      },
+      "refName": "ctgA",
+      "start": 500,
+      "widthPx": 100,
     },
   ],
 }

--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -349,6 +349,62 @@ BlockSet {
 }
 `;
 
+exports[`horizontally flipped displayed regions with elided region and extra block 1 1`] = `
+BlockSet {
+  "blocks": Array [
+    ElidedBlock {
+      "assemblyName": undefined,
+      "elidedBlockCount": 1,
+      "end": 1,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:1-1",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 1,
+        "refName": "ctgA",
+        "start": 0,
+      },
+      "refName": "ctgA",
+      "start": 0,
+      "widthPx": 1,
+    },
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 10000,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:9201-10000",
+      "offsetPx": 1,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
+      "refName": "ctgA",
+      "start": 9200,
+      "widthPx": 800,
+    },
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 9200,
+      "isLeftEndOfDisplayedRegion": false,
+      "isRightEndOfDisplayedRegion": false,
+      "key": "ctgA:8401-9200",
+      "offsetPx": 801,
+      "parentRegion": Object {
+        "end": 10000,
+        "refName": "ctgA",
+        "start": 0,
+      },
+      "refName": "ctgA",
+      "start": 8400,
+      "widthPx": 800,
+    },
+  ],
+}
+`;
+
 exports[`reverse block calculation 1 1`] = `
 BlockSet {
   "blocks": Array [

--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -310,6 +310,45 @@ Array [
 ]
 `;
 
+exports[`horizontally flipped displayed regions 1 1`] = `
+BlockSet {
+  "blocks": Array [
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 200,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:101-200",
+      "offsetPx": 0,
+      "parentRegion": Object {
+        "end": 200,
+        "refName": "ctgA",
+        "start": 100,
+      },
+      "refName": "ctgA",
+      "start": 100,
+      "widthPx": 100,
+    },
+    ContentBlock {
+      "assemblyName": undefined,
+      "end": 600,
+      "isLeftEndOfDisplayedRegion": true,
+      "isRightEndOfDisplayedRegion": true,
+      "key": "ctgA:501-600",
+      "offsetPx": 100,
+      "parentRegion": Object {
+        "end": 600,
+        "refName": "ctgA",
+        "start": 500,
+      },
+      "refName": "ctgA",
+      "start": 500,
+      "widthPx": 100,
+    },
+  ],
+}
+`;
+
 exports[`reverse block calculation 1 1`] = `
 BlockSet {
   "blocks": Array [

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
@@ -25,7 +25,7 @@ export default function calculateDynamicBlocks(
   {
     offsetPx,
     viewingRegionWidth: width,
-    displayedRegions,
+    effectiveRegions,
     bpPerPx,
     minimumBlockWidth,
   },
@@ -35,8 +35,8 @@ export default function calculateDynamicBlocks(
   let displayedRegionLeftPx = 0
   const windowLeftPx = offsetPx
   const windowRightPx = windowLeftPx + width
-  for (let i = 0; i < displayedRegions.length; i += 1) {
-    const parentRegion = displayedRegions[i]
+  for (let i = 0; i < effectiveRegions.length; i += 1) {
+    const parentRegion = effectiveRegions[i]
     const { assemblyName, start, end, refName } = parentRegion
     const displayedRegionRightPx =
       displayedRegionLeftPx + (end - start) / bpPerPx

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
@@ -25,7 +25,7 @@ export default function calculateDynamicBlocks(model, horizontallyFlipped) {
   const {
     offsetPx,
     viewingRegionWidth: width,
-    effectiveRegions,
+    displayedRegionsInOrder,
     bpPerPx,
     minimumBlockWidth,
   } = model
@@ -33,8 +33,8 @@ export default function calculateDynamicBlocks(model, horizontallyFlipped) {
   let displayedRegionLeftPx = 0
   const windowLeftPx = offsetPx
   const windowRightPx = windowLeftPx + width
-  for (let i = 0; i < effectiveRegions.length; i += 1) {
-    const parentRegion = effectiveRegions[i]
+  for (let i = 0; i < displayedRegionsInOrder.length; i += 1) {
+    const parentRegion = displayedRegionsInOrder[i]
     const { assemblyName, start, end, refName } = parentRegion
     const displayedRegionRightPx =
       displayedRegionLeftPx + (end - start) / bpPerPx

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.js
@@ -21,16 +21,14 @@ import { ContentBlock, ElidedBlock, BlockSet } from './blockTypes'
  *
  * @returns {Array} of ` { refName, startBp, endBp, offsetPx, horizontallyFlipped? }`
  */
-export default function calculateDynamicBlocks(
-  {
+export default function calculateDynamicBlocks(model, horizontallyFlipped) {
+  const {
     offsetPx,
     viewingRegionWidth: width,
     effectiveRegions,
     bpPerPx,
     minimumBlockWidth,
-  },
-  horizontallyFlipped,
-) {
+  } = model
   const blocks = new BlockSet()
   let displayedRegionLeftPx = 0
   const windowLeftPx = offsetPx

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.test.js
@@ -8,7 +8,7 @@ test('one', () => {
       {
         offsetPx: 0,
         viewingRegionWidth: 200,
-        effectiveRegions: [ctgA],
+        displayedRegionsInOrder: [ctgA],
         bpPerPx: 1,
       },
       false,
@@ -33,7 +33,7 @@ test('two', () => {
       {
         offsetPx: 0,
         viewingRegionWidth: 200,
-        effectiveRegions: [ctgA],
+        displayedRegionsInOrder: [ctgA],
         bpPerPx: 1,
       },
       true,
@@ -58,7 +58,7 @@ test('three', () => {
       {
         offsetPx: -100,
         viewingRegionWidth: 200,
-        effectiveRegions: [ctgA],
+        displayedRegionsInOrder: [ctgA],
         bpPerPx: 1,
       },
       true,
@@ -83,7 +83,7 @@ test('four', () => {
       {
         offsetPx: -100,
         viewingRegionWidth: 350,
-        effectiveRegions: [ctgA],
+        displayedRegionsInOrder: [ctgA],
         bpPerPx: 1,
       },
       false,
@@ -108,7 +108,7 @@ test('five', () => {
       {
         offsetPx: 521,
         viewingRegionWidth: 927,
-        effectiveRegions: [ctgA],
+        displayedRegionsInOrder: [ctgA],
         bpPerPx: 0.05,
       },
       false,

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.test.js
@@ -8,7 +8,7 @@ test('one', () => {
       {
         offsetPx: 0,
         viewingRegionWidth: 200,
-        displayedRegions: [ctgA],
+        effectiveRegions: [ctgA],
         bpPerPx: 1,
       },
       false,
@@ -33,7 +33,7 @@ test('two', () => {
       {
         offsetPx: 0,
         viewingRegionWidth: 200,
-        displayedRegions: [ctgA],
+        effectiveRegions: [ctgA],
         bpPerPx: 1,
       },
       true,
@@ -58,7 +58,7 @@ test('three', () => {
       {
         offsetPx: -100,
         viewingRegionWidth: 200,
-        displayedRegions: [ctgA],
+        effectiveRegions: [ctgA],
         bpPerPx: 1,
       },
       true,
@@ -83,7 +83,7 @@ test('four', () => {
       {
         offsetPx: -100,
         viewingRegionWidth: 350,
-        displayedRegions: [ctgA],
+        effectiveRegions: [ctgA],
         bpPerPx: 1,
       },
       false,
@@ -108,7 +108,7 @@ test('five', () => {
       {
         offsetPx: 521,
         viewingRegionWidth: 927,
-        displayedRegions: [ctgA],
+        effectiveRegions: [ctgA],
         bpPerPx: 0.05,
       },
       false,

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
@@ -7,8 +7,8 @@ export function calculateBlocksReversed(self, extra = 0) {
       const { parentRegion } = fwdBlock
       const revBlock = new ContentBlock({
         ...fwdBlock,
-        start: parentRegion.end - fwdBlock.end,
-        end: parentRegion.end - fwdBlock.start,
+        start: parentRegion.start + parentRegion.end - fwdBlock.end,
+        end: parentRegion.start + parentRegion.end - fwdBlock.start,
       })
       revBlock.key = assembleLocString(revBlock)
       return revBlock

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
@@ -17,7 +17,13 @@ export function calculateBlocksReversed(self, extra = 0) {
 }
 
 export function calculateBlocksForward(self, extra = 0) {
-  const { offsetPx, bpPerPx, width, effectiveRegions, minimumBlockWidth } = self
+  const {
+    offsetPx,
+    bpPerPx,
+    width,
+    displayedRegionsInOrder,
+    minimumBlockWidth,
+  } = self
   if (!width)
     throw new Error('view has no width, cannot calculate displayed blocks')
   const windowLeftBp = offsetPx * bpPerPx
@@ -27,7 +33,7 @@ export function calculateBlocksForward(self, extra = 0) {
   // for each displayed region
   let regionBpOffset = 0
   const blocks = new BlockSet()
-  effectiveRegions.forEach(region => {
+  displayedRegionsInOrder.forEach(region => {
     // find the block numbers of the left and right window sides,
     // clamp those to the region range, and then make blocks for that range
     const regionBlockCount = Math.ceil(

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
@@ -5,11 +5,15 @@ export function calculateBlocksReversed(self, extra = 0) {
   return new BlockSet(
     calculateBlocksForward(self, extra).map(fwdBlock => {
       const { parentRegion } = fwdBlock
-      const revBlock = new ContentBlock({
+      const args = {
         ...fwdBlock,
         start: parentRegion.start + parentRegion.end - fwdBlock.end,
         end: parentRegion.start + parentRegion.end - fwdBlock.start,
-      })
+      }
+      const revBlock =
+        fwdBlock instanceof ElidedBlock
+          ? new ElidedBlock(args)
+          : new ContentBlock(args)
       revBlock.key = assembleLocString(revBlock)
       return revBlock
     }),

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.js
@@ -17,7 +17,7 @@ export function calculateBlocksReversed(self, extra = 0) {
 }
 
 export function calculateBlocksForward(self, extra = 0) {
-  const { offsetPx, bpPerPx, width, displayedRegions, minimumBlockWidth } = self
+  const { offsetPx, bpPerPx, width, effectiveRegions, minimumBlockWidth } = self
   if (!width)
     throw new Error('view has no width, cannot calculate displayed blocks')
   const windowLeftBp = offsetPx * bpPerPx
@@ -27,7 +27,7 @@ export function calculateBlocksForward(self, extra = 0) {
   // for each displayed region
   let regionBpOffset = 0
   const blocks = new BlockSet()
-  displayedRegions.forEach(region => {
+  effectiveRegions.forEach(region => {
     // find the block numbers of the left and right window sides,
     // clamp those to the region range, and then make blocks for that range
     const regionBlockCount = Math.ceil(

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -1,4 +1,4 @@
-import {
+import calculateBlocks, {
   calculateBlocksForward,
   calculateBlocksReversed,
 } from './calculateStaticBlocks'
@@ -174,7 +174,7 @@ describe('horizontally flipped displayed regions', () => {
 })
 describe('horizontally flipped displayed regions with elided region and extra block', () => {
   test('1', () => {
-    const blocks = calculateBlocksReversed(
+    const blocks = calculateBlocks(
       {
         bpPerPx: 1,
         width: 800,

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -9,7 +9,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      effectiveRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
+      displayedRegionsInOrder: [{ refName: 'ctgA', start: 0, end: 10000 }],
     })
     expect(blocks).toMatchSnapshot()
   })
@@ -19,7 +19,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 30,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 100 },
         { refName: 'ctgB', start: 100, end: 200 },
       ],
@@ -32,7 +32,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 1000,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 100 },
         { refName: 'ctgB', start: 100, end: 200 },
       ],
@@ -46,7 +46,7 @@ describe('block calculation', () => {
         bpPerPx: 1,
         width: 800,
         offsetPx: -1000,
-        effectiveRegions: [
+        displayedRegionsInOrder: [
           { refName: 'ctgA', start: 0, end: 100 },
           { refName: 'ctgB', start: 100, end: 200 },
         ],
@@ -63,7 +63,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 5000,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 10000 },
         { refName: 'ctgB', start: 100, end: 10000 },
       ],
@@ -76,7 +76,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 1000 },
       ],
@@ -90,7 +90,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 801,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 1000 },
       ],
@@ -103,7 +103,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 1600,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 10000000 },
       ],
@@ -117,7 +117,7 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 1069,
       bpPerPx: 2,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 0, end: 50000 },
         { refName: 'ctgB', start: 0, end: 300 },
       ],
@@ -131,7 +131,7 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 0,
       bpPerPx: 0.05,
-      effectiveRegions: [
+      displayedRegionsInOrder: [
         { refName: 'ctgA', start: 100, end: 200 },
         { refName: 'ctgA', start: 300, end: 400 },
       ],
@@ -149,7 +149,7 @@ describe('reverse block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      effectiveRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
+      displayedRegionsInOrder: [{ refName: 'ctgA', start: 0, end: 10000 }],
     })
     expect(blocks).toMatchSnapshot()
   })
@@ -162,7 +162,7 @@ describe('horizontally flipped displayed regions', () => {
         bpPerPx: 1,
         width: 800,
         offsetPx: 0,
-        effectiveRegions: [
+        displayedRegionsInOrder: [
           { refName: 'ctgA', start: 100, end: 200 },
           { refName: 'ctgA', start: 500, end: 600 },
         ],

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -154,3 +154,21 @@ describe('reverse block calculation', () => {
     expect(blocks).toMatchSnapshot()
   })
 })
+
+describe('horizontally flipped displayed regions', () => {
+  test('1', () => {
+    const blocks = calculateBlocksReversed(
+      {
+        bpPerPx: 1,
+        width: 800,
+        offsetPx: 0,
+        effectiveRegions: [
+          { refName: 'ctgA', start: 100, end: 200 },
+          { refName: 'ctgA', start: 500, end: 600 },
+        ],
+      },
+      true,
+    )
+    expect(blocks).toMatchSnapshot()
+  })
+})

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -9,7 +9,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      displayedRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
+      effectiveRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
     })
     expect(blocks).toMatchSnapshot()
   })
@@ -19,7 +19,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 30,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 100 },
         { refName: 'ctgB', start: 100, end: 200 },
       ],
@@ -32,7 +32,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 1000,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 100 },
         { refName: 'ctgB', start: 100, end: 200 },
       ],
@@ -46,7 +46,7 @@ describe('block calculation', () => {
         bpPerPx: 1,
         width: 800,
         offsetPx: -1000,
-        displayedRegions: [
+        effectiveRegions: [
           { refName: 'ctgA', start: 0, end: 100 },
           { refName: 'ctgB', start: 100, end: 200 },
         ],
@@ -63,7 +63,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 5000,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 10000 },
         { refName: 'ctgB', start: 100, end: 10000 },
       ],
@@ -76,7 +76,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 1000 },
       ],
@@ -90,7 +90,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 801,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 1000 },
       ],
@@ -103,7 +103,7 @@ describe('block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 1600,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 200 },
         { refName: 'ctgB', start: 0, end: 10000000 },
       ],
@@ -117,7 +117,7 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 1069,
       bpPerPx: 2,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 0, end: 50000 },
         { refName: 'ctgB', start: 0, end: 300 },
       ],
@@ -131,7 +131,7 @@ describe('block calculation', () => {
       width: 800,
       offsetPx: 0,
       bpPerPx: 0.05,
-      displayedRegions: [
+      effectiveRegions: [
         { refName: 'ctgA', start: 100, end: 200 },
         { refName: 'ctgA', start: 300, end: 400 },
       ],
@@ -149,7 +149,7 @@ describe('reverse block calculation', () => {
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
-      displayedRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
+      effectiveRegions: [{ refName: 'ctgA', start: 0, end: 10000 }],
     })
     expect(blocks).toMatchSnapshot()
   })

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -5,13 +5,21 @@ import calculateBlocks, {
 
 describe('block calculation', () => {
   it('can calculate some blocks 1', () => {
-    const blocks = calculateBlocksForward({
+    const blocks1 = calculateBlocksForward({
       bpPerPx: 1,
       width: 800,
       offsetPx: 0,
       displayedRegionsInOrder: [{ refName: 'ctgA', start: 0, end: 10000 }],
     })
-    expect(blocks).toMatchSnapshot()
+
+    const blocks2 = calculateBlocks({
+      bpPerPx: 1,
+      width: 800,
+      offsetPx: 0,
+      displayedRegionsInOrder: [{ refName: 'ctgA', start: 0, end: 10000 }],
+    })
+    expect(blocks1).toMatchSnapshot()
+    expect(blocks1).toEqual(blocks2)
   })
 
   it('can calculate some blocks 2', () => {
@@ -156,7 +164,7 @@ describe('reverse block calculation', () => {
 })
 
 describe('horizontally flipped displayed regions', () => {
-  test('1', () => {
+  test('without elided region', () => {
     const blocks = calculateBlocksReversed(
       {
         bpPerPx: 1,
@@ -171,9 +179,7 @@ describe('horizontally flipped displayed regions', () => {
     )
     expect(blocks).toMatchSnapshot()
   })
-})
-describe('horizontally flipped displayed regions with elided region and extra block', () => {
-  test('1', () => {
+  test('with elided region', () => {
     const blocks = calculateBlocks(
       {
         bpPerPx: 1,

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.test.js
@@ -172,3 +172,22 @@ describe('horizontally flipped displayed regions', () => {
     expect(blocks).toMatchSnapshot()
   })
 })
+describe('horizontally flipped displayed regions with elided region and extra block', () => {
+  test('1', () => {
+    const blocks = calculateBlocksReversed(
+      {
+        bpPerPx: 1,
+        width: 800,
+        offsetPx: 0,
+        minimumBlockWidth: 2,
+        displayedRegionsInOrder: [
+          { refName: 'ctgA', start: 0, end: 1 },
+          { refName: 'ctgA', start: 0, end: 10000 },
+        ],
+      },
+      true,
+      1,
+    )
+    expect(blocks).toMatchSnapshot()
+  })
+})

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -94,7 +94,7 @@ export function stateModelFactory(pluginManager: any) {
 
       get totalBp() {
         let totalbp = 0
-        this.effectiveRegions.forEach(region => {
+        this.displayedRegionsInOrder.forEach(region => {
           totalbp += region.end - region.start
         })
         return totalbp
@@ -112,7 +112,7 @@ export function stateModelFactory(pluginManager: any) {
         return self.reversed
       },
 
-      get effectiveRegions() {
+      get displayedRegionsInOrder() {
         return self.reversed
           ? self.displayedRegions.slice().reverse()
           : self.displayedRegions
@@ -144,13 +144,17 @@ export function stateModelFactory(pluginManager: any) {
         let bpSoFar = 0
         if (bp < 0) {
           return {
-            ...this.effectiveRegions[0],
+            ...this.displayedRegionsInOrder[0],
             offset: Math.round(bp),
             index: 0,
           }
         }
-        for (let index = 0; index < this.effectiveRegions.length; index += 1) {
-          const r = this.effectiveRegions[index]
+        for (
+          let index = 0;
+          index < this.displayedRegionsInOrder.length;
+          index += 1
+        ) {
+          const r = this.displayedRegionsInOrder[index]
           if (r.end - r.start + bpSoFar > bp && bpSoFar <= bp) {
             return { ...r, offset: Math.round(bp - bpSoFar), index }
           }
@@ -159,7 +163,7 @@ export function stateModelFactory(pluginManager: any) {
 
         return {
           offset: Math.round(bp - bpSoFar),
-          index: this.effectiveRegions.length,
+          index: this.displayedRegionsInOrder.length,
         }
       },
     }))
@@ -270,7 +274,7 @@ export function stateModelFactory(pluginManager: any) {
       navTo({ refName, start, end }: IRegion) {
         let s = start
         let e = end
-        const index = self.effectiveRegions.findIndex(r => {
+        const index = self.displayedRegionsInOrder.findIndex(r => {
           if (refName === r.refName) {
             if (s === undefined) {
               s = r.start
@@ -284,7 +288,7 @@ export function stateModelFactory(pluginManager: any) {
           }
           return false
         })
-        const f = self.effectiveRegions[index]
+        const f = self.displayedRegionsInOrder[index]
         if (index !== -1) {
           this.moveTo(
             { index, offset: s - f.start },
@@ -308,19 +312,20 @@ export function stateModelFactory(pluginManager: any) {
         if (start.index === end.index) {
           bpSoFar += end.offset - start.offset
         } else {
-          const s = self.effectiveRegions[start.index]
+          const s = self.displayedRegionsInOrder[start.index]
           bpSoFar += s.end - start.offset
           if (end.index - start.index >= 2) {
             for (let i = start.index + 1; i < end.index; i += 1) {
               bpSoFar +=
-                self.effectiveRegions[i].end - self.effectiveRegions[i].start
+                self.displayedRegionsInOrder[i].end -
+                self.displayedRegionsInOrder[i].start
             }
           }
           bpSoFar += end.offset
         }
         let bpToStart = 0
-        for (let i = 0; i < self.effectiveRegions.length; i += 1) {
-          const region = self.effectiveRegions[i]
+        for (let i = 0; i < self.displayedRegionsInOrder.length; i += 1) {
+          const region = self.displayedRegionsInOrder[i]
           if (start.index === i) {
             bpToStart += start.offset
             break

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -178,7 +178,6 @@ export function stateModelFactory(pluginManager: any) {
 
       horizontallyFlip() {
         self.reversed = !self.reversed
-        // this.setDisplayedRegions(self.displayedRegions) // will update with flipped displayed regions
         self.offsetPx = self.totalBp / self.bpPerPx - self.offsetPx - self.width
       },
 


### PR DESCRIPTION
This makes the concept of the displayedRegions being horizontallyFlipped into a view called effectiveRegions. I could have modified it so that "displayedRegions" itself was a view, but that would sort of change the "public API" of setting displayedRegions from config files for example, which seems to be something that might be worth keeping. Therefore I chose to make "effectiveRegions" the name of the view.


fixes #502 

