### PR TITLE
Format non-JS/TS files in pre-commit hook

### DIFF
--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -2,7 +2,7 @@
 on:
   push:
     tags:
-    - '@gmod/jbrowse-web*'
+      - '@gmod/jbrowse-web*'
 
 name: Upload jbrowse-web artifacts
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "git diff --cached --name-only | if grep --quiet \"jbrowse-cli\"; then lerna run --scope \"@gmod/jbrowse-cli\" docs; git add products/jbrowse-cli/README.md; fi;"
+      "pre-commit": "node scripts/pre-commit.js"
     }
   },
   "devDependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,12 +1,9 @@
 ## [0.0.1-beta.21](https://github.com/GMOD/jbrowse-components/compare/v0.0.1-beta.14...v0.0.1-beta.21) (2020-09-10)
 
-
 ### Reverts
 
-* Revert "Allow touchscreen using pointer events (#1112)" the pointer ([404546e](https://github.com/GMOD/jbrowse-components/commit/404546e5a1c71510a90a777957d32cd2c8f71ed1)), closes [#1112](https://github.com/GMOD/jbrowse-components/issues/1112)
-* Revert "Simplify command unzip (#1075)" ([9c0b975](https://github.com/GMOD/jbrowse-components/commit/9c0b97504b7a423a9c356ac3ffffc2754224c65a)), closes [#1075](https://github.com/GMOD/jbrowse-components/issues/1075)
-
-
+- Revert "Allow touchscreen using pointer events (#1112)" the pointer ([404546e](https://github.com/GMOD/jbrowse-components/commit/404546e5a1c71510a90a777957d32cd2c8f71ed1)), closes [#1112](https://github.com/GMOD/jbrowse-components/issues/1112)
+- Revert "Simplify command unzip (#1075)" ([9c0b975](https://github.com/GMOD/jbrowse-components/commit/9c0b97504b7a423a9c356ac3ffffc2754224c65a)), closes [#1075](https://github.com/GMOD/jbrowse-components/issues/1075)
 
 ## [0.0.1-beta.20](https://github.com/GMOD/jbrowse-components/compare/v0.0.1-beta.14...v0.0.1-beta.20) (2020-09-09)
 

--- a/packages/development-tools/CHANGELOG.md
+++ b/packages/development-tools/CHANGELOG.md
@@ -1,12 +1,9 @@
 ## [0.0.1-beta.26](https://github.com/GMOD/jbrowse-components/compare/v0.0.1-beta.14...v0.0.1-beta.26) (2020-09-10)
 
-
 ### Reverts
 
-* Revert "Allow touchscreen using pointer events (#1112)" the pointer ([404546e](https://github.com/GMOD/jbrowse-components/commit/404546e5a1c71510a90a777957d32cd2c8f71ed1)), closes [#1112](https://github.com/GMOD/jbrowse-components/issues/1112)
-* Revert "Simplify command unzip (#1075)" ([9c0b975](https://github.com/GMOD/jbrowse-components/commit/9c0b97504b7a423a9c356ac3ffffc2754224c65a)), closes [#1075](https://github.com/GMOD/jbrowse-components/issues/1075)
-
-
+- Revert "Allow touchscreen using pointer events (#1112)" the pointer ([404546e](https://github.com/GMOD/jbrowse-components/commit/404546e5a1c71510a90a777957d32cd2c8f71ed1)), closes [#1112](https://github.com/GMOD/jbrowse-components/issues/1112)
+- Revert "Simplify command unzip (#1075)" ([9c0b975](https://github.com/GMOD/jbrowse-components/commit/9c0b97504b7a423a9c356ac3ffffc2754224c65a)), closes [#1075](https://github.com/GMOD/jbrowse-components/issues/1075)
 
 ## [0.0.1-beta.25](https://github.com/GMOD/jbrowse-components/compare/v0.0.1-beta.14...v0.0.1-beta.25) (2020-09-09)
 


### PR DESCRIPTION
When writing JS/TS code, ESLint gives us feedback about the Prettier formatting. For non-JS/TS code, though, we don't get that feedback, although Prettier is able to format several different file types.

This adds a pre-commit git hook that checks if any of the changed files are not JS/TS files and runs Prettier on them if there are any. If all the changed files are JS/TS files, the hook doesn't add noticeable time when committing.

This will also help with files that have auto-generated content, like CHANGELOG files.

The hook also keeps the existing behavior of regenerating the CLI docs if any files in `products/jbrowse-cli` change.