### PR TITLE
Add button to reload errored block

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.js
@@ -55,7 +55,8 @@ BlockMessage.propTypes = {
 }
 
 const ServerSideRenderedBlockContent = observer(({ model }) => {
-  if (model.error) return <BlockError error={model.error} />
+  if (model.error)
+    return <BlockError error={model.error} reload={model.reload} />
   if (model.message) return <BlockMessage messageText={model.message} />
   if (!model.filled) return <LoadingMessage />
   return <ServerSideRenderedContent model={model} />

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -127,6 +127,20 @@ const blockState = types
         self.renderProps = undefined
         renderInProgress = undefined
       },
+      reload() {
+        self.renderInProgress = undefined
+        self.filled = false
+        self.data = undefined
+        self.html = ''
+        self.error = undefined
+        self.message = undefined
+        self.maxHeightReached = false
+        self.ReactComponent = ServerSideRenderedBlockContent
+        self.renderingComponent = undefined
+        self.renderProps = undefined
+        const data = renderBlockData(self as any)
+        renderBlockEffect(cast(self), data)
+      },
       beforeDestroy() {
         if (renderInProgress && !renderInProgress.signal.aborted) {
           renderInProgress.abort()

--- a/packages/linear-genome-view/src/LinearGenomeView/components/BlockError.js
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/BlockError.js
@@ -1,24 +1,44 @@
 import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import Icon from '@material-ui/core/Icon'
+import Typography from '@material-ui/core/Typography'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const useStyles = makeStyles({
   blockError: {
-    display: 'block',
-    color: 'red',
     width: '30em',
-    wordWrap: 'normal',
     whiteSpace: 'normal',
   },
 })
 
-function Error({ error }) {
+function BlockError({ error, reload }) {
   const classes = useStyles()
-  return <div className={classes.blockError}>{error.message}</div>
+  return (
+    <div className={classes.blockError}>
+      {reload ? (
+        <Button
+          onClick={reload}
+          // variant="outlined"
+          size="small"
+          startIcon={<Icon>refresh</Icon>}
+        >
+          Reload
+        </Button>
+      ) : null}
+      <Typography color="error" variant="body2">
+        {error.message}
+      </Typography>
+    </div>
+  )
 }
-Error.propTypes = {
+BlockError.propTypes = {
   error: MobxPropTypes.objectOrObservableObject.isRequired,
+  reload: PropTypes.func,
+}
+BlockError.defaultProps = {
+  reload: undefined,
 }
 
-const ErrorMessage = observer(Error)
-export default ErrorMessage
+export default observer(BlockError)


### PR DESCRIPTION
This just adds a simple "reload" button to the block error message that reloads the block. I tested by disconnecting my network, getting the error, reconnecting, and then clicking "reload". It seemed to work.

![image](https://user-images.githubusercontent.com/25592344/68346263-ed145c00-00b0-11ea-9b07-156e691b67e5.png)

Resolves #445