### PR TITLE
Dereference tracks on connection close

### DIFF
--- a/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/HierarchicalTrackSelector.js
+++ b/packages/data-management/src/HierarchicalTrackSelectorDrawerWidget/components/HierarchicalTrackSelector.js
@@ -91,6 +91,28 @@ function HierarchicalTrackSelector({ model }) {
     return name.toLowerCase().includes(model.filterText.toLowerCase())
   }
 
+  function handleConnectionToggle(connectionConf) {
+    const assemblyConnections = session.connections.get(assemblyName)
+    const existingConnection =
+      assemblyConnections &&
+      !!assemblyConnections.find(
+        connection =>
+          connection.name === readConfObject(connectionConf, 'name'),
+      )
+    if (existingConnection) {
+      breakConnection(connectionConf)
+    } else {
+      session.makeConnection(connectionConf)
+    }
+  }
+
+  function breakConnection(connectionConf) {
+    const safelyBreakConnection = session.prepareToBreakConnection(
+      connectionConf,
+    )
+    safelyBreakConnection()
+  }
+
   const { assemblyNames } = model
   const assemblyName = assemblyNames[assemblyIdx]
   if (!assemblyName) return null
@@ -158,22 +180,7 @@ function HierarchicalTrackSelector({ model }) {
                         readConfObject(connectionConf, 'name'),
                     )
                 }
-                onChange={() => {
-                  if (
-                    !(
-                      session.connections.has(assemblyName) &&
-                      !!session.connections
-                        .get(assemblyName)
-                        .find(
-                          connection =>
-                            connection.name ===
-                            readConfObject(connectionConf, 'name'),
-                        )
-                    )
-                  )
-                    session.makeConnection(connectionConf)
-                  else session.breakConnection(connectionConf)
-                }}
+                onChange={() => handleConnectionToggle(connectionConf)}
                 // value="checkedA"
               />
             }

--- a/packages/jbrowse-desktop/src/sessionModelFactory.js
+++ b/packages/jbrowse-desktop/src/sessionModelFactory.js
@@ -111,7 +111,7 @@ export default pluginManager => {
             const members = getMembers(node)
             Object.entries(members.properties).forEach(([key, value]) => {
               if (isReferenceType(value) && node[key] === object) {
-                refs.push([node, key])
+                refs.push({ node, key })
               }
             })
           }
@@ -238,13 +238,13 @@ export default pluginManager => {
         const dereferenceTypeCount = {}
         connection.tracks.forEach(track => {
           const referring = self.getReferring(track)
-          referring.forEach(([ref]) => {
+          referring.forEach(({ node }) => {
             let dereferenced = false
             try {
               // If a view is referring to the track config, remove the track
               // from the view
               const type = 'open track(s)'
-              const view = getContainingView(ref)
+              const view = getContainingView(node)
               callbacksToDereferenceTrack.push(() => view.hideTrack(track))
               dereferenced = true
               if (!dereferenceTypeCount[type]) dereferenceTypeCount[type] = 0
@@ -252,11 +252,13 @@ export default pluginManager => {
             } catch (err1) {
               // ignore
             }
-            if (self.hasDrawerWidget(ref)) {
+            if (self.hasDrawerWidget(node)) {
               // If a configuration editor drawer widget has the track config
               // open, close the drawer widget
               const type = 'configuration editor drawer widget(s)'
-              callbacksToDereferenceTrack.push(() => self.hideDrawerWidget(ref))
+              callbacksToDereferenceTrack.push(() =>
+                self.hideDrawerWidget(node),
+              )
               dereferenced = true
               if (!dereferenceTypeCount[type]) dereferenceTypeCount[type] = 0
               dereferenceTypeCount[type] += 1
@@ -264,7 +266,7 @@ export default pluginManager => {
             if (!dereferenced)
               throw new Error(
                 `Error when closing this connection, the following node is still referring to a track configuration: ${JSON.stringify(
-                  getSnapshot(ref),
+                  getSnapshot(node),
                 )}`,
               )
           })

--- a/packages/jbrowse-web/src/declare.d.ts
+++ b/packages/jbrowse-web/src/declare.d.ts
@@ -1,2 +1,3 @@
 declare module '@gmod/jbrowse-core/configuration'
 declare module '@gmod/jbrowse-core/configuration/configurationSchema'
+declare module '@gmod/jbrowse-core/util/tracks'


### PR DESCRIPTION
When closing a connection, if any of its tracks are open in a view or a configuration editor drawer widget, it opens a prompt making sure you want to close before closing.

![image](https://user-images.githubusercontent.com/25592344/69564663-a78cd580-0f70-11ea-8233-26fc5b5f84d7.png)

fixes #653