### PR TITLE
Use viewingRegionWidth instead of width for calculations

### DIFF
--- a/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/calculateStaticBlocks.ts
@@ -49,7 +49,7 @@ export function calculateBlocksForward(self: LGV, extra = 0) {
   const {
     offsetPx,
     bpPerPx,
-    width,
+    viewingRegionWidth: width,
     displayedRegionsInOrder,
     minimumBlockWidth,
   } = self

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -483,7 +483,7 @@ export function stateModelFactory(pluginManager: any) {
           }
         }
         self.bpPerPx = clamp(
-          bpSoFar / self.width,
+          bpSoFar / self.viewingRegionWidth,
           self.minBpPerPx,
           self.maxBpPerPx,
         )


### PR DESCRIPTION
Fixes #833 
The change to the moveTo function is the most important one