### PR TITLE
Add assembly fix when outside of directory

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -98,6 +98,9 @@ OPTIONS
   --gziLocation=gziLocation
       [default: <fastaLocation>.gzi] FASTA gzip index file or URL
 
+  --out=out
+      synonym for target
+
   --overwrite
       Overwrite existing assembly if one with the same name exists
 
@@ -117,7 +120,7 @@ OPTIONS
       Don't check whether or not the sequence file or URL exists or if you are in a JBrowse directory
 
   --target=target
-      [default: ./config.json] path to config file in JB2 installation directory to write out to.
+      path to config file in JB2 installation directory to write out to.
       Creates ./config.json if nonexistent
 
 EXAMPLES

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -164,13 +164,14 @@ OPTIONS
   --connectionId=connectionId      Id for the connection that must be unique to JBrowse.  Defaults to
                                    'connectionType-assemblyName-currentTime'
 
+  --out=out                        synonym for target
+
   --overwrite                      Overwrites any existing connections if same connection id
 
   --skipCheck                      Don't check whether or not the data directory URL exists or if you are in a JBrowse
                                    directory
 
-  --target=target                  [default: ./config.json] path to config file in JB2 installation directory to write
-                                   out to.
+  --target=target                  path to config file in JB2 installation directory to write out to.
 
 EXAMPLES
   $ jbrowse add-connection http://mysite.com/jbrowse/data/
@@ -218,13 +219,14 @@ OPTIONS
   --config=config                       Any extra config settings to add to a track. i.e '{"defaultRendering":
                                         "density"}'
 
+  --out=out                             synonym for target
+
   --overwrite                           Overwrites existing track if it shares the same trackId
 
   --skipCheck                           Skip check for whether or not the file or URL exists or if you are in a JBrowse
                                         directory
 
-  --target=target                       [default: ./config.json] path to config file in JB2 installation to write out
-                                        to.
+  --target=target                       path to config file in JB2 installation to write out to.
 
   --trackId=trackId                     trackId for the track, by default inferred from filename, must be unique
                                         throughout config
@@ -251,8 +253,9 @@ ARGUMENTS
 
 OPTIONS
   -u, --update     update the contents of an existing track, matched based on trackId
+  --out=out        synonym for target
 
-  --target=target  [default: ./config.json] path to config file in JB2 installation directory to write out to.
+  --target=target  path to config file in JB2 installation directory to write out to.
                    Creates ./config.json if nonexistent
 
 EXAMPLES
@@ -274,9 +277,11 @@ OPTIONS
   -p, --port=port  Specifified port to start the server on;
                    Default is 9090.
 
+  --out=out        synonym for target
+
   --skipCheck      Don't check whether or not you are in a JBrowse directory
 
-  --target=target  [default: ./config.json] path to config file in JB2 installation directory to write out to.
+  --target=target  path to config file in JB2 installation directory to write out to.
                    Creates ./config.json if nonexistent
 
 EXAMPLES
@@ -349,7 +354,9 @@ OPTIONS
                          DotplotView.
                          Must be provided if no default session file provided
 
-  --target=target        [default: ./config.json] path to config file in JB2 installation directory to write out to
+  --out=out              synonym for target
+
+  --target=target        path to config file in JB2 installation directory to write out to
 
   --viewId=viewId        Identifier for the view. Will be generated on default
 

--- a/products/jbrowse-cli/src/commands/add-assembly.test.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.test.ts
@@ -79,30 +79,6 @@ describe('add-assembly', () => {
     .it('fails if trying to add an assembly with a name that already exists')
 
   setup
-    .do(async () => {
-      await fsPromises.unlink('manifest.json')
-    })
-    .command(['add-assembly', 'simple.fasta'])
-    .exit(10)
-    .it('fails if no manifest.json found in cwd')
-
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', 'This Is Invalid JSON')
-    })
-    .command(['add-assembly', 'simple.fasta'])
-    .exit(20)
-    .it("fails if it can't parse manifest.json")
-
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', '{"name":"NotJBrowse"}')
-    })
-    .command(['add-assembly', 'simple.fasta'])
-    .exit(30)
-    .it('fails if "name" in manifest.json is not "JBrowse"')
-
-  setup
     .command(['add-assembly', 'simple.unusual.extension.xyz', '--load', 'copy'])
     .exit(170)
     .it('fails if it cannot guess the sequence type')

--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -13,6 +13,9 @@ function isValidJSON(string: string) {
 }
 
 export default class AddAssembly extends JBrowseCommand {
+  // @ts-ignore
+  target: string
+
   static description = 'Add an assembly to a JBrowse 2 configuration'
 
   static examples = [
@@ -93,7 +96,9 @@ custom         Either a JSON file location or inline JSON that defines a custom
     target: flags.string({
       description:
         'path to config file in JB2 installation directory to write out to.\nCreates ./config.json if nonexistent',
-      default: './config.json',
+    }),
+    out: flags.string({
+      description: 'synonym for target',
     }),
     help: flags.help({ char: 'h' }),
     load: flags.string({
@@ -181,12 +186,8 @@ custom         Either a JSON file location or inline JSON that defines a custom
             ])
           : false
         if (loaded) {
-          sequenceLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(sequenceLocation)),
-          )
-          indexLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(indexLocation)),
-          )
+          sequenceLocation = path.basename(sequenceLocation)
+          indexLocation = path.basename(indexLocation)
         }
         sequence = {
           type: 'ReferenceSequenceTrack',
@@ -236,15 +237,9 @@ custom         Either a JSON file location or inline JSON that defines a custom
             ])
           : false
         if (loaded) {
-          sequenceLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(sequenceLocation)),
-          )
-          indexLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(indexLocation)),
-          )
-          bgzipIndexLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(bgzipIndexLocation)),
-          )
+          sequenceLocation = path.basename(sequenceLocation)
+          indexLocation = path.basename(indexLocation)
+          bgzipIndexLocation = path.basename(bgzipIndexLocation)
         }
         sequence = {
           type: 'ReferenceSequenceTrack',
@@ -273,9 +268,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
           ? await this.loadData(runFlags.load, [sequenceLocation])
           : false
         if (loaded) {
-          sequenceLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(sequenceLocation)),
-          )
+          sequenceLocation = path.basename(sequenceLocation)
         }
         sequence = {
           type: 'ReferenceSequenceTrack',
@@ -293,7 +286,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
           !(runFlags.skipCheck || runFlags.force),
           runFlags.load === 'inPlace',
         )
-        this.debug(`chrome.sizes location resolved to: ${sequenceLocation}`)
+        this.debug(`chrom.sizes location resolved to: ${sequenceLocation}`)
         if (!name) {
           name = path.basename(sequenceLocation, '.chrom.sizes')
           this.debug(`Guessing name: ${name}`)
@@ -302,9 +295,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
           ? await this.loadData(runFlags.load, [sequenceLocation])
           : false
         if (loaded) {
-          sequenceLocation = await this.resolveFileLocation(
-            path.join('.', path.basename(sequenceLocation)),
-          )
+          sequenceLocation = path.basename(sequenceLocation)
         }
         sequence = {
           type: 'ReferenceSequenceTrack',
@@ -353,9 +344,10 @@ custom         Either a JSON file location or inline JSON that defines a custom
   async run() {
     const { args: runArgs, flags: runFlags } = this.parse(AddAssembly)
 
-    if (!(runFlags.skipCheck || runFlags.force)) {
-      await this.checkLocation(path.dirname(runFlags.target))
-    }
+    const output = runFlags.target || runFlags.out || '.'
+    const isDir = (await fsPromises.lstat(output)).isDirectory()
+    this.target = isDir ? `${output}/config.json` : output
+
     const { sequence: argsSequence } = runArgs as { sequence: string }
     this.debug(`Sequence location is: ${argsSequence}`)
     const { name } = runFlags
@@ -428,14 +420,14 @@ custom         Either a JSON file location or inline JSON that defines a custom
 
     let configContents: Config
 
-    if (fs.existsSync(runFlags.target)) {
-      this.debug(`Found existing config file ${runFlags.target}`)
+    if (fs.existsSync(this.target)) {
+      this.debug(`Found existing config file ${this.target}`)
       configContents = {
         ...defaultConfig,
-        ...(await this.readJsonFile(runFlags.target)),
+        ...(await this.readJsonFile(this.target)),
       }
     } else {
-      this.debug(`Creating config file ${runFlags.target}`)
+      this.debug(`Creating config file ${this.target}`)
       configContents = { ...defaultConfig }
     }
 
@@ -460,13 +452,13 @@ custom         Either a JSON file location or inline JSON that defines a custom
       configContents.assemblies.push(assembly)
     }
 
-    this.debug(`Writing configuration to file ${runFlags.target}`)
-    await this.writeJsonFile(runFlags.target, configContents)
+    this.debug(`Writing configuration to file ${this.target}`)
+    await this.writeJsonFile(this.target, configContents)
 
     this.log(
       `${idx !== -1 ? 'Overwrote' : 'Added'} assembly "${assembly.name}" ${
         idx !== -1 ? 'in' : 'to'
-      } ${runFlags.target}`,
+      } ${this.target}`,
     )
   }
 
@@ -509,6 +501,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
 
   async loadData(load: string, filePaths: string[]) {
     let locationUrl: URL | undefined
+    const destination = this.target
     try {
       locationUrl = new URL(filePaths[0])
     } catch (error) {
@@ -521,8 +514,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            const dataLocation = path.join('.', path.basename(filePath))
-            return fsPromises.copyFile(filePath, dataLocation)
+            return fsPromises.copyFile(filePath, destination)
           }),
         )
         return true
@@ -531,8 +523,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            const dataLocation = path.join('.', path.basename(filePath))
-            return fsPromises.symlink(filePath, dataLocation)
+            return fsPromises.symlink(filePath, destination)
           }),
         )
         return true
@@ -541,8 +532,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            const dataLocation = path.join('.', path.basename(filePath))
-            return fsPromises.rename(filePath, dataLocation)
+            return fsPromises.rename(filePath, destination)
           }),
         )
         return true

--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -514,7 +514,10 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            return fsPromises.copyFile(filePath, destination)
+            return fsPromises.copyFile(
+              filePath,
+              path.join(path.dirname(destination), path.basename(filePath)),
+            )
           }),
         )
         return true
@@ -523,7 +526,10 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            return fsPromises.symlink(filePath, destination)
+            return fsPromises.symlink(
+              filePath,
+              path.join(path.dirname(destination), path.basename(filePath)),
+            )
           }),
         )
         return true
@@ -532,7 +538,10 @@ custom         Either a JSON file location or inline JSON that defines a custom
         await Promise.all(
           filePaths.map(async filePath => {
             if (!filePath) return undefined
-            return fsPromises.rename(filePath, destination)
+            return fsPromises.rename(
+              filePath,
+              path.join(path.dirname(destination), path.basename(filePath)),
+            )
           }),
         )
         return true

--- a/products/jbrowse-cli/src/commands/add-connection.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.ts
@@ -1,5 +1,6 @@
 import { flags } from '@oclif/command'
 import fetch from 'node-fetch'
+import { promises as fsPromises } from 'fs'
 import path from 'path'
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
@@ -19,6 +20,9 @@ interface Config {
 }
 
 export default class AddConnection extends JBrowseCommand {
+  // @ts-ignore
+  private target: string
+
   static description = 'Add a connection to a JBrowse 2 configuration'
 
   static examples = [
@@ -64,7 +68,9 @@ export default class AddConnection extends JBrowseCommand {
     target: flags.string({
       description:
         'path to config file in JB2 installation directory to write out to.',
-      default: './config.json',
+    }),
+    out: flags.string({
+      description: 'synonym for target',
     }),
     help: flags.help({ char: 'h' }),
     skipCheck: flags.boolean({
@@ -82,14 +88,19 @@ export default class AddConnection extends JBrowseCommand {
 
   async run() {
     const { args: runArgs, flags: runFlags } = this.parse(AddConnection)
+
+    const output = runFlags.target || runFlags.out || '.'
+    const isDir = (await fsPromises.lstat(output)).isDirectory()
+    this.target = isDir ? `${output}/config.json` : output
+
     const { connectionUrlOrPath: argsPath } = runArgs as {
       connectionUrlOrPath: string
     }
-    const { config, target } = runFlags
+    const { config } = runFlags
     let { type, name, connectionId, assemblyName } = runFlags
 
     if (!(runFlags.skipCheck || runFlags.force)) {
-      await this.checkLocation(path.dirname(target))
+      await this.checkLocation(path.dirname(this.target))
     }
 
     const url = await this.resolveURL(
@@ -97,8 +108,8 @@ export default class AddConnection extends JBrowseCommand {
       !(runFlags.skipCheck || runFlags.force),
     )
 
-    const configContents: Config = await this.readJsonFile(target)
-    this.debug(`Using config file ${target}`)
+    const configContents: Config = await this.readJsonFile(this.target)
+    this.debug(`Using config file ${this.target}`)
 
     if (!configContents.assemblies || !configContents.assemblies.length) {
       this.error(
@@ -197,13 +208,13 @@ export default class AddConnection extends JBrowseCommand {
       }
     } else configContents.connections.push(connectionConfig)
 
-    this.debug(`Writing configuration to file ${target}`)
-    await this.writeJsonFile(target, configContents)
+    this.debug(`Writing configuration to file ${this.target}`)
+    await this.writeJsonFile(this.target, configContents)
 
     this.log(
       `${idx !== -1 ? 'Overwrote' : 'Added'} connection "${name}" ${
         idx !== -1 ? 'in' : 'to'
-      } ${target}`,
+      } ${this.target}`,
     )
   }
 

--- a/products/jbrowse-cli/src/commands/add-track-json.ts
+++ b/products/jbrowse-cli/src/commands/add-track-json.ts
@@ -1,8 +1,12 @@
 import { flags } from '@oclif/command'
+import { promises as fsPromises } from 'fs'
 import path from 'path'
 import JBrowseCommand, { Config } from '../base'
 
 export default class AddTrackJson extends JBrowseCommand {
+  // @ts-ignore
+  target: string
+
   static description =
     'Add a track configuration directly from a JSON hunk to the JBrowse 2 configuration'
 
@@ -27,20 +31,27 @@ export default class AddTrackJson extends JBrowseCommand {
     target: flags.string({
       description:
         'path to config file in JB2 installation directory to write out to.\nCreates ./config.json if nonexistent',
-      default: './config.json',
+    }),
+    out: flags.string({
+      description: 'synonym for target',
     }),
   }
 
   async run() {
     const { args, flags: runFlags } = this.parse(AddTrackJson)
+
+    const output = runFlags.target || runFlags.out || '.'
+    const isDir = (await fsPromises.lstat(output)).isDirectory()
+    this.target = isDir ? `${output}/config.json` : output
+
     const { track: inputtedTrack } = args as { track: string }
 
     this.debug(`Sequence location is: ${inputtedTrack}`)
-    const { update, target } = runFlags
-    await this.checkLocation(path.dirname(target))
+    const { update } = runFlags
+    await this.checkLocation(path.dirname(this.target))
 
-    const config: Config = await this.readJsonFile(target)
-    this.debug(`Found existing config file ${target}`)
+    const config: Config = await this.readJsonFile(this.target)
+    this.debug(`Found existing config file ${this.target}`)
 
     const track = await this.readInlineOrFileJson(inputtedTrack)
     if (!config.tracks) {
@@ -64,12 +75,12 @@ export default class AddTrackJson extends JBrowseCommand {
     } else {
       config.tracks.push(track)
     }
-    this.debug(`Writing configuration to file ${target}`)
-    await this.writeJsonFile(target, config)
+    this.debug(`Writing configuration to file ${this.target}`)
+    await this.writeJsonFile(this.target, config)
     this.log(
       `${idx !== -1 ? 'Overwrote' : 'Added'} assembly "${track.name}" ${
         idx !== -1 ? 'in' : 'to'
-      } ${target}`,
+      } ${this.target}`,
     )
   }
 }

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -24,6 +24,9 @@ interface Config {
 }
 
 export default class SetDefaultSession extends JBrowseCommand {
+  // @ts-ignore
+  private target: string
+
   static description = 'Set a default session with views and tracks'
 
   static examples = [
@@ -65,7 +68,9 @@ export default class SetDefaultSession extends JBrowseCommand {
     target: flags.string({
       description:
         'path to config file in JB2 installation directory to write out to',
-      default: './config.json',
+    }),
+    out: flags.string({
+      description: 'synonym for target',
     }),
     help: flags.help({
       char: 'h',
@@ -74,19 +79,14 @@ export default class SetDefaultSession extends JBrowseCommand {
 
   async run() {
     const { flags: runFlags } = this.parse(SetDefaultSession)
-    const {
-      session,
-      name,
-      tracks,
-      currentSession,
-      view,
-      viewId,
-      target,
-    } = runFlags
+    const { session, name, tracks, currentSession, view, viewId } = runFlags
+    const output = runFlags.target || runFlags.out || '.'
+    const isDir = (await fsPromises.lstat(output)).isDirectory()
+    this.target = isDir ? `${output}/config.json` : output
 
-    await this.checkLocation(path.dirname(target))
+    await this.checkLocation(path.dirname(this.target))
 
-    const configContents: Config = await this.readJsonFile(target)
+    const configContents: Config = await this.readJsonFile(this.target)
 
     // if user passes current session flag, print out and exit
     if (currentSession) {
@@ -152,15 +152,15 @@ export default class SetDefaultSession extends JBrowseCommand {
         ],
       }
     }
-    this.debug(`Writing configuration to file ${target}`)
-    await this.writeJsonFile(target, configContents)
+    this.debug(`Writing configuration to file ${this.target}`)
+    await this.writeJsonFile(this.target, configContents)
 
     this.log(
       `${
         existingDefaultSession ? 'Overwrote' : 'Added'
-      } defaultSession "${name}" ${
-        existingDefaultSession ? 'in' : 'to'
-      } ${target}`,
+      } defaultSession "${name}" ${existingDefaultSession ? 'in' : 'to'} ${
+        this.target
+      }`,
     )
   }
 


### PR DESCRIPTION
With this PR I can say


jbrowse create mydir
jbrowse add-assembly ~/volvox.fa --out mydir --load copy

This will copy the files in there and copy them

I also make --out a synonym of --target, and allow using only the foldername instead of directly pointing to a config.json file. This much more commonly matches my expectations of a "data directory", which is what we are building with these commands (files are copied to the directory, etc making the fact that this is a directory an important feature)

 I can propagate this through other files beyond add-assembly if it makes sense.

I also remove the check for manifest.json

I find this check for manifest.json does not fit with my expected workflow with the jbrowse app, and propose removing it. I prefer to not have to type --skipCheck or --force or some combination of this for every command that I run, and would like to not have to be inside the directory to use the command without --skipCheck


