### PR TITLE
Add "notify" to session

### DIFF
--- a/packages/alignments/src/PileupTrack/model.ts
+++ b/packages/alignments/src/PileupTrack/model.ts
@@ -54,10 +54,9 @@ export default (
       copyFeatureToClipboard(feature: Feature) {
         const copiedFeature = feature.toJSON()
         delete copiedFeature.uniqueId
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const session = getSession(self) as any
+        const session = getSession(self)
         copy(JSON.stringify(copiedFeature, null, 4))
-        session.notify('Copied to clipboard')
+        session.notify('Copied to clipboard', 'success')
       },
 
       // returned if there is no feature id under mouse

--- a/packages/alignments/src/PileupTrack/model.ts
+++ b/packages/alignments/src/PileupTrack/model.ts
@@ -57,7 +57,7 @@ export default (
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const session = getSession(self) as any
         copy(JSON.stringify(copiedFeature, null, 4))
-        session.pushSnackbarMessage('Copied to clipboard')
+        session.notify('Copied to clipboard')
       },
 
       // returned if there is no feature id under mouse

--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -66,7 +66,7 @@ function App({ session }) {
       session.savedSessionNames &&
       session.savedSessionNames.includes(newName)
     ) {
-      session.pushSnackbarMessage(
+      session.notify(
         `Cannot rename session to "${newName}", a saved session with that name already exists`,
       )
     } else {

--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -68,6 +68,7 @@ function App({ session }) {
     ) {
       session.notify(
         `Cannot rename session to "${newName}", a saved session with that name already exists`,
+        'warning',
       )
     } else {
       session.renameCurrentSession(newName)

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -1,13 +1,16 @@
 import IconButton from '@material-ui/core/IconButton'
 import Snackbar from '@material-ui/core/Snackbar'
 import CloseIcon from '@material-ui/icons/Close'
+import Alert from '@material-ui/lab/Alert'
 import { observer } from 'mobx-react'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
-import { AbstractSessionModel } from '../util'
+import { AbstractSessionModel, NotificationLevel } from '../util'
+
+type SnackbarMessage = [string, NotificationLevel]
 
 interface SnackbarSession extends AbstractSessionModel {
-  snackbarMessages: unknown[]
+  snackbarMessages: SnackbarMessage[]
   popSnackbarMessage: () => unknown
 }
 
@@ -17,7 +20,9 @@ function MessageSnackbar({
   session: SnackbarSession & IAnyStateTreeNode
 }) {
   const [open, setOpen] = useState(false)
-  const [snackbarMessage, setSnackbarMessage] = useState('')
+  const [snackbarMessage, setSnackbarMessage] = useState<
+    SnackbarMessage | undefined
+  >()
 
   const { popSnackbarMessage, snackbarMessages } = session
 
@@ -30,16 +35,16 @@ function MessageSnackbar({
 
     if (snackbarMessage) {
       if (!latestMessage) {
-        setSnackbarMessage('')
-      } else if (snackbarMessage !== latestMessage) {
+        setSnackbarMessage(undefined)
+      } else if (snackbarMessage[0] !== latestMessage[0]) {
         setOpen(false)
         timeoutId = setTimeout(() => {
-          setSnackbarMessage(String(latestMessage))
+          setSnackbarMessage(latestMessage)
           setOpen(true)
         }, 100)
       }
     } else if (latestMessage) {
-      setSnackbarMessage(String(latestMessage))
+      setSnackbarMessage(latestMessage)
       setOpen(true)
     }
 
@@ -59,17 +64,21 @@ function MessageSnackbar({
     setOpen(false)
   }
 
+  const [message, level] = snackbarMessage || []
   return (
     <Snackbar
       open={open}
       onClose={handleClose}
-      message={snackbarMessage}
       action={
         <IconButton aria-label="close" color="inherit" onClick={handleClose}>
           <CloseIcon />
         </IconButton>
       }
-    />
+    >
+      <Alert onClose={handleClose} severity={level || 'warning'}>
+        {message}
+      </Alert>
+    </Snackbar>
   )
 }
 

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -2,10 +2,20 @@ import IconButton from '@material-ui/core/IconButton'
 import Snackbar from '@material-ui/core/Snackbar'
 import CloseIcon from '@material-ui/icons/Close'
 import { observer } from 'mobx-react'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
 import React, { useEffect, useState } from 'react'
+import { AbstractSessionModel } from '../util'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function MessageSnackbar({ session }: { session?: any }) {
+interface SnackbarSession extends AbstractSessionModel {
+  snackbarMessages: unknown[]
+  popSnackbarMessage: () => unknown
+}
+
+function MessageSnackbar({
+  session,
+}: {
+  session: SnackbarSession & IAnyStateTreeNode
+}) {
   const [open, setOpen] = useState(false)
   const [snackbarMessage, setSnackbarMessage] = useState('')
 
@@ -24,12 +34,12 @@ function MessageSnackbar({ session }: { session?: any }) {
       } else if (snackbarMessage !== latestMessage) {
         setOpen(false)
         timeoutId = setTimeout(() => {
-          setSnackbarMessage(latestMessage)
+          setSnackbarMessage(String(latestMessage))
           setOpen(true)
         }, 100)
       }
     } else if (latestMessage) {
-      setSnackbarMessage(latestMessage)
+      setSnackbarMessage(String(latestMessage))
       setOpen(true)
     }
 

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -32,6 +32,8 @@ export function isViewContainer(
   return isStateTreeNode(thing) && 'removeView' in thing
 }
 
+type NotificationLevel = 'error' | 'info' | 'warning' | 'success'
+
 export type AssemblyManager = Instance<ReturnType<typeof assemblyManager>>
 
 /** minimum interface that all session state models must implement */
@@ -46,7 +48,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   assemblies: AnyConfigurationModel[]
   selection?: unknown
   duplicateCurrentSession(): void
-  notify(message: string): void
+  notify(message: string, level?: NotificationLevel): void
   assemblyManager: AssemblyManager
 }
 export function isSessionModel(thing: unknown): thing is AbstractSessionModel {

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -46,7 +46,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   assemblies: AnyConfigurationModel[]
   selection?: unknown
   duplicateCurrentSession(): void
-  pushSnackbarMessage(message: string): void
+  notify(message: string): void
   assemblyManager: AssemblyManager
 }
 export function isSessionModel(thing: unknown): thing is AbstractSessionModel {

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -32,7 +32,7 @@ export function isViewContainer(
   return isStateTreeNode(thing) && 'removeView' in thing
 }
 
-type NotificationLevel = 'error' | 'info' | 'warning' | 'success'
+export type NotificationLevel = 'error' | 'info' | 'warning' | 'success'
 
 export type AssemblyManager = Instance<ReturnType<typeof assemblyManager>>
 

--- a/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
@@ -95,7 +95,7 @@ function AddTrackDrawerWidget({ model }) {
     if (model.view) {
       model.view.showTrack(trackConf)
     } else {
-      session.pushSnackbarMessage(
+      session.notify(
         'Open a new view, or use the track selector in an existing view, to view this track',
       )
     }

--- a/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
+++ b/packages/data-management/src/AddTrackDrawerWidget/components/AddTrackDrawerWidget.js
@@ -97,6 +97,7 @@ function AddTrackDrawerWidget({ model }) {
     } else {
       session.notify(
         'Open a new view, or use the track selector in an existing view, to view this track',
+        'info',
       )
     }
     session.hideDrawerWidget(model)

--- a/packages/data-management/src/ucsc-trackhub/model.js
+++ b/packages/data-management/src/ucsc-trackhub/model.js
@@ -92,6 +92,7 @@ export default function (pluginManager) {
               console.error(error)
               session.notify(
                 `There was a problem connecting to the UCSC Track Hub "${self.name}". Please make sure you have entered a valid hub.txt file. The error that was thrown is: "${error}"`,
+                'error',
               )
               session.breakConnection(self.configuration)
             })

--- a/packages/data-management/src/ucsc-trackhub/model.js
+++ b/packages/data-management/src/ucsc-trackhub/model.js
@@ -90,7 +90,7 @@ export default function (pluginManager) {
             })
             .catch(error => {
               console.error(error)
-              session.pushSnackbarMessage(
+              session.notify(
                 `There was a problem connecting to the UCSC Track Hub "${self.name}". Please make sure you have entered a valid hub.txt file. The error that was thrown is: "${error}"`,
               )
               session.breakConnection(self.configuration)

--- a/packages/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/packages/jbrowse-desktop/src/sessionModelFactory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
-import { Region } from '@gmod/jbrowse-core/util/types'
+import { Region, NotificationLevel } from '@gmod/jbrowse-core/util/types'
 import { getContainingView } from '@gmod/jbrowse-core/util'
 import { observable } from 'mobx'
 import {
@@ -419,12 +419,12 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           },
         },
         actions: {
-          notify(message: string) {
-            return this.pushSnackbarMessage(message)
+          notify(message: string, level?: NotificationLevel) {
+            return this.pushSnackbarMessage(message, level)
           },
 
-          pushSnackbarMessage(message: string) {
-            return snackbarMessages.push(message)
+          pushSnackbarMessage(message: string, level?: NotificationLevel) {
+            return snackbarMessages.push([message, level])
           },
 
           popSnackbarMessage() {

--- a/packages/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/packages/jbrowse-desktop/src/sessionModelFactory.ts
@@ -419,6 +419,10 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           },
         },
         actions: {
+          notify(message: string) {
+            return this.pushSnackbarMessage(message)
+          },
+
           pushSnackbarMessage(message: string) {
             return snackbarMessages.push(message)
           },

--- a/packages/jbrowse-web/src/sessionModelFactory.ts
+++ b/packages/jbrowse-web/src/sessionModelFactory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
-import { Region } from '@gmod/jbrowse-core/util/types'
+import { Region, NotificationLevel } from '@gmod/jbrowse-core/util/types'
 import { getContainingView } from '@gmod/jbrowse-core/util'
 import { observable } from 'mobx'
 import {
@@ -420,12 +420,12 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           },
         },
         actions: {
-          notify(message: string) {
-            return this.pushSnackbarMessage(message)
+          notify(message: string, level?: NotificationLevel) {
+            return this.pushSnackbarMessage(message, level)
           },
 
-          pushSnackbarMessage(message: string) {
-            return snackbarMessages.push(message)
+          pushSnackbarMessage(message: string, level?: NotificationLevel) {
+            return snackbarMessages.push([message, level])
           },
 
           popSnackbarMessage() {

--- a/packages/jbrowse-web/src/sessionModelFactory.ts
+++ b/packages/jbrowse-web/src/sessionModelFactory.ts
@@ -420,6 +420,10 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           },
         },
         actions: {
+          notify(message: string) {
+            return this.pushSnackbarMessage(message)
+          },
+
           pushSnackbarMessage(message: string) {
             return snackbarMessages.push(message)
           },

--- a/packages/jbrowse1/src/JBrowse1Connection/model.js
+++ b/packages/jbrowse1/src/JBrowse1Connection/model.js
@@ -54,6 +54,7 @@ export default function (pluginManager) {
               console.error(error)
               session.notify(
                 `There was a problem connecting to the JBrowse 1 data directory "${self.name}. Please make sure you have entered a valid location. The error that was thrown is: "${error}"`,
+                'error',
               )
               session.breakConnection(self.configuration)
             })

--- a/packages/jbrowse1/src/JBrowse1Connection/model.js
+++ b/packages/jbrowse1/src/JBrowse1Connection/model.js
@@ -52,7 +52,7 @@ export default function (pluginManager) {
             })
             .catch(error => {
               console.error(error)
-              session.pushSnackbarMessage(
+              session.notify(
                 `There was a problem connecting to the JBrowse 1 data directory "${self.name}. Please make sure you have entered a valid location. The error that was thrown is: "${error}"`,
               )
               session.breakConnection(self.configuration)

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -184,8 +184,8 @@ const Search = observer(({ model }: { model: LGV }) => {
       }
       model.navToLocStrings(locString)
     } catch (e) {
-      console.error(e)
-      session.notify(`${e}`, 'error')
+      console.warn(e)
+      session.notify(`${e}`, 'warning')
     }
   }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -185,7 +185,7 @@ const Search = observer(({ model }: { model: LGV }) => {
       model.navToLocStrings(locString)
     } catch (e) {
       console.error(e)
-      session.pushSnackbarMessage(`${e}`)
+      session.notify(`${e}`)
     }
   }
 

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -185,7 +185,7 @@ const Search = observer(({ model }: { model: LGV }) => {
       model.navToLocStrings(locString)
     } catch (e) {
       console.error(e)
-      session.notify(`${e}`)
+      session.notify(`${e}`, 'error')
     }
   }
 


### PR DESCRIPTION
Makes session have a "notify" action instead of "pushSnackbarMessage". Also adds levels to the snackbar messages. Uses the levels in jbrowse-web and -desktop for customized snackbar messages:

![image](https://user-images.githubusercontent.com/25592344/83579656-1a19d780-a4f7-11ea-8fbe-fed58d8d957c.png)

![image](https://user-images.githubusercontent.com/25592344/83579693-30279800-a4f7-11ea-9f14-d65166d14752.png)

Resolves #975 