### PR TITLE
Fix issue where the rubberband guide would change basepair label in the middle of basepair

### DIFF
--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -96,8 +96,8 @@ const Base1DView = types
           ...getSnapshot(region),
           oob: true,
           coord: region.reversed
-            ? Math.round(region.end - offset) + 1
-            : Math.round(region.start + offset) + 1,
+            ? Math.floor(region.end - offset) + 1
+            : Math.floor(region.start + offset) + 1,
           offset,
           index: 0,
         }
@@ -111,8 +111,8 @@ const Base1DView = types
           oob: true,
           offset,
           coord: region.reversed
-            ? Math.round(region.end - offset) + 1
-            : Math.round(region.start + offset) + 1,
+            ? Math.floor(region.end - offset) + 1
+            : Math.floor(region.start + offset) + 1,
           index: n - 1,
         }
       }
@@ -126,8 +126,8 @@ const Base1DView = types
             oob: false,
             offset,
             coord: region.reversed
-              ? Math.round(region.end - offset) + 1
-              : Math.round(region.start + offset) + 1,
+              ? Math.floor(region.end - offset) + 1
+              : Math.floor(region.start + offset) + 1,
             index,
           }
         }

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -251,8 +251,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
             ...getSnapshot(region),
             oob: true,
             coord: region.reversed
-              ? Math.round(region.end - offset) + 1
-              : Math.round(region.start + offset) + 1,
+              ? Math.floor(region.end - offset) + 1
+              : Math.floor(region.start + offset) + 1,
             offset,
             index: 0,
           }
@@ -266,8 +266,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
             oob: true,
             offset,
             coord: region.reversed
-              ? Math.round(region.end - offset) + 1
-              : Math.round(region.start + offset) + 1,
+              ? Math.floor(region.end - offset) + 1
+              : Math.floor(region.start + offset) + 1,
             index: n - 1,
           }
         }
@@ -281,8 +281,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
               oob: false,
               offset,
               coord: region.reversed
-                ? Math.round(region.end - offset) + 1
-                : Math.round(region.start + offset) + 1,
+                ? Math.floor(region.end - offset) + 1
+                : Math.floor(region.start + offset) + 1,
               index,
             }
           }


### PR DESCRIPTION
On current master when hovering over a base, the coordinate changes in the middle of the base. This is due to a math.round in pxToBp, and changing to a Math.floor appears to fix in both forward and horizontally flipped versions