### PR TITLE
Add `removeAttribute` to workerPolyfill element

### DIFF
--- a/packages/jbrowse-web/src/workerPolyfill.js
+++ b/packages/jbrowse-web/src/workerPolyfill.js
@@ -21,6 +21,11 @@ self.document = {
     return { appendChild() {} }
   },
   createElement() {
-    return { style: {}, setAttribute() {}, appendChild() {} }
+    return {
+      style: {},
+      setAttribute() {},
+      removeAttribute() {},
+      appendChild() {},
+    }
   },
 }


### PR DESCRIPTION
Adds a missing `removeAttribute` method to the workerPolyfill.js element. (workerPolyfill basically exists just to fake out `style-loader`, I wonder if there's a more robust way to do that...)

fixes #920 