### PR TITLE
GitHub paginate

### DIFF
--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -57,7 +57,10 @@ export default abstract class JBrowseCommand extends Command {
     }
     if (locationUrl) {
       const response = await fetch(locationUrl)
-      return response.json()
+      if (response.ok) {
+        return response.json()
+      }
+      throw new Error(`${response.statusText}`)
     }
     return fsPromises.readFile(location, { encoding: 'utf8' })
   }
@@ -78,6 +81,7 @@ export default abstract class JBrowseCommand extends Command {
           if (response.ok) {
             return locationUrl.href
           }
+          throw new Error(`${response.statusText}`)
         } else {
           return locationUrl.href
         }

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -132,18 +132,31 @@ export default abstract class JBrowseCommand extends Command {
     return result
   }
 
+  async fetchVersions() {
+    let versions: GithubRelease[] = []
+    let page = 0
+    let result
+
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(
+        `https://api.github.com/repos/GMOD/jbrowse-components/releases?page=${page}`,
+      )
+      if (response.ok) {
+        // eslint-disable-next-line no-await-in-loop
+        result = await response.json()
+        versions = versions.concat(result)
+        page++
+      } else {
+        throw new Error(`${result.statusText}`)
+      }
+    } while (result && result.length > 0)
+    return versions
+  }
+
   async fetchGithubVersions() {
-    const response = await fetch(
-      'https://api.github.com/repos/GMOD/jbrowse-components/releases',
-    )
-    this.log(`${response}`)
+    const jb2releases = await this.fetchVersions()
 
-    if (!response.ok) {
-      this.error('Failed to fetch version from server')
-    }
-
-    // use all release only if there are only pre-release in repo
-    const jb2releases: GithubRelease[] = await response.json()
     const versions = jb2releases.filter(release =>
       release.tag_name.startsWith('@gmod/jbrowse-web'),
     )

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -178,7 +178,7 @@ export default abstract class JBrowseCommand extends Command {
       ? versions.assets[0].browser_download_url
       : this.error(
           'Could not find version specified. Use --listVersions to see all available versions',
-          { exit: 110 },
+          { exit: 130 },
         )
   }
 }

--- a/products/jbrowse-cli/src/commands/create.test.ts
+++ b/products/jbrowse-cli/src/commands/create.test.ts
@@ -23,8 +23,10 @@ const releaseArray = [
 
 function mockReleases(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases')
+    .get('/repos/GMOD/jbrowse-components/releases?page=0')
     .reply(200, releaseArray)
+    .get('/repos/GMOD/jbrowse-components/releases?page=1')
+    .reply(200, [])
 }
 
 function mockZip(exampleSite: Scope) {
@@ -144,7 +146,7 @@ describe('create', () => {
     .catch(/0/)
     .it('lists versions', ctx => {
       expect(ctx.stdoutWrite).toHaveBeenCalledWith(
-        'All JBrowse versions: @gmod/jbrowse-web@v0.0.1\n',
+        'All JBrowse versions:\n@gmod/jbrowse-web@v0.0.1\n',
       )
     })
 })

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -119,42 +119,6 @@ export default class Create extends JBrowseCommand {
       )
   }
 
-  async fetchGithubVersions() {
-    const response = await fetch(
-      'https://api.github.com/repos/GMOD/jbrowse-components/releases',
-    )
-
-    if (!response.ok) {
-      this.error('Failed to fetch version from server')
-    }
-
-    // use all release only if there are only pre-release in repo
-    const jb2releases: GithubRelease[] = await response.json()
-    const versions = jb2releases.filter(release =>
-      release.tag_name.startsWith('@gmod/jbrowse-web'),
-    )
-
-    const nonprereleases = versions.filter(
-      release => release.prerelease === false,
-    )
-
-    return nonprereleases.length === 0 ? jb2releases : nonprereleases
-  }
-
-  async getTagOrLatest(tag?: string) {
-    const response = await this.fetchGithubVersions()
-    const versions = tag
-      ? response.find(version => version.tag_name === tag)
-      : response[0]
-
-    return versions
-      ? versions.assets[0].browser_download_url
-      : this.error(
-          'Could not find version specified. Use --listVersions to see all available versions',
-          { exit: 130 },
-        )
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async catch(error: any) {
     if (error.parse && error.parse.output.flags.listVersions) {

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -67,7 +67,7 @@ export default class Create extends JBrowseCommand {
         const versions = (await this.fetchGithubVersions()).map(
           version => version.tag_name,
         )
-        this.log(`All JBrowse versions:\n ${versions.join('\n')}`)
+        this.log(`All JBrowse versions:\n${versions.join('\n')}`)
         this.exit()
       } catch (error) {
         this.error(error)
@@ -125,7 +125,7 @@ export default class Create extends JBrowseCommand {
       const versions = (await this.fetchGithubVersions()).map(
         version => version.tag_name,
       )
-      this.log(`All JBrowse versions\n${versions.join('\n')}`)
+      this.log(`All JBrowse versions:\n${versions.join('\n')}`)
       this.exit()
     }
     throw error

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -67,7 +67,7 @@ export default class Create extends JBrowseCommand {
         const versions = (await this.fetchGithubVersions()).map(
           version => version.tag_name,
         )
-        this.log(`All JBrowse versions: ${versions.join(', ')}`)
+        this.log(`All JBrowse versions:\n ${versions.join('\n')}`)
         this.exit()
       } catch (error) {
         this.error(error)
@@ -125,7 +125,7 @@ export default class Create extends JBrowseCommand {
       const versions = (await this.fetchGithubVersions()).map(
         version => version.tag_name,
       )
-      this.log(`All JBrowse versions: ${versions.join(', ')}`)
+      this.log(`All JBrowse versions\n${versions.join('\n')}`)
       this.exit()
     }
     throw error

--- a/products/jbrowse-cli/src/commands/upgrade.test.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.test.ts
@@ -32,8 +32,10 @@ const releaseArray = [
 
 function mockReleases(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases')
+    .get('/repos/GMOD/jbrowse-components/releases?page=0')
     .reply(200, releaseArray)
+    .get('/repos/GMOD/jbrowse-components/releases?page=1')
+    .reply(200, [])
 }
 
 function mockWrongSite(exampleSite: Scope) {
@@ -119,7 +121,7 @@ describe('upgrade', () => {
   setup
     .nock('https://api.github.com', mockReleases)
     .command(['upgrade', '--tag', '@gmod/jbrowse-web@v999.999.999'])
-    .exit(110)
+    .exit(130)
     .it('fails to upgrade if version does not exist')
   setup
     .nock('https://example.com', mockWrongSite)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -58,7 +58,7 @@ export default class Upgrade extends JBrowseCommand {
         const versions = (await this.fetchGithubVersions()).map(
           version => version.tag_name,
         )
-        this.log(`All JBrowse versions: ${versions.join(', ')}`)
+        this.log(`All JBrowse versions\n${versions.join('\n')}`)
         this.exit()
       } catch (error) {
         this.error(error)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -58,7 +58,7 @@ export default class Upgrade extends JBrowseCommand {
         const versions = (await this.fetchGithubVersions()).map(
           version => version.tag_name,
         )
-        this.log(`All JBrowse versions\n${versions.join('\n')}`)
+        this.log(`All JBrowse versions:\n${versions.join('\n')}`)
         this.exit()
       } catch (error) {
         this.error(error)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -3,15 +3,6 @@ import fetch from 'node-fetch'
 import * as unzip from 'unzipper'
 import JBrowseCommand from '../base'
 
-interface GithubRelease {
-  tag_name: string
-  prerelease: boolean
-  assets: [
-    {
-      browser_download_url: string
-    },
-  ]
-}
 export default class Upgrade extends JBrowseCommand {
   static description = 'Upgrades JBrowse 2 to latest version'
 
@@ -97,41 +88,5 @@ export default class Upgrade extends JBrowseCommand {
 
     await response.body.pipe(unzip.Extract({ path: argsPath })).promise()
     this.log(`Unpacked ${locationUrl} at ${argsPath}`)
-  }
-
-  async fetchGithubVersions() {
-    const response = await fetch(
-      'https://api.github.com/repos/GMOD/jbrowse-components/releases',
-    )
-
-    if (!response.ok) {
-      this.error('Failed to fetch version from server')
-    }
-
-    // use all release only if there are only pre-release in repo
-    const jb2releases: GithubRelease[] = await response.json()
-    const versions = jb2releases.filter(release =>
-      release.tag_name.startsWith('@gmod/jbrowse-web'),
-    )
-
-    const nonprereleases = versions.filter(
-      release => release.prerelease === false,
-    )
-
-    return nonprereleases.length === 0 ? jb2releases : nonprereleases
-  }
-
-  async getTagOrLatest(tag?: string) {
-    const response = await this.fetchGithubVersions()
-    const versions = tag
-      ? response.find(version => version.tag_name === tag)
-      : response[0]
-
-    return versions
-      ? versions.assets[0].browser_download_url
-      : this.error(
-          'Could not find version specified. Use --listVersions to see all available versions',
-          { exit: 110 },
-        )
   }
 }


### PR DESCRIPTION
This is a method to paginate multiple pages of output from Github

It fetches one page at a time with await in loop and stops when it gets an empty array response

Check `curl "https://api.github.com/repos/GMOD/jbrowse-components/releases?page=2"` for example of the empty response

