### PR TITLE
Use display:flex to fix SV inspector layout, and fix drag handle

### DIFF
--- a/packages/circular-view/src/CircularView/models/CircularView.js
+++ b/packages/circular-view/src/CircularView/models/CircularView.js
@@ -158,6 +158,7 @@ export default pluginManager => {
     .actions(self => ({
       setWidth(newWidth) {
         self.width = newWidth
+        return self.width
       },
       setHeight(newHeight) {
         if (newHeight > minHeight) self.height = newHeight
@@ -169,7 +170,11 @@ export default pluginManager => {
         const newHeight = self.setHeight(self.height + distance)
         return newHeight - oldHeight
       },
-
+      resizeWidth(distance) {
+        const oldWidth = self.width
+        const newWidth = self.setWidth(self.width + distance)
+        return newWidth - oldWidth
+      },
       rotateClockwiseButton() {
         self.rotateClockwise()
       },

--- a/packages/circular-view/src/CircularView/models/CircularView.js
+++ b/packages/circular-view/src/CircularView/models/CircularView.js
@@ -21,6 +21,7 @@ export default pluginManager => {
   )
 
   const minHeight = 40
+  const minWidth = 100
   const defaultHeight = 400
   const stateModel = types
     .model('CircularView', {
@@ -157,12 +158,11 @@ export default pluginManager => {
     }))
     .actions(self => ({
       setWidth(newWidth) {
-        self.width = newWidth
+        self.width = Math.max(newWidth, minWidth)
         return self.width
       },
       setHeight(newHeight) {
-        if (newHeight > minHeight) self.height = newHeight
-        else self.height = minHeight
+        self.height = Math.max(newHeight, minHeight)
         return self.height
       },
       resizeHeight(distance) {

--- a/packages/core/ui/ResizeHandle.js
+++ b/packages/core/ui/ResizeHandle.js
@@ -11,9 +11,19 @@ const useStyles = makeStyles({
     cursor: 'col-resize',
     height: '100%',
   },
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  flexbox_verticalHandle: {
+    cursor: 'col-resize',
+    alignSelf: 'stretch', // the height: 100% is actually unable to function inside flexbox
+  },
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  flexbox_horizontalHandle: {
+    cursor: 'row-resize',
+    alignSelf: 'stretch', // similar to above
+  },
 })
 
-function ResizeHandle({ style, onDrag, vertical }) {
+function ResizeHandle({ style, onDrag, vertical, flexbox }) {
   const [mouseDragging, setMouseDragging] = useState(false)
   const prevPos = useRef()
   const classes = useStyles()
@@ -63,7 +73,12 @@ function ResizeHandle({ style, onDrag, vertical }) {
       onMouseDown={mouseDown}
       onMouseLeave={mouseLeave}
       role="presentation"
-      className={classes[vertical ? 'verticalHandle' : 'horizontalHandle']}
+      className={
+        classes[
+          (flexbox ? 'flexbox_' : '') +
+            (vertical ? 'verticalHandle' : 'horizontalHandle')
+        ]
+      }
       style={style}
     />
   )

--- a/packages/core/ui/ResizeHandle.js
+++ b/packages/core/ui/ResizeHandle.js
@@ -88,8 +88,9 @@ ResizeHandle.propTypes = {
   style: ReactPropTypes.shape(),
   onDrag: ReactPropTypes.func.isRequired,
   vertical: ReactPropTypes.bool,
+  flexbox: ReactPropTypes.bool,
 }
 
-ResizeHandle.defaultProps = { style: {}, vertical: false }
+ResizeHandle.defaultProps = { style: {}, vertical: false, flexbox: false }
 
 export default ResizeHandle

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
@@ -86,6 +86,7 @@ export default pluginManager => {
     .actions(self => ({
       setWidth(newWidth) {
         self.width = newWidth
+        return self.width
       },
       setHeight(newHeight) {
         if (newHeight > minHeight) self.height = newHeight

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
@@ -97,6 +97,11 @@ export default pluginManager => {
         const newHeight = self.setHeight(self.height + distance)
         return newHeight - oldHeight
       },
+      resizeWidth(distance) {
+        const oldWidth = self.width
+        const newWidth = self.setWidth(self.width + distance)
+        return newWidth - oldWidth
+      },
 
       // load a new spreadsheet and set our mode to display it
       displaySpreadsheet(spreadsheet) {

--- a/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -13,6 +13,12 @@ export default pluginManager => {
 
   const headerHeight = 52
 
+  const style = {
+    width: 4,
+    background: '#ccc',
+    boxSizing: 'border-box',
+    borderTop: '1px solid #fafafa',
+  }
   const useStyles = makeStyles(theme => {
     return {
       root: {
@@ -138,15 +144,9 @@ export default pluginManager => {
             <>
               <ResizeHandle
                 onDrag={model.spreadsheetView.resizeWidth}
-                objectId={model.id}
                 vertical
                 flexbox
-                style={{
-                  width: 4,
-                  background: '#ccc',
-                  boxSizing: 'border-box',
-                  borderTop: '1px solid #fafafa',
-                }}
+                style={style}
               />
               <div className={classes.circularViewContainer}>
                 <CircularViewOptions svInspector={model} />
@@ -157,7 +157,6 @@ export default pluginManager => {
         </div>
         <ResizeHandle
           onDrag={resizeHeight}
-          objectId={model.id}
           style={{
             height: dragHandleHeight,
             background: '#ccc',

--- a/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -143,7 +143,11 @@ export default pluginManager => {
           {showCircularView ? (
             <>
               <ResizeHandle
-                onDrag={model.spreadsheetView.resizeWidth}
+                onDrag={distance => {
+                  model.spreadsheetView.resizeWidth(distance)
+                  model.circularView.resizeWidth(-distance)
+                  return distance
+                }}
                 vertical
                 flexbox
                 style={style}

--- a/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -36,6 +36,7 @@ export default pluginManager => {
       },
       spreadsheetViewContainer: {
         borderRight: [['1px', 'solid', grey[400]]],
+        overflow: 'hidden',
       },
       circularViewOptions: {
         padding: theme.spacing(1),
@@ -132,11 +133,26 @@ export default pluginManager => {
           <div className={classes.spreadsheetViewContainer}>
             <SpreadsheetViewReactComponent model={model.spreadsheetView} />
           </div>
+
           {showCircularView ? (
-            <div className={classes.circularViewContainer}>
-              <CircularViewOptions svInspector={model} />
-              <CircularViewReactComponent model={model.circularView} />
-            </div>
+            <>
+              <ResizeHandle
+                onDrag={model.spreadsheetView.resizeWidth}
+                objectId={model.id}
+                vertical
+                flexbox
+                style={{
+                  width: 4,
+                  background: '#ccc',
+                  boxSizing: 'border-box',
+                  borderTop: '1px solid #fafafa',
+                }}
+              />
+              <div className={classes.circularViewContainer}>
+                <CircularViewOptions svInspector={model} />
+                <CircularViewReactComponent model={model.circularView} />
+              </div>
+            </>
           ) : null}
         </div>
         <ResizeHandle

--- a/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -144,15 +144,18 @@ export default pluginManager => {
             <>
               <ResizeHandle
                 onDrag={distance => {
-                  model.spreadsheetView.resizeWidth(distance)
-                  model.circularView.resizeWidth(-distance)
-                  return distance
+                  const ret1 = model.circularView.resizeWidth(-distance)
+                  const ret2 = model.spreadsheetView.resizeWidth(-ret1)
+                  return ret2
                 }}
                 vertical
                 flexbox
                 style={style}
               />
-              <div className={classes.circularViewContainer}>
+              <div
+                className={classes.circularViewContainer}
+                style={{ width: model.circularView.width }}
+              >
                 <CircularViewOptions svInspector={model} />
                 <CircularViewReactComponent model={model.circularView} />
               </div>

--- a/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -16,7 +16,6 @@ export default pluginManager => {
   const useStyles = makeStyles(theme => {
     return {
       root: {
-        position: 'relative',
         marginBottom: theme.spacing(1),
         background: 'white',
         overflow: 'hidden',
@@ -33,18 +32,10 @@ export default pluginManager => {
         margin: 0,
       },
       viewsContainer: {
-        position: 'relative',
+        display: 'flex',
       },
       spreadsheetViewContainer: {
         borderRight: [['1px', 'solid', grey[400]]],
-        height: '100%',
-        position: 'absolute',
-        top: 0,
-      },
-      circularViewContainer: {
-        position: 'absolute',
-        top: 0,
-        height: '100%',
       },
       circularViewOptions: {
         padding: theme.spacing(1),
@@ -99,7 +90,6 @@ export default pluginManager => {
       >
         <Grid item>
           <FormControlLabel
-            // className={classes.rowNumber}
             control={
               <Checkbox
                 className={classes.rowSelector}
@@ -123,8 +113,6 @@ export default pluginManager => {
     const classes = useStyles()
 
     const {
-      height,
-      width,
       configuration,
       resizeHeight,
       dragHandleHeight,
@@ -134,25 +122,18 @@ export default pluginManager => {
     } = model
 
     return (
-      <div
-        className={classes.root}
-        style={{ height, width }}
-        data-testid={configuration.configId}
-      >
+      <div className={classes.root} data-testid={configuration.configId}>
         <Grid container direction="row" className={classes.header}>
           <Grid item>
             <ViewControls model={model} />
           </Grid>
         </Grid>
         <div className={classes.viewsContainer}>
-          <div className={classes.spreadsheetViewContainer} style={{ left: 0 }}>
+          <div className={classes.spreadsheetViewContainer}>
             <SpreadsheetViewReactComponent model={model.spreadsheetView} />
           </div>
           {showCircularView ? (
-            <div
-              className={classes.circularViewContainer}
-              style={{ left: model.spreadsheetView.width }}
-            >
+            <div className={classes.circularViewContainer}>
               <CircularViewOptions svInspector={model} />
               <CircularViewReactComponent model={model.circularView} />
             </div>
@@ -163,9 +144,6 @@ export default pluginManager => {
           objectId={model.id}
           style={{
             height: dragHandleHeight,
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
             background: '#ccc',
             boxSizing: 'border-box',
             borderTop: '1px solid #fafafa',

--- a/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -29,6 +29,7 @@ export default pluginManager => {
       id: ElementId,
       type: types.literal('SvInspectorView'),
       width: 800,
+      dragHandleHeight: 4,
       height: types.optional(
         types.refinement(
           'SvInspectorViewHeight',


### PR DESCRIPTION
This fixes #667 

It uses flexbox layout instead of absolute positioning for the SV inspector

Also the drag handle height was undefined, leading to there being no drag handle, this simply restores that
