### PR TITLE
Fix issue with mouseover/feature selection appearing across chromosomes

### DIFF
--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.js
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.js
@@ -8,6 +8,7 @@ import runner from 'mobx-run-in-reactive-context'
 
 function PileupRendering(props) {
   const {
+    blockKey,
     trackModel,
     width,
     height,
@@ -137,7 +138,7 @@ function PileupRendering(props) {
     const px = horizontallyFlipped ? width - offsetX : offsetX
     const clientBp = region.start + bpPerPx * px
 
-    const feats = trackModel.getFeatureOverlapping(clientBp, offsetY)
+    const feats = trackModel.getFeatureOverlapping(blockKey, clientBp, offsetY)
     const featureIdCurrentlyUnderMouse = feats.length
       ? feats[0].name
       : undefined

--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.js
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.js
@@ -37,8 +37,13 @@ function PileupRendering(props) {
     const ctx = canvas.getContext('2d')
     ctx.clearRect(0, 0, canvas.width, canvas.height)
     let rect
+    let blockLayoutFeatures
 
-    if (selectedFeatureId && (rect = layoutFeatures.get(selectedFeatureId))) {
+    if (
+      selectedFeatureId &&
+      (blockLayoutFeatures = layoutFeatures.get(blockKey)) &&
+      (rect = blockLayoutFeatures.get(selectedFeatureId))
+    ) {
       const [leftBp, topPx, rightBp, bottomPx] = rect
       const [leftPx, rightPx] = bpSpanPx(
         leftBp,
@@ -64,7 +69,8 @@ function PileupRendering(props) {
     }
     if (
       featureIdUnderMouse &&
-      (rect = layoutFeatures.get(featureIdUnderMouse))
+      (blockLayoutFeatures = layoutFeatures.get(blockKey)) &&
+      (rect = blockLayoutFeatures.get(featureIdUnderMouse))
     ) {
       const [leftBp, topPx, rightBp, bottomPx] = rect
       const [leftPx, rightPx] = bpSpanPx(
@@ -86,6 +92,7 @@ function PileupRendering(props) {
     selectedFeatureId,
     layoutFeatures,
     featureIdUnderMouse,
+    blockKey,
   ])
 
   function onMouseDown(event) {

--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.js
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.js
@@ -19,7 +19,7 @@ function PileupRendering(props) {
   const {
     selectedFeatureId,
     featureIdUnderMouse,
-    layoutFeatures,
+    blockLayoutFeatures,
     features,
     configuration,
   } = trackModel
@@ -37,12 +37,12 @@ function PileupRendering(props) {
     const ctx = canvas.getContext('2d')
     ctx.clearRect(0, 0, canvas.width, canvas.height)
     let rect
-    let blockLayoutFeatures
+    let blockLayout
 
     if (
       selectedFeatureId &&
-      (blockLayoutFeatures = layoutFeatures.get(blockKey)) &&
-      (rect = blockLayoutFeatures.get(selectedFeatureId))
+      (blockLayout = blockLayoutFeatures.get(blockKey)) &&
+      (rect = blockLayout.get(selectedFeatureId))
     ) {
       const [leftBp, topPx, rightBp, bottomPx] = rect
       const [leftPx, rightPx] = bpSpanPx(
@@ -69,8 +69,8 @@ function PileupRendering(props) {
     }
     if (
       featureIdUnderMouse &&
-      (blockLayoutFeatures = layoutFeatures.get(blockKey)) &&
-      (rect = blockLayoutFeatures.get(featureIdUnderMouse))
+      (blockLayout = blockLayoutFeatures.get(blockKey)) &&
+      (rect = blockLayout.get(featureIdUnderMouse))
     ) {
       const [leftBp, topPx, rightBp, bottomPx] = rect
       const [leftPx, rightPx] = bpSpanPx(
@@ -90,9 +90,9 @@ function PileupRendering(props) {
     horizontallyFlipped,
     region,
     selectedFeatureId,
-    layoutFeatures,
     featureIdUnderMouse,
     blockKey,
+    blockLayoutFeatures,
   ])
 
   function onMouseDown(event) {
@@ -229,6 +229,7 @@ PileupRendering.propTypes = {
   region: CommonPropTypes.Region.isRequired,
   bpPerPx: ReactPropTypes.number.isRequired,
   horizontallyFlipped: ReactPropTypes.bool,
+  blockKey: ReactPropTypes.string,
 
   trackModel: ReactPropTypes.shape({
     configuration: ReactPropTypes.shape({}),
@@ -236,7 +237,7 @@ PileupRendering.propTypes = {
     featureIdUnderMouse: ReactPropTypes.string,
     getFeatureOverlapping: ReactPropTypes.func,
     features: ReactPropTypes.shape({ get: ReactPropTypes.func }),
-    layoutFeatures: ReactPropTypes.shape({ get: ReactPropTypes.func }),
+    blockLayoutFeatures: ReactPropTypes.shape({ get: ReactPropTypes.func }),
     setFeatureIdUnderMouse: ReactPropTypes.func,
   }),
 
@@ -257,15 +258,16 @@ PileupRendering.propTypes = {
   onMouseLeave: ReactPropTypes.func,
   onMouseOver: ReactPropTypes.func,
   onMouseOut: ReactPropTypes.func,
-
   onClick: ReactPropTypes.func,
 }
 
 PileupRendering.defaultProps = {
+  blockKey: undefined,
   horizontallyFlipped: false,
-
-  trackModel: { configuration: {}, setFeatureIdUnderMouse: () => {} },
-
+  trackModel: {
+    configuration: {},
+    setFeatureIdUnderMouse: () => {},
+  },
   onFeatureMouseDown: undefined,
   onFeatureMouseEnter: undefined,
   onFeatureMouseOut: undefined,
@@ -273,16 +275,13 @@ PileupRendering.defaultProps = {
   onFeatureMouseUp: undefined,
   onFeatureMouseLeave: undefined,
   onFeatureMouseMove: undefined,
-
   onFeatureClick: undefined,
-
   onMouseDown: undefined,
   onMouseUp: undefined,
   onMouseEnter: undefined,
   onMouseLeave: undefined,
   onMouseOver: undefined,
   onMouseOut: undefined,
-
   onClick: undefined,
 }
 

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
@@ -13,6 +13,7 @@ import RendererType from './RendererType'
 import SerializableFilterChain from './util/serializableFilterChain'
 
 interface RenderArgs {
+  blockKey: string
   sessionId: string
   signal?: AbortSignal
   regions?: any
@@ -41,6 +42,8 @@ export default class ServerSideRenderer extends RendererType {
     const { trackModel } = args.renderProps
     if (trackModel) {
       args.renderProps = {
+        // @ts-ignore
+        blockKey: args.blockKey,
         ...args.renderProps,
         trackModel: {
           id: trackModel.id,
@@ -63,6 +66,8 @@ export default class ServerSideRenderer extends RendererType {
       featuresMap.set(String(f.id()), f)
     })
     result.features = featuresMap
+    // @ts-ignore
+    result.blockKey = args.blockKey
     return result
   }
 

--- a/packages/core/ui/Tooltip.tsx
+++ b/packages/core/ui/Tooltip.tsx
@@ -55,8 +55,12 @@ Tooltip.propTypes = {
   configuration: ReactPropTypes.shape({}).isRequired,
   offsetX: ReactPropTypes.number.isRequired,
   offsetY: ReactPropTypes.number.isRequired,
-  feature: ReactPropTypes.shape({}).isRequired,
+  feature: ReactPropTypes.shape({}),
   timeout: ReactPropTypes.number,
+}
+
+Tooltip.defaultProps = {
+  feature: undefined,
 }
 
 export default observer(Tooltip)

--- a/packages/core/ui/Tooltip.tsx
+++ b/packages/core/ui/Tooltip.tsx
@@ -27,7 +27,7 @@ const Tooltip = ({
   offsetY: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   configuration: any
-  feature: Feature
+  feature?: Feature
   timeout: number
 }) => {
   const classes = useStyles()
@@ -37,12 +37,18 @@ const Tooltip = ({
     const handle = setTimeout(() => setShown(true), timeout)
     return () => clearTimeout(handle)
   })
-  const text = readConfObject(configuration, 'mouseover', [feature])
-  return text && shown ? (
-    <div className={classes.hoverLabel} style={{ left: offsetX, top: offsetY }}>
-      {text}
-    </div>
-  ) : null
+  if (feature && shown) {
+    const text = readConfObject(configuration, 'mouseover', [feature])
+    return (
+      <div
+        className={classes.hoverLabel}
+        style={{ left: offsetX, top: offsetY }}
+      >
+        {text}
+      </div>
+    )
+  }
+  return null
 }
 
 Tooltip.propTypes = {

--- a/packages/jbrowse-desktop/src/rpcMethods.js
+++ b/packages/jbrowse-desktop/src/rpcMethods.js
@@ -192,9 +192,9 @@ function freeResources(pluginManager, specification) {
  * @param {object} args.renderProps
  * @param {AbortSignal} [args.signal]
  */
-async function render(
-  pluginManager,
-  {
+async function render(pluginManager, args) {
+  const {
+    blockKey,
     regions,
     region,
     sessionId,
@@ -204,16 +204,13 @@ async function render(
     renderProps,
     sequenceAdapterType,
     sequenceAdapterConfig,
-    signal,
-  },
-) {
+  } = args
   if (!sessionId) throw new Error('must pass a unique session id')
 
-  if (isRemoteAbortSignal(signal)) {
-    signal = deserializeAbortSignal(signal)
-  }
+  const signal = isRemoteAbortSignal(args.signal)
+    ? deserializeAbortSignal(args.signal)
+    : args.signal
   checkAbortSignal(signal)
-
   const { dataAdapter } = getAdapter(
     pluginManager,
     sessionId,
@@ -237,6 +234,7 @@ async function render(
     regions,
     region,
     signal,
+    blockKey,
   })
   checkAbortSignal(signal)
   return result

--- a/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
+++ b/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
@@ -78,12 +78,11 @@ const blockBasedTrack = types
       get rtree() {
         if (stale) {
           self.rbush.clear()
-          for (const [key, item] of this.features) {
-            const layout = this.layoutFeatures.get(key) || []
+          for (const [key, layout] of this.layoutFeatures) {
             self.rbush.insert({
-              minX: item.get('start'),
+              minX: layout[0],
               minY: layout[1],
-              maxX: item.get('end'),
+              maxX: layout[2],
               maxY: layout[3],
               name: key,
             })

--- a/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
+++ b/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
@@ -30,7 +30,7 @@ const blockBasedTrack = types
   )
   .views(self => {
     let stale = false // used to make rtree refresh, the mobx reactivity fails for some reason
-    let rbush: { [key: string]: typeof RBush } = {}
+    let rbush: { [key: string]: typeof RBush | undefined } = {}
 
     return {
       get blockType() {
@@ -97,16 +97,8 @@ const blockBasedTrack = types
 
       getFeatureOverlapping(blockKey: string, x: number, y: number) {
         const rect = { minX: x, minY: y, maxX: x + 1, maxY: y + 1 }
-        const rtree = this.rtree.get(blockKey)
-        if (rtree && rtree.collides(rect)) {
-          return rtree.search({
-            minX: x,
-            minY: y,
-            maxX: x + 1,
-            maxY: y + 1,
-          })
-        }
-        return []
+        const rtree = this.rtree[blockKey]
+        return rtree && rtree.collides(rect) ? rtree.search(rect) : []
       },
 
       get blockDefinitions() {

--- a/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.js
+++ b/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.js
@@ -55,10 +55,16 @@ BlockMessage.propTypes = {
 }
 
 const ServerSideRenderedBlockContent = observer(({ model }) => {
-  if (model.error)
+  if (model.error) {
     return <BlockError error={model.error} reload={model.reload} />
-  if (model.message) return <BlockMessage messageText={model.message} />
-  if (!model.filled) return <LoadingMessage />
+  }
+  if (model.message) {
+    return <BlockMessage messageText={model.message} />
+  }
+  if (!model.filled) {
+    return <LoadingMessage />
+  }
+
   return <ServerSideRenderedContent model={model} />
 })
 

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -167,11 +167,8 @@ export type BlockStateModel = typeof blockState
 function renderBlockData(self: Instance<BlockStateModel>) {
   const track = getParent(self, 2)
   const view = getContainingView(track)
-  const { rpcManager } = getSession(view) as any
-
+  const { assemblyData, rpcManager } = getSession(self) as any
   const assemblyName = getTrackAssemblyName(track)
-
-  const { assemblyData } = getSession(self) as any
   const trackAssemblyData =
     (assemblyData && assemblyData.get(assemblyName)) || {}
   const trackAssemblyAliases = trackAssemblyData.aliases || []

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -212,6 +212,7 @@ function renderBlockData(self: Instance<BlockStateModel>) {
       rendererType: rendererType.name,
       renderProps,
       sessionId: track.id,
+      blockKey: self.key,
       timeout: 1000000, // 10000,
     },
   }

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -165,9 +165,8 @@ export type BlockStateModel = typeof blockState
 // not using a flow for this, because the flow doesn't
 // work with autorun
 function renderBlockData(self: Instance<BlockStateModel>) {
-  const track = getParent(self, 2)
-  const view = getContainingView(track)
   const { assemblyData, rpcManager } = getSession(self) as any
+  const track = getParent(self, 2)
   const assemblyName = getTrackAssemblyName(track)
   const trackAssemblyData =
     (assemblyData && assemblyData.get(assemblyName)) || {}

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -17,15 +17,15 @@ const renderingStyle = {
 export const SvgSelected = observer(
   ({
     region,
-    trackModel: { layoutFeatures, selectedFeatureId },
+    trackModel: { blockLayoutFeatures, selectedFeatureId },
     bpPerPx,
     horizontallyFlipped,
     blockKey,
   }) => {
-    if (selectedFeatureId && layoutFeatures) {
-      const blockLayoutFeatures = layoutFeatures.get(blockKey)
-      if (blockLayoutFeatures) {
-        const rect = blockLayoutFeatures.get(selectedFeatureId)
+    if (selectedFeatureId && blockLayoutFeatures) {
+      const blockLayout = blockLayoutFeatures.get(blockKey)
+      if (blockLayout) {
+        const rect = blockLayout.get(selectedFeatureId)
         if (rect) {
           const [leftBp, topPx, rightBp, bottomPx] = rect
           const [leftPx, rightPx] = bpSpanPx(
@@ -57,16 +57,16 @@ export const SvgSelected = observer(
 
 export const SvgMouseover = observer(
   ({
-    trackModel: { layoutFeatures, featureIdUnderMouse },
+    trackModel: { blockLayoutFeatures, featureIdUnderMouse },
     region,
     bpPerPx,
     horizontallyFlipped,
     blockKey,
   }) => {
-    if (featureIdUnderMouse && layoutFeatures) {
-      const blockLayoutFeatures = layoutFeatures.get(blockKey)
-      if (blockLayoutFeatures) {
-        const rect = blockLayoutFeatures.get(featureIdUnderMouse)
+    if (featureIdUnderMouse && blockLayoutFeatures) {
+      const blockLayout = blockLayoutFeatures.get(blockKey)
+      if (blockLayout) {
+        const rect = blockLayout.get(featureIdUnderMouse)
         if (rect) {
           const [leftBp, topPx, rightBp, bottomPx] = rect
           const [leftPx, rightPx] = bpSpanPx(

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -20,34 +20,36 @@ export const SvgSelected = observer(
     trackModel: { layoutFeatures, selectedFeatureId },
     bpPerPx,
     horizontallyFlipped,
+    blockKey,
   }) => {
-    let rect
-    if (
-      selectedFeatureId &&
-      layoutFeatures &&
-      (rect = layoutFeatures.get(selectedFeatureId))
-    ) {
-      const [leftBp, topPx, rightBp, bottomPx] = rect
-      const [leftPx, rightPx] = bpSpanPx(
-        leftBp,
-        rightBp,
-        region,
-        bpPerPx,
-        horizontallyFlipped,
-      )
-      const rectTop = Math.round(topPx)
-      const rectHeight = Math.round(bottomPx - topPx)
+    if (selectedFeatureId && layoutFeatures) {
+      const blockLayoutFeatures = layoutFeatures.get(blockKey)
+      if (blockLayoutFeatures) {
+        const rect = blockLayoutFeatures.get(selectedFeatureId)
+        if (rect) {
+          const [leftBp, topPx, rightBp, bottomPx] = rect
+          const [leftPx, rightPx] = bpSpanPx(
+            leftBp,
+            rightBp,
+            region,
+            bpPerPx,
+            horizontallyFlipped,
+          )
+          const rectTop = Math.round(topPx)
+          const rectHeight = Math.round(bottomPx - topPx)
 
-      return (
-        <rect
-          x={leftPx - 2}
-          y={rectTop - 2}
-          width={rightPx - leftPx + 4}
-          height={rectHeight + 4}
-          stroke="#00b8ff"
-          fill="none"
-        />
-      )
+          return (
+            <rect
+              x={leftPx - 2}
+              y={rectTop - 2}
+              width={rightPx - leftPx + 4}
+              height={rectHeight + 4}
+              stroke="#00b8ff"
+              fill="none"
+            />
+          )
+        }
+      }
     }
     return null
   },
@@ -59,33 +61,35 @@ export const SvgMouseover = observer(
     region,
     bpPerPx,
     horizontallyFlipped,
+    blockKey,
   }) => {
-    let rect
-    if (
-      featureIdUnderMouse &&
-      layoutFeatures &&
-      (rect = layoutFeatures.get(featureIdUnderMouse))
-    ) {
-      const [leftBp, topPx, rightBp, bottomPx] = rect
-      const [leftPx, rightPx] = bpSpanPx(
-        leftBp,
-        rightBp,
-        region,
-        bpPerPx,
-        horizontallyFlipped,
-      )
-      const rectTop = Math.round(topPx)
-      const rectHeight = Math.round(bottomPx - topPx)
-      return (
-        <rect
-          x={leftPx - 2}
-          y={rectTop - 2}
-          width={rightPx - leftPx + 4}
-          height={rectHeight + 4}
-          fill="#000"
-          fillOpacity="0.2"
-        />
-      )
+    if (featureIdUnderMouse && layoutFeatures) {
+      const blockLayoutFeatures = layoutFeatures.get(blockKey)
+      if (blockLayoutFeatures) {
+        const rect = blockLayoutFeatures.get(featureIdUnderMouse)
+        if (rect) {
+          const [leftBp, topPx, rightBp, bottomPx] = rect
+          const [leftPx, rightPx] = bpSpanPx(
+            leftBp,
+            rightBp,
+            region,
+            bpPerPx,
+            horizontallyFlipped,
+          )
+          const rectTop = Math.round(topPx)
+          const rectHeight = Math.round(bottomPx - topPx)
+          return (
+            <rect
+              x={leftPx - 2}
+              y={rectTop - 2}
+              width={rightPx - leftPx + 4}
+              height={rectHeight + 4}
+              fill="#000"
+              fillOpacity="0.2"
+            />
+          )
+        }
+      }
     }
     return null
   },
@@ -444,6 +448,7 @@ SvgFeatureRendering.propTypes = {
   onMouseMove: ReactPropTypes.func,
   onClick: ReactPropTypes.func,
   onFeatureClick: ReactPropTypes.func,
+  blockKey: ReactPropTypes.string,
 }
 
 SvgFeatureRendering.defaultProps = {
@@ -452,6 +457,7 @@ SvgFeatureRendering.defaultProps = {
   trackModel: {},
 
   features: new Map(),
+  blockKey: undefined,
 
   onMouseDown: undefined,
   onMouseUp: undefined,

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -251,7 +251,7 @@ function SvgFeatureRendering(props) {
   const [movedDuringLastMouseDown, setMovedDuringLastMouseDown] = useState(
     false,
   )
-  const [offset, setOffset] = useState([0, 0])
+  const [tooltipCoord, setTooltipCoord] = useState([0, 0])
   const [height, setHeight] = useState(0)
   const {
     onMouseOut,
@@ -346,7 +346,7 @@ function SvgFeatureRendering(props) {
       const featureIdCurrentlyUnderMouse = feats.length
         ? feats[0].name
         : undefined
-      setOffset([offsetX, offsetY])
+      setTooltipCoord([offsetX, offsetY])
       setLocalFeatureIdUnderMouse(featureIdCurrentlyUnderMouse)
       trackModel.setFeatureIdUnderMouse(featureIdCurrentlyUnderMouse)
 
@@ -405,8 +405,8 @@ function SvgFeatureRendering(props) {
         <Tooltip
           configuration={configuration}
           feature={features.get(localFeatureIdUnderMouse)}
-          offsetX={offset[0]}
-          offsetY={offset[1]}
+          offsetX={tooltipCoord[0]}
+          offsetY={tooltipCoord[1]}
         />
       ) : null}
     </div>

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -234,7 +234,14 @@ RenderedFeatures.defaultProps = {
 }
 
 function SvgFeatureRendering(props) {
-  const { region, bpPerPx, horizontallyFlipped, features, trackModel } = props
+  const {
+    blockKey,
+    region,
+    bpPerPx,
+    horizontallyFlipped,
+    features,
+    trackModel,
+  } = props
   const { configuration } = trackModel
   const width = (region.end - region.start) / bpPerPx
 
@@ -331,7 +338,11 @@ function SvgFeatureRendering(props) {
       const px = horizontallyFlipped ? width - offsetX : offsetX
       const clientBp = region.start + bpPerPx * px
 
-      const feats = trackModel.getFeatureOverlapping(clientBp, offsetY)
+      const feats = trackModel.getFeatureOverlapping(
+        blockKey,
+        clientBp,
+        offsetY,
+      )
       const featureIdCurrentlyUnderMouse = feats.length
         ? feats[0].name
         : undefined
@@ -343,6 +354,7 @@ function SvgFeatureRendering(props) {
       return handler(event)
     },
     [
+      blockKey,
       bpPerPx,
       horizontallyFlipped,
       mouseIsDown,

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
@@ -199,24 +199,28 @@ test('processed transcript', () => {
 })
 
 test('svg selected', () => {
-  const layoutFeatures = new Map()
-  layoutFeatures.set('one', [0, 0, 10, 10])
+  const blockLayoutFeatures = new Map()
+  const layout = new Map()
+  layout.set('one', [0, 0, 10, 10])
+  blockLayoutFeatures.set('block1', layout)
 
   const { container } = render(
     <svg>
       <SvgMouseover
         width={500}
         height={500}
+        blockKey="block1"
         region={{ refName: 'zonk', start: 0, end: 1000 }}
-        trackModel={{ layoutFeatures, featureIdUnderMouse: 'one' }}
+        trackModel={{ blockLayoutFeatures, featureIdUnderMouse: 'one' }}
         config={SvgRendererConfigSchema.create({})}
         bpPerPx={3}
       />
       <SvgSelected
         width={500}
         height={500}
+        blockKey="block1"
         region={{ refName: 'zonk', start: 0, end: 1000 }}
-        trackModel={{ layoutFeatures, selectedFeatureId: 'one' }}
+        trackModel={{ blockLayoutFeatures, selectedFeatureId: 'one' }}
         config={SvgRendererConfigSchema.create({})}
         bpPerPx={3}
       />

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -420,6 +420,7 @@
           "configId": "wiggle_global_autoscale",
           "type": "WiggleTrack",
           "name": "Encode global autoscale",
+          "autoscale": "global",
           "category": [
             "ENCODE bigWigs"
           ],


### PR DESCRIPTION
Some work was done earlier to make fast mouseovers happen with an rtree, but the features from all the blocks, regardless of whether it was across totally different chromosomes, would be combined into the same rtree.

This PR makes it so the rtree is actually block specific, so that multiple independent layouts do not clobber each other