### PR TITLE
Fix refName labeling zIndex issue and unify implementation of refName labels

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/Ruler.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Ruler.tsx
@@ -1,4 +1,4 @@
-import { PropTypes, IRegion } from '@gmod/jbrowse-core/mst-types'
+import { PropTypes } from '@gmod/jbrowse-core/mst-types'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import ReactPropTypes from 'prop-types'

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Ruler.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Ruler.tsx
@@ -1,15 +1,19 @@
-import { PropTypes } from '@gmod/jbrowse-core/mst-types'
+import { PropTypes, IRegion } from '@gmod/jbrowse-core/mst-types'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import ReactPropTypes from 'prop-types'
-import React, { Fragment } from 'react'
+import React from 'react'
 
 /**
  * Given a scale ( bp/px ) and minimum distances (px) between major
  * and minor gridlines, return an object like { majorPitch: bp,
  * minorPitch: bp } giving the gridline pitches to use.
  */
-function chooseGridPitch(scale, minMajorPitchPx, minMinorPitchPx) {
+function chooseGridPitch(
+  scale: number,
+  minMajorPitchPx: number,
+  minMinorPitchPx: number,
+) {
   scale = Math.abs(scale)
   const minMajorPitchBp = minMajorPitchPx * scale
   const majorMagnitude = parseInt(
@@ -41,8 +45,8 @@ function chooseGridPitch(scale, minMajorPitchPx, minMinorPitchPx) {
 }
 
 export function* makeTicks(
-  region,
-  bpPerPx,
+  region: { start: number; end: number },
+  bpPerPx: number,
   emitMajor = true,
   emitMinor = true,
 ) {
@@ -91,23 +95,21 @@ const useStyles = makeStyles((/* theme */) => ({
     stroke: '#999',
     // stroke: theme.palette.text.hint,
   },
-  refNameLabel: {
-    fontSize: '16px',
-    fontWeight: 'bold',
-    // fill: theme.palette.text.primary,
-  },
-  refNameLabelBackground: {
-    fontSize: '16px',
-    fontWeight: 'bold',
-    fill: 'white',
-    // fill: theme.palette.background.default,
-    fillOpacity: 0.75,
-    filter: 'url(#dilate)',
-  },
 }))
 
-function Ruler(props) {
-  const { region, bpPerPx, flipped, major, minor, showRefNameLabel } = props
+function Ruler({
+  region,
+  bpPerPx,
+  flipped,
+  major,
+  minor,
+}: {
+  region: { start: number; end: number }
+  bpPerPx: number
+  flipped: boolean
+  major: boolean
+  minor: boolean
+}) {
   const classes = useStyles()
   const ticks = []
   const labels = []
@@ -145,41 +147,10 @@ function Ruler(props) {
       )
   }
 
-  const refNameLabels = []
-  if (showRefNameLabel && region.refName) {
-    refNameLabels.push(
-      <Fragment key="refname-label">
-        <g>
-          <defs>
-            <filter id="dilate">
-              <feMorphology operator="dilate" radius="5" />
-            </filter>
-          </defs>
-          <text
-            x={0}
-            y={2}
-            alignmentBaseline="hanging"
-            className={classes.refNameLabelBackground}
-          >
-            {region.refName}
-          </text>
-          <text
-            x={0}
-            y={2}
-            alignmentBaseline="hanging"
-            className={classes.refNameLabel}
-          >
-            {region.refName}
-          </text>
-        </g>
-      </Fragment>,
-    )
-  }
-
   // svg painting is based on the document order,
   // so the labels need to come after the ticks in the
   // doc, so that they draw over them.
-  return [...ticks, ...labels, ...refNameLabels]
+  return <>{[...ticks, ...labels]}</>
 }
 
 Ruler.propTypes = {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.test.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.test.tsx
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render } from '@testing-library/react'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createTestSession } from '@gmod/jbrowse-web/src/rootModel'
+import ScaleBar from './ScaleBar'
+
+describe('ScaleBar genome view component', () => {
+  it('renders two regions', () => {
+    const session = createTestSession({
+      views: [
+        {
+          type: 'LinearGenomeView',
+          offsetPx: 0,
+          bpPerPx: 1,
+          displayedRegions: [
+            { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+            {
+              assemblyName: 'volvox',
+              refName: 'ctgB',
+              start: 100,
+              end: 200,
+            },
+          ],
+          tracks: [],
+          controlsWidth: 100,
+          configuration: {},
+        },
+      ],
+    }) as any
+    session.addDataset({
+      name: 'volvox',
+      assembly: {
+        assemblyName: 'volMyt1',
+        sequence: {
+          adapter: {
+            type: 'FromConfigAdapter',
+            features: [
+              {
+                refName: 'ctgA',
+                uniqueId: 'firstId',
+                start: 0,
+                end: 10,
+                seq: 'cattgttgcg',
+              },
+            ],
+          },
+        },
+      },
+    })
+    const model = session.views[0]
+    const { getByTestId } = render(<ScaleBar height={32} model={model} />)
+    const ret1 = getByTestId('refLabel-ctgA')
+    const ret2 = getByTestId('refLabel-ctgB')
+    expect(ret1.style.left).toBe('0px')
+    expect(ret2.style.left).toBe('102px')
+  })
+  it('renders two regions when scrolled to the left, the label is ctgA to the actual blocks', () => {
+    const session = createTestSession({
+      views: [
+        {
+          type: 'LinearGenomeView',
+          offsetPx: -100,
+          bpPerPx: 1,
+          displayedRegions: [
+            { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 100 },
+            { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 100 },
+          ],
+          tracks: [],
+          controlsWidth: 100,
+          configuration: {},
+        },
+      ],
+    }) as any
+    session.addDataset({
+      name: 'volvox',
+      assembly: {
+        assemblyName: 'volMyt1',
+        sequence: {
+          adapter: {
+            type: 'FromConfigAdapter',
+            features: [
+              {
+                refName: 'ctgA',
+                uniqueId: 'firstId',
+                start: 0,
+                end: 10,
+                seq: 'cattgttgcg',
+              },
+            ],
+          },
+        },
+      },
+    })
+    const model = session.views[0]
+    const { getByTestId } = render(<ScaleBar height={32} model={model} />)
+    const ret1 = getByTestId('refLabel-ctgA')
+    const ret2 = getByTestId('refLabel-ctgB')
+    expect(ret1.style.left).toBe('100px')
+    expect(ret2.style.left).toBe('202px')
+  })
+})

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -69,7 +69,9 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
                 <div
                   style={{
                     left:
-                      i === lastLeftBlock ? 0 : block.offsetPx - model.offsetPx,
+                      i === lastLeftBlock
+                        ? Math.max(0, block.offsetPx - model.offsetPx)
+                        : block.offsetPx - model.offsetPx,
                     zIndex: i,
                   }}
                   className={classes.refLabel}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -75,6 +75,7 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
                     zIndex: i,
                   }}
                   className={classes.refLabel}
+                  data-testid={`refLabel-${block.refName}`}
                 >
                   {block.refName}
                 </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -50,7 +50,7 @@ function findBlockContainingLeftSideOfView(
     if (block.offsetPx <= offsetPx && block.offsetPx + block.widthPx > offsetPx)
       return block
   }
-  return undefined
+  return blocks[0]
 }
 
 type LGV = Instance<LinearGenomeViewStateModel>
@@ -97,9 +97,16 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
         }
         return null
       })}
-      {// put in a floating ref label
-      blockContainingLeftEndOfView ? (
-        <div className={classes.refLabel}>
+      {blockContainingLeftEndOfView ? (
+        <div
+          style={{
+            left: Math.max(
+              0,
+              blockContainingLeftEndOfView.offsetPx - model.offsetPx,
+            ),
+          }}
+          className={classes.refLabel}
+        >
           {blockContainingLeftEndOfView.refName}
         </div>
       ) : null}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -70,10 +70,6 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
               <svg height={height} width={block.widthPx}>
                 <Ruler
                   region={block}
-                  showRefNameLabel={
-                    !!block.isLeftEndOfDisplayedRegion &&
-                    block !== blockContainingLeftEndOfView
-                  }
                   bpPerPx={model.bpPerPx}
                   flipped={model.horizontallyFlipped}
                 />

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -10,7 +10,6 @@ import {
   ContentBlock,
   ElidedBlock,
   InterRegionPaddingBlock,
-  BlockSet,
 } from '../../BasicTrack/util/blockTypes'
 
 import {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -45,6 +45,12 @@ type LGV = Instance<LinearGenomeViewStateModel>
 function ScaleBar({ model, height }: { model: LGV; height: number }) {
   const classes = useStyles()
 
+  // find the block that needs pinning to the left side for context
+  let lastLeftBlock = 0
+  model.staticBlocks.forEach((block, i) => {
+    if (block.offsetPx - model.offsetPx < 0) lastLeftBlock = i
+  })
+
   return (
     <div className={classes.scaleBar}>
       {model.staticBlocks.map((block, i) => {
@@ -60,11 +66,12 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
                   />
                 </svg>
               </Block>
-              {block.isLeftEndOfDisplayedRegion ? (
+              {block.isLeftEndOfDisplayedRegion || i === lastLeftBlock ? (
                 <div
                   style={{
-                    left: Math.max(0, block.offsetPx - model.offsetPx),
-                    zIndex: i, // this makes it so the refLabel "to the right" lives on top of the refLabel on the left
+                    left:
+                      i === lastLeftBlock ? 0 : block.offsetPx - model.offsetPx,
+                    zIndex: i,
                   }}
                   className={classes.refLabel}
                 >

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -60,21 +60,34 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
     model.offsetPx,
     model.staticBlocks,
   )
+  console.log(model.displayedRegions)
 
   return (
     <div className={classes.scaleBar}>
       {model.staticBlocks.map(block => {
         if (block instanceof ContentBlock) {
           return (
-            <Block key={block.offsetPx} block={block} model={model}>
-              <svg height={height} width={block.widthPx}>
-                <Ruler
-                  region={block}
-                  bpPerPx={model.bpPerPx}
-                  flipped={model.horizontallyFlipped}
-                />
-              </svg>
-            </Block>
+            <>
+              <Block key={block.offsetPx} block={block} model={model}>
+                <svg height={height} width={block.widthPx}>
+                  <Ruler
+                    region={block}
+                    bpPerPx={model.bpPerPx}
+                    flipped={model.horizontallyFlipped}
+                  />
+                </svg>
+              </Block>
+              {block.isLeftEndOfDisplayedRegion ? (
+                <div
+                  style={{
+                    left: Math.max(0, block.offsetPx - model.offsetPx),
+                  }}
+                  className={classes.refLabel}
+                >
+                  {block.refName}
+                </div>
+              ) : null}
+            </>
           )
         }
         if (block instanceof ElidedBlock) {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { Fragment } from 'react'
 import Block from '../../BasicTrack/components/Block'
 import Ruler from './Ruler'
 import { LinearGenomeViewStateModel } from '..'
@@ -40,35 +40,18 @@ const useStyles = makeStyles((/* theme */) => ({
   },
 }))
 
-function findBlockContainingLeftSideOfView(
-  offsetPx: number,
-  blockSet: BlockSet,
-) {
-  const blocks = blockSet.getBlocks()
-  for (let i = 0; i < blocks.length; i += 1) {
-    const block = blocks[i]
-    if (block.offsetPx <= offsetPx && block.offsetPx + block.widthPx > offsetPx)
-      return block
-  }
-  return blocks[0]
-}
-
 type LGV = Instance<LinearGenomeViewStateModel>
+
 function ScaleBar({ model, height }: { model: LGV; height: number }) {
   const classes = useStyles()
-  const blockContainingLeftEndOfView = findBlockContainingLeftSideOfView(
-    model.offsetPx,
-    model.staticBlocks,
-  )
-  console.log(model.displayedRegions)
 
   return (
     <div className={classes.scaleBar}>
-      {model.staticBlocks.map(block => {
+      {model.staticBlocks.map((block, i) => {
         if (block instanceof ContentBlock) {
           return (
-            <>
-              <Block key={block.offsetPx} block={block} model={model}>
+            <Fragment key={block.offsetPx}>
+              <Block block={block} model={model}>
                 <svg height={height} width={block.widthPx}>
                   <Ruler
                     region={block}
@@ -81,13 +64,14 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
                 <div
                   style={{
                     left: Math.max(0, block.offsetPx - model.offsetPx),
+                    zIndex: i, // this makes it so the refLabel "to the right" lives on top of the refLabel on the left
                   }}
                   className={classes.refLabel}
                 >
                   {block.refName}
                 </div>
               ) : null}
-            </>
+            </Fragment>
           )
         }
         if (block instanceof ElidedBlock) {
@@ -110,19 +94,6 @@ function ScaleBar({ model, height }: { model: LGV; height: number }) {
         }
         return null
       })}
-      {blockContainingLeftEndOfView ? (
-        <div
-          style={{
-            left: Math.max(
-              0,
-              blockContainingLeftEndOfView.offsetPx - model.offsetPx,
-            ),
-          }}
-          className={classes.refLabel}
-        >
-          {blockContainingLeftEndOfView.refName}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -610,14 +610,15 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
           </svg>
         </div>
         <div
-          class="makeStyles-interRegionPaddingBlock"
-          style="left: 100px; width: 2px;"
-        />
-        <div
           class="makeStyles-refLabel"
+          style="left: 0px; z-index: 0;"
         >
           ctgA
         </div>
+        <div
+          class="makeStyles-interRegionPaddingBlock"
+          style="left: 100px; width: 2px;"
+        />
       </div>
     </div>
     <div

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -611,6 +611,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
         </div>
         <div
           class="makeStyles-refLabel"
+          data-testid="refLabel-ctgA"
           style="left: 0px; z-index: 0;"
         >
           ctgA

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -343,10 +343,12 @@ export function stateModelFactory(pluginManager: any) {
 
       horizontalScroll(distance: number) {
         const oldOffsetPx = self.offsetPx
+        // objectively determined to keep the linear genome on the main screen
         const leftPadding = 10
-        const rightPadding = 10
+        const rightPadding = 30
         const maxOffset = self.displayedRegionsTotalPx - leftPadding
         const minOffset = -self.viewingRegionWidth + rightPadding
+        // the scroll is clamped to keep the linear genome on the main screen
         const newOffsetPx = clamp(
           self.offsetPx + distance,
           minOffset,


### PR DESCRIPTION
This gets rid of the idea of refName labels being part of both Ruler and ScaleBar in slightly different ways, making it all a part of ScaleBar, and also fixes #554 by making the zIndex of the label on the right bigger than the one on the left