### PR TITLE
Remove node 14 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-node_js:
-  - 10
-  - 14
+node_js: 10
 sudo: false
 cache:
 - node_modules
@@ -48,5 +46,4 @@ deploy:
   skip_cleanup: true
   on:
     repo: GMOD/jbrowse-components
-    node_js: 14
     tags: true


### PR DESCRIPTION
This removes the node 14 from the test matrix. I believe it causes issues related to timeouts. I have seen this issue locally where node 14 instantiates the node modules and then node 10 runs a yarn build

The oclif seems to be a particular step that hangs in the yarn build possibly

The yarn cache is shared between node 10 and node 14 from what I can tell because the "Show repository caches" has only one master branch cache for example

I think removing one node version from the build matrix might help, or we can remove yarn caching.

