### PR TITLE
Add code splitting to make loading bar appear faster

### DIFF
--- a/packages/jbrowse-web/src/Loader.test.tsx
+++ b/packages/jbrowse-web/src/Loader.test.tsx
@@ -8,7 +8,7 @@ import rangeParser from 'range-parser'
 import ErrorBoundary, { FallbackProps } from 'react-error-boundary'
 import { QueryParamProvider } from 'use-query-params'
 
-import Loader from './Loader'
+import { Loader } from './Loader'
 
 if (!window.TextEncoder) window.TextEncoder = TextEncoder
 if (!window.TextDecoder) window.TextDecoder = TextDecoder

--- a/packages/jbrowse-web/src/Loader.tsx
+++ b/packages/jbrowse-web/src/Loader.tsx
@@ -10,20 +10,21 @@ import {
   useQueryParam,
   QueryParamProvider,
 } from 'use-query-params'
-import 'mobx-react/batchingForReactDom'
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import { getConf } from '@gmod/jbrowse-core/configuration'
 import { SnapshotOut } from 'mobx-state-tree'
 import { PluginConstructor } from '@gmod/jbrowse-core/Plugin'
 import { FatalErrorDialog } from '@gmod/jbrowse-core/ui'
+import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
+import 'typeface-roboto'
+import 'requestidlecallback-polyfill'
+import 'mobx-react/batchingForReactDom'
+import 'core-js/stable'
 
 import Loading from './Loading'
 import corePlugins from './corePlugins'
 import JBrowse from './JBrowse'
 import JBrowseRootModelFactory from './rootModel'
-import 'typeface-roboto'
-import 'requestidlecallback-polyfill'
-import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 
 if (!window.TextEncoder) {
   window.TextEncoder = TextEncoder
@@ -98,7 +99,7 @@ function NoConfigMessage() {
 
 type Config = SnapshotOut<AnyConfigurationModel>
 
-function Loader() {
+export function Loader() {
   const [configSnapshot, setConfigSnapshot] = useState<Config>()
   const [noDefaultConfig, setNoDefaultConfig] = useState(false)
   const [plugins, setPlugins] = useState<PluginConstructor[]>()
@@ -264,7 +265,7 @@ function factoryReset() {
   // @ts-ignore
   window.location = window.location.pathname
 }
-const PlatformSpecificFatalErrorDialog = (props: any) => {
+const PlatformSpecificFatalErrorDialog = (props: unknown) => {
   return <FatalErrorDialog onFactoryReset={factoryReset} {...props} />
 }
 export default () => {

--- a/packages/jbrowse-web/src/Loader.tsx
+++ b/packages/jbrowse-web/src/Loader.tsx
@@ -2,8 +2,6 @@ import PluginManager from '@gmod/jbrowse-core/PluginManager'
 import PluginLoader from '@gmod/jbrowse-core/PluginLoader'
 import { inDevelopment, fromUrlSafeB64 } from '@gmod/jbrowse-core/util'
 import { openLocation } from '@gmod/jbrowse-core/util/io'
-import CircularProgress from '@material-ui/core/CircularProgress'
-import { makeStyles } from '@material-ui/core/styles'
 import { UndoManager } from 'mst-middlewares'
 import React, { useEffect, useState } from 'react'
 import { StringParam, useQueryParam } from 'use-query-params'
@@ -11,19 +9,10 @@ import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configur
 import { getConf } from '@gmod/jbrowse-core/configuration'
 import { SnapshotOut } from 'mobx-state-tree'
 import { PluginConstructor } from '@gmod/jbrowse-core/Plugin'
+import Loading from './Loading'
 import corePlugins from './corePlugins'
 import JBrowse from './JBrowse'
 import JBrowseRootModelFactory from './rootModel'
-
-const useStyles = makeStyles({
-  loadingIndicator: {
-    position: 'fixed',
-    top: '50%',
-    left: '50%',
-    marginTop: -25,
-    marginLeft: -25,
-  },
-})
 
 function NoConfigMessage() {
   // TODO: Link to docs for how to configure JBrowse
@@ -89,10 +78,9 @@ function NoConfigMessage() {
   )
 }
 
+type Config = SnapshotOut<AnyConfigurationModel>
 export default function Loader() {
-  const [configSnapshot, setConfigSnapshot] = useState<
-    SnapshotOut<AnyConfigurationModel>
-  >()
+  const [configSnapshot, setConfigSnapshot] = useState<Config>()
   const [noDefaultConfig, setNoDefaultConfig] = useState(false)
   const [plugins, setPlugins] = useState<PluginConstructor[]>()
 
@@ -100,8 +88,6 @@ export default function Loader() {
   const [sessionQueryParam] = useQueryParam('session', StringParam)
   const [adminQueryParam] = useQueryParam('admin', StringParam)
   const adminMode = adminQueryParam === '1' || adminQueryParam === 'true'
-
-  const classes = useStyles()
 
   useEffect(() => {
     async function fetchConfig() {
@@ -160,13 +146,7 @@ export default function Loader() {
   }
 
   if (!(configSnapshot && plugins)) {
-    return (
-      <CircularProgress
-        disableShrink
-        className={classes.loadingIndicator}
-        size={50}
-      />
-    )
+    return <Loading />
   }
 
   const pluginManager = new PluginManager(plugins.map(P => new P()))

--- a/packages/jbrowse-web/src/Loading.tsx
+++ b/packages/jbrowse-web/src/Loading.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles({
+  loadingIndicator: {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    marginTop: -25,
+    marginLeft: -25,
+  },
+})
+
+export default function Loading() {
+  const classes = useStyles()
+  return (
+    <CircularProgress
+      disableShrink
+      className={classes.loadingIndicator}
+      size={50}
+    />
+  )
+}

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -1,5 +1,4 @@
 import React, { lazy, Suspense } from 'react'
-import 'core-js/stable'
 import ReactDOM from 'react-dom'
 import Loading from './Loading'
 import * as serviceWorker from './serviceWorker'

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -1,41 +1,16 @@
 import React, { lazy, Suspense } from 'react'
-import { FatalErrorDialog } from '@gmod/jbrowse-core/ui'
 import 'core-js/stable'
-import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
-import 'mobx-react/batchingForReactDom'
 import ReactDOM from 'react-dom'
-import ErrorBoundary from 'react-error-boundary'
-import 'requestidlecallback-polyfill'
-import 'typeface-roboto'
-import { QueryParamProvider } from 'use-query-params'
 import Loading from './Loading'
 import * as serviceWorker from './serviceWorker'
-
-if (!window.TextEncoder) window.TextEncoder = TextEncoder
-if (!window.TextDecoder) window.TextDecoder = TextDecoder
-
 // this is the main process, so start and register our service worker and web workers
 serviceWorker.register()
-
-function factoryReset() {
-  localStorage.removeItem('jbrowse-web-data')
-  localStorage.removeItem('jbrowse-web-session')
-  window.location = window.location.pathname
-}
-
-const PlatformSpecificFatalErrorDialog = props => {
-  return <FatalErrorDialog onFactoryReset={factoryReset} {...props} />
-}
 
 const Main = lazy(() => import('./Loader'))
 
 ReactDOM.render(
-  <ErrorBoundary FallbackComponent={PlatformSpecificFatalErrorDialog}>
-    <QueryParamProvider>
-      <Suspense fallback={<Loading />}>
-        <Main />
-      </Suspense>
-    </QueryParamProvider>
-  </ErrorBoundary>,
+  <Suspense fallback={<Loading />}>
+    <Main />
+  </Suspense>,
   document.getElementById('root'),
 )

--- a/packages/jbrowse-web/src/index.js
+++ b/packages/jbrowse-web/src/index.js
@@ -1,14 +1,14 @@
+import React, { lazy, Suspense } from 'react'
 import { FatalErrorDialog } from '@gmod/jbrowse-core/ui'
 import 'core-js/stable'
 import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import 'mobx-react/batchingForReactDom'
-import React from 'react'
 import ReactDOM from 'react-dom'
 import ErrorBoundary from 'react-error-boundary'
 import 'requestidlecallback-polyfill'
 import 'typeface-roboto'
 import { QueryParamProvider } from 'use-query-params'
-import Loader from './Loader'
+import Loading from './Loading'
 import * as serviceWorker from './serviceWorker'
 
 if (!window.TextEncoder) window.TextEncoder = TextEncoder
@@ -27,10 +27,14 @@ const PlatformSpecificFatalErrorDialog = props => {
   return <FatalErrorDialog onFactoryReset={factoryReset} {...props} />
 }
 
+const Main = lazy(() => import('./Loader'))
+
 ReactDOM.render(
   <ErrorBoundary FallbackComponent={PlatformSpecificFatalErrorDialog}>
     <QueryParamProvider>
-      <Loader />
+      <Suspense fallback={<Loading />}>
+        <Main />
+      </Suspense>
     </QueryParamProvider>
   </ErrorBoundary>,
   document.getElementById('root'),


### PR DESCRIPTION
Results in about 200kb of JS being downloaded before rendering a Loading indicator. Current master is about 3MB

Ref #1056 
