### PR TITLE
Remove need to manually pass in adapterType to RPC

### DIFF
--- a/packages/alignments/src/AlignmentsTrack/model.ts
+++ b/packages/alignments/src/AlignmentsTrack/model.ts
@@ -171,7 +171,6 @@ export default (pluginManager: any, configSchema: any) => {
           .renderInClient(rpcManager, {
             assemblyName: regions[0].assemblyName,
             regions,
-            adapterType: self.PileupTrack.adapterType.name,
             adapterConfig: getConf(self, 'adapter'),
             sequenceAdapterType: sequenceConfig.type,
             sequenceAdapterConfig: sequenceConfig,

--- a/packages/alignments/src/CramAdapter/CramAdapter.ts
+++ b/packages/alignments/src/CramAdapter/CramAdapter.ts
@@ -67,13 +67,12 @@ export default (pluginManager: PluginManager) => {
         'sequenceAdapter',
         'type',
       ])
-      const sequenceAdapterConfig = readConfObject(config, 'sequenceAdapter')
-      const sequenceAdapter = getSubAdapter(
-        sequenceAdapterType,
-        sequenceAdapterConfig,
-      ).dataAdapter
-      if (sequenceAdapter instanceof BaseFeatureDataAdapter) {
-        this.sequenceAdapter = sequenceAdapter
+
+      const { dataAdapter } = getSubAdapter(
+        readConfObject(config, 'sequenceAdapter'),
+      )
+      if (dataAdapter instanceof BaseFeatureDataAdapter) {
+        this.sequenceAdapter = dataAdapter
       } else {
         throw new Error(
           `CRAM feature adapters cannot use sequence adapters of type '${sequenceAdapterType}'`,

--- a/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -89,13 +89,10 @@ export default (pluginManager: PluginManager) => {
     ) {
       super(config)
 
-      const subadapter = getSubAdapter(
-        config.subadapter.type,
-        getSnapshot(config.subadapter),
-      ).dataAdapter
+      const { dataAdapter } = getSubAdapter(getSnapshot(config.subadapter))
 
-      if (subadapter instanceof BaseFeatureDataAdapter) {
-        this.subadapter = subadapter
+      if (dataAdapter instanceof BaseFeatureDataAdapter) {
+        this.subadapter = dataAdapter
       } else {
         throw new Error(`invalid subadapter type '${config.subadapter.type}'`)
       }

--- a/packages/circular-view/src/StructuralVariantChordTrack/models/renderReaction.js
+++ b/packages/circular-view/src/StructuralVariantChordTrack/models/renderReaction.js
@@ -17,7 +17,6 @@ export default ({ jbrequire }) => {
       renderProps,
       renderArgs: {
         assemblyName,
-        adapterType: track.adapterType.name,
         adapterConfig: JSON.parse(JSON.stringify(getConf(track, 'adapter'))),
         rendererType: rendererType.name,
         renderProps,

--- a/packages/core/assemblyManager.js
+++ b/packages/core/assemblyManager.js
@@ -24,7 +24,6 @@ export default self => {
         'getRefNames',
         {
           sessionId: assemblyName,
-          adapterType: readConfObject(adapterConf, 'type'),
           adapterConfig: adapterConf,
           signal,
         },
@@ -118,7 +117,6 @@ export default self => {
             'getRefNameAliases',
             {
               sessionId: assemblyName,
-              adapterType: assemblyConfig.refNameAliases.adapter.type,
               adapterConfig: assemblyConfig.refNameAliases.adapter,
               signal: opts.signal,
             },

--- a/packages/core/data_adapters/dataAdapterCache.ts
+++ b/packages/core/data_adapters/dataAdapterCache.ts
@@ -6,10 +6,9 @@ import { AnyDataAdapter } from './BaseAdapter'
 import { IRegion } from '../mst-types'
 
 function adapterConfigCacheKey(
-  adapterType: string,
   adapterConfig: SnapshotIn<AnyConfigurationSchemaType>,
 ) {
-  return `${adapterType}|${jsonStableStringify(adapterConfig)}`
+  return `${jsonStableStringify(adapterConfig)}`
 }
 
 interface AdapterCacheEntry {
@@ -26,18 +25,17 @@ const adapterCache: Record<string, AdapterCacheEntry> = {}
  * @param {PluginManager} pluginManager
  * @param {string} sessionId session ID of the associated worker session.
  *   used for reference counting
- * @param {string} adapterType type name of the adapter to instantiate
  * @param {object} adapterConfigSnapshot plain-JS configuration snapshot for the adapter
  */
 export function getAdapter(
   pluginManager: PluginManager,
   sessionId: string,
-  adapterType: string,
   adapterConfigSnapshot: SnapshotIn<AnyConfigurationSchemaType>,
 ) {
   // cache the adapter object
-  const cacheKey = adapterConfigCacheKey(adapterType, adapterConfigSnapshot)
+  const cacheKey = adapterConfigCacheKey(adapterConfigSnapshot)
   if (!adapterCache[cacheKey]) {
+    const adapterType = (adapterConfigSnapshot || {}).type
     const dataAdapterType = pluginManager.getAdapterType(adapterType)
     if (!dataAdapterType) {
       throw new Error(`unknown data adapter type ${adapterType}`)
@@ -81,7 +79,6 @@ export function getAdapter(
  * internally, staying with the same worker session ID
  */
 export type getSubAdapterType = (
-  adapterType: string,
   adapterConfigSnapshot: SnapshotIn<AnyConfigurationSchemaType>,
 ) => ReturnType<typeof getAdapter>
 

--- a/packages/dotplot-view/src/DotplotTrack/index.ts
+++ b/packages/dotplot-view/src/DotplotTrack/index.ts
@@ -150,8 +150,6 @@ function renderBlockData(self: DotplotTrack) {
   // Compare to serverSideRenderedBlock
   readConfObject(self.configuration)
 
-  const sequenceConfig: { type?: string } = {}
-
   const { adapterConfig } = self
   const adapterConfigId = jsonStableStringify(adapterConfig)
   const parent = getParent(self, 2)
@@ -163,10 +161,7 @@ function renderBlockData(self: DotplotTrack) {
     rpcManager,
     renderProps,
     renderArgs: {
-      adapterType: self.adapterType.name,
       adapterConfig,
-      sequenceAdapterType: sequenceConfig.type,
-      sequenceAdapterConfig: sequenceConfig,
       rendererType: rendererType.name,
       views,
       renderProps: {

--- a/packages/jbrowse-desktop/src/rpcMethods.js
+++ b/packages/jbrowse-desktop/src/rpcMethods.js
@@ -60,7 +60,7 @@ console.error = async (...args) => {
 
 async function getGlobalStats(
   pluginManager,
-  { adapterType, adapterConfig, signal, sessionId },
+  { adapterConfig, signal, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -69,7 +69,6 @@ async function getGlobalStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getGlobalStats({ signal })
@@ -77,7 +76,7 @@ async function getGlobalStats(
 
 async function getRegionStats(
   pluginManager,
-  { region, adapterType, adapterConfig, signal, bpPerPx, sessionId },
+  { region, adapterConfig, signal, bpPerPx, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -86,7 +85,6 @@ async function getRegionStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRegionStats(region, { signal, bpPerPx })
@@ -94,7 +92,7 @@ async function getRegionStats(
 
 async function getMultiRegionStats(
   pluginManager,
-  { regions, adapterType, adapterConfig, signal, bpPerPx, sessionId },
+  { regions, adapterConfig, signal, bpPerPx, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -103,16 +101,12 @@ async function getMultiRegionStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getMultiRegionStats(regions, { signal, bpPerPx })
 }
 
-async function getRegions(
-  pluginManager,
-  { sessionId, adapterType, signal, adapterConfig },
-) {
+async function getRegions(pluginManager, { sessionId, signal, adapterConfig }) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
   }
@@ -120,7 +114,6 @@ async function getRegions(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRegions({ signal })
@@ -128,7 +121,7 @@ async function getRegions(
 
 async function getRefNames(
   pluginManager,
-  { sessionId, signal, adapterType, adapterConfig },
+  { sessionId, signal, adapterConfig },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -137,7 +130,6 @@ async function getRefNames(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRefNames({ signal })
@@ -145,7 +137,7 @@ async function getRefNames(
 
 async function getRefNameAliases(
   pluginManager,
-  { sessionId, adapterType, signal, adapterConfig },
+  { sessionId, signal, adapterConfig },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -153,7 +145,6 @@ async function getRefNameAliases(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRefNameAliases({ signal })
@@ -186,7 +177,6 @@ function freeResources(pluginManager, specification) {
  * @param {object} args
  * @param {object} args.regions - array of regions to render. some renderers (such as circular chord tracks) accept multiple at a time
  * @param {string} args.sessionId
- * @param {string} args.adapterType
  * @param {object} args.adapterConfig
  * @param {string} args.rendererType
  * @param {object} args.renderProps
@@ -198,7 +188,6 @@ async function render(
     regions,
     originalRegions,
     sessionId,
-    adapterType,
     adapterConfig,
     rendererType,
     renderProps,
@@ -214,12 +203,7 @@ async function render(
   }
   checkAbortSignal(signal)
 
-  const { dataAdapter } = getAdapter(
-    pluginManager,
-    sessionId,
-    adapterType,
-    adapterConfig,
-  )
+  const { dataAdapter } = getAdapter(pluginManager, sessionId, adapterConfig)
 
   const RendererType = pluginManager.getRendererType(rendererType)
   if (!RendererType) throw new Error(`renderer "${rendererType}" not found`)
@@ -249,7 +233,6 @@ async function comparativeRender(
   pluginManager,
   {
     sessionId,
-    adapterType,
     adapterConfig,
     sequenceAdapterType,
     sequenceAdapterConfig,
@@ -268,7 +251,6 @@ async function comparativeRender(
   const { dataAdapter } = getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
     sequenceAdapterType,
     sequenceAdapterConfig,

--- a/packages/jbrowse-web/src/rpcMethods.js
+++ b/packages/jbrowse-web/src/rpcMethods.js
@@ -10,7 +10,7 @@ import {
 
 export async function getGlobalStats(
   pluginManager,
-  { adapterType, adapterConfig, signal, sessionId },
+  { adapterConfig, signal, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -19,7 +19,6 @@ export async function getGlobalStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getGlobalStats({ signal })
@@ -27,7 +26,7 @@ export async function getGlobalStats(
 
 export async function getRegionStats(
   pluginManager,
-  { region, adapterType, adapterConfig, signal, bpPerPx, sessionId },
+  { region, adapterConfig, signal, bpPerPx, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -36,7 +35,6 @@ export async function getRegionStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRegionStats(region, { signal, bpPerPx })
@@ -44,7 +42,7 @@ export async function getRegionStats(
 
 export async function getMultiRegionStats(
   pluginManager,
-  { regions, adapterType, adapterConfig, signal, bpPerPx, sessionId },
+  { regions, adapterConfig, signal, bpPerPx, sessionId },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -53,7 +51,6 @@ export async function getMultiRegionStats(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getMultiRegionStats(regions, { signal, bpPerPx })
@@ -61,7 +58,7 @@ export async function getMultiRegionStats(
 
 export async function getRegions(
   pluginManager,
-  { sessionId, adapterType, signal, adapterConfig },
+  { sessionId, signal, adapterConfig },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -70,7 +67,6 @@ export async function getRegions(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRegions({ signal })
@@ -78,7 +74,7 @@ export async function getRegions(
 
 export async function getRefNames(
   pluginManager,
-  { sessionId, signal, adapterType, adapterConfig },
+  { sessionId, signal, adapterConfig },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -87,7 +83,6 @@ export async function getRefNames(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRefNames({ signal })
@@ -95,7 +90,7 @@ export async function getRefNames(
 
 export async function getRefNameAliases(
   pluginManager,
-  { sessionId, adapterType, signal, adapterConfig },
+  { sessionId, signal, adapterConfig },
 ) {
   if (isRemoteAbortSignal(signal)) {
     signal = deserializeAbortSignal(signal)
@@ -103,7 +98,6 @@ export async function getRefNameAliases(
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
-    adapterType,
     adapterConfig,
   )
   return dataAdapter.getRefNameAliases({ signal })
@@ -136,7 +130,6 @@ export function freeResources(pluginManager, specification) {
  * @param {object} args
  * @param {object} args.regions - array of regions to render. some renderers (such as circular chord tracks) accept multiple at a time
  * @param {string} args.sessionId
- * @param {string} args.adapterType
  * @param {object} args.adapterConfig
  * @param {string} args.rendererType
  * @param {object} args.renderProps
@@ -148,7 +141,6 @@ export async function render(
     regions,
     originalRegions,
     sessionId,
-    adapterType,
     adapterConfig,
     rendererType,
     renderProps,
@@ -164,12 +156,7 @@ export async function render(
   }
   checkAbortSignal(signal)
 
-  const { dataAdapter } = getAdapter(
-    pluginManager,
-    sessionId,
-    adapterType,
-    adapterConfig,
-  )
+  const { dataAdapter } = getAdapter(pluginManager, sessionId, adapterConfig)
 
   const RendererType = pluginManager.getRendererType(rendererType)
   if (!RendererType) throw new Error(`renderer "${rendererType}" not found`)
@@ -197,7 +184,7 @@ export async function render(
  */
 export async function comparativeRender(
   pluginManager,
-  { sessionId, adapterType, adapterConfig, rendererType, renderProps, signal },
+  { sessionId, adapterConfig, rendererType, renderProps, signal },
 ) {
   if (!sessionId) throw new Error('must pass a unique session id')
 
@@ -206,12 +193,7 @@ export async function comparativeRender(
   }
   checkAbortSignal(signal)
 
-  const { dataAdapter } = getAdapter(
-    pluginManager,
-    sessionId,
-    adapterType,
-    adapterConfig,
-  )
+  const { dataAdapter } = getAdapter(pluginManager, sessionId, adapterConfig)
 
   const RendererType = pluginManager.getRendererType(rendererType)
 

--- a/packages/jbrowse-web/src/rpcMethods.test.js
+++ b/packages/jbrowse-web/src/rpcMethods.test.js
@@ -13,7 +13,6 @@ beforeAll(() => {
 const baseprops = {
   regions: [{ refName: 'ctgA', start: 0, end: 800 }],
   sessionId: 'knickers the cow',
-  adapterType: 'BamAdapter',
   adapterConfig: {
     type: 'BamAdapter',
     bamLocation: {

--- a/packages/jbrowse-web/src/sessionModelFactory.ts
+++ b/packages/jbrowse-web/src/sessionModelFactory.ts
@@ -148,7 +148,6 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
               'getRegions',
               {
                 sessionId: assemblyName,
-                adapterType: adapterConfig.type,
                 adapterConfig,
                 signal: opts.signal,
               },

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -218,7 +218,6 @@ function renderBlockData(self: Instance<BlockStateModel>) {
       renderArgs: {
         assemblyName: self.region.assemblyName,
         regions: [self.region],
-        adapterType: track.adapterType.name,
         adapterConfig,
         sequenceAdapterType: sequenceConfig.type,
         sequenceAdapterConfig: sequenceConfig,

--- a/packages/protein-widget/src/rpcMethods.js
+++ b/packages/protein-widget/src/rpcMethods.js
@@ -12,7 +12,6 @@ import {
  * @param {object} args
  * @param {object} args.regions - array of regions to render. some renderers (such as circular chord tracks) accept multiple at a time
  * @param {string} args.sessionId
- * @param {string} args.adapterType
  * @param {object} args.adapterConfig
  * @param {string} args.rendererType
  * @param {object} args.renderProps
@@ -20,15 +19,7 @@ import {
  */
 export async function render(
   pluginManager,
-  {
-    regions,
-    sessionId,
-    adapterType,
-    adapterConfig,
-    rendererType,
-    renderProps,
-    signal,
-  },
+  { regions, sessionId, adapterConfig, rendererType, renderProps, signal },
 ) {
   if (!sessionId) throw new Error('must pass a unique session id')
 
@@ -37,12 +28,7 @@ export async function render(
   }
   checkAbortSignal(signal)
 
-  const { dataAdapter } = getAdapter(
-    pluginManager,
-    sessionId,
-    adapterType,
-    adapterConfig,
-  )
+  const { dataAdapter } = getAdapter(pluginManager, sessionId, adapterConfig)
 
   const RendererType = pluginManager.getRendererType(rendererType)
   if (!RendererType) throw new Error(`renderer "${rendererType}" not found`)

--- a/packages/wiggle/src/WiggleTrack/model.ts
+++ b/packages/wiggle/src/WiggleTrack/model.ts
@@ -138,7 +138,6 @@ const stateModelFactory = (configSchema: any) =>
         if (autoscaleType === 'global' || autoscaleType === 'globalsd') {
           const r = await rpcManager.call('statsGathering', 'getGlobalStats', {
             adapterConfig: getSnapshot(adapter),
-            adapterType: adapter.type,
             signal,
           })
           return autoscaleType === 'globalsd'
@@ -161,7 +160,6 @@ const stateModelFactory = (configSchema: any) =>
             'getMultiRegionStats',
             {
               adapterConfig: getSnapshot(adapter),
-              adapterType: adapter.type,
               // TODO: Figure this out for multiple assembly names
               assemblyName: getTrackAssemblyNames(self)[0],
               regions: JSON.parse(JSON.stringify(dynamicBlocks.contentBlocks)),
@@ -183,7 +181,6 @@ const stateModelFactory = (configSchema: any) =>
         if (autoscaleType === 'zscale') {
           return rpcManager.call('statsGathering', 'getGlobalStats', {
             adapterConfig: getSnapshot(adapter),
-            adapterType: adapter.type,
             signal,
           })
         }


### PR DESCRIPTION
as long as we are in the business of simplifying the RPC interface, getAdapter does not really seem to strictly need adapterType, the config will contain this in itself. I can't think of a reason for manually have it like this, so I just tried removing it