### PR TITLE
Fix add track when there are multiple assemblies

### DIFF
--- a/packages/jbrowse-cli/src/commands/add-track.ts
+++ b/packages/jbrowse-cli/src/commands/add-track.ts
@@ -110,15 +110,23 @@ export default class AddTrack extends Command {
   async run() {
     const { args: runArgs, flags: runFlags } = this.parse(AddTrack)
     const { track: argsTrack } = runArgs
-    const { config, configLocation, category, description, load } = runFlags
+    const {
+      config,
+      skipCheck,
+      force,
+      configLocation,
+      category,
+      description,
+      load,
+    } = runFlags
     let { type, trackId, name, assemblyNames } = runFlags
 
-    if (!(runFlags.skipCheck || runFlags.force)) {
+    if (!(skipCheck || force)) {
       await this.checkLocation(runArgs.location)
     }
     const { location, protocol, local } = await this.resolveFileLocation(
       argsTrack,
-      !(runFlags.skipCheck || runFlags.force),
+      !(skipCheck || force),
     )
     const configPath =
       configLocation || path.join(runArgs.location, 'config.json')
@@ -225,9 +233,8 @@ export default class AddTrack extends Command {
           asm => asm.name === assemblyNames,
         )
         if (assembly) {
-          const sequenceAdapter = assembly.sequence.adapter
           trackConfig.adapter.sequenceAdapter = assembly.sequence.adapter
-        } else {
+        } else if (!skipCheck) {
           this.error(`Failed to find assemblyName ${assemblyNames}`)
         }
         break

--- a/packages/jbrowse-cli/src/commands/add-track.ts
+++ b/packages/jbrowse-cli/src/commands/add-track.ts
@@ -221,11 +221,15 @@ export default class AddTrack extends Command {
     switch (type) {
       case 'PileupTrack':
       case 'AlignmentsTrack': {
-        const idx = configContents.assemblies.findIndex(
-          assemblies => assemblies.name === assemblyNames,
+        const assembly = configContents.assemblies.find(
+          asm => asm.name === assemblyNames,
         )
-        const sequenceAdapter = configContents.assemblies[idx].sequence.adapter
-        trackConfig.adapter.sequenceAdapter = sequenceAdapter
+        if (assembly) {
+          const sequenceAdapter = assembly.sequence.adapter
+          trackConfig.adapter.sequenceAdapter = assembly.sequence.adapter
+        } else {
+          this.error(`Failed to find assemblyName ${assemblyNames}`)
+        }
         break
       }
       case 'SNPCoverageTrack': {

--- a/packages/jbrowse-cli/src/commands/add-track.ts
+++ b/packages/jbrowse-cli/src/commands/add-track.ts
@@ -173,7 +173,7 @@ export default class AddTrack extends Command {
       this.error('No assemblies found. Please add one before adding tracks', {
         exit: 100,
       })
-    } else if (configContents.assemblies.length > 1) {
+    } else if (configContents.assemblies.length > 1 && !assemblyNames) {
       this.error(
         'Too many assemblies, cannot default to one. Please specify the assembly with the --assemblyNames flag',
       )

--- a/packages/jbrowse-cli/test/data/test_config.json
+++ b/packages/jbrowse-cli/test/data/test_config.json
@@ -19,6 +19,5 @@
   "defaultSession": {
     "name": "New Session"
   },
-  "tracks": [
-  ]
+  "tracks": []
 }


### PR DESCRIPTION
Current master branch fails to add a track if there are multiple assemblies present

This adds a test for it, and this additionally fixed some weirdness in the sequenceAdapter search logic for AlignmentsTracks (findIndex was not behaving appropriately and returning 0 for an index that did not exist for some reason...I switched it to use simple find instead of findIndex)