### PR TITLE
Deep sequencing data examples

### DIFF
--- a/packages/alignments/src/CramAdapter/CramAdapter.ts
+++ b/packages/alignments/src/CramAdapter/CramAdapter.ts
@@ -53,7 +53,7 @@ export default class CramAdapter extends BaseAdapter {
       index: new CraiIndex({ filehandle: openLocation(craiLocation) }),
       seqFetch: this.seqFetch.bind(this),
       checkSequenceMD5: false,
-      fetchSizeLimit: config.fetchSizeLimit || 60000000,
+      fetchSizeLimit: config.fetchSizeLimit || 600000000,
     })
     this.sequenceAdapter = sequenceAdapter
   }

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -182,6 +182,51 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "nanopore_targetted_alignments_0.1",
+      "name": "Nanopore amplicon alignments 0.1x (chr7:55,000,000-56,000,000)",
+      "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
+      "assemblyNames": [
+        "hg38"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.0.1.cram"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.0.1.cram.crai"
+        }
+      }
+    },
+    {
+      "type": "SNPCoverageTrack",
+      "trackId": "nanopore_targetted_snpcoverage",
+      "name": "Nanopore amplicon SNPCoverage (chr7:55,000,000-56,000,000)",
+      "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
+      "assemblyNames": [
+        "hg38"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "SNPCoverageAdapter",
+        "subadapter": {
+          "type": "CramAdapter",
+          "cramLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.0.1.cram"
+          },
+          "craiLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.0.1.cram.crai"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "nanopore_targetted_alignments",
       "name": "Nanopore amplicon alignments (chr7:55,000,000-56,000,000)",
       "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -272,6 +272,53 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "deep_hg19_bam",
+      "name": "Deep sequence chr17:41195312..41276764 (SNPCoverage)",
+      "assemblyNames": [
+        "hg19"
+      ],
+      "category": [
+        "Coverage"
+      ],
+      "adapter": {
+        "type": "BamAdapter",
+        "bamLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/out.markdup.bam"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/out.markdup.bam.bai"
+          }
+        }
+      }
+    },
+    {
+      "type": "SNPCoverageTrack",
+      "trackId": "deep_hg19_bam_snpcoverage",
+      "name": "Deep sequence chr17:41195312..41276764 (SNPCoverage)",
+      "assemblyNames": [
+        "hg19"
+      ],
+      "category": [
+        "Coverage"
+      ],
+      "adapter": {
+        "type": "SNPCoverageAdapter",
+        "subadapter": {
+          "type": "BamAdapter",
+          "bamLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/out.markdup.bam"
+          },
+          "index": {
+            "location": {
+              "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/out.markdup.bam.bai"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "amplicon_alignments",
       "name": "Amplicon alignments (chr3:178,916,000-178,918,000)",
       "description": "Source https://github.com/umich-brcf-bioinf/Connor/tree/master/examples",

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -78,7 +78,7 @@
         "hg38"
       ],
       "category": [
-        "Miscellaneous"
+        "Annotation"
       ],
       "adapter": {
         "type": "NCListAdapter",
@@ -189,7 +189,7 @@
         "hg38"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "CramAdapter",
@@ -210,7 +210,7 @@
         "hg38"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",
@@ -228,13 +228,13 @@
     {
       "type": "AlignmentsTrack",
       "trackId": "nanopore_targetted_alignments",
-      "name": "Nanopore amplicon alignments (chr7:55,000,000-56,000,000)",
+      "name": "Nanopore amplicon (chr7:55,000,000-56,000,000) [causes out-of-memory]",
       "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
       "assemblyNames": [
         "hg38"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "CramAdapter",
@@ -249,13 +249,13 @@
     {
       "type": "SNPCoverageTrack",
       "trackId": "nanopore_targetted_snpcoverage",
-      "name": "Nanopore amplicon SNPCoverage (chr7:55,000,000-56,000,000)",
+      "name": "Nanopore amplicon SNPCoverage (chr7:55,000,000-56,000,000) [causes out-of-memory]",
       "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
       "assemblyNames": [
         "hg38"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",
@@ -273,12 +273,12 @@
     {
       "type": "AlignmentsTrack",
       "trackId": "deep_hg19_bam",
-      "name": "Deep sequence chr17:41195312..41276764 (SNPCoverage)",
+      "name": "Deep sequence chr17:41195312..41276764",
       "assemblyNames": [
         "hg19"
       ],
       "category": [
-        "Coverage"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "BamAdapter",
@@ -300,7 +300,7 @@
         "hg19"
       ],
       "category": [
-        "Coverage"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",
@@ -326,7 +326,7 @@
         "hg19"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "BamAdapter",
@@ -349,7 +349,7 @@
         "hg19"
       ],
       "category": [
-        "Amplicon sequencing"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",
@@ -2077,28 +2077,6 @@
       }
     },
     {
-      "type": "AlignmentsTrack",
-      "trackId": "deep_hg19_bam",
-      "name": "Deep hg19 BAM (bam)",
-      "assemblyNames": [
-        "hg19"
-      ],
-      "category": [
-        "Coverage"
-      ],
-      "adapter": {
-        "type": "BamAdapter",
-        "bamLocation": {
-          "uri": "https://idea-cdn.s3.eu-west-2.amazonaws.com/out.marked.bam"
-        },
-        "index": {
-          "location": {
-            "uri": "https://idea-cdn.s3.eu-west-2.amazonaws.com/out.marked.bam.bai"
-          }
-        }
-      }
-    },
-    {
       "type": "SNPCoverageTrack",
       "trackId": "volvox-short-reads-snp-bam",
       "name": "volvox-SNP (bam)",
@@ -2106,7 +2084,7 @@
         "volvox"
       ],
       "category": [
-        "Coverage"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",
@@ -2131,7 +2109,7 @@
         "volvox"
       ],
       "category": [
-        "Coverage"
+        "Deep coverage"
       ],
       "adapter": {
         "type": "SNPCoverageAdapter",

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -203,8 +203,8 @@
     },
     {
       "type": "SNPCoverageTrack",
-      "trackId": "nanopore_targetted_snpcoverage",
-      "name": "Nanopore amplicon SNPCoverage (chr7:55,000,000-56,000,000)",
+      "trackId": "nanopore_targetted_snpcoverage_0.1",
+      "name": "Nanopore amplicon SNPCoverage 0.1x (chr7:55,000,000-56,000,000)",
       "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
       "assemblyNames": [
         "hg38"

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -182,6 +182,51 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "nanopore_targetted_alignments",
+      "name": "Nanopore amplicon alignments (chr7:55,000,000-56,000,000)",
+      "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
+      "assemblyNames": [
+        "hg38"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.cram"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.cram.crai"
+        }
+      }
+    },
+    {
+      "type": "SNPCoverageTrack",
+      "trackId": "nanopore_targetted_snpcoverage",
+      "name": "Nanopore amplicon SNPCoverage (chr7:55,000,000-56,000,000)",
+      "description": "Source http://bioinformatics.uni-muenster.de/share/NanoPipe_test_data/?lang=en",
+      "assemblyNames": [
+        "hg38"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "SNPCoverageAdapter",
+        "subadapter": {
+          "type": "CramAdapter",
+          "cramLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.cram"
+          },
+          "craiLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/nanopore_egfr.cram.crai"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "amplicon_alignments",
       "name": "Amplicon alignments (chr3:178,916,000-178,918,000)",
       "description": "Source https://github.com/umich-brcf-bioinf/Connor/tree/master/examples",

--- a/test_data/config_in_dev.json
+++ b/test_data/config_in_dev.json
@@ -182,6 +182,55 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "amplicon_alignments",
+      "name": "Amplicon alignments (chr3:178,916,000-178,918,000)",
+      "description": "Source https://github.com/umich-brcf-bioinf/Connor/tree/master/examples",
+      "assemblyNames": [
+        "hg19"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "BamAdapter",
+        "bamLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/sample1-original.bam"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/sample1-original.bam.bai"
+          }
+        }
+      }
+    },
+    {
+      "type": "SNPCoverageTrack",
+      "trackId": "amplicon_snpcoverage",
+      "name": "Amplicon SNPCoverage (chr3:178,916,000-178,918,000)",
+      "description": "Source https://github.com/umich-brcf-bioinf/Connor/tree/master/examples",
+      "assemblyNames": [
+        "hg19"
+      ],
+      "category": [
+        "Amplicon sequencing"
+      ],
+      "adapter": {
+        "type": "SNPCoverageAdapter",
+        "subadapter": {
+          "type": "BamAdapter",
+          "bamLocation": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/sample1-original.bam"
+          },
+          "index": {
+            "location": {
+              "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/amplicon_deep_seq/sample1-original.bam.bai"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "ngmlr",
       "name": "SKBR3 pacbio (NGMLR)",
       "assemblyNames": [


### PR DESCRIPTION
This contains some deep sequencing data, also called amplicons or targetted sequencing (not sure if the terms are all interchangeable but main thing we see is high coverage of specific areas). The illumina file is only 13MB and has 12,000x sequence depth and works pretty good I think

Then I also found nanopore data and it is a 400MB BAM, 200+MB CRAM and it ends up crashing with out of memory with both