### PR TITLE
Allow and generate comma-ified locstrings

### DIFF
--- a/packages/circular-view/src/CircularView/models/__snapshots__/slices.test.js.snap
+++ b/packages/circular-view/src/CircularView/models/__snapshots__/slices.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "bpPerRadian": 1591.5494309189535,
   "endRadians": 6.283185307179586,
   "flipped": false,
-  "key": "toast:1..10000",
+  "key": "toast:1..10,000",
   "offsetRadians": 0,
   "radianWidth": 6.288185307179586,
   "region": Object {
@@ -24,7 +24,7 @@ Array [
     "bpPerRadian": 3183.098861837907,
     "endRadians": 3.141592653589793,
     "flipped": false,
-    "key": "toast:1..10000",
+    "key": "toast:1..10,000",
     "offsetRadians": 0,
     "radianWidth": 3.146592653589793,
     "region": Object {
@@ -39,7 +39,7 @@ Array [
     "bpPerRadian": 3183.098861837907,
     "endRadians": 6.288185307179586,
     "flipped": false,
-    "key": "teest:1..10000",
+    "key": "teest:1..10,000",
     "offsetRadians": 3.146592653589793,
     "radianWidth": 3.146592653589793,
     "region": Object {
@@ -59,7 +59,7 @@ Array [
     "bpPerRadian": 8925.40920859349,
     "endRadians": 5.602096086738348,
     "flipped": false,
-    "key": "{volvox}ctgA:1..50001",
+    "key": "{volvox}ctgA:1..50,001",
     "offsetRadians": 0,
     "radianWidth": 5.6070960867383475,
     "region": Object {
@@ -75,7 +75,7 @@ Array [
     "bpPerRadian": 8925.40920859349,
     "endRadians": 6.288185307179587,
     "flipped": false,
-    "key": "{volvox}ctgB:1..6079",
+    "key": "{volvox}ctgB:1..6,079",
     "offsetRadians": 5.6070960867383475,
     "radianWidth": 0.6860892204412394,
     "region": Object {

--- a/packages/core/util/index.test.ts
+++ b/packages/core/util/index.test.ts
@@ -57,6 +57,10 @@ describe('assembleLocString', () => {
     [{ refName: 'chr1', start: 0, end: 100 }, 'chr1:1..100'],
     [{ refName: 'chr1', start: 0, end: 200 }, 'chr1:1..200'],
     [
+      { refName: 'chr1', start: 1000000, end: 2000000 },
+      'chr1:1,000,001..2,000,000',
+    ],
+    [
       { assemblyName: 'hg19', refName: 'chr1', start: 0, end: 100 },
       '{hg19}chr1:1..100',
     ],

--- a/packages/core/util/index.test.ts
+++ b/packages/core/util/index.test.ts
@@ -8,6 +8,10 @@ import {
 describe('parseLocString', () => {
   const cases: [string, ParsedLocString][] = [
     ['chr1:1..200', { start: 0, end: 200, refName: 'chr1' }],
+    [
+      'chr1:1,000,000..2,000,000',
+      { start: 999999, end: 2000000, refName: 'chr1' },
+    ],
     ['chr1:1-200', { start: 0, end: 200, refName: 'chr1' }],
     [
       '{hg19}chr1:1-200',
@@ -29,6 +33,7 @@ describe('parseLocString', () => {
       { start: -101, end: -1, refName: 'chr1' },
     ],
     ['chr2:1000-', { refName: 'chr2', start: 999 }],
+    ['chr2:1,000-', { refName: 'chr2', start: 999 }],
     ['chr1', { refName: 'chr1' }],
     ['{hg19}chr1', { assemblyName: 'hg19', refName: 'chr1' }],
   ]

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -340,22 +340,38 @@ export function parseLocStringOneBased(
   } else if (isValidRefName(prefix, assemblyName)) {
     if (suffix) {
       // see if it's a range
-      const rangeMatch = suffix.match(/^(-?\d+)(\.\.|-)(-?\d+)$/)
+      const rangeMatch = suffix.match(
+        /^(-?(\d+|\d{1,3}(,\d{3})*))(\.\.|-)(-?(\d+|\d{1,3}(,\d{3})*))$/,
+      )
       // see if it's a single point
-      const singleMatch = suffix.match(/^(-?\d+)(\.\.|-)?$/)
+      const singleMatch = suffix.match(/^(-?(\d+|\d{1,3}(,\d{3})*))(\.\.|-)?$/)
       if (rangeMatch) {
-        const [, start, , end] = rangeMatch
+        const [, start, , , , end] = rangeMatch
         if (start !== undefined && end !== undefined) {
-          return { assemblyName, refName: prefix, start: +start, end: +end }
+          return {
+            assemblyName,
+            refName: prefix,
+            start: +start.replace(/,/g, ''),
+            end: +end.replace(/,/g, ''),
+          }
         }
       } else if (singleMatch) {
-        const [, start, separator] = singleMatch
+        const [, start, , , separator] = singleMatch
         if (start !== undefined) {
           if (separator) {
             // indefinite end
-            return { assemblyName, refName: prefix, start: +start }
+            return {
+              assemblyName,
+              refName: prefix,
+              start: +start.replace(/,/g, ''),
+            }
           }
-          return { assemblyName, refName: prefix, start: +start, end: +start }
+          return {
+            assemblyName,
+            refName: prefix,
+            start: +start.replace(/,/g, ''),
+            end: +start.replace(/,/g, ''),
+          }
         }
       } else {
         throw new Error(

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -285,7 +285,7 @@ export function assembleLocString(region: ParsedLocString): string {
   const assemblyNameString = assemblyName ? `{${assemblyName}}` : ''
   let startString
   if (start !== undefined) {
-    startString = `:${(start + 1).toLocaleString()}`
+    startString = `:${(start + 1).toLocaleString('en-US')}`
   } else if (end !== undefined) {
     startString = ':1'
   } else {
@@ -296,7 +296,7 @@ export function assembleLocString(region: ParsedLocString): string {
     endString =
       start !== undefined && start + 1 === end
         ? ''
-        : `..${end.toLocaleString()}`
+        : `..${end.toLocaleString('en-US')}`
   } else {
     endString = start !== undefined ? '..' : ''
   }

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -285,7 +285,7 @@ export function assembleLocString(region: ParsedLocString): string {
   const assemblyNameString = assemblyName ? `{${assemblyName}}` : ''
   let startString
   if (start !== undefined) {
-    startString = `:${start + 1}`
+    startString = `:${(start + 1).toLocaleString()}`
   } else if (end !== undefined) {
     startString = ':1'
   } else {
@@ -293,7 +293,10 @@ export function assembleLocString(region: ParsedLocString): string {
   }
   let endString
   if (end !== undefined) {
-    endString = start !== undefined && start + 1 === end ? '' : `..${end}`
+    endString =
+      start !== undefined && start + 1 === end
+        ? ''
+        : `..${end.toLocaleString()}`
   } else {
     endString = start !== undefined ? '..' : ''
   }

--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateDynamicBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateDynamicBlocks.test.js.snap
@@ -92,7 +92,7 @@ Array [
   InterRegionPaddingBlock {
     "assemblyName": undefined,
     "end": undefined,
-    "key": "ctgA:49901..50000-reversed-beforeFirstRegion",
+    "key": "ctgA:49,901..50,000-reversed-beforeFirstRegion",
     "offsetPx": -100,
     "refName": undefined,
     "start": undefined,
@@ -104,7 +104,7 @@ Array [
     "end": 50000,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:49901..50000-reversed",
+    "key": "ctgA:49,901..50,000-reversed",
     "offsetPx": 0,
     "parentRegion": Object {
       "end": 50000,
@@ -125,7 +125,7 @@ Array [
   InterRegionPaddingBlock {
     "assemblyName": undefined,
     "end": undefined,
-    "key": "ctgA:49801..50000-reversed-beforeFirstRegion",
+    "key": "ctgA:49,801..50,000-reversed-beforeFirstRegion",
     "offsetPx": 0,
     "refName": undefined,
     "start": undefined,
@@ -137,7 +137,7 @@ Array [
     "end": 50000,
     "isLeftEndOfDisplayedRegion": true,
     "isRightEndOfDisplayedRegion": false,
-    "key": "ctgA:49801..50000-reversed",
+    "key": "ctgA:49,801..50,000-reversed",
     "offsetPx": 0,
     "parentRegion": Object {
       "end": 50000,

--- a/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
+++ b/packages/linear-genome-view/src/BasicTrack/util/__snapshots__/calculateStaticBlocks.test.js.snap
@@ -35,7 +35,7 @@ BlockSet {
       "end": 1600,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:801..1600-0",
+      "key": "ctgA:801..1,600-0",
       "offsetPx": 800,
       "parentRegion": Object {
         "end": 10000,
@@ -129,7 +129,7 @@ BlockSet {
       "end": 5600,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:4801..5600-0",
+      "key": "ctgA:4,801..5,600-0",
       "offsetPx": 4800,
       "parentRegion": Object {
         "end": 10000,
@@ -146,7 +146,7 @@ BlockSet {
       "end": 6400,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:5601..6400-0",
+      "key": "ctgA:5,601..6,400-0",
       "offsetPx": 5600,
       "parentRegion": Object {
         "end": 10000,
@@ -247,7 +247,7 @@ BlockSet {
       "end": 1000,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": true,
-      "key": "ctgB:801..1000-1",
+      "key": "ctgB:801..1,000-1",
       "offsetPx": 1002,
       "parentRegion": Object {
         "end": 1000,
@@ -262,7 +262,7 @@ BlockSet {
     InterRegionPaddingBlock {
       "assemblyName": undefined,
       "end": undefined,
-      "key": "ctgB:801..1000-1-afterLastRegion",
+      "key": "ctgB:801..1,000-1-afterLastRegion",
       "offsetPx": 1202,
       "refName": undefined,
       "start": undefined,
@@ -281,7 +281,7 @@ BlockSet {
       "end": 1600,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgB:801..1600-1",
+      "key": "ctgB:801..1,600-1",
       "offsetPx": 1002,
       "parentRegion": Object {
         "end": 10000000,
@@ -298,7 +298,7 @@ BlockSet {
       "end": 2400,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgB:1601..2400-1",
+      "key": "ctgB:1,601..2,400-1",
       "offsetPx": 1802,
       "parentRegion": Object {
         "end": 10000000,
@@ -322,7 +322,7 @@ BlockSet {
       "end": 3200,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:1601..3200-0",
+      "key": "ctgA:1,601..3,200-0",
       "offsetPx": 800,
       "parentRegion": Object {
         "end": 50000,
@@ -339,7 +339,7 @@ BlockSet {
       "end": 4800,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:3201..4800-0",
+      "key": "ctgA:3,201..4,800-0",
       "offsetPx": 1600,
       "parentRegion": Object {
         "end": 50000,
@@ -410,7 +410,7 @@ BlockSet {
     InterRegionPaddingBlock {
       "assemblyName": undefined,
       "end": undefined,
-      "key": "ctgA:9201..10000-0-reversed-beforeFirstRegion",
+      "key": "ctgA:9,201..10,000-0-reversed-beforeFirstRegion",
       "offsetPx": -800,
       "refName": undefined,
       "start": undefined,
@@ -422,7 +422,7 @@ BlockSet {
       "end": 10000,
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:9201..10000-0-reversed",
+      "key": "ctgA:9,201..10,000-0-reversed",
       "offsetPx": 0,
       "parentRegion": Object {
         "end": 10000,
@@ -440,7 +440,7 @@ BlockSet {
       "end": 9200,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:8401..9200-0-reversed",
+      "key": "ctgA:8,401..9,200-0-reversed",
       "offsetPx": 800,
       "parentRegion": Object {
         "end": 10000,
@@ -493,7 +493,7 @@ BlockSet {
       "end": 10000,
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:9201..10000-1-reversed",
+      "key": "ctgA:9,201..10,000-1-reversed",
       "offsetPx": 3,
       "parentRegion": Object {
         "end": 10000,
@@ -511,7 +511,7 @@ BlockSet {
       "end": 9200,
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
-      "key": "ctgA:8401..9200-1-reversed",
+      "key": "ctgA:8,401..9,200-1-reversed",
       "offsetPx": 803,
       "parentRegion": Object {
         "end": 10000,

--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -243,7 +243,7 @@ const Search = observer(({ model }: { model: LGV }) => {
                 (previousValue, currentValue) => previousValue + currentValue,
                 0,
               ),
-          ).toLocaleString()} bp`}
+          ).toLocaleString('en-US')} bp`}
         </Typography>
       </div>
     </>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -1078,7 +1078,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
                 style="padding: 8px;"
                 type="text"
-                value="ctgA:1..100;ctgB:1001..1698"
+                value="ctgA:1..100;ctgB:1,001..1,698"
               />
               <fieldset
                 aria-hidden="true"

--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -198,11 +198,11 @@ test('can instantiate a model that tests navTo/moveTo', async () => {
   expect(() =>
     model.navTo({ refName: 'ctgA', start: 20000, end: 20100 }),
   ).toThrow(
-    'could not find a region that completely contained "ctgA:20001..20100"',
+    'could not find a region that completely contained "ctgA:20,001..20,100"',
   )
 
   expect(() => model.navTo({ refName: 'ctgA', start: 0, end: 20000 })).toThrow(
-    'could not find a region that completely contained "ctgA:1..20000"',
+    'could not find a region that completely contained "ctgA:1..20,000"',
   )
 })
 
@@ -257,14 +257,14 @@ test('can navToMultiple', () => {
       { refName: 'ctgB', start: 5000, end: 10000 },
       { refName: 'ctgC', start: 5000, end: 10000 },
     ]),
-  ).toThrow('Start of region ctgC:5001..10000 should be 1, but it is not')
+  ).toThrow('Start of region ctgC:5,001..10,000 should be 1, but it is not')
 
   expect(() =>
     model.navToMultiple([
       { refName: 'ctgB', start: 0, end: 5000 },
       { refName: 'ctgC', start: 0, end: 5000 },
     ]),
-  ).toThrow('End of region ctgB:1..5000 should be 10000, but it is not')
+  ).toThrow('End of region ctgB:1..5,000 should be 10,000, but it is not')
 
   expect(() =>
     model.navToMultiple([
@@ -272,7 +272,7 @@ test('can navToMultiple', () => {
       { refName: 'ctgA', start: 0, end: 5000 },
     ]),
   ).toThrow(
-    'Entered location ctgA:1..5000 does not match with displayed regions',
+    'Entered location ctgA:1..5,000 does not match with displayed regions',
   )
 })
 

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -606,9 +606,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
                   throw new Error(
                     `${
                       region.reversed ? 'End' : 'Start'
-                    } of region ${assembleLocString(location)} should be ${
-                      region.reversed ? region.end : region.start + 1
-                    }, but it is not`,
+                    } of region ${assembleLocString(
+                      location,
+                    )} should be ${(region.reversed
+                      ? region.end
+                      : region.start + 1
+                    ).toLocaleString('en-US')}, but it is not`,
                   )
                 }
               }
@@ -622,9 +625,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
                   throw new Error(
                     `${
                       region.reversed ? 'Start' : 'End'
-                    } of region ${assembleLocString(location)} should be ${
-                      region.reversed ? region.start + 1 : region.end
-                    }, but it is not`,
+                    } of region ${assembleLocString(
+                      location,
+                    )} should be ${(region.reversed
+                      ? region.start + 1
+                      : region.end
+                    ).toLocaleString('en-US')}, but it is not`,
                   )
                 }
               }


### PR DESCRIPTION
This proposes allowing comma-ified numerical inputs. I would like to parse it but I think generating it in the locstring by default is nice too. It's not the best experience to "count the zeros" in a number to see where you are