### PR TITLE
Add disableRestoreFocus to Popovers in rubberband

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -228,6 +228,7 @@ function OverviewRubberBand({
               horizontal: 'right',
             }}
             keepMounted
+            disableRestoreFocus
           >
             <Typography>
               {leftBpOffset ? stringify(leftBpOffset) : ''}
@@ -249,6 +250,7 @@ function OverviewRubberBand({
               horizontal: 'left',
             }}
             keepMounted
+            disableRestoreFocus
           >
             <Typography>
               {rightBpOffset ? stringify(rightBpOffset) : ''}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RubberBand.tsx
@@ -247,6 +247,7 @@ function RubberBand({
               horizontal: 'right',
             }}
             keepMounted
+            disableRestoreFocus
           >
             <Typography>{stringify(leftBpOffset)}</Typography>
           </Popover>
@@ -266,6 +267,7 @@ function RubberBand({
               horizontal: 'left',
             }}
             keepMounted
+            disableRestoreFocus
           >
             <Typography>{stringify(rightBpOffset)}</Typography>
           </Popover>


### PR DESCRIPTION
Looking at #1193 a clue was that changing Popover to divs stopped this from happening

Then I found this issue thread https://github.com/mui-org/material-ui/issues/10072

This appears to fix #1193