### PR TITLE
Add some optimizations to improve FPS

### DIFF
--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -1,7 +1,6 @@
 // library
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
 
-import { screen } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
 import {
   cleanup,
@@ -149,7 +148,7 @@ describe('valid file tests', () => {
   it('click and drag to rubberBand', async () => {
     const pluginManager = getPluginManager()
     const state = pluginManager.rootModel
-    const { findByTestId, findByText, debug } = render(
+    const { findByTestId, findByText } = render(
       <JBrowse pluginManager={pluginManager} />,
     )
     const track = await findByTestId('rubberBand_controls')

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -1,6 +1,5 @@
 // library
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
-
 import '@testing-library/jest-dom/extend-expect'
 import {
   cleanup,
@@ -154,9 +153,9 @@ describe('valid file tests', () => {
     const track = await findByTestId('rubberBand_controls')
 
     expect(state.session.views[0].bpPerPx).toEqual(0.05)
-    fireEvent.mouseDown(track, { clientX: 100, clientY: 5 })
-    fireEvent.mouseMove(track, { clientX: 250, clientY: 5 })
-    fireEvent.mouseUp(track, { clientX: 250, clientY: 5 })
+    fireEvent.mouseDown(track, { clientX: 100, clientY: 0 })
+    fireEvent.mouseMove(track, { clientX: 250, clientY: 0 })
+    fireEvent.mouseUp(track, { clientX: 250, clientY: 0 })
     const zoomMenuItem = await findByText('Zoom to region')
     fireEvent.click(zoomMenuItem)
     expect(state.session.views[0].bpPerPx).toEqual(0.009375)

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -1,5 +1,7 @@
 // library
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
+
+import { screen } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
 import {
   cleanup,
@@ -147,15 +149,15 @@ describe('valid file tests', () => {
   it('click and drag to rubberBand', async () => {
     const pluginManager = getPluginManager()
     const state = pluginManager.rootModel
-    const { findByTestId, findByText } = render(
+    const { findByTestId, findByText, debug } = render(
       <JBrowse pluginManager={pluginManager} />,
     )
     const track = await findByTestId('rubberBand_controls')
 
     expect(state.session.views[0].bpPerPx).toEqual(0.05)
-    fireEvent.mouseDown(track, { clientX: 100, clientY: 0 })
-    fireEvent.mouseMove(track, { clientX: 250, clientY: 0 })
-    fireEvent.mouseUp(track, { clientX: 250, clientY: 0 })
+    fireEvent.mouseDown(track, { clientX: 100, clientY: 5 })
+    fireEvent.mouseMove(track, { clientX: 250, clientY: 5 })
+    fireEvent.mouseUp(track, { clientX: 250, clientY: 5 })
     const zoomMenuItem = await findByText('Zoom to region')
     fireEvent.click(zoomMenuItem)
     expect(state.session.views[0].bpPerPx).toEqual(0.009375)

--- a/packages/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -93,8 +93,6 @@ const BaseTrack = types
 
     get RenderingComponent(): React.FC<{
       model: typeof self
-      offsetPx: number
-      bpPerPx: number
       onHorizontalScroll: Function
       blockState: Record<string, any>
     }> {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -158,7 +158,6 @@ function RubberBand({
     }
     const leftOffset = model.pxToBp(leftPx)
     const rightOffset = model.pxToBp(rightPx)
-    console.log(leftOffset, rightOffset)
     model.moveTo(leftOffset, rightOffset)
   }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -7,7 +7,6 @@ import Typography from '@material-ui/core/Typography'
 import ZoomInIcon from '@material-ui/icons/ZoomIn'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
-import { trace } from 'mobx'
 import ReactPropTypes from 'prop-types'
 import React, { useRef, useEffect, useState } from 'react'
 import { LinearGenomeViewStateModel } from '..'
@@ -64,7 +63,6 @@ const useStyles = makeStyles(theme => {
 const VerticalGuide = observer(
   ({ model, coordX, open }: { model: LGV; coordX: number; open: boolean }) => {
     const classes = useStyles()
-    console.log('open', open)
     return (
       <Tooltip
         open={open}
@@ -96,8 +94,6 @@ function RubberBand({
   model: LGV
   ControlComponent?: React.ReactElement
 }) {
-  trace(model, 'offsetPx')
-  console.log('here')
   const [startX, setStartX] = useState<number>()
   const [currentX, setCurrentX] = useState<number>()
   const [mouseDragging, setMouseDragging] = useState(false)
@@ -241,7 +237,6 @@ function RubberBand({
   }
   const isRubberBandOpen = startX !== undefined && currentX !== undefined
   if (!isRubberBandOpen) {
-    console.log('here1', guideOpen, !mouseDragging)
     return (
       <>
         {controlComponent}
@@ -253,7 +248,6 @@ function RubberBand({
       </>
     )
   }
-  console.log('here2', guideOpen, !mouseDragging)
 
   const leftBpOffset = model.pxToBp(left)
   const leftBp = (

--- a/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -260,44 +260,48 @@ function RubberBand({
 
   return (
     <>
-      <Popover
-        className={classes.popover}
-        classes={{
-          paper: classes.paper,
-        }}
-        open={isRubberBandOpen}
-        anchorEl={rubberBandRef.current}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        keepMounted
-      >
-        <Typography>{isRubberBandOpen ? leftBp : ''}</Typography>
-      </Popover>
-      <Popover
-        className={classes.popover}
-        classes={{
-          paper: classes.paper,
-        }}
-        open={startX !== undefined && currentX !== undefined}
-        anchorEl={rubberBandRef.current}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        keepMounted
-      >
-        <Typography>{isRubberBandOpen ? rightBp : ''}</Typography>
-      </Popover>
+      {rubberBandRef.current ? (
+        <>
+          <Popover
+            className={classes.popover}
+            classes={{
+              paper: classes.paper,
+            }}
+            open={isRubberBandOpen}
+            anchorEl={rubberBandRef.current}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            transformOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            keepMounted
+          >
+            <Typography>{isRubberBandOpen ? leftBp : ''}</Typography>
+          </Popover>
+          <Popover
+            className={classes.popover}
+            classes={{
+              paper: classes.paper,
+            }}
+            open={startX !== undefined && currentX !== undefined}
+            anchorEl={rubberBandRef.current}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+            keepMounted
+          >
+            <Typography>{isRubberBandOpen ? rightBp : ''}</Typography>
+          </Popover>
+        </>
+      ) : null}
       <div
         ref={rubberBandRef}
         className={classes.rubberBand}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -66,7 +66,7 @@ const VerticalGuide = observer(
     const classes = useStyles()
     return (
       <Tooltip
-        open={true}
+        open
         placement="top"
         title={Math.round(model.pxToBp(coordX).offset + 1).toLocaleString()}
         arrow
@@ -232,7 +232,7 @@ function RubberBand({
             classes={{
               paper: classes.paper,
             }}
-            open={true}
+            open
             anchorEl={rubberBandRef.current}
             anchorOrigin={{
               vertical: 'top',
@@ -251,7 +251,7 @@ function RubberBand({
             classes={{
               paper: classes.paper,
             }}
-            open={startX !== undefined && currentX !== undefined}
+            open
             anchorEl={rubberBandRef.current}
             anchorOrigin={{
               vertical: 'top',

--- a/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -239,12 +239,12 @@ function RubberBand({
   if (!isRubberBandOpen) {
     return (
       <>
-        {controlComponent}
         <VerticalGuide
           model={model}
           open={guideOpen && !mouseDragging}
           coordX={guideX}
         />
+        {controlComponent}
       </>
     )
   }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -64,13 +64,7 @@ function TrackContainer(props: {
 }) {
   const classes = useStyles()
   const { model, track } = props
-  const {
-    bpPerPx,
-    offsetPx,
-    horizontalScroll,
-    draggingTrackId,
-    moveTrack,
-  } = model
+  const { horizontalScroll, draggingTrackId, moveTrack } = model
   function onDragEnter() {
     if (
       draggingTrackId !== undefined &&
@@ -110,8 +104,6 @@ function TrackContainer(props: {
         >
           <RenderingComponent
             model={track}
-            offsetPx={offsetPx}
-            bpPerPx={bpPerPx}
             blockState={{}}
             onHorizontalScroll={horizontalScroll}
           />

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -129,21 +129,21 @@ function TracksContainer({
       onMouseUp={mouseUp}
       onMouseLeave={mouseLeave}
     >
-      <VerticalGuides model={model}></VerticalGuides>
-      {model.showCenterLine && <CenterLine model={model} />}
+      <VerticalGuides model={model} />
+
       <RubberBand
         model={model}
         ControlComponent={
-          // Subtract two from height for ScaleBar borders
           <ScaleBar
             model={model}
             style={{ height: SCALE_BAR_HEIGHT, boxSizing: 'border-box' }}
           />
         }
-      >
-        <div className={classes.spacer} />
-        {children}
-      </RubberBand>
+      />
+      {model.showCenterLine ? <CenterLine model={model} /> : null}
+
+      <div className={classes.spacer} />
+      {children}
     </div>
   )
 }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -130,6 +130,7 @@ function TracksContainer({
       onMouseLeave={mouseLeave}
     >
       <VerticalGuides model={model} />
+      {model.showCenterLine ? <CenterLine model={model} /> : null}
 
       <RubberBand
         model={model}
@@ -140,8 +141,6 @@ function TracksContainer({
           />
         }
       />
-      {model.showCenterLine ? <CenterLine model={model} /> : null}
-
       <div className={classes.spacer} />
       {children}
     </div>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -129,22 +129,21 @@ function TracksContainer({
       onMouseUp={mouseUp}
       onMouseLeave={mouseLeave}
     >
-      <VerticalGuides model={model}>
-        {model.showCenterLine && <CenterLine model={model} />}
-        <RubberBand
-          model={model}
-          ControlComponent={
-            // Subtract two from height for ScaleBar borders
-            <ScaleBar
-              model={model}
-              style={{ height: SCALE_BAR_HEIGHT, boxSizing: 'border-box' }}
-            />
-          }
-        >
-          <div className={classes.spacer} />
-          {children}
-        </RubberBand>
-      </VerticalGuides>
+      <VerticalGuides model={model}></VerticalGuides>
+      {model.showCenterLine && <CenterLine model={model} />}
+      <RubberBand
+        model={model}
+        ControlComponent={
+          // Subtract two from height for ScaleBar borders
+          <ScaleBar
+            model={model}
+            style={{ height: SCALE_BAR_HEIGHT, boxSizing: 'border-box' }}
+          />
+        }
+      >
+        <div className={classes.spacer} />
+        {children}
+      </RubberBand>
     </div>
   )
 }

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -408,55 +408,54 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-guide"
-      style="left: 0px;"
-      title="1"
-    />
-    <div
-      class="MuiPaper-root makeStyles-scaleBarContainer makeStyles-rubberBandControl MuiPaper-outlined MuiPaper-rounded"
+      class="makeStyles-rubberBandControl"
       data-testid="rubberBand_controls"
       role="presentation"
-      style="height: 17px; box-sizing: border-box;"
     >
       <div
-        class="makeStyles-scaleBarZoomContainer"
+        class="MuiPaper-root makeStyles-scaleBarContainer MuiPaper-outlined MuiPaper-rounded"
+        style="height: 17px; box-sizing: border-box;"
       >
         <div
-          class="makeStyles-scaleBar"
-          style="left: -801px; width: 1700px; height: 17px; box-sizing: border-box;"
+          class="makeStyles-scaleBarZoomContainer"
         >
           <div
-            class="makeStyles-boundaryPaddingBlock"
-            style="background: none; width: 800px;"
-          />
-          <div
-            class="makeStyles-block"
-            style="width: 100px;"
+            class="makeStyles-scaleBar"
+            style="left: -801px; width: 1700px; height: 17px; box-sizing: border-box;"
           >
             <div
-              class="makeStyles-tick"
-              style="left: -1px;"
+              class="makeStyles-boundaryPaddingBlock"
+              style="background: none; width: 800px;"
+            />
+            <div
+              class="makeStyles-block"
+              style="width: 100px;"
             >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+              <div
+                class="makeStyles-tick"
+                style="left: -1px;"
               >
-                0
-              </p>
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  0
+                </p>
+              </div>
             </div>
+            <div
+              class="makeStyles-boundaryPaddingBlock"
+              style="background: none; width: 800px;"
+            />
           </div>
-          <div
-            class="makeStyles-boundaryPaddingBlock"
-            style="background: none; width: 800px;"
-          />
         </div>
+        <p
+          class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
+          data-testid="refLabel-ctgA"
+          style="left: -1px; padding-left: 1px;"
+        >
+          ctgA
+        </p>
       </div>
-      <p
-        class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
-        data-testid="refLabel-ctgA"
-        style="left: -1px; padding-left: 1px;"
-      >
-        ctgA
-      </p>
     </div>
     <div
       class="makeStyles-spacer"
@@ -1454,146 +1453,145 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-guide"
-      style="left: 0px;"
-      title="1"
-    />
-    <div
-      class="MuiPaper-root makeStyles-scaleBarContainer makeStyles-rubberBandControl MuiPaper-outlined MuiPaper-rounded"
+      class="makeStyles-rubberBandControl"
       data-testid="rubberBand_controls"
       role="presentation"
-      style="height: 17px; box-sizing: border-box;"
     >
       <div
-        class="makeStyles-scaleBarZoomContainer"
+        class="MuiPaper-root makeStyles-scaleBarContainer MuiPaper-outlined MuiPaper-rounded"
+        style="height: 17px; box-sizing: border-box;"
       >
         <div
-          class="makeStyles-scaleBar"
-          style="left: -801px; width: 2702px; height: 17px; box-sizing: border-box;"
+          class="makeStyles-scaleBarZoomContainer"
         >
           <div
-            class="makeStyles-boundaryPaddingBlock"
-            style="background: none; width: 800px;"
-          />
-          <div
-            class="makeStyles-block"
-            style="width: 100px;"
+            class="makeStyles-scaleBar"
+            style="left: -801px; width: 2702px; height: 17px; box-sizing: border-box;"
           >
             <div
-              class="makeStyles-tick"
-              style="left: -1px;"
+              class="makeStyles-boundaryPaddingBlock"
+              style="background: none; width: 800px;"
+            />
+            <div
+              class="makeStyles-block"
+              style="width: 100px;"
             >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+              <div
+                class="makeStyles-tick"
+                style="left: -1px;"
               >
-                0
-              </p>
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  0
+                </p>
+              </div>
             </div>
+            <div
+              class="makeStyles-interRegionPaddingBlock"
+              style="background: none; width: 2px;"
+            />
+            <div
+              class="makeStyles-block"
+              style="width: 800px;"
+            >
+              <div
+                class="makeStyles-tick"
+                style="left: -1px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,000
+                </p>
+              </div>
+              <div
+                class="makeStyles-tick"
+                style="left: 199px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,200
+                </p>
+              </div>
+              <div
+                class="makeStyles-tick"
+                style="left: 399px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,400
+                </p>
+              </div>
+              <div
+                class="makeStyles-tick"
+                style="left: 599px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,600
+                </p>
+              </div>
+              <div
+                class="makeStyles-tick"
+                style="left: 799px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,800
+                </p>
+              </div>
+            </div>
+            <div
+              class="makeStyles-block"
+              style="width: 200px;"
+            >
+              <div
+                class="makeStyles-tick"
+                style="left: -1px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  1,800
+                </p>
+              </div>
+              <div
+                class="makeStyles-tick"
+                style="left: 199px;"
+              >
+                <p
+                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
+                >
+                  2,000
+                </p>
+              </div>
+            </div>
+            <div
+              class="makeStyles-boundaryPaddingBlock"
+              style="background: none; width: 800px;"
+            />
           </div>
-          <div
-            class="makeStyles-interRegionPaddingBlock"
-            style="background: none; width: 2px;"
-          />
-          <div
-            class="makeStyles-block"
-            style="width: 800px;"
-          >
-            <div
-              class="makeStyles-tick"
-              style="left: -1px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,000
-              </p>
-            </div>
-            <div
-              class="makeStyles-tick"
-              style="left: 199px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,200
-              </p>
-            </div>
-            <div
-              class="makeStyles-tick"
-              style="left: 399px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,400
-              </p>
-            </div>
-            <div
-              class="makeStyles-tick"
-              style="left: 599px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,600
-              </p>
-            </div>
-            <div
-              class="makeStyles-tick"
-              style="left: 799px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,800
-              </p>
-            </div>
-          </div>
-          <div
-            class="makeStyles-block"
-            style="width: 200px;"
-          >
-            <div
-              class="makeStyles-tick"
-              style="left: -1px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                1,800
-              </p>
-            </div>
-            <div
-              class="makeStyles-tick"
-              style="left: 199px;"
-            >
-              <p
-                class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-              >
-                2,000
-              </p>
-            </div>
-          </div>
-          <div
-            class="makeStyles-boundaryPaddingBlock"
-            style="background: none; width: 800px;"
-          />
         </div>
+        <p
+          class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
+          data-testid="refLabel-ctgA"
+          style="left: -1px; padding-left: 1px;"
+        >
+          ctgA
+        </p>
+        <p
+          class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
+          data-testid="refLabel-ctgB"
+          style="left: 101px; padding-left: 1px;"
+        >
+          ctgB
+        </p>
       </div>
-      <p
-        class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
-        data-testid="refLabel-ctgA"
-        style="left: -1px; padding-left: 1px;"
-      >
-        ctgA
-      </p>
-      <p
-        class="MuiTypography-root makeStyles-refLabel MuiTypography-body1"
-        data-testid="refLabel-ctgB"
-        style="left: 101px; padding-left: 1px;"
-      >
-        ctgB
-      </p>
     </div>
     <div
       class="makeStyles-spacer"

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -359,7 +359,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
   >
     <div
       class="makeStyles-verticalGuidesZoomContainer"
-      style="transform: scaleX(1);"
     >
       <div
         class="makeStyles-verticalGuidesContainer"
@@ -409,18 +408,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-rubberBand"
-      style="left: 0px; width: 0px;"
-    >
-      <h6
-        class="MuiTypography-root makeStyles-rubberBandText MuiTypography-h6"
-      >
-        0
-         bp
-         
-      </h6>
-    </div>
-    <div
       class="makeStyles-guide"
       style="left: 0px;"
       title="1"
@@ -433,7 +420,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
     >
       <div
         class="makeStyles-scaleBarZoomContainer"
-        style="transform: scaleX(1);"
       >
         <div
           class="makeStyles-scaleBar"
@@ -1189,7 +1175,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
   >
     <div
       class="makeStyles-verticalGuidesZoomContainer"
-      style="transform: scaleX(1);"
     >
       <div
         class="makeStyles-verticalGuidesContainer"
@@ -1469,18 +1454,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       </div>
     </div>
     <div
-      class="makeStyles-rubberBand"
-      style="left: 0px; width: 0px;"
-    >
-      <h6
-        class="MuiTypography-root makeStyles-rubberBandText MuiTypography-h6"
-      >
-        0
-         bp
-         
-      </h6>
-    </div>
-    <div
       class="makeStyles-guide"
       style="left: 0px;"
       title="1"
@@ -1493,7 +1466,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
     >
       <div
         class="makeStyles-scaleBarZoomContainer"
-        style="transform: scaleX(1);"
       >
         <div
           class="makeStyles-scaleBar"

--- a/test_data/config.json
+++ b/test_data/config.json
@@ -1,6 +1,6 @@
 {
   "configuration": {
-    "useUrlSession": false
+    "useUrlSession": true
   },
   "assemblies": [
     {


### PR DESCRIPTION
There were quite a few things that get constantly re-rendered at each frame including

TrackContainer and all children such as TrackLabels
RubberBand which included all children
All VerticalGuides
All scale bar contents

Also removes the usage of children in VerticalGuides/RubberBand because I observed that the  usage of it was

```
<>
   <SomeStuff>
   {children}
</>
```

This implied to me that since it was a React fragment, it didn't really need to actually be using children

FPS for various parts of the app are restored to 60FPS

Applies to #117 (side scroll slow on firefox) but similarly accelerates chrome just because it accelerates a lot of per frame work

Fails opening the zoom scroll menu currently but should be fixable
