### PR TITLE
Center moveTo region bugfix

### DIFF
--- a/packages/core/ui/EditableTypography.tsx
+++ b/packages/core/ui/EditableTypography.tsx
@@ -79,12 +79,9 @@ const EditableTypography = React.forwardRef(
     }
 
     function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-      // "Enter"
-      if (event.keyCode === 13) {
+      if (event.key === 'Enter') {
         inputNode && inputNode.blur()
-      }
-      // "Esc"
-      else if (event.keyCode === 27) {
+      } else if (event.key === 'Escape') {
         setEditedValue(undefined)
         setBlur(true)
       }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -106,7 +106,7 @@ function OverviewRubberBand({
     }
 
     function globalKeyDown(event: KeyboardEvent) {
-      if (event.keyCode === 27) {
+      if (event.key === 'Escape') {
         setStartX(undefined)
         setCurrentX(undefined)
       }

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -384,7 +384,7 @@ describe('Zoom to selected displayed regions', () => {
         refName: 'ctgA',
       },
     )
-    expect(model.offsetPx).toBe(802)
+    expect(model.offsetPx).toBe(1202)
     expect(model.bpPerPx).toBe(12.5)
     expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -848,13 +848,19 @@ export function stateModelFactory(pluginManager: PluginManager) {
           }
           bpSoFar += end.offset
         }
-        self.zoomTo(
+        const targetBpPerPx =
           bpSoFar /
-            (self.width -
-              self.interRegionPaddingWidth * (end.index - start.index)),
-        )
+          (self.width -
+            self.interRegionPaddingWidth * (end.index - start.index))
+        const newBpPerPx = self.zoomTo(targetBpPerPx)
+        // If our target bpPerPx was smaller than the allowed minBpPerPx, adjust
+        // the scroll so the requested range is in the middle of the screen
+        let extraBp = 0
+        if (targetBpPerPx < newBpPerPx) {
+          extraBp = ((newBpPerPx - targetBpPerPx) * self.width) / 2
+        }
 
-        let bpToStart = 0
+        let bpToStart = -extraBp
         for (let i = 0; i < self.displayedRegions.length; i += 1) {
           const region = self.displayedRegions[i]
           if (start.index === i) {
@@ -868,16 +874,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
           Math.round(bpToStart / self.bpPerPx) +
             self.interRegionPaddingWidth * start.index,
         )
-
-        // centerAtBase logic
-        if (start.index === end.index) {
-          const { offsetPx } = self.bpToPx({
-            coord: (end.offset - start.offset) / 2,
-            refName: self.displayedRegions[start.index].refName,
-          }) || { offsetPx: 0 }
-
-          this.horizontalScroll(offsetPx - self.width / 2)
-        }
       },
 
       horizontalScroll(distance: number) {


### PR DESCRIPTION
This fixes #1188, which looks like it was introduced in 69fa77d88b277914c9d7be3e09cd34d661cf6f69. This is the same idea as 69fa77d88b277914c9d7be3e09cd34d661cf6f69 (in moveTo, center a region that's smaller than the screen width), implemented in a different way.

Also includes a small fix since my editor was warning me that `event.keyCode` is deprecated.