### PR TITLE
Add sorting on the locstring column

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -438,14 +438,7 @@ export function parseLocString(
   return parsed
 }
 
-export function compareLocStrings(
-  a: string,
-  b: string,
-  isValidRefName: (refName: string, assemblyName?: string) => boolean,
-) {
-  const locA = parseLocString(a, isValidRefName)
-  const locB = parseLocString(b, isValidRefName)
-
+export function compareLocs(locA: ParsedLocString, locB: ParsedLocString) {
   const assemblyComp =
     locA.assemblyName || locB.assemblyName
       ? (locA.assemblyName || '').localeCompare(locB.assemblyName || '')
@@ -467,6 +460,16 @@ export function compareLocStrings(
     if (endComp) return endComp
   }
   return 0
+}
+
+export function compareLocStrings(
+  a: string,
+  b: string,
+  isValidRefName: (refName: string, assemblyName?: string) => boolean,
+) {
+  const locA = parseLocString(a, isValidRefName)
+  const locB = parseLocString(b, isValidRefName)
+  return compareLocs(locA, locB)
 }
 
 /**

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -60,8 +60,8 @@ export async function parseBedBuffer(buffer: Buffer, options: ParseOptions) {
     dataType: { type: 'LocString' },
     isDerived: true,
     derivationFunctionText: `function deriveLocationColumn(row, column) {
-      var cells = row.cells
-      return {text:cells[0].text+':'+cells[1].text+'..'+cells[2].text}
+      var [ref, start, end] = row.cells
+      return {text:ref.text+':'+start.text+'..'+end.text, extendedData: {refName: ref.text, start: +start.text, end: +end.text} }
     }`,
   })
   return data

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
@@ -17,7 +17,9 @@ export interface Row {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extendedData?: any
   cells: {
-    text?: string
+    text: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    extendedData?: any
   }[]
 }
 
@@ -111,10 +113,24 @@ function dataToSpreadsheetSnapshot(
   const columnDisplayOrder = []
   for (let columnNumber = 0; columnNumber < maxCols; columnNumber += 1) {
     columnDisplayOrder.push(columnNumber)
+    const guessedType = guessColumnType(
+      rowSet,
+      columnNumber,
+      options.isValidRefName,
+    )
+
+    // store extendeddata for LocString column
+    if (guessedType === 'LocString') {
+      rowSet.rows.forEach(row => {
+        const cell = row.cells[columnNumber]
+        cell.extendedData = parseLocString(cell.text, options.isValidRefName)
+      })
+    }
+
     columns[columnNumber] = {
       name: columnNames[columnNumber],
       dataType: {
-        type: guessColumnType(rowSet, columnNumber, options.isValidRefName),
+        type: guessedType,
       },
     }
   }

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -206,7 +206,6 @@ export default pluginManager => {
       },
       // returns a function that tests the given row
       get predicate() {
-        const session = getSession(self)
         if (!self.locString || self.locStringIsInvalid) {
           return function alwaysTrue() {
             return true
@@ -218,13 +217,10 @@ export default pluginManager => {
           const { cellsWithDerived: cells } = row
           const cell = cells[columnNumber]
 
-          if (!cell || !cell.text) {
+          if (!cell || !cell.text || !cell.extendedData) {
             return false
           }
-          const parsedCellText = parseLocString(cell.text, refName =>
-            session.assemblyManager.isValidRefName(refName, sheet.assemblyName),
-          )
-
+          const parsedCellText = cell.extendedData
           if (!parsedCellText.refName) {
             return false
           }

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -15,7 +15,7 @@ export default pluginManager => {
     '@gmod/jbrowse-core/util/mst-reflection',
   )
 
-  const { compareLocStrings, getSession, parseLocString } = jbrequire(
+  const { compareLocs, getSession, parseLocString } = jbrequire(
     '@gmod/jbrowse-core/util',
   )
 
@@ -308,7 +308,7 @@ export default pluginManager => {
     categoryName: 'Location',
     displayName: 'Full location',
     compare(cellA, cellB) {
-      return compareLocStrings(cellA.text, cellB.text)
+      return compareLocs(cellA.extendedData, cellB.extendedData)
     },
     FilterModelType,
     DataCellReactComponent,


### PR DESCRIPTION
I noticed sorting a LocString column was not working in spreadsheet, but it was close to working.

I added these steps to help fix it

- ~~Removes some exception throwing in parse loc string, instead returning an undefined result, which is to be handled by code. This is sort of in the "spirit" of the robustness principle here https://en.wikipedia.org/wiki/Robustness_principle I really do like exceptions/assertions for truly exceptional things but having unknown refName from parseLocString seems like a normal runtime condition, not an exception~~
- Reduce dependence on isValidRefName in parseLocString. I allow it to be a function that by default just returns true.  In the case of this sort, I think it is better to allow it to be a true identity function. My reasoning was that having isValidRefName in a tight sort loop is unnecessary, and we know it will have a valid locstring format here, so rely on that.
- The above change to allow isValidRefName being a ()=>true callback required removing a check for isValidRefName(prefix) and isValidRefName(location) both being true being a fail condition