### PR TITLE
Add refNameColor to LGV overview

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -134,6 +134,11 @@ function OverviewScaleBar({
     <>
       <div className={classes.scaleBar}>
         {wholeRefSeqs.map((seq, idx) => {
+          const assembly = assemblyManager.get(seq.assemblyName)
+          let refNameColor: string | undefined
+          if (assembly) {
+            refNameColor = assembly.getRefNameColor(seq.refName)
+          }
           const regionLength = seq.end - seq.start
           const numLabels = Math.floor(regionLength / gridPitch.majorPitch)
           const labels = []
@@ -148,11 +153,15 @@ function OverviewScaleBar({
                 minWidth: regionLength / scale,
                 marginRight:
                   idx === wholeRefSeqs.length - 1 ? undefined : wholeSeqSpacer,
+                borderColor: refNameColor,
               }}
               className={classes.scaleBarContig}
               variant="outlined"
             >
-              <Typography className={classes.scaleBarRefName}>
+              <Typography
+                style={{ color: refNameColor }}
+                className={classes.scaleBarRefName}
+              >
                 {seq.refName}
               </Typography>
               {visibleRegions.map((r, visibleRegionIdx) => {
@@ -179,6 +188,7 @@ function OverviewScaleBar({
                   className={classes.scaleBarLabel}
                   style={{
                     left: ((labelIdx + 1) * gridPitch.majorPitch) / scale,
+                    color: refNameColor,
                   }}
                 >
                   {label.toLocaleString()}

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -7,10 +7,11 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
   >
     <div
       class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-      style="min-width: 800px;"
+      style="min-width: 800px; border-color: rgb(153, 102, 0);"
     >
       <p
         class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
+        style="color: rgb(153, 102, 0);"
       >
         ctgA
       </p>
@@ -20,13 +21,13 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       />
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 400px;"
+        style="left: 400px; color: rgb(153, 102, 0);"
       >
         5
       </div>
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 800px;"
+        style="left: 800px; color: rgb(153, 102, 0);"
       >
         10
       </div>
@@ -820,10 +821,11 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
   >
     <div
       class="MuiPaper-root makeStyles-scaleBarContig MuiPaper-outlined MuiPaper-rounded"
-      style="min-width: 800px;"
+      style="min-width: 800px; border-color: rgb(153, 102, 0);"
     >
       <p
         class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
+        style="color: rgb(153, 102, 0);"
       >
         ctgA
       </p>
@@ -833,13 +835,13 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       />
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 400px;"
+        style="left: 400px; color: rgb(153, 102, 0);"
       >
         5
       </div>
       <div
         class="makeStyles-scaleBarLabel"
-        style="left: 800px;"
+        style="left: 800px; color: rgb(153, 102, 0);"
       >
         10
       </div>


### PR DESCRIPTION
May or may not be something we want to do, but this is just a small change that adds the refNameColor (currently used in the circular view) to the LGV overview.

![image](https://user-images.githubusercontent.com/25592344/83677003-c364da00-a598-11ea-8ce6-e7c44bf3583d.png)
