### PR TITLE
add Tooltip descriptions to FeatureDetail Widgets

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography'
 import ExpandMore from '@material-ui/icons/ExpandMore'
 import Divider from '@material-ui/core/Divider'
 import Paper from '@material-ui/core/Paper'
+import Tooltip from '@material-ui/core/Tooltip'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import React, { FunctionComponent } from 'react'
@@ -79,6 +80,7 @@ export const BaseCard: FunctionComponent<BaseCardProps> = props => {
 
 interface BaseProps extends BaseCardProps {
   feature: Record<string, any>
+  descriptions?: Record<string, React.ReactNode>
 }
 
 export const BaseCoreDetails = (props: BaseProps) => {
@@ -133,6 +135,7 @@ interface AttributeProps {
   attributes: Record<string, any>
   omit?: string[]
   formatter?: (val: unknown) => JSX.Element
+  descriptions?: Record<string, React.ReactNode>
 }
 
 const Attributes: FunctionComponent<AttributeProps> = props => {
@@ -145,28 +148,45 @@ const Attributes: FunctionComponent<AttributeProps> = props => {
         html={isObject(value) ? JSON.stringify(value) : String(value)}
       />
     ),
+    descriptions,
   } = props
 
   const SimpleValue = ({ name, value }: { name: string; value: any }) => {
+    const description = descriptions && descriptions[name]
     return (
       <div style={{ display: 'flex' }}>
-        <div className={classes.fieldName}>{name}</div>
+        {description ? (
+          <Tooltip title={description} placement="left">
+            <div className={classes.fieldName}>{name}</div>
+          </Tooltip>
+        ) : (
+          <div className={classes.fieldName}>{name}</div>
+        )}
         <div className={classes.fieldValue}>{formatter(value)}</div>
       </div>
     )
   }
-  const ArrayValue = ({ name, value }: { name: string; value: any[] }) => (
-    <div style={{ display: 'flex' }}>
-      <div className={classes.fieldName}>{name}</div>
-      {value.map((val, i) => (
-        <div key={`${name}-${i}`} className={classes.fieldSubvalue}>
-          <SanitizedHTML
-            html={isObject(val) ? JSON.stringify(val) : String(val)}
-          />
-        </div>
-      ))}
-    </div>
-  )
+  const ArrayValue = ({ name, value }: { name: string; value: any[] }) => {
+    const description = descriptions && descriptions[name]
+    return (
+      <div style={{ display: 'flex' }}>
+        {description ? (
+          <Tooltip title={description} placement="left">
+            <div className={classes.fieldName}>{name}</div>
+          </Tooltip>
+        ) : (
+          <div className={classes.fieldName}>{name}</div>
+        )}
+        {value.map((val, i) => (
+          <div key={`${name}-${i}`} className={classes.fieldSubvalue}>
+            <SanitizedHTML
+              html={isObject(val) ? JSON.stringify(val) : String(val)}
+            />
+          </div>
+        ))}
+      </div>
+    )
+  }
 
   return (
     <>
@@ -184,7 +204,13 @@ const Attributes: FunctionComponent<AttributeProps> = props => {
             )
           }
           if (isObject(value)) {
-            return <Attributes key={key} attributes={value} />
+            return (
+              <Attributes
+                key={key}
+                attributes={value}
+                descriptions={descriptions}
+              />
+            )
           }
 
           return <SimpleValue key={key} name={key} value={value} />
@@ -194,10 +220,10 @@ const Attributes: FunctionComponent<AttributeProps> = props => {
 }
 
 export const BaseAttributes = (props: BaseProps) => {
-  const { feature } = props
+  const { feature, descriptions } = props
   return (
     <BaseCard {...props} title="Attributes">
-      <Attributes {...props} attributes={feature} />
+      <Attributes {...props} attributes={feature} descriptions={descriptions} />
     </BaseCard>
   )
 }
@@ -206,17 +232,18 @@ interface BaseInputProps extends BaseCardProps {
   omit?: string[]
   model: any
   formatter?: (val: unknown) => JSX.Element
+  descriptions?: Record<string, React.ReactNode>
 }
 
 export const BaseFeatureDetails = observer((props: BaseInputProps) => {
   const classes = useStyles()
-  const { model } = props
+  const { model, descriptions } = props
   const feat = JSON.parse(JSON.stringify(model.featureData))
   return (
     <Paper className={classes.paperRoot}>
       <BaseCoreDetails feature={feat} {...props} />
       <Divider />
-      <BaseAttributes feature={feat} {...props} />
+      <BaseAttributes feature={feat} {...props} descriptions={descriptions} />
     </Paper>
   )
 })

--- a/packages/variants/src/VariantFeatureWidget/VariantFeatureWidget.js
+++ b/packages/variants/src/VariantFeatureWidget/VariantFeatureWidget.js
@@ -104,9 +104,28 @@ function VariantFeatureDetails(props) {
   const { model } = props
   const feat = JSON.parse(JSON.stringify(model.featureData))
   const { samples, ...rest } = feat
+  const descriptions = {
+    CHROM: 'chromosome: An identifier from the reference genome',
+    POS:
+      'position: The reference position, with the 1st base having position 1',
+    ID:
+      'identifier: Semi-colon separated list of unique identifiers where available',
+    REF:
+      'reference base(s): Each base must be one of A,C,G,T,N (case insensitive).',
+    ALT:
+      ' alternate base(s): Comma-separated list of alternate non-reference alleles',
+    QUAL: 'quality: Phred-scaled quality score for the assertion made in ALT',
+    FILTER:
+      'filter status: PASS if this position has passed all filters, otherwise a semicolon-separated list of codes for filters that fail',
+  }
+
   return (
     <Paper className={classes.root} data-testid="variant-side-drawer">
-      <BaseFeatureDetails feature={rest} {...props} />
+      <BaseFeatureDetails
+        feature={rest}
+        descriptions={descriptions}
+        {...props}
+      />
       <Divider />
       <VariantSamples feature={feat} {...props} />
     </Paper>

--- a/packages/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/packages/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -192,6 +192,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 >
                   <div
                     class="makeStyles-fieldName"
+                    title="reference base(s): Each base must be one of A,C,G,T,N (case insensitive)."
                   >
                     REF
                   </div>
@@ -208,6 +209,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 >
                   <div
                     class="makeStyles-fieldName"
+                    title=" alternate base(s): Comma-separated list of alternate non-reference alleles"
                   >
                     ALT
                   </div>
@@ -224,6 +226,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 >
                   <div
                     class="makeStyles-fieldName"
+                    title="quality: Phred-scaled quality score for the assertion made in ALT"
                   >
                     QUAL
                   </div>


### PR DESCRIPTION
This adds the possibility of adding descriptions to FeatureDetail widgets (for the fields or the values of a drawer). 
An example of how it is used can be found in packages/variants/src/VariantFeatureWidget/VariantFeatureWidget.js . 
This addition is made possible through the use of Tooltips provided by Material-UI.