### PR TITLE
JBrowse 1 Connection updates

### DIFF
--- a/packages/core/BaseConnectionModel.js
+++ b/packages/core/BaseConnectionModel.js
@@ -5,9 +5,6 @@ export default pluginManager => {
     .model('Connection', {
       name: types.identifier,
       tracks: types.array(pluginManager.pluggableConfigSchemaType('track')),
-      sequence:
-        pluginManager.elementTypes.track.ReferenceSequenceTrack.configSchema,
-      defaultSequence: false,
     })
     .views(self => ({
       get assemblyConf() {
@@ -29,13 +26,6 @@ export default pluginManager => {
       setTrackConfs(trackConfs) {
         self.tracks = trackConfs
         return self.track
-      },
-      setSequence(sequenceConf) {
-        self.sequence = sequenceConf
-        return self.sequence
-      },
-      setDefaultSequence(isDefault) {
-        self.defaultSequence = isDefault
       },
       clear() {},
     }))

--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -1,6 +1,5 @@
 import jsonStableStringify from 'json-stable-stringify'
 import { observable, toJS } from 'mobx'
-import { getParent } from 'mobx-state-tree'
 import { readConfObject } from './configuration'
 
 export default self => ({
@@ -42,43 +41,6 @@ export default self => ({
             ...assemblyInfo,
             aliases: newAliases,
           })
-        })
-      }
-      for (const assemblyName of getParent(self).session.connections.keys()) {
-        const connectionConfs = getParent(self).session.connections.get(
-          assemblyName,
-        )
-        connectionConfs.forEach(connectionConf => {
-          if (!assemblyData.has(assemblyName)) {
-            const assemblyInfo = {}
-            assemblyInfo.sequence = connectionConf.sequence
-            assemblyInfo.refNameAliases = connectionConf.refNameAliases
-            assemblyData.set(assemblyName, assemblyInfo)
-          } else {
-            if (
-              !assemblyData.get(assemblyName).refNameAliases &&
-              connectionConf.refNameAliases
-            ) {
-              assemblyData.get(assemblyName).refNameAliases = readConfObject(
-                connectionConf.refNameAliases,
-              )
-              assemblyData.get(assemblyName).aliases.forEach(alias => {
-                assemblyData.get(alias).refNameAliases = readConfObject(
-                  connectionConf.refNameAliases,
-                )
-              })
-            }
-            if (
-              (!assemblyData.get(assemblyName).sequence &&
-                connectionConf.sequence) ||
-              connectionConf.defaultSequence
-            ) {
-              assemblyData.get(assemblyName).sequence = connectionConf.sequence
-              assemblyData.get(assemblyName).aliases.forEach(alias => {
-                assemblyData.get(alias).sequence = connectionConf.sequence
-              })
-            }
-          }
         })
       }
       return assemblyData

--- a/packages/core/util/tracks.js
+++ b/packages/core/util/tracks.js
@@ -23,17 +23,8 @@ export function getTrackAssemblyName(track) {
   let trackConfParent = trackConf
   do {
     trackConfParent = getParent(trackConfParent)
-  } while (
-    !(trackConfParent.assembly || 'defaultSequence' in trackConfParent) &&
-    !isRoot(trackConfParent)
-  )
+  } while (!trackConfParent.assembly && !isRoot(trackConfParent))
 
-  if ('defaultSequence' in trackConfParent) {
-    trackConfParent = trackConfParent.configuration
-    do {
-      trackConfParent = getParent(trackConfParent)
-    } while (!trackConfParent.assembly && !isRoot(trackConfParent))
-  }
   const assemblyName = readConfObject(trackConfParent, ['assembly', 'name'])
   return assemblyName
 }

--- a/packages/core/util/tracks.js
+++ b/packages/core/util/tracks.js
@@ -97,15 +97,15 @@ export function guessAdapter(fileName, protocol) {
       type: UNSUPPORTED,
     }
 
-  if (/\.gff3?\.gz$/i.test(fileName))
+  if (/\.gff3?\.b?gz$/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
-  if (/\.gff3?\.gz.tbi$/i.test(fileName))
+  if (/\.gff3?\.b?gz.tbi$/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
-  if (/\.gff3?\.gz.csi$/i.test(fileName))
+  if (/\.gff3?\.b?gz.csi$/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
@@ -120,19 +120,19 @@ export function guessAdapter(fileName, protocol) {
       type: UNSUPPORTED,
     }
 
-  if (/\.vcf\.gz$/i.test(fileName))
+  if (/\.vcf\.b?gz$/i.test(fileName))
     return {
       type: 'VcfTabixAdapter',
       vcfGzLocation: { [protocol]: fileName },
       index: { location: { [protocol]: `${fileName}.tbi` }, indexType: 'TBI' },
     }
-  if (/\.vcf\.gz\.tbi$/i.test(fileName))
+  if (/\.vcf\.b?gz\.tbi$/i.test(fileName))
     return {
       type: 'VcfTabixAdapter',
       vcfGzLocation: { [protocol]: fileName.replace(/\.tbi$/i, '') },
       index: { location: { [protocol]: fileName }, indexType: 'TBI' },
     }
-  if (/\.vcf\.gz\.csi$/i.test(fileName))
+  if (/\.vcf\.b?gz\.csi$/i.test(fileName))
     return {
       type: 'VcfTabixAdapter',
       vcfGzLocation: { [protocol]: fileName.replace(/\.csi$/i, '') },
@@ -149,15 +149,15 @@ export function guessAdapter(fileName, protocol) {
       type: UNSUPPORTED,
     }
 
-  if (/\.bed\.gz$/i.test(fileName))
+  if (/\.bed\.b?gz$/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
-  if (/\.bed.gz.tbi$/i.test(fileName))
+  if (/\.bed.b?gz.tbi$/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
-  if (/\.bed.gz.csi/i.test(fileName))
+  if (/\.bed.b?gz.csi/i.test(fileName))
     return {
       type: UNSUPPORTED,
     }
@@ -192,21 +192,21 @@ export function guessAdapter(fileName, protocol) {
       faiLocation: { [protocol]: fileName },
     }
 
-  if (/\.(fa|fasta|fna|mfa)\.gz$/i.test(fileName))
+  if (/\.(fa|fasta|fna|mfa)\.b?gz$/i.test(fileName))
     return {
       type: 'BgzipFastaAdapter',
       fastaLocation: { [protocol]: fileName },
       faiLocation: { [protocol]: `${fileName}.fai` },
       gziLocation: { [protocol]: `${fileName}.gzi` },
     }
-  if (/\.(fa|fasta|fna|mfa)\.gz\.fai$/i.test(fileName))
+  if (/\.(fa|fasta|fna|mfa)\.b?gz\.fai$/i.test(fileName))
     return {
       type: 'BgzipFastaAdapter',
       fastaLocation: { [protocol]: fileName.replace(/\.fai$/i, '') },
       faiLocation: { [protocol]: fileName },
       gziLocation: { [protocol]: `${fileName.replace(/\.fai$/i, '')}.gzi` },
     }
-  if (/\.(fa|fasta|fna|mfa)\.gz\.gzi$/i.test(fileName))
+  if (/\.(fa|fasta|fna|mfa)\.b?gz\.gzi$/i.test(fileName))
     return {
       type: 'BgzipFastaAdapter',
       fastaLocation: { [protocol]: fileName.replace(/\.gzi$/i, '') },

--- a/packages/core/util/tracks.js
+++ b/packages/core/util/tracks.js
@@ -21,10 +21,28 @@ export function getTrackAssemblyName(track) {
   // otherwise use the assembly from the dataset that it is part of
   const trackConf = track.configuration
   let trackConfParent = trackConf
+  let isConnectionTrack = false
+  // If it's a normal track, go up the tree until you find the assembly
+  // If it's a connection track, go up the tree until you find the connection
   do {
     trackConfParent = getParent(trackConfParent)
-  } while (!trackConfParent.assembly && !isRoot(trackConfParent))
+    isConnectionTrack = Boolean(
+      trackConfParent.configuration &&
+        trackConfParent.configuration.connectionId,
+    )
+  } while (
+    !(trackConfParent.assembly || isConnectionTrack) &&
+    !isRoot(trackConfParent)
+  )
 
+  // If a connection was found above, go up the tree from that connection's
+  // configuration until you find the assembly
+  if (isConnectionTrack) {
+    trackConfParent = trackConfParent.configuration
+    do {
+      trackConfParent = getParent(trackConfParent)
+    } while (!trackConfParent.assembly && !isRoot(trackConfParent))
+  }
   const assemblyName = readConfObject(trackConfParent, ['assembly', 'name'])
   return assemblyName
 }

--- a/packages/data-management/src/ucsc-trackhub/model.js
+++ b/packages/data-management/src/ucsc-trackhub/model.js
@@ -10,7 +10,6 @@ import {
   fetchHubFile,
   fetchTrackDbFile,
   generateTracks,
-  // ucscAssemblies,
 } from './ucscTrackHub'
 
 export default function(pluginManager) {
@@ -51,37 +50,6 @@ export default function(pluginManager) {
                   `Assembly "${assemblyName}" not in genomes file from connection "${connectionName}"`,
                 )
               // const twoBitPath = genomesFile.get(assemblyName).get('twoBitPath')
-              let sequence
-              // if (twoBitPath) {
-              //   let twoBitLocation
-              //   if (hubFileLocation.uri)
-              //     twoBitLocation = {
-              //       uri: new URL(
-              //         twoBitPath,
-              //         new URL(hubFile.get('genomesFile'), hubFileLocation.uri),
-              //       ).href,
-              //     }
-              //   else
-              //     twoBitLocation = {
-              //       localPath: twoBitPath,
-              //     }
-              //   sequence = {
-              //     type: 'ReferenceSequenceTrack',
-              //     adapter: {
-              //       type: 'TwoBitAdapter',
-              //       twoBitLocation,
-              //     },
-              //   }
-              // } else if (ucscAssemblies.includes(assemblyName))
-              //   sequence = {
-              //     type: 'ReferenceSequenceTrack',
-              //     adapter: {
-              //       type: 'TwoBitAdapter',
-              //       twoBitLocation: {
-              //         uri: `http://hgdownload.soe.ucsc.edu/goldenPath/${assemblyName}/bigZips/${assemblyName}.2bit`,
-              //       },
-              //     },
-              //   }
               let trackDbFileLocation
               if (hubFileLocation.uri)
                 trackDbFileLocation = {
@@ -97,12 +65,10 @@ export default function(pluginManager) {
               return Promise.all([
                 trackDbFileLocation,
                 fetchTrackDbFile(trackDbFileLocation),
-                sequence,
               ])
             })
-            .then(([trackDbFileLocation, trackDbFile, sequence]) => {
+            .then(([trackDbFileLocation, trackDbFile]) => {
               const tracks = generateTracks(trackDbFile, trackDbFileLocation)
-              self.setSequence(sequence)
               self.setTrackConfs(tracks)
             })
             .catch(error => {

--- a/packages/jbrowse1/src/JBrowse1Connection/index.d.ts
+++ b/packages/jbrowse1/src/JBrowse1Connection/index.d.ts
@@ -16,6 +16,12 @@ interface ProtoTrack {
   storeClass?: string
   type?: string
   urlTemplate?: string
+  baiUrlTemplate?: string
+  craiUrlTemplate?: string
+  tbiUrlTemplate?: string
+  csiUrlTemplate?: string
+  faiUrlTemplate?: string
+  gziUrlTemplate?: string
   useAsRefSeqStore?: boolean
 }
 

--- a/packages/jbrowse1/src/JBrowse1Connection/jb1ConfigParse.ts
+++ b/packages/jbrowse1/src/JBrowse1Connection/jb1ConfigParse.ts
@@ -284,17 +284,19 @@ function guessStoreClass(
   if (/\.cram$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/CRAM'
   if (/\.gff3?$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/GFF3'
   if (/\.bed$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/BED'
-  if (/\.vcf.gz$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/VCFTabix'
-  if (/\.gff3?.gz$/i.test(urlTemplate))
+  if (/\.vcf.b?gz$/i.test(urlTemplate))
+    return 'JBrowse/Store/SeqFeature/VCFTabix'
+  if (/\.gff3?.b?gz$/i.test(urlTemplate))
     return 'JBrowse/Store/SeqFeature/GFF3Tabix'
-  if (/\.bed.gz$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/BEDTabix'
+  if (/\.bed.b?gz$/i.test(urlTemplate))
+    return 'JBrowse/Store/SeqFeature/BEDTabix'
   if (/\.(bw|bigwig)$/i.test(urlTemplate))
     return 'JBrowse/Store/SeqFeature/BigWig'
   if (/\.(bb|bigbed)$/i.test(urlTemplate))
     return 'JBrowse/Store/SeqFeature/BigBed'
   if (/\.(fa|fasta)$/i.test(urlTemplate))
     return 'JBrowse/Store/SeqFeature/IndexedFasta'
-  if (/\.(fa|fasta)\.gz$/i.test(urlTemplate))
+  if (/\.(fa|fasta)\.b?gz$/i.test(urlTemplate))
     return 'JBrowse/Store/SeqFeature/BgzipIndexedFasta'
   if (/\.2bit$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/TwoBit'
   if (trackConfig.type && /\/Sequence$/.test(trackConfig.type))

--- a/packages/jbrowse1/src/JBrowse1Connection/jb1ToJb2.ts
+++ b/packages/jbrowse1/src/JBrowse1Connection/jb1ToJb2.ts
@@ -70,11 +70,17 @@ export function convertTrackConfig(
         jb1TrackConfig.storeClass &&
         jb1TrackConfig.storeClass.endsWith('FromConfig')
       )
-    )
-      throw new Error(
-        `JBrowse1 track "${jb1TrackConfig.key ||
-          jb1TrackConfig.label}" must have a "urlTemplate" or be a "FromConfig" track`,
+    ) {
+      const trackIdentifier = jb1TrackConfig.key || jb1TrackConfig.label
+      console.warn(
+        `Could not import JBrowse1 track "${trackIdentifier}" because it does not have a "urlTemplate" or is not a "FromConfig" track`,
       )
+      return generateUnsupportedTrackConf(
+        jb2TrackConfig.name,
+        trackIdentifier,
+        jb2TrackConfig.category,
+      )
+    }
     return generateFromConfigTrackConfig(jb1TrackConfig, jb2TrackConfig)
   }
 

--- a/packages/jbrowse1/src/JBrowse1Connection/model.js
+++ b/packages/jbrowse1/src/JBrowse1Connection/model.js
@@ -7,7 +7,7 @@ import { types } from 'mobx-state-tree'
 import configSchema from './configSchema'
 
 import { fetchJb1 } from './jb1ConfigLoad'
-import { convertTrackConfig, createRefSeqsAdapter } from './jb1ToJb2'
+import { convertTrackConfig } from './jb1ToJb2'
 
 export default function(pluginManager) {
   return types.compose(
@@ -25,18 +25,12 @@ export default function(pluginManager) {
             'dataDirLocation',
           )
           fetchJb1(dataDirLocation)
-            .then(config =>
-              createRefSeqsAdapter(config.refSeqs).then((/* adapter */) => {
-                const jb2Tracks = config.tracks.map(track =>
-                  convertTrackConfig(track, config.dataRoot),
-                )
-                // self.setSequence({
-                //   type: 'ReferenceSequenceTrack',
-                //   adapter,
-                // })
-                self.setTrackConfs(jb2Tracks)
-              }),
-            )
+            .then(config => {
+              const jb2Tracks = config.tracks.map(track =>
+                convertTrackConfig(track, config.dataRoot),
+              )
+              self.setTrackConfs(jb2Tracks)
+            })
             .catch(error => {
               console.error(error)
             })


### PR DESCRIPTION
This fixes a few things found while @keiranmraine has been testing connections with his JBrowse 1 configs

- Connections can no longer provide reference sequences for datasets. It was unused, complicated, and probably didn't actually work correctly. We'll add back in the ability to add assembly sequences from certain types of sources (like JBrowse 1) later as part of dataset management.
- If the JBrowse 1 track is recognized as valid, it just flags it as unsupported and moves on instead of erroring out
- JBrowse 1 store classes are used to guess the JBrowse 2 track and adapters, and if the store class isn't recognized it falls back to guessing based on the `urlTemplate` filename
- When falling back to `urlTemplate` filename, it now recognizes the `.bgz` file extension for block-gzipped files

I'll send a build based on this to Keiran