### PR TITLE
Check for assemblyConfig existing to avoid assembly name being undefined

### DIFF
--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -90,9 +90,10 @@ export default self => ({
      */
     async addRefNameMapForAdapter(adapterConf, assemblyName, opts = {}) {
       const assemblyConfig = self.assemblyData.get(assemblyName)
-      const sequenceConfig = assemblyConfig.sequence
-        ? getSnapshot(assemblyConfig.sequence.adapter)
-        : {}
+      let sequenceConfig = {}
+      if (assemblyConfig && assemblyConfig.sequence) {
+        sequenceConfig = getSnapshot(assemblyConfig.sequence.adapter)
+      }
       const refNameAliases = await self.getRefNameAliases(assemblyName, opts)
       const adapterConfigId = jsonStableStringify(adapterConf)
       const refNameMap = observable.map({})


### PR DESCRIPTION
This is a fix that patches the #826 bug

This is probably a good fix to put in place, and we could streamline it into master

Additional efforts could include

(a) wire a proper assemblyName to this code from SV inspector
(b) create an integration test for SV inspector
