### PR TITLE
Dotplot coordinate indicator

### DIFF
--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -182,19 +182,15 @@ const Base1DView = types
     zoomIn() {
       this.zoomTo(self.bpPerPx / 2)
     },
-    zoomTo(newBpPerPx: number) {
+    zoomTo(newBpPerPx: number, offset = self.width / 2) {
       const bpPerPx = newBpPerPx
       if (bpPerPx === self.bpPerPx) return
       const oldBpPerPx = self.bpPerPx
       self.bpPerPx = bpPerPx
 
       // tweak the offset so that the center of the view remains at the same coordinate
-      const viewWidth = self.width
       self.offsetPx = clamp(
-        Math.round(
-          ((self.offsetPx + viewWidth / 2) * oldBpPerPx) / bpPerPx -
-            viewWidth / 2,
-        ),
+        Math.round(((self.offsetPx + offset) * oldBpPerPx) / bpPerPx - offset),
         self.minOffset,
         self.maxOffset,
       )

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -106,6 +106,7 @@ export default (pluginManager: PluginManager) => {
     return blockLabelKeysToHide
   }
 
+  // produces offsetX/offsetY coordinates from a clientX and an element's getBoundingClientRect
   function getOffset(coord: Coord, rect: { left: number; top: number }) {
     return coord && ([coord[0] - rect.left, coord[1] - rect.top] as Coord)
   }

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react'
-import Popper from '@material-ui/core/Popper'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer } from 'mobx-react'
 import { transaction } from 'mobx'

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -8,7 +8,7 @@ import { getConf } from '@gmod/jbrowse-core/configuration'
 import { Menu } from '@gmod/jbrowse-core/ui'
 import { BaseBlock } from '@gmod/jbrowse-core/util/blockTypes'
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
-import { DotplotViewModel, Dotplot1DView } from '../model'
+import { DotplotViewModel, Dotplot1DViewModel } from '../model'
 
 const useStyles = makeStyles(theme => {
   return {
@@ -69,7 +69,7 @@ const useStyles = makeStyles(theme => {
 
 type Coord = [number, number] | undefined
 
-function locstr(px: number, view: typeof Dotplot1DView) {
+function locstr(px: number, view: Dotplot1DViewModel) {
   const obj = view.pxToBp(px)
   return `${obj.refName}:${Math.floor(obj.offset).toLocaleString('en-US')}`
 }
@@ -124,7 +124,6 @@ export default (pluginManager: PluginManager) => {
       const [mousedown, setMouseDown] = useState<Coord>()
       const [mousedownClient, setMouseDownClient] = useState<Coord>()
       const [mouseup, setMouseUp] = useState<Coord>()
-      const [tracking, setTracking] = useState(false)
       const ref = useRef<SVGSVGElement>(null)
       const root = useRef<HTMLDivElement>(null)
       const distanceX = useRef(0)
@@ -272,9 +271,11 @@ export default (pluginManager: PluginManager) => {
                     Math.abs(mousedown[0] - mousecurr[0]) > 3 &&
                     Math.abs(mousedown[1] - mousecurr[1]) > 3
                   ) {
-                    setMouseUp([event.pageX, event.pageY])
+                    setMouseUp([
+                      event.nativeEvent.offsetX,
+                      event.nativeEvent.offsetY,
+                    ])
                   }
-                  setTracking(false)
                 }}
                 onMouseDown={event => {
                   if (event.button === 0) {
@@ -282,12 +283,11 @@ export default (pluginManager: PluginManager) => {
                       event.nativeEvent.offsetX,
                       event.nativeEvent.offsetY,
                     ])
-                    setMouseDownClient([event.clientX, event.clientY])
                     setMouseCurr([
                       event.nativeEvent.offsetX,
                       event.nativeEvent.offsetY,
                     ])
-                    setTracking(true)
+                    setMouseDownClient([event.clientX, event.clientY])
                   }
                 }}
               >

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -261,6 +261,8 @@ export default (pluginManager: PluginManager) => {
                   // the mouseleave is called on mouseup when the menu appears
                   // so disable leave for this, but otherwise make cursor/zoombox go away
                   if (!mouseup) {
+                    setMouseDown(undefined)
+                    setMouseDownClient(undefined)
                     setMouseCurr(undefined)
                     setMouseCurrClient(undefined)
                   }

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -123,6 +123,7 @@ export default (pluginManager: PluginManager) => {
       const [mousedown, setMouseDown] = useState<Coord>()
       const [mousedownClient, setMouseDownClient] = useState<Coord>()
       const [mouseup, setMouseUp] = useState<Coord>()
+      const [mouseupClient, setMouseUpClient] = useState<Coord>()
       const ref = useRef<SVGSVGElement>(null)
       const root = useRef<HTMLDivElement>(null)
       const distanceX = useRef(0)
@@ -274,6 +275,7 @@ export default (pluginManager: PluginManager) => {
                       event.nativeEvent.offsetX,
                       event.nativeEvent.offsetY,
                     ])
+                    setMouseUpClient([event.clientX, event.clientY])
                   }
                 }}
                 onMouseDown={event => {
@@ -389,7 +391,12 @@ export default (pluginManager: PluginManager) => {
                 }}
                 anchorReference="anchorPosition"
                 anchorPosition={
-                  mouseup ? { top: mouseup[1], left: mouseup[0] } : undefined
+                  mouseupClient
+                    ? {
+                        top: mouseupClient[1] + 30,
+                        left: mouseupClient[0] + 30,
+                      }
+                    : undefined
                 }
                 style={{ zIndex: 1000 }}
                 menuItems={[

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -257,6 +257,14 @@ export default (pluginManager: PluginManager) => {
                 width={viewWidth}
                 height={viewHeight}
                 style={{ cursor: 'crosshair' }}
+                onMouseLeave={() => {
+                  // the mouseleave is called on mouseup when the menu appears
+                  // so disable leave for this, but otherwise make cursor/zoombox go away
+                  if (!mouseup) {
+                    setMouseCurr(undefined)
+                    setMouseCurrClient(undefined)
+                  }
+                }}
                 onMouseMove={event => {
                   setMouseCurr([
                     event.nativeEvent.offsetX,

--- a/packages/dotplot-view/src/DotplotView/model.ts
+++ b/packages/dotplot-view/src/DotplotView/model.ts
@@ -306,7 +306,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         const result = this.getCoords(mousedown, mouseup)
         if (result) {
           const [x1, x2, y1, y2] = result
-          console.log({ x1, x2, y1, y2 })
           const session = getSession(self)
 
           const d1 = Dotplot1DView.create(getSnapshot(self.hview))

--- a/packages/dotplot-view/src/DotplotView/model.ts
+++ b/packages/dotplot-view/src/DotplotView/model.ts
@@ -47,6 +47,8 @@ export const Dotplot1DView = Base1DView.extend(self => {
   }
 })
 
+export type Dotplot1DViewModel = Instance<typeof Dotplot1DView>
+
 const DotplotHView = Dotplot1DView.extend(self => ({
   views: {
     get width() {

--- a/packages/dotplot-view/src/DotplotView/model.ts
+++ b/packages/dotplot-view/src/DotplotView/model.ts
@@ -306,16 +306,21 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         const result = this.getCoords(mousedown, mouseup)
         if (result) {
           const [x1, x2, y1, y2] = result
+          console.log({ x1, x2, y1, y2 })
           const session = getSession(self)
 
-          const d1 = Base1DView.create(getSnapshot(self.hview))
-          const d2 = Base1DView.create(getSnapshot(self.vview))
+          const d1 = Dotplot1DView.create(getSnapshot(self.hview))
+          const d2 = Dotplot1DView.create(getSnapshot(self.vview))
           d1.setVolatileWidth(self.hview.width)
-          d2.setVolatileWidth(self.hview.width)
+          d2.setVolatileWidth(self.vview.width)
           d1.moveTo(x1, x2)
           d2.moveTo(y2, y1)
+          d1.zoomTo(d1.bpPerPx / (self.width / self.hview.width), 0)
+          d2.zoomTo(d2.bpPerPx / (self.width / self.vview.width), 0)
 
           // add the specific evidence tracks to the LGVs in the split view
+          // note: scales the bpPerPx by scaling proportional of the dotplot
+          // width to the eventual lgv width
           const viewSnapshot = {
             type: 'LinearSyntenyView',
             views: [


### PR DESCRIPTION
The dotplot was in need of some notion of a hover to keep the user oriented

This uses a simple div based tooltip with mouse hover next to crosshair cursor

![t1](https://user-images.githubusercontent.com/6511937/91626635-e1b35980-e97e-11ea-89fd-a1111aa3020a.png)
![t2](https://user-images.githubusercontent.com/6511937/91626642-f2fc6600-e97e-11ea-8e73-39e5c7691f72.png)


Note that there are a couple tuned values that make it look better for this example, and could possible look weirder with long refnames (the top left coordinate indictor would not automatically put its endpoint right on the top left corner of the red box, thats a coincidence here)

The code is noticeably using both client coordinates vs offset coordinates, which is not great, maybe there's an easier way. The logic is that we want the operations inside the dotplot grid to be actual pixel offsets in that grid, but we want the tooltip div to be coordinates calculated relative to the whole dotplotview div container.


