### PR TITLE
Fix hq_isoform.bam rendering with fixes to getTemplateLocalCoord

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
@@ -69,10 +69,59 @@ test('get mismatches', () => {
     { altbase: 'A', base: 'C', length: 1, start: 5, type: 'mismatch' },
     { altbase: 'C', base: 'A', length: 1, start: 6, type: 'mismatch' },
   ])
+})
+
+test('basic skip', () => {
   expect(getMismatches('6M200N6M', '5AC5', 'GGGGGCATTTTT')).toEqual([
     { base: 'N', length: 200, start: 6, type: 'skip' },
     { altbase: 'A', base: 'C', length: 1, start: 5, type: 'mismatch' },
     { altbase: 'C', base: 'A', length: 1, start: 206, type: 'mismatch' },
+  ])
+})
+
+test('vsbuffalo', () => {
+  // https://github.com/vsbuffalo/devnotes/wiki/The-MD-Tag-in-BAM-Files
+  // example 1
+  expect(
+    getMismatches(
+      '89M1I11M',
+      '100',
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    ),
+  ).toEqual([{ base: '1', length: 1, start: 89, type: 'insertion' }])
+
+  // https://github.com/vsbuffalo/devnotes/wiki/The-MD-Tag-in-BAM-Files
+  // example 2
+  expect(
+    getMismatches(
+      '9M1I91M',
+      '48T42G8',
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    ),
+  ).toEqual([
+    { base: '1', length: 1, start: 9, type: 'insertion' },
+    {
+      altbase: 'T',
+      base: 'A',
+      length: 1,
+      start: 48,
+      type: 'mismatch',
+    },
+    {
+      altbase: 'G',
+      base: 'A',
+      length: 1,
+      start: 91,
+      type: 'mismatch',
+    },
+  ])
+})
+
+test('more skip', () => {
+  expect(getMismatches('3M200N3M200N3M', '8A', 'GGGGGCATTTTT')).toEqual([
+    { base: 'N', length: 200, start: 3, type: 'skip' },
+    { base: 'N', length: 200, start: 206, type: 'skip' },
+    { altbase: 'A', base: 'T', length: 1, start: 408, type: 'mismatch' },
   ])
   expect(
     getMismatches('31M1I17M1D37M', '6G4C20G1A5C5A1^C3A15G1G15', seq).sort(

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -93,26 +93,17 @@ export function mdToMismatches(
 ): Mismatch[] {
   const mismatchRecords: Mismatch[] = []
   let curr: Mismatch = { start: 0, base: '', length: 0, type: 'mismatch' }
-  const hasSkip = cigarMismatches.find(cigar => cigar.type === 'skip')
+  const skips = cigarMismatches.filter(cigar => cigar.type === 'skip')
   let lastCigar = 0
   let lastTemplateOffset = 0
   let lastRefOffset = 0
+  let lastSkipPos = 0
 
   // convert a position on the reference sequence to a position
   // on the template sequence, taking into account hard and soft
   // clipping of reads
 
   function nextRecord(): void {
-    // correct the start of the current mismatch if it comes after a cigar skip
-    if (hasSkip) {
-      cigarMismatches.forEach((mismatch: Mismatch) => {
-        if (mismatch.type === 'skip' && curr.start >= mismatch.start) {
-          curr.start += mismatch.length
-        }
-      })
-    }
-
-    // record it
     mismatchRecords.push(curr)
 
     // get a new mismatch record ready
@@ -136,7 +127,7 @@ export function mdToMismatches(
       const op = cigarOps[i + 1]
       if (op === 'S' || op === 'I') {
         templateOffset += len
-      } else if (op === 'D' || op === 'P') {
+      } else if (op === 'D' || op === 'P' || op === 'N') {
         refOffset += len
       } else if (op !== 'H') {
         templateOffset += len
@@ -145,6 +136,7 @@ export function mdToMismatches(
     }
     lastTemplateOffset = templateOffset
     lastRefOffset = refOffset
+
     return templateOffset - (refOffset - refCoord)
   }
 
@@ -164,6 +156,16 @@ export function mdToMismatches(
       // mismatch
       for (let j = 0; j < token.length; j += 1) {
         curr.length = 1
+
+        while (lastSkipPos < skips.length) {
+          const mismatch = skips[lastSkipPos]
+          if (curr.start >= mismatch.start) {
+            curr.start += mismatch.length
+            lastSkipPos++
+          } else {
+            break
+          }
+        }
         curr.base = seq
           ? seq.substr(
               cigarOps ? getTemplateCoordLocal(curr.start) : curr.start,


### PR DESCRIPTION
Fix for #1235 

Instead of making "getTemplateLocalCoord ignore the N" which is what it currently does, and works ok when there was just one N in a read, we incorporate N for getTemplateLocalCoord which helps with isoseq which can have many N segments

Still draft PR for the moment