### PR TITLE
Change wording from "tabular data" to "spreadsheet view"

### DIFF
--- a/packages/spreadsheet-view/src/index.ts
+++ b/packages/spreadsheet-view/src/index.ts
@@ -18,7 +18,7 @@ export default class SpreadsheetViewPlugin extends Plugin {
   configure(pluginManager: PluginManager) {
     if (isAbstractMenuManager(pluginManager.rootModel)) {
       pluginManager.rootModel.appendToSubMenu(['File', 'Add'], {
-        label: 'Tabular data',
+        label: 'Spreadsheet view',
         icon: ViewComfyIcon,
         onClick: (session: AbstractViewContainer) => {
           session.addView('SpreadsheetView', {})


### PR DESCRIPTION
Calling it what it is.... a spreadsheet! Could also just say Spreadsheet instead of Spreadsheet view. But I think it makes it clear that what you are adding is a viewable spreadsheet. It could be interpreted to be a "track containing tabular data" or something the way it is currently worded