### PR TITLE
Add minicontrols

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -17,6 +17,7 @@ import Header from './Header'
 import TrackContainer from './TrackContainer'
 import TracksContainer from './TracksContainer'
 import ImportForm from './ImportForm'
+import MiniControls from './MiniControls'
 
 type LGV = Instance<LinearGenomeViewStateModel>
 
@@ -37,8 +38,20 @@ const LinearGenomeView = observer((props: { model: LGV }) => {
   return !initialized ? (
     <ImportForm model={model} />
   ) : (
-    <div>
-      {!hideHeader ? <Header model={model} /> : null}
+    <div style={{ position: 'relative' }}>
+      {!hideHeader ? (
+        <Header model={model} />
+      ) : (
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            zIndex: 100000,
+          }}
+        >
+          <MiniControls model={model} />
+        </div>
+      )}
       {error ? (
         <Paper variant="outlined" className={classes.errorMessage}>
           <Typography color="error">{error.message}</Typography>

--- a/packages/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react'
+import { observer } from 'mobx-react'
+import IconButton from '@material-ui/core/IconButton'
+import ZoomIn from '@material-ui/icons/ZoomIn'
+import ZoomOut from '@material-ui/icons/ZoomOut'
+import ArrowDown from '@material-ui/icons/KeyboardArrowDown'
+import Paper from '@material-ui/core/Paper'
+import Menu from '@gmod/jbrowse-core/ui/Menu'
+import { LinearGenomeViewModel } from '..'
+
+const MiniControls = observer((props: { model: LinearGenomeViewModel }) => {
+  const { model } = props
+  const { bpPerPx, maxBpPerPx, minBpPerPx, scaleFactor } = model
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>()
+
+  return (
+    <>
+      <Paper style={{ background: '#aaa7' }}>
+        <IconButton
+          size="small"
+          color="secondary"
+          onClick={event => {
+            setAnchorEl(event.currentTarget)
+          }}
+        >
+          <ArrowDown fontSize="small" />
+        </IconButton>
+
+        <IconButton
+          data-testid="zoom_out"
+          onClick={() => {
+            model.zoom(bpPerPx * 2)
+          }}
+          disabled={bpPerPx >= maxBpPerPx - 0.0001 || scaleFactor !== 1}
+          size="small"
+          color="secondary"
+        >
+          <ZoomOut fontSize="small" />
+        </IconButton>
+        <IconButton
+          data-testid="zoom_in"
+          onClick={() => {
+            model.zoom(model.bpPerPx / 2)
+          }}
+          disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
+          color="secondary"
+          size="small"
+        >
+          <ZoomIn fontSize="small" />
+        </IconButton>
+      </Paper>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onMenuItemClick={(event, callback) => {
+          callback()
+          setAnchorEl(undefined)
+        }}
+        onClose={() => {
+          setAnchorEl(undefined)
+        }}
+        menuOptions={model.menuOptions}
+      />
+    </>
+  )
+})
+
+export default MiniControls

--- a/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import { observer } from 'mobx-react'
 import IconButton from '@material-ui/core/IconButton'
 import Slider from '@material-ui/core/Slider'
 import { makeStyles } from '@material-ui/core/styles'
@@ -55,10 +55,6 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
       </IconButton>
     </div>
   )
-}
-
-ZoomControls.propTypes = {
-  model: MobxPropTypes.observableObject.isRequired,
 }
 
 export default observer(ZoomControls)

--- a/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/packages/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<LinearGenomeView /> renders one track, one region 1`] = `
-<div>
+<div
+  style="position: relative;"
+>
   <div>
     <div
       style="position: relative;"
@@ -827,7 +829,9 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
 `;
 
 exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
-<div>
+<div
+  style="position: relative;"
+>
   <div>
     <div
       style="position: relative;"


### PR DESCRIPTION
This adds a concept of minicontrols when the header is hidden

This is helpful in synteny because having the header visible is obtrusive

screenshot with and without synteny enabled
![t2](https://user-images.githubusercontent.com/6511937/90151580-db08cd80-dd54-11ea-8692-e89bdec63a16.png)
![t1](https://user-images.githubusercontent.com/6511937/90151583-dba16400-dd54-11ea-937a-667c5504cd30.png)




