### PR TITLE
Support node >=10 in development-tools

### DIFF
--- a/packages/development-tools/babel.config.js
+++ b/packages/development-tools/babel.config.js
@@ -9,7 +9,7 @@ module.exports = api => {
         '@babel/preset-env',
         {
           targets: {
-            node: 'current',
+            node: 10,
           },
         },
       ],

--- a/packages/development-tools/package.json
+++ b/packages/development-tools/package.json
@@ -8,7 +8,7 @@
     "lint": "tsc --noEmit && eslint --ext .js,.ts,.jsx,.tsx src",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
-    "build": "babel src --root-mode upward --out-dir dist --extensions '.ts,.js'",
+    "build": "babel src --out-dir dist --extensions '.ts,.js'",
     "version": "standard-changelog && git add CHANGELOG.md",
     "postpublish": "git push origin master --follow-tags"
   },

--- a/packages/development-tools/src/build.ts
+++ b/packages/development-tools/src/build.ts
@@ -143,7 +143,7 @@ export function baseJBrowsePluginWebpackConfig(
                       '@babel/preset-env',
                       {
                         targets: {
-                          node: 'current',
+                          node: 10,
                           browsers: ['> 0.5%', 'last 2 versions'],
                         },
                       },


### PR DESCRIPTION
Have babel target be node 10 instead of current node version. Also remove `--root-mode upward` since the package has its own babel.config.js and doesn't need to look for the monorepo root one.