### PR TITLE
Add dotplot ctrl zoom

### DIFF
--- a/packages/dotplot-view/package.json
+++ b/packages/dotplot-view/package.json
@@ -27,6 +27,7 @@
     "clsx": "^1.0.0",
     "generic-filehandle": "^2.0.0",
     "json-stable-stringify": "^1.0.1",
+    "normalize-wheel": "^1.0.1",
     "react-sizeme": "^2.0.0"
   },
   "private": true

--- a/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/packages/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -68,6 +68,7 @@ const useStyles = makeStyles(theme => {
 })
 
 type Coord = [number, number] | undefined
+type Timer = ReturnType<typeof setTimeout>
 
 function locstr(px: number, view: Dotplot1DViewModel) {
   const obj = view.pxToBp(px)
@@ -131,6 +132,8 @@ export default (pluginManager: PluginManager) => {
       const root = useRef<HTMLDivElement>(null)
       const distanceX = useRef(0)
       const distanceY = useRef(0)
+      const timeout = useRef<Timer>()
+      const delta = useRef(0)
       const scheduled = useRef(false)
 
       // require non-react wheel handler to properly prevent body scrolling
@@ -139,28 +142,50 @@ export default (pluginManager: PluginManager) => {
           const event = normalizeWheel(origEvent)
           origEvent.preventDefault()
           if (origEvent.ctrlKey === true) {
-            const { pixelY } = event
-            const { offsetX, offsetY } = origEvent
-            const factor = 1 + pixelY/500
-            model.vview.zoomTo(model.vview.bpPerPx * factor, offsetY)
-            model.hview.zoomTo(model.hview.bpPerPx * factor, offsetX)
-          } else {
-          distanceX.current += event.pixelX
-          distanceY.current -= event.pixelY
-          if (!scheduled.current) {
-            scheduled.current = true
-
-            window.requestAnimationFrame(() => {
+            delta.current += event.pixelY / 500
+            model.vview.setScaleFactor(
+              delta.current < 0 ? 1 - delta.current : 1 / (1 + delta.current),
+            )
+            model.hview.setScaleFactor(
+              delta.current < 0 ? 1 - delta.current : 1 / (1 + delta.current),
+            )
+            if (timeout.current) {
+              clearTimeout(timeout.current)
+            }
+            timeout.current = setTimeout(() => {
               transaction(() => {
-                model.hview.scroll(distanceX.current)
-                model.vview.scroll(distanceY.current)
+                model.hview.setScaleFactor(1)
+                model.vview.setScaleFactor(1)
+                model.hview.zoomTo(
+                  delta.current > 0
+                    ? model.hview.bpPerPx * (1 + delta.current)
+                    : model.hview.bpPerPx / (1 - delta.current),
+                )
+                model.vview.zoomTo(
+                  delta.current > 0
+                    ? model.vview.bpPerPx * (1 + delta.current)
+                    : model.vview.bpPerPx / (1 - delta.current),
+                )
               })
-              scheduled.current = false
-              distanceX.current = 0
-              distanceY.current = 0
-            })
+              delta.current = 0
+            }, 300)
+          } else {
+            distanceX.current += event.pixelX
+            distanceY.current -= event.pixelY
+            if (!scheduled.current) {
+              scheduled.current = true
+
+              window.requestAnimationFrame(() => {
+                transaction(() => {
+                  model.hview.scroll(distanceX.current)
+                  model.vview.scroll(distanceY.current)
+                })
+                scheduled.current = false
+                distanceX.current = 0
+                distanceY.current = 0
+              })
+            }
           }
-}
         }
         if (ref.current) {
           const curr = ref.current
@@ -234,7 +259,12 @@ export default (pluginManager: PluginManager) => {
             </div>
           ) : null}
           <div className={classes.container}>
-            <div style={{ display: 'grid' }}>
+            <div
+              style={{
+                display: 'grid',
+                transform: `scaleX(${model.hview.scaleFactor}) scaleY(${model.vview.scaleFactor})`,
+              }}
+            >
               <svg
                 className={classes.vtext}
                 width={borderX}

--- a/packages/dotplot-view/src/DotplotView/components/declare.d.ts
+++ b/packages/dotplot-view/src/DotplotView/components/declare.d.ts
@@ -1,1 +1,2 @@
 declare module 'svg-path-generator'
+declare module 'normalize-wheel'

--- a/packages/dotplot-view/src/DotplotView/model.ts
+++ b/packages/dotplot-view/src/DotplotView/model.ts
@@ -8,7 +8,7 @@ import {
   addDisposer,
 } from 'mobx-state-tree'
 
-import { autorun, transaction } from 'mobx'
+import { observable, autorun, transaction } from 'mobx'
 import { BaseTrackStateModel } from '@gmod/jbrowse-plugin-linear-genome-view/src/BasicTrack/baseTrackModel'
 import Base1DView, {
   Base1DViewModel,
@@ -31,7 +31,9 @@ function approxPixelStringLen(str: string) {
 type Coord = [number, number]
 
 // Used in the renderer
+// ref https://mobx-state-tree.js.org/concepts/volatiles on volatile state used here
 export const Dotplot1DView = Base1DView.extend(self => {
+  const scaleFactor = observable.box(1)
   return {
     views: {
       get interRegionPaddingWidth() {
@@ -42,6 +44,14 @@ export const Dotplot1DView = Base1DView.extend(self => {
       },
       get dynamicBlocks() {
         return calculateDynamicBlocks(self, false, false)
+      },
+      get scaleFactor() {
+        return scaleFactor.get()
+      },
+    },
+    actions: {
+      setScaleFactor(n: number) {
+        scaleFactor.set(n)
       },
     },
   }


### PR DESCRIPTION
This adds a ctrl+zoom handle for dotplot similar to linear genome view

Doesn't have the ability to "zoom to mouse pointer", same limitation as lgv, but I think this is nice in terms of aided zooming navigation in the dotplot