### PR TITLE
Overview rubber band fixes

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -86,7 +86,11 @@ function OverviewRubberBand({
     }
 
     function globalMouseUp(event: MouseEvent) {
-      if (controlsRef.current && startX && currentX) {
+      if (
+        controlsRef.current &&
+        startX !== undefined &&
+        currentX !== undefined
+      ) {
         if (Math.abs(currentX - startX) > 3)
           model.zoomToDisplayedRegions(
             overview.pxToBp(startX),

--- a/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -87,14 +87,14 @@ function OverviewRubberBand({
 
     function globalMouseUp(event: MouseEvent) {
       if (controlsRef.current && startX && currentX) {
-        if (startX !== currentX)
+        if (startX !== currentX && Math.abs(currentX - startX) > 3)
           model.zoomToDisplayedRegions(
             overview.pxToBp(startX),
             overview.pxToBp(currentX),
           )
-        setStartX(undefined)
-        setCurrentX(undefined)
       }
+      setStartX(undefined)
+      setCurrentX(undefined)
 
       if (startX !== undefined) {
         setGuideX(undefined)

--- a/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -87,7 +87,7 @@ function OverviewRubberBand({
 
     function globalMouseUp(event: MouseEvent) {
       if (controlsRef.current && startX && currentX) {
-        if (startX !== currentX && Math.abs(currentX - startX) > 3)
+        if (Math.abs(currentX - startX) > 3)
           model.zoomToDisplayedRegions(
             overview.pxToBp(startX),
             overview.pxToBp(currentX),

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -408,6 +408,32 @@ describe.only('Zoom to selected displayed regions', () => {
     expect(model.bpPerPx).toBeCloseTo(8.771)
     expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })
+
+  it('can navigate to overlapping regions with a region between', () => {
+    model.setDisplayedRegions([
+      { assemblyName: 'volvox', refName: 'ctgA', start: 5000, end: 20000 },
+      { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 3000 },
+      { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 35000 },
+    ])
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 10000,
+        refName: 'ctgA',
+      },
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 15000,
+        refName: 'ctgA',
+      },
+    )
+    expect(model.offsetPx).toBe(142)
+    expect(model.bpPerPx).toBeCloseTo(35.176)
+  })
 })
 
 test('can instantiate a model that >2 regions', () => {

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -276,127 +276,138 @@ test('can navToMultiple', () => {
   )
 })
 
-test('can zoom to displayed regions given a selection', () => {
-  const session = Session.create({
-    configuration: {},
+describe.only('Zoom to selected displayed regions', () => {
+  let model: Instance<ReturnType<typeof stateModelFactory>>
+  let largestBpPerPx: number
+  beforeAll(() => {
+    const session = Session.create({
+      configuration: {},
+    })
+    const width = 800
+    model = session.setView(
+      LinearGenomeModel.create({
+        id: 'testZoomToDisplayed',
+        type: 'LinearGenomeView',
+      }),
+    )
+    model.setWidth(width)
+    model.setDisplayedRegions([
+      { assemblyName: 'volvox', refName: 'ctgA', start: 5000, end: 20000 },
+      { assemblyName: 'volvox', refName: 'ctgA', start: 30000, end: 40000 },
+      { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 3000 },
+    ])
   })
-  const width = 800
-  const model = session.setView(
-    LinearGenomeModel.create({
-      id: 'testZoomToDisplayed',
-      type: 'LinearGenomeView',
-    }),
-  )
-  model.setWidth(width)
-  model.setDisplayedRegions([
-    { assemblyName: 'volvox', refName: 'ctgA', start: 5000, end: 20000 },
-    { assemblyName: 'volvox', refName: 'ctgA', start: 30000, end: 40000 },
-    { assemblyName: 'volvox', refName: 'ctgB', start: 0, end: 3000 },
-  ])
 
-  // select whole region, should have no offset and largest bpPerPx
-  model.zoomToDisplayedRegions(
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 0,
-      refName: 'ctgA',
-    },
-    {
-      start: 0,
-      index: 1,
-      end: 6079,
-      offset: 6079,
-      refName: 'ctgB',
-    },
-  )
-  const largestBpPerPx = model.bpPerPx
-  expect(model.offsetPx).toBe(0)
-  expect(model.bpPerPx).toBeCloseTo(28)
+  it('can select whole region', () => {
+    // should have no offset and largest bpPerPx
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 0,
+        refName: 'ctgA',
+      },
+      {
+        start: 0,
+        index: 1,
+        end: 6079,
+        offset: 6079,
+        refName: 'ctgB',
+      },
+    )
+    largestBpPerPx = model.bpPerPx
+    expect(model.offsetPx).toBe(0)
+    expect(model.bpPerPx).toBeCloseTo(28)
+  })
 
-  // same results if start and end object are swapped
-  model.zoomToDisplayedRegions(
-    {
-      start: 0,
-      index: 1,
-      end: 6079,
-      offset: 6079,
-      refName: 'ctgB',
-    },
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 0,
-      refName: 'ctgA',
-    },
-  )
-  expect(model.offsetPx).toBe(0)
-  expect(model.bpPerPx).toEqual(largestBpPerPx)
+  it('can select if start and end object are swapped', () => {
+    // should be same results as above test
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 1,
+        end: 6079,
+        offset: 6079,
+        refName: 'ctgB',
+      },
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 0,
+        refName: 'ctgA',
+      },
+    )
+    expect(model.offsetPx).toBe(0)
+    expect(model.bpPerPx).toEqual(largestBpPerPx)
+  })
 
-  // select over one refSeq
-  model.zoomToDisplayedRegions(
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 10000,
-      refName: 'ctgA',
-    },
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 35000,
-      refName: 'ctgA',
-    },
-  )
-  expect(model.offsetPx).toBe(266)
-  expect(model.bpPerPx).toBeCloseTo(18.796)
-  expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  it('can select over one refSeq', () => {
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 10000,
+        refName: 'ctgA',
+      },
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 35000,
+        refName: 'ctgA',
+      },
+    )
+    expect(model.offsetPx).toBe(266)
+    expect(model.bpPerPx).toBeCloseTo(18.796)
+    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  })
 
-  // over one, select start and end outside of displayed region
-  model.zoomToDisplayedRegions(
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 29000,
-      refName: 'ctgA',
-    },
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 50000,
-      refName: 'ctgA',
-    },
-  )
-  expect(model.offsetPx).toBe(1202)
-  expect(model.bpPerPx).toBe(12.5)
-  expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  it('can select one region with start and end outside of displayed region', () => {
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 29000,
+        refName: 'ctgA',
+      },
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 50000,
+        refName: 'ctgA',
+      },
+    )
+    expect(model.offsetPx).toBe(1202)
+    expect(model.bpPerPx).toBe(12.5)
+    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  })
 
-  // over two, select start in ctgA and end in ctgA
-  model.zoomToDisplayedRegions(
-    {
-      start: 0,
-      index: 0,
-      end: 50001,
-      offset: 35000,
-      refName: 'ctgA',
-    },
-    {
-      start: 0,
-      index: 1,
-      end: 6709,
-      offset: 2000,
-      refName: 'ctgB',
-    },
-  )
-  expect(model.offsetPx).toBe(2282)
-  expect(model.bpPerPx).toBeCloseTo(8.771)
-  expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  it('can select over two regions in the same reference sequence', () => {
+    model.zoomToDisplayedRegions(
+      {
+        start: 0,
+        index: 0,
+        end: 50001,
+        offset: 35000,
+        refName: 'ctgA',
+      },
+      {
+        start: 0,
+        index: 1,
+        end: 6709,
+        offset: 2000,
+        refName: 'ctgB',
+      },
+    )
+    expect(model.offsetPx).toBe(2282)
+    expect(model.bpPerPx).toBeCloseTo(8.771)
+    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
+  })
 })
 
 test('can instantiate a model that >2 regions', () => {

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -276,7 +276,7 @@ test('can navToMultiple', () => {
   )
 })
 
-describe.only('Zoom to selected displayed regions', () => {
+describe('Zoom to selected displayed regions', () => {
   let model: Instance<ReturnType<typeof stateModelFactory>>
   let largestBpPerPx: number
   beforeAll(() => {


### PR DESCRIPTION
I was navigating using the new overview rubber band, and found a situation where selecting a region caused a crash. See the added failing test in 2ebe710c2ce7825a117180725298c79ee9ce4fc6.

While looking at the zoomToDisplayedRegions code, I had an idea for a new algorithm for determining where to navigate to. Basically it does this:

- For each displayed region, check if it intersects with any the selection regions
  - If it does, use that region and selection to calculate a start offset and an end offset
  - Only set the start offset once, and update the end offset with each new overlap
- If there were any overlaps, use moveTo to navigate to the offsets (no longer uses navToMultiple)

This change passes all the previously existing tests as well as the one I added that was originally failing.

Also has one small change so that you have to select more than 3 pixels to trigger a navigation (this matches the behavior other rubber band).

One note on the bit of reorganizing I did on the overview rubber band tests, I was trying to separate each case out into its own test. For naming, I used [this suggestion](https://jasmine.github.io/2.6/introduction#section-Grouping_Related_Specs_with_%3Ccode%3Edescribe%3C/code%3E) that the `describe` and `it` parameters when combined should form a sentence.