### PR TITLE
Fix pileup sorting of deletion alleles

### DIFF
--- a/packages/alignments/src/PileupRenderer/sortUtil.ts
+++ b/packages/alignments/src/PileupRenderer/sortUtil.ts
@@ -44,9 +44,13 @@ export const sortFeature = (
         const mismatches: Mismatch[] = feature.get('mismatches')
         mismatches.forEach(mismatch => {
           const start = feature.get('start')
+          const offset = start + mismatch.start + 1
+          const consuming =
+            mismatch.type === 'insertion' || mismatch.type === 'softclip'
+          const len = consuming ? 0 : mismatch.length
           if (
-            sortObject.position >= start + mismatch.start &&
-            sortObject.position <= start + mismatch.start + mismatch.length
+            sortObject.position >= offset &&
+            sortObject.position < offset + len
           ) {
             baseSortArray.push([feature.id(), mismatch])
           }

--- a/packages/alignments/src/PileupRenderer/sortUtil.ts
+++ b/packages/alignments/src/PileupRenderer/sortUtil.ts
@@ -10,13 +10,13 @@ export const sortFeature = (
   features: Map<string, Feature>,
   sortObject: SortObject,
 ) => {
-  const featureArray = Array.from(features)
-  const featuresInCenterLine: typeof featureArray = []
-  const featuresOutsideCenter: typeof featureArray = []
+  const featureArray = Array.from(features.values())
+  const featuresInCenterLine: Feature[] = []
+  const featuresOutsideCenter: Feature[] = []
 
   // only sort on features that intersect center line, append those outside post-sort
   featureArray.forEach(innerArray => {
-    const feature = innerArray[1]
+    const feature = innerArray
     if (
       doesIntersect2(
         sortObject.position - 1,
@@ -33,22 +33,21 @@ export const sortFeature = (
 
   switch (sortObject.by) {
     case 'Start location': {
-      featuresInCenterLine.sort(
-        (a: [string, Feature], b: [string, Feature]) =>
-          a[1].get('start') - b[1].get('start'),
-      )
+      featuresInCenterLine.sort((a, b) => a.get('start') - b.get('start'))
       break
     }
 
     // first sort all mismatches, then all reference bases at the end
     case 'Base pair': {
       const baseSortArray: [string, Mismatch][] = []
-      featuresInCenterLine.forEach(array => {
-        const feature = array[1]
+      featuresInCenterLine.forEach(feature => {
         const mismatches: Mismatch[] = feature.get('mismatches')
         mismatches.forEach(mismatch => {
-          const positionOfMismatch = feature.get('start') + mismatch.start + 1
-          if (positionOfMismatch === sortObject.position) {
+          const start = feature.get('start')
+          if (
+            sortObject.position >= start + mismatch.start &&
+            sortObject.position <= start + mismatch.start + mismatch.length
+          ) {
             baseSortArray.push([feature.id(), mismatch])
           }
         })
@@ -56,9 +55,8 @@ export const sortFeature = (
 
       const baseMap = new Map(baseSortArray)
       featuresInCenterLine.sort((a, b) => {
-        const aMismatch = baseMap.get(a[1].id())
-        const bMismatch = baseMap.get(b[1].id())
-
+        const aMismatch = baseMap.get(a.id())
+        const bMismatch = baseMap.get(b.id())
         return (
           (bMismatch ? bMismatch.base.toUpperCase().charCodeAt(0) : 0) -
           (aMismatch ? aMismatch.base.toUpperCase().charCodeAt(0) : 0)
@@ -70,19 +68,18 @@ export const sortFeature = (
 
     // sorts positive strands then negative strands
     case 'Read strand': {
-      featuresInCenterLine.sort(
-        (a: [string, Feature], b: [string, Feature]) => {
-          return a[1].get('strand') <= b[1].get('strand') ? 1 : -1
-        },
+      featuresInCenterLine.sort((a, b) =>
+        a.get('strand') <= b.get('strand') ? 1 : -1,
       )
       break
     }
-
-    default:
-      break
   }
 
-  const sortedMap = new Map(featuresInCenterLine.concat(featuresOutsideCenter))
+  const sortedMap = new Map(
+    featuresInCenterLine
+      .concat(featuresOutsideCenter)
+      .map(feature => [feature.id(), feature]),
+  )
 
   return sortedMap
 }

--- a/packages/alignments/src/PileupRenderer/sortUtil.ts
+++ b/packages/alignments/src/PileupRenderer/sortUtil.ts
@@ -61,9 +61,14 @@ export const sortFeature = (
       featuresInCenterLine.sort((a, b) => {
         const aMismatch = baseMap.get(a.id())
         const bMismatch = baseMap.get(b.id())
+        const acode = bMismatch && bMismatch.base.toUpperCase()
+        const bcode = aMismatch && aMismatch.base.toUpperCase()
+        if (acode === bcode && acode === '*') {
+          // @ts-ignore
+          return aMismatch.length - bMismatch.length
+        }
         return (
-          (bMismatch ? bMismatch.base.toUpperCase().charCodeAt(0) : 0) -
-          (aMismatch ? aMismatch.base.toUpperCase().charCodeAt(0) : 0)
+          (acode ? acode.charCodeAt(0) : 0) - (bcode ? bcode.charCodeAt(0) : 0)
         )
       })
 


### PR DESCRIPTION
This proposes a fix for #1102 


Note that this does not try to handle sorting insertion alleles

Example of a position with multiple deletion allele lengths

http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=eJztVU1v2kAQ_StoT61EjDEQsG9JqiZpKUVAS5OqQmt7sLex1-7umo8g__fO2hRMIVEjVeqlBx92vt6b2beeDeE0BuKQASxrY5CSJbxmmZZ5Zp6fWebEbDpWy-l0jY7duyd1ElMRME4cs058QZcgpsxXIXFavXadLBgsJXG-bgjzsWQ4fTf9MuT3Geb5TKYRXQ9KsDBo2mhU61Sf-owDFdfAkxg-Ywn0JPO5BDVcEafX7va6tmF2283zc8vu2nXipkMQ2mcaprUrDf4IAmRfEhAw32I1sZxUVKiCNHBkZrVtq2OeW806xi1ASEDjnEYS6oRKCbEbHTDNvyFXQb2HSnNtz77PLj9BuO_jImIBj4ErOdHB6AiBBSECd9o4HS_hcxZkgipkieE8iCMxQ-5MKeSA4UMWQZaWyc4WZ5X-EO6du7yL90DVuD1I0zSPQDanU4pmbv1jErO0iJut1o8YtpXG-P3lqFVLqeeypPZqcP2hP3pd26XUEh6ta2UeOZyfHlc5QRygRxUEiVhrW1FRG6lPUyxSIXpJ44utEW-axv3E2_WSCaavRKlUOo2GbBk0po8Jp0tpeEnc-O6KZCnBSETQCAo1yYZGb8gHV7QaAqgvZ7pbfTTmdFY0f2YaltGaxTRNwTd2bRmITfI6YdyHlQaP_iER_BjJ81zrFfkILRekUV7qaGs6uu2dA_PGi-AtUJUJOBF-wpkXaOPB8CrBB0IDOFTl99WDfXW3eNPei_Iodq_M9jPCPJH2tDolT71t8MslWkn-Czqt8N7rVWbuf0W_SNG_S7oy1lNCPeEtakiIwFN6BWgr4wEG615lmCx_ZRBHiQxKW_lASov-u4fMhxtsQqNtF8He9BHz9WrbuQqBjgvIRExKaiFDEOGFzKMRKUEKPfepC5GsYl_hhgChl94ef8n8AFQxgWqhSRVo9_iejtg9xpunQqYFENHvMYpoWmy-DQ5qziIkNYGV0pMrV_nBCtdTpp5iC5j-EddnfHnxN-B4QPHdclzO3NNvcJPnPwEG7vb9