### PR TITLE
Turn off webSecurity on the web worker for the purpose of disabling same origin policy

### DIFF
--- a/packages/jbrowse-desktop/public/electron.js
+++ b/packages/jbrowse-desktop/public/electron.js
@@ -84,6 +84,7 @@ ipcMain.on('createWindowWorker', event => {
   const workerWindow = new BrowserWindow({
     show: false,
     webPreferences: {
+      webSecurity: false,
       preload: isDev
         ? path.join(app.getAppPath(), 'public', 'preload.js')
         : `file://${path.join(app.getAppPath(), 'build', 'preload.js')}`,


### PR DESCRIPTION
Discussed with @garrettjstevens 

This allows easier fetching of resources that have CORS blocked without stepping into node-fetch territory and there is no nodeIntegration on these workers