### PR TITLE
Move navToLocString logic from Header to model

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -1,9 +1,5 @@
 import { Region } from '@gmod/jbrowse-core/util/types'
-import {
-  getSession,
-  isSessionModelWithWidgets,
-  parseLocString,
-} from '@gmod/jbrowse-core/util'
+import { getSession, isSessionModelWithWidgets } from '@gmod/jbrowse-core/util'
 import Button from '@material-ui/core/Button'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
@@ -11,7 +7,7 @@ import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import ToggleButton from '@material-ui/lab/ToggleButton'
 import { observer } from 'mobx-react'
-import { getSnapshot, Instance } from 'mobx-state-tree'
+import { Instance } from 'mobx-state-tree'
 import React, { useCallback, useRef, useState } from 'react'
 import TrackSelectorIcon from '@material-ui/icons/LineStyle'
 import SearchIcon from '@material-ui/icons/Search'
@@ -87,83 +83,12 @@ const Search = observer(({ model }: { model: LGV }) => {
     dynamicBlocks: { contentBlocks },
     displayedRegions,
     visibleLocStrings,
-    setDisplayedRegions,
   } = model
   const session = getSession(model)
 
   function navTo(locString: string) {
     try {
-      const { assemblyManager } = session
-      const { isValidRefName } = assemblyManager
-      const locStrings = locString.split(';')
-      if (displayedRegions.length === 1) {
-        const displayedRegion = displayedRegions[0]
-        let assembly = assemblyManager.get(displayedRegion.assemblyName)
-        if (!assembly) {
-          throw new Error(
-            `Could not find assembly ${displayedRegion.assemblyName}`,
-          )
-        }
-        const { regions } = assembly
-        if (!regions) {
-          throw new Error(
-            `Regions for assembly ${displayedRegion.assemblyName} not yet loaded`,
-          )
-        }
-        const matchedRegion = regions.find(
-          region =>
-            region.refName === displayedRegion.refName &&
-            region.start === displayedRegion.start &&
-            region.end === displayedRegion.end,
-        )
-        if (matchedRegion) {
-          if (locStrings.length > 1) {
-            throw new Error(
-              'Navigating to multiple locations is not allowed when viewing a whole chromosome',
-            )
-          }
-          const parsedLocString = parseLocString(locStrings[0], isValidRefName)
-          let changedAssembly = false
-          if (
-            parsedLocString.assemblyName &&
-            parsedLocString.assemblyName !== displayedRegion.assemblyName
-          ) {
-            const newAssembly = assemblyManager.get(
-              parsedLocString.assemblyName,
-            )
-            if (!newAssembly) {
-              throw new Error(
-                `Could not find assembly ${parsedLocString.assemblyName}`,
-              )
-            }
-            assembly = newAssembly
-            changedAssembly = true
-          }
-          const canonicalRefName = assembly.getCanonicalRefName(
-            parsedLocString.refName,
-          )
-          if (!canonicalRefName) {
-            throw new Error(
-              `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
-            )
-          }
-          if (changedAssembly || canonicalRefName !== displayedRegion.refName) {
-            const newDisplayedRegion = regions.find(
-              region => region.refName === canonicalRefName,
-            )
-            if (newDisplayedRegion) {
-              setDisplayedRegions([getSnapshot(newDisplayedRegion)])
-            } else {
-              throw new Error(
-                `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
-              )
-            }
-          }
-          model.navTo(parsedLocString)
-          return
-        }
-      }
-      model.navToLocStrings(locString)
+      model.navToLocString(locString)
     } catch (e) {
       console.warn(e)
       session.notify(`${e}`, 'warning')

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -467,18 +467,80 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
 
       navToLocString(locString: string) {
-        const session = getSession(self)
-        const { isValidRefName } = session.assemblyManager
-        this.navTo(parseLocString(locString, isValidRefName))
-      },
-
-      navToLocStrings(locStrings: string) {
-        const session = getSession(self)
-        const { isValidRefName } = session.assemblyManager
-        const locations = locStrings
-          .split(';')
-          .map(locString => parseLocString(locString, isValidRefName))
-        this.navToMultiple(locations)
+        const { assemblyManager } = getSession(self)
+        const { isValidRefName } = assemblyManager
+        const locStrings = locString.split(';')
+        if (self.displayedRegions.length > 1) {
+          const locations = locStrings.map(ls =>
+            parseLocString(ls, isValidRefName),
+          )
+          this.navToMultiple(locations)
+          return
+        }
+        const displayedRegion = self.displayedRegions[0]
+        let assembly = assemblyManager.get(displayedRegion.assemblyName)
+        if (!assembly) {
+          throw new Error(
+            `Could not find assembly ${displayedRegion.assemblyName}`,
+          )
+        }
+        const { regions } = assembly
+        if (!regions) {
+          throw new Error(
+            `Regions for assembly ${displayedRegion.assemblyName} not yet loaded`,
+          )
+        }
+        const matchedRegion = regions.find(
+          region =>
+            region.refName === displayedRegion.refName &&
+            region.start === displayedRegion.start &&
+            region.end === displayedRegion.end,
+        )
+        if (matchedRegion) {
+          if (locStrings.length > 1) {
+            throw new Error(
+              'Navigating to multiple locations is not allowed when viewing a whole chromosome',
+            )
+          }
+          const parsedLocString = parseLocString(locStrings[0], isValidRefName)
+          let changedAssembly = false
+          if (
+            parsedLocString.assemblyName &&
+            parsedLocString.assemblyName !== displayedRegion.assemblyName
+          ) {
+            const newAssembly = assemblyManager.get(
+              parsedLocString.assemblyName,
+            )
+            if (!newAssembly) {
+              throw new Error(
+                `Could not find assembly ${parsedLocString.assemblyName}`,
+              )
+            }
+            assembly = newAssembly
+            changedAssembly = true
+          }
+          const canonicalRefName = assembly.getCanonicalRefName(
+            parsedLocString.refName,
+          )
+          if (!canonicalRefName) {
+            throw new Error(
+              `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
+            )
+          }
+          if (changedAssembly || canonicalRefName !== displayedRegion.refName) {
+            const newDisplayedRegion = regions.find(
+              region => region.refName === canonicalRefName,
+            )
+            if (newDisplayedRegion) {
+              this.setDisplayedRegions([getSnapshot(newDisplayedRegion)])
+            } else {
+              throw new Error(
+                `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
+              )
+            }
+          }
+          this.navTo(parsedLocString)
+        }
       },
 
       /**


### PR DESCRIPTION
https://github.com/GMOD/jbrowse-components/pull/945 added logic described in https://github.com/GMOD/jbrowse-components/issues/899 for navigating to locStrings, especially in the case that there may be multiple locations in one locString. The logic got added to the Header so the the location box could use it. This PR proposes that  the logic be moved to the LGV model so other things can use it too.

This is a change I made to make the embedded linear view work, but I wanted to bring it in separately while the embedded linear view build gets worked out.