### PR TITLE
Show snackbar when connection fails to connect

### DIFF
--- a/packages/data-management/src/AddConnectionDrawerWidget/components/AddConnectionDrawerWidget.js
+++ b/packages/data-management/src/AddConnectionDrawerWidget/components/AddConnectionDrawerWidget.js
@@ -93,7 +93,8 @@ function AddConnectionDrawerWidget({ model }) {
   }
 
   function handleFinish() {
-    session.addConnectionConf(configModel)
+    const connectionConf = session.addConnectionConf(configModel)
+    session.makeConnection(connectionConf)
     session.hideDrawerWidget(model)
   }
 

--- a/packages/data-management/src/AddConnectionDrawerWidget/components/AddConnectionDrawerWidget.test.js
+++ b/packages/data-management/src/AddConnectionDrawerWidget/components/AddConnectionDrawerWidget.test.js
@@ -62,7 +62,7 @@ email genome@test.com
 descriptionUrl test.html
 `
       else if (urlText.endsWith('genomes.txt'))
-        responseText = `genome testAssembly
+        responseText = `genome volMyt1
 trackDb hg19/trackDb.txt
 `
       else if (urlText.endsWith('trackDb.txt'))

--- a/packages/data-management/src/ucsc-trackhub/model.js
+++ b/packages/data-management/src/ucsc-trackhub/model.js
@@ -87,7 +87,7 @@ export default function(pluginManager) {
             .catch(error => {
               console.error(error)
               session.setSnackbarMessage(
-                `There was a problem connecting to this UCSC Track Hub. Please make sure you have entered a valid hub.txt file. The error that was thrown is: "${error}"`,
+                `There was a problem connecting to the UCSC Track Hub "${self.name}". Please make sure you have entered a valid hub.txt file. The error that was thrown is: "${error}"`,
               )
               session.breakConnection(self.configuration)
             })

--- a/packages/data-management/src/ucsc-trackhub/model.js
+++ b/packages/data-management/src/ucsc-trackhub/model.js
@@ -3,6 +3,7 @@ import {
   ConfigurationReference,
   readConfObject,
 } from '@gmod/jbrowse-core/configuration'
+import { getSession } from '@gmod/jbrowse-core/util'
 import { types } from 'mobx-state-tree'
 import configSchema from './configSchema'
 import {
@@ -28,6 +29,7 @@ export default function(pluginManager) {
             self.configuration,
             'hubTxtLocation',
           )
+          const session = getSession(self)
           fetchHubFile(hubFileLocation)
             .then(hubFile => {
               let genomesFileLocation
@@ -84,6 +86,10 @@ export default function(pluginManager) {
             })
             .catch(error => {
               console.error(error)
+              session.setSnackbarMessage(
+                `There was a problem connecting to this UCSC Track Hub. Please make sure you have entered a valid hub.txt file. The error that was thrown is: "${error}"`,
+              )
+              session.breakConnection(self.configuration)
             })
         },
       })),

--- a/packages/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/packages/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -7,8 +7,12 @@ import ucscAssemblies from './ucscAssemblies'
 export { ucscAssemblies }
 
 export async function fetchHubFile(hubFileLocation) {
-  const hubFileText = await openLocation(hubFileLocation).readFile('utf8')
-  return new HubFile(hubFileText)
+  try {
+    const hubFileText = await openLocation(hubFileLocation).readFile('utf8')
+    return new HubFile(hubFileText)
+  } catch (error) {
+    throw new Error(`Not a valid hub.txt file, got error: '${error}'`)
+  }
 }
 
 export async function fetchGenomesFile(genomesFileLocation) {

--- a/packages/jbrowse-web/src/sessionModelFactory.ts
+++ b/packages/jbrowse-web/src/sessionModelFactory.ts
@@ -314,11 +314,7 @@ export default function sessionModelFactory(pluginManager: any) {
 
       breakConnection(configuration: any) {
         const name = readConfObject(configuration, 'name')
-        let confParent = configuration
-        do {
-          confParent = getParent(confParent)
-        } while (!confParent.assembly)
-        const assemblyName = readConfObject(confParent.assembly, 'name')
+        const assemblyName = readConfObject(configuration, 'assemblyName')
         const connectionInstances = self.connectionInstances.get(assemblyName)
         if (!connectionInstances)
           throw new Error(`connections for ${assemblyName} not found`)

--- a/packages/jbrowse1/src/JBrowse1Connection/model.js
+++ b/packages/jbrowse1/src/JBrowse1Connection/model.js
@@ -42,7 +42,7 @@ export default function(pluginManager) {
             .catch(error => {
               console.error(error)
               session.setSnackbarMessage(
-                `There was a problem connecting to this JBrowse 1 data directory. Please make sure you have entered a valid location. The error that was thrown is: "${error}"`,
+                `There was a problem connecting to the JBrowse 1 data directory "${self.name}. Please make sure you have entered a valid location. The error that was thrown is: "${error}"`,
               )
               session.breakConnection(self.configuration)
             })

--- a/packages/jbrowse1/src/JBrowse1Connection/model.js
+++ b/packages/jbrowse1/src/JBrowse1Connection/model.js
@@ -2,6 +2,7 @@ import {
   ConfigurationReference,
   readConfObject,
 } from '@gmod/jbrowse-core/configuration'
+import { getSession } from '@gmod/jbrowse-core/util'
 import connectionModelFactory from '@gmod/jbrowse-core/BaseConnectionModel'
 import { types } from 'mobx-state-tree'
 import configSchema from './configSchema'
@@ -24,6 +25,7 @@ export default function(pluginManager) {
             self.configuration,
             'dataDirLocation',
           )
+          const session = getSession(self)
           fetchJb1(dataDirLocation)
             .then(config => {
               const assemblyName = readConfObject(
@@ -39,6 +41,10 @@ export default function(pluginManager) {
             })
             .catch(error => {
               console.error(error)
+              session.setSnackbarMessage(
+                `There was a problem connecting to this JBrowse 1 data directory. Please make sure you have entered a valid location. The error that was thrown is: "${error}"`,
+              )
+              session.breakConnection(self.configuration)
             })
         },
       })),


### PR DESCRIPTION
This is from a pairing between @peterkxie and me today.

When a UCSC hub or JBrowse 1 connection fails to connect, it shows a snackbar message and turns the connection off. It also tries to connect as soon as the connection is added, mirroring the behavior of when you add a track.

fixes #805 