### PR TITLE
1246 flaky admin test

### DIFF
--- a/products/jbrowse-cli/src/commands/admin-server.test.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.test.ts
@@ -69,11 +69,16 @@ const setupWithCreate = setup.do(async ctx => {
 })
 
 async function killExpress(ctx: { stdoutWrite: jest.Mock }, port: number) {
+  const adminKey = ctx.stdoutWrite.mock.calls[0][0].match(
+    /adminKey=([a-zA-Z0-9]{10,12}) /,
+  )[1]
+  const payload = { adminKey }
   await fetch(`http://localhost:${port}/shutdown`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify(payload),
   })
 }
 

--- a/products/jbrowse-cli/src/commands/admin-server.test.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.test.ts
@@ -69,16 +69,11 @@ const setupWithCreate = setup.do(async ctx => {
 })
 
 async function killExpress(ctx: { stdoutWrite: jest.Mock }, port: number) {
-  const adminKey = ctx.stdoutWrite.mock.calls[0][0].match(
-    /adminKey=([a-zA-Z0-9]{10,12}) /,
-  )[1]
-  const payload = { adminKey }
   await fetch(`http://localhost:${port}/shutdown`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
   })
 }
 

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -1,18 +1,16 @@
 import { flags } from '@oclif/command'
 import { promises as fsPromises } from 'fs'
+import crypto from 'crypto'
 import * as path from 'path'
 import * as express from 'express'
 import JBrowseCommand, { Config } from '../base'
-
-// test
 
 function isValidPort(port: number) {
   return port > 0 && port < 65535
 }
 
-// generate a string of random alphanumeric characters to serve as admin key
 function generateKey() {
-  return Math.random().toString(36).slice(2)
+  return crypto.randomBytes(5).toString('hex')
 }
 
 export default class AdminServer extends JBrowseCommand {

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -4,6 +4,8 @@ import * as path from 'path'
 import * as express from 'express'
 import JBrowseCommand, { Config } from '../base'
 
+// test
+
 function isValidPort(port: number) {
   return port > 0 && port < 65535
 }
@@ -102,8 +104,14 @@ export default class AdminServer extends JBrowseCommand {
     app.post(
       '/shutdown',
       async (req: express.Request, res: express.Response) => {
-        res.send('Exiting')
-        server.close()
+        this.debug('Req body: ', req.body)
+        if (req.body.adminKey === adminKey) {
+          this.debug('Admin key matches')
+          res.send('Exiting')
+          server.close()
+        } else {
+          res.status(403).send('Admin key does not match')
+        }
       },
     )
 

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -4,6 +4,8 @@ import * as path from 'path'
 import * as express from 'express'
 import JBrowseCommand, { Config } from '../base'
 
+// test
+
 function isValidPort(port: number) {
   return port > 0 && port < 65535
 }

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -4,8 +4,6 @@ import * as path from 'path'
 import * as express from 'express'
 import JBrowseCommand, { Config } from '../base'
 
-// test
-
 function isValidPort(port: number) {
   return port > 0 && port < 65535
 }
@@ -104,14 +102,8 @@ export default class AdminServer extends JBrowseCommand {
     app.post(
       '/shutdown',
       async (req: express.Request, res: express.Response) => {
-        this.debug('Req body: ', req.body)
-        if (req.body.adminKey === adminKey) {
-          this.debug('Admin key matches')
-          res.send('Exiting')
-          server.close()
-        } else {
-          res.status(403).send('Admin key does not match')
-        }
+        res.send('Exiting')
+        server.close()
       },
     )
 


### PR DESCRIPTION
I was able to reproduce the flaky error in the tests for `admin-server` from #1246 .

Occasionally, there would be an error where the string match in `killExpress()` which I use to kill the express server after tests where it is started would return `null`. I got rid of posting `adminKey` for the shutdown, and the flakiness seemed to go away. 

I'm not totally sure what would cause this to intermittently fail, since the match would have to work once before hitting this code. But seems to be solved. The adminKey would already have been checked in the test, and this change doesn't affect test logic.