### PR TITLE
Fix error of destructuring on initial load of the sv inspector view

### DIFF
--- a/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/packages/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -221,42 +221,44 @@ export default pluginManager => {
               const { tracks } = circularView
               const session = getSession(self)
               if (assemblyName) {
-                let { regions: assemblyRegions } = session.assemblyManager.get(
-                  assemblyName,
-                )
-                if (!assemblyRegions) {
-                  assemblyRegions = []
-                } else {
-                  assemblyRegions = getSnapshot(assemblyRegions)
-                }
-                if (onlyDisplayRelevantRegionsInCircularView) {
-                  if (tracks.length === 1) {
-                    const { getCanonicalRefName } = session.assemblyManager.get(
-                      assemblyName,
-                    )
+                const assembly = session.assemblyManager.get(assemblyName)
+                if (assembly) {
+                  let { regions: assemblyRegions } = assembly
+                  if (!assemblyRegions) {
+                    assemblyRegions = []
+                  } else {
+                    assemblyRegions = getSnapshot(assemblyRegions)
+                  }
+                  if (onlyDisplayRelevantRegionsInCircularView) {
+                    if (tracks.length === 1) {
+                      const {
+                        getCanonicalRefName,
+                      } = session.assemblyManager.get(assemblyName)
 
-                    featuresRefNamesP
-                      .then(featureRefNames => {
-                        // canonicalize the store's ref names if necessary
-                        const canonicalFeatureRefNames = new Set(
-                          featureRefNames.map(
-                            refName => getCanonicalRefName(refName) || refName,
-                          ),
-                        )
-                        const displayedRegions = assemblyRegions.filter(r =>
-                          canonicalFeatureRefNames.has(r.refName),
-                        )
-                        circularView.setDisplayedRegions(
-                          JSON.parse(JSON.stringify(displayedRegions)),
-                        )
-                      })
-                      .catch(e => console.error(e))
+                      featuresRefNamesP
+                        .then(featureRefNames => {
+                          // canonicalize the store's ref names if necessary
+                          const canonicalFeatureRefNames = new Set(
+                            featureRefNames.map(
+                              refName =>
+                                getCanonicalRefName(refName) || refName,
+                            ),
+                          )
+                          const displayedRegions = assemblyRegions.filter(r =>
+                            canonicalFeatureRefNames.has(r.refName),
+                          )
+                          circularView.setDisplayedRegions(
+                            JSON.parse(JSON.stringify(displayedRegions)),
+                          )
+                        })
+                        .catch(e => console.error(e))
+                    }
+                  } else {
+                    circularView.setDisplayedRegions(assemblyRegions)
                   }
                 } else {
-                  circularView.setDisplayedRegions(assemblyRegions)
+                  circularView.setDisplayedRegions([])
                 }
-              } else {
-                circularView.setDisplayedRegions([])
               }
             },
             { name: 'SvInspectorView displayed regions bind' },


### PR DESCRIPTION
This is an add on fix for a console related error in #950, just checks for an assembly existing before destructuring