### PR TITLE
Update granular rect layout extension to use original jbrowse 1 code

### DIFF
--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -139,7 +139,9 @@ class LayoutRow<T> {
         )
         this.initialize(left, right)
       } else if (additionalLength > 0) {
-        this.rowState.bits.push(...new Array(additionalLength))
+        this.rowState.bits = this.rowState.bits.concat(
+          new Array(additionalLength),
+        )
         // this.log(`expand right (${additionalLength}): ${this.rowState.offset} | ${
         // this.rowState.min} - ${this.rowState.max}`)
       }
@@ -149,17 +151,13 @@ class LayoutRow<T> {
     if (left < this.rowState.offset) {
       // expand to new left - the whole current length (or 0)
       // additionalLength = (offset - left) + currLength = -(left - offset) + currLength
-      const additionalLength = Math.max(
-        currLength - oLeft,
-        this.rowState.offset,
-      )
+      const additionalLength = currLength - oLeft
       if (this.rowState.bits.length + additionalLength > this.widthLimit) {
-        console.warn(
-          'Layout width limit exceeded, discarding old layout. Please be more careful about discarding unused blocks.',
-        )
         this.initialize(left, right)
       } else {
-        this.rowState.bits.unshift(...new Array(additionalLength))
+        this.rowState.bits = new Array(additionalLength).concat(
+          this.rowState.bits,
+        )
         this.rowState.offset -= additionalLength
         oLeft = left - this.rowState.offset
         // this.log(`expand left (${additionalLength}): ${this.rowState.offset} | ${

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -153,6 +153,10 @@ class LayoutRow<T> {
       // additionalLength = (offset - left) + currLength = -(left - offset) + currLength
       const additionalLength = currLength - oLeft
       if (this.rowState.bits.length + additionalLength > this.widthLimit) {
+        console.warn(
+          'Layout width limit exceeded, discarding old layout. Please be more careful about discarding unused blocks.',
+        )
+
         this.initialize(left, right)
       } else {
         this.rowState.bits = new Array(additionalLength).concat(

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -151,7 +151,10 @@ class LayoutRow<T> {
     if (left < this.rowState.offset) {
       // expand to new left - the whole current length (or 0)
       // additionalLength = (offset - left) + currLength = -(left - offset) + currLength
-      const additionalLength = currLength - oLeft
+      const additionalLength = Math.min(
+        currLength - oLeft,
+        this.rowState.offset,
+      )
       if (this.rowState.bits.length + additionalLength > this.widthLimit) {
         console.warn(
           'Layout width limit exceeded, discarding old layout. Please be more careful about discarding unused blocks.',


### PR DESCRIPTION
The granular rect layout was producing two errors

1) Maximum stack size exceeded due to the spread being bad
2) Excessive layout being thrown away and re-initialized due to apparently the Math.max being used and being set to this.offset, which was way larger than the additionalLength that was proposed to be added

This reverts those changes to a jbrowse 1 style code (currLength - oLeft == this.offset - left + currLength  from jb1's granular rect layout)
