### PR TITLE
Fix issue with some undefined features being found in layout due to granular rect resolution

### DIFF
--- a/packages/core/util/layouts/GranularRectLayout.test.js
+++ b/packages/core/util/layouts/GranularRectLayout.test.js
@@ -66,3 +66,13 @@ it('stacks up overlapping features', () => {
 
   expect(() => l.discardRange(0, 20000)).not.toThrow()
 })
+
+it('stacks up overlapping features', () => {
+  const l = new Layout({ pitchX: 91.21851599727707, pitchY: 3 })
+
+  l.addRect('test', 2581541, 2581542, 1)
+
+  expect(
+    l.serializeRegion({ start: 2581491, end: 2818659 }).rectangles.test,
+  ).toBeTruthy()
+})

--- a/packages/core/util/layouts/GranularRectLayout.test.js
+++ b/packages/core/util/layouts/GranularRectLayout.test.js
@@ -67,7 +67,8 @@ it('stacks up overlapping features', () => {
   expect(() => l.discardRange(0, 20000)).not.toThrow()
 })
 
-it('stacks up overlapping features', () => {
+// see issue #486
+it('tests that adding +/- pitchX fixes resolution causing errors', () => {
   const l = new Layout({ pitchX: 91.21851599727707, pitchY: 3 })
 
   l.addRect('test', 2581541, 2581542, 1)

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -509,11 +509,11 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
       } else {
         const t = (top || 0) * this.pitchY
         const b = t + originalHeight
-        // use l-1 and r+1 to avoid issue with pitchX resolution causing errors
         const y1 = l * this.pitchX
         const y2 = r * this.pitchX
         const x1 = region.start
         const x2 = region.end
+        // add +/- pitchX to avoid resolution causing errors
         if (segmentsIntersect(x1, x2, y1 - this.pitchX, y2 + this.pitchX)) {
           regionRectangles[id] = [y1, t, y2, b]
         }

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -509,8 +509,9 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
       } else {
         const t = (top || 0) * this.pitchY
         const b = t + originalHeight
-        const y1 = l * this.pitchX
-        const y2 = r * this.pitchX
+        // use l-1 and r+1 to avoid issue with pitchX resolution causing errors
+        const y1 = (l - 1) * this.pitchX
+        const y2 = (r + 1) * this.pitchX
         const x1 = region.start
         const x2 = region.end
         if (segmentsIntersect(x1, x2, y1, y2)) {

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -510,11 +510,11 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
         const t = (top || 0) * this.pitchY
         const b = t + originalHeight
         // use l-1 and r+1 to avoid issue with pitchX resolution causing errors
-        const y1 = (l - 1) * this.pitchX
-        const y2 = (r + 1) * this.pitchX
+        const y1 = l * this.pitchX
+        const y2 = r * this.pitchX
         const x1 = region.start
         const x2 = region.end
-        if (segmentsIntersect(x1, x2, y1, y2)) {
+        if (segmentsIntersect(x1, x2, y1 - this.pitchX, y2 + this.pitchX)) {
           regionRectangles[id] = [y1, t, y2, b]
         }
       }


### PR DESCRIPTION
Fixes #486 

This bug was a bit tricky

This error actually wasn't occurring on master because the max height for SVG bugfix introduced a concept that hard-filters undefined features from the layout, however, there was a actual issue with serializeRegion where it was filtering out things that were getting missed due to the pitchX resolution apparently missing things

I added a pitchX adjustment of -1 and +1 on the left and right to avoid missing layout'd features that should actually be included