### PR TITLE
Make sure bpPerPx and offsetPx are clamped

### DIFF
--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -158,7 +158,7 @@ describe('valid file tests', () => {
     fireEvent.mouseUp(track, { clientX: 250, clientY: 0 })
     const zoomMenuItem = await findByText('Zoom to region')
     fireEvent.click(zoomMenuItem)
-    expect(state.session.views[0].bpPerPx).toEqual(0.009375)
+    expect(state.session.views[0].bpPerPx).toEqual(0.02)
   })
 
   it('click and drag to reorder tracks', async () => {

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -174,13 +174,13 @@ const Search = observer(({ model }: { model: LGV }) => {
     (region: Region | undefined) => {
       if (region) {
         model.setDisplayedRegions([region])
-        model.showAllRegionsButSlightlyZoomedIn()
+        model.showAllRegions()
       }
     },
     [model],
   )
 
-  const { assemblyName, refName } = contentBlocks[0] || {}
+  const { assemblyName, refName } = contentBlocks[0] || { refName: '' }
   return (
     <>
       <RefNameAutocomplete

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -300,7 +300,7 @@ test('can instantiate a model that >2 regions', () => {
   expect(model.offsetPx).toEqual(10000 / model.bpPerPx + 2)
   expect(model.displayedRegionsTotalPx).toEqual(30000 / model.bpPerPx)
   model.showAllRegions()
-  expect(model.offsetPx).toEqual(125)
+  expect(model.offsetPx).toEqual(100)
 
   expect(model.bpToPx({ refName: 'ctgA', coord: 100 })).toEqual({
     index: 0,

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -300,7 +300,7 @@ test('can instantiate a model that >2 regions', () => {
   expect(model.offsetPx).toEqual(10000 / model.bpPerPx + 2)
   expect(model.displayedRegionsTotalPx).toEqual(30000 / model.bpPerPx)
   model.showAllRegions()
-  expect(model.offsetPx).toEqual(0)
+  expect(model.offsetPx).toEqual(125)
 
   expect(model.bpToPx({ refName: 'ctgA', coord: 100 })).toEqual({
     index: 0,

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -690,9 +690,14 @@ export function stateModelFactory(pluginManager: PluginManager) {
         /* TODO */
       },
 
+      center() {
+        const centerBp = self.totalBp / 2
+        self.scrollTo(Math.round(centerBp / self.bpPerPx - self.width / 2))
+      },
+
       showAllRegions() {
-        self.zoomTo(self.totalBp / self.width)
-        self.scrollTo(self.displayedRegionsTotalPx / 8)
+        self.zoomTo(self.maxBpPerPx)
+        this.center()
       },
 
       setDraggingTrackId(idx?: string) {

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -695,14 +695,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.scrollTo(self.displayedRegionsTotalPx / 8)
       },
 
-      // this makes a zoomed out view that shows all displayedRegions
-      // but is slightly zoomed in, which looks nicer than having the overview
-      // scale bar square with the scale bar
-      showAllRegionsButSlightlyZoomedIn() {
-        self.zoomTo((self.totalBp * 0.75) / self.width)
-        self.scrollTo(self.width / 8)
-      },
-
       setDraggingTrackId(idx?: string) {
         self.draggingTrackId = idx
       },

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -737,9 +737,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.zoomTo(self.bpPerPx)
         if (
           // already zoomed all the way in
-          self.bpPerPx === self.minBpPerPx ||
+          (targetBpPerPx < self.bpPerPx && self.bpPerPx === self.minBpPerPx) ||
           // already zoomed all the way out
-          self.bpPerPx === self.maxBpPerPx
+          (targetBpPerPx > self.bpPerPx && self.bpPerPx === self.maxBpPerPx)
         ) {
           return
         }


### PR DESCRIPTION
This makes sure that all places in the LGV model that modify `bpPerPx` or `offsetPx` use `zoomTo(bpPerPx)` and `scrollTo(bpPerPx)`, which makes sure they are properly clamped. Before this, using setDisplayedRegion might result in the new region being completely offscreen (the root cause of #987), but now the clamping ensures that any new regions are on screen.

Also removes `showAllRegionsButSlightlyZoomedIn` since with bpPerPx being clamped, you never end up with the displayed regions square with the overview scale bar.