### PR TITLE
Fix insertion positioning in horizontally flipped mode

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
@@ -40,7 +40,7 @@ test('get mismatches', () => {
       '100',
       'AAAAAAAAAACAAAAAAAAAAAAAACCCCCCCCCCCCCCCCCCCCCCCCCGGGGGGGGGGGGGGGGGGGGGGGGGTTTTTTTTTTTTTTTTTTTTTTTTTA',
     ),
-  ).toEqual([{ start: 89, type: 'insertion', base: '1', length: 1 }])
+  ).toEqual([{ start: 89, type: 'insertion', base: '1', length: 0 }])
 
   // contains a deletion and a SNP
   // read GGGGG--ATTTTTT
@@ -88,7 +88,7 @@ test('vsbuffalo', () => {
       '100',
       'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     ),
-  ).toEqual([{ base: '1', length: 1, start: 89, type: 'insertion' }])
+  ).toEqual([{ base: '1', length: 0, start: 89, type: 'insertion' }])
 
   // https://github.com/vsbuffalo/devnotes/wiki/The-MD-Tag-in-BAM-Files
   // example 2
@@ -99,7 +99,7 @@ test('vsbuffalo', () => {
       'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     ),
   ).toEqual([
-    { base: '1', length: 1, start: 9, type: 'insertion' },
+    { base: '1', length: 0, start: 9, type: 'insertion' },
     {
       altbase: 'T',
       base: 'A',
@@ -145,7 +145,7 @@ test('more skip', () => {
       },
       Object {
         "base": "1",
-        "length": 1,
+        "length": 0,
         "start": 31,
         "type": "insertion",
       },

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -22,12 +22,11 @@ export function cigarToMismatches(ops: string[], seq: string): Mismatch[] {
       seqOffset += len
     }
     if (op === 'I') {
-      // GAH: shouldn't length of insertion really by 0, since JBrowse internally uses zero-interbase coordinates?
       mismatches.push({
         start: currOffset,
         type: 'insertion',
         base: `${len}`,
-        length: 1,
+        length: 0,
       })
       seqOffset += len
     } else if (op === 'D') {

--- a/plugins/alignments/src/BamAdapter/__snapshots__/BamAdapter.test.ts.snap
+++ b/plugins/alignments/src/BamAdapter/__snapshots__/BamAdapter.test.ts.snap
@@ -370,7 +370,7 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 108,
     "type": "insertion",
   },
@@ -388,13 +388,13 @@ Array [
   },
   Object {
     "base": "3",
-    "length": 1,
+    "length": 0,
     "start": 177,
     "type": "insertion",
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 209,
     "type": "insertion",
   },
@@ -466,7 +466,7 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 284,
     "type": "insertion",
   },
@@ -544,19 +544,19 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 339,
     "type": "insertion",
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 345,
     "type": "insertion",
   },
   Object {
     "base": "2",
-    "length": 1,
+    "length": 0,
     "start": 352,
     "type": "insertion",
   },
@@ -574,19 +574,19 @@ Array [
   },
   Object {
     "base": "67",
-    "length": 1,
+    "length": 0,
     "start": 403,
     "type": "insertion",
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 427,
     "type": "insertion",
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 433,
     "type": "insertion",
   },
@@ -616,13 +616,13 @@ Array [
   },
   Object {
     "base": "7",
-    "length": 1,
+    "length": 0,
     "start": 626,
     "type": "insertion",
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 627,
     "type": "insertion",
   },
@@ -676,7 +676,7 @@ Array [
   },
   Object {
     "base": "4",
-    "length": 1,
+    "length": 0,
     "start": 818,
     "type": "insertion",
   },
@@ -688,13 +688,13 @@ Array [
   },
   Object {
     "base": "4",
-    "length": 1,
+    "length": 0,
     "start": 822,
     "type": "insertion",
   },
   Object {
     "base": "8",
-    "length": 1,
+    "length": 0,
     "start": 828,
     "type": "insertion",
   },
@@ -712,7 +712,7 @@ Array [
   },
   Object {
     "base": "47",
-    "length": 1,
+    "length": 0,
     "start": 889,
     "type": "insertion",
   },
@@ -748,7 +748,7 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 968,
     "type": "insertion",
   },
@@ -778,13 +778,13 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 1063,
     "type": "insertion",
   },
   Object {
     "base": "2",
-    "length": 1,
+    "length": 0,
     "start": 1068,
     "type": "insertion",
   },
@@ -934,7 +934,7 @@ Array [
   },
   Object {
     "base": "5",
-    "length": 1,
+    "length": 0,
     "start": 4455,
     "type": "insertion",
   },
@@ -994,7 +994,7 @@ Array [
   },
   Object {
     "base": "1",
-    "length": 1,
+    "length": 0,
     "start": 5903,
     "type": "insertion",
   },

--- a/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
@@ -384,7 +384,7 @@ export default class CramSlightlyLazyFeature implements Feature {
             start: refPos,
             type: 'insertion',
             base: `${data.length}`,
-            length: data.length,
+            length: 0,
           })
         } else if (code === 'N') {
           // reference skip

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -291,7 +291,10 @@ export default class PileupRenderer extends BoxRendererType {
             ctx.fillRect(pos, topPx + 1, w, heightPx - 2)
             ctx.fillRect(pos - w, topPx, w * 3, 1)
             ctx.fillRect(pos - w, topPx + heightPx - 1, w * 3, 1)
-            if (heightPx >= charSize.height - 2) {
+            if (
+              1 / bpPerPx >= charSize.width &&
+              heightPx >= charSize.height - 2
+            ) {
               ctx.fillText(
                 `(${mismatch.base})`,
                 mismatchLeftPx + 2,

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -255,10 +255,9 @@ export default class PileupRenderer extends BoxRendererType {
         }
         for (let i = 0; i < mismatches.length; i += 1) {
           const mismatch = mismatches[i]
-          const len = mismatch.type === 'insertion' ? 0 : mismatch.length
           const [mismatchLeftPx, mismatchRightPx] = bpSpanPx(
             feature.get('start') + mismatch.start,
-            feature.get('start') + mismatch.start + len,
+            feature.get('start') + mismatch.start + mismatch.length,
             region,
             bpPerPx,
           )

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -255,12 +255,14 @@ export default class PileupRenderer extends BoxRendererType {
         }
         for (let i = 0; i < mismatches.length; i += 1) {
           const mismatch = mismatches[i]
+          const len = mismatch.type === 'insertion' ? 0 : mismatch.length
           const [mismatchLeftPx, mismatchRightPx] = bpSpanPx(
             feature.get('start') + mismatch.start,
-            feature.get('start') + mismatch.start + mismatch.length,
+            feature.get('start') + mismatch.start + len,
             region,
             bpPerPx,
           )
+
           const mismatchWidthPx = Math.max(
             minFeatWidth,
             Math.abs(mismatchLeftPx - mismatchRightPx),
@@ -290,10 +292,7 @@ export default class PileupRenderer extends BoxRendererType {
             ctx.fillRect(pos, topPx + 1, w, heightPx - 2)
             ctx.fillRect(pos - w, topPx, w * 3, 1)
             ctx.fillRect(pos - w, topPx + heightPx - 1, w * 3, 1)
-            if (
-              mismatchWidthPx >= charSize.width &&
-              heightPx >= charSize.height - 2
-            ) {
+            if (heightPx >= charSize.height - 2) {
               ctx.fillText(
                 `(${mismatch.base})`,
                 mismatchLeftPx + 2,


### PR DESCRIPTION
This uses 0 length insertions to correctly position the insertions in both forward and reversed (horizontally flipped) modes

Note that the real bug started because CRAM encoded the insertion length into the mismatch.length field but this is meant for length-on-reference, so this caused an issue

BAM used insertion length 1, and had a comment that was carried from jb1-jb2 but was originally committed in 2013 that said

//// GAH: shouldn't length of insertion really by 0, since JBrowse internally uses zero-interbase coordinates?


commit 7bdcebe8947815d657d5ea9832e73dc35965c6e7

Well, now it is length 0

We will need to see if there are ramifications to this but this fixes forward and reverse rendering of insertions in my initial testing
