### PR TITLE
Remove @typescript-eslint/recommended-requiring-type-checking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
   "extends": [
     "airbnb-typescript",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:monorepo/recommended",
     "plugin:prettier/recommended",
     "prettier/@typescript-eslint",


### PR DESCRIPTION
I think maybe we can remove @typescript-eslint/recommended-requiring-type-checking rules

It was something I added in the first place but I think it just wastes cpu

Running eslint ~20 second less without it for me, and I think the rules in it are not that interesting, garretts script/getSuggestions is basically doing the same thing probably