### PR TITLE
Remove setting to have feature.id() as a label

### DIFF
--- a/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/packages/config/src/ConfigurationEditorDrawerWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2828,7 +2828,7 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the PileupTr
                         spellcheck="false"
                         style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-size: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
                       >
-                        function(feature) { return feature.get('name') || feature.get('id') || feature.id() }
+                        function(feature) { return feature.get('name') || feature.get('id') }
                       </textarea>
                       <pre
                         aria-hidden="true"
@@ -2918,33 +2918,6 @@ exports[`ConfigurationEditor drawer widget renders with defaults of the PileupTr
                           class="token string"
                         >
                           'id'
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          )
-                        </span>
-                         
-                        <span
-                          class="token operator"
-                        >
-                          ||
-                        </span>
-                         feature
-                        <span
-                          class="token punctuation"
-                        >
-                          .
-                        </span>
-                        <span
-                          class="token function"
-                        >
-                          id
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          (
                         </span>
                         <span
                           class="token punctuation"

--- a/packages/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.js.snap
+++ b/packages/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.js.snap
@@ -110,7 +110,7 @@ exports[`one feature 1`] = `
 >
   <svg
     class="SvgFeatureRendering"
-    height="25px"
+    height="10px"
     style="display: block;"
     width="333.3333333333333px"
   >
@@ -123,14 +123,6 @@ exports[`one feature 1`] = `
         x="0.3"
         y="0"
       />
-      <text
-        dominant-baseline="hanging"
-        style="font-size: 13px; fill: black; cursor: default;"
-        x="0.3"
-        y="12"
-      >
-        one
-      </text>
     </g>
   </svg>
 </div>
@@ -142,7 +134,7 @@ exports[`processed transcript (reducedRepresentation mode) 1`] = `
 >
   <svg
     class="SvgFeatureRendering"
-    height="25px"
+    height="10px"
     style="display: block;"
     width="333.3333333333333px"
   >
@@ -153,14 +145,6 @@ exports[`processed transcript (reducedRepresentation mode) 1`] = `
         points="0.3,0,1.3,5,0.3,10"
         stroke="goldenrod"
       />
-      <text
-        dominant-baseline="hanging"
-        style="font-size: 13px; fill: black; cursor: default;"
-        x="0.3"
-        y="12"
-      >
-        one
-      </text>
     </g>
   </svg>
 </div>

--- a/packages/svg/src/SvgFeatureRenderer/configSchema.ts
+++ b/packages/svg/src/SvgFeatureRenderer/configSchema.ts
@@ -37,7 +37,7 @@ export default ConfigurationSchema(
         description:
           'the primary name of the feature to show, if space is available',
         defaultValue:
-          "function(feature) { return feature.get('name') || feature.get('id') || feature.id() }",
+          "function(feature) { return feature.get('name') || feature.get('id') }",
         functionSignature: ['feature'],
       },
       nameColor: {


### PR DESCRIPTION
This was a carry-over from #886 

I propose not allowing feature.id() as a feature label. I think it is reserved as an internal id system and does not help to give features that have no name or id a label