### PR TITLE
Change block loading to decrease test timeouts

### DIFF
--- a/packages/jbrowse-web/src/JBrowse.test.js
+++ b/packages/jbrowse-web/src/JBrowse.test.js
@@ -312,9 +312,9 @@ describe('test renamed refs', () => {
     )
     fireEvent.click(await findByTestId('htsTrackEntry-volvox_bam_altname'))
     await expect(
-      findAllByText('ctgA_110_638_0:0:0_3:0:0_15b', {}, { timeout: 60000 }),
+      findAllByText('ctgA_110_638_0:0:0_3:0:0_15b'),
     ).resolves.toBeTruthy()
-  }, 60000)
+  })
 
   it('open a bigwig with a renamed reference', async () => {
     const pluginManager = getPluginManager()
@@ -347,8 +347,8 @@ describe('max height test', () => {
     fireEvent.click(
       await findByTestId('htsTrackEntry-volvox_bam_small_max_height'),
     )
-    await findAllByText('Max height reached', {}, { timeout: 60000 })
-  }, 60000)
+    await findAllByText('Max height reached')
+  })
 })
 
 test('lollipop track test', async () => {
@@ -641,7 +641,7 @@ describe('alignments track', () => {
 
     // this is to confirm a alignment detail drawer widget opened
     await expect(findAllByTestId('alignment-side-drawer')).resolves.toBeTruthy()
-  }, 15000)
+  }, 10000)
   it('opens a SNPCoverageTrack', async () => {
     const pluginManager = getPluginManager()
     const state = pluginManager.rootModel
@@ -663,7 +663,7 @@ describe('alignments track', () => {
       failureThreshold: 0.05,
       failureThresholdType: 'percent',
     })
-  }, 15000)
+  }, 10000)
 
   it('opens a PileupTrack', async () => {
     const pluginManager = getPluginManager()
@@ -683,7 +683,7 @@ describe('alignments track', () => {
       failureThreshold: 0.05,
       failureThresholdType: 'percent',
     })
-  }, 15000)
+  }, 10000)
 
   // Note: tracks with assembly volvox don't have much soft clipping
   it('opens the track menu and enables soft clipping', async () => {
@@ -724,7 +724,7 @@ describe('alignments track', () => {
       failureThreshold: 0.2,
       failureThresholdType: 'percent',
     })
-  }, 12000)
+  }, 10000)
 
   it('selects a sort, updates object and layout', async () => {
     const pluginManager = getPluginManager()

--- a/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
@@ -3,6 +3,7 @@ import Typography from '@material-ui/core/Typography'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
+import LinearProgress from '@material-ui/core/LinearProgress'
 import Button from '@material-ui/core/Button'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import ServerSideRenderedContent from '../../LinearGenomeView/components/ServerSideRenderedContent'
@@ -50,20 +51,15 @@ function LoadingMessage() {
   // only show the loading message after 300ms to prevent excessive flickering
   const [shown, setShown] = useState(false)
   const classes = useStyles()
-  const [dots, setDots] = useState(0)
   useEffect(() => {
     const timeout = setTimeout(() => setShown(true), 300)
     return () => clearTimeout(timeout)
   }, [])
 
-  useEffect(() => {
-    const timeout = setTimeout(() => setDots(state => (state + 1) % 4), 400)
-    return () => clearTimeout(timeout)
-  })
-
   return shown ? (
     <div className={classes.loading}>
-      Loading {new Array(dots).fill('.').join('')}
+      Loading &hellip;
+      <LinearProgress />
     </div>
   ) : null
 }


### PR DESCRIPTION
I was having trouble with test timeouts on my branch and noticed that the linear track block loading animation seemed to be causing it. This PR reverts the loading animation to the Material-UI LinearProgress, and is then able to reduce or remove several test timeout increases.

The LinearProgress component is probably not the best, so if we decide to merge this we should probably re-open https://github.com/GMOD/jbrowse-components/issues/968, but seems like a good quick fix for now.