### PR TITLE
Add reset method for config slot and use it to go to the default value

### DIFF
--- a/packages/config/src/ConfigurationEditorDrawerWidget/components/SlotEditor.js
+++ b/packages/config/src/ConfigurationEditorDrawerWidget/components/SlotEditor.js
@@ -261,6 +261,8 @@ const NumberEditor = observer(({ slot }) => {
     const num = parseFloat(val, 10)
     if (!Number.isNaN(num)) {
       slot.set(num)
+    } else {
+      slot.reset()
     }
   }, [slot, val])
   return (

--- a/packages/core/configuration/configurationSlot.js
+++ b/packages/core/configuration/configurationSlot.js
@@ -223,6 +223,9 @@ export default function ConfigSlot(
       set(newVal) {
         self.value = newVal
       },
+      reset() {
+        self.value = defaultValue
+      },
       convertToCallback() {
         if (self.isCallback) return
         self.value = `function(${self.functionSignature.join(', ')}) {


### PR DESCRIPTION
This fixes #519 

This is a small PR to reset a config slot to it's default value, which I thought was valid for invalid inputs to the number editor for example