### PR TITLE
Remove usage of display:flex in the feature details drawer

### DIFF
--- a/packages/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/packages/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -69,9 +69,7 @@ exports[`open up a drawer widget 1`] = `
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -85,9 +83,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -101,9 +97,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -117,9 +111,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -203,9 +195,7 @@ exports[`open up a drawer widget 1`] = `
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -219,9 +209,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -235,9 +223,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -251,9 +237,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -267,9 +251,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -283,9 +265,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -299,9 +279,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -315,9 +293,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -331,9 +307,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -347,9 +321,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -363,9 +335,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -379,9 +349,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -395,9 +363,7 @@ exports[`open up a drawer widget 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >

--- a/packages/core/BaseFeatureDrawerWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureDrawerWidget/BaseFeatureDetail.tsx
@@ -109,7 +109,7 @@ const BaseCoreDetails = (props: BaseProps) => {
         const value = displayedDetails[key.toLowerCase()]
         const strValue = String(value)
         return value ? (
-          <div key={key} style={{ display: 'flex' }}>
+          <div key={key}>
             <div className={classes.fieldName}>{key}</div>
             <div className={classes.fieldValue}>
               <SanitizedHTML html={strValue} />
@@ -143,7 +143,7 @@ const Attributes: FunctionComponent<AttributeProps> = props => {
   const classes = useStyles()
   const { attributes } = props
   const SimpleValue = ({ name, value }: { name: string; value: any }) => (
-    <div style={{ display: 'flex' }}>
+    <div>
       <div className={classes.fieldName}>{name}</div>
       <div className={classes.fieldValue}>
         <SanitizedHTML
@@ -153,7 +153,7 @@ const Attributes: FunctionComponent<AttributeProps> = props => {
     </div>
   )
   const ArrayValue = ({ name, value }: { name: string; value: any[] }) => (
-    <div style={{ display: 'flex' }}>
+    <div>
       <div className={classes.fieldName}>{name}</div>
       {value.map((val, i) => (
         <div key={`${name}-${i}`} className={classes.fieldSubvalue}>

--- a/packages/core/BaseFeatureDrawerWidget/__snapshots__/index.test.js.snap
+++ b/packages/core/BaseFeatureDrawerWidget/__snapshots__/index.test.js.snap
@@ -65,9 +65,7 @@ exports[`open up a drawer widget 1`] = `
             <div
               class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
             >
-              <div
-                style="display: flex;"
-              >
+              <div>
                 <div
                   class="makeStyles-fieldName"
                 >
@@ -81,9 +79,7 @@ exports[`open up a drawer widget 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                style="display: flex;"
-              >
+              <div>
                 <div
                   class="makeStyles-fieldName"
                 >
@@ -167,9 +163,7 @@ exports[`open up a drawer widget 1`] = `
             <div
               class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
             >
-              <div
-                style="display: flex;"
-              >
+              <div>
                 <div
                   class="makeStyles-fieldName"
                 >

--- a/packages/gdc/src/GDCFeatureDrawerWidget/__snapshots__/GDCFeatureDrawerWidget.test.js.snap
+++ b/packages/gdc/src/GDCFeatureDrawerWidget/__snapshots__/GDCFeatureDrawerWidget.test.js.snap
@@ -69,9 +69,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -85,9 +83,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -101,9 +97,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -117,9 +111,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -133,9 +125,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -219,9 +209,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -235,9 +223,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -251,9 +237,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -267,9 +251,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -283,9 +265,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -299,9 +279,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -315,9 +293,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -331,9 +307,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -347,9 +321,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -363,9 +335,7 @@ exports[`GDCTrack drawer widget renders gene with just the required model elemen
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -488,9 +458,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -504,9 +472,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -520,9 +486,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -606,9 +570,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -622,9 +584,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -638,9 +598,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -654,9 +612,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -670,9 +626,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -686,9 +640,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -702,9 +654,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -718,9 +668,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -734,9 +682,7 @@ exports[`GDCTrack drawer widget renders mutation with just the required model el
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >

--- a/packages/variants/src/VariantFeatureDrawerWidget/__snapshots__/VariantFeatureDrawerWidget.test.js.snap
+++ b/packages/variants/src/VariantFeatureDrawerWidget/__snapshots__/VariantFeatureDrawerWidget.test.js.snap
@@ -69,9 +69,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -85,9 +83,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -101,9 +97,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -187,9 +181,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
               <div
                 class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
               >
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -203,9 +195,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -219,9 +209,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >
@@ -235,9 +223,7 @@ exports[`VariantTrack drawer widget renders with just the required model element
                     </div>
                   </div>
                 </div>
-                <div
-                  style="display: flex;"
-                >
+                <div>
                   <div
                     class="makeStyles-fieldName"
                   >


### PR DESCRIPTION
We found that usage of flexbox in the basic detail drawer widgets was basically unnecessary, and actually caused some slowdown when it contained long reads related to #745

Doesn't completely solve #745 still, but this just suggests removing the unnecessary style element