### PR TITLE
Block level status and track level status

### DIFF
--- a/packages/alignments/src/BamAdapter/BamAdapter.ts
+++ b/packages/alignments/src/BamAdapter/BamAdapter.ts
@@ -81,6 +81,8 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
       if (idToName.length) {
         this.samHeader = { idToName, nameToId }
       }
+
+      statusCallback('')
     }
   }
 

--- a/packages/alignments/src/BamAdapter/BamAdapter.ts
+++ b/packages/alignments/src/BamAdapter/BamAdapter.ts
@@ -81,8 +81,6 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
       if (idToName.length) {
         this.samHeader = { idToName, nameToId }
       }
-
-      statusCallback('')
     }
   }
 

--- a/packages/alignments/src/BamAdapter/BamAdapter.ts
+++ b/packages/alignments/src/BamAdapter/BamAdapter.ts
@@ -81,6 +81,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
       if (idToName.length) {
         this.samHeader = { idToName, nameToId }
       }
+      statusCallback('')
     }
   }
 
@@ -162,6 +163,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
         }
         observer.next(new BamSlightlyLazyFeature(record, this, ref))
       }
+      statusCallback('')
       observer.complete()
     }, signal)
   }

--- a/packages/alignments/src/CramAdapter/CramAdapter.ts
+++ b/packages/alignments/src/CramAdapter/CramAdapter.ts
@@ -151,6 +151,7 @@ export default (pluginManager: PluginManager) => {
         if (idToName.length) {
           this.samHeader = { idToName, nameToId }
         }
+        statusCallback('')
       }
     }
 
@@ -223,6 +224,7 @@ export default (pluginManager: PluginManager) => {
             observer.next(this.cramRecordToFeature(record))
           })
         }
+        statusCallback('')
         observer.complete()
       }, signal)
     }

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -138,7 +138,6 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
       abortSignal?: AbortSignal,
       statusCallback?: Function,
     ) {
-      console.log({ statusCallback })
       const { adapterConf, adapterId, self, options } = args
       return loadRefNameMap(
         self,

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -133,9 +133,20 @@ interface CacheData {
 export default function assemblyFactory(assemblyConfigType: IAnyType) {
   const adapterLoads = new AbortablePromiseCache({
     cache: new QuickLRU({ maxSize: 1000 }),
-    async fill(args: CacheData, abortSignal?: AbortSignal) {
+    async fill(
+      args: CacheData,
+      abortSignal?: AbortSignal,
+      statusCallback?: Function,
+    ) {
+      console.log({ statusCallback })
       const { adapterConf, adapterId, self, options } = args
-      return loadRefNameMap(self, adapterId, adapterConf, options, abortSignal)
+      return loadRefNameMap(
+        self,
+        adapterId,
+        adapterConf,
+        { ...options, statusCallback },
+        abortSignal,
+      )
     },
   })
 
@@ -249,7 +260,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
     }))
     .views(self => ({
       getAdapterMapEntry(adapterConf: unknown, options: BaseOptions) {
-        const { signal, ...rest } = options
+        const { signal, statusCallback, ...rest } = options
         if (!options.sessionId) {
           throw new Error('sessionId is required')
         }
@@ -263,6 +274,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
             options: rest,
           } as CacheData,
           signal,
+          options.statusCallback,
         )
       },
 

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -273,7 +273,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
             options: rest,
           } as CacheData,
           signal,
-          options.statusCallback,
+          statusCallback,
         )
       },
 

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
@@ -255,11 +255,14 @@ export default class ServerSideRenderer extends RendererType {
     // serialize the results for passing back to the main thread.
     // these will be transmitted to the main process, and will come out
     // as the result of renderRegionWithWorker.
-    return this.serializeResultsInWorker(
+    statusCallback('Serializing results')
+    const serialized = this.serializeResultsInWorker(
       { ...results, html },
       features,
       deserializedArgs,
     )
+    statusCallback('')
+    return serialized
   }
 
   freeResourcesInClient(rpcManager: RpcManager, args: RenderArgs) {

--- a/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
+++ b/packages/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
@@ -77,10 +77,12 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
     return () => clearTimeout(timeout)
   }, [])
 
-  const { message } = getParent(model, 2)
+  const { status: blockStatus } = model
+  const { message: trackStatus } = getParent(model, 2)
+  const status = trackStatus || blockStatus
   return shown ? (
     <div className={classes.loading}>
-      <div className={classes.dots}>{message ? `${message}` : 'Loading'}</div>
+      <div className={classes.dots}>{status ? `${status}` : 'Loading'}</div>
     </div>
   ) : null
 })

--- a/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
+++ b/packages/linear-genome-view/src/BasicTrack/util/serverSideRenderedBlock.ts
@@ -30,6 +30,7 @@ const blockState = types
     filled: false,
     data: undefined as any,
     html: '',
+    status: '',
     error: undefined as Error | undefined,
     message: undefined as string | undefined,
     maxHeightReached: false,
@@ -55,6 +56,9 @@ const blockState = types
           this.setRendered,
           this.setError,
         )
+      },
+      setStatus(message: string) {
+        self.status = message
       },
       setLoading(abortController: AbortController) {
         if (renderInProgress !== undefined) {
@@ -212,8 +216,8 @@ function renderBlockData(self: Instance<BlockStateModel>) {
       trackError: track.error,
       renderArgs: {
         statusCallback: (message: string) => {
-          if (isAlive(track)) {
-            track.setMessage(message)
+          if (isAlive(self)) {
+            self.setStatus(message)
           }
         },
         assemblyName: self.region.assemblyName,

--- a/packages/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/packages/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -34,7 +34,9 @@ export default class BigWigAdapter extends BaseFeatureDataAdapter
   private getHeader(opts?: BaseOptions) {
     const { statusCallback = () => {} } = opts || {}
     statusCallback('Downloading bigwig header')
-    return this.bigwig.getHeader(opts)
+    const result = this.bigwig.getHeader(opts)
+    statusCallback('')
+    return result
   }
 
   public async getRefNames(opts?: BaseOptions) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,10 +1963,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.1.tgz#b6eb75cac279588d3100baecd1b9894ea2840822"
-  integrity sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==
+"@babel/runtime@^7.0.0":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1974,6 +1974,13 @@
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.1.tgz#b6eb75cac279588d3100baecd1b9894ea2840822"
+  integrity sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -5139,7 +5146,15 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.1.3, abortable-promise-cache@^1.2.0:
+abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.1.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.3.0.tgz#c51a9fe670d50c04dcc2c695345b039d2212c040"
+  integrity sha512-GneJsLjdKirdN2xYkNoHg8oBMzRLYFyNMRRvfm5hEhz58kP3yUc4EGQ7+TZ/5AAgsb3N84pqhmRpWO46RamGpA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    abortcontroller-polyfill "^1.2.9"
+
+abortable-promise-cache@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.2.0.tgz#cb48bc5583654383d23709cf5d0d5b56d9c8146f"
   integrity sha512-kKEN5e569SV8br+gqDwMmpglTD2wlJshaBfU97o+5OCYMUQx5terlWTfgb0a0uq1bvt82SrwzEium5gR0n2frQ==
@@ -5147,10 +5162,15 @@ abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.1.3, abortable-promis
     "@babel/runtime" "^7.0.0"
     abortcontroller-polyfill "^1.2.9"
 
-abortcontroller-polyfill@^1.2.4, abortcontroller-polyfill@^1.2.9:
+abortcontroller-polyfill@^1.2.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"
   integrity sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==
+
+abortcontroller-polyfill@^1.2.9:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz#2c562f530869abbcf88d949a2b60d1d402e87a7c"
+  integrity sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
@@ -17794,10 +17814,15 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.3:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"


### PR DESCRIPTION
In looking at block level status as in #1136, I concluded that we might need block level and track level status

I tried using block level status only but for example, the first thing that is done is getRefNames for the track, and this is initiated from a block, which then does renameRegionsIfNeeded, which then does a getRefNames guarded by an AbortablePromiseCache, so only one request to getRefNames actually ever goes out for the multiple blocks requesting it. Therefore, in order to properly handle this, it might be that abortable-promise-cache itself needs to handle statusCallback and dispatch the status requests to all waiting requests.

An alternative, presented in this PR, is a little weirder, and implies usage of a trackLevel status and a blockLevel status.

This makes it so that, for example, the BamAdapter is coded to set the track level status by calling statusCallback({ message: "Downloading index file", level: 1}) where level 1 implies setting a track level status, and level===0 or level undefined is block level. The BamAdapter therefore sort of needs to "know" about what is a track level status to make this work which is sort of awkward.

Note that even this isn't perfect, and points to, a need for super-track-level status too. The alignments track demonstrates this because the SNPCoverage track gets the status for "Downloading index" set on it's track but PileupTrack doesn't get it, it would be more ideal if

(a) they both got it from a super track level status
(b) the abortable-promise-cache-with-status was implemented