### PR TITLE
Desktop improvements

### DIFF
--- a/packages/core/util/io/ElectronRemoteFile.ts
+++ b/packages/core/util/io/ElectronRemoteFile.ts
@@ -11,13 +11,10 @@ import ElectronLocalFile from './ElectronLocalFile'
 
 declare global {
   interface Window {
-    electronBetterIpc: {
-      ipcRenderer?: import('electron-better-ipc-extra').RendererProcessIpc
-    }
+    electron?: import('electron').AllElectron
   }
 }
-const { electronBetterIpc = {} } = window
-const { ipcRenderer } = electronBetterIpc
+const { electron } = window
 
 interface SerializedResponse {
   buffer: Buffer
@@ -39,12 +36,14 @@ export default class ElectronRemoteFile implements GenericFilehandle {
 
   private nodeFetchFallback = false
 
-  private ipcRenderer: import('electron-better-ipc-extra').RendererProcessIpc
+  private ipcRenderer: import('electron').IpcRenderer
 
   public constructor(source: string, opts: FilehandleOptions = {}) {
+    let ipcRenderer
+    if (electron) ipcRenderer = electron.ipcRenderer
     if (!ipcRenderer)
       throw new Error(
-        'Cannot use ElectronLocalFile without ipcRenderer from electron-better-ipc-extra',
+        'Cannot use ElectronLocalFile without ipcRenderer from electron',
       )
     this.ipcRenderer = ipcRenderer
 
@@ -94,7 +93,7 @@ export default class ElectronRemoteFile implements GenericFilehandle {
     init?: RequestInit,
   ): Promise<Response> => {
     if (init) init.signal = undefined
-    const serializedResponse = (await this.ipcRenderer.callMain(
+    const serializedResponse = (await this.ipcRenderer.invoke(
       'fetch',
       input,
       init,

--- a/packages/jbrowse-desktop/package.json
+++ b/packages/jbrowse-desktop/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "start": "concurrently \"yarn serve\" \"wait-on http://localhost:3000 && yarn develop\"",
     "serve": "cross-env BROWSER=none yarn cra-start",
-    "develop": "ELECTRON_ENABLE_LOGGING=1 electron .",
+    "develop": "electron .",
     "cra-start": "rescripts start",
     "test": "rescripts test",
     "build": "rescripts build",

--- a/packages/jbrowse-desktop/public/electron.js
+++ b/packages/jbrowse-desktop/public/electron.js
@@ -191,9 +191,18 @@ ipcMain.handle('renameSession', async (event, oldName, newName) => {
   } catch {
     // ignore
   }
-  await fsRename(
+  const sessionJson = await fsReadFile(
     path.join(sessionDirectory, `${encodeURIComponent(oldName)}.json`),
+    { encoding: 'utf8' },
+  )
+  const sessionSnapshot = JSON.parse(sessionJson)
+  sessionSnapshot.name = newName
+  await fsUnlink(
+    path.join(sessionDirectory, `${encodeURIComponent(oldName)}.json`),
+  )
+  await fsWriteFile(
     path.join(sessionDirectory, `${encodeURIComponent(newName)}.json`),
+    JSON.stringify(sessionSnapshot, null, 2),
   )
 })
 

--- a/packages/jbrowse-desktop/public/electron.js
+++ b/packages/jbrowse-desktop/public/electron.js
@@ -104,6 +104,8 @@ ipcMain.on('createWindowWorker', event => {
   event.returnValue = workerWindow.id
 })
 
+ipcMain.handle('getMainWindowId', async () => mainWindow.id)
+
 ipcMain.answerRenderer('loadConfig', async () => {
   let configJSON
   try {

--- a/packages/jbrowse-desktop/public/windowWorker.js
+++ b/packages/jbrowse-desktop/public/windowWorker.js
@@ -1,4 +1,4 @@
-const { electronBetterIpc, rpcMethods, rpcStuff } = window
+const { electronBetterIpc, rpcMethods, rpcStuff, electron } = window
 
 const { ipcRenderer } = electronBetterIpc
 
@@ -12,6 +12,40 @@ const {
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useStaticRendering(true)
+
+let mainWindow
+
+// eslint-disable-next-line no-console
+const originalConsoleLog = console.log.bind(console)
+// eslint-disable-next-line no-console
+console.log = async (...args) => {
+  if (!mainWindow) {
+    const mainWindowId = await ipcRenderer.invoke('getMainWindowId')
+    mainWindow = electron.remote.BrowserWindow.fromId(mainWindowId)
+  }
+  ipcRenderer.sendTo(mainWindow.webContents.id, 'consoleLog', ...args)
+  originalConsoleLog(...args)
+}
+
+const originalConsoleWarn = console.warn.bind(console)
+console.warn = async (...args) => {
+  if (!mainWindow) {
+    const mainWindowId = await ipcRenderer.invoke('getMainWindowId')
+    mainWindow = electron.remote.BrowserWindow.fromId(mainWindowId)
+  }
+  ipcRenderer.sendTo(mainWindow.webContents.id, 'consoleWarn', ...args)
+  originalConsoleWarn(...args)
+}
+
+const originalConsoleError = console.error.bind(console)
+console.error = async (...args) => {
+  if (!mainWindow) {
+    const mainWindowId = await ipcRenderer.invoke('getMainWindowId')
+    mainWindow = electron.remote.BrowserWindow.fromId(mainWindowId)
+  }
+  ipcRenderer.sendTo(mainWindow.webContents.id, 'consoleError', ...args)
+  originalConsoleError(...args)
+}
 
 const jbPluginManager = new PluginManager(corePlugins.map(P => new P()))
 jbPluginManager.configure()

--- a/packages/jbrowse-desktop/src/JBrowse.js
+++ b/packages/jbrowse-desktop/src/JBrowse.js
@@ -18,8 +18,10 @@ export default observer(() => {
   const [status, setStatus] = useState('loading')
   const [message, setMessage] = useState('')
   const [root, setRoot] = useState({})
+  const [firstLoad, setFirstLoad] = useState(true)
 
   const { session, jbrowse } = root
+  if (firstLoad && session) setFirstLoad(false)
 
   useEffect(() => {
     async function loadConfig() {
@@ -85,7 +87,7 @@ export default observer(() => {
   if (status === 'error') DisplayComponent = <div>{message}</div>
   if (status === 'loaded') {
     if (session) DisplayComponent = <App session={session} />
-    else DisplayComponent = <StartScreen root={root} />
+    else DisplayComponent = <StartScreen root={root} bypass={firstLoad} />
   }
 
   return (

--- a/packages/jbrowse-desktop/src/JBrowse.js
+++ b/packages/jbrowse-desktop/src/JBrowse.js
@@ -11,9 +11,8 @@ import App from './ui/App'
 import StartScreen from './ui/StartScreen'
 import Theme from './ui/theme'
 
-const { electronBetterIpc = {}, electron = {} } = window
-const { ipcRenderer } = electronBetterIpc
-const { desktopCapturer } = electron
+const { electron = {} } = window
+const { desktopCapturer, ipcRenderer } = electron
 
 export default observer(() => {
   const [status, setStatus] = useState('loading')
@@ -25,7 +24,7 @@ export default observer(() => {
   useEffect(() => {
     async function loadConfig() {
       try {
-        const configSnapshot = await ipcRenderer.callMain('loadConfig')
+        const configSnapshot = await ipcRenderer.invoke('loadConfig')
         const r = rootModel.create({ jbrowse: configSnapshot })
 
         // poke some things for testing (this stuff will eventually be removed)
@@ -53,7 +52,7 @@ export default observer(() => {
         })
         const jbWindow = sources.find(source => source.name === 'JBrowse')
         const screenshot = jbWindow.thumbnail.toDataURL()
-        ipcRenderer.callMain('saveSession', snapshot, screenshot)
+        ipcRenderer.send('saveSession', snapshot, screenshot)
       })
     }
 
@@ -64,7 +63,7 @@ export default observer(() => {
     let disposer = () => {}
     if (jbrowse) {
       disposer = onSnapshot(jbrowse, snapshot => {
-        ipcRenderer.callMain('saveConfig', snapshot)
+        ipcRenderer.send('saveConfig', snapshot)
       })
     }
 

--- a/packages/jbrowse-desktop/src/index.js
+++ b/packages/jbrowse-desktop/src/index.js
@@ -2,7 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import JBrowse from './JBrowse'
 
-const { BrowserWindow, getCurrentWindow } = window.electron.remote
+const { electron } = window
+const { ipcRenderer, remote } = electron
+const { BrowserWindow, getCurrentWindow } = remote
 
 window.onbeforeunload = () => {
   const thisWindowId = getCurrentWindow().id
@@ -10,6 +12,19 @@ window.onbeforeunload = () => {
     if (win.id !== thisWindowId) win.close()
   })
 }
+
+ipcRenderer.on('consoleLog', async (event, ...args) => {
+  // eslint-disable-next-line no-console
+  console.log(`windowWorker-${event.senderId}-log`, ...args)
+})
+
+ipcRenderer.on('consoleWarn', async (event, ...args) => {
+  console.warn(`windowWorker-${event.senderId}-warn`, ...args)
+})
+
+ipcRenderer.on('consoleError', async (event, ...args) => {
+  console.error(`windowWorker-${event.senderId}-error`, ...args)
+})
 
 const app = <JBrowse />
 

--- a/packages/jbrowse-desktop/src/jbrowseModel.js
+++ b/packages/jbrowse-desktop/src/jbrowseModel.js
@@ -1,7 +1,12 @@
 import { ConfigurationSchema } from '@gmod/jbrowse-core/configuration'
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
 import RpcManager from '@gmod/jbrowse-core/rpc/RpcManager'
-import { getSnapshot, resolveIdentifier, types } from 'mobx-state-tree'
+import {
+  getSnapshot,
+  resolveIdentifier,
+  types,
+  getParent,
+} from 'mobx-state-tree'
 import assemblyManager from './assemblyManager'
 import AssemblyConfigSchemasFactory from './assemblyConfigSchemas'
 import corePlugins from './corePlugins'
@@ -98,7 +103,7 @@ const JBrowseWeb = types
   }))
   .views(self => ({
     get savedSessionNames() {
-      return self.savedSessions.map(sessionSnap => sessionSnap.name)
+      return getParent(self).savedSessionNames
     },
   }))
   // Grouping the "assembly manager" stuff under an `extend` just for

--- a/packages/jbrowse-desktop/src/ui/RecentSessionCard.js
+++ b/packages/jbrowse-desktop/src/ui/RecentSessionCard.js
@@ -7,6 +7,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
+import Tooltip from '@material-ui/core/Tooltip'
 import Typography from '@material-ui/core/Typography'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
@@ -58,31 +59,34 @@ function RecentSessionCard({
         onClick={() => onClick(sessionName)}
         raised={Boolean(hovered)}
       >
-        <CardMedia
-          className={classes.media}
-          image={sessionScreenshot}
-          title={sessionName}
-        />
+        <CardMedia className={classes.media} image={sessionScreenshot} />
         <CardHeader
           action={
             <IconButton onClick={onMenuClick}>
               <Icon>more_vert</Icon>
             </IconButton>
           }
-          title={sessionName}
-          titleTypographyProps={{
-            variant: 'body2',
-            noWrap: true,
-            style: { width: 178 },
-          }}
-          subheader={`Last modified ${new Date(
-            sessionStats.mtimeMs,
-          ).toLocaleDateString(undefined, { dateStyle: 'medium' })}`}
-          subheaderTypographyProps={{
-            variant: 'body2',
-            noWrap: true,
-            style: { width: 178 },
-          }}
+          disableTypography
+          title={
+            <Tooltip title={sessionName} enterDelay={300}>
+              <Typography variant="body2" noWrap style={{ width: 178 }}>
+                {sessionName}
+              </Typography>
+            </Tooltip>
+          }
+          subheader={
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              noWrap
+              style={{ width: 178 }}
+            >
+              Last modified{' '}
+              {new Date(sessionStats.mtimeMs).toLocaleDateString(undefined, {
+                dateStyle: 'medium',
+              })}
+            </Typography>
+          }
         />
       </Card>
       <Menu

--- a/packages/jbrowse-desktop/src/ui/StartScreen.js
+++ b/packages/jbrowse-desktop/src/ui/StartScreen.js
@@ -53,13 +53,16 @@ export default function StartScreen({ root, bypass }) {
   const [menuAnchorEl, setMenuAnchorEl] = useState(null)
   const [reset, setReset] = useState(false)
 
+  const sessionNames = sessions && Object.keys(sessions)
+  if (sessionNames) root.setSavedSessionNames(sessionNames)
+
   const sortedSessions =
     sessions &&
     Object.entries(sessions)
       .filter(([, sessionData]) => sessionData.stats)
       .sort((a, b) => b[1].stats.mtimeMs - a[1].stats.mtimeMs)
 
-  if (bypass && inDevelopment && sortedSessions) {
+  if (bypass && inDevelopment && sortedSessions && sortedSessions.length) {
     onCardClick(sortedSessions[0][0])
   }
 
@@ -136,7 +139,6 @@ export default function StartScreen({ root, bypass }) {
       />
     )
 
-  const sessionNames = Object.keys(sessions)
   let DialogComponent = <></>
   if (sessionNameToDelete)
     DialogComponent = (

--- a/packages/jbrowse-desktop/src/ui/StartScreen.js
+++ b/packages/jbrowse-desktop/src/ui/StartScreen.js
@@ -54,7 +54,7 @@ export default function StartScreen({ root }) {
   const classes = useStyles()
 
   async function getSessions() {
-    setSessions(await ipcRenderer.callMain('listSessions'))
+    setSessions(await ipcRenderer.invoke('listSessions'))
   }
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export default function StartScreen({ root }) {
   }, [])
 
   async function onCardClick(sessionName) {
-    const sessionJSON = await ipcRenderer.callMain('loadSession', sessionName)
+    const sessionJSON = await ipcRenderer.invoke('loadSession', sessionName)
     const sessionSnapshot = JSON.parse(sessionJSON)
     root.activateSession(sessionSnapshot)
   }
@@ -77,17 +77,17 @@ export default function StartScreen({ root }) {
 
   async function handleDialogClose(action) {
     if (action === 'delete') {
-      await ipcRenderer.callMain('deleteSession', sessionNameToDelete)
+      await ipcRenderer.invoke('deleteSession', sessionNameToDelete)
       getSessions()
     } else if (action === 'rename') {
-      await ipcRenderer.callMain(
+      await ipcRenderer.invoke(
         'renameSession',
         sessionNameToRename,
         newSessionName,
       )
       getSessions()
     } else if (action === 'reset') {
-      await ipcRenderer.callMain('reset')
+      await ipcRenderer.invoke('reset')
       window.location.reload()
     }
     setNewSessionName('')

--- a/packages/jbrowse-web/src/rootModel.ts
+++ b/packages/jbrowse-web/src/rootModel.ts
@@ -25,8 +25,8 @@ const RootModel = types
         const snapshot = JSON.parse(JSON.stringify(getSnapshot(self.session)))
         const oldName = snapshot.name
         snapshot.name = sessionName
-        this.setSession(snapshot)
         self.jbrowse.replaceSavedSession(oldName, snapshot)
+        this.setSession(snapshot)
       }
     },
     duplicateCurrentSession() {

--- a/packages/menus/src/MainMenuBar/components/MainMenuBar.js
+++ b/packages/menus/src/MainMenuBar/components/MainMenuBar.js
@@ -81,7 +81,7 @@ function MainMenuBar(props) {
   }, [session.name])
 
   const scrollWidth = sizerNode && sizerNode.scrollWidth
-  const padding = 32
+  const padding = 12 + 1.5 * editedName.length
   if (scrollWidth + padding !== width) setWidth(scrollWidth + padding)
 
   const sizerRef = node => {
@@ -94,12 +94,25 @@ function MainMenuBar(props) {
 
   function handleBlur() {
     if (editedName !== session.name) {
-      if (session.savedSessionNames.includes(editedName)) {
+      if (
+        session.savedSessionNames &&
+        session.savedSessionNames.includes(editedName)
+      ) {
         setEditedName(session.name)
         console.error(
           `Cannot rename session to ${editedName}, a saved session with that name already exists`,
         )
       } else session.renameCurrentSession(editedName)
+    }
+  }
+
+  function handleKeyDown(event) {
+    // "Enter"
+    if (event.keyCode === 13) inputNode.blur()
+    // "Esc"
+    else if (event.keyCode === 27) {
+      setEditedName(session.name)
+      inputNode.blur()
     }
   }
 
@@ -117,10 +130,7 @@ function MainMenuBar(props) {
           classes={{ root: classes.inputRoot, focused: classes.inputFocused }}
           value={editedName}
           onChange={handleChange}
-          // Remove focus on pressing "Esc" or "Enter"
-          onKeyDown={event => {
-            if ([13, 27].includes(event.keyCode)) inputNode.blur()
-          }}
+          onKeyDown={handleKeyDown}
           onBlur={handleBlur}
         />
       </Tooltip>

--- a/packages/menus/src/MainMenuBar/components/MainMenuBar.js
+++ b/packages/menus/src/MainMenuBar/components/MainMenuBar.js
@@ -1,74 +1,133 @@
 import { getSession } from '@gmod/jbrowse-core/util'
 import AppBar from '@material-ui/core/AppBar'
-import Icon from '@material-ui/core/Icon'
-import IconButton from '@material-ui/core/IconButton'
-import Input from '@material-ui/core/Input'
+import InputBase from '@material-ui/core/InputBase'
 import { makeStyles } from '@material-ui/core/styles'
 import Toolbar from '@material-ui/core/Toolbar'
+import Tooltip from '@material-ui/core/Tooltip'
 import Typography from '@material-ui/core/Typography'
 import { values } from 'mobx'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import DropDownMenu from './DropDownMenu'
 
-const isElectron = !!window.electron
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    flexGrow: 1,
-  },
-  grow: {
-    flexGrow: 1,
-  },
-  input: {
-    color: theme.palette.primary.contrastText,
-  },
-  icon: {
-    color: theme.palette.primary.contrastText,
-  },
-}))
+const useStyles = makeStyles(theme => {
+  const light = theme.palette.type === 'light'
+  const backgroundColor = light
+    ? 'rgba(0, 0, 0, 0.09)'
+    : 'rgba(255, 255, 255, 0.09)'
+  return {
+    root: {
+      flexGrow: 1,
+    },
+    grow: {
+      flexGrow: 1,
+    },
+    input: {
+      color: theme.palette.primary.contrastText,
+    },
+    icon: {
+      color: theme.palette.primary.contrastText,
+    },
+    sizer: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      visibility: 'hidden',
+      height: 0,
+      overflow: 'scroll',
+      whiteSpace: 'pre',
+    },
+    inputRoot: {
+      padding: theme.spacing(0.5),
+      '&:hover': {
+        backgroundColor: light
+          ? 'rgba(0, 0, 0, 0.13)'
+          : 'rgba(255, 255, 255, 0.13)',
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor,
+        },
+      },
+      '&$focused': {
+        backgroundColor: light
+          ? 'rgba(0, 0, 0, 0.09)'
+          : 'rgba(255, 255, 255, 0.09)',
+      },
+    },
+    inputFocused: {
+      borderStyle: 'solid',
+      borderRadius: theme.shape.borderRadius,
+      borderColor: theme.palette.secondary.main,
+      borderWidth: 2,
+      backgroundColor: light
+        ? 'rgba(0, 0, 0, 0.09)'
+        : 'rgba(255, 255, 255, 0.09)',
+    },
+  }
+})
 
 function MainMenuBar(props) {
   const { model } = props
   const session = getSession(model)
 
   const classes = useStyles()
-  const [editing, setEditing] = useState(false)
   const [editedName, setEditedName] = useState('')
+  const [width, setWidth] = useState(0)
+  const [sizerNode, setSizerNode] = useState(null)
+  const [inputNode, setInputNode] = useState(null)
 
-  function handleEditToggle() {
-    if (editing) {
-      if (editedName !== session.name) {
-        if (session.savedSessionNames.includes(editedName))
-          console.error(
-            `Cannot rename session to ${editedName}, a saved session with that name already exists`,
-          )
-        else session.renameCurrentSession(editedName)
-      }
-      setEditedName('')
-      setEditing(false)
-    } else {
-      setEditedName(session.name)
-      setEditing(true)
+  useEffect(() => {
+    setEditedName(session.name)
+  }, [session.name])
+
+  const scrollWidth = sizerNode && sizerNode.scrollWidth
+  const padding = 32
+  if (scrollWidth + padding !== width) setWidth(scrollWidth + padding)
+
+  const sizerRef = node => {
+    setSizerNode(node)
+  }
+
+  const inputRef = node => {
+    setInputNode(node)
+  }
+
+  function handleBlur() {
+    if (editedName !== session.name) {
+      if (session.savedSessionNames.includes(editedName)) {
+        setEditedName(session.name)
+        console.error(
+          `Cannot rename session to ${editedName}, a saved session with that name already exists`,
+        )
+      } else session.renameCurrentSession(editedName)
     }
   }
 
-  function handleSessionNameChange(event) {
+  function handleChange(event) {
     setEditedName(event.target.value)
   }
 
-  const sessionNameComponent = editing ? (
-    <Input
-      className={classes.input}
-      autoFocus
-      value={editedName}
-      onChange={handleSessionNameChange}
-      onKeyDown={event => {
-        if (event.keyCode === 13) handleEditToggle()
-      }}
-    />
-  ) : (
-    <Typography>{session.name}</Typography>
+  const sessionNameComponent = (
+    <>
+      <Tooltip title="Rename">
+        <InputBase
+          inputRef={inputRef}
+          className={classes.input}
+          style={{ width }}
+          classes={{ root: classes.inputRoot, focused: classes.inputFocused }}
+          value={editedName}
+          onChange={handleChange}
+          // Remove focus on pressing "Esc" or "Enter"
+          onKeyDown={event => {
+            if ([13, 27].includes(event.keyCode)) inputNode.blur()
+          }}
+          onBlur={handleBlur}
+        />
+      </Tooltip>
+      <div ref={sizerRef} className={classes.sizer}>
+        {editedName}
+      </div>
+    </>
   )
 
   return (
@@ -84,13 +143,7 @@ function MainMenuBar(props) {
         ))}
         <div className={classes.grow} />
         {sessionNameComponent}
-        <div className={classes.grow}>
-          {isElectron ? null : (
-            <IconButton onClick={handleEditToggle}>
-              <Icon className={classes.icon}>{editing ? 'check' : 'edit'}</Icon>
-            </IconButton>
-          )}{' '}
-        </div>
+        <div className={classes.grow} />
         <Typography variant="h6" color="inherit">
           JBrowse
         </Typography>

--- a/packages/menus/src/MainMenuBar/components/MainMenuBar.js
+++ b/packages/menus/src/MainMenuBar/components/MainMenuBar.js
@@ -11,6 +11,8 @@ import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import React, { useState } from 'react'
 import DropDownMenu from './DropDownMenu'
 
+const isElectron = !!window.electron
+
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
@@ -83,9 +85,11 @@ function MainMenuBar(props) {
         <div className={classes.grow} />
         {sessionNameComponent}
         <div className={classes.grow}>
-          <IconButton onClick={handleEditToggle}>
-            <Icon className={classes.icon}>{editing ? 'check' : 'edit'}</Icon>
-          </IconButton>{' '}
+          {isElectron ? null : (
+            <IconButton onClick={handleEditToggle}>
+              <Icon className={classes.icon}>{editing ? 'check' : 'edit'}</Icon>
+            </IconButton>
+          )}{' '}
         </div>
         <Typography variant="h6" color="inherit">
           JBrowse

--- a/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
+++ b/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
@@ -64,35 +64,25 @@ exports[`<MainMenuBar /> renders 1`] = `
     <div
       class="makeStyles-grow"
     />
-    <p
-      class="MuiTypography-root MuiTypography-body1"
+    <div
+      class="MuiInputBase-root makeStyles-inputRoot makeStyles-input"
+      style="width: 32px;"
+      title="Rename"
+    >
+      <input
+        class="MuiInputBase-input"
+        type="text"
+        value="testSession"
+      />
+    </div>
+    <div
+      class="makeStyles-sizer"
     >
       testSession
-    </p>
+    </div>
     <div
       class="makeStyles-grow"
-    >
-      <button
-        class="MuiButtonBase-root MuiIconButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <span
-            aria-hidden="true"
-            class="material-icons MuiIcon-root makeStyles-icon"
-          >
-            edit
-          </span>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-       
-    </div>
+    />
     <h6
       class="MuiTypography-root MuiTypography-h6 MuiTypography-colorInherit"
     >

--- a/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
+++ b/packages/menus/src/MainMenuBar/components/__snapshots__/MainMenuBar.test.js.snap
@@ -66,7 +66,7 @@ exports[`<MainMenuBar /> renders 1`] = `
     />
     <div
       class="MuiInputBase-root makeStyles-inputRoot makeStyles-input"
-      style="width: 32px;"
+      style="width: 28.5px;"
       title="Rename"
     >
       <input


### PR DESCRIPTION
This has some bugfixes and improvements to desktop user and dev experience:

- Electron window worker logs now appear in the main window's devtools console
- Recent session card names show full name in a tooltip
- Session renaming bugfixes, and also now renaming the current session from the menu bar is supported in desktop
- When in development, most recent session automatically loads on first load or refresh, so you can essentially refresh to the same session when developing