### PR TITLE
Fix insertion calculation for SNPCoverage

### DIFF
--- a/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -266,26 +266,28 @@ export default (pluginManager: PluginManager) => {
           if (mismatches) {
             for (let i = 0; i < mismatches.length; i++) {
               const mismatch = mismatches[i]
-              forEachBin(
-                start + mismatch.start,
-                start + mismatch.start + mismatch.length,
-                (binNum, overlap) => {
-                  // Note: we decrement 'reference' so that total of the score is the total coverage
-                  const bin = coverageBins[binNum]
-                  bin.getNested('reference').decrement(strand, overlap)
-                  let { base } = mismatch
+              if (mismatch.type !== 'insertion') {
+                forEachBin(
+                  start + mismatch.start,
+                  start + mismatch.start + mismatch.length,
+                  (binNum, overlap) => {
+                    // Note: we decrement 'reference' so that total of the score is the total coverage
+                    const bin = coverageBins[binNum]
+                    bin.getNested('reference').decrement(strand, overlap)
+                    let { base } = mismatch
 
-                  if (mismatch.type === 'insertion') {
-                    base = `ins ${base}`
-                  } else if (mismatch.type === 'skip') {
-                    base = 'skip'
-                  }
+                    if (mismatch.type === 'insertion') {
+                      base = `ins ${base}`
+                    } else if (mismatch.type === 'skip') {
+                      base = 'skip'
+                    }
 
-                  if (base && base !== '*') {
-                    bin.getNested(base).increment(strand, overlap)
-                  }
-                },
-              )
+                    if (base && base !== '*') {
+                      bin.getNested(base).increment(strand, overlap)
+                    }
+                  },
+                )
+              }
             }
           }
         }

--- a/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/packages/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -282,7 +282,11 @@ export default (pluginManager: PluginManager) => {
                       base = 'skip'
                     }
 
-                    if (base && base !== '*') {
+                    if (base === 'skip') {
+                      bin.getNested(base).decrement('reference', overlap)
+                    }
+
+                    if (base && base !== '*' && base !== 'skip') {
                       bin.getNested(base).increment(strand, overlap)
                     }
                   },


### PR DESCRIPTION
The insertions were being expanded to cover a range of genome coordinates, causing some weirdness as seen in the below screenshots

IGV
![Screenshot from 2020-07-12 13-33-42](https://user-images.githubusercontent.com/6511937/87252875-75b77900-c444-11ea-8694-d9cdb4c99d31.png)
JBrowse 2
![Screenshot from 2020-07-12 13-33-52](https://user-images.githubusercontent.com/6511937/87252876-76500f80-c444-11ea-8dd1-94568723accb.png)
Samtools tview
![Screenshot from 2020-07-12 14-21-22](https://user-images.githubusercontent.com/6511937/87253673-0d1fca80-c44b-11ea-84cd-b4a02cf96b10.png)

There is a large insertion to the left of these, and the code would expand it so that the insertion would cover the range to the right of the insertions, but that would be incorrect

Now one thing that may be worth noting is that insertions are not not plotted from snpcoverage, and already deletions are also not plotted. Indeed
