### PR TITLE
Fix elided region click

### DIFF
--- a/packages/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/packages/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -37,6 +37,8 @@ export default ({ jbrequire }: { jbrequire: Function }) => {
       )
 
       let mateRefName: string | undefined
+      let startMod = 0
+      let endMod = 0
 
       if (breakendSpecification) {
         // a VCF breakend feature
@@ -48,6 +50,8 @@ export default ({ jbrequire }: { jbrequire: Function }) => {
           const matePosition = breakendSpecification.MatePosition.split(':')
           endPos = parseInt(matePosition[1], 10) - 1
           mateRefName = await getCanonicalRefName(matePosition[0])
+          if (breakendSpecification.Join === 'left') startMod = -1
+          if (breakendSpecification.MateDirection === 'left') endMod = -1
         }
 
         // if (breakendSpecification.Join === 'left') {
@@ -82,10 +86,10 @@ export default ({ jbrequire }: { jbrequire: Function }) => {
 
       const topMarkedRegion = [{ ...topRegion }, { ...topRegion }]
       const bottomMarkedRegion = [{ ...bottomRegion }, { ...bottomRegion }]
-      topMarkedRegion[0].end = startPos
-      topMarkedRegion[1].start = startPos
-      bottomMarkedRegion[0].end = endPos
-      bottomMarkedRegion[1].start = endPos
+      topMarkedRegion[0].end = startPos + startMod
+      topMarkedRegion[1].start = startPos + startMod
+      bottomMarkedRegion[0].end = endPos + endMod
+      bottomMarkedRegion[1].start = endPos + endMod
       const snapshot = {
         type: 'BreakpointSplitView',
         views: [

--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -11,6 +11,7 @@ export default self => ({
         aliases.forEach(alias => {
           aliasesToCanonical[alias] = ref
         })
+        aliasesToCanonical[ref] = ref
       })
       return aliasesToCanonical[refName]
     },

--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -4,6 +4,16 @@ import { readConfObject } from './configuration'
 
 export default self => ({
   views: {
+    async getCanonicalRefName(refName, assemblyName) {
+      const refNameAliases = await self.getRefNameAliases(assemblyName)
+      const aliasesToCanonical = {}
+      Object.entries(refNameAliases).forEach(([ref, aliases]) => {
+        aliases.forEach(alias => {
+          aliasesToCanonical[alias] = ref
+        })
+      })
+      return aliasesToCanonical[refName]
+    },
     get assemblyData() {
       const assemblyData = observable.map({})
       for (const datasetConfig of self.datasets) {


### PR DESCRIPTION
This is a template that could fix elided region click (#669 ) by manually finding in the views displayedRegions rather than the blocks which can be elided blocks

Note that this loses refName renaming