### PR TITLE
Add locstring sort

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -438,14 +438,7 @@ export function parseLocString(
   return parsed
 }
 
-export function compareLocStrings(
-  a: string,
-  b: string,
-  isValidRefName: (refName: string, assemblyName?: string) => boolean,
-) {
-  const locA = parseLocString(a, isValidRefName)
-  const locB = parseLocString(b, isValidRefName)
-
+export function compareLocs(locA: ParsedLocString, locB: ParsedLocString) {
   const assemblyComp =
     locA.assemblyName || locB.assemblyName
       ? (locA.assemblyName || '').localeCompare(locB.assemblyName || '')
@@ -467,6 +460,16 @@ export function compareLocStrings(
     if (endComp) return endComp
   }
   return 0
+}
+
+export function compareLocStrings(
+  a: string,
+  b: string,
+  isValidRefName: (refName: string, assemblyName?: string) => boolean,
+) {
+  const locA = parseLocString(a, isValidRefName)
+  const locB = parseLocString(b, isValidRefName)
+  return compareLocs(locA, locB)
 }
 
 /**

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -60,8 +60,8 @@ export async function parseBedBuffer(buffer: Buffer, options: ParseOptions) {
     dataType: { type: 'LocString' },
     isDerived: true,
     derivationFunctionText: `function deriveLocationColumn(row, column) {
-      var cells = row.cells
-      return {text:cells[0].text+':'+cells[1].text+'..'+cells[2].text}
+      var [ref, start, end] = row.cells
+      return {text:ref.text+':'+start.text+'..'+end.text, extendedData: {refName: ref.text, start: +start.text, end: +end.text} }
     }`,
   })
   return data

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/ImportUtils.ts
@@ -17,7 +17,9 @@ export interface Row {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extendedData?: any
   cells: {
-    text?: string
+    text: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    extendedData?: any
   }[]
 }
 
@@ -111,10 +113,24 @@ function dataToSpreadsheetSnapshot(
   const columnDisplayOrder = []
   for (let columnNumber = 0; columnNumber < maxCols; columnNumber += 1) {
     columnDisplayOrder.push(columnNumber)
+    const guessedType = guessColumnType(
+      rowSet,
+      columnNumber,
+      options.isValidRefName,
+    )
+
+    // store extendeddata for LocString column
+    if (guessedType === 'LocString') {
+      rowSet.rows.forEach(row => {
+        const cell = row.cells[columnNumber]
+        cell.extendedData = parseLocString(cell.text, options.isValidRefName)
+      })
+    }
+
     columns[columnNumber] = {
       name: columnNames[columnNumber],
       dataType: {
-        type: guessColumnType(rowSet, columnNumber, options.isValidRefName),
+        type: guessedType,
       },
     }
   }

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
@@ -88,7 +88,11 @@ export function parseVcfBuffer(
     dataType: { type: 'LocString' },
     isDerived: true,
     derivationFunctionText: `function deriveLocationColumn(row, column) {
-      return {text:row.extendedData.vcfFeature.refName+':'+row.extendedData.vcfFeature.start+'..'+row.extendedData.vcfFeature.end}
+      const feat = row.extendedData.vcfFeature
+      const refName = feat.refName
+      const start = feat.start
+      const end = feat.end
+      return {text:refName+':'+start+'..'+end, extendedData: {refName:refName,start:start,end:end} }
     }`,
   })
 

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -22,7 +22,11 @@ Object {
         "type": "LocString",
       },
       "derivationFunctionText": "function deriveLocationColumn(row, column) {
-      return {text:row.extendedData.vcfFeature.refName+':'+row.extendedData.vcfFeature.start+'..'+row.extendedData.vcfFeature.end}
+      const feat = row.extendedData.vcfFeature
+      const refName = feat.refName
+      const start = feat.start
+      const end = feat.end
+      return {text:refName+':'+start+'..'+end, extendedData: {refName:refName,start:start,end:end} }
     }",
       "isDerived": true,
       "name": "Location",

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -206,7 +206,6 @@ export default pluginManager => {
       },
       // returns a function that tests the given row
       get predicate() {
-        const session = getSession(self)
         if (!self.locString || self.locStringIsInvalid) {
           return function alwaysTrue() {
             return true
@@ -218,13 +217,10 @@ export default pluginManager => {
           const { cellsWithDerived: cells } = row
           const cell = cells[columnNumber]
 
-          if (!cell || !cell.text) {
+          if (!cell || !cell.text || !cell.extendedData) {
             return false
           }
-          const parsedCellText = parseLocString(cell.text, refName =>
-            session.assemblyManager.isValidRefName(refName, sheet.assemblyName),
-          )
-
+          const parsedCellText = cell.extendedData
           if (!parsedCellText.refName) {
             return false
           }

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -15,7 +15,7 @@ export default pluginManager => {
     '@gmod/jbrowse-core/util/mst-reflection',
   )
 
-  const { compareLocStrings, getSession, parseLocString } = jbrequire(
+  const { compareLocs, getSession, parseLocString } = jbrequire(
     '@gmod/jbrowse-core/util',
   )
 
@@ -308,7 +308,7 @@ export default pluginManager => {
     categoryName: 'Location',
     displayName: 'Full location',
     compare(cellA, cellB) {
-      return compareLocStrings(cellA.text, cellB.text)
+      return compareLocs(cellA.extendedData, cellB.extendedData)
     },
     FilterModelType,
     DataCellReactComponent,


### PR DESCRIPTION
I replaced this older PR for sorting with a new approach that stores cell.extendedData on LocString cells

This is facilitated by

a) ImportUtils, which performs a parseLocString on all rows when LocString column type is detected
b) the derivation callbacks for generated LocString columns

This has fairly good behavior on both importing and the generated columns that we have

It would not work if someone manually changed their column to LocString and it was not previously guessed to be a LocString column. The SpreadsheetModel.setColumnType would need to be able to handle this if that was the case

Nevertheless, this is basically working nicely for the simple circumstances we are using now


The alternative would be using parseLocString maybe as a computed property but it requires a lot of work for example to parseLocString properly (access to assemblyManager isValidRefName for example), so storing in extendedData seemed nicer