### PR TITLE
Speedup for sparse SNPCoverage tracks

### DIFF
--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.test.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.test.ts
@@ -63,7 +63,7 @@ test('SNP adapter can fetch features from volvox.bam using bam subadapter', asyn
   expect(featuresArray[0].get('snpinfo')).toBeTruthy()
 
   const featuresJsonArray = featuresArray.map(f => f.toJSON())
-  expect(featuresJsonArray.length).toEqual(20000)
+  expect(featuresJsonArray.length).toEqual(19998)
   expect(featuresJsonArray.slice(1000, 1010)).toMatchSnapshot()
 
   expect(await adapter.hasDataForRefName('ctgA')).toBe(true)

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -144,18 +144,20 @@ export default (pluginManager: PluginManager) => {
           opts.bpPerPx || 1,
         )
         coverageBins.forEach((bin, index) => {
-          observer.next(
-            new SimpleFeature({
-              id: `pos_${region.start}${index}`,
-              data: {
-                score: bin.total(),
-                snpinfo: generateInfoList(bin), // info needed to draw snps
-                start: region.start + index,
-                end: region.start + index + 1,
-                refName: region.refName,
-              },
-            }),
-          )
+          if (bin.total()) {
+            observer.next(
+              new SimpleFeature({
+                id: `pos_${region.start}${index}`,
+                data: {
+                  score: bin.total(),
+                  snpinfo: generateInfoList(bin), // info needed to draw snps
+                  start: region.start + index,
+                  end: region.start + index + 1,
+                  refName: region.refName,
+                },
+              }),
+            )
+          }
         })
 
         observer.complete()


### PR DESCRIPTION
Fixes #1222 (git checkout skbr3_rnaseq; git pull --rebase origin speedup_snpcoverage to test)


A more scalable solution might be helpful since it could be useful to render large regions, but this helps with sparse ones a lot