### PR TITLE
Reduce re-rendering of track blocks

### DIFF
--- a/packages/core/util/calculateStaticBlocks.ts
+++ b/packages/core/util/calculateStaticBlocks.ts
@@ -80,9 +80,8 @@ export default function calculateBlocks(self: any, extra = 0) {
         isRightEndOfDisplayedRegion,
         key: '',
       }
-      blockData.key = `${assembleLocString(blockData)}${
-        reversed ? '-reversed' : ''
-      }`
+      const locstring = assembleLocString(blockData)
+      blockData.key = `${locstring}-${index}-${reversed ? '-reversed' : ''}`
       if (index === 0 && blockNum === 0) {
         blocks.push(
           new InterRegionPaddingBlock({
@@ -107,7 +106,7 @@ export default function calculateBlocks(self: any, extra = 0) {
       ) {
         blocks.push(
           new InterRegionPaddingBlock({
-            key: `${blockData.key}-${index}-rightpad`,
+            key: `${blockData.key}-rightpad`,
             widthPx: interRegionPaddingWidth,
             offsetPx: blockData.offsetPx + blockData.widthPx,
           }),

--- a/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/components/TrackBlocks.tsx
@@ -49,7 +49,7 @@ const RenderedBlocks = observer(
           if (block instanceof ContentBlock) {
             const state = blockState.get(block.key)
             return (
-              <Block block={block} key={`${model.id}-${block.key}-${idx}`}>
+              <Block block={block} key={`${model.id}-${block.key}`}>
                 {state && state.ReactComponent ? (
                   <state.ReactComponent model={state} />
                 ) : null}


### PR DESCRIPTION
This suggests to remove the index parameter from the TrackBlocks in favor of blockKey which can incorporate the index from the displayedRegions (ref 2362665866)