### PR TITLE
Speedup side scrolling in LGV

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
   LinearGenomeViewStateModel,
   RESIZE_HANDLE_HEIGHT,
@@ -33,33 +33,37 @@ function TracksContainer({
   model: LGV
 }) {
   const classes = useStyles()
-  const [scheduled, setScheduled] = useState(false)
-  const [delta, setDelta] = useState(0)
+  // refs are to store these variables to avoid repeated rerenders associated with useState/setState
+  const delta = useRef(0)
+  const scheduled = useRef(false)
+
   const [mouseDragging, setMouseDragging] = useState(false)
-  const [prevX, setPrevX] = useState()
+  const prevX = useRef<number | null>(null)
+  useState()
 
   useEffect(() => {
     let cleanup = () => {}
 
     function globalMouseMove(event: MouseEvent) {
       event.preventDefault()
-      const distance = event.clientX - prevX
+      const distance =
+        prevX.current !== null ? event.clientX - prevX.current : event.clientX
       if (distance) {
-        if (!scheduled) {
-          // use rAF to make it so multiple event handlers aren't fired per-frame
-          // see https://calendar.perfplanet.com/2013/the-runtime-performance-checklist/
+        // use rAF to make it so multiple event handlers aren't fired per-frame
+        // see https://calendar.perfplanet.com/2013/the-runtime-performance-checklist/
+        if (!scheduled.current) {
+          scheduled.current = true
           window.requestAnimationFrame(() => {
             model.horizontalScroll(-distance)
-            setScheduled(false)
-            setPrevX(event.clientX)
+            scheduled.current = false
+            prevX.current = event.clientX
           })
-          setScheduled(true)
         }
       }
     }
 
     function globalMouseUp() {
-      setPrevX(undefined)
+      prevX.current = null
       setMouseDragging(false)
     }
 
@@ -72,21 +76,20 @@ function TracksContainer({
       }
     }
     return cleanup
-  }, [delta, model, mouseDragging, prevX, scheduled])
+  }, [model, mouseDragging, prevX])
 
   function onWheel(event: React.WheelEvent) {
     const { deltaX, deltaMode } = event
-    if (scheduled) {
-      setDelta(delta + deltaX)
-    } else {
+    delta.current += deltaX
+    if (!scheduled.current) {
       // use rAF to make it so multiple event handlers aren't fired per-frame
       // see https://calendar.perfplanet.com/2013/the-runtime-performance-checklist/
+      scheduled.current = true
       window.requestAnimationFrame(() => {
-        model.horizontalScroll((delta + deltaX) * (1 + 50 * deltaMode))
-        setScheduled(false)
+        model.horizontalScroll(delta.current * (1 + 50 * deltaMode))
+        delta.current = 0
+        scheduled.current = false
       })
-      setScheduled(true)
-      setDelta(0)
     }
   }
 
@@ -94,7 +97,7 @@ function TracksContainer({
     if ((event.target as HTMLElement).draggable) return
     if (event.button === 0) {
       event.preventDefault()
-      setPrevX(event.clientX)
+      prevX.current = event.clientX
       setMouseDragging(true)
     }
   }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -63,7 +63,9 @@ function TracksContainer({
 
     function globalMouseUp() {
       prevX.current = null
-      setMouseDragging(false)
+      if (mouseDragging) {
+        setMouseDragging(false)
+      }
     }
 
     if (mouseDragging) {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -39,7 +39,6 @@ function TracksContainer({
 
   const [mouseDragging, setMouseDragging] = useState(false)
   const prevX = useRef<number | null>(null)
-  useState()
 
   useEffect(() => {
     let cleanup = () => {}


### PR DESCRIPTION
The usage of setState to batch event updates in the LGV on side scroll was causing double renders as any setState will cause a re-render and slowness. I am not sure if it was just less obvious before but it became more noticeable following the LGV UI update. This makes the event updates batched using refs instead of state

Similar stuff to what Ian was seeing in his work on abrowse :)


