### PR TITLE
Fix weird behavior found when zooming close to the max/min values of the slider

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
   },
   slider: {
-    width: 48,
+    width: 70,
   },
 })
 
@@ -40,7 +40,7 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
         value={-Math.log2(bpPerPx)}
         min={-Math.log2(maxBpPerPx)}
         max={-Math.log2(minBpPerPx)}
-        onChange={(event, value) => model.zoomTo(2 ** -value)}
+        onChangeCommitted={(event, value) => model.zoomTo(2 ** -value)}
       />
       <IconButton
         data-testid="zoom_in"

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -2,13 +2,10 @@ import IconButton from '@material-ui/core/IconButton'
 import Slider from '@material-ui/core/Slider'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import { Instance } from 'mobx-state-tree'
 import React from 'react'
 import ZoomIn from '@material-ui/icons/ZoomIn'
 import ZoomOut from '@material-ui/icons/ZoomOut'
-import { LinearGenomeViewStateModel } from '..'
-
-type LGV = Instance<LinearGenomeViewStateModel>
+import { LinearGenomeViewModel } from '..'
 
 const useStyles = makeStyles({
   container: {
@@ -21,17 +18,18 @@ const useStyles = makeStyles({
   },
 })
 
-function ZoomControls({ model }: { model: LGV }) {
+function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
   const classes = useStyles()
+  const { maxBpPerPx, minBpPerPx, bpPerPx, scaleFactor } = model
 
   return (
     <div className={classes.container}>
       <IconButton
         data-testid="zoom_out"
         onClick={() => {
-          model.zoom(model.bpPerPx * 2)
+          model.zoom(bpPerPx * 2)
         }}
-        disabled={model.bpPerPx >= model.maxBpPerPx || model.scaleFactor !== 1}
+        disabled={bpPerPx >= maxBpPerPx - 0.0001 || scaleFactor !== 1}
         color="secondary"
       >
         <ZoomOut fontSize="small" />
@@ -39,9 +37,9 @@ function ZoomControls({ model }: { model: LGV }) {
 
       <Slider
         className={classes.slider}
-        value={-Math.log2(model.bpPerPx)}
-        min={-Math.log2(model.maxBpPerPx)}
-        max={-Math.log2(model.minBpPerPx)}
+        value={-Math.log2(bpPerPx)}
+        min={-Math.log2(maxBpPerPx)}
+        max={-Math.log2(minBpPerPx)}
         onChange={(event, value) => model.zoomTo(2 ** -value)}
       />
       <IconButton
@@ -49,7 +47,7 @@ function ZoomControls({ model }: { model: LGV }) {
         onClick={() => {
           model.zoom(model.bpPerPx / 2)
         }}
-        disabled={model.bpPerPx <= model.minBpPerPx || model.scaleFactor !== 1}
+        disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
         color="secondary"
       >
         <ZoomIn fontSize="small" />

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -1,8 +1,8 @@
+import React, { useState } from 'react'
+import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import IconButton from '@material-ui/core/IconButton'
 import Slider from '@material-ui/core/Slider'
 import { makeStyles } from '@material-ui/core/styles'
-import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import React from 'react'
 import ZoomIn from '@material-ui/icons/ZoomIn'
 import ZoomOut from '@material-ui/icons/ZoomOut'
 import { LinearGenomeViewModel } from '..'
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
 function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
   const classes = useStyles()
   const { maxBpPerPx, minBpPerPx, bpPerPx, scaleFactor } = model
-
+  const [value, setValue] = useState(-Math.log2(bpPerPx) * 100)
   return (
     <div className={classes.container}>
       <IconButton
@@ -37,10 +37,11 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
 
       <Slider
         className={classes.slider}
-        defaultValue={-Math.log2(bpPerPx) * 100}
+        value={value}
         min={-Math.log2(maxBpPerPx) * 100}
         max={-Math.log2(minBpPerPx) * 100}
-        onChangeCommitted={(event, value) => model.zoomTo(2 ** (-value / 100))}
+        onChange={(event, val) => setValue(val as number)}
+        onChangeCommitted={event => model.zoomTo(2 ** (-value / 100))}
       />
       <IconButton
         data-testid="zoom_in"

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -37,10 +37,10 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
 
       <Slider
         className={classes.slider}
-        value={-Math.log2(bpPerPx)}
-        min={-Math.log2(maxBpPerPx)}
-        max={-Math.log2(minBpPerPx)}
-        onChangeCommitted={(event, value) => model.zoomTo(2 ** -value)}
+        defaultValue={-Math.log2(bpPerPx) * 100}
+        min={-Math.log2(maxBpPerPx) * 100}
+        max={-Math.log2(minBpPerPx) * 100}
+        onChangeCommitted={(event, value) => model.zoomTo(2 ** (-value / 100))}
       />
       <IconButton
         data-testid="zoom_in"

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -318,13 +318,13 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             />
             <input
               type="hidden"
-              value="3.321928094887362"
+              value="332.1928094887362"
             />
             <span
               aria-orientation="horizontal"
-              aria-valuemax="5.643856189774724"
-              aria-valuemin="3.321928094887362"
-              aria-valuenow="3.321928094887362"
+              aria-valuemax="564.3856189774724"
+              aria-valuemin="332.1928094887362"
+              aria-valuenow="332.1928094887362"
               class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
               data-index="0"
               role="slider"
@@ -1142,7 +1142,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             />
             <span
               class="MuiSlider-track"
-              style="left: 0%; width: 2.378394193813357%;"
+              style="left: 0%; width: 2.3783941938133566%;"
             />
             <input
               type="hidden"
@@ -1150,13 +1150,13 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             />
             <span
               aria-orientation="horizontal"
-              aria-valuemax="5.643856189774724"
-              aria-valuemin="-0.13750352374993502"
+              aria-valuemax="564.3856189774724"
+              aria-valuemin="-13.750352374993502"
               aria-valuenow="0"
               class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
               data-index="0"
               role="slider"
-              style="left: 2.378394193813357%;"
+              style="left: 2.3783941938133566%;"
               tabindex="0"
             />
           </span>

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -352,8 +352,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.bpPerPx = newBpPerPx
 
         if (Math.abs(oldBpPerPx - newBpPerPx) < 0.000001) {
-          console.warn('rounding error?')
-          return
+          console.warn('zoomTo bpPerPx rounding error')
+          return oldBpPerPx
         }
 
         // tweak the offset so that the center of the view remains at the same coordinate

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -351,6 +351,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const oldBpPerPx = self.bpPerPx
         self.bpPerPx = newBpPerPx
 
+        if (Math.abs(oldBpPerPx - newBpPerPx) < 0.000001) {
+          console.warn('rounding error?')
+          return
+        }
+
         // tweak the offset so that the center of the view remains at the same coordinate
         const viewWidth = self.width
         this.scrollTo(

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -360,7 +360,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const viewWidth = self.width
         this.scrollTo(
           Math.round(
-            ((self.offsetPx + viewWidth / 2) * oldBpPerPx) / bpPerPx -
+            ((self.offsetPx + viewWidth / 2) * oldBpPerPx) / newBpPerPx -
               viewWidth / 2,
           ),
         )


### PR DESCRIPTION
Addresses #1053 

I added some sort of random heuristics but it disables the zoom in button when the slider is fully to the right or left, and also disables the zoomTo function behavior if there is basically a value that it interprets to be too close (and console.warn's rounding error)