### PR TITLE
Add a bugfix to PileupRenderer

### DIFF
--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -320,7 +320,11 @@ export default class PileupRenderer extends BoxRendererType {
               )
             }
           } else if (mismatch.type === 'skip') {
-            ctx.clearRect(mismatchLeftPx, topPx, mismatchWidthPx, heightPx)
+            // fix to avoid bad rendering
+            // ref #1236
+            if (mismatchLeftPx + mismatchWidthPx > 0) {
+              ctx.clearRect(mismatchLeftPx, topPx, mismatchWidthPx, heightPx)
+            }
             ctx.fillStyle = '#333'
             ctx.fillRect(
               mismatchLeftPx,

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -321,6 +321,7 @@ export default class PileupRenderer extends BoxRendererType {
             }
           } else if (mismatch.type === 'skip') {
             // fix to avoid bad rendering
+            // note that this was also related to chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=1131528
             // ref #1236
             if (mismatchLeftPx + mismatchWidthPx > 0) {
               ctx.clearRect(mismatchLeftPx, topPx, mismatchWidthPx, heightPx)


### PR DESCRIPTION
This was a rendering bug with the skip/intron rendering that was triggered by long isoseq reads

![t1](https://user-images.githubusercontent.com/6511937/93886905-0071eb00-fcb4-11ea-8236-d27039902e8b.png)

fixed

![t2](https://user-images.githubusercontent.com/6511937/93886980-14b5e800-fcb4-11ea-92b3-c618cbf392d4.png)

Possibly caused by long off-screen rendering of canvas, but kind of surprising still

