### PR TITLE
Restore track selector button

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -3,18 +3,18 @@ import { generateLocString } from '@gmod/jbrowse-core/util'
 import { IRegion } from '@gmod/jbrowse-core/mst-types'
 
 // material ui things
+import { makeStyles } from '@material-ui/core/styles'
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Icon from '@material-ui/core/Icon'
 import IconButton from '@material-ui/core/IconButton'
 import InputBase from '@material-ui/core/InputBase'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import Paper from '@material-ui/core/Paper'
-import Checkbox from '@material-ui/core/Checkbox'
 import Select from '@material-ui/core/Select'
-import { makeStyles } from '@material-ui/core/styles'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
-import FormControlLabel from '@material-ui/core/FormControlLabel'
 
 // misc
 import clsx from 'clsx'
@@ -350,6 +350,14 @@ const Controls = observer(({ model }) => {
         title="close this view"
       >
         <Icon fontSize="small">close</Icon>
+      </IconButton>
+
+      <IconButton
+        onClick={model.activateTrackSelector}
+        title="select tracks"
+        value="track_select"
+      >
+        <Icon fontSize="small">line_style</Icon>
       </IconButton>
       <LongMenu className={classes.iconButton} model={model} />
     </>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -32,6 +32,27 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
         />
       </button>
       <button
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            line_style
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
         aria-controls="long-menu"
         aria-haspopup="true"
         aria-label="more"
@@ -321,6 +342,27 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
             class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
           >
             close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            line_style
           </span>
         </span>
         <span
@@ -833,6 +875,27 @@ exports[`LinearGenomeView genome view component renders with an empty model 1`] 
             class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
           >
             close
+          </span>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root"
+        tabindex="0"
+        title="select tracks"
+        type="button"
+        value="track_select"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <span
+            aria-hidden="true"
+            class="material-icons MuiIcon-root MuiIcon-fontSizeSmall"
+          >
+            line_style
           </span>
         </span>
         <span

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -392,12 +392,6 @@ export function stateModelFactory(pluginManager: any) {
         get menuOptions(): LGVMenuOption[] {
           return [
             {
-              title: 'Show track selector',
-              key: 'track_selector',
-              callback: self.activateTrackSelector,
-              isCheckbox: false,
-            },
-            {
               title: 'Horizontally flip',
               key: 'flip',
               callback: self.horizontallyFlip,


### PR DESCRIPTION
This restores the button for the track selector instead of having to use the dropdown menu for accessing it. I think the UI is probably a little better off this way, and it appears to fit within the UI just fine

Here are screenshots with and without the LGV header turned on

![t2](https://user-images.githubusercontent.com/6511937/67147802-4d5c6e80-f266-11e9-9fec-9bfdb2b9b00a.png)
![t1](https://user-images.githubusercontent.com/6511937/67147803-4d5c6e80-f266-11e9-97bb-385a6f2ba3f0.png)
