### PR TITLE
Keep static and dynamic blocks in sync

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -64,7 +64,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": true,
       "key": "ctgB:101-200",
-      "offsetPx": 100,
+      "offsetPx": 102,
       "parentRegion": Object {
         "end": 200,
         "refName": "ctgB",
@@ -142,7 +142,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgB:1-800",
-      "offsetPx": 200,
+      "offsetPx": 202,
       "parentRegion": Object {
         "end": 1000,
         "refName": "ctgB",
@@ -165,7 +165,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgB:1-800",
-      "offsetPx": 200,
+      "offsetPx": 202,
       "parentRegion": Object {
         "end": 1000,
         "refName": "ctgB",
@@ -181,7 +181,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": true,
       "key": "ctgB:801-1000",
-      "offsetPx": 1000,
+      "offsetPx": 1002,
       "parentRegion": Object {
         "end": 1000,
         "refName": "ctgB",
@@ -204,7 +204,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgB:801-1600",
-      "offsetPx": 1000,
+      "offsetPx": 1002,
       "parentRegion": Object {
         "end": 10000000,
         "refName": "ctgB",
@@ -220,7 +220,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgB:1601-2400",
-      "offsetPx": 1800,
+      "offsetPx": 1802,
       "parentRegion": Object {
         "end": 10000000,
         "refName": "ctgB",
@@ -336,7 +336,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgA:9201-10000-reversed",
-      "offsetPx": 1,
+      "offsetPx": 3,
       "parentRegion": Object {
         "end": 10000,
         "refName": "ctgA",
@@ -352,7 +352,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "ctgA:8401-9200-reversed",
-      "offsetPx": 801,
+      "offsetPx": 803,
       "parentRegion": Object {
         "end": 10000,
         "refName": "ctgA",
@@ -391,7 +391,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": true,
       "key": "ctgA:501-600-reversed",
-      "offsetPx": 100,
+      "offsetPx": 102,
       "parentRegion": Object {
         "end": 600,
         "refName": "ctgA",

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.ts
@@ -47,6 +47,7 @@ export default function calculateDynamicBlocks(
   for (let i = 0; i < displayedRegionsInOrder.length; i += 1) {
     const parentRegion = displayedRegionsInOrder[i]
     const { assemblyName, start, end, refName } = parentRegion
+    const parentRegionWidthPx = (end - start) / bpPerPx
     const displayedRegionRightPx =
       displayedRegionLeftPx + (end - start) / bpPerPx
     if (
@@ -93,14 +94,14 @@ export default function calculateDynamicBlocks(
         key: '',
       }
       blockData.key = assembleLocString(blockData)
-      if (widthPx < minimumBlockWidth) {
+      if (parentRegionWidthPx < minimumBlockWidth) {
         blocks.push(new ElidedBlock(blockData))
       } else {
         blocks.push(new ContentBlock(blockData))
       }
       // insert a inter-region padding block if we are crossing a displayed region
       if (
-        widthPx >= minimumBlockWidth &&
+        parentRegionWidthPx >= minimumBlockWidth &&
         blockData.isRightEndOfDisplayedRegion &&
         i < displayedRegionsInOrder.length - 1
       ) {

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateDynamicBlocks.ts
@@ -111,9 +111,9 @@ export default function calculateDynamicBlocks(
             offsetPx: blockData.offsetPx + blockData.widthPx,
           }),
         )
-        displayedRegionLeftPx += interRegionPaddingWidth
       }
     }
+    displayedRegionLeftPx += interRegionPaddingWidth
     displayedRegionLeftPx += (end - start) / bpPerPx
   }
   return blocks

--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.ts
@@ -122,10 +122,10 @@ export function calculateBlocksForward(self: LGV, extra = 0) {
             offsetPx: blockData.offsetPx + blockData.widthPx,
           }),
         )
-        regionBpOffset += interRegionPaddingWidth * bpPerPx
       }
     }
 
+    regionBpOffset += interRegionPaddingWidth * bpPerPx
     regionBpOffset += region.end - region.start
   })
 


### PR DESCRIPTION
Fixes #839 

Dynamic blocks were missing InterRegionPaddingBlocks, but just adding those didn't fix it completely: 
![image](https://user-images.githubusercontent.com/25592344/75466519-8eb50700-5947-11ea-8cbf-8c8646146ec9.png)

The only way to keep everything in sync was to have both block types allocate space in the offset for all potential padding blocks, whether or not they were in the returned block set.

Also includes a bug fix where a dynamic block got elided when it was scrolled to be almost off screen. 
![image](https://user-images.githubusercontent.com/25592344/75466778-ed7a8080-5947-11ea-9322-3b3a97ff6cb2.png)

