### PR TITLE
Fix so click and drag doesn't select feature

### DIFF
--- a/packages/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/packages/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -185,13 +185,13 @@ function PileupRendering(props: {
         style={{ position: 'absolute', left: 0, top: 0 }}
         className="highlightOverlayCanvas"
         ref={highlightOverlayCanvas}
-        onMouseDown={event => runner(() => onMouseDown(event))}
+        onPointerDown={event => runner(() => onMouseDown(event))}
         onMouseEnter={event => runner(() => onMouseEnter(event))}
         onMouseOut={event => runner(() => onMouseOut(event))}
         onMouseOver={event => runner(() => onMouseOver(event))}
-        onMouseUp={event => runner(() => onMouseUp(event))}
+        onPointerUp={event => runner(() => onMouseUp(event))}
         onMouseLeave={event => runner(() => onMouseLeave(event))}
-        onMouseMove={event => runner(() => mouseMove(event))}
+        onPointerMove={event => runner(() => mouseMove(event))}
         onClick={event => runner(() => onClick(event))}
         onContextMenu={event => runner(() => onContextMenu(event))}
         onFocus={() => {}}

--- a/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/packages/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -409,13 +409,13 @@ function SvgFeatureRendering(props) {
         className="SvgFeatureRendering"
         width={`${width}px`}
         height={`${height}px`}
-        onMouseDown={mouseDown}
-        onMouseUp={mouseUp}
+        onPointerDown={mouseDown}
+        onPointerUp={mouseUp}
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
         onMouseOver={mouseOver}
         onMouseOut={mouseOut}
-        onMouseMove={mouseMove}
+        onPointerMove={mouseMove}
         onFocus={mouseEnter}
         onBlur={mouseLeave}
         onClick={click}


### PR DESCRIPTION
After #1112, the fix in #551 didn't work anymore. It looks like the rendering components no longer get "onMouseDown" and "onMouseUp" events, and only get the "onMouseMove" event when the mouse button is not pressed down. This changes the events the renderings use to "onPointerDown", "onPointerUp", and "onPointerMove" instead, but they still call the "onMouseDown", "onMouseUp", and "onMouseMove" callbacks passed in the render props.