### PR TITLE
792 context menu with improved alignments colin

### DIFF
--- a/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrack.js
+++ b/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrack.js
@@ -32,10 +32,10 @@ function AlignmentsTrackComponent(props) {
   const [state, setState] = useState(initialState)
   const handleRightClick = e => {
     e.preventDefault()
-    setState(() => ({
+    setState({
       mouseX: e.clientX - 2,
       mouseY: e.clientY - 4,
-    }))
+    })
   }
   const ref = useRef()
   const zIndex = useTheme().zIndex.tooltip // zIndex matches tooltip zindex to bring to front

--- a/packages/alignments/src/AlignmentsTrack/model.ts
+++ b/packages/alignments/src/AlignmentsTrack/model.ts
@@ -93,10 +93,8 @@ export default (pluginManager: any, configSchema: any) => {
             subMenu: self.sortOptions.map((option: string) => {
               return {
                 label: option,
-                type: option !== 'Clear Sort' && 'radio',
-                checked: self.sortedBy === option,
                 onClick:
-                  option === 'Clear Sort' || self.sortedBy === option
+                  option === 'Clear Sort'
                     ? self.clearSelected
                     : () => self.sortSelected(option),
               }

--- a/packages/alignments/src/PileupRenderer/declare.d.ts
+++ b/packages/alignments/src/PileupRenderer/declare.d.ts
@@ -1,3 +1,4 @@
 declare module '@gmod/jbrowse-core/util/offscreenCanvasPonyfill'
+declare module '@gmod/jbrowse-core/util/range'
 declare module '@gmod/jbrowse-core/configuration'
 declare module '@gmod/jbrowse-core/pluggableElementTypes/renderers/BoxRendererType'

--- a/packages/alignments/src/PileupRenderer/sortUtil.ts
+++ b/packages/alignments/src/PileupRenderer/sortUtil.ts
@@ -14,12 +14,12 @@ export const sortFeature = (
   region: IRegion,
 ) => {
   const featureArray = Array.from(features) // this is an array of arrays
-  const featuresInCenterLine: [string, Feature][] = []
-  const featuresOutsideCenter: [string, Feature][] = []
+  const featuresInCenterLine: typeof featureArray = []
+  const featuresOutsideCenter: typeof featureArray = []
+  console.log(sortObject)
 
   featureArray.forEach((innerArray, idx) => {
     const feature = innerArray[1]
-    console.log(feature.get('start'), feature.get('end'))
     if (
       doesIntersect2(
         sortObject.position - 1,
@@ -29,10 +29,10 @@ export const sortFeature = (
       )
     ) {
       featuresInCenterLine.push(innerArray)
-    } else featuresOutsideCenter.push(innerArray)
+    } else {
+      featuresOutsideCenter.push(innerArray)
+    }
   })
-
-  console.log(featureArray.length, featuresInCenterLine.length)
 
   // NOTE: is not sorted when the last sort call featuresInCenterLine length > 0, happens at zoom level 0.05
   switch (sortObject.by) {

--- a/packages/alignments/src/PileupRenderer/sortUtil.ts
+++ b/packages/alignments/src/PileupRenderer/sortUtil.ts
@@ -1,4 +1,5 @@
 import { Feature } from '@gmod/jbrowse-core/util/simpleFeature'
+import { doesIntersect2 } from '@gmod/jbrowse-core/util/range'
 import { IRegion } from '@gmod/jbrowse-core/mst-types'
 import { Mismatch } from '../BamAdapter/BamSlightlyLazyFeature'
 
@@ -16,14 +17,16 @@ export const sortFeature = (
   const featuresInCenterLine: [string, Feature][] = []
   const featuresOutsideCenter: [string, Feature][] = []
 
-//   console.log(bpPerPx, sortObject.position)
-  console.log('NEW SORT -------')
   featureArray.forEach((innerArray, idx) => {
     const feature = innerArray[1]
     console.log(feature.get('start'), feature.get('end'))
     if (
-      sortObject.position <= feature.get('end') &&
-      sortObject.position >= feature.get('start')
+      doesIntersect2(
+        sortObject.position - 1,
+        sortObject.position,
+        feature.get('start'),
+        feature.get('end'),
+      )
     ) {
       featuresInCenterLine.push(innerArray)
     } else featuresOutsideCenter.push(innerArray)

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -272,10 +272,10 @@ const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
               />
             )
           }
-          let onClick
-          if ('onClick' in menuOption) {
-            onClick = handleClick(menuOption.onClick)
-          }
+          const onClick =
+            'onClick' in menuOption
+              ? handleClick(menuOption.onClick)
+              : undefined
           return (
             <MenuItem
               key={menuOption.label}

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -209,7 +209,7 @@ export function stateModelFactory(pluginManager: any) {
 
         return {
           ...r,
-          offset: Math.round(bp - bpSoFar),
+          offset: Math.floor(bp - bpSoFar),
           index: self.displayedRegions.length,
         }
       },


### PR DESCRIPTION
This is a small PR onto the current 792 branch of @peterkxie 's

I propose not using radio buttons to indicate the current sort, because we want to be able to repeatedly perform a sort after scrolling sideways a little

Also there is a clue that the centerline position may have a bug, possibly in the underlying pxToBp code, where it isn't able to properly get some positions

Screenshot attached of a position that should say 3212 but says 3211

![t1](https://user-images.githubusercontent.com/6511937/78454967-9e6feb80-7669-11ea-98b9-fd7131805521.png)
