### PR TITLE
Add optimizations for faster FPS

### DIFF
--- a/packages/jbrowse-web/src/JBrowse.js
+++ b/packages/jbrowse-web/src/JBrowse.js
@@ -27,13 +27,22 @@ export default observer(({ config, initialState }) => {
 
   useEffect(() => {
     if (debouncedUrlSnapshot) {
-      const l = document.location
-      const updatedUrl = `${l.origin}${l.pathname}?session=${toUrlSafeB64(
-        JSON.stringify(debouncedUrlSnapshot),
-      )}`
-      window.history.replaceState({}, '', updatedUrl)
+      const { origin, pathname } = document.location
+      window.history.replaceState(
+        {},
+        '',
+        `${origin}${pathname}?session=${toUrlSafeB64(
+          JSON.stringify(debouncedUrlSnapshot),
+        )}`,
+      )
     }
   }, [debouncedUrlSnapshot])
+
+  useEffect(() => {
+    if (root && root.session && debouncedUrlSnapshot) {
+      root.jbrowse.updateSavedSession(debouncedUrlSnapshot)
+    }
+  }, [debouncedUrlSnapshot, root])
 
   useEffect(() => {
     async function loadConfig() {
@@ -106,16 +115,6 @@ export default observer(({ config, initialState }) => {
       window.ROOTMODEL = root
     }
   }, [root, root.session])
-
-  useEffect(() => {
-    let disposer = () => {}
-    if (root && root.session)
-      disposer = onSnapshot(root.session, snapshot => {
-        root.jbrowse.updateSavedSession(snapshot)
-      })
-
-    return disposer
-  }, [root])
 
   const { session, jbrowse } = root || {}
   const useLocalStorage = jbrowse

--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -15,10 +15,9 @@ import Paper from '@material-ui/core/Paper'
 import Select from '@material-ui/core/Select'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
-
-// misc
 import clsx from 'clsx'
 import { observer } from 'mobx-react'
+
 import { Instance } from 'mobx-state-tree'
 import ReactPropTypes from 'prop-types'
 import React, { useState, CSSProperties } from 'react'
@@ -97,8 +96,10 @@ const useStyles = makeStyles(theme => ({
   },
   ...buttonStyles(theme),
 }))
+
 const TrackContainer = observer(
-  ({ model, track }: { model: LGV; track: Instance<BaseTrackStateModel> }) => {
+  (props: { model: LGV; track: Instance<BaseTrackStateModel> }) => {
+    const { model, track } = props
     const classes = useStyles()
     const { bpPerPx, offsetPx } = model
     const { RenderingComponent } = track
@@ -106,20 +107,16 @@ const TrackContainer = observer(
       <>
         <div
           className={clsx(classes.controls, classes.trackControls)}
-          key={`controls:${track.id}`}
           style={{ gridRow: `track-${track.id}`, gridColumn: 'controls' }}
         >
           <track.ControlsComponent
             track={track}
-            key={track.id}
             view={model}
             onConfigureClick={track.activateConfigurationUI}
           />
         </div>
         <TrackRenderingContainer
-          key={`track-rendering:${track.id}`}
           trackId={track.id}
-          height={track.height}
           onHorizontalScroll={model.horizontalScroll}
         >
           <RenderingComponent
@@ -131,7 +128,6 @@ const TrackContainer = observer(
           />
         </TrackRenderingContainer>
         <ResizeHandle
-          key={`handle:${track.id}`}
           onDrag={track.resizeHeight}
           style={{
             gridRow: `resize-${track.id}`,
@@ -191,7 +187,6 @@ const LongMenu = observer(
                     />
                   }
                   label={option.title}
-                  key={option.key}
                 />
               </MenuItem>
             ) : (
@@ -364,8 +359,9 @@ const Controls = observer(({ model }) => {
   )
 })
 
-function LinearGenomeView({ model }: { model: LGV }) {
-  const { id, staticBlocks, tracks, bpPerPx, controlsWidth, offsetPx } = model
+function LinearGenomeView(props: { model: LGV }) {
+  const { model } = props
+  const { tracks, controlsWidth } = model
   const classes = useStyles()
 
   /*
@@ -388,11 +384,7 @@ function LinearGenomeView({ model }: { model: LGV }) {
 
   return (
     <div className={classes.root}>
-      <div
-        className={classes.linearGenomeView}
-        key={`view-${id}`}
-        style={style}
-      >
+      <div className={classes.linearGenomeView} style={style}>
         {!model.hideHeader ? <Header model={model} /> : null}
         <div
           className={clsx(classes.controls, classes.viewControls)}
@@ -408,9 +400,6 @@ function LinearGenomeView({ model }: { model: LGV }) {
             gridColumn: 'blocks',
             gridRow: 'scale-bar',
           }}
-          offsetPx={offsetPx}
-          blocks={staticBlocks}
-          bpPerPx={bpPerPx}
           model={model}
         >
           <ScaleBar model={model} height={32} />

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.js
@@ -1,64 +1,59 @@
 /* eslint-disable react/require-default-props */
-import { withStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 
-const styles = {
+const useStyles = makeStyles({
   trackRenderingContainer: {
     overflowY: 'auto',
     overflowX: 'hidden',
     background: '#333',
     whiteSpace: 'nowrap',
   },
-}
+})
 
 /**
  * mostly does UI gestures: drag scrolling, etc
  */
-class TrackRenderingContainer extends Component {
-  constructor(props) {
-    super(props)
-    this.mainNode = React.createRef()
-    this.wheel = this.wheel.bind(this)
-  }
+function TrackRenderingContainer(props) {
+  const { onHorizontalScroll, trackId, children } = props
+  const classes = useStyles()
+  const [scheduled, setScheduled] = useState(false)
+  const [delta, setDelta] = useState(0)
 
-  componentDidMount() {
-    if (this.mainNode.current)
-      this.mainNode.current.addEventListener('wheel', this.wheel, {
-        passive: false,
-      })
-  }
-
-  wheel(event) {
-    const { onHorizontalScroll } = this.props
-    onHorizontalScroll(event.deltaX)
-  }
-
-  render() {
-    const { trackId, children, classes } = this.props
-
-    return (
-      <div
-        className={classes.trackRenderingContainer}
-        ref={this.mainNode}
-        style={{
-          gridRow: `track-${trackId}`,
-          gridColumn: 'blocks',
-        }}
-        role="presentation"
-      >
-        {children}
-      </div>
-    )
-  }
-
-  static propTypes = {
-    classes: PropTypes.objectOf(PropTypes.string).isRequired,
-    trackId: PropTypes.string.isRequired,
-    children: PropTypes.node,
-    onHorizontalScroll: PropTypes.func.isRequired,
-  }
+  return (
+    <div
+      className={classes.trackRenderingContainer}
+      onWheel={({ deltaX }) => {
+        if (scheduled) {
+          setDelta(delta + deltaX)
+        } else {
+          // use rAF to make it so multiple event handlers aren't fired per-frame
+          // see https://calendar.perfplanet.com/2013/the-runtime-performance-checklist/
+          window.requestAnimationFrame(() => {
+            onHorizontalScroll(delta + deltaX)
+            setScheduled(false)
+          })
+          setScheduled(true)
+          setDelta(0)
+        }
+      }}
+      style={{
+        gridRow: `track-${trackId}`,
+        gridColumn: 'blocks',
+      }}
+      role="presentation"
+    >
+      {children}
+    </div>
+  )
 }
 
-export default withStyles(styles)(observer(TrackRenderingContainer))
+TrackRenderingContainer.propTypes = {
+  trackId: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  onHorizontalScroll: PropTypes.func.isRequired,
+}
+
+export default observer(TrackRenderingContainer)

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -293,7 +293,7 @@ exports[`LinearGenomeView genome view component renders one track, no blocks 1`]
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer"
+      class="makeStyles-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
@@ -720,7 +720,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer"
+      class="makeStyles-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-foo; grid-column: blocks;"
     >
@@ -811,7 +811,7 @@ exports[`LinearGenomeView genome view component renders two tracks, two regions 
       />
     </div>
     <div
-      class="TrackRenderingContainer-trackRenderingContainer"
+      class="makeStyles-trackRenderingContainer"
       role="presentation"
       style="grid-row: track-bar; grid-column: blocks;"
     >

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -387,7 +387,7 @@ export function stateModelFactory(pluginManager: any) {
     }))
     .views(self => {
       let currentlyCalculatedStaticBlocks: BlockSet | undefined
-      let stringifiedCurrentlyCalculatedStaticBlocks: string
+      let stringifiedCurrentlyCalculatedStaticBlocks = ''
       return {
         get menuOptions(): LGVMenuOption[] {
           return [


### PR DESCRIPTION
* Use rAF for scrolling to prevent multiple scroll events per frame, this is a big fps win. You could see in performance traces multiple wheel events would fire per-frame and this would cause lots of excessive CPU burn (https://calendar.perfplanet.com/2013/the-runtime-performance-checklist/)

* Remove need for LinearGenomeView to re-render on each frame

* Switch from toLocaleString to a "mathPower" function in Ruler. This is faster and the Ruler re-rendering can cause a significant frame rate stutter if it is slow (https://jsperf.com/locale-number-formatting/16)

* Debounce the session updater