### PR TITLE
Remove blockState as a extra prop, assume it comes from track model

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/components/BlockBasedTrack.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/BlockBasedTrack.js
@@ -13,11 +13,7 @@ function BlockBasedTrack(props) {
       {model.trackMessageComponent ? (
         <model.trackMessageComponent model={model} />
       ) : (
-        <TrackBlocks
-          {...props}
-          viewModel={getParent(getParent(model))}
-          blockState={model.blockState}
-        />
+        <TrackBlocks {...props} viewModel={getParent(getParent(model))} />
       )}
       {children}
     </Track>

--- a/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.tsx
@@ -40,14 +40,10 @@ const useStyles = makeStyles({
   },
 })
 const RenderedBlocks = observer(
-  (props: {
-    model: Instance<BlockBasedTrackStateModel>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    blockState: Record<string, any>
-  }) => {
-    const { model, blockState } = props
+  (props: { model: Instance<BlockBasedTrackStateModel> }) => {
+    const { model } = props
     const classes = useStyles()
-    const { blockDefinitions } = model
+    const { blockDefinitions, blockState } = model
     return (
       <>
         {blockDefinitions.map((block: BaseBlock) => {
@@ -97,12 +93,9 @@ const RenderedBlocks = observer(
 function TrackBlocks({
   model,
   viewModel,
-  blockState,
 }: {
   model: Instance<BlockBasedTrackStateModel>
   viewModel: Instance<LinearGenomeViewStateModel>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  blockState: Record<string, any>
 }) {
   const classes = useStyles()
   const { blockDefinitions } = model
@@ -114,13 +107,12 @@ function TrackBlocks({
         left: blockDefinitions.offsetPx - viewModel.offsetPx,
       }}
     >
-      <RenderedBlocks model={model} blockState={blockState} />
+      <RenderedBlocks model={model} />
     </div>
   )
 }
 
 TrackBlocks.propTypes = {
-  blockState: PropTypes.observableMap.isRequired,
   model: PropTypes.observableObject.isRequired,
   viewModel: PropTypes.observableObject.isRequired,
 }


### PR DESCRIPTION
This is a miscellaneous change but it looked like it was unnecessary to pass blockState manually to the tracks, as the track models contain this info