### PR TITLE
Paired read connections

### DIFF
--- a/packages/breakpoint-split-view/src/components/AlignmentConnections.tsx
+++ b/packages/breakpoint-split-view/src/components/AlignmentConnections.tsx
@@ -22,7 +22,9 @@ export default (pluginManager: any) => {
       trackConfigId: string
     }) => {
       const { views } = model
-      const features = model.getMatchedAlignmentFeatures(trackConfigId)
+      const features = model.hasPairedReads(trackConfigId)
+        ? model.getBadlyPairedAlignments(trackConfigId)
+        : model.getMatchedAlignmentFeatures(trackConfigId)
       const layoutMatches = model.getMatchedFeaturesInLayout(
         trackConfigId,
         features,

--- a/packages/breakpoint-split-view/src/components/BreakpointSplitView.tsx
+++ b/packages/breakpoint-split-view/src/components/BreakpointSplitView.tsx
@@ -60,10 +60,11 @@ export default (pluginManager: any) => {
         return <AlignmentConnections {...props} />
       }
       if (tracks[0].type === 'VariantTrack') {
-        if (model.hasTranslocations(trackConfigId)) {
-          return <Translocations {...props} />
-        }
-        return <Breakends {...props} />
+        return model.hasTranslocations(trackConfigId) ? (
+          <Translocations {...props} />
+        ) : (
+          <Breakends {...props} />
+        )
       }
       return null
     },


### PR DESCRIPTION
This creates a basic paired read connection overlay

Even though this is not fully implemented to take advantage of all the details of paired reads, I think this is basically a sound contribution that can provide a solid starting point

It does a basic search of "hasPairedReads" similar to the existing switch on "hasTranslocations" and then calls some paired code, which then only plots the "not paired correctly" reads using the connectors, which is always turned on for cross-chromosomal pairs and other types of discordancies, and therefore filters out all the other normal paired end connections

![Screenshot from 2019-11-21 05-38-12](https://user-images.githubusercontent.com/6511937/69330559-260c0f00-0c21-11ea-9a6e-04491ec3a938.png)
