### PR TITLE
Make paste shortcut on Mac work in desktop

### DIFF
--- a/packages/jbrowse-desktop/public/electron.js
+++ b/packages/jbrowse-desktop/public/electron.js
@@ -58,7 +58,104 @@ function createWindow() {
     event.preventDefault()
     shell.openExternal(outboundUrl)
   })
-  Menu.setApplicationMenu(null)
+
+  const isMac = process.platform === 'darwin'
+
+  const template = [
+    // { role: 'appMenu' }
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideothers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' },
+            ],
+          },
+        ]
+      : []),
+    // { role: 'fileMenu' }
+    {
+      label: 'File',
+      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
+    },
+    // { role: 'editMenu' }
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...(isMac
+          ? [
+              { role: 'pasteAndMatchStyle' },
+              { role: 'delete' },
+              { role: 'selectAll' },
+              { type: 'separator' },
+              {
+                label: 'Speech',
+                submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+              },
+            ]
+          : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
+      ],
+    },
+    // { role: 'viewMenu' }
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        { role: 'resetzoom' },
+        { role: 'zoomin' },
+        { role: 'zoomout' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    // { role: 'windowMenu' }
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac
+          ? [
+              { type: 'separator' },
+              { role: 'front' },
+              { type: 'separator' },
+              { role: 'window' },
+            ]
+          : [{ role: 'close' }]),
+      ],
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: async () => {
+            await electron.shell.openExternal('https://jbrowse.org')
+          },
+        },
+      ],
+    },
+  ]
+  const mainMenu = Menu.buildFromTemplate(template)
+
+  isMac ? Menu.setApplicationMenu(mainMenu) : Menu.setApplicationMenu(null)
   // if (isDev) {
   // Open the DevTools.
   // BrowserWindow.addDevToolsExtension('<location to your react chrome extension>');


### PR DESCRIPTION
Mac requires an app menu to be registered for any of the normal copy paste shortcuts

Therfore, we are just going to create the app menu on mac, on other platforms we'll leave it null because on linux and windows @garrettjstevens confirmed paste works fine