### PR TITLE
Clamp SVG values to the current block area

### DIFF
--- a/packages/svg/src/SvgFeatureRenderer/components/Box.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/Box.js
@@ -21,13 +21,12 @@ function Box(props) {
   const { left, top, width, height } = featureLayout.absolute
 
   // clamp the SVG boxes to the current block area
+  // only clamps from the left hand side of the screen and may
+  // create negative width rects if they go off the right hand side
   const x = Math.max(left, 0)
   const diff = x - left
   const w = width - diff
 
-  // the below Math.min/Math.max 10000px limits are because SVG produces
-  // silent non-rendered elements if it's like millions of px
-  // renders -50000 to screenwidth (up to 100000) +50000
   return (
     <rect
       data-testid={feature.id()}

--- a/packages/svg/src/SvgFeatureRenderer/components/Box.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/Box.js
@@ -6,7 +6,8 @@ import ReactPropTypes from 'prop-types'
 import React from 'react'
 
 function Box(props) {
-  const { feature, config, featureLayout, selected } = props
+  const { feature, region, config, featureLayout, selected, bpPerPx } = props
+  const screenWidth = (region.end - region.start) / bpPerPx
 
   const color1 = readConfObject(config, 'color1', [feature])
   let emphasizedColor1
@@ -19,15 +20,20 @@ function Box(props) {
 
   const { left, top, width, height } = featureLayout.absolute
 
+  // clamp the SVG boxes to the current block area
+  const x = Math.max(left, 0)
+  const diff = x - left
+  const w = width - diff
+
   // the below Math.min/Math.max 10000px limits are because SVG produces
   // silent non-rendered elements if it's like millions of px
   // renders -50000 to screenwidth (up to 100000) +50000
   return (
     <rect
       data-testid={feature.id()}
-      x={Math.max(left, -50000)}
+      x={x}
       y={top}
-      width={Math.min(Math.max(width, 1), 200000)}
+      width={Math.min(w, screenWidth)}
       height={height}
       fill={selected ? emphasizedColor1 : color1}
       stroke={selected ? color2 : undefined}

--- a/packages/svg/src/SvgFeatureRenderer/components/Box.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/Box.js
@@ -46,6 +46,8 @@ Box.propTypes = {
     get: ReactPropTypes.func.isRequired,
     id: ReactPropTypes.func.isRequired,
   }).isRequired,
+  region: CommonPropTypes.Region.isRequired,
+  bpPerPx: ReactPropTypes.number.isRequired,
   featureLayout: ReactPropTypes.shape({
     absolute: ReactPropTypes.shape({
       top: ReactPropTypes.number.isRequired,

--- a/packages/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.js.snap
+++ b/packages/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.js.snap
@@ -119,7 +119,7 @@ exports[`one feature 1`] = `
         data-testid="one"
         fill="goldenrod"
         height="10"
-        width="1"
+        width="0.6666666666666666"
         x="0.3"
         y="0"
       />


### PR DESCRIPTION
This accomplishes a tentative fix for #1030 

It does not address the issue for non-box features though. I'd be curious if there are any ideas on whether that is needed or whether there is a good way to apply this fix through other SVG feature shapes