### PR TITLE
Pre-commit formatting bugfix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 **/coverage/
 **/umd
 **/dist/
+**/build/
 
 # JSON files we don't want to format
 **/*nclist*/**/*.json

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.5.0",
-    "prettier": "^2.0.0",
+    "prettier": "^2.1.0",
     "prop-types": "^15.0.0",
     "range-parser": "^1.2.1",
     "react": "^16.8.0",

--- a/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
@@ -18,7 +18,8 @@ import { configSchema as FromConfigAdapterConfigSchema } from './configSchema'
  *   `"features": [ { "refName": "ctgA", "start":1, "end":20 }, ... ]`
  */
 
-export default class FromConfigAdapter extends BaseFeatureDataAdapter
+export default class FromConfigAdapter
+  extends BaseFeatureDataAdapter
   implements RegionsAdapter {
   private features: Map<string, Feature[]>
 

--- a/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
+++ b/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
@@ -12,7 +12,8 @@ import { Instance } from 'mobx-state-tree'
 
 import configSchema from './configSchema'
 
-export default class TwoBitAdapter extends BaseFeatureDataAdapter
+export default class TwoBitAdapter
+  extends BaseFeatureDataAdapter
   implements RegionsAdapter {
   private twobit: typeof TwoBitFile
 

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -20,7 +20,8 @@ import {
 
 import configSchema from './configSchema'
 
-export default class BigWigAdapter extends BaseFeatureDataAdapter
+export default class BigWigAdapter
+  extends BaseFeatureDataAdapter
   implements DataAdapterWithGlobalStats {
   private bigwig: BigWig
 

--- a/products/jbrowse-web/public/index.html
+++ b/products/jbrowse-web/public/index.html
@@ -22,7 +22,7 @@
     -->
     <title>JBrowse</title>
   </head>
-  <body style="overscroll-behavior: none;">
+  <body style="overscroll-behavior: none">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -27,9 +27,11 @@ function main() {
   const filesToFormat = changedFiles.filter(fileName => !isJSOrTSFile(fileName))
   // Run prettier formatting on non-JS/TS files
   if (filesToFormat.length) {
-    spawn.sync('yarn', ['prettier', '--write', ...filesToFormat], {
-      stdio: 'inherit',
-    })
+    spawn.sync(
+      'yarn',
+      ['prettier', ...filesToFormat, '--write', '--ignore-unknown'],
+      { stdio: 'inherit' },
+    )
     spawn.sync('git', ['add', ...filesToFormat], { stdio: 'inherit' })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17909,10 +17909,10 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-bytes@^5.1.0, pretty-bytes@^5.2.0:
   version "5.3.0"


### PR DESCRIPTION
Originally noticed by @elliothershberg, in the pre-commit hook, if the prettier didn't recognize any of the file types it tried to format, it threw an error:

![image](https://user-images.githubusercontent.com/25592344/93527681-76fa9b80-f8f6-11ea-8b45-133dc96e4376.png)

Fixed by using the `--ignore-unknown` prettier CLI flag, new in v2.1.0.

