### PR TITLE
Add a sequence cache backing indexed fasta

### DIFF
--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@gmod/indexedfasta": "^1.0.13",
     "@gmod/twobit": "^1.1.10",
+    "abortable-promise-cache": "^1.3.0",
     "generic-filehandle": "^2.0.1"
   },
   "peerDependencies": {

--- a/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
@@ -17,7 +17,10 @@ export default class extends BaseFeatureDataAdapter implements RegionsAdapter {
 
   private seqCache = new AbortablePromiseCache({
     cache: new LRU({ maxSize: 200 }),
-    fill: async (args: unknown, abortSignal?: AbortSignal) => {
+    fill: async (
+      args: { refName: string; start: number; end: number },
+      abortSignal?: AbortSignal,
+    ) => {
       const { refName, start, end } = args
       return this.fasta.getSequence(refName, start, end)
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5936,7 +5936,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.1.3:
+abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.1.3, abortable-promise-cache@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.3.0.tgz#c51a9fe670d50c04dcc2c695345b039d2212c040"
   integrity sha512-GneJsLjdKirdN2xYkNoHg8oBMzRLYFyNMRRvfm5hEhz58kP3yUc4EGQ7+TZ/5AAgsb3N84pqhmRpWO46RamGpA==


### PR DESCRIPTION
This adds a sequence cache for the indexed fasta

I found that trying to view the HG0096 high cov dataset was quite slow even when pretty zoomed in

Performance tracking revealed many many unzipping operations for tiny chunks of the bgzip indexed fasta

This is due to seqFetch calculating the MD tag for BAM, trying to unzip very tiny chunks sequence data repeatedly, e.g. each feature. Note that CRAM also benefits here since it uses the same seqFetch strategy



This adds a cache layer that extracts sequence chunks 128kb in size, and then slicing that as needed, for all operations involving sequence fetches. This is easier than trying to optimize the seqFetch operation specifically

Speedup

Before: 110s 
After: 20s

Viewing a 45kb region




