### PR TITLE
Session tracks

### DIFF
--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -41,9 +41,9 @@ interface ConfigurationSchemaOptions {
   explicitIdentifier?: string
   implicitIdentifier?: string
   baseConfiguration?: AnyConfigurationSchemaType
-  actions?: (self: unknown) => Record<string, Function>
-  views?: (self: unknown) => Record<string, Function>
-  extend?: (self: unknown) => Record<string, Function>
+  actions?: (self: unknown) => any
+  views?: (self: unknown) => any
+  extend?: (self: unknown) => any
 }
 
 function preprocessConfigurationSchemaArguments(
@@ -174,11 +174,6 @@ function makeConfigurationSchemaModel<
         return newSchema
       },
     }))
-
-  // add computed members to the configuration itself
-  if (options.views) {
-    completeModel = completeModel.views(options.views)
-  }
 
   if (Object.keys(volatileConstants).length) {
     completeModel = completeModel.volatile((/* self */) => volatileConstants)

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -174,6 +174,12 @@ function makeConfigurationSchemaModel<
         return newSchema
       },
     }))
+
+  // add computed members to the configuration itself
+  if (options.views) {
+    completeModel = completeModel.views(options.views)
+  }
+
   if (Object.keys(volatileConstants).length) {
     completeModel = completeModel.volatile((/* self */) => volatileConstants)
   }

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -41,9 +41,10 @@ interface ConfigurationSchemaOptions {
   explicitIdentifier?: string
   implicitIdentifier?: string
   baseConfiguration?: AnyConfigurationSchemaType
-  actions?: (self: unknown) => any
-  views?: (self: unknown) => any
-  extend?: (self: unknown) => any
+
+  actions?: (self: unknown) => any // eslint-disable-line @typescript-eslint/no-explicit-any
+  views?: (self: unknown) => any // eslint-disable-line @typescript-eslint/no-explicit-any
+  extend?: (self: unknown) => any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function preprocessConfigurationSchemaArguments(

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -144,14 +144,9 @@ export function findParentThat(
 ) {
   let currentNode: IAnyStateTreeNode | undefined = node
   while (currentNode && isAlive(currentNode)) {
-    if (predicate(currentNode)) {
-      return currentNode
-    }
-    if (hasParent(currentNode)) {
-      currentNode = getParent(currentNode)
-    } else {
-      break
-    }
+    if (predicate(currentNode)) return currentNode
+    if (hasParent(currentNode)) currentNode = getParent(currentNode)
+    else break
   }
   throw new Error('no matching node found')
 }
@@ -236,10 +231,6 @@ export function findParentThatIs<
 /** get the current JBrowse session model, starting at any node in the state tree */
 export function getSession(node: IAnyStateTreeNode) {
   try {
-    if (isSessionModel(node)) {
-      return node
-    }
-
     return findParentThatIs(node, isSessionModel)
   } catch (e) {
     throw new Error('no session model found!')

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -144,9 +144,14 @@ export function findParentThat(
 ) {
   let currentNode: IAnyStateTreeNode | undefined = node
   while (currentNode && isAlive(currentNode)) {
-    if (predicate(currentNode)) return currentNode
-    if (hasParent(currentNode)) currentNode = getParent(currentNode)
-    else break
+    if (predicate(currentNode)) {
+      return currentNode
+    }
+    if (hasParent(currentNode)) {
+      currentNode = getParent(currentNode)
+    } else {
+      break
+    }
   }
   throw new Error('no matching node found')
 }
@@ -231,6 +236,10 @@ export function findParentThatIs<
 /** get the current JBrowse session model, starting at any node in the state tree */
 export function getSession(node: IAnyStateTreeNode) {
   try {
+    if (isSessionModel(node)) {
+      return node
+    }
+
     return findParentThatIs(node, isSessionModel)
   } catch (e) {
     throw new Error('no session model found!')

--- a/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.test.js
+++ b/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.test.js
@@ -110,7 +110,7 @@ describe('<AddTrackWidget />', () => {
 
   it('adds a track', async () => {
     const { getByTestId, getByText } = render(<AddTrackWidget model={model} />)
-    expect(session.tracks.length).toBe(1)
+    expect(session.sessionTracks.length).toBe(1)
     fireEvent.click(getByTestId('addTrackFromConfigRadio'))
     fireEvent.click(getByTestId('addTrackNextButton'))
     fireEvent.change(getByTestId('trackNameInput'), {
@@ -125,6 +125,6 @@ describe('<AddTrackWidget />', () => {
     const volMyt1 = await waitForElement(() => getByText('volMyt1'))
     fireEvent.click(volMyt1)
     fireEvent.click(getByTestId('addTrackNextButton'))
-    expect(session.tracks.length).toBe(2)
+    expect(session.sessionTracks.length).toBe(2)
   })
 })

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
@@ -119,7 +119,7 @@ function Contents({
         })}
       </FormGroup>
       {doneLoading ? null : <CircularProgress />}
-      {categories.map(([name]) => (
+      {categories.sort().map(([name]) => (
         <Category
           key={name}
           model={model}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
@@ -36,54 +36,19 @@ function Contents({
     hierarchy = hierarchy.get(pathEntry) || new Map()
   })
 
-  const initialTrackConfigurations = []
-  const initialCategories = []
+  const trackConfigurations = []
+  const categories = []
   Array.from(hierarchy)
-    .slice(0, 50)
+    .slice(0)
     .forEach(([name, contents]) => {
       if (contents.trackId) {
-        initialTrackConfigurations.push(contents)
+        trackConfigurations.push(contents)
       } else {
-        initialCategories.push([name, contents])
+        categories.push([name, contents])
       }
     })
-  const [categories, setCategories] = useState(initialCategories)
-  const [trackConfigurations, setTrackConfigurations] = useState(
-    initialTrackConfigurations,
-  )
-
-  useEffect(() => {
-    function loadMoreTracks() {
-      const numLoaded = categories.length + trackConfigurations.length
-      const loadedTrackConfigurations = []
-      const loadedCategories = []
-      Array.from(hierarchy)
-        .slice(numLoaded, numLoaded + 10)
-        .forEach(([name, contents]) => {
-          if (contents.trackId) {
-            loadedTrackConfigurations.push(contents)
-          } else {
-            loadedCategories.push([name, contents])
-          }
-        })
-      setCategories(categories.concat(loadedCategories))
-      setTrackConfigurations(
-        trackConfigurations.concat(loadedTrackConfigurations),
-      )
-    }
-
-    const handle = requestIdleCallback(loadMoreTracks)
-
-    return function cleanup() {
-      cancelIdleCallback(handle)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hierarchy.size, categories.length, trackConfigurations.length])
-
   const { assemblyManager } = getSession(model)
   const assembly = assemblyManager.get(assemblyName)
-  const doneLoading =
-    categories.length + trackConfigurations.length === hierarchy.size
 
   const showRefSeqTrack =
     top &&
@@ -118,7 +83,6 @@ function Contents({
           )
         })}
       </FormGroup>
-      {doneLoading ? null : <CircularProgress />}
       {categories.sort().map(([name]) => (
         <Category
           key={name}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Contents.js
@@ -1,12 +1,11 @@
 import { getSession } from '@gmod/jbrowse-core/util'
 import { getConf } from '@gmod/jbrowse-core/configuration'
-import CircularProgress from '@material-ui/core/CircularProgress'
 import Divider from '@material-ui/core/Divider'
 import FormGroup from '@material-ui/core/FormGroup'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import propTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Category from './Category'
 import TrackEntry from './TrackEntry'
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -228,11 +228,9 @@ function HierarchicalTrackSelector({ model }) {
         </>
       ) : null}
 
-      {session.editConfiguration ? (
-        <Fab color="secondary" className={classes.fab} onClick={handleFabClick}>
-          <AddIcon />
-        </Fab>
-      ) : null}
+      <Fab color="secondary" className={classes.fab} onClick={handleFabClick}>
+        <AddIcon />
+      </Fab>
       <Menu
         id="simple-menu"
         anchorEl={anchorEl}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -133,8 +133,9 @@ function HierarchicalTrackSelector({ model }) {
     return null
   }
   const filterError =
-    model.trackConfigurations(assemblyName) > 0 &&
-    model.trackConfigurations(assemblyName).filter(filter).length === 0
+    model.trackConfigurations(assemblyName, session.tracks) > 0 &&
+    model.trackConfigurations(assemblyName, session.tracks).filter(filter)
+      .length === 0
 
   return (
     <div

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.test.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.test.js
@@ -65,8 +65,8 @@ describe('HierarchicalTrackSelector widget', () => {
         },
       ],
     })
-    firstView.showTrack(session.tracks[0])
-    firstView.showTrack(session.tracks[1])
+    firstView.showTrack(session.sessionTracks[0])
+    firstView.showTrack(session.sessionTracks[1])
     const model = firstView.activateTrackSelector()
 
     const { container, getByTestId } = render(
@@ -120,8 +120,8 @@ describe('HierarchicalTrackSelector widget', () => {
         },
       ],
     })
-    firstView.showTrack(session.tracks[0])
-    firstView.showTrack(session.tracks[1])
+    firstView.showTrack(session.sessionTracks[0])
+    firstView.showTrack(session.sessionTracks[1])
     firstView.tracks[0].configuration.category.set(['Foo Category'])
     firstView.tracks[1].configuration.category.set([
       'Foo Category',

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -7,8 +7,10 @@ import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
+import CallSplitIcon from '@material-ui/icons/CallSplit'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 import React from 'react'
 
@@ -75,21 +77,37 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
             disabled={disabled || unsupported}
           />
         </Tooltip>
+        {/* eslint-disable-next-line no-nested-ternary */}
         {session.editConfiguration && !assemblyName ? (
-          <IconButton
-            className={classes.configureButton}
-            onClick={() => {
-              const newTrackConf = session.editTrackConfiguration(trackConf)
-              if (newTrackConf && newTrackConf !== trackConf) {
-                model.view.hideTrack(trackConf)
-                model.view.showTrack(newTrackConf)
-              }
-            }}
-            color="secondary"
-            data-testid={`htsTrackEntryConfigure-${trackConfigId}`}
-          >
-            <SettingsIcon fontSize="small" />
-          </IconButton>
+          !trackConf.sessionTrack ? (
+            <IconButton
+              className={classes.configureButton}
+              onClick={() => {
+                const trackSnapshot = JSON.parse(
+                  JSON.stringify(getSnapshot(trackConf)),
+                )
+                trackSnapshot.trackId += `-${Date.now()}`
+                trackSnapshot.name += ' (copy)'
+                trackSnapshot.category = [' Session tracks']
+                session.addTrackConf(trackSnapshot)
+              }}
+              color="secondary"
+              data-testid={`htsTrackEntryFork-${trackConfigId}`}
+            >
+              <CallSplitIcon fontSize="small" />
+            </IconButton>
+          ) : (
+            <IconButton
+              className={classes.configureButton}
+              onClick={() => {
+                session.editTrackConfiguration(trackConf)
+              }}
+              color="secondary"
+              data-testid={`htsTrackEntryConfigure-${trackConfigId}`}
+            >
+              <SettingsIcon />
+            </IconButton>
+          )
         ) : null}
       </div>
     </Fade>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -79,7 +79,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
         </Tooltip>
         {/* eslint-disable-next-line no-nested-ternary */}
         {session.editConfiguration && !assemblyName ? (
-          !trackConf.sessionTrack ? (
+          !trackConf.sessionTrack && !session.adminMode ? (
             <IconButton
               className={classes.configureButton}
               onClick={() => {
@@ -105,7 +105,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
               color="secondary"
               data-testid={`htsTrackEntryConfigure-${trackConfigId}`}
             >
-              <SettingsIcon />
+              <SettingsIcon fontSize="small" />
             </IconButton>
           )
         ) : null}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { readConfObject } from '@gmod/jbrowse-core/configuration'
+import { getSession } from '@gmod/jbrowse-core/util'
 import { Menu } from '@gmod/jbrowse-core/ui'
 import Checkbox from '@material-ui/core/Checkbox'
 import Fade from '@material-ui/core/Fade'
@@ -44,6 +45,7 @@ const useStyles = makeStyles(theme => ({
 function TrackEntry({ model, disabled, trackConf, assemblyName }) {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
+  const session = getSession(model)
   const titleText = assemblyName
     ? `The reference sequence for ${assemblyName}`
     : readConfObject(trackConf, 'description')
@@ -94,7 +96,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           onClose={() => {
             setAnchorEl(null)
           }}
-          menuItems={trackConf.fileMenuItems}
+          menuItems={session.getTrackActionMenuItems(trackConf)}
         />
       </div>
     </Fade>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -9,9 +9,7 @@ import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
-import SettingsIcon from '@material-ui/icons/Settings'
 import HorizontalDots from '@material-ui/icons/MoreHoriz'
-import CopyIcon from '@material-ui/icons/FileCopy'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
@@ -51,11 +49,11 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
   const titleText = assemblyName
     ? `The reference sequence for ${assemblyName}`
     : readConfObject(trackConf, 'description')
+  const trackName = readConfObject(trackConf, 'name')
+  const trackId = readConfObject(trackConf, 'trackId')
   const unsupported =
-    readConfObject(trackConf, 'name') &&
-    (readConfObject(trackConf, 'name').endsWith('(Unsupported)') ||
-      readConfObject(trackConf, 'name').endsWith('(Unknown)'))
-  const trackConfigId = readConfObject(trackConf, 'trackId')
+    trackName &&
+    (trackName.endsWith('(Unsupported)') || trackName.endsWith('(Unknown)'))
   return (
     <Fade in>
       <div className={classes.track}>
@@ -65,15 +63,13 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
             control={
               <Checkbox
                 inputProps={{
-                  'data-testid': `htsTrackEntry-${trackConfigId}`,
+                  'data-testid': `htsTrackEntry-${trackId}`,
                 }}
                 className={classes.checkbox}
               />
             }
             label={
-              assemblyName
-                ? `Reference Sequence (${assemblyName})`
-                : readConfObject(trackConf, 'name')
+              assemblyName ? `Reference Sequence (${assemblyName})` : trackName
             }
             checked={model.view.tracks.some(t => t.configuration === trackConf)}
             onChange={() => model.view.toggleTrack(trackConf)}
@@ -86,7 +82,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
             setAnchorEl(event.currentTarget)
           }}
           color="secondary"
-          data-testid={`htsTrackEntryMenu-${trackConfigId}`}
+          data-testid={`htsTrackEntryMenu-${trackId}`}
         >
           <HorizontalDots fontSize="small" />
         </IconButton>
@@ -100,37 +96,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           onClose={() => {
             setAnchorEl(null)
           }}
-          menuItems={[
-            {
-              label: 'Settings',
-              disabled: !(session.adminMode || trackConf.sessionTrack),
-              onClick: () => {
-                session.editTrackConfiguration(trackConf)
-              },
-              icon: SettingsIcon,
-            },
-            {
-              label: 'Delete track',
-              disabled: !(session.adminMode || trackConf.sessionTrack),
-              onClick: () => {
-                session.deleteTrackConf(trackConf)
-              },
-              icon: SettingsIcon,
-            },
-            {
-              label: 'Copy track',
-              onClick: () => {
-                const trackSnapshot = JSON.parse(
-                  JSON.stringify(getSnapshot(trackConf)),
-                )
-                trackSnapshot.trackId += `-${Date.now()}`
-                trackSnapshot.name += ' (copy)'
-                trackSnapshot.category = [' Session tracks']
-                session.addTrackConf(trackSnapshot)
-              },
-              icon: CopyIcon,
-            },
-          ]}
+          menuItems={trackConf.fileOptions}
         />
       </div>
     </Fade>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -7,7 +7,7 @@ import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
-import CallSplitIcon from '@material-ui/icons/CallSplit'
+import ForkIcon from '@material-ui/icons/CallSplit'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
@@ -94,7 +94,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
               color="secondary"
               data-testid={`htsTrackEntryFork-${trackConfigId}`}
             >
-              <CallSplitIcon fontSize="small" />
+              <ForkIcon fontSize="small" />
             </IconButton>
           ) : (
             <IconButton

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles(theme => ({
       },
     },
     flexGrow: 1,
+    wordBreak: 'break-all',
   },
   checkbox: {
     padding: 0,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -86,7 +86,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
             setAnchorEl(event.currentTarget)
           }}
           color="secondary"
-          data-testid={`htsTrackEntryFork-${trackConfigId}`}
+          data-testid={`htsTrackEntryMenu-${trackConfigId}`}
         >
           <HorizontalDots fontSize="small" />
         </IconButton>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -80,22 +80,10 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           <IconButton
             className={classes.configureButton}
             onClick={() => {
-              if (
-                !session.adminMode &&
-                confirm(
-                  'To edit the track configuration currently, you must clone ' +
-                    'the track. Press OK to clone the track',
-                )
-              ) {
-                const trackSnapshot = JSON.parse(
-                  JSON.stringify(getSnapshot(trackConf)),
-                )
-                trackSnapshot.trackId += `-${Date.now()}`
-                trackSnapshot.category = [' Session tracks']
-                const newTrackConf = session.addTrackConf(trackSnapshot)
-                setTimeout(() => {
-                  session.editConfiguration(newTrackConf)
-                }, 500)
+              const newTrackConf = session.editTrackConfiguration(trackConf)
+              if (newTrackConf !== trackConf) {
+                model.view.hideTrack(trackConf)
+                model.view.showTrack(newTrackConf)
               }
             }}
             color="secondary"

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -9,7 +9,6 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 import React from 'react'
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -136,37 +136,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
     </Fade>
   )
 }
-// {session.editConfiguration && !assemblyName ? (
-//   !trackConf.sessionTrack && !session.adminMode ? (
-//     <IconButton
-//       className={classes.configureButton}
-//       onClick={() => {
-//         const trackSnapshot = JSON.parse(
-//           JSON.stringify(getSnapshot(trackConf)),
-//         )
-//         trackSnapshot.trackId += `-${Date.now()}`
-//         trackSnapshot.name += ' (copy)'
-//         trackSnapshot.category = [' Session tracks']
-//         session.addTrackConf(trackSnapshot)
-//       }}
-//       color="secondary"
-//       data-testid={`htsTrackEntryFork-${trackConfigId}`}
-//     >
-//       <ForkIcon fontSize="small" />
-//     </IconButton>
-//   ) : (
-//     <IconButton
-//       className={classes.configureButton}
-//       onClick={() => {
-//         session.editTrackConfiguration(trackConf)
-//       }}
-//       color="secondary"
-//       data-testid={`htsTrackEntryConfigure-${trackConfigId}`}
-//     >
-//       <SettingsIcon fontSize="small" />
-//     </IconButton>
-//   )
-// ) : null}
+
 TrackEntry.propTypes = {
   model: MobxPropTypes.observableObject.isRequired,
   disabled: propTypes.bool,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -93,7 +93,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           onClose={() => {
             setAnchorEl(null)
           }}
-          menuItems={trackConf.fileOptions}
+          menuItems={trackConf.fileMenuItems}
         />
       </div>
     </Fade>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -9,6 +9,7 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 import React from 'react'
 
@@ -78,7 +79,25 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
         {session.editConfiguration && !assemblyName ? (
           <IconButton
             className={classes.configureButton}
-            onClick={() => session.editConfiguration(trackConf)}
+            onClick={() => {
+              if (
+                !session.adminMode &&
+                confirm(
+                  'To edit the track configuration currently, you must clone ' +
+                    'the track. Press OK to clone the track',
+                )
+              ) {
+                const trackSnapshot = JSON.parse(
+                  JSON.stringify(getSnapshot(trackConf)),
+                )
+                trackSnapshot.trackId += `-${Date.now()}`
+                trackSnapshot.category = [' Session tracks']
+                const newTrackConf = session.addTrackConf(trackSnapshot)
+                setTimeout(() => {
+                  session.editConfiguration(newTrackConf)
+                }, 500)
+              }
+            }}
             color="secondary"
             data-testid={`htsTrackEntryConfigure-${trackConfigId}`}
           >

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -96,7 +96,10 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           onClose={() => {
             setAnchorEl(null)
           }}
-          menuItems={session.getTrackActionMenuItems(trackConf)}
+          menuItems={
+            session.getTrackActionMenuItems &&
+            session.getTrackActionMenuItems(trackConf)
+          }
         />
       </div>
     </Fade>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -102,6 +102,22 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           }}
           menuItems={[
             {
+              label: 'Settings',
+              disabled: !(session.adminMode || trackConf.sessionTrack),
+              onClick: () => {
+                session.editTrackConfiguration(trackConf)
+              },
+              icon: SettingsIcon,
+            },
+            {
+              label: 'Delete track',
+              disabled: !(session.adminMode || trackConf.sessionTrack),
+              onClick: () => {
+                session.deleteTrackConf(trackConf)
+              },
+              icon: SettingsIcon,
+            },
+            {
               label: 'Copy track',
               onClick: () => {
                 const trackSnapshot = JSON.parse(
@@ -113,14 +129,6 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
                 session.addTrackConf(trackSnapshot)
               },
               icon: CopyIcon,
-            },
-            {
-              label: 'Settings',
-              disabled: !(session.adminMode || trackConf.sessionTrack),
-              onClick: () => {
-                session.editTrackConfiguration(trackConf)
-              },
-              icon: SettingsIcon,
             },
           ]}
         />

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { readConfObject } from '@gmod/jbrowse-core/configuration'
 import { Menu } from '@gmod/jbrowse-core/ui'
-import { getSession } from '@gmod/jbrowse-core/util'
 import Checkbox from '@material-ui/core/Checkbox'
 import Fade from '@material-ui/core/Fade'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
@@ -11,7 +10,6 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import Tooltip from '@material-ui/core/Tooltip'
 import HorizontalDots from '@material-ui/icons/MoreHoriz'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
 import propTypes from 'prop-types'
 
 const useStyles = makeStyles(theme => ({
@@ -45,7 +43,6 @@ const useStyles = makeStyles(theme => ({
 function TrackEntry({ model, disabled, trackConf, assemblyName }) {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
-  const session = getSession(model)
   const titleText = assemblyName
     ? `The reference sequence for ${assemblyName}`
     : readConfObject(trackConf, 'description')

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -80,7 +80,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
             className={classes.configureButton}
             onClick={() => {
               const newTrackConf = session.editTrackConfiguration(trackConf)
-              if (newTrackConf !== trackConf) {
+              if (newTrackConf && newTrackConf !== trackConf) {
                 model.view.hideTrack(trackConf)
                 model.view.showTrack(newTrackConf)
               }

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -216,6 +216,31 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                       Track
                     </span>
                   </label>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+                    data-testid="htsTrackEntryConfigure-fooC"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+                          transform="scale(1.2, 1.2)"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
                 </div>
               </div>
               <div
@@ -325,6 +350,31 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                   Track
                                 </span>
                               </label>
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+                                data-testid="htsTrackEntryConfigure-barC"
+                                tabindex="0"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+                                      transform="scale(1.2, 1.2)"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
                             </div>
                           </div>
                         </div>
@@ -342,6 +392,29 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
   <div
     class="MuiFormGroup-root"
   />
+  <button
+    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiFab-label"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
 </div>
 `;
 
@@ -496,6 +569,31 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
           Track
         </span>
       </label>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+        data-testid="htsTrackEntryConfigure-fooC"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+              transform="scale(1.2, 1.2)"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
     </div>
     <div
       class="makeStyles-track"
@@ -541,10 +639,58 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
           Track
         </span>
       </label>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+        data-testid="htsTrackEntryConfigure-barC"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+              transform="scale(1.2, 1.2)"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
     </div>
   </div>
   <div
     class="MuiFormGroup-root"
   />
+  <button
+    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiFab-label"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
 </div>
 `;

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -101,6 +101,30 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
           Reference Sequence (volMyt1)
         </span>
       </label>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+        data-testid="htsTrackEntryMenu-sequenceConfigId"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
     </div>
   </div>
   <hr
@@ -218,7 +242,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                   </label>
                   <button
                     class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-                    data-testid="htsTrackEntryConfigure-fooC"
+                    data-testid="htsTrackEntryMenu-fooC"
                     tabindex="0"
                     type="button"
                   >
@@ -232,8 +256,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
-                          transform="scale(1.2, 1.2)"
+                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                         />
                       </svg>
                     </span>
@@ -352,7 +375,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                               </label>
                               <button
                                 class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-                                data-testid="htsTrackEntryConfigure-barC"
+                                data-testid="htsTrackEntryMenu-barC"
                                 tabindex="0"
                                 type="button"
                               >
@@ -366,8 +389,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                     viewBox="0 0 24 24"
                                   >
                                     <path
-                                      d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
-                                      transform="scale(1.2, 1.2)"
+                                      d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                                     />
                                   </svg>
                                 </span>
@@ -517,6 +539,30 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
           Reference Sequence (volMyt1)
         </span>
       </label>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+        data-testid="htsTrackEntryMenu-sequenceConfigId"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
     </div>
   </div>
   <hr
@@ -571,7 +617,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
       </label>
       <button
         class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-        data-testid="htsTrackEntryConfigure-fooC"
+        data-testid="htsTrackEntryMenu-fooC"
         tabindex="0"
         type="button"
       >
@@ -585,8 +631,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
             viewBox="0 0 24 24"
           >
             <path
-              d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
-              transform="scale(1.2, 1.2)"
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
         </span>
@@ -641,7 +686,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
       </label>
       <button
         class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-        data-testid="htsTrackEntryConfigure-barC"
+        data-testid="htsTrackEntryMenu-barC"
         tabindex="0"
         type="button"
       >
@@ -655,8 +700,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
             viewBox="0 0 24 24"
           >
             <path
-              d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
-              transform="scale(1.2, 1.2)"
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
             />
           </svg>
         </span>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -150,7 +150,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
         <p
           class="MuiTypography-root MuiTypography-body2"
         >
-          Foo Category (1)
+           Session tracks
         </p>
       </div>
       <div
@@ -195,77 +195,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
             >
               <div
                 class="MuiFormGroup-root"
-              >
-                <div
-                  class="makeStyles-track"
-                  style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
-                >
-                  <label
-                    class="MuiFormControlLabel-root makeStyles-formControlLabel"
-                    title=""
-                  >
-                    <span
-                      aria-disabled="false"
-                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <input
-                          checked=""
-                          class="PrivateSwitchBase-input"
-                          data-indeterminate="false"
-                          data-testid="htsTrackEntry-fooC"
-                          type="checkbox"
-                          value=""
-                        />
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </span>
-                    <span
-                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                    >
-                      Track
-                    </span>
-                  </label>
-                  <button
-                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-                    data-testid="htsTrackEntryMenu-fooC"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-              </div>
+              />
               <div
                 class="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-expanded MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
                 style="margin-top: 4px;"
@@ -283,7 +213,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                     <p
                       class="MuiTypography-root MuiTypography-body2"
                     >
-                      Bar Category (1)
+                      Foo Category (1)
                     </p>
                   </div>
                   <div
@@ -348,7 +278,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                       checked=""
                                       class="PrivateSwitchBase-input"
                                       data-indeterminate="false"
-                                      data-testid="htsTrackEntry-barC"
+                                      data-testid="htsTrackEntry-fooC"
                                       type="checkbox"
                                       value=""
                                     />
@@ -375,7 +305,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                               </label>
                               <button
                                 class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-                                data-testid="htsTrackEntryMenu-barC"
+                                data-testid="htsTrackEntryMenu-fooC"
                                 tabindex="0"
                                 type="button"
                               >
@@ -397,6 +327,145 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                   class="MuiTouchRipple-root"
                                 />
                               </button>
+                            </div>
+                          </div>
+                          <div
+                            class="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-expanded MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                            style="margin-top: 4px;"
+                          >
+                            <div
+                              aria-disabled="false"
+                              aria-expanded="true"
+                              class="MuiButtonBase-root MuiExpansionPanelSummary-root MuiExpansionPanelSummary-expanded"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="MuiExpansionPanelSummary-content MuiExpansionPanelSummary-expanded"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body2"
+                                >
+                                  Bar Category (1)
+                                </p>
+                              </div>
+                              <div
+                                aria-disabled="false"
+                                aria-hidden="true"
+                                class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiExpansionPanelSummary-expanded MuiIconButton-edgeEnd"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root makeStyles-expandIcon"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              class="MuiCollapse-container MuiCollapse-entered"
+                              style="min-height: 0px;"
+                            >
+                              <div
+                                class="MuiCollapse-wrapper"
+                              >
+                                <div
+                                  class="MuiCollapse-wrapperInner"
+                                >
+                                  <div
+                                    role="region"
+                                  >
+                                    <div
+                                      class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
+                                    >
+                                      <div
+                                        class="MuiFormGroup-root"
+                                      >
+                                        <div
+                                          class="makeStyles-track"
+                                          style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+                                        >
+                                          <label
+                                            class="MuiFormControlLabel-root makeStyles-formControlLabel"
+                                            title=""
+                                          >
+                                            <span
+                                              aria-disabled="false"
+                                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+                                            >
+                                              <span
+                                                class="MuiIconButton-label"
+                                              >
+                                                <input
+                                                  checked=""
+                                                  class="PrivateSwitchBase-input"
+                                                  data-indeterminate="false"
+                                                  data-testid="htsTrackEntry-barC"
+                                                  type="checkbox"
+                                                  value=""
+                                                />
+                                                <svg
+                                                  aria-hidden="true"
+                                                  class="MuiSvgIcon-root"
+                                                  focusable="false"
+                                                  viewBox="0 0 24 24"
+                                                >
+                                                  <path
+                                                    d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                                  />
+                                                </svg>
+                                              </span>
+                                              <span
+                                                class="MuiTouchRipple-root"
+                                              />
+                                            </span>
+                                            <span
+                                              class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                            >
+                                              Track
+                                            </span>
+                                          </label>
+                                          <button
+                                            class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+                                            data-testid="htsTrackEntryMenu-barC"
+                                            tabindex="0"
+                                            type="button"
+                                          >
+                                            <span
+                                              class="MuiIconButton-label"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                                focusable="false"
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="MuiTouchRipple-root"
+                                            />
+                                          </button>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -570,144 +639,213 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
   />
   <div
     class="MuiFormGroup-root"
+  />
+  <div
+    class="MuiPaper-root MuiExpansionPanel-root MuiExpansionPanel-expanded MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+    style="margin-top: 4px;"
   >
     <div
-      class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      aria-disabled="false"
+      aria-expanded="true"
+      class="MuiButtonBase-root MuiExpansionPanelSummary-root MuiExpansionPanelSummary-expanded"
+      role="button"
+      tabindex="0"
     >
-      <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel"
-        title=""
+      <div
+        class="MuiExpansionPanelSummary-content MuiExpansionPanelSummary-expanded"
       >
-        <span
-          aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+        <p
+          class="MuiTypography-root MuiTypography-body2"
         >
-          <span
-            class="MuiIconButton-label"
-          >
-            <input
-              checked=""
-              class="PrivateSwitchBase-input"
-              data-indeterminate="false"
-              data-testid="htsTrackEntry-fooC"
-              type="checkbox"
-              value=""
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </span>
-        <span
-          class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          Track
-        </span>
-      </label>
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-        data-testid="htsTrackEntryMenu-fooC"
-        tabindex="0"
-        type="button"
+           Session tracks (2)
+        </p>
+      </div>
+      <div
+        aria-disabled="false"
+        aria-hidden="true"
+        class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiExpansionPanelSummary-expanded MuiIconButton-edgeEnd"
       >
         <span
           class="MuiIconButton-label"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root makeStyles-expandIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
             />
           </svg>
         </span>
         <span
           class="MuiTouchRipple-root"
         />
-      </button>
+      </div>
     </div>
     <div
-      class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      class="MuiCollapse-container MuiCollapse-entered"
+      style="min-height: 0px;"
     >
-      <label
-        class="MuiFormControlLabel-root makeStyles-formControlLabel"
-        title=""
+      <div
+        class="MuiCollapse-wrapper"
       >
-        <span
-          aria-disabled="false"
-          class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+        <div
+          class="MuiCollapse-wrapperInner"
         >
-          <span
-            class="MuiIconButton-label"
+          <div
+            role="region"
           >
-            <input
-              checked=""
-              class="PrivateSwitchBase-input"
-              data-indeterminate="false"
-              data-testid="htsTrackEntry-barC"
-              type="checkbox"
-              value=""
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <div
+              class="MuiExpansionPanelDetails-root makeStyles-expansionPanelDetails"
             >
-              <path
-                d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </span>
-        <span
-          class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          Track
-        </span>
-      </label>
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
-        data-testid="htsTrackEntryMenu-barC"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
+              <div
+                class="MuiFormGroup-root"
+              >
+                <div
+                  class="makeStyles-track"
+                  style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+                >
+                  <label
+                    class="MuiFormControlLabel-root makeStyles-formControlLabel"
+                    title=""
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          checked=""
+                          class="PrivateSwitchBase-input"
+                          data-indeterminate="false"
+                          data-testid="htsTrackEntry-fooC"
+                          type="checkbox"
+                          value=""
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Track
+                    </span>
+                  </label>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+                    data-testid="htsTrackEntryMenu-fooC"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="makeStyles-track"
+                  style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+                >
+                  <label
+                    class="MuiFormControlLabel-root makeStyles-formControlLabel"
+                    title=""
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-checkbox PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          checked=""
+                          class="PrivateSwitchBase-input"
+                          data-indeterminate="false"
+                          data-testid="htsTrackEntry-barC"
+                          type="checkbox"
+                          value=""
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Track
+                    </span>
+                  </label>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root makeStyles-configureButton MuiIconButton-colorSecondary"
+                    data-testid="htsTrackEntryMenu-barC"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -8,6 +8,9 @@ export function generateHierarchy(trackConfigurations) {
 
   trackConfigurations.forEach(trackConf => {
     const categories = [...(readConfObject(trackConf, 'category') || [])]
+    if (trackConf.sessionTrack) {
+      categories.unshift(' Session tracks')
+    }
 
     let currLevel = hierarchy
     for (let i = 0; i < categories.length; i += 1) {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -79,8 +79,14 @@ export default pluginManager =>
 
       hierarchy(assemblyName) {
         const session = getSession(self)
-        const tracks = session.tracks.concat(session.sessionTracks)
-        return generateHierarchy(self.trackConfigurations(assemblyName, tracks))
+        const sessionTracks = session.sessionTracks.slice(0)
+        sessionTracks.forEach(t => {
+          t.sessionTrack = true
+        })
+        const allTracks = session.tracks.concat(sessionTracks)
+        return generateHierarchy(
+          self.trackConfigurations(assemblyName, allTracks),
+        )
       },
 
       connectionHierarchy(connection) {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -48,10 +48,10 @@ export default pluginManager =>
       },
     }))
     .views(self => ({
-      trackConfigurations(assemblyName) {
-        if (!self.view) return []
-        const session = getSession(self)
-        const trackConfigurations = session.tracks
+      trackConfigurations(assemblyName, trackConfigurations) {
+        if (!self.view) {
+          return []
+        }
 
         const relevantTrackConfigurations = trackConfigurations.filter(
           conf =>
@@ -66,7 +66,9 @@ export default pluginManager =>
       },
 
       connectionTrackConfigurations(connection) {
-        if (!self.view) return []
+        if (!self.view) {
+          return []
+        }
         const trackConfigurations = connection.tracks
 
         const relevantTrackConfigurations = trackConfigurations.filter(
@@ -76,7 +78,9 @@ export default pluginManager =>
       },
 
       hierarchy(assemblyName) {
-        return generateHierarchy(self.trackConfigurations(assemblyName))
+        const session = getSession(self)
+        const tracks = session.tracks.concat(session.sessionTracks)
+        return generateHierarchy(self.trackConfigurations(assemblyName, tracks))
       },
 
       connectionHierarchy(connection) {

--- a/plugins/data-management/src/index.ts
+++ b/plugins/data-management/src/index.ts
@@ -77,27 +77,25 @@ export default class extends Plugin {
 
   configure(pluginManager: PluginManager) {
     if (isAbstractMenuManager(pluginManager.rootModel)) {
-      if (pluginManager.rootModel.adminMode) {
-        pluginManager.rootModel.appendToMenu('File', {
-          label: 'Open new track',
-          icon: NoteAddIcon,
-          onClick: (session: SessionWithWidgets) => {
-            const widget = session.addWidget('AddTrackWidget', 'addTrackWidget')
-            session.showWidget(widget)
-          },
-        })
-        pluginManager.rootModel.appendToMenu('File', {
-          label: 'Open new connection',
-          icon: InputIcon,
-          onClick: (session: SessionWithWidgets) => {
-            const widget = session.addWidget(
-              'AddConnectionWidget',
-              'addConnectionWidget',
-            )
-            session.showWidget(widget)
-          },
-        })
-      }
+      pluginManager.rootModel.appendToMenu('File', {
+        label: 'Open new track',
+        icon: NoteAddIcon,
+        onClick: (session: SessionWithWidgets) => {
+          const widget = session.addWidget('AddTrackWidget', 'addTrackWidget')
+          session.showWidget(widget)
+        },
+      })
+      pluginManager.rootModel.appendToMenu('File', {
+        label: 'Open new connection',
+        icon: InputIcon,
+        onClick: (session: SessionWithWidgets) => {
+          const widget = session.addWidget(
+            'AddConnectionWidget',
+            'addConnectionWidget',
+          )
+          session.showWidget(widget)
+        },
+      })
     }
   }
 }

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -294,8 +294,16 @@ const BaseTrackWithReferences = types
   .actions(self => ({
     activateConfigurationUI() {
       const session = getSession(self)
+      const view = getContainingView(self)
       if (isSessionModelWithConfigEditing(session)) {
-        session.editConfiguration(self.configuration)
+        // @ts-ignore
+        const newTrackConf = session.editTrackConfiguration(self.configuration)
+        if (newTrackConf !== self.configuration) {
+          // @ts-ignore
+          view.hideTrack(self.configuration)
+          // @ts-ignore
+          view.showTrack(newTrackConf)
+        }
       }
     },
   }))

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -5,19 +5,12 @@ import { ElementId } from '@gmod/jbrowse-core/util/types/mst'
 import { MenuItem } from '@gmod/jbrowse-core/ui'
 import { getSession, getContainingView } from '@gmod/jbrowse-core/util'
 import { getParentRenderProps } from '@gmod/jbrowse-core/util/tracks'
-import {
-  types,
-  getSnapshot,
-  getRoot,
-  Instance,
-  IAnyStateTreeNode,
-} from 'mobx-state-tree'
+import { types, Instance } from 'mobx-state-tree'
 import InfoIcon from '@material-ui/icons/Info'
 import React from 'react'
 import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
 
-import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import { LinearGenomeViewModel } from '../LinearGenomeView'
 
 // these MST models only exist for tracks that are *shown*.

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -175,6 +175,8 @@ const BaseTrack = types
       return (
         isSessionModelWithConfigEditing(session) &&
         // @ts-ignore
+        session.adminMode &&
+        // @ts-ignore
         session.sessionTracks.findIndex(track => {
           // @ts-ignore
           return track.trackId === self.configuration.trackId

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -88,7 +88,7 @@ const generateBaseTrackConfig = (base: any) =>
     {
       explicitIdentifier: 'trackId',
       views: (self: unknown) => ({
-        get fileOptions() {
+        get fileMenuItems() {
           let session: any
           const config = self as IAnyStateTreeNode
           try {
@@ -283,18 +283,6 @@ const BaseTrack = types
     reload() {},
   }))
   .views(self => ({
-    get trackMenuItems(): MenuItem[] {
-      return [
-        {
-          label: 'About this track',
-          icon: InfoIcon,
-          onClick: () => {
-            self.setShowAbout(true)
-          },
-        },
-      ]
-    },
-
     /**
      * @param region -
      * @returns falsy if the region is fine to try rendering. Otherwise,
@@ -378,6 +366,17 @@ const BaseTrackWithReferences = types
             return track.trackId === self.configuration.trackId
           }))
       )
+    },
+    get trackMenuItems(): MenuItem[] {
+      return [
+        {
+          label: 'About this track',
+          icon: InfoIcon,
+          onClick: () => {
+            self.setShowAbout(true)
+          },
+        },
+      ]
     },
   }))
 

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ConfigurationSchema, getConf } from '@gmod/jbrowse-core/configuration'
 import { isSessionModelWithConfigEditing } from '@gmod/jbrowse-core/util/types'
-import { getDefaultValue } from '@gmod/jbrowse-core/util/mst-reflection'
 import { ElementId } from '@gmod/jbrowse-core/util/types/mst'
 import { MenuItem } from '@gmod/jbrowse-core/ui'
 import { getSession, getContainingView } from '@gmod/jbrowse-core/util'

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -170,20 +170,6 @@ const BaseTrack = types
       return adapterType
     },
 
-    get canConfigure() {
-      const session = getSession(self)
-      return (
-        isSessionModelWithConfigEditing(session) &&
-        // @ts-ignore
-        session.adminMode &&
-        // @ts-ignore
-        session.sessionTracks.findIndex(track => {
-          // @ts-ignore
-          return track.trackId === self.configuration.trackId
-        }) !== -1
-      )
-    },
-
     /**
      * if a track-level message should be displayed instead of the blocks,
      * make this return a react component
@@ -318,8 +304,17 @@ const BaseTrackWithReferences = types
     },
   }))
   .views(self => ({
-    get hello() {
-      return 'world'
+    get canConfigure() {
+      const session = getSession(self)
+      return (
+        isSessionModelWithConfigEditing(session) &&
+        // @ts-ignore
+        (session.adminMode ||
+          // @ts-ignore
+          session.sessionTracks.find(track => {
+            return track.trackId === self.configuration.trackId
+          })
+      )
     },
   }))
 

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -292,6 +292,7 @@ const BaseTrack = types
   }))
 
 export const BaseTrackConfig = generateBaseTrackConfig(BaseTrack)
+console.log({ BaseTrackConfig })
 
 const BaseTrackWithReferences = types
   .compose(
@@ -314,6 +315,11 @@ const BaseTrackWithReferences = types
           view.showTrack(newTrackConf)
         }
       }
+    },
+  }))
+  .views(self => ({
+    get hello() {
+      return 'world'
     },
   }))
 

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -172,7 +172,14 @@ const BaseTrack = types
 
     get canConfigure() {
       const session = getSession(self)
-      return isSessionModelWithConfigEditing(session)
+      return (
+        isSessionModelWithConfigEditing(session) &&
+        // @ts-ignore
+        session.sessionTracks.findIndex(track => {
+          // @ts-ignore
+          return track.trackId === self.configuration.trackId
+        }) !== -1
+      )
     },
 
     /**

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -278,7 +278,6 @@ const BaseTrack = types
   }))
 
 export const BaseTrackConfig = generateBaseTrackConfig(BaseTrack)
-console.log({ BaseTrackConfig })
 
 const BaseTrackWithReferences = types
   .compose(
@@ -313,7 +312,7 @@ const BaseTrackWithReferences = types
           // @ts-ignore
           session.sessionTracks.find(track => {
             return track.trackId === self.configuration.trackId
-          })
+          }))
       )
     },
   }))

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -16,9 +16,7 @@ import InfoIcon from '@material-ui/icons/Info'
 import React from 'react'
 import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
-import SettingsIcon from '@material-ui/icons/Settings'
-import CopyIcon from '@material-ui/icons/FileCopy'
-import DeleteIcon from '@material-ui/icons/Delete'
+
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import { LinearGenomeViewModel } from '../LinearGenomeView'
 
@@ -86,57 +84,6 @@ const generateBaseTrackConfig = (base: any) =>
     },
     {
       explicitIdentifier: 'trackId',
-      views: (self: unknown) => ({
-        get fileMenuItems() {
-          let session: any
-          const config = self as IAnyStateTreeNode
-          try {
-            session = getSession(config)
-          } catch (e) {
-            // TODO likely want a better way to do this
-            session = getRoot(config).session
-          }
-
-          const canEdit =
-            session.adminMode ||
-            session.sessionTracks.find((track: AnyConfigurationModel) => {
-              // @ts-ignore
-              return track.trackId === config.trackId
-            })
-
-          return [
-            {
-              label: 'Settings',
-              disabled: !canEdit,
-              onClick: () => {
-                session.editTrackConfiguration(config)
-              },
-              icon: SettingsIcon,
-            },
-            {
-              label: 'Delete track',
-              disabled: !canEdit,
-              onClick: () => {
-                session.deleteTrackConf(config)
-              },
-              icon: DeleteIcon,
-            },
-            {
-              label: 'Copy track',
-              onClick: () => {
-                const trackSnapshot = JSON.parse(
-                  JSON.stringify(getSnapshot(config)),
-                )
-                trackSnapshot.trackId += `-${Date.now()}`
-                trackSnapshot.name += ' (copy)'
-                trackSnapshot.category = [' Session tracks']
-                session.addTrackConf(trackSnapshot)
-              },
-              icon: CopyIcon,
-            },
-          ]
-        },
-      }),
     },
   )
 

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -298,7 +298,7 @@ const BaseTrackWithReferences = types
       if (isSessionModelWithConfigEditing(session)) {
         // @ts-ignore
         const newTrackConf = session.editTrackConfiguration(self.configuration)
-        if (newTrackConf !== self.configuration) {
+        if (newTrackConf && newTrackConf !== self.configuration) {
           // @ts-ignore
           view.hideTrack(self.configuration)
           // @ts-ignore

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -95,8 +95,9 @@ const generateBaseTrackConfig = (base: any) =>
             session = getSession(config)
           } catch (e) {
             // TODO likely want a better way to do this
-            session = getRoot(config)
+            session = getRoot(config).session
           }
+
           const canEdit =
             session.adminMode ||
             session.sessionTracks.find((track: AnyConfigurationModel) => {
@@ -341,7 +342,6 @@ const BaseTrack = types
   }))
 
 export const BaseTrackConfig = generateBaseTrackConfig(BaseTrack)
-console.log(getDefaultValue(BaseTrackConfig))
 
 const BaseTrackWithReferences = types
   .compose(
@@ -384,46 +384,3 @@ const BaseTrackWithReferences = types
 export type BaseTrackStateModel = typeof BaseTrackWithReferences
 export type BaseTrackModel = Instance<BaseTrackStateModel>
 export default BaseTrackWithReferences
-
-// generate file config options given a track config and a model
-// note that model.configuration is not used and this is not in a model because
-// this is derived directly from the configuration, not an instance of a track
-// export function getFileConfigOptions(
-//   model: BaseTrackModel,
-//   trackConf: AnyConfigurationModel,
-// ) {
-//   const session = getSession(model)
-// const canEdit = session.adminMode||session.sessionTracks.find(track => {
-
-//             return track.trackId === self.configuration.trackId
-//           })
-//   return [
-//     {
-//       label: 'Settings',
-//       disabled: !(session.adminMode || trackConf.sessionTrack),
-//       onClick: () => {
-//         session.editTrackConfiguration(trackConf)
-//       },
-//       icon: SettingsIcon,
-//     },
-//     {
-//       label: 'Delete track',
-//       disabled: !(session.adminMode || trackConf.sessionTrack),
-//       onClick: () => {
-//         session.deleteTrackConf(trackConf)
-//       },
-//       icon: DeleteIcon,
-//     },
-//     {
-//       label: 'Copy track',
-//       onClick: () => {
-//         const trackSnapshot = JSON.parse(JSON.stringify(getSnapshot(trackConf)))
-//         trackSnapshot.trackId += `-${Date.now()}`
-//         trackSnapshot.name += ' (copy)'
-//         trackSnapshot.category = [' Session tracks']
-//         session.addTrackConf(trackSnapshot)
-//       },
-//       icon: CopyIcon,
-//     },
-//   ]
-// }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -10,7 +10,8 @@ import MoreVertIcon from '@material-ui/icons/MoreVert'
 import DragIcon from '@material-ui/icons/DragIndicator'
 import CloseIcon from '@material-ui/icons/Close'
 import SettingsIcon from '@material-ui/icons/Settings'
-import ForkIcon from '@material-ui/icons/CallSplit'
+import DeleteIcon from '@material-ui/icons/Delete'
+import CopyIcon from '@material-ui/icons/FileCopy'
 
 import clsx from 'clsx'
 import { observer } from 'mobx-react'
@@ -120,17 +121,25 @@ const TrackLabel = React.forwardRef(
       handleClose()
     }
 
-    const trackMenuItems: MenuItem[] = track.canConfigure
-      ? [{ label: 'Settings', onClick: onConfigureClick, icon: SettingsIcon }]
-      : [{ label: 'Fork', onClick: onFork, icon: ForkIcon }]
+    const trackOptions: MenuItem[] = [
+      {
+        label: 'Settings',
+        onClick: onConfigureClick,
+        disabled: track.canConfigure,
+        icon: SettingsIcon,
+      },
+      {
+        label: 'Delete',
+        onClick: () => {
+          session.deleteTrackConf(track.configuration)
+        },
+        disabled: track.canConfigure,
+        icon: DeleteIcon,
+      },
+      { label: 'Copy', onClick: onFork, icon: CopyIcon },
+    ]
 
-    if (track.trackMenuItems.length) {
-      if (trackMenuItems.length) {
-        trackMenuItems.push({ type: 'divider' })
-      }
-      trackMenuItems.push(...track.trackMenuItems)
-    }
-
+    const trackMenuItems = [...trackOptions, ...track.trackMenuItems]
     return (
       <>
         <Paper ref={ref} className={clsx(className, classes.root)}>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -125,7 +125,7 @@ const TrackLabel = React.forwardRef(
       {
         label: 'Settings',
         onClick: onConfigureClick,
-        disabled: track.canConfigure,
+        disabled: !track.canConfigure,
         icon: SettingsIcon,
       },
       {
@@ -133,7 +133,7 @@ const TrackLabel = React.forwardRef(
         onClick: () => {
           session.deleteTrackConf(track.configuration)
         },
-        disabled: track.canConfigure,
+        disabled: !track.canConfigure,
         icon: DeleteIcon,
       },
       { label: 'Copy', onClick: onFork, icon: CopyIcon },

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -74,18 +74,6 @@ const TrackLabel = React.forwardRef(
       setAnchorEl(null)
     }
 
-    const onFork = () => {
-      const trackSnapshot = JSON.parse(
-        JSON.stringify(getSnapshot(track.configuration)),
-      )
-      trackSnapshot.trackId += `-${Date.now()}`
-      trackSnapshot.name += ' (copy)'
-      trackSnapshot.category = [' Session tracks']
-      // @ts-ignore
-      session.addTrackConf(trackSnapshot)
-      handleClose()
-    }
-
     const onConfigureClick = () => {
       track.activateConfigurationUI()
       handleClose()
@@ -136,7 +124,21 @@ const TrackLabel = React.forwardRef(
         disabled: !track.canConfigure,
         icon: DeleteIcon,
       },
-      { label: 'Copy', onClick: onFork, icon: CopyIcon },
+      {
+        label: 'Copy',
+        onClick: () => {
+          const trackSnapshot = JSON.parse(
+            JSON.stringify(getSnapshot(track.configuration)),
+          )
+          trackSnapshot.trackId += `-${Date.now()}`
+          trackSnapshot.name += ' (copy)'
+          trackSnapshot.category = [' Session tracks']
+          // @ts-ignore
+          session.addTrackConf(trackSnapshot)
+          handleClose()
+        },
+        icon: CopyIcon,
+      },
     ]
 
     const trackMenuItems = [...trackOptions, ...track.trackMenuItems]

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -119,7 +119,9 @@ const TrackLabel = React.forwardRef(
       {
         label: 'Delete',
         onClick: () => {
+          // @ts-ignore
           session.deleteTrackConf(track.configuration)
+          handleClose()
         },
         disabled: !track.canConfigure,
         icon: DeleteIcon,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -109,41 +109,6 @@ const TrackLabel = React.forwardRef(
       handleClose()
     }
 
-    const trackOptions: MenuItem[] = [
-      {
-        label: 'Settings',
-        onClick: onConfigureClick,
-        disabled: !track.canConfigure,
-        icon: SettingsIcon,
-      },
-      {
-        label: 'Delete',
-        onClick: () => {
-          // @ts-ignore
-          session.deleteTrackConf(track.configuration)
-          handleClose()
-        },
-        disabled: !track.canConfigure,
-        icon: DeleteIcon,
-      },
-      {
-        label: 'Copy',
-        onClick: () => {
-          const trackSnapshot = JSON.parse(
-            JSON.stringify(getSnapshot(track.configuration)),
-          )
-          trackSnapshot.trackId += `-${Date.now()}`
-          trackSnapshot.name += ' (copy)'
-          trackSnapshot.category = [' Session tracks']
-          // @ts-ignore
-          session.addTrackConf(trackSnapshot)
-          handleClose()
-        },
-        icon: CopyIcon,
-      },
-    ]
-
-    const trackMenuItems = [...trackOptions, ...track.trackMenuItems]
     return (
       <>
         <Paper ref={ref} className={clsx(className, classes.root)}>
@@ -178,7 +143,7 @@ const TrackLabel = React.forwardRef(
             className={classes.iconButton}
             color="secondary"
             data-testid="track_menu_icon"
-            disabled={!trackMenuItems.length}
+            disabled={!track.trackMenuItems.length}
           >
             <MoreVertIcon fontSize="small" />
           </IconButton>
@@ -188,7 +153,10 @@ const TrackLabel = React.forwardRef(
           onMenuItemClick={handleMenuItemClick}
           open={Boolean(anchorEl)}
           onClose={handleClose}
-          menuItems={trackMenuItems}
+          menuItems={[
+            ...track.configuration.fileMenuItems,
+            ...track.trackMenuItems,
+          ]}
         />
       </>
     )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -1,5 +1,5 @@
 import { getConf, readConfObject } from '@gmod/jbrowse-core/configuration'
-import { Menu, MenuItem } from '@gmod/jbrowse-core/ui'
+import { Menu } from '@gmod/jbrowse-core/ui'
 import { getSession, getContainingView } from '@gmod/jbrowse-core/util'
 import IconButton from '@material-ui/core/IconButton'
 import Paper from '@material-ui/core/Paper'
@@ -9,13 +9,10 @@ import Typography from '@material-ui/core/Typography'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 import DragIcon from '@material-ui/icons/DragIndicator'
 import CloseIcon from '@material-ui/icons/Close'
-import SettingsIcon from '@material-ui/icons/Settings'
-import DeleteIcon from '@material-ui/icons/Delete'
-import CopyIcon from '@material-ui/icons/FileCopy'
 
 import clsx from 'clsx'
 import { observer } from 'mobx-react'
-import { getSnapshot, Instance } from 'mobx-state-tree'
+import { Instance } from 'mobx-state-tree'
 import React from 'react'
 import { BaseTrackStateModel } from '../../BasicTrack/baseTrackModel'
 import { LinearGenomeViewStateModel } from '..'
@@ -72,11 +69,6 @@ const TrackLabel = React.forwardRef(
 
     const handleClose = () => {
       setAnchorEl(null)
-    }
-
-    const onConfigureClick = () => {
-      track.activateConfigurationUI()
-      handleClose()
     }
 
     const onDragStart = (event: React.DragEvent<HTMLSpanElement>) => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -148,7 +148,10 @@ const TrackLabel = React.forwardRef(
           open={Boolean(anchorEl)}
           onClose={handleClose}
           menuItems={[
-            ...session.getTrackActionMenuItems(trackConf),
+            // @ts-ignore
+            ...(session.getTrackActionMenuItems &&
+              // @ts-ignore
+              session.getTrackActionMenuItems(trackConf)),
             ...track.trackMenuItems,
           ]}
         />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -148,7 +148,7 @@ const TrackLabel = React.forwardRef(
           open={Boolean(anchorEl)}
           onClose={handleClose}
           menuItems={[
-            ...(trackConf.fileMenuItems || []),
+            ...session.getTrackActionMenuItems(trackConf),
             ...track.trackMenuItems,
           ]}
         />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -62,6 +62,7 @@ const TrackLabel = React.forwardRef(
     const { track, className } = props
     const view = (getContainingView(track) as unknown) as LGV
     const session = getSession(track)
+    const trackConf = track.configuration
 
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
       setAnchorEl(event.currentTarget)
@@ -91,8 +92,9 @@ const TrackLabel = React.forwardRef(
     if (getConf(track, 'type') === 'ReferenceSequenceTrack') {
       trackName = 'Reference Sequence'
       session.assemblies.forEach(assembly => {
-        if (assembly.sequence === track.configuration)
+        if (assembly.sequence === trackConf) {
           trackName = `Reference Sequence (${readConfObject(assembly, 'name')})`
+        }
       })
     }
 
@@ -114,7 +116,7 @@ const TrackLabel = React.forwardRef(
             <DragIcon fontSize="small" className={classes.dragHandleIcon} />
           </span>
           <IconButton
-            onClick={() => view.hideTrack(track.configuration)}
+            onClick={() => view.hideTrack(trackConf)}
             className={classes.iconButton}
             title="close this track"
             color="secondary"
@@ -146,7 +148,7 @@ const TrackLabel = React.forwardRef(
           open={Boolean(anchorEl)}
           onClose={handleClose}
           menuItems={[
-            ...track.configuration.fileMenuItems,
+            ...(trackConf.fileMenuItems || []),
             ...track.trackMenuItems,
           ]}
         />

--- a/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
@@ -7,6 +7,7 @@ Object {
   "drawerWidth": 384,
   "margin": 0,
   "name": "testSession",
+  "sessionTracks": Array [],
   "views": Array [],
   "widgets": Object {},
 }

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -23,7 +23,7 @@ export default function RootModel(
   pluginManager: PluginManager,
   adminMode = false,
 ) {
-  const Session = sessionModelFactory(pluginManager, adminMode)
+  const Session = sessionModelFactory(pluginManager)
   const { assemblyConfigSchemas, dispatcher } = AssemblyConfigSchemasFactory(
     pluginManager,
   )

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -458,24 +458,28 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         const root = getParent(self)
         if (
           !root.adminMode &&
-          self.sessionTracks.indexOf(configuration) === -1 &&
-          // eslint-disable-next-line no-restricted-globals,no-alert
-          confirm(
-            'To edit the track configuration, you must clone ' +
-              'the track. Press OK to clone the track',
-          )
+          self.sessionTracks.indexOf(configuration) === -1
         ) {
-          const trackSnapshot = JSON.parse(
-            JSON.stringify(getSnapshot(configuration)),
-          )
-          trackSnapshot.trackId += `-${Date.now()}`
-          trackSnapshot.name += ' (copy)'
-          trackSnapshot.category = [' Session tracks']
-          const newTrackConf = self.addTrackConf(trackSnapshot)
-          setTimeout(() => {
-            this.editConfiguration(newTrackConf)
-          }, 500)
-          return newTrackConf
+          if (
+            // eslint-disable-next-line no-restricted-globals,no-alert
+            confirm(
+              'To edit the track configuration, you must clone ' +
+                'the track. Press OK to clone the track',
+            )
+          ) {
+            const trackSnapshot = JSON.parse(
+              JSON.stringify(getSnapshot(configuration)),
+            )
+            trackSnapshot.trackId += `-${Date.now()}`
+            trackSnapshot.name += ' (copy)'
+            trackSnapshot.category = [' Session tracks']
+            const newTrackConf = self.addTrackConf(trackSnapshot)
+            setTimeout(() => {
+              this.editConfiguration(newTrackConf)
+            }, 500)
+            return newTrackConf
+          }
+          return undefined
         }
 
         this.editConfiguration(configuration)

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -458,6 +458,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         const root = getParent(self)
         if (
           !root.adminMode &&
+          self.sessionTracks.indexOf(configuration) === -1 &&
           // eslint-disable-next-line no-restricted-globals
           confirm(
             'To edit the track configuration, you must clone ' +
@@ -468,6 +469,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
             JSON.stringify(getSnapshot(configuration)),
           )
           trackSnapshot.trackId += `-${Date.now()}`
+          trackSnapshot.name += ' (copy)'
           trackSnapshot.category = [' Session tracks']
           const newTrackConf = self.addTrackConf(trackSnapshot)
           setTimeout(() => {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -316,7 +316,6 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         const callbacksToDereferenceTrack: Function[] = []
         const dereferenceTypeCount: Record<string, number> = {}
         const referring = self.getReferring(trackConf)
-        console.log({ referring })
         this.removeReferring(
           referring,
           trackConf,

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -540,7 +540,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
               )
               trackSnapshot.trackId += `-${Date.now()}`
               trackSnapshot.name += ' (copy)'
-              trackSnapshot.category = [' Session tracks']
+              trackSnapshot.category = undefined
               session.addTrackConf(trackSnapshot)
             },
             icon: CopyIcon,

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -28,6 +28,9 @@ import {
   isConfigurationModel,
 } from '@gmod/jbrowse-core/configuration'
 import RpcManager from '@gmod/jbrowse-core/rpc/RpcManager'
+import SettingsIcon from '@material-ui/icons/Settings'
+import CopyIcon from '@material-ui/icons/FileCopy'
+import DeleteIcon from '@material-ui/icons/Delete'
 
 declare interface ReferringNode {
   node: IAnyStateTreeNode
@@ -500,6 +503,49 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           throw new Error("Can't edit the configuration of a non-session track")
         }
         this.editConfiguration(configuration)
+      },
+    }))
+    .views(self => ({
+      getTrackActionMenuItems(config: any) {
+        const session = self
+        const canEdit =
+          session.adminMode ||
+          session.sessionTracks.find((track: AnyConfigurationModel) => {
+            // @ts-ignore
+            return track.trackId === config.trackId
+          })
+
+        return [
+          {
+            label: 'Settings',
+            disabled: !canEdit,
+            onClick: () => {
+              session.editTrackConfiguration(config)
+            },
+            icon: SettingsIcon,
+          },
+          {
+            label: 'Delete track',
+            disabled: !canEdit,
+            onClick: () => {
+              session.deleteTrackConf(config)
+            },
+            icon: DeleteIcon,
+          },
+          {
+            label: 'Copy track',
+            onClick: () => {
+              const trackSnapshot = JSON.parse(
+                JSON.stringify(getSnapshot(config)),
+              )
+              trackSnapshot.trackId += `-${Date.now()}`
+              trackSnapshot.name += ' (copy)'
+              trackSnapshot.category = [' Session tracks']
+              session.addTrackConf(trackSnapshot)
+            },
+            icon: CopyIcon,
+          },
+        ]
       },
     }))
 }

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -454,6 +454,31 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         )
         editableConfigSession.showWidget(editor)
       },
+      editTrackConfiguration(configuration: AnyConfigurationModel) {
+        const root = getParent(self)
+        if (
+          !root.adminMode &&
+          // eslint-disable-next-line no-restricted-globals
+          confirm(
+            'To edit the track configuration, you must clone ' +
+              'the track. Press OK to clone the track',
+          )
+        ) {
+          const trackSnapshot = JSON.parse(
+            JSON.stringify(getSnapshot(configuration)),
+          )
+          trackSnapshot.trackId += `-${Date.now()}`
+          trackSnapshot.category = [' Session tracks']
+          const newTrackConf = self.addTrackConf(trackSnapshot)
+          setTimeout(() => {
+            this.editConfiguration(newTrackConf)
+          }, 500)
+          return newTrackConf
+        }
+
+        this.editConfiguration(configuration)
+        return configuration
+      },
     }))
 }
 

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -95,6 +95,9 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       get connections() {
         return getParent(self).jbrowse.connections
       },
+      get adminMode() {
+        return getParent(self).adminMode
+      },
       get savedSessions() {
         return getParent(self).jbrowse.savedSessions
       },
@@ -273,7 +276,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       addTrackConf(trackConf: any) {
-        if (getParent(self).adminMode) {
+        if (self.adminMode) {
           return getParent(self).jbrowse.addTrackConf(trackConf)
         }
         const { trackId, type } = trackConf
@@ -455,8 +458,10 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         editableConfigSession.showWidget(editor)
       },
       editTrackConfiguration(configuration: AnyConfigurationModel) {
-        const { adminMode } = getParent(self)
-        if (!adminMode && self.sessionTracks.indexOf(configuration) === -1) {
+        if (
+          !self.adminMode &&
+          self.sessionTracks.indexOf(configuration) === -1
+        ) {
           throw new Error("Can't edit the configuration of a non-session track")
         }
         this.editConfiguration(configuration)

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -2,7 +2,6 @@
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import {
   Region,
-  SessionWithWidgets,
   NotificationLevel,
   AbstractSessionModel,
   TrackViewModel,

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -455,35 +455,11 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         editableConfigSession.showWidget(editor)
       },
       editTrackConfiguration(configuration: AnyConfigurationModel) {
-        const root = getParent(self)
-        if (
-          !root.adminMode &&
-          self.sessionTracks.indexOf(configuration) === -1
-        ) {
-          if (
-            // eslint-disable-next-line no-restricted-globals,no-alert
-            confirm(
-              'To edit the track configuration, you must clone ' +
-                'the track. Press OK to clone the track',
-            )
-          ) {
-            const trackSnapshot = JSON.parse(
-              JSON.stringify(getSnapshot(configuration)),
-            )
-            trackSnapshot.trackId += `-${Date.now()}`
-            trackSnapshot.name += ' (copy)'
-            trackSnapshot.category = [' Session tracks']
-            const newTrackConf = self.addTrackConf(trackSnapshot)
-            setTimeout(() => {
-              this.editConfiguration(newTrackConf)
-            }, 500)
-            return newTrackConf
-          }
-          return undefined
+        const { adminMode } = getParent(self)
+        if (!adminMode && self.sessionTracks.indexOf(configuration) === -1) {
+          throw new Error("Can't edit the configuration of a non-session track")
         }
-
         this.editConfiguration(configuration)
-        return configuration
       },
     }))
 }

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -20,7 +20,6 @@ import {
   SnapshotIn,
   types,
   walk,
-  cast,
   Instance,
 } from 'mobx-state-tree'
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
@@ -288,11 +287,11 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         self.views.remove(view)
       },
 
-      addAssemblyConf(assemblyConf: any) {
+      addAssemblyConf(assemblyConf: AnyConfigurationModel) {
         return getParent(self).jbrowse.addAssemblyConf(assemblyConf)
       },
 
-      addTrackConf(trackConf: any) {
+      addTrackConf(trackConf: AnyConfigurationModel) {
         if (self.adminMode) {
           return getParent(self).jbrowse.addTrackConf(trackConf)
         }
@@ -308,13 +307,16 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         return self.sessionTracks[length - 1]
       },
 
-      deleteTrackConf(trackConf: any) {
+      deleteTrackConf(trackConf: AnyConfigurationModel) {
         const { trackId } = trackConf
         const idx = self.sessionTracks.findIndex(t => t.trackId === trackId)
-        console.log({ idx })
+        if (idx === -1) {
+          return undefined
+        }
         const callbacksToDereferenceTrack: Function[] = []
         const dereferenceTypeCount: Record<string, number> = {}
         const referring = self.getReferring(trackConf)
+        console.log({ referring })
         this.removeReferring(
           referring,
           trackConf,

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -37,7 +37,7 @@ declare interface ReferringNode {
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
   const minDrawerWidth = 128
-  const session = types
+  return types
     .model('JBrowseWebSessionModel', {
       name: types.identifier,
       margin: 0,

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -459,7 +459,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         if (
           !root.adminMode &&
           self.sessionTracks.indexOf(configuration) === -1 &&
-          // eslint-disable-next-line no-restricted-globals
+          // eslint-disable-next-line no-restricted-globals,no-alert
           confirm(
             'To edit the track configuration, you must clone ' +
               'the track. Press OK to clone the track',

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -102,9 +102,8 @@ describe('test configuration editor', () => {
     await findByText('Help')
     state.session.views[0].setNewView(0.05, 5000)
     fireEvent.click(await findByTestId('htsTrackEntry-volvox_filtered_vcf'))
-    fireEvent.click(
-      await findByTestId('htsTrackEntryConfigure-volvox_filtered_vcf'),
-    )
+    fireEvent.click(await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf'))
+    fireEvent.click(await findByText('Settings'))
     await expect(findByTestId('configEditor')).resolves.toBeTruthy()
     const input = await findByDisplayValue('goldenrod')
     fireEvent.change(input, { target: { value: 'green' } })

--- a/products/jbrowse-web/src/tests/util.js
+++ b/products/jbrowse-web/src/tests/util.js
@@ -13,7 +13,7 @@ configSnapshot.configuration = {
   useUrlSession: false,
 }
 
-export function getPluginManager(initialState, adminMode = false, sessionName) {
+export function getPluginManager(initialState, adminMode = true, sessionName) {
   const pluginManager = new PluginManager(corePlugins.map(P => new P()))
   pluginManager.createPluggableElements()
 


### PR DESCRIPTION
This is a very simple minimal set of changes to allow session tracks

Notes

1) Very minimal set of changes, checks if admin mode in addTrackConf, diverts to rootModel.jbrowse if so, otherwise adds to session.sessionTracks
2) Then we generateHierarchy(session.tracks.concat(session.sessionTracks)) for the hierarchical track selector

This is very minimal nicely and allows refreshing the page and keeping your added track if it is a URL

Other notes
1) Does not know how to handle refreshing a local file that was opened, might want to check for that
2) Has xss related to config callbacks in the URL

