### PR TITLE
Don't throw error from offscreenCanvasPolyfill

### DIFF
--- a/packages/core/util/offscreenCanvasPonyfill.js
+++ b/packages/core/util/offscreenCanvasPonyfill.js
@@ -59,8 +59,4 @@ if (isElectron) {
     })
   }
   ImageBitmapType = Image
-} else {
-  throw new Error(
-    'no ponyfill available for OffscreenCanvas in this environment',
-  )
 }


### PR DESCRIPTION
This gets rid of the concept of throwing an error from offscreenCanvasPolyfill as this fatally errors out browsers instead of allowing us to give our unsupported message