### PR TITLE
export Attributes

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -138,7 +138,7 @@ interface AttributeProps {
   descriptions?: Record<string, React.ReactNode>
 }
 
-const Attributes: FunctionComponent<AttributeProps> = props => {
+export const Attributes: FunctionComponent<AttributeProps> = props => {
   const classes = useStyles()
   const {
     attributes,


### PR DESCRIPTION
This feature makes available the creation of tables without being restricted to containing inner collapsible elements. This is especially useful for smaller tables, with few inner elements which don't contain too much information. 

Furthermore, the elements already exported from BaseFeatureDetail have fixed titles (such as "Attributes" and "Primary Data"), requiring more changes to be made in order to use them for other purposes. Exporting Attributes gives the possibility to use a BaseCard as a customized wrapper for certain element or for the entire table.

For example:
table that uses Attributes
![table that uses Attributes](https://user-images.githubusercontent.com/50514608/90789513-ae822200-e30f-11ea-90c3-4715a7ca90ea.png)

table that uses BaseAttributes
![table that uses BaseAttributes](https://user-images.githubusercontent.com/50514608/90789517-afb34f00-e30f-11ea-993b-589bf8490c50.png)

