### PR TITLE
Bump mobx-react version

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,6 @@ module.exports = {
     '<rootDir>/config/jest/createRange.js',
     '<rootDir>/config/jest/fetchMock.js',
   ],
-  setupFilesAfterEnv: ['mobx-react/batchingForReactDom'],
   testEnvironment: 'jest-environment-jsdom-fourteen',
   testURL: 'http://localhost',
   moduleNameMapper: {

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -47,7 +47,7 @@
     "electron-is-dev": "^1.1.0",
     "json-stable-stringify": "^1.0.1",
     "mobx": "^5.10.1",
-    "mobx-react": "^6.0.3",
+    "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "mst-middlewares": "^3.10.2",
     "node-fetch": "^2.6.0",

--- a/products/jbrowse-protein-widget/package.json
+++ b/products/jbrowse-protein-widget/package.json
@@ -27,7 +27,7 @@
     "@gmod/jbrowse-plugin-svg": "^0.0.1-beta.13",
     "@material-ui/core": "^4.9.5",
     "mobx": "^5.10.1",
-    "mobx-react": "^6.0.3",
+    "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -47,7 +47,7 @@
     "json-stable-stringify": "^1.0.1",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",
-    "mobx-react": "^6.0.3",
+    "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "mst-middlewares": "^3.10.2",
     "prop-types": "^15.7.2",

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -18,7 +18,6 @@ import { FatalErrorDialog } from '@gmod/jbrowse-core/ui'
 import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import 'typeface-roboto'
 import 'requestidlecallback-polyfill'
-import 'mobx-react/batchingForReactDom'
 import 'core-js/stable'
 
 import Loading from './Loading'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15749,17 +15749,17 @@ mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdir
   dependencies:
     minimist "^1.2.5"
 
-mobx-react-lite@2:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.0.7.tgz#1bfb3b4272668e288047cf0c7940b14e91cba284"
-  integrity sha512-YKAh2gThC6WooPnVZCoC+rV1bODAKFwkhxikzgH18wpBjkgTkkR9Sb0IesQAH5QrAEH/JQVmy47jcpQkf2Au3Q==
+mobx-react-lite@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz#87c217dc72b4e47b22493daf155daf3759f868a6"
+  integrity sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==
 
-mobx-react@^6.0.0, mobx-react@^6.0.3:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.2.2.tgz#45e8e7c4894cac8399bba0a91060d7cfb8ea084b"
-  integrity sha512-Us6V4ng/iKIRJ8pWxdbdysC6bnS53ZKLKlVGBqzHx6J+gYPYbOotWvhHZnzh/W5mhpYXxlXif4kL2cxoWJOplQ==
+mobx-react@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.3.1.tgz#204f9756e42e19d91cb6598837063b7e7de87c52"
+  integrity sha512-IOxdJGnRSNSJrL2uGpWO5w9JH5q5HoxEqwOF4gye1gmZYdjoYkkMzSGMDnRCUpN/BNzZcFoMdHXrjvkwO7KgaQ==
   dependencies:
-    mobx-react-lite "2"
+    mobx-react-lite "^2.2.0"
 
 mobx-run-in-reactive-context@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Currently I was seeing a warning (on master, have seen it for awhile) where dragging on the overview scale bar would cause a React warning about setState from another component running 
https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render


Looking at the stack trace as recommended yielded a useForceUpdate in mobx code.

Found a lengthy thread that I didn't read entirely but found that updating mobx-react made the warning go away. Looks like it does something like "queued force updating now"

https://github.com/mobxjs/mobx-react-lite/issues/274 
https://github.com/mobxjs/mobx-react-lite/pull/299/files

Upgrading to the latest version printed a console log message said batchingForReactDom is not needed, so that is removed now too