### PR TITLE
Slow push tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,3 @@ deploy:
     on:
       repo: GMOD/jbrowse-components
       all_branches: true
-  - provider: releases
-    token: $GITHUB_TOKEN
-    file: products/jbrowse-web/build/jbrowse-web-*.zip
-    file_glob: true
-    skip_cleanup: true
-    on:
-      repo: GMOD/jbrowse-components
-      tags: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:other": "cross-env NODE_ENV=production lerna run build --ignore \"@gmod/jbrowse-plugin*\"",
     "useDist": "lerna run useDist --scope \"@gmod/jbrowse-plugin*\"",
     "useSrc": "lerna run useSrc --scope \"@gmod/jbrowse-plugin*\"",
-    "lerna-publish": "cross-env lerna publish",
+    "lerna-publish": "lerna publish --no-push && git push origin tag \"@gmod/jbrowse-web*\" && git push --follow-tags",
     "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
     "format": "prettier --write .",
     "check-format": "prettier --check .",


### PR DESCRIPTION
This is a possible fix for #1184 

The syntax

git push origin tag "v2*"


Ref https://stackoverflow.com/a/60802071/2129219, tested and does work. So it first does a


`git push origin tag "@gmod/jbrowse-web*"` and then a `git push --follow-tags` to push the rest



