### PR TITLE
Fix horizontal flip in translocation

### DIFF
--- a/packages/breakpoint-split-view/src/components/AlignmentConnections.tsx
+++ b/packages/breakpoint-split-view/src/components/AlignmentConnections.tsx
@@ -69,10 +69,12 @@ export default (pluginManager: any) => {
 
               const x1 = getPxFromCoordinate(
                 views[level1],
+                f1.get('refName'),
                 c1[f1.get('strand') === -1 ? LEFT : RIGHT],
               )
               const x2 = getPxFromCoordinate(
                 views[level2],
+                f2.get('refName'),
                 c2[f2.get('strand') === -1 ? RIGHT : LEFT],
               )
 

--- a/packages/breakpoint-split-view/src/components/Breakends.tsx
+++ b/packages/breakpoint-split-view/src/components/Breakends.tsx
@@ -58,8 +58,16 @@ export default (pluginManager: any) => {
               )
               const relevantAlt = findMatchingAlt(f1, f2)
               if (!c1 || !c2) return null
-              const x1 = getPxFromCoordinate(views[level1], c1[LEFT])
-              const x2 = getPxFromCoordinate(views[level2], c2[LEFT])
+              const x1 = getPxFromCoordinate(
+                views[level1],
+                f1.get('refName'),
+                c1[LEFT],
+              )
+              const x2 = getPxFromCoordinate(
+                views[level2],
+                f2.get('refName'),
+                c2[LEFT],
+              )
 
               const tracks = views.map(v => v.getTrack(trackConfigId))
               const y1 = yPos(trackConfigId, level1, views, tracks, c1)

--- a/packages/breakpoint-split-view/src/components/Translocations.tsx
+++ b/packages/breakpoint-split-view/src/components/Translocations.tsx
@@ -67,13 +67,16 @@ export default (pluginManager: any) => {
               const end2 = info.END[0]
               const [myDirection, mateDirection] = info.STRANDS[0].split('')
 
-              const r = views[level2].bpToPx({ refName: chr2, coord: end2 })
+              const r = getPxFromCoordinate(views[level2], chr2, end2)
               if (r) {
-                const left = r.offsetPx - views[level2].offsetPx
-                const c2: LayoutRecord = [left, 0, left + 1, 0]
+                const c2: LayoutRecord = [r, 0, r + 1, 0]
 
-                const x1 = getPxFromCoordinate(views[level1], c1[LEFT])
-                const x2 = left
+                const x1 = getPxFromCoordinate(
+                  views[level1],
+                  f1.get('refName'),
+                  c1[LEFT],
+                )
+                const x2 = r
 
                 const tracks = views.map(v => v.getTrack(trackConfigId))
                 const y1 = yPos(trackConfigId, level1, views, tracks, c1)

--- a/packages/breakpoint-split-view/src/util.ts
+++ b/packages/breakpoint-split-view/src/util.ts
@@ -26,16 +26,12 @@ function heightFromSpecificLevel(
   )
 }
 
-// TODO: this is only working because the breakpoint
-// split view is displaying a single refseq on the top region
-// need to update to use a proper bpToPx which is in dev
 export function getPxFromCoordinate(
   view: Instance<LinearGenomeViewStateModel>,
+  refName: string,
   coord: number,
 ) {
-  const region = { start: 0, end: view.totalBp }
-  const { bpPerPx, horizontallyFlipped, offsetPx } = view
-  return bpToPx(coord, region, bpPerPx, horizontallyFlipped) - offsetPx
+  return ((view.bpToPx({ refName, coord }) || {}).offsetPx || 0) - view.offsetPx
 }
 
 // get's the yposition of a layout record in a track

--- a/packages/breakpoint-split-view/src/util.ts
+++ b/packages/breakpoint-split-view/src/util.ts
@@ -1,6 +1,6 @@
 import { Instance } from 'mobx-state-tree'
 import { LinearGenomeViewStateModel } from '@gmod/jbrowse-plugin-linear-genome-view/src/LinearGenomeView'
-import { clamp, bpToPx } from '@gmod/jbrowse-core/util'
+import { clamp } from '@gmod/jbrowse-core/util'
 import { LayoutRecord } from './model'
 
 const [, TOP, , BOTTOM] = [0, 1, 2, 3]


### PR DESCRIPTION
Fixes #773 

The synteny_demo branch worked a bit on the getPxFromCoordinate concept so this enhances the getPxFromCoordinate call for the breakpoint split view which takes into account horizontal flipping and has a further bugfix (see removed TODO comment in this PR) that is relevant to the code being scalable to there being multiple displayedRegions in a single row of the breakpoint split view (previously assumed just one displayedRegion in the split view)

