### PR TITLE
Fix layout bug #553

### DIFF
--- a/packages/core/util/layouts/GranularRectLayout.test.js
+++ b/packages/core/util/layouts/GranularRectLayout.test.js
@@ -94,7 +94,7 @@ describe('GranularRectLayout', () => {
     ).toBeTruthy()
   })
 
-  it('tests adding some gigantic layouts', () => {
+  it('tests reinitializing layout due to throwing away old one', () => {
     const l = new Layout({
       pitchX: 1,
       pitchY: 1,
@@ -105,5 +105,20 @@ describe('GranularRectLayout', () => {
     l.addRect('test2', 1000000, 1000100, 1)
     l.addRect('test3', 0, 10000, 1)
     expect(l.rectangles.size).toBe(3)
+  })
+
+  it('tests adding a gigantic feature that fills entire row with another smaller added on top', () => {
+    const l = new Layout({
+      pitchX: 100,
+      pitchY: 1,
+      maxHeight: 600,
+    })
+
+    expect(l.getByCoord(50000, 0)).toEqual(undefined)
+    l.addRect('test1', 0, 100000000, 1, { id: 'feat1' })
+    expect(l.getByCoord(50000, 0)).toEqual({ id: 'feat1' })
+    l.addRect('test2', 0, 1000, 1, { id: 'feat2' })
+    expect(l.getByCoord(500, 1)).toEqual({ id: 'feat2' })
+    expect(l.rectangles.size).toBe(2)
   })
 })

--- a/packages/core/util/layouts/GranularRectLayout.test.js
+++ b/packages/core/util/layouts/GranularRectLayout.test.js
@@ -93,4 +93,17 @@ describe('GranularRectLayout', () => {
       l.serializeRegion({ start: 2581491, end: 2818659 }).rectangles.test,
     ).toBeTruthy()
   })
+
+  it('tests adding some gigantic layouts', () => {
+    const l = new Layout({
+      pitchX: 1,
+      pitchY: 1,
+      maxHeight: 600,
+    })
+
+    l.addRect('test1', 0, 10000, 1)
+    l.addRect('test2', 1000000, 1000100, 1)
+    l.addRect('test3', 0, 10000, 1)
+    expect(l.rectangles.size).toBe(3)
+  })
 })

--- a/packages/core/util/layouts/GranularRectLayout.test.js
+++ b/packages/core/util/layouts/GranularRectLayout.test.js
@@ -71,8 +71,8 @@ describe('GranularRectLayout', () => {
       expect(top).toEqual((i % 2) * 4)
     }
 
-    expect(l.bitmap[0].rowState.bits.length).toBe(34809)
-    expect(l.bitmap[1].rowState.bits.length).toBe(34809)
+    expect(l.bitmap[0].rowState.bits.length).toBe(34812)
+    expect(l.bitmap[1].rowState.bits.length).toBe(34812)
     l.discardRange(190000, 220000)
     expect(l.bitmap[0].rowState.bits.length).toBe(24802)
     expect(l.bitmap[1].rowState.bits.length).toBe(23802)

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -57,11 +57,11 @@ class LayoutRow<T> {
     // this.rowState.max is the rightmost edge of all the rectangles we have in the layout
   }
 
-  log(msg: string): void {
-    // if (this.rowNumber === 0)
-    // eslint-disable-next-line no-console
-    console.log(`r${this.rowNumber}: ${msg}`)
-  }
+  // log(msg: string): void {
+  //   // if (this.rowNumber === 0)
+  //   // eslint-disable-next-line no-console
+  //   console.log(`r${this.rowNumber}: ${msg}`)
+  // }
 
   setAllFilled(data: Record<string, T> | boolean): void {
     this.allFilled = data

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -125,25 +125,22 @@ class LayoutRow<T> {
     // or check if we need to expand to the left and/or to the right
 
     let oLeft = left - this.rowState.offset
-    const oRight = right - this.rowState.offset
+    let oRight = right - this.rowState.offset
     const currLength = this.rowState.bits.length
 
     // expand rightward if necessary
     if (oRight >= this.rowState.bits.length) {
       // expand to new right + the whole current length
-      // additionalLength = (oRight - currLength) + currentLength
-      const additionalLength = oRight
+      const additionalLength = oRight + 1
       if (this.rowState.bits.length + additionalLength > this.widthLimit) {
         console.warn(
           'Layout width limit exceeded, discarding old layout. Please be more careful about discarding unused blocks.',
         )
-        this.initialize(left, right)
+        this.rowState = this.initialize(left, right)
       } else if (additionalLength > 0) {
         this.rowState.bits = this.rowState.bits.concat(
           new Array(additionalLength),
         )
-        // this.log(`expand right (${additionalLength}): ${this.rowState.offset} | ${
-        // this.rowState.min} - ${this.rowState.max}`)
       }
     }
 
@@ -160,17 +157,16 @@ class LayoutRow<T> {
           'Layout width limit exceeded, discarding old layout. Please be more careful about discarding unused blocks.',
         )
 
-        this.initialize(left, right)
+        this.rowState = this.initialize(left, right)
       } else {
         this.rowState.bits = new Array(additionalLength).concat(
           this.rowState.bits,
         )
         this.rowState.offset -= additionalLength
-        oLeft = left - this.rowState.offset
-        // this.log(`expand left (${additionalLength}): ${this.rowState.offset} | ${
-        //   this.rowState.min} - ${this.rowState.max}`)
       }
     }
+    oRight = right - this.rowState.offset
+    oLeft = left - this.rowState.offset
 
     // set the bits in the bitmask
     // if (oLeft < 0) debugger

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -127,10 +127,10 @@ class LayoutRow<T> {
     let oLeft = left - this.rowState.offset
     let oRight = right - this.rowState.offset
     const currLength = this.rowState.bits.length
+    // console.log(oRight, this.rowState.bits.length)
 
     // expand rightward if necessary
     if (oRight >= this.rowState.bits.length) {
-      // expand to new right + the whole current length
       const additionalLength = oRight + 1
       if (this.rowState.bits.length + additionalLength > this.widthLimit) {
         console.warn(
@@ -146,8 +146,7 @@ class LayoutRow<T> {
 
     // expand leftward if necessary
     if (left < this.rowState.offset) {
-      // expand to new left - the whole current length (or 0)
-      // additionalLength = (offset - left) + currLength = -(left - offset) + currLength
+      // use math.min to avoid negative lengths
       const additionalLength = Math.min(
         currLength - oLeft,
         this.rowState.offset,


### PR DESCRIPTION
This fixes #553 by making sure to take into account this.rowState.offset in all cases (specifically, it seems that oRight was not re-initialized with right-this.rowState.offset after the block in question). If you console.log this.rowState.offset before and after the loop, it can change in some cases, and oRight was specifically not updated.

This also re-initializes this.rowState=initialize(left,right) as calling initialize(left,right) with no assignment would be void when the layout width is exceeded.