### PR TITLE
Add testing for valid VCF END

### DIFF
--- a/packages/variants/src/VcfTabixAdapter/VcfFeature.test.ts
+++ b/packages/variants/src/VcfTabixAdapter/VcfFeature.test.ts
@@ -17,3 +17,39 @@ test('test usage of the VcfFeature', () => {
   expect(f.id()).toEqual('myuniqueid')
   expect(f.get('name')).toEqual('rs118266897')
 })
+
+test('try INS feature with END less than start', () => {
+  const parser = new VcfParser({
+    header: `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tBAMs/caudaus.sorted.sam`,
+  })
+  const line = `chr1\t100\trs123\tR\tA\t29\tPASS\tEND=1;SVTYPE=INS`
+
+  const variant = parser.parseLine(line)
+
+  const f = new VcfFeature({
+    parser,
+    variant,
+    id: 'myuniqueid',
+  })
+  expect(f.id()).toEqual('myuniqueid')
+  expect(f.get('start')).toEqual(99)
+  expect(f.get('end')).toEqual(100)
+})
+
+test('try DEL feature with END info field valid', () => {
+  const parser = new VcfParser({
+    header: `#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tBAMs/caudaus.sorted.sam`,
+  })
+  const line = `chr1\t100\trs123\tR\t<DEL>\t29\tPASS\tEND=1000;SVTYPE=DEL`
+
+  const variant = parser.parseLine(line)
+
+  const f = new VcfFeature({
+    parser,
+    variant,
+    id: 'myuniqueid',
+  })
+  expect(f.id()).toEqual('myuniqueid')
+  expect(f.get('start')).toEqual(99)
+  expect(f.get('end')).toEqual(1000)
+})

--- a/packages/variants/src/VcfTabixAdapter/VcfFeature.ts
+++ b/packages/variants/src/VcfTabixAdapter/VcfFeature.ts
@@ -83,8 +83,10 @@ export default class VCFFeature implements Feature {
       variant.REF,
       variant.ALT,
     )
-    const isTRA = variant.ALT.some((f: string) => f === '<TRA>')
-    const isSymbolic = variant.ALT.some((f: string) => f.indexOf('<') !== -1)
+    const isTRA = variant.ALT.some((f: string | Breakend) => f === '<TRA>')
+    const isSymbolic = variant.ALT.some(
+      (f: string | Breakend) => typeof f === 'string' && f.indexOf('<') !== -1,
+    )
     const featureData: FeatureData = {
       refName: variant.CHROM,
       start,

--- a/packages/variants/src/VcfTabixAdapter/VcfFeature.ts
+++ b/packages/variants/src/VcfTabixAdapter/VcfFeature.ts
@@ -84,11 +84,12 @@ export default class VCFFeature implements Feature {
       variant.ALT,
     )
     const isTRA = variant.ALT.some((f: string) => f === '<TRA>')
+    const isSymbolic = variant.ALT.some((f: string) => f.indexOf('<') !== -1)
     const featureData: FeatureData = {
       refName: variant.CHROM,
       start,
       end:
-        variant.INFO.END && !isTRA
+        isSymbolic && variant.INFO.END && !isTRA
           ? Number(variant.INFO.END[0])
           : start + variant.REF.length,
       description,


### PR DESCRIPTION
This is a follow up on a gitter comment where https://solgenomics.net/projects/tomato100 has vcf with END in the INFO field that is less than the start, and actually appears to be basically a bogus value so it is ignored


@garrettjstevens  suggested that we check if it is truly a symbolic field to see if we interpret the END

I tried this out here in this PR but I did have a couple of concerns

1) It is a little unclear of the checking of the symbolic field is really the right behavior here? It seems to work, so as a stop gap it does help this situation
2) It is sort of clear to me that, given that there can be multiple alternative alleles, each alternative allele could have it's own "END" field potentially. this is a little weird, and we could consider this maybe a non-issue and say our "parent variant" is the maximum range of the individual alternative alleles in it's "container"