### PR TITLE
Move control of spacing/size to theme

### DIFF
--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -87,7 +87,7 @@ function App({ session }) {
       <div className={classes.menuBarAndComponents}>
         <div className={classes.menuBar}>
           <AppBar className={classes.appBar} position="static">
-            <Toolbar variant="dense">
+            <Toolbar>
               {session.menus.map(menu => (
                 <DropDownMenu
                   key={menu.label}

--- a/packages/core/ui/DrawerWidget.js
+++ b/packages/core/ui/DrawerWidget.js
@@ -50,11 +50,7 @@ const DrawerWidget = observer(props => {
     <Drawer session={session} open={Boolean(session.activeWidgets.size)}>
       <div className={classes.defaultDrawer}>
         <AppBar position="static" color="secondary">
-          <Toolbar
-            variant="dense"
-            disableGutters
-            className={classes.drawerToolbar}
-          >
+          <Toolbar disableGutters className={classes.drawerToolbar}>
             <Typography variant="h6" color="inherit">
               {HeadingComponent ? (
                 <HeadingComponent model={visibleWidget} />
@@ -70,7 +66,7 @@ const DrawerWidget = observer(props => {
               aria-label="Close"
               onClick={() => session.hideWidget(visibleWidget)}
             >
-              <CloseIcon fontSize="small" />
+              <CloseIcon />
             </IconButton>
           </Toolbar>
         </AppBar>

--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -62,7 +62,6 @@ const FileLocationEditor = observer(
             <ToggleButtonGroup
               value={fileOrUrlState}
               exclusive
-              size="small"
               onChange={handleFileOrUrlChange}
               aria-label="file or url picker"
             >
@@ -104,7 +103,6 @@ const UrlChooser = (props: {
   }
   return (
     <TextField
-      margin="dense"
       fullWidth
       defaultValue={location && isUriLocation(location) ? location.uri : ''}
       onChange={handleChange}
@@ -134,7 +132,7 @@ const LocalFileChooser = observer(
 
     return (
       <div style={{ position: 'relative' }}>
-        <Button size="small" variant="outlined" component="label">
+        <Button variant="outlined" component="label">
           Choose File
           <input
             type="file"

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -68,20 +68,20 @@ function MenuItemEndDecoration(props: MenuItemEndDecorationProps) {
   }
   let icon
   if (type === 'subMenu') {
-    icon = <ArrowRightIcon fontSize="small" color="action" />
+    icon = <ArrowRightIcon color="action" />
   } else if (type === 'checkbox') {
     if (checked) {
       const color = disabled ? 'inherit' : 'secondary'
-      icon = <CheckBoxIcon fontSize="small" color={color} />
+      icon = <CheckBoxIcon color={color} />
     } else {
-      icon = <CheckBoxOutlineBlankIcon fontSize="small" color="action" />
+      icon = <CheckBoxOutlineBlankIcon color="action" />
     }
   } else if (type === 'radio') {
     if (checked) {
       const color = disabled ? 'inherit' : 'secondary'
-      icon = <RadioButtonCheckedIcon fontSize="small" color={color} />
+      icon = <RadioButtonCheckedIcon color={color} />
     } else {
-      icon = <RadioButtonUncheckedIcon fontSize="small" color="action" />
+      icon = <RadioButtonUncheckedIcon color="action" />
     }
   }
   return <div className={classes.menuItemEndDecoration}>{icon}</div>
@@ -283,7 +283,7 @@ const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
             const Icon = menuItem.icon
             icon = (
               <ListItemIcon>
-                <Icon fontSize="small" />
+                <Icon />
               </ListItemIcon>
             )
           }

--- a/packages/core/ui/RecentSessionCard.js
+++ b/packages/core/ui/RecentSessionCard.js
@@ -100,13 +100,13 @@ function RecentSessionCard({
       >
         <MenuItem onClick={() => handleMenuClose('rename')}>
           <ListItemIcon>
-            <TextFieldsIcon color="secondary" fontSize="small" />
+            <TextFieldsIcon color="secondary" />
           </ListItemIcon>
           <Typography variant="inherit">Rename</Typography>
         </MenuItem>
         <MenuItem onClick={() => handleMenuClose('delete')}>
           <ListItemIcon>
-            <DeleteIcon color="secondary" fontSize="small" />
+            <DeleteIcon color="secondary" />
           </ListItemIcon>
           <Typography variant="inherit">Delete</Typography>
         </MenuItem>

--- a/packages/core/ui/StartScreen.tsx
+++ b/packages/core/ui/StartScreen.tsx
@@ -345,7 +345,7 @@ export default function StartScreen({
           }}
         >
           <ListItemIcon>
-            <WarningIcon fontSize="small" />
+            <WarningIcon />
           </ListItemIcon>
           <Typography variant="inherit">Factory Reset</Typography>
         </MenuItem>

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -173,10 +173,9 @@ export default withContentRect('bounds')(
               model={view}
               IconButtonProps={{
                 classes: { root: classes.iconRoot },
-                size: 'small',
                 edge: 'start',
               }}
-              IconProps={{ fontSize: 'small', className: classes.icon }}
+              IconProps={{ className: classes.icon }}
             />
             <div className={classes.grow} />
             {view.displayName ? (
@@ -197,11 +196,10 @@ export default withContentRect('bounds')(
             <div className={classes.grow} />
             <IconButton
               classes={{ root: classes.iconRoot }}
-              size="small"
               edge="end"
               onClick={onClose}
             >
-              <CloseIcon fontSize="small" className={classes.icon} />
+              <CloseIcon className={classes.icon} />
             </IconButton>
           </div>
           <Paper>{children}</Paper>

--- a/packages/core/ui/theme.test.ts
+++ b/packages/core/ui/theme.test.ts
@@ -52,4 +52,16 @@ describe('theme utils', () => {
     expect(theme.overrides?.MuiButton).toEqual(muiButtonStyle)
     expect(Object.keys(theme.overrides || {}).length).toBe(7)
   })
+  it('allows adding a custom prop', () => {
+    const muiPaperProps = { variant: 'outlined' as 'outlined' }
+    const theme = createJBrowseTheme({ props: { MuiPaper: muiPaperProps } })
+    expect(theme.props?.MuiPaper).toEqual(muiPaperProps)
+    expect(Object.keys(theme.props || {}).length).toBe(18)
+  })
+  it('allows modifying a prop override', () => {
+    const muiButtonProps = { size: 'medium' as 'medium' }
+    const theme = createJBrowseTheme({ props: { MuiButton: muiButtonProps } })
+    expect(theme.props?.MuiButton).toEqual(muiButtonProps)
+    expect(Object.keys(theme.props || {}).length).toBe(17)
+  })
 })

--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -42,6 +42,63 @@ export const jbrowseDefaultPalette = {
   quaternary: refTheme.palette.augmentColor({ main: mandarin }),
 }
 
+export function createJBrowseDefaultProps(/* palette: PaletteOptions = {} */) {
+  return {
+    MuiButton: {
+      size: 'small' as 'small',
+    },
+    MuiFilledInput: {
+      margin: 'dense' as 'dense',
+    },
+    MuiFormControl: {
+      margin: 'dense' as 'dense',
+    },
+    MuiFormHelperText: {
+      margin: 'dense' as 'dense',
+    },
+    MuiIconButton: {
+      size: 'small' as 'small',
+    },
+    MuiInputBase: {
+      margin: 'dense' as 'dense',
+    },
+    MuiInputLabel: {
+      margin: 'dense' as 'dense',
+    },
+    MuiList: {
+      dense: true,
+    },
+    MuiListItem: {
+      dense: true,
+    },
+    MuiOutlinedInput: {
+      margin: 'dense' as 'dense',
+    },
+    MuiFab: {
+      size: 'small' as 'small',
+    },
+    MuiTable: {
+      size: 'small' as 'small',
+    },
+    MuiTextField: {
+      margin: 'dense' as 'dense',
+      size: 'small' as 'small',
+    },
+    MuiToolbar: {
+      variant: 'dense' as 'dense',
+    },
+    MuiSvgIcon: {
+      fontSize: 'small' as 'small',
+    },
+    MuiToggleButtonGroup: {
+      size: 'small' as 'small',
+    },
+    MuiCheckbox: {
+      size: 'small' as 'small',
+    },
+  }
+}
+
 export function createJBrowseDefaultOverrides(palette: PaletteOptions = {}) {
   const generatedPalette = deepmerge(jbrowseDefaultPalette, palette)
   return {
@@ -108,10 +165,9 @@ export function createJBrowseDefaultOverrides(palette: PaletteOptions = {}) {
 
 export const jbrowseBaseTheme: ThemeOptions = {
   palette: jbrowseDefaultPalette,
-  typography: {
-    fontSize: 12,
-  },
+  // typography: { fontSize: 12 },
   spacing: 4,
+  props: createJBrowseDefaultProps(),
   overrides: createJBrowseDefaultOverrides(),
 }
 
@@ -139,6 +195,7 @@ export function createJBrowseTheme(theme?: ThemeOptions) {
   }
   theme = {
     ...theme,
+    props: deepmerge(createJBrowseDefaultProps(), theme.props || {}),
     overrides: deepmerge(
       createJBrowseDefaultOverrides(theme.palette),
       theme.overrides || {},

--- a/plugins/breakpoint-split-view/src/components/Header.tsx
+++ b/plugins/breakpoint-split-view/src/components/Header.tsx
@@ -59,11 +59,7 @@ export default ({ jbrequire }: { jbrequire: any }) => {
           className={classes.iconButton}
           title="Toggle interacting with the overlay"
         >
-          {model.interactToggled ? (
-            <LocationSearching fontSize="small" />
-          ) : (
-            <LocationDisabled fontSize="small" />
-          )}
+          {model.interactToggled ? <LocationSearching /> : <LocationDisabled />}
         </IconButton>
       )
     },
@@ -80,9 +76,9 @@ export default ({ jbrequire }: { jbrequire: any }) => {
         title="Toggle linked scrolls and behavior across views"
       >
         {model.linkViews ? (
-          <LinkIcon color="secondary" fontSize="small" />
+          <LinkIcon color="secondary" />
         ) : (
-          <LinkOffIcon color="secondary" fontSize="small" />
+          <LinkOffIcon color="secondary" />
         )}
       </IconButton>
     )
@@ -99,9 +95,9 @@ export default ({ jbrequire }: { jbrequire: any }) => {
         title="Toggle rendering intraview links"
       >
         {model.showIntraviewLinks ? (
-          <LeakAdd color="secondary" fontSize="small" />
+          <LeakAdd color="secondary" />
         ) : (
-          <LeakRemove color="secondary" fontSize="small" />
+          <LeakRemove color="secondary" />
         )}
       </IconButton>
     )

--- a/plugins/circular-view/src/CircularView/components/CircularView.js
+++ b/plugins/circular-view/src/CircularView/components/CircularView.js
@@ -114,7 +114,7 @@ export default pluginManager => {
           }
           color="secondary"
         >
-          <ZoomOut fontSize="small" />
+          <ZoomOut />
         </IconButton>
 
         <IconButton
@@ -124,7 +124,7 @@ export default pluginManager => {
           disabled={!showingFigure || model.atMinBpPerPx}
           color="secondary"
         >
-          <ZoomIn fontSize="small" />
+          <ZoomIn />
         </IconButton>
 
         <IconButton
@@ -134,7 +134,7 @@ export default pluginManager => {
           disabled={!showingFigure}
           color="secondary"
         >
-          <RotateLeft fontSize="small" />
+          <RotateLeft />
         </IconButton>
 
         <IconButton
@@ -144,7 +144,7 @@ export default pluginManager => {
           disabled={!showingFigure}
           color="secondary"
         >
-          <RotateRight fontSize="small" />
+          <RotateRight />
         </IconButton>
 
         <IconButton
@@ -158,11 +158,7 @@ export default pluginManager => {
           disabled={model.tooSmallToLock}
           color="secondary"
         >
-          {model.lockedFitToWindow ? (
-            <LockOutline fontSize="small" />
-          ) : (
-            <LockOpen fontSize="small" />
-          )}
+          {model.lockedFitToWindow ? <LockOutline /> : <LockOpen />}
         </IconButton>
 
         {model.hideTrackSelectorButton ? null : (
@@ -178,7 +174,7 @@ export default pluginManager => {
             data-testid="circular_track_select"
             color="secondary"
           >
-            <LineStyle fontSize="small" />
+            <LineStyle />
           </ToggleButton>
         )}
       </div>

--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
@@ -65,9 +65,9 @@ const StringArrayEditor = observer(({ slot }) => {
   return (
     <>
       {slot.name ? <InputLabel>{slot.name}</InputLabel> : null}
-      <List dense disablePadding>
+      <List disablePadding>
         {slot.value.map((val, idx) => (
-          <ListItem key={idx} dense disableGutters>
+          <ListItem key={idx} disableGutters>
             <TextField
               value={val}
               onChange={evt => slot.setAtIndex(idx, evt.target.value)}
@@ -86,7 +86,7 @@ const StringArrayEditor = observer(({ slot }) => {
             />
           </ListItem>
         ))}
-        <ListItem dense disableGutters>
+        <ListItem disableGutters>
           <TextField
             value={value}
             placeholder="add new"

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -93,7 +93,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
             <button
               aria-label="local file"
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiToggleButton-sizeSmall MuiButtonBase-disabled"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
               disabled=""
               tabindex="-1"
               type="button"
@@ -108,7 +108,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
             <button
               aria-label="url"
               aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected MuiToggleButton-sizeSmall"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
               tabindex="0"
               type="button"
               value="url"
@@ -128,14 +128,14 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
           class="MuiGrid-root MuiGrid-item"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                class="MuiInputBase-input MuiInput-input"
                 type="text"
                 value="/path/to/my.file"
               />
@@ -190,10 +190,10 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
         stringArrayTest
       </label>
       <ul
-        class="MuiList-root MuiList-dense"
+        class="MuiList-root"
       >
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -238,7 +238,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -283,7 +283,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -420,10 +420,10 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
           class="MuiCardContent-root"
         >
           <ul
-            class="MuiList-root MuiList-dense"
+            class="MuiList-root"
           >
             <li
-              class="MuiListItem-root MuiListItem-dense"
+              class="MuiListItem-root"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -468,7 +468,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
               </div>
             </li>
             <li
-              class="MuiListItem-root MuiListItem-dense"
+              class="MuiListItem-root"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -513,7 +513,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
               </div>
             </li>
             <li
-              class="MuiListItem-root MuiListItem-dense"
+              class="MuiListItem-root"
             >
               <div
                 class="MuiFormControl-root MuiTextField-root"
@@ -999,10 +999,10 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
         assemblyNames
       </label>
       <ul
-        class="MuiList-root MuiList-dense"
+        class="MuiList-root"
       >
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -1047,7 +1047,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
           </div>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -1199,10 +1199,10 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
         category
       </label>
       <ul
-        class="MuiList-root MuiList-dense"
+        class="MuiList-root"
       >
         <li
-          class="MuiListItem-root MuiListItem-dense"
+          class="MuiListItem-root"
         >
           <div
             class="MuiFormControl-root MuiTextField-root"
@@ -1837,7 +1837,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                 <button
                   aria-label="local file"
                   aria-pressed="false"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiToggleButton-sizeSmall MuiButtonBase-disabled"
+                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -1852,7 +1852,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                 <button
                   aria-label="url"
                   aria-pressed="true"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected MuiToggleButton-sizeSmall"
+                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
                   tabindex="0"
                   type="button"
                   value="url"
@@ -1872,14 +1872,14 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
               class="MuiGrid-root MuiGrid-item"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+                class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                 >
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                    class="MuiInputBase-input MuiInput-input"
                     type="text"
                     value="/path/to/my.bam"
                   />
@@ -2031,7 +2031,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                     <button
                       aria-label="local file"
                       aria-pressed="false"
-                      class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiToggleButton-sizeSmall MuiButtonBase-disabled"
+                      class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -2046,7 +2046,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                     <button
                       aria-label="url"
                       aria-pressed="true"
-                      class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected MuiToggleButton-sizeSmall"
+                      class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
                       tabindex="0"
                       type="button"
                       value="url"
@@ -2066,14 +2066,14 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                   class="MuiGrid-root MuiGrid-item"
                 >
                   <div
-                    class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                     >
                       <input
                         aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                        class="MuiInputBase-input MuiInput-input"
                         type="text"
                         value="/path/to/my.bam.bai"
                       />

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
@@ -203,7 +203,7 @@ exports[`<AddTrackWidget /> renders 1`] = `
                         <button
                           aria-label="local file"
                           aria-pressed="false"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiToggleButton-sizeSmall MuiButtonBase-disabled"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
                           disabled=""
                           tabindex="-1"
                           type="button"
@@ -218,7 +218,7 @@ exports[`<AddTrackWidget /> renders 1`] = `
                         <button
                           aria-label="url"
                           aria-pressed="true"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected MuiToggleButton-sizeSmall"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
                           tabindex="0"
                           type="button"
                           value="url"
@@ -238,14 +238,14 @@ exports[`<AddTrackWidget /> renders 1`] = `
                       class="MuiGrid-root MuiGrid-item"
                     >
                       <div
-                        class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                       >
                         <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                         >
                           <input
                             aria-invalid="false"
-                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                            class="MuiInputBase-input MuiInput-input"
                             type="text"
                             value=""
                           />

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
@@ -143,7 +143,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
           <button
             aria-label="local file"
             aria-pressed="false"
-            class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiToggleButton-sizeSmall MuiButtonBase-disabled"
+            class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
             disabled=""
             tabindex="-1"
             type="button"
@@ -158,7 +158,7 @@ exports[`<TrackSourceSelect /> renders 1`] = `
           <button
             aria-label="url"
             aria-pressed="true"
-            class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected MuiToggleButton-sizeSmall"
+            class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
             tabindex="0"
             type="button"
             value="url"
@@ -178,14 +178,14 @@ exports[`<TrackSourceSelect /> renders 1`] = `
         class="MuiGrid-root MuiGrid-item"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+              class="MuiInputBase-input MuiInput-input"
               type="text"
               value=""
             />

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -84,7 +84,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           color="secondary"
           data-testid={`htsTrackEntryMenu-${trackId}`}
         >
-          <HorizontalDots fontSize="small" />
+          <HorizontalDots />
         </IconButton>
         <Menu
           anchorEl={anchorEl}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -112,7 +112,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -314,7 +314,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                    class="MuiSvgIcon-root"
                                     focusable="false"
                                     viewBox="0 0 24 24"
                                   >
@@ -447,7 +447,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                                             >
                                               <svg
                                                 aria-hidden="true"
-                                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                                class="MuiSvgIcon-root"
                                                 focusable="false"
                                                 viewBox="0 0 24 24"
                                               >
@@ -619,7 +619,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -758,7 +758,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        class="MuiSvgIcon-root"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
@@ -827,7 +827,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                        class="MuiSvgIcon-root"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >

--- a/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
@@ -47,7 +47,7 @@ export default () => {
           title="left"
           color="secondary"
         >
-          <ArrowLeft fontSize="small" />
+          <ArrowLeft />
         </IconButton>
 
         <IconButton
@@ -58,7 +58,7 @@ export default () => {
           title="left"
           color="secondary"
         >
-          <ArrowRight fontSize="small" />
+          <ArrowRight />
         </IconButton>
         <IconButton
           onClick={() => {
@@ -68,7 +68,7 @@ export default () => {
           title="left"
           color="secondary"
         >
-          <ArrowDown fontSize="small" />
+          <ArrowDown />
         </IconButton>
         <IconButton
           onClick={() => {
@@ -78,7 +78,7 @@ export default () => {
           title="left"
           color="secondary"
         >
-          <ArrowUp fontSize="small" />
+          <ArrowUp />
         </IconButton>
         <IconButton
           onClick={model.zoomOutButton}

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -34,7 +34,7 @@ export default () => {
   const Controls = observer(({ model }: { model: DotplotViewModel }) => {
     return (
       <IconButton onClick={model.closeView} title="close this view">
-        <CloseIcon fontSize="small" />
+        <CloseIcon />
       </IconButton>
     )
   })
@@ -101,7 +101,7 @@ export default () => {
             value="track_select"
             color="secondary"
           >
-            <LineStyleIcon fontSize="small" />
+            <LineStyleIcon />
           </IconButton>
           <div className={classes.spacer} />
         </div>

--- a/plugins/linear-comparative-view/src/BlockError.js
+++ b/plugins/linear-comparative-view/src/BlockError.js
@@ -22,7 +22,6 @@ function BlockError({ error, reload }) {
         <Button
           onClick={reload}
           // variant="outlined"
-          size="small"
           startIcon={<RefreshIcon />}
         >
           Reload

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
@@ -54,9 +54,9 @@ const InteractWithSquiggles = observer(
         title="Toggle interacting with the overlay"
       >
         {model.interactToggled ? (
-          <LocationSearchingIcon fontSize="small" />
+          <LocationSearchingIcon />
         ) : (
-          <LocationDisabledIcon fontSize="small" />
+          <LocationDisabledIcon />
         )}
       </IconButton>
     )
@@ -71,9 +71,9 @@ const LinkViews = observer(
         title="Toggle linked scrolls and behavior across views"
       >
         {model.linkViews ? (
-          <LinkIcon color="secondary" fontSize="small" />
+          <LinkIcon color="secondary" />
         ) : (
-          <LinkOffIcon color="secondary" fontSize="small" />
+          <LinkOffIcon color="secondary" />
         )}
       </IconButton>
     )
@@ -87,9 +87,9 @@ const Sync = observer(({ model }: { model: LinearComparativeViewModel }) => {
       title="Toggle rendering intraview links"
     >
       {model.showIntraviewLinks ? (
-        <LeakAddIcon color="secondary" fontSize="small" />
+        <LeakAddIcon color="secondary" />
       ) : (
-        <LeakRemoveIcon color="secondary" fontSize="small" />
+        <LeakRemoveIcon color="secondary" />
       )}
     </IconButton>
   )

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -50,7 +50,6 @@ const FormRow = observer(
           }}
           error={Boolean(error)}
           disabled={Boolean(error)}
-          margin="dense"
           className={classes.importFormEntry}
         >
           {assemblyNames.map((name, idx) => (

--- a/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/baseTrackModel.tsx
@@ -243,7 +243,6 @@ const BaseTrack = types
                 self.setUserBpPerPxLimit(view.bpPerPx)
                 self.reload()
               }}
-              size="small"
               variant="outlined"
             >
               Force Load

--- a/plugins/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BasicTrack/components/ServerSideRenderedBlockContent.tsx
@@ -127,7 +127,6 @@ function BlockError({
           <Button
             data-testid="reload_button"
             onClick={reload}
-            size="small"
             startIcon={<RefreshIcon />}
           >
             Reload

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -71,7 +71,7 @@ const Controls = observer(({ model }: { model: LGV }) => {
         session.visibleWidget.view.id === model.id
       }
     >
-      <TrackSelectorIcon fontSize="small" />
+      <TrackSelectorIcon />
     </ToggleButton>
   )
 })
@@ -108,13 +108,12 @@ const Search = observer(({ model }: { model: LGV }) => {
         onChange={event => setValue(event.target.value)}
         className={classes.input}
         variant="outlined"
-        size="small"
         value={value === undefined ? visibleLocStrings : value}
+        style={{ margin: SPACING, marginLeft: SPACING * 3 }}
         InputProps={{
-          startAdornment: <SearchIcon fontSize="small" />,
+          startAdornment: <SearchIcon />,
           style: {
             background: fade(theme.palette.background.paper, 0.8),
-            margin: SPACING,
             height: WIDGET_HEIGHT,
           },
         }}
@@ -128,7 +127,6 @@ function PanControls({ model }: { model: LGV }) {
   return (
     <>
       <Button
-        size="small"
         variant="outlined"
         className={classes.panButton}
         onClick={() => model.slide(-0.9)}
@@ -136,7 +134,6 @@ function PanControls({ model }: { model: LGV }) {
         <ArrowBackIcon />
       </Button>
       <Button
-        size="small"
         variant="outlined"
         className={classes.panButton}
         onClick={() => model.slide(0.9)}
@@ -173,17 +170,14 @@ export default observer(({ model }: { model: LGV }) => {
       <FormGroup row>
         <PanControls model={model} />
         <RefNameAutocomplete
-          style={{
-            margin: SPACING,
-          }}
           onSelect={setDisplayedRegion}
           assemblyName={assemblyName}
           defaultRegionName={displayedRegions.length > 1 ? '' : refName}
           model={model}
           TextFieldProps={{
             variant: 'outlined',
-            size: 'small',
             className: classes.headerRefName,
+            style: { margin: SPACING },
             InputProps: {
               style: {
                 padding: 0,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -17,13 +17,12 @@ const MiniControls = observer((props: { model: LinearGenomeViewModel }) => {
     <>
       <Paper style={{ background: '#aaa7' }}>
         <IconButton
-          size="small"
           color="secondary"
           onClick={event => {
             setAnchorEl(event.currentTarget)
           }}
         >
-          <ArrowDown fontSize="small" />
+          <ArrowDown />
         </IconButton>
 
         <IconButton
@@ -32,10 +31,9 @@ const MiniControls = observer((props: { model: LinearGenomeViewModel }) => {
             model.zoom(bpPerPx * 2)
           }}
           disabled={bpPerPx >= maxBpPerPx - 0.0001 || scaleFactor !== 1}
-          size="small"
           color="secondary"
         >
-          <ZoomOut fontSize="small" />
+          <ZoomOut />
         </IconButton>
         <IconButton
           data-testid="zoom_in"
@@ -44,9 +42,8 @@ const MiniControls = observer((props: { model: LinearGenomeViewModel }) => {
           }}
           disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
           color="secondary"
-          size="small"
         >
-          <ZoomIn fontSize="small" />
+          <ZoomIn />
         </IconButton>
       </Paper>
       <Menu

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -114,7 +114,7 @@ const TrackLabel = React.forwardRef(
             onDragEnd={onDragEnd}
             data-testid={`dragHandle-${view.id}-${trackId}`}
           >
-            <DragIcon fontSize="small" className={classes.dragHandleIcon} />
+            <DragIcon className={classes.dragHandleIcon} />
           </span>
           <IconButton
             onClick={() => view.hideTrack(trackId)}
@@ -122,7 +122,7 @@ const TrackLabel = React.forwardRef(
             title="close this track"
             color="secondary"
           >
-            <CloseIcon fontSize="small" />
+            <CloseIcon />
           </IconButton>
           <Typography
             variant="body1"
@@ -140,7 +140,7 @@ const TrackLabel = React.forwardRef(
             data-testid="track_menu_icon"
             disabled={!track.trackMenuItems.length}
           >
-            <MoreVertIcon fontSize="small" />
+            <MoreVertIcon />
           </IconButton>
         </Paper>
         <Menu

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -32,7 +32,7 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
         disabled={bpPerPx >= maxBpPerPx - 0.0001 || scaleFactor !== 1}
         color="secondary"
       >
-        <ZoomOut fontSize="small" />
+        <ZoomOut />
       </IconButton>
 
       <Slider
@@ -51,7 +51,7 @@ function ZoomControls({ model }: { model: LinearGenomeViewModel }) {
         disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
         color="secondary"
       >
-        <ZoomIn fontSize="small" />
+        <ZoomIn />
       </IconButton>
     </div>
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -76,7 +76,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -96,7 +96,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           class="MuiFormGroup-root MuiFormGroup-row"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
             tabindex="0"
             type="button"
           >
@@ -119,7 +119,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             />
           </button>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
             tabindex="0"
             type="button"
           >
@@ -145,13 +145,13 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             aria-expanded="false"
             class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon"
             role="combobox"
-            style="margin: 7px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
+              style="margin: 7px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
               >
                 <input
@@ -159,7 +159,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                   aria-invalid="false"
                   autocapitalize="none"
                   autocomplete="off"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
                   id="refNameAutocomplete-lgv"
                   spellcheck="false"
                   type="text"
@@ -214,14 +214,15 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           <form>
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-input"
+              style="margin: 7px 7px 7px 21px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 32px;"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+                style="background: rgba(255, 255, 255, 0.8); height: 32px;"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  class="MuiSvgIcon-root"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -231,7 +232,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 </svg>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
                   type="text"
                   value="ctgA:1..100"
                 />
@@ -273,7 +274,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                class="MuiSvgIcon-root"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -320,7 +321,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                class="MuiSvgIcon-root"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -464,7 +465,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root makeStyles-dragHandleIcon MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root makeStyles-dragHandleIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -484,7 +485,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -515,7 +516,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -851,7 +852,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -871,7 +872,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           class="MuiFormGroup-root MuiFormGroup-row"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
             tabindex="0"
             type="button"
           >
@@ -894,7 +895,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             />
           </button>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
             tabindex="0"
             type="button"
           >
@@ -919,14 +920,15 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           <form>
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-input"
+              style="margin: 7px 7px 7px 21px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-marginDense MuiOutlinedInput-marginDense"
-                style="background: rgba(255, 255, 255, 0.8); margin: 7px; height: 32px;"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+                style="background: rgba(255, 255, 255, 0.8); height: 32px;"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                  class="MuiSvgIcon-root"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -936,7 +938,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 </svg>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
                   type="text"
                   value="ctgA:1..100;ctgB:1,001..1,698"
                 />
@@ -977,7 +979,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                class="MuiSvgIcon-root"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -1027,7 +1029,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                class="MuiSvgIcon-root"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -1464,7 +1466,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root makeStyles-dragHandleIcon MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root makeStyles-dragHandleIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -1484,7 +1486,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -1515,7 +1517,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -1646,7 +1648,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root makeStyles-dragHandleIcon MuiSvgIcon-fontSizeSmall"
+            class="MuiSvgIcon-root makeStyles-dragHandleIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -1666,7 +1668,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -1697,7 +1699,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+              class="MuiSvgIcon-root"
               focusable="false"
               viewBox="0 0 24 24"
             >

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ColumnFilterControls.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ColumnFilterControls.js
@@ -64,7 +64,7 @@ export default pluginManager => {
           style={{ height }}
         >
           <Grid item className={classes.filterIconBg}>
-            <FilterIcon className={classes.filterIcon} fontSize="small" />
+            <FilterIcon className={classes.filterIcon} />
           </Grid>
           <Grid item>
             <IconButton
@@ -72,7 +72,7 @@ export default pluginManager => {
               title="remove filter"
               color="secondary"
             >
-              <CloseIcon fontSize="small" />
+              <CloseIcon />
             </IconButton>
             <Typography className={classes.columnName} component="span">
               {columnDefinition.name}

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/GlobalFilterControls.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/GlobalFilterControls.js
@@ -36,7 +36,6 @@ export default pluginManager => {
           value={textFilterValue}
           onChange={evt => setTextFilterValue(evt.target.value)}
           className={classes.textFilterControl}
-          margin="dense"
           variant="outlined"
           InputProps={{
             startAdornment: (

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
@@ -188,7 +188,6 @@ export default pluginManager => {
                   className={classes.rowSelector}
                   checked={rowModel.isSelected}
                   onClick={labelClick}
-                  size="small"
                 />
               )
             }
@@ -226,15 +225,9 @@ export default pluginManager => {
     if (sortSpec) {
       const { descending } = sortSpec
       return descending ? (
-        <KeyboardArrowUpIcon
-          fontSize="small"
-          className={classes.sortIndicator}
-        />
+        <KeyboardArrowUpIcon className={classes.sortIndicator} />
       ) : (
-        <KeyboardArrowDownIcon
-          fontSize="small"
-          className={classes.sortIndicator}
-        />
+        <KeyboardArrowDownIcon className={classes.sortIndicator} />
       )
     }
     return null
@@ -300,7 +293,6 @@ export default pluginManager => {
                       className={classes.unselectAllButton}
                       onClick={model.unselectAll}
                       disabled={!model.rowSet.selectedCount}
-                      size="small"
                       color="secondary"
                     >
                       <CropFreeIcon className={classes.columnButtonIcon} />

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
@@ -84,7 +84,7 @@ export default pluginManager => {
             data-testid="spreadsheet_view_open"
             color="secondary"
           >
-            <FolderOpenIcon fontSize="small" />
+            <FolderOpenIcon />
           </IconButton>
         </Grid>
       </Grid>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -75,7 +75,6 @@ export default pluginManager => {
           value={filterModel.locString}
           onChange={evt => filterModel.setLocString(evt.target.value)}
           className={classes.textFilterControl}
-          margin="dense"
           InputProps={{
             endAdornment: (
               <InputAdornment

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
@@ -95,7 +95,6 @@ export default ({ jbrequire }) => {
             filterModel.setFirstNumber(parseFloat(evt.target.value))
           }}
           className={classes.textFilterControl}
-          margin="dense"
         />
         {filterModel.operation !== 'between' &&
         filterModel.operation !== 'not between' ? null : (
@@ -111,7 +110,6 @@ export default ({ jbrequire }) => {
                 filterModel.setSecondNumber(parseFloat(evt.target.value))
               }
               className={classes.textFilterControl}
-              margin="dense"
             />
           </>
         )}

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
@@ -97,7 +97,6 @@ export default pluginManager => {
           value={filterModel.stringToFind}
           onChange={evt => filterModel.setString(evt.target.value)}
           className={classes.textFilterControl}
-          margin="dense"
           InputProps={{
             endAdornment: (
               <InputAdornment

--- a/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.js
@@ -70,7 +70,7 @@ export default pluginManager => {
             data-testid="sv_inspector_view_open"
             color="secondary"
           >
-            <FolderOpenIcon fontSize="small" />
+            <FolderOpenIcon />
           </IconButton>
         </Grid>
       </Grid>
@@ -97,7 +97,6 @@ export default pluginManager => {
                     evt.target.checked,
                   )
                 }
-                size="small"
               />
             }
             label="show only regions with data"

--- a/products/generator-jbrowse/generators/app/templates/HelloWorldMenuBar/components/HelloWorld.js
+++ b/products/generator-jbrowse/generators/app/templates/HelloWorldMenuBar/components/HelloWorld.js
@@ -19,7 +19,7 @@ function HelloWorld({ model }) {
 
   return (
     <AppBar className={classes.root} position="static">
-      <Toolbar variant="dense">
+      <Toolbar>
         <Typography variant="h6" color="inherit">
           Hello, World! ({model.id})
         </Typography>

--- a/products/generator-jbrowse/generators/app/templates/HelloWorldMenuBarAndWidget/components/HelloWorldMenuBar.js
+++ b/products/generator-jbrowse/generators/app/templates/HelloWorldMenuBarAndWidget/components/HelloWorldMenuBar.js
@@ -27,7 +27,7 @@ function HelloWorld({ model }) {
 
   return (
     <AppBar className={classes.root} position="static">
-      <Toolbar variant="dense">
+      <Toolbar>
         <Button onClick={() => onClick(session)} color="inherit">
           Click Me!
         </Button>


### PR DESCRIPTION
This is a proposed add-on to #1270 and #1255.

This changes the default props of various of the Material-UI components to use smaller versions (e.g. `size="small"`, `margin="dense"`) using the theme. We were already manually specifying most these props anyway. This way they can be specified in one place and we don't have to worry about specifying them each time they are used. Also, someone could override the theme and use bigger components if they wanted.