### PR TITLE
Optimize drawer rerendering

### DIFF
--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -54,14 +54,10 @@ const useStyles = makeStyles(theme => ({
 }))
 
 const DrawerWidget = React.memo(props => {
-  const { session } = props
+  const { session, LazyReactComponent, HeadingComponent, heading } = props
   const { visibleDrawerWidget, pluginManager } = session
   const classes = useStyles()
-  const {
-    LazyReactComponent,
-    HeadingComponent,
-    heading,
-  } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
+
   return (
     <Drawer session={session} open={Boolean(session.activeDrawerWidgets.size)}>
       <Slide direction="left" in>
@@ -120,21 +116,25 @@ function App({ size, session }) {
   }, [session, size.width])
 
   const { visibleDrawerWidget } = session
-
+  const {
+    LazyReactComponent,
+    HeadingComponent,
+    heading,
+  } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
   return (
     <div className={classes.root}>
       <div className={classes.menuBarsAndComponents}>
         <div className={classes.menuBars}>
           {session.menuBars.map(menuBar => {
-            const { LazyReactComponent } = pluginManager.getMenuBarType(
-              menuBar.type,
-            )
+            const {
+              LazyReactComponent: MenuBarLazyReactComponent,
+            } = pluginManager.getMenuBarType(menuBar.type)
             return (
               <React.Suspense
                 key={`view-${menuBar.id}`}
                 fallback={<div>Loading...</div>}
               >
-                <LazyReactComponent
+                <MenuBarLazyReactComponent
                   key={`view-${menuBar.id}`}
                   model={menuBar}
                   session={session}
@@ -159,7 +159,14 @@ function App({ size, session }) {
         </div>
       </div>
 
-      {visibleDrawerWidget ? <DrawerWidget session={session} /> : null}
+      {visibleDrawerWidget ? (
+        <DrawerWidget
+          LazyReactComponent={LazyReactComponent}
+          HeadingComponent={HeadingComponent}
+          heading={heading}
+          session={session}
+        />
+      ) : null}
     </div>
   )
 }

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -53,9 +53,14 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const DrawerWidget = React.memo(props => {
-  const { session, LazyReactComponent, HeadingComponent, heading } = props
-  const { visibleDrawerWidget } = session
+const DrawerWidget = observer(props => {
+  const { session } = props
+  const { visibleDrawerWidget, pluginManager } = session
+  const {
+    LazyReactComponent,
+    HeadingComponent,
+    heading,
+  } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
   const classes = useStyles()
 
   return (
@@ -104,12 +109,6 @@ const DrawerWidget = React.memo(props => {
 
 DrawerWidget.propTypes = {
   session: PropTypes.observableObject.isRequired,
-  LazyReactComponent: ReactPropTypes.any.isRequired,
-  heading: ReactPropTypes.string.isRequired,
-  HeadingComponent: ReactPropTypes.any,
-}
-DrawerWidget.defaultProps = {
-  HeadingComponent: null,
 }
 
 function App({ size, session }) {
@@ -122,11 +121,6 @@ function App({ size, session }) {
   }, [session, size.width])
 
   const { visibleDrawerWidget } = session
-  let drawer = {}
-  if (visibleDrawerWidget) {
-    drawer = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
-  }
-  const { LazyReactComponent, HeadingComponent, heading } = drawer
   return (
     <div className={classes.root}>
       <div className={classes.menuBarsAndComponents}>
@@ -165,14 +159,7 @@ function App({ size, session }) {
         </div>
       </div>
 
-      {visibleDrawerWidget ? (
-        <DrawerWidget
-          LazyReactComponent={LazyReactComponent}
-          HeadingComponent={HeadingComponent}
-          heading={heading}
-          session={session}
-        />
-      ) : null}
+      {visibleDrawerWidget ? <DrawerWidget session={session} /> : null}
     </div>
   )
 }

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -53,24 +53,17 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-function App({ size, session }) {
+const DrawerWidget = React.memo(props => {
+  const { session } = props
+  const { visibleDrawerWidget, pluginManager } = session
   const classes = useStyles()
-
-  const { pluginManager } = session
-
-  useEffect(() => {
-    session.updateWidth(size.width)
-  }, [session, size.width])
-
-  const { visibleDrawerWidget } = session
-  let drawerComponent
-  if (visibleDrawerWidget) {
-    const {
-      LazyReactComponent,
-      HeadingComponent,
-      heading,
-    } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
-    drawerComponent = (
+  const {
+    LazyReactComponent,
+    HeadingComponent,
+    heading,
+  } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
+  return (
+    <Drawer session={session} open={Boolean(session.activeDrawerWidgets.size)}>
       <Slide direction="left" in>
         <div className={classes.defaultDrawer}>
           <AppBar position="static">
@@ -109,8 +102,24 @@ function App({ size, session }) {
           </React.Suspense>
         </div>
       </Slide>
-    )
-  }
+    </Drawer>
+  )
+})
+
+DrawerWidget.propTypes = {
+  session: PropTypes.observableObject.isRequired,
+}
+
+function App({ size, session }) {
+  const classes = useStyles()
+
+  const { pluginManager } = session
+
+  useEffect(() => {
+    session.updateWidth(size.width)
+  }, [session, size.width])
+
+  const { visibleDrawerWidget } = session
 
   return (
     <div className={classes.root}>
@@ -149,12 +158,8 @@ function App({ size, session }) {
           <DevTools session={session} />
         </div>
       </div>
-      <Drawer
-        session={session}
-        open={Boolean(session.activeDrawerWidgets.size)}
-      >
-        {drawerComponent}
-      </Drawer>
+
+      {visibleDrawerWidget ? <DrawerWidget session={session} /> : null}
     </div>
   )
 }

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -104,9 +104,12 @@ const DrawerWidget = React.memo(props => {
 
 DrawerWidget.propTypes = {
   session: PropTypes.observableObject.isRequired,
-  LazyReactComponent: ReactPropTypes.node.isRequired,
+  LazyReactComponent: ReactPropTypes.any.isRequired,
   heading: ReactPropTypes.string.isRequired,
-  HeadingComponent: ReactPropTypes.node.isRequired,
+  HeadingComponent: ReactPropTypes.any,
+}
+DrawerWidget.defaultProps = {
+  HeadingComponent: null,
 }
 
 function App({ size, session }) {
@@ -119,11 +122,11 @@ function App({ size, session }) {
   }, [session, size.width])
 
   const { visibleDrawerWidget } = session
-  const {
-    LazyReactComponent,
-    HeadingComponent,
-    heading,
-  } = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
+  let drawer = {}
+  if (visibleDrawerWidget) {
+    drawer = pluginManager.getDrawerWidgetType(visibleDrawerWidget.type)
+  }
+  const { LazyReactComponent, HeadingComponent, heading } = drawer
   return (
     <div className={classes.root}>
       <div className={classes.menuBarsAndComponents}>

--- a/packages/jbrowse-web/src/ui/App.js
+++ b/packages/jbrowse-web/src/ui/App.js
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
 
 const DrawerWidget = React.memo(props => {
   const { session, LazyReactComponent, HeadingComponent, heading } = props
-  const { visibleDrawerWidget, pluginManager } = session
+  const { visibleDrawerWidget } = session
   const classes = useStyles()
 
   return (
@@ -104,6 +104,9 @@ const DrawerWidget = React.memo(props => {
 
 DrawerWidget.propTypes = {
   session: PropTypes.observableObject.isRequired,
+  LazyReactComponent: ReactPropTypes.node.isRequired,
+  heading: ReactPropTypes.string.isRequired,
+  HeadingComponent: ReactPropTypes.node.isRequired,
 }
 
 function App({ size, session }) {


### PR DESCRIPTION
This uses React.memo to optimize the re-rendering of the drawer widget

This is pretty helpful for performance, you can see in all our performance traces that the Drawer widget will get constantly re-rendered without this

