### PR TITLE
Add longer timeout for jbrowse test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: 10
+node_js:
+  - 10
+  - 14
 sudo: false
 cache:
 - node_modules

--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -300,9 +300,9 @@ describe('test renamed refs', () => {
     )
     fireEvent.click(await findByTestId('htsTrackEntry-volvox_bam_altname'))
     await expect(
-      findAllByText('ctgA_110_638_0:0:0_3:0:0_15b'),
+      findAllByText('ctgA_110_638_0:0:0_3:0:0_15b', {}, { timeout: 15000 }),
     ).resolves.toBeTruthy()
-  })
+  }, 20000)
 
   it('open a bigwig with a renamed reference', async () => {
     const pluginManager = getPluginManager()


### PR DESCRIPTION
Unfortunately the cause of some slowness in #1008 is sort of unclear. There are some patterns I observed

- Using only pako can improve some performance, e.g. remove nodeUnzip
- Using gunzipSync can improve some performance, e.g. change nodeUnzip to use gunzipSync 
- There was another thing where we can sometimes reduce the amount of data we unzip in the BAM header because it by default adds two BGZIP blocks onto the end of the first request (indexData.firstDataLine + 65535 and then again). These added blocks are probably paranoid, and can likely be removed, only unzipping up to firstDataLine which improves some performance
- Other general BAM header and BAI index parsing improvements could be made (the babelization of the BAI parsing seems to result in some inefficient code sometimes, too much abort checking while parsing BAI header, etc)


 All those things could be done, and it could cut down on BAM setup time. For now, it seems like just adding a timeout is helpful though, and if there is any feedback I can go and make some of the other changes here.


This PR also adds node14 to the build matrix

Also, while it seemed to affect that particular test a lot, it's not clear if it particularly affects this test super badly, as any BAM test seems to be affected, it's just this one ended up standing out somehow.