### PR TITLE
Measure View width instead of App width

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@types/react": "16.9.2",
         "@types/react-color": "^3.0.1",
         "@types/react-dom": "^16.9.1",
+        "@types/react-measure": "^2.0.6",
         "@types/react-window": "^1.8.1",
         "@types/set-value": "^2.0.0",
         "@types/shortid": "^0.0.29",

--- a/packages/breakpoint-split-view/src/components/__snapshots__/BreakpointSplitView.test.js.snap
+++ b/packages/breakpoint-split-view/src/components/__snapshots__/BreakpointSplitView.test.js.snap
@@ -114,7 +114,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
           >
             <div
               class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-              style="min-width: 1024px;"
+              style="min-width: 800px;"
             >
               <p
                 class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -123,17 +123,17 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
               </p>
               <div
                 class="makeStyles-scaleBarVisibleRegion"
-                style="width: 512px; left: -1px;"
+                style="width: 400px; left: -1px;"
               />
               <div
                 class="makeStyles-scaleBarLabel"
-                style="left: 512px;"
+                style="left: 400px;"
               >
                 5
               </div>
               <div
                 class="makeStyles-scaleBarLabel"
-                style="left: 1024px;"
+                style="left: 800px;"
               >
                 10
               </div>
@@ -149,7 +149,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
             >
               <polygon
                 fill="rgba(121, 134, 203, 0.3)"
-                points="0,48,5,48,513,0,1,0"
+                points="0,48,5,48,401,0,1,0"
                 stroke="rgba(121, 134, 203, 0.8)"
               />
             </svg>
@@ -419,11 +419,11 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
           >
             <div
               class="makeStyles-verticalGuidesContainer"
-              style="left: -1024px; width: 2053px;"
+              style="left: -800px; width: 1605px;"
             >
               <div
                 class="makeStyles-boundaryPaddingBlock"
-                style="width: 1024px;"
+                style="width: 800px;"
               />
               <div
                 class="makeStyles-elidedBlock"
@@ -431,7 +431,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
               />
               <div
                 class="makeStyles-boundaryPaddingBlock"
-                style="width: 1024px;"
+                style="width: 800px;"
               />
             </div>
             <div
@@ -459,11 +459,11 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
             >
               <div
                 class="makeStyles-scaleBar"
-                style="left: -1025px; width: 2053px; height: 17px; box-sizing: border-box;"
+                style="left: -801px; width: 1605px; height: 17px; box-sizing: border-box;"
               >
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
                 <div
                   class="makeStyles-elidedBlock"
@@ -471,7 +471,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
                 />
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
               </div>
             </div>
@@ -512,7 +512,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
           >
             <div
               class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-              style="min-width: 1024px;"
+              style="min-width: 800px;"
             >
               <p
                 class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -521,17 +521,17 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
               </p>
               <div
                 class="makeStyles-scaleBarVisibleRegion"
-                style="width: 512px; left: 511px;"
+                style="width: 400px; left: 399px;"
               />
               <div
                 class="makeStyles-scaleBarLabel"
-                style="left: 512px;"
+                style="left: 400px;"
               >
                 5
               </div>
               <div
                 class="makeStyles-scaleBarLabel"
-                style="left: 1024px;"
+                style="left: 800px;"
               >
                 10
               </div>
@@ -547,7 +547,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
             >
               <polygon
                 fill="rgba(121, 134, 203, 0.3)"
-                points="0,48,5,48,1025,0,513,0"
+                points="0,48,5,48,801,0,401,0"
                 stroke="rgba(121, 134, 203, 0.8)"
               />
             </svg>
@@ -817,11 +817,11 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
           >
             <div
               class="makeStyles-verticalGuidesContainer"
-              style="left: -1024px; width: 2053px;"
+              style="left: -800px; width: 1605px;"
             >
               <div
                 class="makeStyles-boundaryPaddingBlock"
-                style="width: 1024px;"
+                style="width: 800px;"
               />
               <div
                 class="makeStyles-elidedBlock"
@@ -829,7 +829,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
               />
               <div
                 class="makeStyles-boundaryPaddingBlock"
-                style="width: 1024px;"
+                style="width: 800px;"
               />
             </div>
             <div
@@ -857,11 +857,11 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
             >
               <div
                 class="makeStyles-scaleBar"
-                style="left: -1025px; width: 2053px; height: 17px; box-sizing: border-box;"
+                style="left: -801px; width: 1605px; height: 17px; box-sizing: border-box;"
               >
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
                 <div
                   class="makeStyles-elidedBlock"
@@ -869,7 +869,7 @@ exports[`BreakpointSplitView genome view component renders with an empty model 1
                 />
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
               </div>
             </div>

--- a/packages/breakpoint-split-view/src/model.ts
+++ b/packages/breakpoint-split-view/src/model.ts
@@ -35,7 +35,6 @@ export default function stateModelFactory(pluginManager: any) {
     .model('BreakpointSplitView', {
       type: types.literal('BreakpointSplitView'),
       headerHeight: 0,
-      width: 800,
       height: types.optional(
         types.refinement(
           'viewHeight',
@@ -53,6 +52,9 @@ export default function stateModelFactory(pluginManager: any) {
           .stateModel as LinearGenomeViewStateModel,
       ),
     })
+    .volatile(() => ({
+      width: 800,
+    }))
     .views(self => ({
       // Find all track ids that match across multiple views
       get matchedTracks(): string[] {

--- a/packages/breakpoint-split-view/src/model.ts
+++ b/packages/breakpoint-split-view/src/model.ts
@@ -27,13 +27,12 @@ export default function stateModelFactory(pluginManager: any) {
     addDisposer,
     getPath,
   } = jbrequire('mobx-state-tree')
-  const { ElementId } = jbrequire('@gmod/jbrowse-core/mst-types')
+  const BaseViewModel = jbrequire('@gmod/jbrowse-core/BaseViewModel')
 
   const minHeight = 40
   const defaultHeight = 400
-  const stateModel = (jbrequiredTypes as Instance<typeof types>)
+  const model = (jbrequiredTypes as Instance<typeof types>)
     .model('BreakpointSplitView', {
-      id: ElementId,
       type: types.literal('BreakpointSplitView'),
       headerHeight: 0,
       width: 800,
@@ -45,7 +44,6 @@ export default function stateModelFactory(pluginManager: any) {
         ),
         defaultHeight,
       ),
-      displayName: 'breakpoint detail',
       trackSelectorType: 'hierarchical',
       showIntraviewLinks: true,
       linkViews: false,
@@ -260,10 +258,6 @@ export default function stateModelFactory(pluginManager: any) {
         })
       },
 
-      setDisplayName(name: string) {
-        self.displayName = name
-      },
-
       setWidth(newWidth: number) {
         self.width = newWidth
         self.views.forEach(v => v.setWidth(newWidth))
@@ -291,6 +285,11 @@ export default function stateModelFactory(pluginManager: any) {
         self.linkViews = !self.linkViews
       },
     }))
+
+  const stateModel = (jbrequiredTypes as typeof types).compose(
+    BaseViewModel,
+    model,
+  )
 
   return { stateModel }
 }

--- a/packages/circular-view/src/CircularView/models/CircularView.js
+++ b/packages/circular-view/src/CircularView/models/CircularView.js
@@ -4,9 +4,10 @@ export default pluginManager => {
   const { jbrequire } = pluginManager
   const { transaction } = jbrequire('mobx')
   const { types, getParent } = jbrequire('mobx-state-tree')
-  const { ElementId, Region } = jbrequire('@gmod/jbrowse-core/mst-types')
+  const { Region } = jbrequire('@gmod/jbrowse-core/mst-types')
   const { readConfObject } = jbrequire('@gmod/jbrowse-core/configuration')
   const { clamp, getSession } = jbrequire('@gmod/jbrowse-core/util')
+  const BaseViewModel = jbrequire('@gmod/jbrowse-core/BaseViewModel')
 
   const { calculateStaticSlices, sliceIsVisible } = jbrequire(
     require('./slices'),
@@ -15,9 +16,8 @@ export default pluginManager => {
   const minHeight = 40
   const minWidth = 100
   const defaultHeight = 400
-  const stateModel = types
+  const model = types
     .model('CircularView', {
-      id: ElementId,
       type: types.literal('CircularView'),
       offsetRadians: -Math.PI / 2,
       bpPerPx: 2000000,
@@ -305,6 +305,8 @@ export default pluginManager => {
         return self.lockedFitToWindow
       },
     }))
+
+  const stateModel = types.compose(BaseViewModel, model)
 
   return { stateModel }
 }

--- a/packages/circular-view/src/CircularView/models/CircularView.js
+++ b/packages/circular-view/src/CircularView/models/CircularView.js
@@ -30,7 +30,6 @@ export default pluginManager => {
       lockedFitToWindow: true,
       disableImportForm: false,
 
-      width: 800,
       height: types.optional(
         types.refinement('trackHeight', types.number, n => n >= minHeight),
         defaultHeight,
@@ -46,6 +45,9 @@ export default pluginManager => {
       scrollY: 0,
       trackSelectorType: 'hierarchical',
     })
+    .volatile(() => ({
+      width: 800,
+    }))
     .views(self => ({
       get staticSlices() {
         return calculateStaticSlices(self)

--- a/packages/core/BaseViewModel.ts
+++ b/packages/core/BaseViewModel.ts
@@ -1,0 +1,27 @@
+import { types, Instance } from 'mobx-state-tree'
+import { ElementId } from './mst-types'
+import { MenuOptions } from './ui'
+
+const BaseViewModel = types
+  .model('BaseView', {
+    id: ElementId,
+    displayName: types.maybe(types.string),
+    width: 800,
+  })
+  .views((/* self */) => ({
+    get menuOptions(): MenuOptions[] {
+      return []
+    },
+  }))
+  .actions(self => ({
+    setDisplayName(name: string) {
+      self.displayName = name
+    },
+    setWidth(newWidth: number) {
+      self.width = newWidth
+    },
+  }))
+
+export default BaseViewModel
+// eslint-disable-next-line @typescript-eslint/no-empty-interface,@typescript-eslint/interface-name-prefix
+export interface IBaseViewModel extends Instance<typeof BaseViewModel> {}

--- a/packages/core/BaseViewModel.ts
+++ b/packages/core/BaseViewModel.ts
@@ -6,8 +6,10 @@ const BaseViewModel = types
   .model('BaseView', {
     id: ElementId,
     displayName: types.maybe(types.string),
-    width: 800,
   })
+  .volatile((/* self */) => ({
+    width: 800,
+  }))
   .views((/* self */) => ({
     get menuOptions(): MenuOptions[] {
       return []

--- a/packages/core/ReExports.js
+++ b/packages/core/ReExports.js
@@ -57,6 +57,7 @@ import * as coreUtil from './util'
 import * as trackUtils from './util/tracks'
 import * as coreIo from './util/io'
 import * as coreMstReflection from './util/mst-reflection'
+import BaseViewModel from './BaseViewModel'
 
 import * as MUIColors from './ReExports/material-ui-colors'
 
@@ -122,4 +123,5 @@ export default {
   '@gmod/jbrowse-core/util/tracks': trackUtils,
   '@gmod/jbrowse-core/util/io': coreIo,
   '@gmod/jbrowse-core/util/mst-reflection': coreMstReflection,
+  '@gmod/jbrowse-core/BaseViewModel': BaseViewModel,
 }

--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -1,10 +1,7 @@
-import { makeStyles, useTheme } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 
 import { observer, PropTypes } from 'mobx-react'
-import { isAlive } from 'mobx-state-tree'
-import ReactPropTypes from 'prop-types'
-import React, { useEffect } from 'react'
-import { withContentRect } from 'react-measure'
+import React from 'react'
 
 import DrawerWidget from './DrawerWidget'
 import Snackbar from './Snackbar'
@@ -36,28 +33,17 @@ const useStyles = makeStyles({
   },
 })
 
-function App({ contentRect, measureRef, session }) {
-  const theme = useTheme()
-  const margin = theme.spacing(1)
+function App({ session }) {
   const classes = useStyles()
   const { pluginManager } = session
-  const { width } = contentRect.bounds
-  useEffect(() => {
-    if (width) {
-      if (isAlive(session)) {
-        session.updateWidth(width, margin * 2)
-      }
-    }
-  }, [session, width, margin])
 
-  const { visibleDrawerWidget, appWidth, drawerWidth } = session
+  const { visibleDrawerWidget, drawerWidth } = session
 
   return (
     <div
-      ref={measureRef}
       className={classes.root}
       style={{
-        gridTemplateColumns: `[main] ${appWidth}px${
+        gridTemplateColumns: `[main] 1fr${
           visibleDrawerWidget ? ` [drawer] ${drawerWidth}px` : ''
         }`,
       }}
@@ -94,12 +80,6 @@ function App({ contentRect, measureRef, session }) {
                 key={`view-${view.id}`}
                 view={view}
                 onClose={() => session.removeView(view)}
-                style={{
-                  margin,
-                  paddingLeft: margin,
-                  paddingRight: margin,
-                  paddingBottom: margin,
-                }}
               >
                 <ReactComponent
                   model={view}
@@ -121,10 +101,6 @@ function App({ contentRect, measureRef, session }) {
 
 App.propTypes = {
   session: PropTypes.observableObject.isRequired,
-  contentRect: ReactPropTypes.shape({
-    bounds: ReactPropTypes.shape({ width: ReactPropTypes.number }),
-  }).isRequired,
-  measureRef: ReactPropTypes.func.isRequired,
 }
 
-export default withContentRect('bounds')(observer(App))
+export default observer(App)

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -7,10 +7,12 @@ import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
 import { observer } from 'mobx-react'
+import { isAlive } from 'mobx-state-tree'
 import React, { useEffect, useRef, useState } from 'react'
 import { ContentRect, withContentRect } from 'react-measure'
+import { IBaseViewModel } from '../BaseViewModel'
 import EditableTypography from './EditableTypography'
-import Menu, { MenuOptions } from './Menu'
+import Menu from './Menu'
 
 const useStyles = makeStyles(theme => ({
   viewContainer: {
@@ -74,7 +76,7 @@ const ViewMenu = observer(
     IconButtonProps,
     IconProps,
   }: {
-    model: { menuOptions: MenuOptions[] }
+    model: IBaseViewModel
     IconButtonProps: IBP
     IconProps: IP
   }) => {
@@ -96,7 +98,7 @@ const ViewMenu = observer(
       setAnchorEl(null)
     }
 
-    if (!model.menuOptions) {
+    if (!(model.menuOptions && model.menuOptions.length)) {
       return null
     }
 
@@ -133,12 +135,7 @@ export default withContentRect('bounds')(
       contentRect,
       measureRef,
     }: {
-      view: {
-        menuOptions: MenuOptions[]
-        displayName: string
-        setDisplayName: (displayName: string) => void
-        setWidth: (width: number) => void
-      }
+      view: IBaseViewModel
       onClose: () => void
       style: React.CSSProperties
       children: React.ReactNode
@@ -155,7 +152,9 @@ export default withContentRect('bounds')(
       }
       useEffect(() => {
         if (width) {
-          view.setWidth(width - padWidth * 2)
+          if (isAlive(view)) {
+            view.setWidth(width - padWidth * 2)
+          }
         }
       }, [padWidth, view, width])
 

--- a/packages/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
+++ b/packages/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
@@ -10,6 +10,5 @@ Object {
   "menuBars": Array [],
   "name": "testSession",
   "views": Array [],
-  "width": 1024,
 }
 `;

--- a/packages/jbrowse-web/src/sessionModelFactory.test.js
+++ b/packages/jbrowse-web/src/sessionModelFactory.test.js
@@ -24,12 +24,5 @@ describe('JBrowseWebSessionModel', () => {
   it('accepts a custom drawer width', () => {
     const session = createTestSession({ drawerWidth: 256 })
     expect(session.drawerWidth).toBe(256)
-    expect(session.viewsWidth).toBe(1024)
-  })
-
-  it('shrinks a drawer width that is too big', () => {
-    const session = createTestSession({ width: 1024, drawerWidth: 512 })
-    session.updateWidth(512)
-    expect(session.drawerWidth).toBe(256)
   })
 })

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -7,7 +7,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
   >
     <div
       class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-      style="min-width: 1024px;"
+      style="min-width: 800px;"
     >
       <p
         class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -16,17 +16,17 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       </p>
       <div
         class="makeStyles-scaleBarVisibleRegion"
-        style="width: 10240px; left: -1px;"
+        style="width: 8000px; left: -1px;"
       />
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 512px;"
+        style="left: 400px;"
       >
         5
       </div>
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 1024px;"
+        style="left: 800px;"
       >
         10
       </div>
@@ -42,7 +42,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
     >
       <polygon
         fill="rgba(121, 134, 203, 0.3)"
-        points="0,48,100,48,10241,0,1,0"
+        points="0,48,100,48,8001,0,1,0"
         stroke="rgba(121, 134, 203, 0.8)"
       />
     </svg>
@@ -262,7 +262,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           />
           <input
             type="hidden"
-            value="4.321928094887363"
+            value="3.321928094887362"
           />
           <span
             class="MuiSlider-mark MuiSlider-markActive"
@@ -272,6 +272,15 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             aria-hidden="true"
             class="MuiSlider-markLabel MuiSlider-markLabelActive"
             style="left: 0%;"
+          />
+          <span
+            class="MuiSlider-mark"
+            style="left: 43.06765580733933%;"
+          />
+          <span
+            aria-hidden="true"
+            class="MuiSlider-markLabel"
+            style="left: 43.06765580733933%;"
           />
           <span
             class="MuiSlider-mark"
@@ -285,8 +294,8 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           <span
             aria-orientation="horizontal"
             aria-valuemax="5.643856189774724"
-            aria-valuemin="4.321928094887363"
-            aria-valuenow="4.321928094887363"
+            aria-valuemin="3.321928094887362"
+            aria-valuenow="3.321928094887362"
             class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
             data-index="0"
             role="slider"
@@ -325,11 +334,11 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
   >
     <div
       class="makeStyles-verticalGuidesContainer"
-      style="left: -1024px; width: 2148px;"
+      style="left: -800px; width: 1700px;"
     >
       <div
         class="makeStyles-boundaryPaddingBlock"
-        style="width: 1024px;"
+        style="width: 800px;"
       />
       <div
         class="makeStyles-block"
@@ -366,7 +375,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       </div>
       <div
         class="makeStyles-boundaryPaddingBlock"
-        style="width: 1024px;"
+        style="width: 800px;"
       />
     </div>
     <div
@@ -394,11 +403,11 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
     >
       <div
         class="makeStyles-scaleBar"
-        style="left: -1025px; width: 2148px; height: 17px; box-sizing: border-box;"
+        style="left: -801px; width: 1700px; height: 17px; box-sizing: border-box;"
       >
         <div
           class="makeStyles-boundaryPaddingBlock"
-          style="background: none; width: 1024px;"
+          style="background: none; width: 800px;"
         />
         <div
           class="makeStyles-block"
@@ -417,7 +426,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         </div>
         <div
           class="makeStyles-boundaryPaddingBlock"
-          style="background: none; width: 1024px;"
+          style="background: none; width: 800px;"
         />
       </div>
       <p
@@ -512,11 +521,11 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               <div
                 class="makeStyles-trackBlocks"
                 data-testid="Blockset"
-                style="left: -1024px;"
+                style="left: -800px;"
               >
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
                 <div
                   class="makeStyles-block"
@@ -551,7 +560,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 </div>
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
               </div>
             </div>
@@ -752,7 +761,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
   >
     <div
       class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-      style="min-width: 1024px;"
+      style="min-width: 800px;"
     >
       <p
         class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -761,17 +770,17 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       </p>
       <div
         class="makeStyles-scaleBarVisibleRegion"
-        style="width: 10240px; left: -1px;"
+        style="width: 8000px; left: -1px;"
       />
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 512px;"
+        style="left: 400px;"
       >
         5
       </div>
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 1024px;"
+        style="left: 800px;"
       >
         10
       </div>
@@ -787,7 +796,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
     >
       <polygon
         fill="rgba(121, 134, 203, 0.3)"
-        points="0,48,100,48,10241,0,1,0"
+        points="0,48,100,48,8001,0,1,0"
         stroke="rgba(121, 134, 203, 0.8)"
       />
     </svg>
@@ -948,7 +957,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               disabled=""
               style="padding: 8px;"
               type="text"
-              value="ctgA:1..100;ctgB:1001..1922"
+              value="ctgA:1..100;ctgB:1001..1698"
             />
             <fieldset
               aria-hidden="true"
@@ -973,7 +982,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <p
           class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
         >
-          1,022 bp
+          798 bp
         </p>
       </div>
       <div
@@ -1108,11 +1117,11 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
   >
     <div
       class="makeStyles-verticalGuidesContainer"
-      style="left: -1024px; width: 3150px;"
+      style="left: -800px; width: 2702px;"
     >
       <div
         class="makeStyles-boundaryPaddingBlock"
-        style="width: 1024px;"
+        style="width: 800px;"
       />
       <div
         class="makeStyles-block"
@@ -1153,7 +1162,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       />
       <div
         class="makeStyles-block"
-        style="width: 1000px;"
+        style="width: 800px;"
       >
         <div
           class="makeStyles-tick makeStyles-majorTick"
@@ -1323,50 +1332,63 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           class="makeStyles-tick makeStyles-minorTick"
           style="left: 819px;"
         />
+      </div>
+      <div
+        class="makeStyles-block"
+        style="width: 200px;"
+      >
         <div
-          class="makeStyles-tick makeStyles-minorTick"
-          style="left: 839px;"
+          class="makeStyles-tick makeStyles-majorTick"
+          style="left: -1px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 859px;"
+          style="left: 19px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 879px;"
+          style="left: 39px;"
+        />
+        <div
+          class="makeStyles-tick makeStyles-minorTick"
+          style="left: 59px;"
+        />
+        <div
+          class="makeStyles-tick makeStyles-minorTick"
+          style="left: 79px;"
         />
         <div
           class="makeStyles-tick makeStyles-majorTick"
-          style="left: 899px;"
+          style="left: 99px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 919px;"
+          style="left: 119px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 939px;"
+          style="left: 139px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 959px;"
+          style="left: 159px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 979px;"
+          style="left: 179px;"
         />
         <div
           class="makeStyles-tick makeStyles-majorTick"
-          style="left: 999px;"
+          style="left: 199px;"
         />
         <div
           class="makeStyles-tick makeStyles-minorTick"
-          style="left: 1019px;"
+          style="left: 219px;"
         />
       </div>
       <div
         class="makeStyles-boundaryPaddingBlock"
-        style="width: 1024px;"
+        style="width: 800px;"
       />
     </div>
     <div
@@ -1394,11 +1416,11 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
     >
       <div
         class="makeStyles-scaleBar"
-        style="left: -1025px; width: 3150px; height: 17px; box-sizing: border-box;"
+        style="left: -801px; width: 2702px; height: 17px; box-sizing: border-box;"
       >
         <div
           class="makeStyles-boundaryPaddingBlock"
-          style="background: none; width: 1024px;"
+          style="background: none; width: 800px;"
         />
         <div
           class="makeStyles-block"
@@ -1421,7 +1443,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         />
         <div
           class="makeStyles-block"
-          style="width: 1000px;"
+          style="width: 800px;"
         >
           <div
             class="makeStyles-tick"
@@ -1473,9 +1495,24 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               1,800
             </p>
           </div>
+        </div>
+        <div
+          class="makeStyles-block"
+          style="width: 200px;"
+        >
           <div
             class="makeStyles-tick"
-            style="left: 999px;"
+            style="left: -1px;"
+          >
+            <p
+              class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+            >
+              1,800
+            </p>
+          </div>
+          <div
+            class="makeStyles-tick"
+            style="left: 199px;"
           >
             <p
               class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
@@ -1486,7 +1523,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         </div>
         <div
           class="makeStyles-boundaryPaddingBlock"
-          style="background: none; width: 1024px;"
+          style="background: none; width: 800px;"
         />
       </div>
       <p
@@ -1588,11 +1625,11 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               <div
                 class="makeStyles-trackBlocks"
                 data-testid="Blockset"
-                style="left: -1024px;"
+                style="left: -800px;"
               >
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
                 <div
                   class="makeStyles-block"
@@ -1631,7 +1668,38 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 />
                 <div
                   class="makeStyles-block"
-                  style="width: 1000px;"
+                  style="width: 800px;"
+                >
+                  <div
+                    class="ssr-container"
+                    data-html-size="328"
+                  >
+                    <div
+                      classname="ssr-container-inner"
+                    >
+                      <div
+                        class="PileupRendering"
+                        style="position:relative;width:0;height:0"
+                      >
+                        <canvas
+                          data-testid="prerendered_canvas_PileupRenderer"
+                          height="0"
+                          style="width:0;height:0;position:absolute;left:0;top:0"
+                          width="0"
+                        />
+                        <canvas
+                          class="highlightOverlayCanvas"
+                          height="0"
+                          style="position:absolute;left:0;top:0"
+                          width="0"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-block"
+                  style="width: 200px;"
                 >
                   <div
                     class="ssr-container"
@@ -1662,7 +1730,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 </div>
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
               </div>
             </div>
@@ -1759,11 +1827,11 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               <div
                 class="makeStyles-trackBlocks"
                 data-testid="Blockset"
-                style="left: -1024px;"
+                style="left: -800px;"
               >
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
                 <div
                   class="makeStyles-block"
@@ -1802,7 +1870,38 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 />
                 <div
                   class="makeStyles-block"
-                  style="width: 1000px;"
+                  style="width: 800px;"
+                >
+                  <div
+                    class="ssr-container"
+                    data-html-size="328"
+                  >
+                    <div
+                      classname="ssr-container-inner"
+                    >
+                      <div
+                        class="PileupRendering"
+                        style="position:relative;width:0;height:0"
+                      >
+                        <canvas
+                          data-testid="prerendered_canvas_PileupRenderer"
+                          height="0"
+                          style="width:0;height:0;position:absolute;left:0;top:0"
+                          width="0"
+                        />
+                        <canvas
+                          class="highlightOverlayCanvas"
+                          height="0"
+                          style="position:absolute;left:0;top:0"
+                          width="0"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-block"
+                  style="width: 200px;"
                 >
                   <div
                     class="ssr-container"
@@ -1833,7 +1932,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 </div>
                 <div
                   class="makeStyles-boundaryPaddingBlock"
-                  style="background: none; width: 1024px;"
+                  style="background: none; width: 800px;"
                 />
               </div>
             </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -148,6 +148,7 @@ test('can instantiate a model that tests navTo/moveTo', async () => {
       tracks: [{ name: 'foo track', type: 'PileupTrack' }],
     }),
   )
+  model.setWidth(width)
   model.setDisplayedRegions([
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgB' },
@@ -178,9 +179,9 @@ test('can instantiate a model that >2 regions', () => {
       id: 'test4',
       type: 'LinearGenomeView',
       tracks: [{ name: 'foo track', type: 'PileupTrack' }],
-      width,
     }),
   )
+  model.setWidth(width)
   model.setDisplayedRegions([
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgB' },

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getConf, readConfObject } from '@gmod/jbrowse-core/configuration'
+import BaseViewModel from '@gmod/jbrowse-core/BaseViewModel'
 import { ElementId, Region, IRegion } from '@gmod/jbrowse-core/mst-types'
 import { MenuOptions } from '@gmod/jbrowse-core/ui'
 import {
@@ -62,14 +63,13 @@ export const SCALE_BAR_HEIGHT = 17
 export const RESIZE_HANDLE_HEIGHT = 3
 
 export function stateModelFactory(pluginManager: any) {
-  return types
+  const model = types
     .model('LinearGenomeView', {
       id: ElementId,
       type: types.literal('LinearGenomeView'),
       offsetPx: 0,
       bpPerPx: 1,
       displayedRegions: types.array(Region),
-      displayName: types.maybe(types.string),
       // we use an array for the tracks because the tracks are displayed in a specific
       // order that we need to keep.
       tracks: types.array(
@@ -262,10 +262,6 @@ export function stateModelFactory(pluginManager: any) {
 
       setError(error: Error | undefined) {
         self.error = error
-      },
-
-      setDisplayName(name: string) {
-        self.displayName = name
       },
 
       toggleHeader() {
@@ -664,5 +660,7 @@ export function stateModelFactory(pluginManager: any) {
         },
       }
     })
+
+  return types.compose(BaseViewModel, model)
 }
 export type LinearGenomeViewStateModel = ReturnType<typeof stateModelFactory>

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -75,7 +75,6 @@ export function stateModelFactory(pluginManager: any) {
       tracks: types.array(
         pluginManager.pluggableMstType('track', 'stateModel'),
       ),
-      width: 800,
       hideHeader: false,
       hideHeaderOverview: false,
       trackSelectorType: types.optional(
@@ -85,6 +84,7 @@ export function stateModelFactory(pluginManager: any) {
       minimumBlockWidth: 20,
     })
     .volatile(() => ({
+      width: 800,
       draggingTrackId: undefined as undefined | string,
       error: undefined as undefined | Error,
 

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
@@ -15,7 +15,6 @@ export default pluginManager => {
     .model('SpreadsheetView', {
       type: types.literal('SpreadsheetView'),
       offsetPx: 0,
-      width: 400,
       height: types.optional(
         types.refinement(
           'SpreadsheetViewHeight',
@@ -43,6 +42,9 @@ export default pluginManager => {
       ),
       spreadsheet: types.maybe(SpreadsheetModel),
     })
+    .volatile(() => ({
+      width: 400,
+    }))
     .views(self => ({
       get readyToDisplay() {
         return !!self.spreadsheet

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.js
@@ -3,7 +3,7 @@ import { readConfObject } from '@gmod/jbrowse-core/configuration'
 export default pluginManager => {
   const { jbrequire } = pluginManager
   const { types, getParent, getRoot, getEnv } = jbrequire('mobx-state-tree')
-  const { ElementId } = jbrequire('@gmod/jbrowse-core/mst-types')
+  const BaseViewModel = jbrequire('@gmod/jbrowse-core/BaseViewModel')
 
   const SpreadsheetModel = jbrequire(require('./Spreadsheet'))
   const ImportWizardModel = jbrequire(require('./ImportWizard'))
@@ -11,9 +11,8 @@ export default pluginManager => {
 
   const minHeight = 40
   const defaultHeight = 440
-  const stateModel = types
+  const model = types
     .model('SpreadsheetView', {
-      id: ElementId,
       type: types.literal('SpreadsheetView'),
       offsetPx: 0,
       width: 400,
@@ -116,6 +115,8 @@ export default pluginManager => {
         getParent(self, 2).removeView(self)
       },
     }))
+
+  const stateModel = types.compose(BaseViewModel, model)
 
   return { stateModel }
 }

--- a/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -66,7 +66,6 @@ export default pluginManager => {
   const model = types
     .model('SvInspectorView', {
       type: types.literal('SvInspectorView'),
-      width: 800,
       dragHandleHeight: 4,
       height: types.optional(
         types.refinement(
@@ -102,6 +101,9 @@ export default pluginManager => {
         }),
       ),
     })
+    .volatile(() => ({
+      width: 800,
+    }))
     .views(self => ({
       get selectedRows() {
         return self.spreadsheetView.rowSet.selectedRows

--- a/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -4,7 +4,7 @@ export default pluginManager => {
   const { types, getParent, addDisposer, getRoot } = jbrequire(
     'mobx-state-tree',
   )
-  const { ElementId } = jbrequire('@gmod/jbrowse-core/mst-types')
+  const BaseViewModel = jbrequire('@gmod/jbrowse-core/BaseViewModel')
   const { getSession } = jbrequire('@gmod/jbrowse-core/util')
   const { readConfObject } = jbrequire('@gmod/jbrowse-core/configuration')
 
@@ -63,9 +63,8 @@ export default pluginManager => {
     return undefined
   }
 
-  const stateModel = types
+  const model = types
     .model('SvInspectorView', {
-      id: ElementId,
       type: types.literal('SvInspectorView'),
       width: 800,
       dragHandleHeight: 4,
@@ -334,6 +333,8 @@ export default pluginManager => {
         self.onlyDisplayRelevantRegionsInCircularView = Boolean(val)
       },
     }))
+
+  const stateModel = types.compose(BaseViewModel, model)
 
   return { stateModel }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,6 +3378,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-measure@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-measure/-/react-measure-2.0.6.tgz#d66efad1960ea8b38eef9d8cc3cc857e7767b09e"
+  integrity sha512-FxAwgDVKvxm4SPXu24x9cwzsty8x33UueazHcpxM1UWZlGJI57yIHM2djE3xUJhYVxuzNzi4E8UL3kmCkdh+4A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.3.tgz#4924133f7268694058e415bf7aea2d4c21131470"


### PR DESCRIPTION
We were measuring the whole app width and passing that to the session, which had an autorun that then updated the view widths.

This simplifies things by just measuring the view widths directly and setting them, and not worrying about the whole app width at all. Since it measures the actual view widths, if a view shrinks due to a scroll bar appearing, everything updates accordingly and there isn't a problem with unwanted horizontal scroll bars.

The second commit adds a BaseViewModel for views to compose so they will be sure to have the basic requirements of a view (id, width, optional displayName, optional menuOptions).

Resolves #727