### PR TITLE
Have alignments context menu functional again

### DIFF
--- a/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrackBlocks.tsx
+++ b/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrackBlocks.tsx
@@ -49,8 +49,7 @@ function AlignmentsTrackBlocks({
     trackModel: Instance<BlockBasedTrackStateModel>,
   ) => {
     e.preventDefault()
-    // only open context menu if hovered over feature
-    if (trackModel.contextMenuOptions.length) {
+    if (trackModel.contextMenuOptions) {
       setContextMenu(trackModel.contextMenuOptions)
       setState({
         mouseX: e.clientX - 2,

--- a/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrackBlocks.tsx
+++ b/packages/alignments/src/AlignmentsTrack/components/AlignmentsTrackBlocks.tsx
@@ -49,7 +49,7 @@ function AlignmentsTrackBlocks({
     trackModel: Instance<BlockBasedTrackStateModel>,
   ) => {
     e.preventDefault()
-    if (trackModel.contextMenuOptions) {
+    if (trackModel.contextMenuOptions.length) {
       setContextMenu(trackModel.contextMenuOptions)
       setState({
         mouseX: e.clientX - 2,

--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -119,6 +119,10 @@ function PileupRendering(props: {
     setLocalFeatureIdUnderMouse(undefined)
   }
 
+  function onContextMenu(event: MouseEvent) {
+    if (!movedDuringLastMouseDown) callMouseHandler('ContextMenu', event)
+  }
+
   function onMouseMove(event: MouseEvent) {
     if (mouseIsDown) setMovedDuringLastMouseDown(true)
     let offsetX = 0
@@ -193,6 +197,7 @@ function PileupRendering(props: {
         onMouseLeave={event => runner(() => onMouseLeave(event))}
         onMouseMove={event => runner(() => onMouseMove(event))}
         onClick={event => runner(() => onClick(event))}
+        onContextMenu={event => runner(() => onContextMenu(event))}
         onFocus={() => {}}
         onBlur={() => {}}
       />

--- a/packages/alignments/src/PileupTrack/model.ts
+++ b/packages/alignments/src/PileupTrack/model.ts
@@ -57,7 +57,7 @@ export default (
       // returned if there is no feature id under mouse
       contextMenuNoFeature() {
         const { trackModel } = getParentRenderProps(self)
-        self.contextMenuOptions = trackModel.meuOptions
+        self.contextMenuOptions = trackModel.menuOptions
       },
 
       // returned if there is a feature id under mouse

--- a/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
+++ b/packages/linear-genome-view/src/BasicTrack/blockBasedTrackModel.ts
@@ -217,8 +217,16 @@ const blockBasedTrack = types
       }
     },
 
-    contextMenuFeature() {
-      self.contextMenuOptions = []
+    contextMenuFeature(feature: Feature) {
+      self.contextMenuOptions = [
+        {
+          label: 'Open feature details',
+          icon: 'menu_open',
+          onClick: () => {
+            this.selectFeature(feature)
+          },
+        },
+      ]
     },
 
     contextMenuNoFeature() {
@@ -258,7 +266,9 @@ const blockBasedTrack = types
           if (!f) {
             self.clearFeatureSelection()
           } else {
-            self.contextMenuFeature()
+            // feature id under mouse passed to context menu
+            const feature = self.features.get(f)
+            self.contextMenuFeature(feature as Feature)
           }
         },
         onContextMenu() {


### PR DESCRIPTION
Some stuff got removed during the cleanup to blockbasedtrackmodel and typescriptifying pileuprendering, these commits fix up the functionality to have right clicking on alignment features working again