### PR TITLE
Refnamemap cache

### DIFF
--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -6,7 +6,7 @@ import QuickLRU from './util/QuickLRU'
 import { readConfObject } from './configuration'
 
 export default self => {
-  const cache = new AbortablePromiseCache({
+  const refNameMapCache = new AbortablePromiseCache({
     // QuickLRU is a good backing cache to use, but you can use any
     // cache as long as it supports `get`, `set`, `delete`, and `keys`.
     cache: new QuickLRU({ maxSize: 1000 }),
@@ -194,13 +194,9 @@ export default self => {
       /**
        * get Map of canonical-name -> adapter-specific-name
        */
-      async getRefNameMapForAdapter(
-        adapterConf,
-        assemblyName,
-        opts = {},
-      ) {
+      async getRefNameMapForAdapter(adapterConf, assemblyName, opts = {}) {
         const adapterConfigId = jsonStableStringify(adapterConf)
-        return cache.get(
+        return refNameMapCache.get(
           adapterConfigId,
           {
             adapterConf,
@@ -214,13 +210,13 @@ export default self => {
        * get Map of adapter-specific-name -> canonical-name
        */
       async getReverseRefNameMapForAdapter(adapterConf, assemblyName, opts) {
-        const refNameMap = await self.getRefNameMapForAdapter(
+        const map = await self.getRefNameMapForAdapter(
           adapterConf,
           assemblyName,
           opts,
         )
         const reversed = new Map()
-        for (const [canonicalName, adapterName] of refNameMap) {
+        for (const [canonicalName, adapterName] of map) {
           reversed.set(adapterName, canonicalName)
         }
         return reversed

--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -1,105 +1,32 @@
 import jsonStableStringify from 'json-stable-stringify'
 import { observable, toJS } from 'mobx'
 import { getSnapshot } from 'mobx-state-tree'
+import AbortablePromiseCache from 'abortable-promise-cache'
+import QuickLRU from './util/QuickLRU'
 import { readConfObject } from './configuration'
 
-export default self => ({
-  views: {
-    get assemblyData() {
-      const assemblyData = observable.map({})
-      for (const assemblyConfig of self.assemblies) {
-        const assemblyName = readConfObject(assemblyConfig, 'name')
-        const assemblyInfo = {}
-        if (assemblyConfig.sequence) {
-          assemblyInfo.sequence = assemblyConfig.sequence
-        }
-        const refNameAliasesConf = readConfObject(
-          assemblyConfig,
-          'refNameAliases',
-        )
-        if (refNameAliasesConf) {
-          assemblyInfo.refNameAliases = refNameAliasesConf
-        }
-        const aliases = readConfObject(assemblyConfig, 'aliases')
-        assemblyInfo.aliases = aliases
-        assemblyData.set(assemblyName, assemblyInfo)
-        aliases.forEach((assemblyAlias, idx) => {
-          const newAliases = [
-            ...aliases.slice(0, idx),
-            ...aliases.slice(idx + 1),
-            assemblyName,
-          ]
-          assemblyData.set(assemblyAlias, {
-            ...assemblyInfo,
-            aliases: newAliases,
-          })
-        })
-      }
-      return assemblyData
-    },
-  },
-  actions: {
-    async getCanonicalRefName(refName, assemblyName) {
-      const aliasesToCanonical = await self.getRefNameCanonicalizationMap(
-        assemblyName,
-      )
-      return aliasesToCanonical.get(refName)
-    },
+export default self => {
+  const cache = new AbortablePromiseCache({
+    // QuickLRU is a good backing cache to use, but you can use any
+    // cache as long as it supports `get`, `set`, `delete`, and `keys`.
+    cache: new QuickLRU({ maxSize: 1000 }),
 
-    // returns Map of alias-or-canonical -> canonical
-    async getRefNameCanonicalizationMap(assemblyName, opts = {}) {
-      const refNameAliases = await self.getRefNameAliases(assemblyName, opts)
-      const aliasesToCanonical = new Map()
-      Object.entries(refNameAliases).forEach(([ref, aliases]) => {
-        aliases.forEach(alias => {
-          aliasesToCanonical.set(alias, ref)
-        })
-        aliasesToCanonical.set(ref, ref)
-      })
-      return aliasesToCanonical
-    },
-
-    async getRefNameAliases(assemblyName, opts = {}) {
-      const refNameAliases = {}
-      const assemblyConfig = self.assemblyData.get(assemblyName)
-      if (assemblyConfig && assemblyConfig.refNameAliases) {
-        const adapterConfigId = jsonStableStringify(
-          toJS(assemblyConfig.refNameAliases.adapter),
-        )
-        const adapterRefNameAliases = await self.rpcManager.call(
-          adapterConfigId,
-          'getRefNameAliases',
-          {
-            sessionId: assemblyName,
-            adapterType: assemblyConfig.refNameAliases.adapter.type,
-            adapterConfig: assemblyConfig.refNameAliases.adapter,
-            signal: opts.signal,
-          },
-          { timeout: 1000000 },
-        )
-        adapterRefNameAliases.forEach(alias => {
-          refNameAliases[alias.refName] = alias.aliases
-        })
-      }
-      return refNameAliases
-    },
-
-    /**
-     * gets the list of reference sequence names from the adapter in question, and
-     * uses those to build a Map of adapter_ref_name -> canonical_ref_name
-     */
-    async addRefNameMapForAdapter(adapterConf, assemblyName, opts = {}) {
+    // the `fill` callback will be called for a cache miss
+    async fill({ adapterConf, assemblyName }, signal) {
       const assemblyConfig = self.assemblyData.get(assemblyName)
       let sequenceConfig = {}
       if (assemblyConfig && assemblyConfig.sequence) {
         sequenceConfig = getSnapshot(assemblyConfig.sequence.adapter)
       }
-      const refNameAliases = await self.getRefNameAliases(assemblyName, opts)
+      const refNameAliases = await self.getRefNameAliases(assemblyName, {
+        signal,
+      })
       const adapterConfigId = jsonStableStringify(adapterConf)
       const refNameMap = observable.map({})
+      const stateGroupName = jsonStableStringify(adapterConf)
 
       const refNames = await self.rpcManager.call(
-        adapterConfigId,
+        stateGroupName,
         'getRefNames',
         {
           sessionId: assemblyName,
@@ -107,7 +34,7 @@ export default self => ({
           adapterConfig: adapterConf,
           sequenceAdapterType: sequenceConfig.type,
           sequenceAdapterConfig: sequenceConfig,
-          signal: opts.signal,
+          signal,
         },
         { timeout: 1000000 },
       )
@@ -130,32 +57,174 @@ export default self => ({
       self.refNameMaps.set(adapterConfigId, refNameMap)
       return refNameMap
     },
-
-    /**
-     * get Map of canonical-name -> adapter-specific-name
-     */
-    async getRefNameMapForAdapter(adapterConf, assemblyName, opts = {}) {
-      const adapterConfigId = jsonStableStringify(adapterConf)
-      if (!self.refNameMaps.has(adapterConfigId)) {
-        return self.addRefNameMapForAdapter(adapterConf, assemblyName, opts)
-      }
-      return self.refNameMaps.get(adapterConfigId)
+  })
+  return {
+    views: {
+      get assemblyData() {
+        const assemblyData = observable.map({})
+        for (const assemblyConfig of self.assemblies) {
+          const assemblyName = readConfObject(assemblyConfig, 'name')
+          const assemblyInfo = {}
+          if (assemblyConfig.sequence) {
+            assemblyInfo.sequence = assemblyConfig.sequence
+          }
+          const refNameAliasesConf = readConfObject(
+            assemblyConfig,
+            'refNameAliases',
+          )
+          if (refNameAliasesConf) {
+            assemblyInfo.refNameAliases = refNameAliasesConf
+          }
+          const aliases = readConfObject(assemblyConfig, 'aliases')
+          assemblyInfo.aliases = aliases
+          assemblyData.set(assemblyName, assemblyInfo)
+          aliases.forEach((assemblyAlias, idx) => {
+            const newAliases = [
+              ...aliases.slice(0, idx),
+              ...aliases.slice(idx + 1),
+              assemblyName,
+            ]
+            assemblyData.set(assemblyAlias, {
+              ...assemblyInfo,
+              aliases: newAliases,
+            })
+          })
+        }
+        return assemblyData
+      },
     },
+    actions: {
+      async getCanonicalRefName(refName, assemblyName) {
+        const aliasesToCanonical = await self.getRefNameCanonicalizationMap(
+          assemblyName,
+        )
+        return aliasesToCanonical.get(refName)
+      },
 
-    /**
-     * get Map of adapter-specific-name -> canonical-name
-     */
-    async getReverseRefNameMapForAdapter(adapterConf, assemblyName, opts) {
-      const refNameMap = await self.getRefNameMapForAdapter(
+      // returns Map of alias-or-canonical -> canonical
+      async getRefNameCanonicalizationMap(assemblyName, opts = {}) {
+        const refNameAliases = await self.getRefNameAliases(assemblyName, opts)
+        const aliasesToCanonical = new Map()
+        Object.entries(refNameAliases).forEach(([ref, aliases]) => {
+          aliases.forEach(alias => {
+            aliasesToCanonical.set(alias, ref)
+          })
+          aliasesToCanonical.set(ref, ref)
+        })
+        return aliasesToCanonical
+      },
+
+      async getRefNameAliases(assemblyName, opts = {}) {
+        const refNameAliases = {}
+        const assemblyConfig = self.assemblyData.get(assemblyName)
+        if (assemblyConfig && assemblyConfig.refNameAliases) {
+          const adapterConfigId = jsonStableStringify(
+            toJS(assemblyConfig.refNameAliases.adapter),
+          )
+          const adapterRefNameAliases = await self.rpcManager.call(
+            adapterConfigId,
+            'getRefNameAliases',
+            {
+              sessionId: assemblyName,
+              adapterType: assemblyConfig.refNameAliases.adapter.type,
+              adapterConfig: assemblyConfig.refNameAliases.adapter,
+              signal: opts.signal,
+            },
+            { timeout: 1000000 },
+          )
+          adapterRefNameAliases.forEach(alias => {
+            refNameAliases[alias.refName] = alias.aliases
+          })
+        }
+        return refNameAliases
+      },
+
+      /**
+       * gets the list of reference sequence names from the adapter in question, and
+       * uses those to build a Map of adapter_ref_name -> canonical_ref_name
+       */
+      async addRefNameMapForAdapter(
         adapterConf,
         assemblyName,
-        opts,
-      )
-      const reversed = new Map()
-      for (const [canonicalName, adapterName] of refNameMap) {
-        reversed.set(adapterName, canonicalName)
-      }
-      return reversed
+        stateGroupName,
+        opts = {},
+      ) {
+        const assemblyConfig = self.assemblyData.get(assemblyName)
+        let sequenceConfig = {}
+        if (assemblyConfig && assemblyConfig.sequence) {
+          sequenceConfig = getSnapshot(assemblyConfig.sequence.adapter)
+        }
+        const refNameAliases = await self.getRefNameAliases(assemblyName, opts)
+        const adapterConfigId = jsonStableStringify(adapterConf)
+        const refNameMap = observable.map({})
+
+        const refNames = await self.rpcManager.call(
+          stateGroupName,
+          'getRefNames',
+          {
+            sessionId: assemblyName,
+            adapterType: readConfObject(adapterConf, 'type'),
+            adapterConfig: adapterConf,
+            sequenceAdapterType: sequenceConfig.type,
+            sequenceAdapterConfig: sequenceConfig,
+            signal: opts.signal,
+          },
+          { timeout: 1000000 },
+        )
+        refNames.forEach(refName => {
+          if (refNameAliases[refName])
+            refNameAliases[refName].forEach(refNameAlias => {
+              refNameMap.set(refNameAlias, refName)
+            })
+          else
+            Object.keys(refNameAliases).forEach(configRefName => {
+              if (refNameAliases[configRefName].includes(refName)) {
+                refNameMap.set(configRefName, refName)
+                refNameAliases[configRefName].forEach(refNameAlias => {
+                  if (refNameAlias !== refName)
+                    refNameMap.set(refNameAlias, refName)
+                })
+              }
+            })
+        })
+        self.refNameMaps.set(adapterConfigId, refNameMap)
+        return refNameMap
+      },
+
+      /**
+       * get Map of canonical-name -> adapter-specific-name
+       */
+      async getRefNameMapForAdapter(
+        adapterConf,
+        assemblyName,
+        opts = {},
+      ) {
+        const adapterConfigId = jsonStableStringify(adapterConf)
+        return cache.get(
+          adapterConfigId,
+          {
+            adapterConf,
+            assemblyName,
+          },
+          opts.signal,
+        )
+      },
+
+      /**
+       * get Map of adapter-specific-name -> canonical-name
+       */
+      async getReverseRefNameMapForAdapter(adapterConf, assemblyName, opts) {
+        const refNameMap = await self.getRefNameMapForAdapter(
+          adapterConf,
+          assemblyName,
+          opts,
+        )
+        const reversed = new Map()
+        for (const [canonicalName, adapterName] of refNameMap) {
+          reversed.set(adapterName, canonicalName)
+        }
+        return reversed
+      },
     },
-  },
-})
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@librpc/web": "rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0",
     "@material-ui/lab": "^4.0.0-alpha.20",
+    "abortable-promise-cache": "^1.1.2",
     "base64-js": "^1.3.0",
     "canvas": "^2.5.0",
     "deep-equal": "^1.1.0",

--- a/packages/wiggle/package.json
+++ b/packages/wiggle/package.json
@@ -14,6 +14,7 @@
     "abortable-promise-cache": "^1.0.1",
     "color": "^3.1.1",
     "d3-scale": "^3.0.0",
+    "json-stable-stringify": "^1.0.1",
     "react-d3-axis": "^0.1.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3700,6 +3700,14 @@ abortable-promise-cache@^1.0.1:
     abortcontroller-polyfill "^1.2.9"
     babel-runtime "^6.26.0"
 
+abortable-promise-cache@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.1.2.tgz#79a6c752db48d652e8d78afd14e386bb0d42b2f4"
+  integrity sha512-hPWOIk+dhs/zCur11a/bf/QoHej1aQdWsChCGAh3DIFKlXFLe0rBqQaoH16Pu9DgZN7bN3/bi9NxyUI8L9raXQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    abortcontroller-polyfill "^1.2.9"
+
 abortcontroller-polyfill@^1.2.9:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"


### PR DESCRIPTION
This is a small change that aims to improve the logic around the refNameMap code. It seems the logic for addRefNameMap and getRefNameMap could be combined into a single abortable-promise-cache