### PR TITLE
Abortable reaction for blocks

### DIFF
--- a/packages/circular-view/src/StructuralVariantChordTrack/models/renderReaction.js
+++ b/packages/circular-view/src/StructuralVariantChordTrack/models/renderReaction.js
@@ -1,8 +1,6 @@
 export default ({ jbrequire }) => {
   const { getConf } = jbrequire('@gmod/jbrowse-core/configuration')
-  const { getTrackAssemblyNames, getRpcSessionId } = jbrequire(
-    '@gmod/jbrowse-core/util/tracks',
-  )
+  const { getRpcSessionId } = jbrequire('@gmod/jbrowse-core/util/tracks')
   const { getContainingView } = jbrequire('@gmod/jbrowse-core/util')
   const { getSession } = jbrequire('@gmod/jbrowse-core/util')
 
@@ -12,14 +10,11 @@ export default ({ jbrequire }) => {
     const { rendererType, renderProps } = track
     const { rpcManager } = getSession(view)
 
-    // TODO: do multiple assemblies
-    const [assemblyName] = getTrackAssemblyNames(track)
-    const data = {
+    return {
       rendererType,
       rpcManager,
       renderProps,
       renderArgs: {
-        assemblyName,
         adapterConfig: JSON.parse(JSON.stringify(getConf(track, 'adapter'))),
         rendererType: rendererType.name,
         renderProps,
@@ -29,7 +24,6 @@ export default ({ jbrequire }) => {
         timeout: 1000000, // 10000,
       },
     }
-    return data
   }
 
   async function renderReactionEffect(props, signal, self) {

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
@@ -94,7 +94,7 @@ export default class ServerSideRenderer extends RendererType {
       config: isStateTreeNode(args.config)
         ? getSnapshot(args.config)
         : args.config,
-      regions: [...args.regions],
+      regions: JSON.parse(JSON.stringify(args.regions)),
       filters: args.filters ? args.filters.toJSON().filters : [],
     }
   }

--- a/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
@@ -3,8 +3,6 @@ import Typography from '@material-ui/core/Typography'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
-import Button from '@material-ui/core/Button'
-import RefreshIcon from '@material-ui/icons/Refresh'
 import ServerSideRenderedContent from '../../LinearGenomeView/components/ServerSideRenderedContent'
 
 const useStyles = makeStyles(theme => ({
@@ -81,15 +79,10 @@ BlockMessage.propTypes = {
   messageText: PropTypes.string.isRequired,
 }
 
-function BlockError({ error, reload }: { error: Error; reload: () => void }) {
+function BlockError({ error }: { error: Error }) {
   const classes = useStyles()
   return (
     <div className={classes.blockError}>
-      {reload ? (
-        <Button onClick={reload} size="small" startIcon={<RefreshIcon />}>
-          Reload
-        </Button>
-      ) : null}
       <Typography color="error" variant="body2">
         {error.message}
       </Typography>
@@ -98,10 +91,6 @@ function BlockError({ error, reload }: { error: Error; reload: () => void }) {
 }
 BlockError.propTypes = {
   error: MobxPropTypes.objectOrObservableObject.isRequired,
-  reload: PropTypes.func,
-}
-BlockError.defaultProps = {
-  reload: undefined,
 }
 
 const ServerSideRenderedBlockContent = observer(
@@ -111,7 +100,6 @@ const ServerSideRenderedBlockContent = observer(
     // requires typing out to avoid circular reference with this component being referenced in the model itself
     model: {
       error: Error | undefined
-      reload: () => void
       message: string | undefined
       filled: boolean
     }
@@ -119,7 +107,7 @@ const ServerSideRenderedBlockContent = observer(
     if (model.error) {
       return (
         <Repeater>
-          <BlockError error={model.error} reload={model.reload} />
+          <BlockError error={model.error} />
         </Repeater>
       )
     }

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  types,
-  getParent,
-  isAlive,
-  addDisposer,
-  cast,
-  Instance,
-} from 'mobx-state-tree'
+import { types, getParent, isAlive, cast, Instance } from 'mobx-state-tree'
 import { Component } from 'react'
-import { reaction } from 'mobx'
 import { getConf, readConfObject } from '@gmod/jbrowse-core/configuration'
 import { Region } from '@gmod/jbrowse-core/util/types/mst'
 
 import {
   assembleLocString,
-  checkAbortSignal,
-  isAbortException,
   makeAbortableReaction,
   getSession,
 } from '@gmod/jbrowse-core/util'

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -16,6 +16,7 @@ import {
   assembleLocString,
   checkAbortSignal,
   isAbortException,
+  makeAbortableReaction,
   getSession,
 } from '@gmod/jbrowse-core/util'
 import {
@@ -51,16 +52,19 @@ const blockState = types
     return {
       afterAttach() {
         const track = getParent<any>(self, 2)
-        const renderDisposer = reaction(
-          () => renderBlockData(self as any),
-          data => (renderBlockEffect(cast(self), data) as unknown) as void, // reaction doesn't expect async here
+        makeAbortableReaction(
+          self as any,
+          renderBlockData,
+          renderBlockEffect as any, // reaction doesn't expect async here
           {
             name: `${track.id}/${assembleLocString(self.region)} rendering`,
             delay: track.renderDelay,
             fireImmediately: true,
           },
+          this.setLoading,
+          this.setRendered,
+          this.setError,
         )
-        addDisposer(self, renderDisposer)
       },
       setLoading(abortController: AbortController) {
         if (renderInProgress !== undefined) {
@@ -92,13 +96,19 @@ const blockState = types
         self.renderProps = undefined
         renderInProgress = undefined
       },
-      setRendered(
-        data: any,
-        html: any,
-        maxHeightReached: boolean,
-        renderingComponent: Component,
-        renderProps: any,
-      ) {
+      setRendered({
+        data,
+        html,
+        maxHeightReached,
+        renderingComponent,
+        renderProps,
+      }: {
+        data: any
+        html: any
+        maxHeightReached: boolean
+        renderingComponent: Component
+        renderProps: any
+      }) {
         self.filled = true
         self.message = undefined
         self.html = html
@@ -234,69 +244,26 @@ interface ErrorProps {
 }
 
 async function renderBlockEffect(
-  self: Instance<BlockStateModel>,
   props: RenderProps | ErrorProps,
-  allowRefetch = true,
+  signal: AbortSignal,
+  self: Instance<BlockStateModel>,
 ) {
   const {
-    trackError,
     rendererType,
     renderProps,
     rpcManager,
-    cannotBeRenderedReason,
     renderArgs,
   } = props as RenderProps
-  if (!isAlive(self)) return
 
-  if (trackError) {
-    self.setError(trackError)
-    return
-  }
-  if (cannotBeRenderedReason) {
-    self.setMessage(cannotBeRenderedReason)
-    return
-  }
-
-  const aborter = new AbortController()
-  self.setLoading(aborter)
-  if (renderProps.notReady) return
-
-  try {
-    renderArgs.signal = aborter.signal
-    // const callId = [
-    //   assembleLocString(renderArgs.region),
-    //   renderArgs.rendererType,
-    // ]
-    const {
-      html,
-      maxHeightReached,
-      ...data
-    } = await rendererType.renderInClient(rpcManager, renderArgs)
-    // if (aborter.signal.aborted) {
-    //   console.log(...callId, 'request to abort render was ignored', html, data)
-    checkAbortSignal(aborter.signal)
-    self.setRendered(
-      data,
-      html,
-      maxHeightReached,
-      rendererType.ReactComponent,
-      renderProps,
-    )
-  } catch (error) {
-    if (isAbortException(error) && !aborter.signal.aborted) {
-      // there is a bug in the underlying code and something is caching aborts. try to refetch once
-      const track = getParent<any>(self, 2)
-      if (allowRefetch) {
-        console.warn(`cached abort detected, refetching "${track.name}"`)
-        renderBlockEffect(self, props, false)
-        return
-      }
-      console.warn(`cached abort detected, failed to recover "${track.name}"`)
-    }
-    if (isAlive(self) && !isAbortException(error)) {
-      // setting the aborted exception as an error will draw the "aborted" error, and we
-      // have not found how to create a re-render if this occurs
-      self.setError(error)
-    }
+  const { html, maxHeightReached, ...data } = await rendererType.renderInClient(
+    rpcManager,
+    renderArgs,
+  )
+  return {
+    data,
+    html,
+    maxHeightReached,
+    renderingComponent: rendererType.ReactComponent,
+    renderProps,
   }
 }

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -253,8 +253,6 @@ async function renderBlockEffect(
     return undefined
   }
 
-  renderArgs.regions = JSON.parse(JSON.stringify(renderArgs.regions))
-
   const { html, maxHeightReached, ...data } = await rendererType.renderInClient(
     rpcManager,
     renderArgs,


### PR DESCRIPTION
This changes the mobx reaction to our custom makeAbortableReaction for the serverSideRenderedBlock code

See #1012 for issue

I haven't seen the issue happen since using this. There was a think where the regions array would be marked as a dead state tree node and I had to manually serialize it here, which I'm not exactly sure why. The older code did not require this