### PR TITLE
More compact UI

### DIFF
--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles({
     right: 16,
     top: '50%',
     transform: 'translateY(-50%)',
-    padding: 12,
+    padding: 2,
     marginRight: -12,
     display: 'inline-flex',
   },
@@ -68,20 +68,20 @@ function MenuItemEndDecoration(props: MenuItemEndDecorationProps) {
   }
   let icon
   if (type === 'subMenu') {
-    icon = <ArrowRightIcon color="action" />
+    icon = <ArrowRightIcon fontSize="small" color="action" />
   } else if (type === 'checkbox') {
     if (checked) {
       const color = disabled ? 'inherit' : 'secondary'
-      icon = <CheckBoxIcon color={color} />
+      icon = <CheckBoxIcon fontSize="small" color={color} />
     } else {
-      icon = <CheckBoxOutlineBlankIcon color="action" />
+      icon = <CheckBoxOutlineBlankIcon fontSize="small" color="action" />
     }
   } else if (type === 'radio') {
     if (checked) {
       const color = disabled ? 'inherit' : 'secondary'
-      icon = <RadioButtonCheckedIcon color={color} />
+      icon = <RadioButtonCheckedIcon fontSize="small" color={color} />
     } else {
-      icon = <RadioButtonUncheckedIcon color="action" />
+      icon = <RadioButtonUncheckedIcon fontSize="small" color="action" />
     }
   }
   return <div className={classes.menuItemEndDecoration}>{icon}</div>
@@ -283,7 +283,7 @@ const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
             const Icon = menuItem.icon
             icon = (
               <ListItemIcon>
-                <Icon />
+                <Icon fontSize="small" />
               </ListItemIcon>
             )
           }

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   viewContainer: {
     overflow: 'hidden',
     background: theme.palette.secondary.main,
-    margin: theme.spacing(1),
+    margin: theme.spacing(0.5),
   },
   icon: {
     color: theme.palette.secondary.contrastText,

--- a/packages/core/ui/theme.js
+++ b/packages/core/ui/theme.js
@@ -15,6 +15,7 @@ export default createMuiTheme({
   typography: {
     fontSize: 12,
   },
+  spacing: 4,
   palette: {
     // type: 'dark',
     primary: { main: midnight },

--- a/packages/core/ui/theme.js
+++ b/packages/core/ui/theme.js
@@ -12,6 +12,9 @@ const forest = '#135560'
 const mandarin = '#FFB11D'
 
 export default createMuiTheme({
+  typography: {
+    fontSize: 12,
+  },
   palette: {
     // type: 'dark',
     primary: { main: midnight },
@@ -27,8 +30,36 @@ export default createMuiTheme({
       mainApp: grey[700],
     },
   },
-  spacing: 4,
+  props: {
+    MuiMenuItem: {
+      root: {
+        padding: 0,
+      },
+    },
+    MuiButtonBase: {
+      disableRipple: true,
+    },
+  },
   overrides: {
+    // makes menus more compact
+    MuiMenuItem: {
+      root: {
+        paddingTop: 3,
+        paddingBottom: 3,
+      },
+    },
+
+    // the below two are linked to make menus more compact
+    MuiListItemIcon: {
+      root: {
+        minWidth: 32,
+      },
+    },
+    MuiListItemText: {
+      inset: {
+        paddingLeft: 32,
+      },
+    },
     MuiIconButton: {
       colorSecondary: {
         color: forest,

--- a/packages/core/util/blockTypes.ts
+++ b/packages/core/util/blockTypes.ts
@@ -54,6 +54,12 @@ export class BlockSet {
   get contentBlocks() {
     return this.blocks.filter(block => block instanceof ContentBlock)
   }
+
+  get totalBp() {
+    return this.contentBlocks
+      .map(block => block.end - block.start)
+      .reduce((a, b) => a + b, 0)
+  }
 }
 
 export class BaseBlock {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -176,7 +176,6 @@ export default observer(({ model }: { model: LGV }) => {
         <RefNameAutocomplete
           style={{
             display: 'inline-flex',
-            height: WIDGET_HEIGHT,
             margin: SPACING,
           }}
           onSelect={setDisplayedRegion}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -6,7 +6,6 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import ToggleButton from '@material-ui/lab/ToggleButton'
-import Autocomplete from '@material-ui/lab/Autocomplete'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import React, { useCallback, useRef, useState } from 'react'
@@ -31,15 +30,14 @@ const useStyles = makeStyles(theme => ({
   spacer: {
     flexGrow: 1,
   },
-  input: {
-    width: 300,
-  },
+  input: {},
   headerRefName: {
     minWidth: 100,
   },
   panButton: {
     background: fade(theme.palette.background.paper, 0.8),
     height: WIDGET_HEIGHT,
+    margin: 7,
   },
   bp: {
     display: 'flex',
@@ -115,6 +113,7 @@ const Search = observer(({ model }: { model: LGV }) => {
           startAdornment: <SearchIcon fontSize="small" />,
           style: {
             background: fade(theme.palette.background.paper, 0.8),
+            margin: 7,
             height: WIDGET_HEIGHT,
           },
         }}
@@ -177,6 +176,7 @@ export default observer(({ model }: { model: LGV }) => {
             style={{
               display: 'inline-flex',
               height: WIDGET_HEIGHT,
+              margin: 7,
             }}
             onSelect={setDisplayedRegion}
             assemblyName={assemblyName}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -20,6 +20,8 @@ import ZoomControls from './ZoomControls'
 
 type LGV = Instance<LinearGenomeViewStateModel>
 
+const WIDGET_HEIGHTS = 35
+
 const useStyles = makeStyles(theme => ({
   headerBar: {
     height: HEADER_BAR_HEIGHT,
@@ -30,19 +32,18 @@ const useStyles = makeStyles(theme => ({
   },
   input: {
     width: 300,
-    padding: theme.spacing(0, 1),
   },
   headerRefName: {
     minWidth: 100,
-    margin: theme.spacing(2, 0, 1),
   },
   panButton: {
-    margin: theme.spacing(2),
     background: fade(theme.palette.background.paper, 0.8),
+    height: WIDGET_HEIGHTS,
   },
   bp: {
     display: 'flex',
     alignItems: 'center',
+    marginLeft: 5,
   },
   toggleButton: {
     height: 44,
@@ -107,71 +108,32 @@ const Search = observer(({ model }: { model: LGV }) => {
 
   const { assemblyName, refName } = contentBlocks[0] || { refName: '' }
   return (
-    <>
-      <RefNameAutocomplete
-        model={model}
-        onSelect={setDisplayedRegion}
-        assemblyName={assemblyName}
-        defaultRegionName={displayedRegions.length > 1 ? '' : refName}
-        TextFieldProps={{
-          variant: 'outlined',
-          margin: 'dense',
-          size: 'small',
-          className: classes.headerRefName,
-          InputProps: {
-            style: {
-              paddingTop: 2,
-              paddingBottom: 2,
-              background: fade(theme.palette.background.paper, 0.8),
-            },
+    <form
+      style={{ display: 'inline' }}
+      onSubmit={event => {
+        event.preventDefault()
+        inputRef && inputRef.current && inputRef.current.blur()
+        value && navTo(value)
+      }}
+    >
+      <TextField
+        inputRef={inputRef}
+        onFocus={() => setValue(visibleLocStrings)}
+        onBlur={() => setValue(undefined)}
+        onChange={event => setValue(event.target.value)}
+        className={classes.input}
+        variant="outlined"
+        size="small"
+        value={value === undefined ? visibleLocStrings : value}
+        InputProps={{
+          startAdornment: <SearchIcon fontSize="small" />,
+          style: {
+            background: fade(theme.palette.background.paper, 0.8),
+            height: WIDGET_HEIGHTS,
           },
         }}
       />
-      <form
-        onSubmit={event => {
-          event.preventDefault()
-          inputRef && inputRef.current && inputRef.current.blur()
-          value && navTo(value)
-        }}
-      >
-        <TextField
-          inputRef={inputRef}
-          onFocus={() => setValue(visibleLocStrings)}
-          onBlur={() => setValue(undefined)}
-          onChange={event => setValue(event.target.value)}
-          className={classes.input}
-          variant="outlined"
-          margin="dense"
-          size="small"
-          value={value === undefined ? visibleLocStrings : value}
-          InputProps={{
-            startAdornment: <SearchIcon fontSize="small" />,
-            style: {
-              background: fade(theme.palette.background.paper, 0.8),
-              height: 32,
-            },
-          }}
-          // eslint-disable-next-line react/jsx-no-duplicate-props
-          inputProps={{ style: { padding: theme.spacing() } }}
-        />
-      </form>
-      <div className={classes.bp}>
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          className={classes.bp}
-        >
-          {`${Math.round(
-            contentBlocks
-              .map(block => block.end - block.start)
-              .reduce(
-                (previousValue, currentValue) => previousValue + currentValue,
-                0,
-              ),
-          ).toLocaleString('en-US')} bp`}
-        </Typography>
-      </div>
-    </>
+    </form>
   )
 })
 
@@ -206,9 +168,14 @@ export default observer(({ model }: { model: LGV }) => {
     <div className={classes.headerBar}>
       <Controls model={model} />
       <div className={classes.spacer} />
-      <PanControls model={model} />
-      <Search model={model} />
-      <ZoomControls model={model} />
+      <div style={{ display: 'flex' }}>
+        <div style={{ margin: 'auto' }}>
+          <PanControls model={model} />
+          <Search model={model} />
+        </div>
+        <RegionWidth model={model} />
+        <ZoomControls model={model} />
+      </div>
       <div className={classes.spacer} />
     </div>
   )
@@ -218,4 +185,14 @@ export default observer(({ model }: { model: LGV }) => {
   }
 
   return <OverviewScaleBar model={model}>{controls}</OverviewScaleBar>
+})
+
+const RegionWidth = observer(({ model }: { model: LGV }) => {
+  const classes = useStyles()
+  const { dynamicBlocks } = model
+  return (
+    <Typography variant="body2" color="textSecondary" className={classes.bp}>
+      {`${Math.round(dynamicBlocks.totalBp).toLocaleString('en-US')} bp`}
+    </Typography>
+  )
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -6,6 +6,7 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import ToggleButton from '@material-ui/lab/ToggleButton'
+import Autocomplete from '@material-ui/lab/Autocomplete'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import React, { useCallback, useRef, useState } from 'react'
@@ -20,7 +21,7 @@ import ZoomControls from './ZoomControls'
 
 type LGV = Instance<LinearGenomeViewStateModel>
 
-const WIDGET_HEIGHTS = 35
+const WIDGET_HEIGHT = 27
 
 const useStyles = makeStyles(theme => ({
   headerBar: {
@@ -38,7 +39,7 @@ const useStyles = makeStyles(theme => ({
   },
   panButton: {
     background: fade(theme.palette.background.paper, 0.8),
-    height: WIDGET_HEIGHTS,
+    height: WIDGET_HEIGHT,
   },
   bp: {
     display: 'flex',
@@ -80,11 +81,7 @@ const Search = observer(({ model }: { model: LGV }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const classes = useStyles()
   const theme = useTheme()
-  const {
-    dynamicBlocks: { contentBlocks },
-    displayedRegions,
-    visibleLocStrings,
-  } = model
+  const { visibleLocStrings } = model
   const session = getSession(model)
 
   function navTo(locString: string) {
@@ -118,7 +115,7 @@ const Search = observer(({ model }: { model: LGV }) => {
           startAdornment: <SearchIcon fontSize="small" />,
           style: {
             background: fade(theme.palette.background.paper, 0.8),
-            height: WIDGET_HEIGHTS,
+            height: WIDGET_HEIGHT,
           },
         }}
       />
@@ -152,7 +149,23 @@ function PanControls({ model }: { model: LGV }) {
 
 export default observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
+  const theme = useTheme()
+  const {
+    dynamicBlocks: { contentBlocks },
+    displayedRegions,
+  } = model
 
+  const setDisplayedRegion = useCallback(
+    (region: Region | undefined) => {
+      if (region) {
+        model.setDisplayedRegions([region])
+        model.showAllRegions()
+      }
+    },
+    [model],
+  )
+
+  const { assemblyName, refName } = contentBlocks[0] || { refName: '' }
   const controls = (
     <div className={classes.headerBar}>
       <Controls model={model} />
@@ -160,6 +173,33 @@ export default observer(({ model }: { model: LGV }) => {
       <div style={{ display: 'flex' }}>
         <div style={{ margin: 'auto' }}>
           <PanControls model={model} />
+          <RefNameAutocomplete
+            style={{
+              display: 'inline-flex',
+              height: WIDGET_HEIGHT,
+            }}
+            onSelect={setDisplayedRegion}
+            assemblyName={assemblyName}
+            defaultRegionName={displayedRegions.length > 1 ? '' : refName}
+            model={model}
+            ListboxProps={{
+              style: {
+                maxHeight: WIDGET_HEIGHT,
+              },
+            }}
+            TextFieldProps={{
+              variant: 'outlined',
+              size: 'small',
+              className: classes.headerRefName,
+              InputProps: {
+                style: {
+                  padding: 0,
+                  height: WIDGET_HEIGHT,
+                  background: fade(theme.palette.background.paper, 0.8),
+                },
+              },
+            }}
+          />
           <Search model={model} />
         </div>
         <RegionWidth model={model} />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -3,6 +3,7 @@ import { getSession, isSessionModelWithWidgets } from '@gmod/jbrowse-core/util'
 import Button from '@material-ui/core/Button'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
+import FormGroup from '@material-ui/core/FormGroup'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import ToggleButton from '@material-ui/lab/ToggleButton'
@@ -169,37 +170,35 @@ export default observer(({ model }: { model: LGV }) => {
     <div className={classes.headerBar}>
       <Controls model={model} />
       <div className={classes.spacer} />
-      <div style={{ display: 'flex' }}>
-        <div style={{ margin: 'auto' }}>
-          <PanControls model={model} />
-          <RefNameAutocomplete
-            style={{
-              display: 'inline-flex',
-              height: WIDGET_HEIGHT,
-              margin: 7,
-            }}
-            onSelect={setDisplayedRegion}
-            assemblyName={assemblyName}
-            defaultRegionName={displayedRegions.length > 1 ? '' : refName}
-            model={model}
-            TextFieldProps={{
-              variant: 'outlined',
-              size: 'small',
-              className: classes.headerRefName,
-              InputProps: {
-                style: {
-                  padding: 0,
-                  height: WIDGET_HEIGHT,
-                  background: fade(theme.palette.background.paper, 0.8),
-                },
+      <FormGroup row>
+        <PanControls model={model} />
+        <RefNameAutocomplete
+          style={{
+            display: 'inline-flex',
+            height: WIDGET_HEIGHT,
+            margin: 7,
+          }}
+          onSelect={setDisplayedRegion}
+          assemblyName={assemblyName}
+          defaultRegionName={displayedRegions.length > 1 ? '' : refName}
+          model={model}
+          TextFieldProps={{
+            variant: 'outlined',
+            size: 'small',
+            className: classes.headerRefName,
+            InputProps: {
+              style: {
+                padding: 0,
+                height: WIDGET_HEIGHT,
+                background: fade(theme.palette.background.paper, 0.8),
               },
-            }}
-          />
-          <Search model={model} />
-        </div>
-        <RegionWidth model={model} />
-        <ZoomControls model={model} />
-      </div>
+            },
+          }}
+        />
+        <Search model={model} />
+      </FormGroup>
+      <RegionWidth model={model} />
+      <ZoomControls model={model} />
       <div className={classes.spacer} />
     </div>
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -21,7 +21,7 @@ import ZoomControls from './ZoomControls'
 
 type LGV = Instance<LinearGenomeViewStateModel>
 
-const WIDGET_HEIGHT = 27
+const WIDGET_HEIGHT = 32
 const SPACING = 7
 
 const useStyles = makeStyles(theme => ({
@@ -95,7 +95,6 @@ const Search = observer(({ model }: { model: LGV }) => {
 
   return (
     <form
-      style={{ display: 'inline' }}
       onSubmit={event => {
         event.preventDefault()
         inputRef && inputRef.current && inputRef.current.blur()
@@ -175,7 +174,6 @@ export default observer(({ model }: { model: LGV }) => {
         <PanControls model={model} />
         <RefNameAutocomplete
           style={{
-            display: 'inline-flex',
             margin: SPACING,
           }}
           onSelect={setDisplayedRegion}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -22,6 +22,7 @@ import ZoomControls from './ZoomControls'
 type LGV = Instance<LinearGenomeViewStateModel>
 
 const WIDGET_HEIGHT = 27
+const SPACING = 7
 
 const useStyles = makeStyles(theme => ({
   headerBar: {
@@ -38,7 +39,7 @@ const useStyles = makeStyles(theme => ({
   panButton: {
     background: fade(theme.palette.background.paper, 0.8),
     height: WIDGET_HEIGHT,
-    margin: 7,
+    margin: SPACING,
   },
   bp: {
     display: 'flex',
@@ -114,7 +115,7 @@ const Search = observer(({ model }: { model: LGV }) => {
           startAdornment: <SearchIcon fontSize="small" />,
           style: {
             background: fade(theme.palette.background.paper, 0.8),
-            margin: 7,
+            margin: SPACING,
             height: WIDGET_HEIGHT,
           },
         }}
@@ -176,7 +177,7 @@ export default observer(({ model }: { model: LGV }) => {
           style={{
             display: 'inline-flex',
             height: WIDGET_HEIGHT,
-            margin: 7,
+            margin: SPACING,
           }}
           onSelect={setDisplayedRegion}
           assemblyName={assemblyName}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -96,17 +96,6 @@ const Search = observer(({ model }: { model: LGV }) => {
     }
   }
 
-  const setDisplayedRegion = useCallback(
-    (region: Region | undefined) => {
-      if (region) {
-        model.setDisplayedRegions([region])
-        model.showAllRegions()
-      }
-    },
-    [model],
-  )
-
-  const { assemblyName, refName } = contentBlocks[0] || { refName: '' }
   return (
     <form
       style={{ display: 'inline' }}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -182,11 +182,6 @@ export default observer(({ model }: { model: LGV }) => {
             assemblyName={assemblyName}
             defaultRegionName={displayedRegions.length > 1 ? '' : refName}
             model={model}
-            ListboxProps={{
-              style: {
-                maxHeight: WIDGET_HEIGHT,
-              },
-            }}
             TextFieldProps={{
               variant: 'outlined',
               size: 'small',

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -102,7 +102,7 @@ function RefNameAutocomplete({
   onSelect: (region: Region | undefined) => void
   assemblyName?: string
   defaultRegionName?: string
-  style: unknown
+  style?: React.CSSProperties
   TextFieldProps?: TFP
 }) {
   const [selectedRegionName, setSelectedRegionName] = useState<

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -16,14 +16,11 @@ import React, { useEffect, useState } from 'react'
 import { ListChildComponentProps, VariableSizeList } from 'react-window'
 import { LinearGenomeViewModel } from '..'
 
-const LISTBOX_PADDING = 8 // px
-
 function renderRow(props: ListChildComponentProps) {
   const { data, index, style } = props
   return React.cloneElement(data[index], {
     style: {
       ...style,
-      top: (style.top as number) + LISTBOX_PADDING,
     },
   })
 }
@@ -64,7 +61,7 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(
         <OuterElementContext.Provider value={other}>
           <VariableSizeList
             itemData={itemData}
-            height={getHeight() + 2 * LISTBOX_PADDING}
+            height={getHeight()}
             width="100%"
             key={itemCount}
             outerElementType={OuterElementType}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -85,6 +85,9 @@ const useStyles = makeStyles({
       margin: 0,
     },
   },
+  autocomplete: {
+    display: 'inline',
+  },
 })
 
 function RefNameAutocomplete({
@@ -92,12 +95,14 @@ function RefNameAutocomplete({
   onSelect,
   assemblyName,
   defaultRegionName,
+  style,
   TextFieldProps = {},
 }: {
   model: LinearGenomeViewModel
   onSelect: (region: Region | undefined) => void
   assemblyName?: string
   defaultRegionName?: string
+  style: unknown
   TextFieldProps?: TFP
 }) {
   const [selectedRegionName, setSelectedRegionName] = useState<
@@ -141,9 +146,9 @@ function RefNameAutocomplete({
 
   return (
     <Autocomplete
+      classes={{ root: classes.autocomplete }}
       id={`refNameAutocomplete-${model.id}`}
       disableListWrap
-      classes={classes}
       ListboxComponent={
         ListboxComponent as React.ComponentType<
           React.HTMLAttributes<HTMLElement>
@@ -156,6 +161,7 @@ function RefNameAutocomplete({
           : selectedRegionName
       }
       disabled={!assemblyName || loading}
+      style={style}
       onChange={onChange}
       renderInput={params => {
         const { helperText, InputProps = {} } = TextFieldProps

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -6,7 +6,6 @@ import { Region as MSTRegion } from '@gmod/jbrowse-core/util/types/mst'
 import { getSession } from '@gmod/jbrowse-core/util'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import ListSubheader from '@material-ui/core/ListSubheader'
-import { makeStyles } from '@material-ui/core/styles'
 import TextField, { TextFieldProps as TFP } from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import Autocomplete from '@material-ui/lab/Autocomplete'
@@ -77,15 +76,6 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(
     )
   },
 )
-
-const useStyles = makeStyles({
-  listbox: {
-    '& ul': {
-      padding: 0,
-      margin: 0,
-    },
-  },
-})
 
 function RefNameAutocomplete({
   model,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -154,10 +154,11 @@ function RefNameAutocomplete({
           React.HTMLAttributes<HTMLElement>
         >
       }
+      disableClearable
       options={regionNames}
       value={
         !assemblyName || loading || !selectedRegionName
-          ? null
+          ? undefined
           : selectedRegionName
       }
       disabled={!assemblyName || loading}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -127,8 +127,6 @@ function RefNameAutocomplete({
     }
   }, [assemblyName, defaultRegionName, onSelect, loading, regions])
 
-  const classes = useStyles()
-
   const regionNames = regions.map(region => region.refName)
 
   function onChange(_: unknown, newRegionName: string | null) {
@@ -141,9 +139,8 @@ function RefNameAutocomplete({
     }
   }
 
-  return (
+  return !assemblyName || loading || !selectedRegionName ? null : (
     <Autocomplete
-      classes={{ root: classes.autocomplete }}
       id={`refNameAutocomplete-${model.id}`}
       disableListWrap
       ListboxComponent={
@@ -153,11 +150,7 @@ function RefNameAutocomplete({
       }
       disableClearable
       options={regionNames}
-      value={
-        !assemblyName || loading || !selectedRegionName
-          ? undefined
-          : selectedRegionName
-      }
+      value={selectedRegionName}
       disabled={!assemblyName || loading}
       style={style}
       onChange={onChange}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -85,9 +85,6 @@ const useStyles = makeStyles({
       margin: 0,
     },
   },
-  autocomplete: {
-    display: 'inline',
-  },
 })
 
 function RefNameAutocomplete({

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -685,8 +685,8 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
           class="MuiFormControl-root MuiTextField-root makeStyles-importFormEntry MuiFormControl-marginNormal MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
-            data-shrink="false"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+            data-shrink="true"
             for="refNameAutocomplete-lgv"
             id="refNameAutocomplete-lgv-label"
           >
@@ -705,7 +705,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
               id="refNameAutocomplete-lgv"
               spellcheck="false"
               type="text"
-              value=""
+              value="ctgA"
             />
             <div
               class="MuiAutocomplete-endAdornment"
@@ -741,7 +741,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
               class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled"
+                class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
               >
                 <span>
                   Sequence
@@ -750,7 +750,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
             </fieldset>
           </div>
           <p
-            class="MuiFormHelperText-root MuiFormHelperText-contained"
+            class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled"
             id="refNameAutocomplete-lgv-helper-text"
           >
             Select sequence to view
@@ -921,76 +921,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               class="MuiTouchRipple-root"
             />
           </button>
-          <div
-            aria-expanded="false"
-            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon"
-            role="combobox"
-            style="margin: 7px;"
-          >
-            <div
-              class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
-            >
-              <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
-              >
-                <input
-                  aria-autocomplete="list"
-                  aria-invalid="false"
-                  autocapitalize="none"
-                  autocomplete="off"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                  id="refNameAutocomplete-lgv"
-                  spellcheck="false"
-                  type="text"
-                  value=""
-                />
-                <div
-                  class="MuiAutocomplete-endAdornment"
-                >
-                  <button
-                    aria-label="Open"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                    tabindex="-1"
-                    title="Open"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7 10l5 5 5-5z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-                <fieldset
-                  aria-hidden="true"
-                  class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                  style="padding-left: 8px;"
-                >
-                  <legend
-                    class="PrivateNotchedOutline-legend"
-                    style="width: 0.01px;"
-                  >
-                    <span>
-                      ​
-                    </span>
-                  </legend>
-                </fieldset>
-              </div>
-            </div>
-          </div>
           <form>
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-input"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -93,260 +93,158 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           class="makeStyles-spacer"
         />
         <div
-          style="display: flex;"
+          class="MuiFormGroup-root MuiFormGroup-row"
         >
-          <div
-            style="margin: auto;"
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            tabindex="0"
+            type="button"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-              tabindex="0"
-              type="button"
+            <span
+              class="MuiButton-label"
             >
-              <span
-                class="MuiButton-label"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-              tabindex="0"
-              type="button"
+                <path
+                  d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
             >
-              <span
-                class="MuiButton-label"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            aria-expanded="false"
+            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+            role="combobox"
+            style="display: inline-flex; height: 27px; margin: 7px;"
+          >
             <div
-              aria-expanded="false"
-              class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-              role="combobox"
-              style="display: inline-flex; height: 27px; margin: 7px;"
+              class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
               >
+                <input
+                  aria-autocomplete="list"
+                  aria-invalid="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  id="refNameAutocomplete-lgv"
+                  spellcheck="false"
+                  type="text"
+                  value="ctgA"
+                />
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                  style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
+                  class="MuiAutocomplete-endAdornment"
                 >
-                  <input
-                    aria-autocomplete="list"
-                    aria-invalid="false"
-                    autocapitalize="none"
-                    autocomplete="off"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                    id="refNameAutocomplete-lgv"
-                    spellcheck="false"
-                    type="text"
-                    value="ctgA"
-                  />
-                  <div
-                    class="MuiAutocomplete-endAdornment"
+                  <button
+                    aria-label="Clear"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+                    tabindex="-1"
+                    title="Clear"
+                    type="button"
                   >
-                    <button
-                      aria-label="Clear"
-                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
-                      tabindex="-1"
-                      title="Clear"
-                      type="button"
+                    <span
+                      class="MuiIconButton-label"
                     >
-                      <span
-                        class="MuiIconButton-label"
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        focusable="false"
+                        viewBox="0 0 24 24"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                    <button
-                      aria-label="Open"
-                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                      tabindex="-1"
-                      title="Open"
-                      type="button"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M7 10l5 5 5-5z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                  </div>
-                  <fieldset
-                    aria-hidden="true"
-                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                  <button
+                    aria-label="Open"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                    tabindex="-1"
+                    title="Open"
+                    type="button"
                   >
-                    <legend
-                      class="PrivateNotchedOutline-legend"
-                      style="width: 0.01px;"
+                    <span
+                      class="MuiIconButton-label"
                     >
-                      <span>
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
                 </div>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
               </div>
             </div>
-            <form
-              style="display: inline;"
+          </div>
+          <form
+            style="display: inline;"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root makeStyles-input"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-input"
-              >
-                <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                  style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                    />
-                  </svg>
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                    type="text"
-                    value="ctgA:1..100"
-                  />
-                  <fieldset
-                    aria-hidden="true"
-                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
-                  >
-                    <legend
-                      class="PrivateNotchedOutline-legend"
-                      style="width: 0.01px;"
-                    >
-                      <span>
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
-                </div>
-              </div>
-            </form>
-          </div>
-          <p
-            class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
-          >
-            100 bp
-          </p>
-          <div
-            class="makeStyles-container"
-          >
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-              data-testid="zoom_out"
-              disabled=""
-              tabindex="-1"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
-                  />
-                </svg>
-              </span>
-            </button>
-            <span
-              class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
-            >
-              <span
-                class="MuiSlider-rail"
-              />
-              <span
-                class="MuiSlider-track"
-                style="left: 0%; width: 0%;"
-              />
-              <input
-                type="hidden"
-                value="332.1928094887362"
-              />
-              <span
-                aria-orientation="horizontal"
-                aria-valuemax="564.3856189774724"
-                aria-valuemin="332.1928094887362"
-                aria-valuenow="332.1928094887362"
-                class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
-                data-index="0"
-                role="slider"
-                style="left: 0%;"
-                tabindex="0"
-              />
-            </span>
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-              data-testid="zoom_in"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
               >
                 <svg
                   aria-hidden="true"
@@ -357,16 +255,114 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                   <path
                     d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                  <path
-                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                  />
                 </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  type="text"
+                  value="ctgA:1..100"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </form>
+        </div>
+        <p
+          class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
+        >
+          100 bp
+        </p>
+        <div
+          class="makeStyles-container"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+            data-testid="zoom_out"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
+                />
+              </svg>
+            </span>
+          </button>
+          <span
+            class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
+          >
+            <span
+              class="MuiSlider-rail"
+            />
+            <span
+              class="MuiSlider-track"
+              style="left: 0%; width: 0%;"
+            />
+            <input
+              type="hidden"
+              value="332.1928094887362"
+            />
+            <span
+              aria-orientation="horizontal"
+              aria-valuemax="564.3856189774724"
+              aria-valuemin="332.1928094887362"
+              aria-valuenow="332.1928094887362"
+              class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
+              data-index="0"
+              role="slider"
+              style="left: 0%;"
+              tabindex="0"
+            />
+          </span>
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+            data-testid="zoom_in"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+                <path
+                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
         </div>
         <div
           class="makeStyles-spacer"
@@ -929,262 +925,158 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           class="makeStyles-spacer"
         />
         <div
-          style="display: flex;"
+          class="MuiFormGroup-root MuiFormGroup-row"
         >
-          <div
-            style="margin: auto;"
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            tabindex="0"
+            type="button"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-              tabindex="0"
-              type="button"
+            <span
+              class="MuiButton-label"
             >
-              <span
-                class="MuiButton-label"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-              tabindex="0"
-              type="button"
+                <path
+                  d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-label"
             >
-              <span
-                class="MuiButton-label"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
+                <path
+                  d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            aria-expanded="false"
+            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+            role="combobox"
+            style="display: inline-flex; height: 27px; margin: 7px;"
+          >
             <div
-              aria-expanded="false"
-              class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-              role="combobox"
-              style="display: inline-flex; height: 27px; margin: 7px;"
+              class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
               >
+                <input
+                  aria-autocomplete="list"
+                  aria-invalid="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  id="refNameAutocomplete-lgv"
+                  spellcheck="false"
+                  type="text"
+                  value=""
+                />
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                  style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
+                  class="MuiAutocomplete-endAdornment"
                 >
-                  <input
-                    aria-autocomplete="list"
-                    aria-invalid="false"
-                    autocapitalize="none"
-                    autocomplete="off"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                    id="refNameAutocomplete-lgv"
-                    spellcheck="false"
-                    type="text"
-                    value=""
-                  />
-                  <div
-                    class="MuiAutocomplete-endAdornment"
+                  <button
+                    aria-label="Clear"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                    tabindex="-1"
+                    title="Clear"
+                    type="button"
                   >
-                    <button
-                      aria-label="Clear"
-                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                      tabindex="-1"
-                      title="Clear"
-                      type="button"
+                    <span
+                      class="MuiIconButton-label"
                     >
-                      <span
-                        class="MuiIconButton-label"
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        focusable="false"
+                        viewBox="0 0 24 24"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                    <button
-                      aria-label="Open"
-                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                      tabindex="-1"
-                      title="Open"
-                      type="button"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M7 10l5 5 5-5z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                  </div>
-                  <fieldset
-                    aria-hidden="true"
-                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                  <button
+                    aria-label="Open"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                    tabindex="-1"
+                    title="Open"
+                    type="button"
                   >
-                    <legend
-                      class="PrivateNotchedOutline-legend"
-                      style="width: 0.01px;"
+                    <span
+                      class="MuiIconButton-label"
                     >
-                      <span>
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
                 </div>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
               </div>
             </div>
-            <form
-              style="display: inline;"
+          </div>
+          <form
+            style="display: inline;"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root makeStyles-input"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root makeStyles-input"
-              >
-                <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                  style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                    />
-                  </svg>
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                    type="text"
-                    value="ctgA:1..100;ctgB:1,001..1,698"
-                  />
-                  <fieldset
-                    aria-hidden="true"
-                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                    style="padding-left: 8px;"
-                  >
-                    <legend
-                      class="PrivateNotchedOutline-legend"
-                      style="width: 0.01px;"
-                    >
-                      <span>
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
-                </div>
-              </div>
-            </form>
-          </div>
-          <p
-            class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
-          >
-            798 bp
-          </p>
-          <div
-            class="makeStyles-container"
-          >
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-              data-testid="zoom_out"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <span
-              class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
-            >
-              <span
-                class="MuiSlider-rail"
-              />
-              <span
-                class="MuiSlider-track"
-                style="left: 0%; width: 2.3783941938133566%;"
-              />
-              <input
-                type="hidden"
-                value="0"
-              />
-              <span
-                aria-orientation="horizontal"
-                aria-valuemax="564.3856189774724"
-                aria-valuemin="-13.750352374993502"
-                aria-valuenow="0"
-                class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
-                data-index="0"
-                role="slider"
-                style="left: 2.3783941938133566%;"
-                tabindex="0"
-              />
-            </span>
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-              data-testid="zoom_in"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
               >
                 <svg
                   aria-hidden="true"
@@ -1195,16 +1087,116 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                   <path
                     d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
-                  <path
-                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                  />
                 </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  type="text"
+                  value="ctgA:1..100;ctgB:1,001..1,698"
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </form>
+        </div>
+        <p
+          class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
+        >
+          798 bp
+        </p>
+        <div
+          class="makeStyles-container"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+            data-testid="zoom_out"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <span
+            class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
+          >
+            <span
+              class="MuiSlider-rail"
+            />
+            <span
+              class="MuiSlider-track"
+              style="left: 0%; width: 2.3783941938133566%;"
+            />
+            <input
+              type="hidden"
+              value="0"
+            />
+            <span
+              aria-orientation="horizontal"
+              aria-valuemax="564.3856189774724"
+              aria-valuemin="-13.750352374993502"
+              aria-valuenow="0"
+              class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
+              data-index="0"
+              role="slider"
+              style="left: 2.3783941938133566%;"
+              tabindex="0"
+            />
+          </span>
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+            data-testid="zoom_in"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+                <path
+                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
         </div>
         <div
           class="makeStyles-spacer"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -143,16 +143,16 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           </button>
           <div
             aria-expanded="false"
-            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
+            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon"
             role="combobox"
-            style="display: inline-flex; margin: 7px;"
+            style="margin: 7px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
+                style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
               >
                 <input
                   aria-autocomplete="list"
@@ -211,15 +211,13 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               </div>
             </div>
           </div>
-          <form
-            style="display: inline;"
-          >
+          <form>
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-input"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
+                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 32px;"
               >
                 <svg
                   aria-hidden="true"
@@ -680,7 +678,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
     >
       <div
         aria-expanded="false"
-        class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
+        class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon"
         role="combobox"
       >
         <div
@@ -925,16 +923,16 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           </button>
           <div
             aria-expanded="false"
-            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
+            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon"
             role="combobox"
-            style="display: inline-flex; margin: 7px;"
+            style="margin: 7px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
+                style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
               >
                 <input
                   aria-autocomplete="list"
@@ -993,15 +991,13 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               </div>
             </div>
           </div>
-          <form
-            style="display: inline;"
-          >
+          <form>
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-input"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
+                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 32px;"
               >
                 <svg
                   aria-hidden="true"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -92,275 +92,281 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         <div
           class="makeStyles-spacer"
         />
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
         <div
-          aria-expanded="false"
-          class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          style="display: flex;"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-marginDense MuiFormControl-fullWidth"
+            style="margin: auto;"
           >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-              style="padding-top: 2px; padding-bottom: 2px; background: rgba(255, 255, 255, 0.8);"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+              tabindex="0"
+              type="button"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                id="refNameAutocomplete-lgv"
-                spellcheck="false"
-                type="text"
-                value="ctgA"
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
               />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <div
+              aria-expanded="false"
+              class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+              role="combobox"
+              style="display: inline-flex; height: 27px; margin: 7px;"
+            >
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                  style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <input
+                    aria-autocomplete="list"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                    id="refNameAutocomplete-lgv"
+                    spellcheck="false"
+                    type="text"
+                    value="ctgA"
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
+                  <div
+                    class="MuiAutocomplete-endAdornment"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
+                    <button
+                      aria-label="Clear"
+                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
+                      tabindex="-1"
+                      title="Clear"
+                      type="button"
                     >
-                      <path
-                        d="M7 10l5 5 5-5z"
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
                       />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                    </button>
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
               </div>
-              <fieldset
-                aria-hidden="true"
-                class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                style="padding-left: 8px;"
-              >
-                <legend
-                  class="PrivateNotchedOutline-legend"
-                  style="width: 0.01px;"
-                >
-                  <span>
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
             </div>
-          </div>
-        </div>
-        <form>
-          <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-input MuiFormControl-marginDense"
-          >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-              style="background: rgba(255, 255, 255, 0.8); height: 32px;"
+            <form
+              style="display: inline;"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="MuiFormControl-root MuiTextField-root makeStyles-input"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                style="padding: 8px;"
-                type="text"
-                value="ctgA:1..100"
-              />
-              <fieldset
-                aria-hidden="true"
-                class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                style="padding-left: 8px;"
-              >
-                <legend
-                  class="PrivateNotchedOutline-legend"
-                  style="width: 0.01px;"
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                  style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
                 >
-                  <span>
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                    type="text"
+                    value="ctgA:1..100"
+                  />
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </form>
           </div>
-        </form>
-        <div
-          class="makeStyles-bp"
-        >
           <p
             class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
           >
             100 bp
           </p>
-        </div>
-        <div
-          class="makeStyles-container"
-        >
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-            data-testid="zoom_out"
-            disabled=""
-            tabindex="-1"
-            type="button"
+          <div
+            class="makeStyles-container"
           >
-            <span
-              class="MuiIconButton-label"
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+              data-testid="zoom_out"
+              disabled=""
+              tabindex="-1"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <span
+                class="MuiIconButton-label"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <span
+              class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
+            >
+              <span
+                class="MuiSlider-rail"
+              />
+              <span
+                class="MuiSlider-track"
+                style="left: 0%; width: 0%;"
+              />
+              <input
+                type="hidden"
+                value="332.1928094887362"
+              />
+              <span
+                aria-orientation="horizontal"
+                aria-valuemax="564.3856189774724"
+                aria-valuemin="332.1928094887362"
+                aria-valuenow="332.1928094887362"
+                class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
+                data-index="0"
+                role="slider"
+                style="left: 0%;"
+                tabindex="0"
+              />
             </span>
-          </button>
-          <span
-            class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
-          >
-            <span
-              class="MuiSlider-rail"
-            />
-            <span
-              class="MuiSlider-track"
-              style="left: 0%; width: 0%;"
-            />
-            <input
-              type="hidden"
-              value="332.1928094887362"
-            />
-            <span
-              aria-orientation="horizontal"
-              aria-valuemax="564.3856189774724"
-              aria-valuemin="332.1928094887362"
-              aria-valuenow="332.1928094887362"
-              class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
-              data-index="0"
-              role="slider"
-              style="left: 0%;"
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+              data-testid="zoom_in"
               tabindex="0"
-            />
-          </span>
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-            data-testid="zoom_in"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiIconButton-label"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <span
+                class="MuiIconButton-label"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
         </div>
         <div
           class="makeStyles-spacer"
@@ -703,7 +709,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
     >
       <div
         aria-expanded="false"
-        class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+        class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
         role="combobox"
       >
         <div
@@ -922,277 +928,283 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <div
           class="makeStyles-spacer"
         />
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-              />
-            </svg>
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
         <div
-          aria-expanded="false"
-          class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-          role="combobox"
+          style="display: flex;"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-marginDense MuiFormControl-fullWidth"
+            style="margin: auto;"
           >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-              style="padding-top: 2px; padding-bottom: 2px; background: rgba(255, 255, 255, 0.8);"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+              tabindex="0"
+              type="button"
             >
-              <input
-                aria-autocomplete="list"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                id="refNameAutocomplete-lgv"
-                spellcheck="false"
-                type="text"
-                value=""
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
               />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <div
+              aria-expanded="false"
+              class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+              role="combobox"
+              style="display: inline-flex; height: 27px; margin: 7px;"
+            >
               <div
-                class="MuiAutocomplete-endAdornment"
+                class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
               >
-                <button
-                  aria-label="Clear"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                  tabindex="-1"
-                  title="Clear"
-                  type="button"
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                  style="padding: 0px; height: 27px; background: rgba(255, 255, 255, 0.8);"
                 >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
+                  <input
+                    aria-autocomplete="list"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                    id="refNameAutocomplete-lgv"
+                    spellcheck="false"
+                    type="text"
+                    value=""
                   />
-                </button>
-                <button
-                  aria-label="Open"
-                  class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                  tabindex="-1"
-                  title="Open"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
+                  <div
+                    class="MuiAutocomplete-endAdornment"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
+                    <button
+                      aria-label="Clear"
+                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                      tabindex="-1"
+                      title="Clear"
+                      type="button"
                     >
-                      <path
-                        d="M7 10l5 5 5-5z"
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
                       />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
+                    </button>
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
               </div>
-              <fieldset
-                aria-hidden="true"
-                class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                style="padding-left: 8px;"
-              >
-                <legend
-                  class="PrivateNotchedOutline-legend"
-                  style="width: 0.01px;"
-                >
-                  <span>
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
             </div>
-          </div>
-        </div>
-        <form>
-          <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-input MuiFormControl-marginDense"
-          >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-              style="background: rgba(255, 255, 255, 0.8); height: 32px;"
+            <form
+              style="display: inline;"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="MuiFormControl-root MuiTextField-root makeStyles-input"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                style="padding: 8px;"
-                type="text"
-                value="ctgA:1..100;ctgB:1,001..1,698"
-              />
-              <fieldset
-                aria-hidden="true"
-                class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                style="padding-left: 8px;"
-              >
-                <legend
-                  class="PrivateNotchedOutline-legend"
-                  style="width: 0.01px;"
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                  style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 27px;"
                 >
-                  <span>
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                    type="text"
+                    value="ctgA:1..100;ctgB:1,001..1,698"
+                  />
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </form>
           </div>
-        </form>
-        <div
-          class="makeStyles-bp"
-        >
           <p
             class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
           >
             798 bp
           </p>
-        </div>
-        <div
-          class="makeStyles-container"
-        >
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-            data-testid="zoom_out"
-            tabindex="0"
-            type="button"
+          <div
+            class="makeStyles-container"
           >
-            <span
-              class="MuiIconButton-label"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
-          <span
-            class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
-          >
-            <span
-              class="MuiSlider-rail"
-            />
-            <span
-              class="MuiSlider-track"
-              style="left: 0%; width: 2.3783941938133566%;"
-            />
-            <input
-              type="hidden"
-              value="0"
-            />
-            <span
-              aria-orientation="horizontal"
-              aria-valuemax="564.3856189774724"
-              aria-valuemin="-13.750352374993502"
-              aria-valuenow="0"
-              class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
-              data-index="0"
-              role="slider"
-              style="left: 2.3783941938133566%;"
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+              data-testid="zoom_out"
               tabindex="0"
-            />
-          </span>
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-            data-testid="zoom_in"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiIconButton-label"
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <span
+                class="MuiIconButton-label"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                />
-              </svg>
-            </span>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
             <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
+              class="MuiSlider-root MuiSlider-colorPrimary makeStyles-slider"
+            >
+              <span
+                class="MuiSlider-rail"
+              />
+              <span
+                class="MuiSlider-track"
+                style="left: 0%; width: 2.3783941938133566%;"
+              />
+              <input
+                type="hidden"
+                value="0"
+              />
+              <span
+                aria-orientation="horizontal"
+                aria-valuemax="564.3856189774724"
+                aria-valuemin="-13.750352374993502"
+                aria-valuenow="0"
+                class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
+                data-index="0"
+                role="slider"
+                style="left: 2.3783941938133566%;"
+                tabindex="0"
+              />
+            </span>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+              data-testid="zoom_in"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
         </div>
         <div
           class="makeStyles-spacer"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -143,9 +143,9 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           </button>
           <div
             aria-expanded="false"
-            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
             role="combobox"
-            style="display: inline-flex; height: 27px; margin: 7px;"
+            style="display: inline-flex; margin: 7px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
@@ -168,31 +168,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 <div
                   class="MuiAutocomplete-endAdornment"
                 >
-                  <button
-                    aria-label="Clear"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
-                    tabindex="-1"
-                    title="Clear"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
                   <button
                     aria-label="Open"
                     class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
@@ -705,15 +680,15 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
     >
       <div
         aria-expanded="false"
-        class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+        class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
         role="combobox"
       >
         <div
           class="MuiFormControl-root MuiTextField-root makeStyles-importFormEntry MuiFormControl-marginNormal MuiFormControl-fullWidth"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
-            data-shrink="true"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+            data-shrink="false"
             for="refNameAutocomplete-lgv"
             id="refNameAutocomplete-lgv-label"
           >
@@ -732,36 +707,11 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
               id="refNameAutocomplete-lgv"
               spellcheck="false"
               type="text"
-              value="ctgA"
+              value=""
             />
             <div
               class="MuiAutocomplete-endAdornment"
             >
-              <button
-                aria-label="Clear"
-                class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator MuiAutocomplete-clearIndicatorDirty"
-                tabindex="-1"
-                title="Clear"
-                type="button"
-              >
-                <span
-                  class="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="MuiTouchRipple-root"
-                />
-              </button>
               <button
                 aria-label="Open"
                 class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
@@ -793,7 +743,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
               class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                class="PrivateNotchedOutline-legendLabelled"
               >
                 <span>
                   Sequence
@@ -802,7 +752,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
             </fieldset>
           </div>
           <p
-            class="MuiFormHelperText-root MuiFormHelperText-contained MuiFormHelperText-filled"
+            class="MuiFormHelperText-root MuiFormHelperText-contained"
             id="refNameAutocomplete-lgv-helper-text"
           >
             Select sequence to view
@@ -975,9 +925,9 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           </button>
           <div
             aria-expanded="false"
-            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+            class="MuiAutocomplete-root makeStyles-autocomplete MuiAutocomplete-hasPopupIcon"
             role="combobox"
-            style="display: inline-flex; height: 27px; margin: 7px;"
+            style="display: inline-flex; margin: 7px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
@@ -1000,31 +950,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <div
                   class="MuiAutocomplete-endAdornment"
                 >
-                  <button
-                    aria-label="Clear"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                    tabindex="-1"
-                    title="Clear"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
                   <button
                     aria-label="Open"
                     class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"


### PR DESCRIPTION
This is an attempt at a more compact user interface

Things that it touches

1) More compact menus
2) Making global typography smaller
3) Use FormGroup row to keep controls inline in the header, and make them all the same height (kind of annoyingly intricately hardcoded still but might be a little better). There was some sensitivity to changing things like theme.spacing e.g. from 4->8 caused the lgv header layout to get distorted, so hopefully this is a little better
4) Removes the little x icon on the refseq dropdown

It has to manually specify the height of certain things, but it puts them all in a little better and more consistent vertical spacing

![t2](https://user-images.githubusercontent.com/6511937/94656709-6d960980-02ce-11eb-8c8e-4edaa0e13048.png)
![t1](https://user-images.githubusercontent.com/6511937/94656711-6e2ea000-02ce-11eb-89d2-7694047c73c3.png)
