### PR TITLE
Use a when to wait on the assembly from the reaction

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,9 @@
 <a name="0.0.1-beta.4"></a>
+
 ## [0.0.1-beta.4](https://github.com/GMOD/jbrowse-components/compare/0.0.1-alpha...0.0.1-beta.4) (2020-07-14)
 
-
-
 <a name="0.0.1-beta.3"></a>
+
 ## [0.0.1-beta.3](https://github.com/GMOD/jbrowse-components/compare/0.0.1-alpha...0.0.1-beta.3) (2020-07-14)
-
-
 
 - Initial refactor out of jbrowse-web

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -8,6 +8,9 @@ import {
   types,
   Instance,
 } from 'mobx-state-tree'
+
+import { when } from '../util'
+
 import { readConfObject } from '../configuration'
 import { AnyConfigurationModel } from '../configuration/configurationSchema'
 import assemblyFactory from './assembly'
@@ -51,22 +54,31 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
       },
     }))
     .views(self => ({
-      getRefNameMapForAdapter(
+      async getRefNameMapForAdapter(
         adapterConf: unknown,
         assemblyName: string,
         opts: { signal?: AbortSignal; sessionId: string },
       ) {
+        await when(() => self.get(assemblyName), {
+          signal: opts.signal,
+          name: 'when assembly ready',
+        })
+
         const assembly = self.get(assemblyName)
         if (assembly) {
           return assembly.getRefNameMapForAdapter(adapterConf, opts)
         }
         return undefined
       },
-      getReverseRefNameMapForAdapter(
+      async getReverseRefNameMapForAdapter(
         adapterConf: unknown,
         assemblyName: string,
         opts: { signal?: AbortSignal; sessionId: string },
       ) {
+        await when(() => self.get(assemblyName), {
+          signal: opts.signal,
+          name: 'when assembly ready',
+        })
         const assembly = self.get(assemblyName)
         if (assembly) {
           return assembly.getReverseRefNameMapForAdapter(adapterConf, opts)

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -59,7 +59,7 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
         assemblyName: string,
         opts: { signal?: AbortSignal; sessionId: string },
       ) {
-        await when(() => self.get(assemblyName), {
+        await when(() => Boolean(self.get(assemblyName)), {
           signal: opts.signal,
           name: 'when assembly ready',
         })
@@ -75,7 +75,7 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
         assemblyName: string,
         opts: { signal?: AbortSignal; sessionId: string },
       ) {
-        await when(() => self.get(assemblyName), {
+        await when(() => Boolean(self.get(assemblyName)), {
           signal: opts.signal,
           name: 'when assembly ready',
         })


### PR DESCRIPTION
Due to code from this PR https://github.com/GMOD/jbrowse-components/pull/1038

The waiting for assembly to load was broken

These lines in particular

https://github.com/GMOD/jbrowse-components/pull/1038/files#diff-de94407b67871344a97594d4eb5e8cbfL731-L738

This PR restores an when(() => {}) on the assembly being loaded from the reaction