### PR TITLE
Add basic electron mock unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "devtron": "^1.4.0",
         "electron": "^7.1.0",
         "electron-builder": "^22.1.0",
+        "electron-mock-ipc": "^0.2.0",
         "eslint-config-airbnb": "^18.0.0",
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-config-prettier": "^6.0.0",

--- a/packages/__mocks__/electron.ts
+++ b/packages/__mocks__/electron.ts
@@ -1,0 +1,6 @@
+import createIPCMock from 'electron-mock-ipc'
+
+const mocked = createIPCMock()
+const { ipcMain } = mocked
+const { ipcRenderer } = mocked
+export { ipcMain, ipcRenderer }

--- a/packages/jbrowse-desktop/src/JBrowse.js
+++ b/packages/jbrowse-desktop/src/JBrowse.js
@@ -10,9 +10,6 @@ import React, { useEffect, useState } from 'react'
 import rootModel from './rootModel'
 import 'typeface-roboto'
 
-const { electron = {} } = window
-const { desktopCapturer, ipcRenderer } = electron
-
 const debounceMs = 1000
 export default observer(() => {
   const [status, setStatus] = useState('loading')
@@ -23,7 +20,8 @@ export default observer(() => {
   const [configSnapshot, setConfigSnapshot] = useState()
   const debouncedSessionSnapshot = useDebounce(sessionSnapshot, debounceMs)
   const debouncedConfigSnapshot = useDebounce(configSnapshot, debounceMs)
-
+  const { electron = {} } = window
+  const { desktopCapturer, ipcRenderer } = electron
   const { session, jbrowse } = root
   if (firstLoad && session) setFirstLoad(false)
 
@@ -50,7 +48,7 @@ export default observer(() => {
     }
 
     loadConfig()
-  }, [])
+  }, [ipcRenderer])
 
   useEffect(() => {
     let disposer = () => {}
@@ -86,7 +84,7 @@ export default observer(() => {
       }
     })()
     return () => {}
-  }, [debouncedSessionSnapshot])
+  }, [debouncedSessionSnapshot, desktopCapturer, ipcRenderer])
 
   useEffect(() => {
     if (debouncedConfigSnapshot) {
@@ -94,7 +92,7 @@ export default observer(() => {
     }
 
     return () => {}
-  }, [debouncedConfigSnapshot])
+  }, [debouncedConfigSnapshot, ipcRenderer])
 
   useEffect(() => {
     if (root) {

--- a/packages/jbrowse-desktop/src/JBrowse.test.tsx
+++ b/packages/jbrowse-desktop/src/JBrowse.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import fs from 'fs'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ipcMain, ipcRenderer } from 'electron'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, waitForElement } from '@testing-library/react'
+import React from 'react'
+import JBrowse from './JBrowse'
+
+declare global {
+  interface Window {
+    electronBetterIpc: {
+      ipcRenderer?: import('electron-better-ipc-extra').RendererProcessIpc
+    }
+    electron?: import('electron').AllElectron
+  }
+}
+
+ipcRenderer.invoke = async arg => {
+  if (arg === 'loadConfig') {
+    const config = fs.readFileSync(
+      'test_data/config_integration_test.json',
+      'utf8',
+    )
+    return JSON.parse(config)
+  }
+  console.warn(
+    `electron.ipcRenderer.invoke received unknown call for ${arg}, returning undefined`,
+  )
+  return undefined
+}
+window.electronBetterIpc = {
+  ipcRenderer: {
+    ...Object.create(ipcRenderer),
+    callMain: () => {},
+    answerMain: () => {},
+    callRenderer: () => {},
+    answerRenderer: () => {},
+  },
+}
+
+// @ts-ignore
+window.electronBetterIpc.ipcRenderer.invoke = async arg => {
+  if (arg === 'listSessions') {
+    return {}
+  }
+  console.warn(
+    `electronBetterIpc.ipcRenderer.invoke received unknown ${arg}, returning undefined`,
+  )
+  return undefined
+}
+
+window.electron = {
+  ipcRenderer,
+  ipcMain,
+  desktopCapturer: {
+    getSources: () => [] as any,
+  },
+} as any
+
+test('basic test of electron-mock-ipc', async () => {
+  const testMessage = 'test'
+  ipcMain.once('test-event', (ev: Event, obj: string) => {
+    expect(obj).toEqual(testMessage)
+  })
+
+  ipcRenderer.send('test-event', testMessage)
+})
+
+describe('main jbrowse app render', () => {
+  it('renders empty', async () => {
+    // we use preload script to load onto the window global
+    // ipcMain.handle('loadConfig', (ev: Event, obj: string) => {
+    //   return {}
+    // })
+
+    const { getByText } = render(<JBrowse />)
+    expect(
+      await waitForElement(() => getByText('Start a new session')),
+    ).toBeTruthy()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,6 +6193,13 @@ electron-localshortcut@^3.1.0:
     keyboardevent-from-electron-accelerator "^1.1.0"
     keyboardevents-areequal "^0.2.1"
 
+electron-mock-ipc@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/electron-mock-ipc/-/electron-mock-ipc-0.2.0.tgz#51356d777cbbd8888dd46057788798e75e591224"
+  integrity sha512-oEW4kS0W5ioQi5XprKXkBbD1zRINZk6AkGXsZD/mhgXaqTZuA0Qtsw1QoMWxykqnURVRl9plpmbHIvkYedsvNQ==
+  dependencies:
+    typescript "^3.5.2"
+
 electron-publish@21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-21.2.0.tgz#cc225cb46aa62e74b899f2f7299b396c9802387d"
@@ -15479,7 +15486,7 @@ typescript@3.5.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.7.2:
+typescript@^3.5.2, typescript@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==


### PR DESCRIPTION
This adds a bare electron mock for doing some unit testing

The electron-mock-ipc does not appear to implement invoke/handle so this is kind of done in a hacky way, but still works for some purposes.

Note that window.electron is read inside the component for this to work

Also I was getting a crazy infinite loop because a lint rule changed this

```
  async function getSessions() {
    setSessions(await ipcRenderer.invoke('listSessions'))
  }

  useEffect(() => {
    getSessions()
  }, [])
```

Into this

```
  async function getSessions() {
    setSessions(await ipcRenderer.invoke('listSessions'))
  }

  useEffect(() => {
    getSessions()
  }, [getSessions])
```

And that made it re-render infinitely 

Changed to this

```
    ;(async function getSessions() {
      setSessions(await ipcRenderer.invoke('listSessions'))
    })()
  }, [ipcRenderer])
```