### PR TITLE
Fix SV inspector view

### DIFF
--- a/plugins/circular-view/src/CircularView/models/CircularView.js
+++ b/plugins/circular-view/src/CircularView/models/CircularView.js
@@ -282,14 +282,10 @@ export default pluginManager => {
       showTrack(trackId, initialSnapshot = {}) {
         const IT = pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(IT, getRoot(self), trackId)
-        if (!configuration) {
-          throw new Error(`failed to find track config ${trackId}`)
-        }
         const name = readConfObject(configuration, 'name')
         const trackType = pluginManager.getTrackType(configuration.type)
-        if (!trackType) {
+        if (!trackType)
           throw new Error(`unknown track type ${configuration.type}`)
-        }
         const track = trackType.stateModel.create({
           ...initialSnapshot,
           name,
@@ -299,7 +295,7 @@ export default pluginManager => {
         self.tracks.push(track)
       },
 
-      showTrackConf(configuration, initialSnapshot) {
+      addTrackConf(configuration, initialSnapshot) {
         const { type } = configuration
         const name = readConfObject(configuration, 'name')
         const trackType = pluginManager.getTrackType(type)

--- a/plugins/circular-view/src/CircularView/models/CircularView.js
+++ b/plugins/circular-view/src/CircularView/models/CircularView.js
@@ -45,10 +45,6 @@ export default pluginManager => {
       scrollX: 0,
       scrollY: 0,
       trackSelectorType: 'hierarchical',
-
-      viewTrackConfigs: types.array(
-        pluginManager.pluggableConfigSchemaType('track'),
-      ),
     })
     .volatile(() => ({
       width: 800,
@@ -283,15 +279,6 @@ export default pluginManager => {
         self.error = error
       },
 
-      addTrack(trackConf) {
-        const existing = self.viewTrackConfigs.find(
-          track => track.trackId === trackConf.trackId,
-        )
-        if (!existing) {
-          self.viewTrackConfigs.push(trackConf)
-        }
-      },
-
       showTrack(trackId, initialSnapshot = {}) {
         const IT = pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(IT, getRoot(self), trackId)
@@ -307,6 +294,22 @@ export default pluginManager => {
           ...initialSnapshot,
           name,
           type: configuration.type,
+          configuration,
+        })
+        self.tracks.push(track)
+      },
+
+      showTrackConf(configuration, initialSnapshot) {
+        const { type } = configuration
+        const name = readConfObject(configuration, 'name')
+        const trackType = pluginManager.getTrackType(type)
+        if (!trackType) {
+          throw new Error(`unknown track type ${configuration.type}`)
+        }
+        const track = trackType.stateModel.create({
+          ...initialSnapshot,
+          name,
+          type,
           configuration,
         })
         self.tracks.push(track)

--- a/plugins/circular-view/src/CircularView/models/CircularView.js
+++ b/plugins/circular-view/src/CircularView/models/CircularView.js
@@ -45,6 +45,10 @@ export default pluginManager => {
       scrollX: 0,
       scrollY: 0,
       trackSelectorType: 'hierarchical',
+
+      viewTrackConfigs: types.array(
+        pluginManager.pluggableConfigSchemaType('track'),
+      ),
     })
     .volatile(() => ({
       width: 800,
@@ -279,13 +283,26 @@ export default pluginManager => {
         self.error = error
       },
 
+      addTrack(trackConf) {
+        const existing = self.viewTrackConfigs.find(
+          track => track.trackId === trackConf.trackId,
+        )
+        if (!existing) {
+          self.viewTrackConfigs.push(trackConf)
+        }
+      },
+
       showTrack(trackId, initialSnapshot = {}) {
         const IT = pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(IT, getRoot(self), trackId)
+        if (!configuration) {
+          throw new Error(`failed to find track config ${trackId}`)
+        }
         const name = readConfObject(configuration, 'name')
         const trackType = pluginManager.getTrackType(configuration.type)
-        if (!trackType)
+        if (!trackType) {
           throw new Error(`unknown track type ${configuration.type}`)
+        }
         const track = trackType.stateModel.create({
           ...initialSnapshot,
           name,

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -278,7 +278,7 @@ export default pluginManager => {
 
               // put our track in as the only track
               if (assemblyName && generatedTrackConf) {
-                self.circularView.showTrackConf(generatedTrackConf, {
+                self.circularView.addTrackConf(generatedTrackConf, {
                   assemblyName,
                 })
               }

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -278,8 +278,7 @@ export default pluginManager => {
 
               // put our track in as the only track
               if (assemblyName && generatedTrackConf) {
-                self.circularView.addTrack(generatedTrackConf)
-                self.circularView.showTrack(generatedTrackConf.trackId, {
+                self.circularView.showTrackConf(generatedTrackConf, {
                   assemblyName,
                 })
               }

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -243,7 +243,7 @@ export default pluginManager => {
                             JSON.parse(JSON.stringify(displayedRegions)),
                           )
                         })
-                        .catch(e => console.error(e))
+                        .catch(e => circularView.setError(e))
                     }
                   } else {
                     circularView.setDisplayedRegions(assemblyRegions)
@@ -278,6 +278,7 @@ export default pluginManager => {
 
               // put our track in as the only track
               if (assemblyName && generatedTrackConf) {
+                self.circularView.addTrack(generatedTrackConf)
                 self.circularView.showTrack(generatedTrackConf.trackId, {
                   assemblyName,
                 })


### PR DESCRIPTION
 PR #1249 broke SV inspector view unfortunately. Basically the cause was that we created generatedTrackConf but this was not added to the tree so using showTrack(generatedTrackConf.trackId) and then using resolveIdentifier did not work

I made it so there is an alternative interface, addTrackConf, on the circular view model, that helps with this scenario

I tried using a viewTrackConfs similar to what exists on dotplot/synteny views, e.g. adding the config to the tree to a specialized spot on the view only, but this made the live updating after spreadsheet filters were applied not update the view.

