### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js: 10
-sudo: false
+os: linux
+dist: xenial
 cache:
 - node_modules
 - yarn
@@ -34,13 +35,13 @@ deploy:
   access_key_id: $AWS_ACCESS_KEY
   secret_access_key: $AWS_SECRET
   bucket: "jbrowse.org"
-  local-dir: packages/jbrowse-web/build
-  upload-dir: code/jb2/alpha/$TRAVIS_BRANCH
+  local_dir: packages/jbrowse-web/build
+  upload_dir: code/jb2/alpha/$TRAVIS_BRANCH
   on:
     repo: GMOD/jbrowse-components
     all_branches: true
 - provider: releases
-  api_key: $GITHUB_TOKEN
+  token: $GITHUB_TOKEN
   file: packages/jbrowse-web/build/jbrowse-web-*.zip
   file_glob: true
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 - yarn checkprettier || true
 - yarn test-ci
 - yarn tsc --noEmit
-- travis_wait 30 yarn build
+- NODE_OPTIONS='--max-old-space-size=7000' yarn build
 - BUILT_TESTS=1 yarn built-test-ci
 
 after_success:


### PR DESCRIPTION
These are some updates to the Travis build configuration:

* Increase v8 memory size in build step (https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes).
  * [This Travis run](https://travis-ci.com/github/GMOD/jbrowse-components/builds/182668859) has some logging that shows the build is running out of memory (I enabled `--stream` in `lerna run` to get this logging). Setting `--max-old-space-size` seems to help.
* Address Travis config validation
![image](https://user-images.githubusercontent.com/25592344/92179976-23228980-ee03-11ea-99c0-bb8cabbad127.png)
  * The "skip_cleanup" warnings actually only apply if you're using v2 of travis deploy, which we're not, so we'll continue to ignore those (https://travis-ci.community/t/misleading-dpl-v2-deprecation-warnings-with-v1-config/8153).