### PR TITLE
Enable development on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,22 @@ You should already have [git](https://git-scm.com/downloads),
 [npm](https://nodejs.org/en/download/), and
 [yarn](https://yarnpkg.com/en/docs/install) installed
 
+**Linux/Mac**
 ```sh
 git clone https://github.com/GMOD/jbrowse-components.git
 cd jbrowse-components
+yarn
+```
+
+**Windows**
+```pwsh
+# Make sure you check out line-endings as-is by running
+# `git config --global core.autocrlf false`
+# Also, make sure symlinks are enabled by running
+# `git config --global core.symlinks true`.
+# You may also need to clone as an administrator for symlinks to work.
+git clone -c core.symlinks=true https://github.com/GMOD/jbrowse-components.git
+cd .\jbrowse-components\
 yarn
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "packages/*"
     ],
     "scripts": {
-        "build": "NODE_ENV=production lerna run build",
+        "build": "cross-env NODE_ENV=production lerna run build",
         "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
         "typecheck": "tsc --noEmit",
         "test-ci": "jest --ci --coverage",
@@ -52,6 +52,7 @@
         "chalk": "^2.4.1",
         "concurrently": "^4.1.2",
         "core-js": "^3.2.1",
+        "cross-env": "^6.0.3",
         "css-loader": "^2.1.0",
         "electron": "^6.0.0",
         "eslint-config-airbnb": "^18.0.0",

--- a/packages/jbrowse-desktop/package.json
+++ b/packages/jbrowse-desktop/package.json
@@ -47,8 +47,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "concurrently \"BROWSER=none yarn cra-start\" \"wait-on http://localhost:3000 && electron .\"",
-    "serve": "BROWSER=none yarn cra-start",
+    "start": "concurrently \"yarn serve\" \"wait-on http://localhost:3000 && electron .\"",
+    "serve": "cross-env BROWSER=none yarn cra-start",
     "develop": "electron .",
     "cra-start": "rescripts start",
     "test": "rescripts test",

--- a/packages/jbrowse-web/package.json
+++ b/packages/jbrowse-web/package.json
@@ -54,7 +54,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "NODE_OPTIONS='--max-http-header-size=100000' rescripts start",
+    "start": "cross-env NODE_OPTIONS='--max-http-header-size=100000' rescripts start",
     "build": "rescripts build",
     "test": "rescripts test",
     "eject": "rescripts eject",

--- a/packages/jbrowse1/src/NCListAdapter/NCListAdapter.test.js
+++ b/packages/jbrowse1/src/NCListAdapter/NCListAdapter.test.js
@@ -1,13 +1,25 @@
 import { promises as fsPromises } from 'fs'
+import path from 'path'
+import { URL } from 'url'
 import { toArray } from 'rxjs/operators'
 
 import Adapter from './NCListAdapter'
 
 test('adapter can fetch features from ensembl_genes test set', async () => {
-  const rootTemplate = `${process.cwd()}/packages/jbrowse1/test_data/ensembl_genes/{refseq}/trackData.json`
+  const rootTemplate = path
+    .join(
+      process.cwd(),
+      'packages',
+      'jbrowse1',
+      'test_data',
+      'ensembl_genes',
+      '{refseq}',
+      'trackData.json',
+    )
+    .replace(/\\/g, '\\\\')
   await fsPromises.stat(rootTemplate.replace('{refseq}', 21)) // will throw if doesnt exist
   const adapter = new Adapter({
-    rootUrlTemplate: `file://${rootTemplate}`,
+    rootUrlTemplate: decodeURI(new URL(`file://${rootTemplate}`).href),
   })
 
   const features = await adapter.getFeatures({

--- a/packages/protein-widget/package.json
+++ b/packages/protein-widget/package.json
@@ -4,8 +4,8 @@
   "description": "an embeddable protein viewer widget",
   "main": "umd/jbrowse-protein-viewer.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack",
-    "start": "echo opening app in file:/// to demonstrate the simplicity of this setup. refresh when webpack --watch is done building && sleep 3 && open-cli umd.html &&  NODE_ENV=development webpack -w",
+    "build": "cross-env NODE_ENV=production webpack",
+    "start": "echo opening app in file:/// to demonstrate the simplicity of this setup. refresh when webpack --watch is done building && sleep 3 && open-cli umd.html && cross-env NODE_ENV=development webpack -w",
     "test": "jest --config ../../jest.config.js --roots packages/protein-widget/",
     "lint": "eslint src/"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4971,6 +4971,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
+  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+  dependencies:
+    cross-spawn "^7.0.0"
+
 cross-fetch@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
@@ -5005,6 +5012,15 @@ cross-spawn@^3.0.0:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypt@~0.0.1:
   version "0.0.2"
@@ -11229,6 +11245,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -13604,10 +13625,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.6.1:
   version "1.6.1"
@@ -15461,6 +15494,13 @@ which@1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
In order to make sure the desktop version works well on Windows, I made some changes so our whole development toolchain can be done purely on Windows. Also now url encodes/decodes session file names on desktop so people can put whatever characters they want in their session name and the filesystem on any OS shouldn't complain.