### PR TITLE
Move updateUrl and useLocalStorage logic to rootModel for jbrowse-web

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
   "peerDependencies": {
     "@material-ui/core": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "@material-ui/icons": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "^3.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
   "peerDependencies": {
     "@material-ui/core": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.45",
-    "@material-ui/icons": "^4.0.0",
     "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "^3.14.1",

--- a/packages/jbrowse-web/src/JBrowse.js
+++ b/packages/jbrowse-web/src/JBrowse.js
@@ -1,92 +1,12 @@
-import { readConfObject } from '@gmod/jbrowse-core/configuration'
 import '@gmod/jbrowse-core/fonts/material-icons.css'
 import { App, theme } from '@gmod/jbrowse-core/ui'
-import { toUrlSafeB64, useDebounce } from '@gmod/jbrowse-core/util'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import { ThemeProvider } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
-import { getSnapshot, onSnapshot } from 'mobx-state-tree'
-import queryString from 'query-string'
-import React, { useEffect, useState } from 'react'
-
-const MAX_SESSION_SIZE_IN_URL = 100000
+import React from 'react'
 
 const JBrowse = observer(({ pluginManager }) => {
-  const [urlSnapshot, setUrlSnapshot] = useState()
-  const debouncedUrlSnapshot = useDebounce(urlSnapshot, 400)
-
   const { rootModel } = pluginManager
-  const { session, jbrowse, error } = rootModel || {}
-  const useLocalStorage = jbrowse
-    ? readConfObject(jbrowse.configuration, 'useLocalStorage')
-    : false
-
-  const useUpdateUrl = jbrowse
-    ? readConfObject(jbrowse.configuration, 'updateUrl')
-    : false
-
-  // This serializes the session to URL
-  useEffect(() => {
-    if (debouncedUrlSnapshot) {
-      const parsed = queryString.parse(document.location.search)
-      const urlSplit = window.location.href.split('?')
-      const json = JSON.stringify(debouncedUrlSnapshot)
-      if (json.length < MAX_SESSION_SIZE_IN_URL) {
-        parsed.session = toUrlSafeB64(json)
-      } else {
-        parsed.session = undefined
-      }
-      window.history.replaceState(
-        {},
-        '',
-        `${urlSplit[0]}?${queryString.stringify(parsed)}`,
-      )
-    }
-  }, [debouncedUrlSnapshot])
-
-  // This updates savedSession list on the rootModel
-  useEffect(() => {
-    if (rootModel && rootModel.session && debouncedUrlSnapshot) {
-      rootModel.jbrowse.updateSavedSession(debouncedUrlSnapshot)
-    }
-  }, [debouncedUrlSnapshot, rootModel])
-
-  // set session in localstorage
-  useEffect(
-    () =>
-      useLocalStorage
-        ? onSnapshot(rootModel.session, snapshot => {
-            localStorage.setItem(
-              'jbrowse-web-session',
-              JSON.stringify(snapshot),
-            )
-          })
-        : () => {},
-    [rootModel, useLocalStorage],
-  )
-
-  // Set session URL on first render only, before `onSnapshot` has fired
-  useEffect(() => {
-    if (useUpdateUrl) {
-      setUrlSnapshot(getSnapshot(session))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(
-    () =>
-      session && useUpdateUrl
-        ? onSnapshot(session, snapshot => {
-            setUrlSnapshot(snapshot)
-          })
-        : () => {},
-    [useUpdateUrl, session],
-  )
-
-  if (error) {
-    throw new Error(error)
-  }
-
   return <App session={rootModel.session} />
 })
 


### PR DESCRIPTION
Addresses a dev warning that we see pretty much each time we open a track #907 
Basically the idea behind this is that it is improper to call the useState setter outside of the context of the function that it is created in

Therefore the logic like this (not verbatim)

    useEffect(() => onSnapshot(session, setUrlSession(session)))

was invalid.

I found that moving it to the rootModel resulted in more understandable code, no onSnapshot needed (just watches session via autorun), no need for useDebounce, etc.