### PR TITLE
Add logic to "center at base" for locstring navigation

### DIFF
--- a/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -384,7 +384,7 @@ describe('Zoom to selected displayed regions', () => {
         refName: 'ctgA',
       },
     )
-    expect(model.offsetPx).toBe(1202)
+    expect(model.offsetPx).toBe(802)
     expect(model.bpPerPx).toBe(12.5)
     expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })

--- a/packages/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/packages/linear-genome-view/src/LinearGenomeView/index.ts
@@ -865,6 +865,16 @@ export function stateModelFactory(pluginManager: PluginManager) {
           Math.round(bpToStart / self.bpPerPx) +
             self.interRegionPaddingWidth * start.index,
         )
+
+        // centerAtBase logic
+        if (start.index === end.index) {
+          const { offsetPx } = self.bpToPx({
+            coord: (end.offset - start.offset) / 2,
+            refName: self.displayedRegions[start.index].refName,
+          }) || { offsetPx: 0 }
+
+          this.horizontalScroll(offsetPx - self.width / 2)
+        }
       },
 
       horizontalScroll(distance: number) {


### PR DESCRIPTION
Fixes #1171 
Uses a centerAtBase logic when the start displayed region === end displayed region

I wasn't necessarily ready to tackle this in the general case

To test, you can see that navigating to

ctgA:1000-1001 will center on this base, but navigating to a broader region like ctgA:500-1000 not have any offset related to centering