### PR TITLE
Allow skip check to apply to localpath

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -382,19 +382,15 @@ export default class AddTrack extends JBrowseCommand {
       }
     }
     try {
-      locationPath = await fsPromises.realpath(location)
+      locationPath = check
+        ? path.relative(process.cwd(), await fsPromises.realpath(location))
+        : location
     } catch (e) {
       // ignore
     }
     if (locationPath) {
-      const filePath = path.relative(process.cwd(), locationPath)
-      //   if (filePath.startsWith('..')) {
-      //     this.warn(
-      //       `Location ${filePath} is not in the JBrowse directory. Make sure it is still in your server directory.`,
-      //     )
-      //   }
       locationObj = {
-        location: filePath,
+        location: locationPath,
         protocol: 'uri',
         local: true,
       }


### PR DESCRIPTION
Addresses #1228 

Resulting command can be like this, which dumps my results into a target config
```
jbrowse add-track test_data/CANVAS.chr4-39348425_AAGGG_0_0.bam --target test_data/config_demo.json --assemblyNames hg38 --skipCheck --load trust
```


