### PR TITLE
Derived column containing locstring for BED and VCF imports

### DIFF
--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -55,6 +55,18 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
       },
     }))
     .views(self => ({
+      async loadAssembly(assemblyName: string) {
+        const canonicalName = self.aliasMap.get(assemblyName)
+        const assembly = self.assemblies.find(
+          asm => asm.name === (canonicalName || assemblyName),
+        )
+        if (assembly) {
+          await when(() => Boolean(assembly.regions && assembly.refNameAliases))
+          return assembly
+        }
+        return undefined
+      },
+
       async getRefNameMapForAdapter(
         adapterConf: unknown,
         assemblyName: string,

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -55,7 +55,9 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
       },
     }))
     .views(self => ({
-      async loadAssembly(assemblyName: string) {
+      // use this method instead of assemblyManager.get(assemblyName)
+      // get an assembly with regions loaded
+      async waitForAssembly(assemblyName: string) {
         const canonicalName = self.aliasMap.get(assemblyName)
         const assembly = self.assemblies.find(
           asm => asm.name === (canonicalName || assemblyName),

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -58,6 +58,9 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
       // use this method instead of assemblyManager.get(assemblyName)
       // get an assembly with regions loaded
       async waitForAssembly(assemblyName: string) {
+        if (!assemblyName) {
+          throw new Error('no assembly name supplied to waitForAssembly')
+        }
         const canonicalName = self.aliasMap.get(assemblyName)
         const assembly = self.assemblies.find(
           asm => asm.name === (canonicalName || assemblyName),
@@ -106,6 +109,9 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
           if (assembly) {
             return assembly.isValidRefName(refName)
           }
+          throw new Error(
+            `isValidRefName for ${assemblyName} failed, assembly does not exist`,
+          )
         }
         if (!self.allPossibleRefNames) {
           throw new Error(

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -95,7 +95,7 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
         }
         if (!self.allPossibleRefNames) {
           throw new Error(
-            `isValidRefName not available, assemblyManager has not yet finished loading`,
+            `isValidRefName not available, assemblyManager has not yet finished loading. If you are looking for a refname in a specific assembly, pass assembly argument`,
           )
         }
         return self.allPossibleRefNames.includes(refName)

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -487,7 +487,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
           return
         }
         const displayedRegion = self.displayedRegions[0]
-        let assembly = assemblyManager.get(displayedRegion.assemblyName)
+        const { assemblyName } = displayedRegion
+        let assembly = assemblyManager.get(assemblyName)
         if (!assembly) {
           throw new Error(
             `Could not find assembly ${displayedRegion.assemblyName}`,
@@ -511,7 +512,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
               'Navigating to multiple locations is not allowed when viewing a whole chromosome',
             )
           }
-          const parsedLocString = parseLocString(locStrings[0], isValidRefName)
+          const parsedLocString = parseLocString(locStrings[0], refName =>
+            isValidRefName(refName, assemblyName),
+          )
           let changedAssembly = false
           if (
             parsedLocString.assemblyName &&

--- a/packages/spreadsheet-view/package.json
+++ b/packages/spreadsheet-view/package.json
@@ -18,6 +18,7 @@
   "peerDependencies": {
     "@gmod/jbrowse-core": "^0.0.1-beta.1",
     "@material-ui/core": "^4.9.13",
+    "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",

--- a/packages/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
@@ -204,9 +204,9 @@ export default pluginManager => {
         </th>
         {columnDisplayOrder.map(colNumber => (
           <td key={colNumber}>
-            {rowModel.cells.length > colNumber ? (
+            {rowModel.cellsWithDerived.length > colNumber ? (
               <CellData
-                cell={rowModel.cells[colNumber]}
+                cell={rowModel.cellsWithDerived[colNumber]}
                 spreadsheetModel={spreadsheetModel}
                 columnNumber={colNumber}
               />

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -54,6 +54,16 @@ export async function parseBedBuffer(buffer: Buffer, options: ParseOptions) {
   data.hasColumnNames = true
   data.assemblyName = options.selectedAssemblyName
 
+  data.columnDisplayOrder.push(data.columnDisplayOrder.length)
+  data.columns.unshift({
+    name: 'Location',
+    dataType: { type: 'LocString' },
+    isDerived: true,
+    derivationFunctionText: `function deriveLocationColumn(row, column) {
+      var cells = row.cells
+      return {text:cells[0].text+':'+cells[1].text+'..'+cells[2].text}
+    }`,
+  })
   return data
 }
 

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -37,9 +37,9 @@ export async function parseBedBuffer(buffer: Buffer, options: ParseOptions) {
   const b = removeBedHeaders(buffer)
   const data = await parseTsvBuffer(b)
   const bedColumns = [
-    { name: 'chrom', dataType: { type: 'Text' } },
-    { name: 'chromStart', dataType: { type: 'Number' } },
-    { name: 'chromEnd', dataType: { type: 'Number' } },
+    { name: 'chrom', dataType: { type: 'LocRef' } },
+    { name: 'chromStart', dataType: { type: 'LocStart' } },
+    { name: 'chromEnd', dataType: { type: 'LocEnd' } },
     { name: 'name', dataType: { type: 'Text' } },
     { name: 'score', dataType: { type: 'Number' } },
     { name: 'strand', dataType: { type: 'Text' } },

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
@@ -37,6 +37,7 @@ export interface Column {
   name: string
   dataType: { type: string }
   isDerived?: boolean
+  derivationFunctionText?: string
 }
 
 function guessColumnType(

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
@@ -36,22 +36,7 @@ function vcfRecordToRow(vcfParser: any, line: string, lineNumber: number): Row {
     parser: vcfParser,
     id: `vcf-${lineNumber}`,
   })
-  // if (!record) console.log(`no parse for "${line}"`)
-  // const cells = [
-  //   ...vcfCoreColumns.map((colName, columnNumber) => {
-  //     const text = formatters[colName]
-  //       ? formatters[colName](record[colName])
-  //       : String(record[colName])
-  //     return { columnNumber, text, dataType: 'text' }
-  //   }),
-  //   ...vcfParser.samples.map((sampleName: string, sampleNumber: number) => {
-  //     return {
-  //       columnNumber: vcfCoreColumns.length + sampleNumber,
-  //       text: record.SAMPLES[sampleName],
-  //       dataType: 'text',
-  //     }
-  //   }),
-  // ]
+
   const data = line.split('\t').map(d => (d === '.' ? '' : d))
   const row: Row = {
     id: String(lineNumber + 1),
@@ -119,7 +104,7 @@ export function parseVcfBuffer(
           ? Number(variant.INFO.END[0])
           : start + variant.REF.length,
     }
-    row.extendedData = featureData
+    row.extendedData.simple = featureData
   })
 
   // TODO: synthesize a linkable location column after the POS column
@@ -129,11 +114,10 @@ export function parseVcfBuffer(
     dataType: { type: 'LocString' },
     isDerived: true,
     derivationFunctionText: `function deriveLocationColumn(row, column) {
-      return {text:row.extendedData.refName+':'+row.extendedData.start+'..'+row.extendedData.end}
+      return {text:row.extendedData.simple.refName+':'+row.extendedData.simple.start+'..'+row.extendedData.simple.end}
     }`,
   })
 
-  console.log({ rowSet: JSON.stringify(rowSet) })
   return {
     rowSet,
     columnDisplayOrder,

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
@@ -107,7 +107,6 @@ export function parseVcfBuffer(
     row.extendedData.simple = featureData
   })
 
-  // TODO: synthesize a linkable location column after the POS column
   columnDisplayOrder.push(columnDisplayOrder.length)
   columns.unshift({
     name: 'Location',

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -14,8 +14,19 @@ Object {
     7,
     8,
     9,
+    10,
   ],
   "columns": Array [
+    Object {
+      "dataType": Object {
+        "type": "LocString",
+      },
+      "derivationFunctionText": "function deriveLocationColumn(row, column) {
+      return {text:row.extendedData.simple.refName+':'+row.extendedData.simple.start+'..'+row.extendedData.simple.end}
+    }",
+      "isDerived": true,
+      "name": "Location",
+    },
     Object {
       "dataType": Object {
         "type": "Text",
@@ -125,6 +136,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 156845493,
+            "refName": "1",
+            "start": 156845492,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "AGTGT",
@@ -242,6 +258,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 156848996,
+            "refName": "1",
+            "start": 156848995,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -410,6 +431,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 47601107,
+            "refName": "2",
+            "start": 47601106,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -584,6 +610,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 47630551,
+            "refName": "2",
+            "start": 47630550,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -752,6 +783,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 47641565,
+            "refName": "2",
+            "start": 47641559,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -880,6 +916,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 47693960,
+            "refName": "2",
+            "start": 47693959,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -1054,6 +1095,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48010559,
+            "refName": "2",
+            "start": 48010558,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -1228,6 +1274,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48010655,
+            "refName": "2",
+            "start": 48010654,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1396,6 +1447,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48018031,
+            "refName": "2",
+            "start": 48018030,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1564,6 +1620,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48018082,
+            "refName": "2",
+            "start": 48018081,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1738,6 +1799,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48023116,
+            "refName": "2",
+            "start": 48023115,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -1912,6 +1978,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48030839,
+            "refName": "2",
+            "start": 48030838,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -2074,6 +2145,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48032879,
+            "refName": "2",
+            "start": 48032874,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -2245,6 +2321,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48033552,
+            "refName": "2",
+            "start": 48033551,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2401,6 +2482,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48033891,
+            "refName": "2",
+            "start": 48033890,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "CT",
@@ -2524,6 +2610,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215632257,
+            "refName": "2",
+            "start": 215632256,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2686,6 +2777,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215645546,
+            "refName": "2",
+            "start": 215645545,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2854,6 +2950,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215657184,
+            "refName": "2",
+            "start": 215657182,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -2977,6 +3078,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215674091,
+            "refName": "2",
+            "start": 215674090,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3139,6 +3245,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215674324,
+            "refName": "2",
+            "start": 215674323,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3301,6 +3412,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 215674342,
+            "refName": "2",
+            "start": 215674341,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3463,6 +3579,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 10191524,
+            "refName": "3",
+            "start": 10191523,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3585,6 +3706,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 37083741,
+            "refName": "3",
+            "start": 37083740,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3753,6 +3879,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112103136,
+            "refName": "5",
+            "start": 112103135,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -3912,6 +4043,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112162855,
+            "refName": "5",
+            "start": 112162854,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -4080,6 +4216,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112164562,
+            "refName": "5",
+            "start": 112164561,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4248,6 +4389,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112175771,
+            "refName": "5",
+            "start": 112175770,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4416,6 +4562,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112176326,
+            "refName": "5",
+            "start": 112176325,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4584,6 +4735,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112176560,
+            "refName": "5",
+            "start": 112176559,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -4752,6 +4908,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112176757,
+            "refName": "5",
+            "start": 112176756,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4932,6 +5093,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112177172,
+            "refName": "5",
+            "start": 112177171,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5106,6 +5272,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 112178796,
+            "refName": "5",
+            "start": 112178795,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5286,6 +5457,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 131892980,
+            "refName": "5",
+            "start": 131892979,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5442,6 +5618,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6022627,
+            "refName": "7",
+            "start": 6022626,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -5612,6 +5793,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6026776,
+            "refName": "7",
+            "start": 6026775,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -5786,6 +5972,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6026989,
+            "refName": "7",
+            "start": 6026988,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5960,6 +6151,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6036981,
+            "refName": "7",
+            "start": 6036980,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6128,6 +6324,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6037059,
+            "refName": "7",
+            "start": 6037057,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6251,6 +6452,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 6038723,
+            "refName": "7",
+            "start": 6038722,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6419,6 +6625,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 116381123,
+            "refName": "7",
+            "start": 116381121,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6542,6 +6753,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 116409678,
+            "refName": "7",
+            "start": 116409675,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6670,6 +6886,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 21968200,
+            "refName": "9",
+            "start": 21968199,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6832,6 +7053,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 97873958,
+            "refName": "9",
+            "start": 97873957,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6994,6 +7220,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 98221862,
+            "refName": "9",
+            "start": 98221861,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -7156,6 +7387,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 98229390,
+            "refName": "9",
+            "start": 98229389,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7318,6 +7554,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 98238359,
+            "refName": "9",
+            "start": 98238358,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -7486,6 +7727,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 98270647,
+            "refName": "9",
+            "start": 98270646,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "TGCC",
@@ -7615,6 +7861,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 43595969,
+            "refName": "10",
+            "start": 43595968,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7789,6 +8040,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 43606688,
+            "refName": "10",
+            "start": 43606687,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7969,6 +8225,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 43612227,
+            "refName": "10",
+            "start": 43612226,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -8137,6 +8398,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 43613844,
+            "refName": "10",
+            "start": 43613843,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -8317,6 +8583,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 43622218,
+            "refName": "10",
+            "start": 43622217,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -8491,6 +8762,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 89720635,
+            "refName": "10",
+            "start": 89720633,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -8614,6 +8890,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 89720908,
+            "refName": "10",
+            "start": 89720907,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -8782,6 +9063,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 64572019,
+            "refName": "11",
+            "start": 64572018,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -8956,6 +9242,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 64572558,
+            "refName": "11",
+            "start": 64572557,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -9124,6 +9415,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 64572603,
+            "refName": "11",
+            "start": 64572602,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -9298,6 +9594,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 64577621,
+            "refName": "11",
+            "start": 64577620,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -9460,6 +9761,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 94197261,
+            "refName": "11",
+            "start": 94197260,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -9628,6 +9934,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 94225921,
+            "refName": "11",
+            "start": 94225920,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -9790,6 +10101,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108098462,
+            "refName": "11",
+            "start": 108098459,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -9949,6 +10265,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108114663,
+            "refName": "11",
+            "start": 108114661,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -10072,6 +10393,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108121411,
+            "refName": "11",
+            "start": 108121410,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "CT",
@@ -10195,6 +10521,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108141957,
+            "refName": "11",
+            "start": 108141955,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -10318,6 +10649,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108151708,
+            "refName": "11",
+            "start": 108151707,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "TA",
@@ -10435,6 +10771,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 108183168,
+            "refName": "11",
+            "start": 108183167,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -10597,6 +10938,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 58144666,
+            "refName": "12",
+            "start": 58144665,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -10759,6 +11105,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32890573,
+            "refName": "13",
+            "start": 32890572,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -10927,6 +11278,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32906730,
+            "refName": "13",
+            "start": 32906729,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -11107,6 +11463,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32911889,
+            "refName": "13",
+            "start": 32911888,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -11281,6 +11642,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32913056,
+            "refName": "13",
+            "start": 32913055,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -11449,6 +11815,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32915006,
+            "refName": "13",
+            "start": 32915005,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -11611,6 +11982,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 32929388,
+            "refName": "13",
+            "start": 32929387,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -11785,6 +12161,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 68771373,
+            "refName": "16",
+            "start": 68771372,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -11947,6 +12328,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 68855967,
+            "refName": "16",
+            "start": 68855966,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12121,6 +12507,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 7579473,
+            "refName": "17",
+            "start": 7579472,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -12289,6 +12680,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 7579802,
+            "refName": "17",
+            "start": 7579801,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -12463,6 +12859,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29508821,
+            "refName": "17",
+            "start": 29508819,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12586,6 +12987,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29553486,
+            "refName": "17",
+            "start": 29553485,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12748,6 +13154,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29559933,
+            "refName": "17",
+            "start": 29559932,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12904,6 +13315,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29563077,
+            "refName": "17",
+            "start": 29563076,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "TG",
@@ -13060,6 +13476,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29563086,
+            "refName": "17",
+            "start": 29563085,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "TG",
@@ -13219,6 +13640,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29663626,
+            "refName": "17",
+            "start": 29663625,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "TA",
@@ -13378,6 +13804,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 29670191,
+            "refName": "17",
+            "start": 29670190,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -13534,6 +13965,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41223095,
+            "refName": "17",
+            "start": 41223094,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -13714,6 +14150,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41234471,
+            "refName": "17",
+            "start": 41234470,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -13888,6 +14329,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41244001,
+            "refName": "17",
+            "start": 41244000,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -14068,6 +14514,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41244436,
+            "refName": "17",
+            "start": 41244435,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -14248,6 +14699,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41244937,
+            "refName": "17",
+            "start": 41244936,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -14428,6 +14884,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41245238,
+            "refName": "17",
+            "start": 41245237,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -14602,6 +15063,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41245467,
+            "refName": "17",
+            "start": 41245466,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -14776,6 +15242,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41245472,
+            "refName": "17",
+            "start": 41245471,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -14956,6 +15427,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 41256104,
+            "refName": "17",
+            "start": 41256089,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -15079,6 +15555,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 56798208,
+            "refName": "17",
+            "start": 56798207,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -15241,6 +15722,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 59760997,
+            "refName": "17",
+            "start": 59760996,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -15403,6 +15889,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 59763348,
+            "refName": "17",
+            "start": 59763347,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -15571,6 +16062,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 59763466,
+            "refName": "17",
+            "start": 59763465,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -15733,6 +16229,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 59857810,
+            "refName": "17",
+            "start": 59857809,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -15895,6 +16396,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 48584856,
+            "refName": "18",
+            "start": 48584855,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "ATT",
@@ -16018,6 +16524,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 1219275,
+            "refName": "19",
+            "start": 1219274,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -16186,6 +16697,11 @@ Object {
           },
         ],
         "extendedData": Object {
+          "simple": Object {
+            "end": 1222013,
+            "refName": "19",
+            "start": 1222012,
+          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",

--- a/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/packages/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -22,7 +22,7 @@ Object {
         "type": "LocString",
       },
       "derivationFunctionText": "function deriveLocationColumn(row, column) {
-      return {text:row.extendedData.simple.refName+':'+row.extendedData.simple.start+'..'+row.extendedData.simple.end}
+      return {text:row.extendedData.vcfFeature.refName+':'+row.extendedData.vcfFeature.start+'..'+row.extendedData.vcfFeature.end}
     }",
       "isDerived": true,
       "name": "Location",
@@ -136,11 +136,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 156845493,
-            "refName": "1",
-            "start": 156845492,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "AGTGT",
@@ -258,11 +253,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 156848996,
-            "refName": "1",
-            "start": 156848995,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -431,11 +421,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 47601107,
-            "refName": "2",
-            "start": 47601106,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -610,11 +595,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 47630551,
-            "refName": "2",
-            "start": 47630550,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -783,11 +763,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 47641565,
-            "refName": "2",
-            "start": 47641559,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -916,11 +891,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 47693960,
-            "refName": "2",
-            "start": 47693959,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -1095,11 +1065,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48010559,
-            "refName": "2",
-            "start": 48010558,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -1274,11 +1239,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48010655,
-            "refName": "2",
-            "start": 48010654,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1447,11 +1407,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48018031,
-            "refName": "2",
-            "start": 48018030,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1620,11 +1575,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48018082,
-            "refName": "2",
-            "start": 48018081,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -1799,11 +1749,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48023116,
-            "refName": "2",
-            "start": 48023115,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -1978,11 +1923,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48030839,
-            "refName": "2",
-            "start": 48030838,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -2145,11 +2085,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48032879,
-            "refName": "2",
-            "start": 48032874,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -2321,11 +2256,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48033552,
-            "refName": "2",
-            "start": 48033551,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2482,11 +2412,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48033891,
-            "refName": "2",
-            "start": 48033890,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "CT",
@@ -2610,11 +2535,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215632257,
-            "refName": "2",
-            "start": 215632256,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2777,11 +2697,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215645546,
-            "refName": "2",
-            "start": 215645545,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -2950,11 +2865,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215657184,
-            "refName": "2",
-            "start": 215657182,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -3078,11 +2988,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215674091,
-            "refName": "2",
-            "start": 215674090,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3245,11 +3150,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215674324,
-            "refName": "2",
-            "start": 215674323,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3412,11 +3312,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 215674342,
-            "refName": "2",
-            "start": 215674341,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3579,11 +3474,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 10191524,
-            "refName": "3",
-            "start": 10191523,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3706,11 +3596,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 37083741,
-            "refName": "3",
-            "start": 37083740,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -3879,11 +3764,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112103136,
-            "refName": "5",
-            "start": 112103135,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -4043,11 +3923,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112162855,
-            "refName": "5",
-            "start": 112162854,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -4216,11 +4091,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112164562,
-            "refName": "5",
-            "start": 112164561,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4389,11 +4259,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112175771,
-            "refName": "5",
-            "start": 112175770,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4562,11 +4427,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112176326,
-            "refName": "5",
-            "start": 112176325,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -4735,11 +4595,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112176560,
-            "refName": "5",
-            "start": 112176559,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -4908,11 +4763,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112176757,
-            "refName": "5",
-            "start": 112176756,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5093,11 +4943,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112177172,
-            "refName": "5",
-            "start": 112177171,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5272,11 +5117,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 112178796,
-            "refName": "5",
-            "start": 112178795,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5457,11 +5297,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 131892980,
-            "refName": "5",
-            "start": 131892979,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -5618,11 +5453,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6022627,
-            "refName": "7",
-            "start": 6022626,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -5793,11 +5623,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6026776,
-            "refName": "7",
-            "start": 6026775,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -5972,11 +5797,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6026989,
-            "refName": "7",
-            "start": 6026988,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -6151,11 +5971,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6036981,
-            "refName": "7",
-            "start": 6036980,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6324,11 +6139,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6037059,
-            "refName": "7",
-            "start": 6037057,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6452,11 +6262,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 6038723,
-            "refName": "7",
-            "start": 6038722,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6625,11 +6430,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 116381123,
-            "refName": "7",
-            "start": 116381121,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -6753,11 +6553,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 116409678,
-            "refName": "7",
-            "start": 116409675,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -6886,11 +6681,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 21968200,
-            "refName": "9",
-            "start": 21968199,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7053,11 +6843,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 97873958,
-            "refName": "9",
-            "start": 97873957,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7220,11 +7005,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 98221862,
-            "refName": "9",
-            "start": 98221861,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -7387,11 +7167,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 98229390,
-            "refName": "9",
-            "start": 98229389,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -7554,11 +7329,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 98238359,
-            "refName": "9",
-            "start": 98238358,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -7727,11 +7497,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 98270647,
-            "refName": "9",
-            "start": 98270646,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "TGCC",
@@ -7861,11 +7626,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 43595969,
-            "refName": "10",
-            "start": 43595968,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -8040,11 +7800,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 43606688,
-            "refName": "10",
-            "start": 43606687,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -8225,11 +7980,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 43612227,
-            "refName": "10",
-            "start": 43612226,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -8398,11 +8148,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 43613844,
-            "refName": "10",
-            "start": 43613843,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -8583,11 +8328,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 43622218,
-            "refName": "10",
-            "start": 43622217,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -8762,11 +8502,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 89720635,
-            "refName": "10",
-            "start": 89720633,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -8890,11 +8625,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 89720908,
-            "refName": "10",
-            "start": 89720907,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -9063,11 +8793,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 64572019,
-            "refName": "11",
-            "start": 64572018,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -9242,11 +8967,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 64572558,
-            "refName": "11",
-            "start": 64572557,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -9415,11 +9135,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 64572603,
-            "refName": "11",
-            "start": 64572602,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -9594,11 +9309,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 64577621,
-            "refName": "11",
-            "start": 64577620,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -9761,11 +9471,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 94197261,
-            "refName": "11",
-            "start": 94197260,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -9934,11 +9639,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 94225921,
-            "refName": "11",
-            "start": 94225920,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -10101,11 +9801,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108098462,
-            "refName": "11",
-            "start": 108098459,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -10265,11 +9960,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108114663,
-            "refName": "11",
-            "start": 108114661,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -10393,11 +10083,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108121411,
-            "refName": "11",
-            "start": 108121410,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "CT",
@@ -10521,11 +10206,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108141957,
-            "refName": "11",
-            "start": 108141955,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -10649,11 +10329,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108151708,
-            "refName": "11",
-            "start": 108151707,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "TA",
@@ -10771,11 +10446,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 108183168,
-            "refName": "11",
-            "start": 108183167,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -10938,11 +10608,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 58144666,
-            "refName": "12",
-            "start": 58144665,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -11105,11 +10770,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32890573,
-            "refName": "13",
-            "start": 32890572,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -11278,11 +10938,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32906730,
-            "refName": "13",
-            "start": 32906729,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -11463,11 +11118,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32911889,
-            "refName": "13",
-            "start": 32911888,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -11642,11 +11292,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32913056,
-            "refName": "13",
-            "start": 32913055,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -11815,11 +11460,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32915006,
-            "refName": "13",
-            "start": 32915005,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -11982,11 +11622,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 32929388,
-            "refName": "13",
-            "start": 32929387,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -12161,11 +11796,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 68771373,
-            "refName": "16",
-            "start": 68771372,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -12328,11 +11958,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 68855967,
-            "refName": "16",
-            "start": 68855966,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12507,11 +12132,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 7579473,
-            "refName": "17",
-            "start": 7579472,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -12680,11 +12300,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 7579802,
-            "refName": "17",
-            "start": 7579801,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -12859,11 +12474,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29508821,
-            "refName": "17",
-            "start": 29508819,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -12987,11 +12597,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29553486,
-            "refName": "17",
-            "start": 29553485,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -13154,11 +12759,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29559933,
-            "refName": "17",
-            "start": 29559932,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -13315,11 +12915,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29563077,
-            "refName": "17",
-            "start": 29563076,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "TG",
@@ -13476,11 +13071,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29563086,
-            "refName": "17",
-            "start": 29563085,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "TG",
@@ -13640,11 +13230,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29663626,
-            "refName": "17",
-            "start": 29663625,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "TA",
@@ -13804,11 +13389,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 29670191,
-            "refName": "17",
-            "start": 29670190,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -13965,11 +13545,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41223095,
-            "refName": "17",
-            "start": 41223094,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -14150,11 +13725,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41234471,
-            "refName": "17",
-            "start": 41234470,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -14329,11 +13899,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41244001,
-            "refName": "17",
-            "start": 41244000,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -14514,11 +14079,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41244436,
-            "refName": "17",
-            "start": 41244435,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -14699,11 +14259,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41244937,
-            "refName": "17",
-            "start": 41244936,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -14884,11 +14439,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41245238,
-            "refName": "17",
-            "start": 41245237,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -15063,11 +14613,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41245467,
-            "refName": "17",
-            "start": 41245466,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -15242,11 +14787,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41245472,
-            "refName": "17",
-            "start": 41245471,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "T",
@@ -15427,11 +14967,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 41256104,
-            "refName": "17",
-            "start": 41256089,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -15555,11 +15090,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 56798208,
-            "refName": "17",
-            "start": 56798207,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -15722,11 +15252,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 59760997,
-            "refName": "17",
-            "start": 59760996,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -15889,11 +15414,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 59763348,
-            "refName": "17",
-            "start": 59763347,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -16062,11 +15582,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 59763466,
-            "refName": "17",
-            "start": 59763465,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",
@@ -16229,11 +15744,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 59857810,
-            "refName": "17",
-            "start": 59857809,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "G",
@@ -16396,11 +15906,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 48584856,
-            "refName": "18",
-            "start": 48584855,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "ATT",
@@ -16524,11 +16029,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 1219275,
-            "refName": "19",
-            "start": 1219274,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "A",
@@ -16697,11 +16197,6 @@ Object {
           },
         ],
         "extendedData": Object {
-          "simple": Object {
-            "end": 1222013,
-            "refName": "19",
-            "start": 1222012,
-          },
           "vcfFeature": Object {
             "ALT": Array [
               "C",

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -243,9 +243,7 @@ export default pluginManager => {
     const { assemblyManager } = session
     const { assemblyName } = spreadsheet
     const { id: viewId } = getParent(spreadsheet)
-    const assembly = await assemblyManager.loadAssembly(
-      spreadsheet.assemblyName,
-    )
+    const assembly = await assemblyManager.waitForAssembly(assemblyName)
     const loc = parseLocString(cell.text, name =>
       assemblyManager.isValidRefName(name, spreadsheet.assemblyName),
     )

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -244,13 +244,14 @@ export default pluginManager => {
     const { assemblyManager } = session
     const { assemblyName } = spreadsheet
     await when(() => assemblyManager.get(assemblyName))
-    const loc = parseLocString(
-      cell.text,
-      session.assemblyManager.isValidRefName,
+    const assembly = assemblyManager.get(assemblyName)
+    await when(() => Boolean(assembly.regions && assembly.refNameAliases))
+    const loc = parseLocString(cell.text, name =>
+      assemblyManager.isValidRefName(name, assemblyName),
     )
     if (loc) {
       const { refName } = loc
-      const assembly = assemblyManager.get(assemblyName)
+
       const canonicalRefName = assembly.getCanonicalRefName(refName)
       const newDisplayedRegion = assembly.regions.find(
         region => region.refName === canonicalRefName,

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -7,7 +7,7 @@ import { when } from '@gmod/jbrowse-core/util'
 
 export default pluginManager => {
   const { jbrequire } = pluginManager
-  const { types, getType, getParent } = jbrequire('mobx-state-tree')
+  const { types, getType } = jbrequire('mobx-state-tree')
   const { observer } = jbrequire('mobx-react')
   const React = jbrequire('react')
 
@@ -18,8 +18,6 @@ export default pluginManager => {
   const { compareLocStrings, getSession, parseLocString } = jbrequire(
     '@gmod/jbrowse-core/util',
   )
-
-  const { readConfObject } = jbrequire('@gmod/jbrowse-core/configuration')
 
   const MakeSpreadsheetColumnType = jbrequire(
     require('./MakeSpreadsheetColumnType'),

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -244,10 +244,10 @@ export default pluginManager => {
     const { assemblyName } = spreadsheet
     const { id: viewId } = getParent(spreadsheet)
     const assembly = await assemblyManager.waitForAssembly(assemblyName)
-    const loc = parseLocString(cell.text, name =>
-      assemblyManager.isValidRefName(name, spreadsheet.assemblyName),
-    )
-    if (loc) {
+    try {
+      const loc = parseLocString(cell.text, name =>
+        assemblyManager.isValidRefName(name, spreadsheet.assemblyName),
+      )
       const { refName } = loc
       const canonicalRefName = assembly.getCanonicalRefName(refName)
       const newDisplayedRegion = assembly.regions.find(
@@ -258,7 +258,7 @@ export default pluginManager => {
       let view = session.views.find(v => v.id === newViewId)
       if (!view) {
         view = session.addView('LinearGenomeView', {
-          displayName: cell.text,
+          displayName: assemblyName,
           id: newViewId,
         })
 
@@ -270,6 +270,8 @@ export default pluginManager => {
         await when(() => view.initialized)
       }
       view.navToLocString(cell.text)
+    } catch (e) {
+      session.pushSnackbarMessage(`${e}`)
     }
   }
 

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
@@ -34,7 +34,7 @@ export default (pluginManager: PluginManager) => {
       get cellsWithDerived() {
         const { columns } = getParent(self, 3)
         let i = 0
-        return columns.map(column => {
+        return columns.map((column: { isDerived: boolean; func: Function }) => {
           if (column.isDerived) {
             return column.func(self, column)
           }

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
@@ -26,7 +26,7 @@ export default (pluginManager: PluginManager) => {
       select() {
         self.isSelected = true
       },
-      setExtendedData(data: any) {
+      setExtendedData(data: unknown) {
         self.extendedData = data
       },
     }))

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/Row.ts
@@ -2,7 +2,7 @@ import PluginManager from '@gmod/jbrowse-core/PluginManager'
 
 export default (pluginManager: PluginManager) => {
   const { lib } = pluginManager
-  const { types } = lib['mobx-state-tree']
+  const { types, getParent } = lib['mobx-state-tree']
 
   const CellModel = types.model('SpreadsheetCell', {
     text: types.string,
@@ -25,6 +25,21 @@ export default (pluginManager: PluginManager) => {
       },
       select() {
         self.isSelected = true
+      },
+      setExtendedData(data: any) {
+        self.extendedData = data
+      },
+    }))
+    .views(self => ({
+      get cellsWithDerived() {
+        const { columns } = getParent(self, 3)
+        let i = 0
+        return columns.map(column => {
+          if (column.isDerived) {
+            return column.func(self, column)
+          }
+          return self.cells[i++]
+        })
       },
     }))
 

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/Spreadsheet.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/Spreadsheet.ts
@@ -90,8 +90,8 @@ export default (pluginManager: PluginManager) => {
           const { columnNumber, descending } = self.sortColumns[i]
           const { dataType } = self.columns[columnNumber]
           const result = dataType.compare(
-            rowA.cells[columnNumber],
-            rowB.cells[columnNumber],
+            rowA.cellsWithDerived[columnNumber],
+            rowB.cellsWithDerived[columnNumber],
           )
           if (result) return descending ? -result : result
         }

--- a/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
+++ b/packages/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
@@ -84,7 +84,7 @@ export default (pluginManager: PluginManager) => {
     }))
     .views(self => ({
       get readyToDisplay() {
-        return !!self.spreadsheet
+        return !!self.spreadsheet && self.spreadsheet.isLoaded
       },
 
       get hideRowSelection() {


### PR DESCRIPTION
This provides a clickable locstring for BED and VCF format imports

The locstring can be clicked

Things to observe

There is a `cellsWithDerived` which instantiates cells that contain derived functions
Contains a lightweight copy of some VcfFeature processing code for determining the end of a VCF feature


General observation

- The assembly manager stuff is sort of complex with this deep poking with when, as indicated by the code below needed to do two when calls. The second one (checking for assembly.region) was found to be needed if open a tabular view before any LGV usage. Would really like some more simplicity here
- The LGV has to instantiate a displayedRegion before doing a navigation, which is somewhat burdensome here
- This always launches a new view but potentially navigating an existing view would be desirable
- There is a function in the URL which is technically an XSS risk. Storing track configs such as session tracks might also have same thing. Might need a general solution to this

Other feedback welcome
