### PR TITLE
Make navigating via RefNameAutocomplete create a "showAllRegions" type view

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -174,23 +174,20 @@ const Search = observer(({ model }: { model: LGV }) => {
     (region: Region | undefined) => {
       if (region) {
         model.setDisplayedRegions([region])
+        model.showAllRegionsButSlightlyZoomedIn()
       }
     },
     [model],
   )
 
-  const assemblyName = contentBlocks.length
-    ? contentBlocks[0].assemblyName
-    : undefined
+  const { assemblyName, refName } = contentBlocks[0] || {}
   return (
     <>
       <RefNameAutocomplete
         model={model}
         onSelect={setDisplayedRegion}
         assemblyName={assemblyName}
-        defaultRegionName={
-          displayedRegions.length > 1 ? '' : contentBlocks[0].refName
-        }
+        defaultRegionName={displayedRegions.length > 1 ? '' : refName}
         TextFieldProps={{
           variant: 'outlined',
           margin: 'dense',

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -691,11 +691,16 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.offsetPx = offsetPx
       },
 
+      // this makes a zoomed out view that shows all displayedRegions
+      // that makes the overview bar square with the scale bar
       showAllRegions() {
         self.bpPerPx = self.totalBp / self.width
         self.offsetPx = 0
       },
 
+      // this makes a zoomed out view that shows all displayedRegions
+      // but is slightly zoomed in, which looks nicer than having the overview
+      // scale bar square with the scale bar
       showAllRegionsButSlightlyZoomedIn() {
         self.bpPerPx = (self.totalBp * 0.75) / self.width
         self.offsetPx = self.width / 8

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -696,6 +696,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.offsetPx = 0
       },
 
+      showAllRegionsButSlightlyZoomedIn() {
+        self.bpPerPx = (self.totalBp * 0.75) / self.width
+        self.offsetPx = self.width / 8
+      },
+
       setDraggingTrackId(idx?: string) {
         self.draggingTrackId = idx
       },


### PR DESCRIPTION
This fixes #987 by navigating to a new refName causing basically a "showAllRegions" but I make it slightly zoomed in because it looks a little nicer that way (has a nice trapezoid pattern a la jbrowse 1 rather than both overview bars being square with each other)

