### PR TITLE
Put menu items for 'Open new track' and 'Open new connection' on menu

### DIFF
--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -9,6 +9,7 @@ import { withContentRect } from 'react-measure'
 import { inDevelopment } from '../util'
 import DrawerWidget from './DrawerWidget'
 import DevTools from './DevTools'
+import Snackbar from './Snackbar'
 
 const useStyles = makeStyles(() => ({
   '@global': {
@@ -90,6 +91,7 @@ function App({ contentRect, measureRef, session }) {
       </div>
 
       {visibleDrawerWidget ? <DrawerWidget session={session} /> : null}
+      {session.snackbarMessage ? <Snackbar session={session} /> : null}
     </div>
   )
 }

--- a/packages/core/ui/ErrorSnackbar.tsx
+++ b/packages/core/ui/ErrorSnackbar.tsx
@@ -1,0 +1,30 @@
+import Icon from '@material-ui/core/Icon'
+import IconButton from '@material-ui/core/IconButton'
+import Snackbar from '@material-ui/core/Snackbar'
+import React, { useState } from 'react'
+
+export default function ErrorSnackbar({ error }: { error?: Error }) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <Snackbar
+      open={open}
+      onClose={() => {
+        setOpen(false)
+      }}
+      message={
+        <span style={{ display: 'flex' }}>
+          <div>{error ? error.toString() : null} </div>
+          <IconButton
+            key="close"
+            aria-label="close"
+            color="inherit"
+            onClick={() => setOpen(false)}
+          >
+            <Icon>close</Icon>
+          </IconButton>
+        </span>
+      }
+    />
+  )
+}

--- a/packages/core/ui/NewSessionCards.js
+++ b/packages/core/ui/NewSessionCards.js
@@ -104,6 +104,26 @@ const emptySessionSnapshot = {
               callback:
                 "function(session) { session.addView('SpreadsheetView', {})}",
             },
+            {
+              name: 'Open new track',
+              icon: 'note_add',
+              callback: `function(session) {
+const drawerWidget = session.addDrawerWidget(
+      'AddTrackDrawerWidget',
+      'addTrackDrawerWidget',
+    )
+    session.showDrawerWidget(drawerWidget)`,
+            },
+            {
+              name: 'Open new connection',
+              icon: 'input',
+              callback: `function(session) {
+const drawerWidget = session.addDrawerWidget(
+      'AddConnectionDrawerWidget',
+      'addConnectionDrawerWidget',
+    )
+    session.showDrawerWidget(drawerWidget)`,
+            },
           ],
         },
         {

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -3,7 +3,8 @@ import IconButton from '@material-ui/core/IconButton'
 import Snackbar from '@material-ui/core/Snackbar'
 import React, { useState } from 'react'
 
-export default function ErrorSnackbar({ error }: { error?: Error }) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function MessageSnackbar({ session }: { session?: any }) {
   const [open, setOpen] = useState(true)
 
   return (
@@ -11,10 +12,11 @@ export default function ErrorSnackbar({ error }: { error?: Error }) {
       open={open}
       onClose={() => {
         setOpen(false)
+        session.setSnackbarMessage(undefined)
       }}
       message={
         <span style={{ display: 'flex' }}>
-          <div>{error ? error.toString() : null} </div>
+          <div>{session.snackbarMessage}</div>
           <IconButton
             key="close"
             aria-label="close"

--- a/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
@@ -89,7 +89,13 @@ function AddTrackDrawerWidget({ model }) {
         name: trackName,
         adapter: trackAdapter,
       })
-    model.view.showTrack(trackConf)
+    if (model.view) {
+      model.view.showTrack(trackConf)
+    } else {
+      session.setSnackbarMessage(
+        'Open a new view, or use the track selector in an existing view, to view this track',
+      )
+    }
     session.hideDrawerWidget(model)
   }
 

--- a/packages/jbrowse-desktop/src/sessionModelFactory.js
+++ b/packages/jbrowse-desktop/src/sessionModelFactory.js
@@ -48,6 +48,8 @@ export default pluginManager => {
        * { taskName: "configure", target: thing_being_configured }
        */
       task: undefined,
+
+      snackbarMessage: undefined,
     }))
     .views(self => ({
       get rpcManager() {
@@ -121,6 +123,10 @@ export default pluginManager => {
             })
           }),
         )
+      },
+
+      setSnackbarMessage(str) {
+        self.snackbarMessage = str
       },
 
       getRegionsForAssemblyName(assemblyName, opts = {}) {

--- a/packages/jbrowse-web/src/sessionModelFactory.ts
+++ b/packages/jbrowse-web/src/sessionModelFactory.ts
@@ -56,6 +56,8 @@ export default function sessionModelFactory(pluginManager: any) {
        * { taskName: "configure", target: thing_being_configured }
        */
       task: undefined,
+
+      snackbarMessage: undefined as string | undefined,
     }))
     .views(self => ({
       get rpcManager() {
@@ -131,6 +133,10 @@ export default function sessionModelFactory(pluginManager: any) {
           }
         })
         addDisposer(self, displayedRegionsDisposer)
+      },
+
+      setSnackbarMessage(str: string | undefined) {
+        self.snackbarMessage = str
       },
 
       getRegionsForAssembly(


### PR DESCRIPTION
This adds a bare-bones "Open new track" and "Open new connection" icons to the menubar. I think that this improves some discoverability of the mechanism

It also adds a global "snackbar message" on the session, and it opens one of these when the "Open new track" function ends up not automatically adding a track to a view
