### PR TITLE
Use noEmit: false to get lib output and fix cli build

### DIFF
--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -59,7 +59,6 @@ export default class Create extends JBrowseCommand {
     const { args: runArgs, flags: runFlags } = this.parse(Create)
     const { localPath: argsPath } = runArgs as { localPath: string }
     this.debug(`Want to install path at: ${argsPath}`)
-    console.log('wow')
 
     const { force, url, listVersions, tag } = runFlags
 

--- a/products/jbrowse-cli/tsconfig.json
+++ b/products/jbrowse-cli/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
+    "noEmit": false,
     "target": "es2017"
   },
   "include": ["src"],


### PR DESCRIPTION
Fixes #1187 


This uses noEmit: false in the CLI but an alternative would be to remove noEmit: true in root tsconfig.json

No sure the ramifications of that, but seems a little more straightforward. I think using --noEmit as a CLI option is a bit better when we want noEmit