### PR TITLE
Make sort, show soft clipping stateful aspects of the track

### DIFF
--- a/plugins/alignments/src/AlignmentsTrack/model.ts
+++ b/plugins/alignments/src/AlignmentsTrack/model.ts
@@ -2,8 +2,10 @@ import {
   getConf,
   ConfigurationReference,
 } from '@gmod/jbrowse-core/configuration'
+
+import deepEqual from 'deep-equal'
 import { BaseTrack } from '@gmod/jbrowse-plugin-linear-genome-view'
-import { types, addDisposer, Instance } from 'mobx-state-tree'
+import { types, addDisposer, getSnapshot, Instance } from 'mobx-state-tree'
 import { autorun } from 'mobx'
 import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
@@ -51,8 +53,13 @@ const stateModelFactory = (
       const { trackMenuItems } = self
       return {
         get pileupTrackConfig() {
+          const conf = getConf(self)
+          const { SNPCoverageRenderer, ...rest } = conf.renderers
           return {
-            ...getConf(self),
+            ...conf,
+            renderers: {
+              ...rest,
+            },
             type: 'PileupTrack',
             name: `${getConf(self, 'name')} pileup`,
             trackId: `${self.configuration.trackId}_pileup_xyz`, // xyz to avoid someone accidentally namign the trackId similar to this
@@ -82,8 +89,13 @@ const stateModelFactory = (
         },
 
         get snpCoverageTrackConfig() {
+          const conf = getConf(self)
+          const { SNPCoverageRenderer } = conf.renderers
           return {
-            ...getConf(self),
+            ...conf,
+            renderers: {
+              SNPCoverageRenderer,
+            },
             type: 'SNPCoverageTrack',
             name: `${getConf(self, 'name')} snpcoverage`,
             trackId: `${self.configuration.trackId}_snpcoverage_xyz`, // xyz to avoid someone accidentally namign the trackId similar to this
@@ -122,8 +134,27 @@ const stateModelFactory = (
         addDisposer(
           self,
           autorun(() => {
-            this.setSNPCoverageTrack(self.snpCoverageTrackConfig)
-            this.setPileupTrack(self.pileupTrackConfig)
+            if (!self.SNPCoverageTrack) {
+              this.setSNPCoverageTrack(self.snpCoverageTrackConfig)
+            } else if (
+              !deepEqual(
+                self.snpCoverageTrackConfig,
+                getSnapshot(self.SNPCoverageTrack.configuration),
+              )
+            ) {
+              self.SNPCoverageTrack.setConfig(self.snpCoverageTrackConfig)
+            }
+
+            if (!self.PileupTrack) {
+              this.setPileupTrack(self.pileupTrackConfig)
+            } else if (
+              !deepEqual(
+                self.pileupTrackConfig,
+                getSnapshot(self.PileupTrack.configuration),
+              )
+            ) {
+              self.PileupTrack.setConfig(self.pileupTrackConfig)
+            }
           }),
         )
       },

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -31,11 +31,12 @@ export interface PileupRenderProps {
   height: number
   width: number
   highResolutionScaling: number
-  sortObject: {
-    position: number
-    by: string
-  }
   showSoftClip: boolean
+  sortedBy: {
+    type: string
+    pos: number
+    refName: string
+  }
 }
 
 interface LayoutRecord {
@@ -54,7 +55,7 @@ interface PileupLayoutSessionProps {
   config: AnyConfigurationModel
   bpPerPx: number
   filters: SerializableFilterChain
-  sortObject: unknown
+  sortedBy: unknown
   showSoftClip: unknown
 }
 
@@ -63,14 +64,14 @@ interface CachedPileupLayout {
   layout: MyMultiLayout
   config: AnyConfigurationModel
   filters: SerializableFilterChain
-  sortObject: unknown
+  sortedBy: unknown
   showSoftClip: unknown
 }
 
 // Sorting and revealing soft clip changes the layout of Pileup renderer
 // Adds extra conditions to see if cached layout is valid
 class PileupLayoutSession extends LayoutSession {
-  sortObject: unknown
+  sortedBy: unknown
 
   showSoftClip: unknown
 
@@ -82,7 +83,7 @@ class PileupLayoutSession extends LayoutSession {
   cachedLayoutIsValid(cachedLayout: CachedPileupLayout) {
     return (
       super.cachedLayoutIsValid(cachedLayout) &&
-      deepEqual(this.sortObject, cachedLayout.sortObject) &&
+      deepEqual(this.sortedBy, cachedLayout.sortedBy) &&
       deepEqual(this.showSoftClip, cachedLayout.showSoftClip)
     )
   }
@@ -95,7 +96,7 @@ class PileupLayoutSession extends LayoutSession {
         layout: this.makeLayout(),
         config: readConfObject(this.config),
         filters: this.filters,
-        sortObject: this.sortObject,
+        sortedBy: this.sortedBy,
         showSoftClip: this.showSoftClip,
       }
     }
@@ -187,7 +188,7 @@ export default class PileupRenderer extends BoxRendererType {
       config,
       regions,
       bpPerPx,
-      sortObject,
+      sortedBy,
       highResolutionScaling = 1,
       showSoftClip,
     } = props
@@ -203,8 +204,8 @@ export default class PileupRenderer extends BoxRendererType {
     const w = Math.max(minFeatWidth, pxPerBp)
 
     const sortedFeatures =
-      sortObject && sortObject.by && region.start === sortObject.position
-        ? sortFeature(features, sortObject)
+      sortedBy && sortedBy.type && region.start === sortedBy.pos
+        ? sortFeature(features, sortedBy)
         : null
 
     const featureMap = sortedFeatures || features

--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -13,7 +13,7 @@ function PileupRendering(props: {
   height: number
   regions: Region[]
   bpPerPx: number
-  sortObject?: { by: string; position: number }
+  sortedBy?: { type: string; pos: number; refName: string }
   onMouseMove?: (event: React.MouseEvent, featureId: string | undefined) => void
 }) {
   const {
@@ -24,7 +24,7 @@ function PileupRendering(props: {
     height,
     regions,
     bpPerPx,
-    sortObject,
+    sortedBy,
   } = props
   const {
     selectedFeatureId,
@@ -171,7 +171,7 @@ function PileupRendering(props: {
   return (
     <div
       className="PileupRendering"
-      data-testid={`pileup-${sortObject ? sortObject.by : 'normal'}`}
+      data-testid={`pileup-${sortedBy ? sortedBy.type : 'normal'}`}
       style={{ position: 'relative', width: canvasWidth, height }}
     >
       <PrerenderedCanvas

--- a/plugins/alignments/src/PileupRenderer/sortUtil.ts
+++ b/plugins/alignments/src/PileupRenderer/sortUtil.ts
@@ -3,35 +3,31 @@ import { doesIntersect2 } from '@gmod/jbrowse-core/util/range'
 import { Mismatch } from '../BamAdapter/MismatchParser'
 
 interface SortObject {
-  position: number
-  by: string
+  pos: number
+  type: string
 }
 export const sortFeature = (
   features: Map<string, Feature>,
-  sortObject: SortObject,
+  sortedBy: SortObject,
 ) => {
   const featureArray = Array.from(features.values())
   const featuresInCenterLine: Feature[] = []
   const featuresOutsideCenter: Feature[] = []
+  const { pos, type } = sortedBy
 
   // only sort on features that intersect center line, append those outside post-sort
   featureArray.forEach(innerArray => {
     const feature = innerArray
-    if (
-      doesIntersect2(
-        sortObject.position - 1,
-        sortObject.position,
-        feature.get('start'),
-        feature.get('end'),
-      )
-    ) {
+    const start = feature.get('start')
+    const end = feature.get('end')
+    if (doesIntersect2(pos - 1, pos, start, end)) {
       featuresInCenterLine.push(innerArray)
     } else {
       featuresOutsideCenter.push(innerArray)
     }
   })
 
-  switch (sortObject.by) {
+  switch (type) {
     case 'Start location': {
       featuresInCenterLine.sort((a, b) => a.get('start') - b.get('start'))
       break
@@ -48,10 +44,7 @@ export const sortFeature = (
           const consuming =
             mismatch.type === 'insertion' || mismatch.type === 'softclip'
           const len = consuming ? 0 : mismatch.length
-          if (
-            sortObject.position >= offset &&
-            sortObject.position < offset + len
-          ) {
+          if (pos >= offset && pos < offset + len) {
             baseSortArray.push([feature.id(), mismatch])
           }
         })

--- a/plugins/alignments/src/PileupTrack/components/PileupTrackBlurb.tsx
+++ b/plugins/alignments/src/PileupTrack/components/PileupTrackBlurb.tsx
@@ -4,27 +4,30 @@ import Typography from '@material-ui/core/Typography'
 
 export interface TrackBlurbProps {
   model: {
-    sortedBy?: string
-    sortedByRefName?: string
-    sortedByPosition?: number
+    sortedBy?: {
+      pos: number
+      refName: number
+      type: string
+    }
   }
 }
 
 function TrackBlurb(props: TrackBlurbProps) {
   const { model } = props
-  return (
+  const { sortedBy } = model
+  return sortedBy ? (
     <div
       data-testid={`blurb-${model.sortedBy}`}
       style={{ backgroundColor: 'white' }}
     >
       <Typography color="secondary" variant="caption">
         {model.sortedBy
-          ? `Sorted by ${model.sortedBy.toLowerCase()} at ${
-              model.sortedByRefName
-            }:${model.sortedByPosition}`
+          ? `Sorted by ${sortedBy.type.toLowerCase()} at ${sortedBy.refName}:${
+              sortedBy.pos
+            }`
           : null}
       </Typography>
     </div>
-  )
+  ) : null
 }
 export default observer(TrackBlurb)

--- a/plugins/alignments/src/PileupTrack/model.ts
+++ b/plugins/alignments/src/PileupTrack/model.ts
@@ -61,11 +61,15 @@ const stateModelFactory = (
     )
     .volatile(() => ({
       ready: false,
+      currBpPerPx: 0,
     }))
 
     .actions(self => ({
       setReady(flag: boolean) {
         self.ready = flag
+      },
+      setCurrBpPerPx(n: number) {
+        self.currBpPerPx = n
       },
     }))
     .actions(self => ({
@@ -77,6 +81,7 @@ const stateModelFactory = (
               try {
                 const { rpcManager } = getSession(self)
                 const { sortedBy, renderProps } = self
+                const view = getContainingView(self) as LGV
                 if (sortedBy) {
                   const { pos, refName, assemblyName } = sortedBy
                   const region = {
@@ -97,6 +102,7 @@ const stateModelFactory = (
                     timeout: 1000000,
                   })
                   self.setReady(true)
+                  self.setCurrBpPerPx(view.bpPerPx)
                 } else {
                   self.setReady(true)
                 }
@@ -237,13 +243,16 @@ const stateModelFactory = (
         },
 
         get renderProps() {
+          const view = getContainingView(self) as LGV
           const config = self.rendererType.configSchema.create(
             getConf(self, ['renderers', self.rendererTypeName]) || {},
           )
           return {
             ...self.composedRenderProps,
             ...getParentRenderProps(self),
-            notReady: !self.ready,
+            notReady:
+              !self.ready ||
+              (self.sortedBy && self.currBpPerPx !== view.bpPerPx),
             trackModel: self,
             sortedBy: self.sortedBy,
             showSoftClip: self.showSoftClipping,

--- a/plugins/alignments/src/PileupTrack/model.ts
+++ b/plugins/alignments/src/PileupTrack/model.ts
@@ -18,12 +18,14 @@ import {
   blockBasedTrackModel,
   LinearGenomeViewModel,
 } from '@gmod/jbrowse-plugin-linear-genome-view'
-import { types, Instance } from 'mobx-state-tree'
+import { types, addDisposer, Instance } from 'mobx-state-tree'
 import copy from 'copy-to-clipboard'
 import PluginManager from '@gmod/jbrowse-core/PluginManager'
 import { Feature } from '@gmod/jbrowse-core/util/simpleFeature'
 import MenuOpenIcon from '@material-ui/icons/MenuOpen'
 import SortIcon from '@material-ui/icons/Sort'
+import { autorun } from 'mobx'
+import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import { PileupConfigModel } from './configSchema'
 import PileupTrackBlurb from './components/PileupTrackBlurb'
 
@@ -31,8 +33,9 @@ import PileupTrackBlurb from './components/PileupTrackBlurb'
 const rendererTypes = new Map([
   ['pileup', 'PileupRenderer'],
   ['svg', 'SvgFeatureRenderer'],
-  ['snpcoverage', 'SNPCoverageRenderer'],
 ])
+
+type LGV = LinearGenomeViewModel
 
 const stateModelFactory = (
   pluginManager: PluginManager,
@@ -45,15 +48,66 @@ const stateModelFactory = (
       types.model({
         type: types.literal('PileupTrack'),
         configuration: ConfigurationReference(configSchema),
+        showSoftClipping: false,
+        sortedBy: types.maybe(
+          types.model({
+            type: types.string,
+            pos: types.number,
+            refName: types.string,
+            assemblyName: types.string,
+          }),
+        ),
       }),
     )
     .volatile(() => ({
-      showSoftClipping: false,
-      sortedBy: '',
-      sortedByPosition: 0,
-      sortedByRefName: '',
+      ready: false,
+    }))
+
+    .actions(self => ({
+      setReady(flag: boolean) {
+        self.ready = flag
+      },
     }))
     .actions(self => ({
+      afterAttach() {
+        addDisposer(
+          self,
+          autorun(
+            async () => {
+              try {
+                const { rpcManager } = getSession(self)
+                const { sortedBy, renderProps } = self
+                if (sortedBy) {
+                  const { pos, refName, assemblyName } = sortedBy
+                  const region = {
+                    start: pos,
+                    end: pos + 1,
+                    refName,
+                    assemblyName,
+                  }
+
+                  // render just the sorted region first
+                  await self.rendererType.renderInClient(rpcManager, {
+                    assemblyName,
+                    regions: [region],
+                    adapterConfig: getConf(self, 'adapter'),
+                    rendererType: self.rendererType.name,
+                    renderProps,
+                    sessionId: getRpcSessionId(self),
+                    timeout: 1000000,
+                  })
+                  self.setReady(true)
+                } else {
+                  self.setReady(true)
+                }
+              } catch (error) {
+                self.setError(error.message)
+              }
+            },
+            { delay: 1000 },
+          ),
+        )
+      },
       selectFeature(feature: Feature) {
         const session = getSession(self)
         if (isSessionModelWithWidgets(session)) {
@@ -68,9 +122,7 @@ const stateModelFactory = (
       },
 
       clearSelected() {
-        self.sortedBy = ''
-        self.sortedByPosition = 0
-        self.sortedByRefName = ''
+        self.sortedBy = undefined
       },
 
       // uses copy-to-clipboard and generates notification
@@ -86,64 +138,38 @@ const stateModelFactory = (
         self.showSoftClipping = !self.showSoftClipping
       },
 
-      async sortSelected(selected: string) {
-        const { rpcManager } = getSession(self)
-        const { centerLineInfo } = getContainingView(
-          self,
-        ) as LinearGenomeViewModel
+      setConfig(configuration: AnyConfigurationModel) {
+        self.configuration = configuration
+      },
+
+      async sortSelected(type: string) {
+        const { centerLineInfo } = getContainingView(self) as LGV
         if (!centerLineInfo) {
           return
         }
-
-        const centerBp = Math.round(centerLineInfo.offset) + 1
-        const centerRefName = centerLineInfo.refName
+        const { refName, assemblyName, offset } = centerLineInfo
+        const centerBp = Math.round(offset) + 1
+        const centerRefName = refName
 
         if (centerBp < 0) {
           return
         }
 
-        const regions = [
-          {
-            refName: centerLineInfo.refName,
-            start: centerBp,
-            end: centerBp + 1,
-            assemblyName: centerLineInfo.assemblyName,
-          },
-        ]
-
-        // render just the sorted region first
-        self.rendererType
-          .renderInClient(rpcManager, {
-            assemblyName: regions[0].assemblyName,
-            regions,
-            adapterConfig: getConf(self, 'adapter'),
-            rendererType: self.rendererType.name,
-            renderProps: {
-              ...self.renderProps,
-              sortObject: {
-                position: centerBp,
-                by: selected,
-              },
-            },
-            sessionId: getRpcSessionId(self),
-            timeout: 1000000,
-          })
-          .then(() => {
-            this.applySortSelected(selected, centerBp, centerRefName)
-          })
-          .catch((error: Error) => {
-            console.error(error)
-            self.setError(error.message)
-          })
+        this.setSortedBy({
+          type,
+          pos: centerBp,
+          refName: centerRefName,
+          assemblyName,
+        })
       },
-      applySortSelected(
-        selected: string,
-        centerBp: number,
-        centerRefName: string,
-      ) {
-        self.sortedBy = selected
-        self.sortedByPosition = centerBp
-        self.sortedByRefName = centerRefName
+      setSortedBy(sort: {
+        type: string
+        pos: number
+        refName: string
+        assemblyName: string
+      }) {
+        self.sortedBy = sort
+        self.ready = false
       },
     }))
     .actions(self => {
@@ -202,12 +228,6 @@ const stateModelFactory = (
           return contextMenuItems
         },
 
-        get sortObject() {
-          return {
-            position: self.sortedByPosition,
-            by: self.sortedBy,
-          }
-        },
         get sortOptions() {
           return ['Start location', 'Read strand', 'Base pair', 'Clear sort']
         },
@@ -223,8 +243,9 @@ const stateModelFactory = (
           return {
             ...self.composedRenderProps,
             ...getParentRenderProps(self),
+            notReady: !self.ready,
             trackModel: self,
-            sortObject: this.sortObject,
+            sortedBy: self.sortedBy,
             showSoftClip: self.showSoftClipping,
             config,
           }
@@ -239,7 +260,8 @@ const stateModelFactory = (
               checked: self.showSoftClipping,
               onClick: () => {
                 self.toggleSoftClipping()
-                // if toggling from off to on, will break sort for this track so clear it
+                // if toggling from off to on, will break sort for this track
+                // so clear it
                 if (self.showSoftClipping) {
                   self.clearSelected()
                 }

--- a/plugins/alignments/src/SNPCoverageTrack/model.ts
+++ b/plugins/alignments/src/SNPCoverageTrack/model.ts
@@ -3,6 +3,7 @@ import {
   wiggleTrackModelFactory,
   WiggleTrackComponent,
 } from '@gmod/jbrowse-plugin-wiggle'
+import { AnyConfigurationModel } from '@gmod/jbrowse-core/configuration/configurationSchema'
 import Tooltip from './Tooltip'
 
 // using a map because it preserves order
@@ -18,6 +19,11 @@ const stateModelFactory = (configSchema: any) =>
     )
     .volatile(() => ({
       ReactComponent: (WiggleTrackComponent as unknown) as React.FC,
+    }))
+    .actions(self => ({
+      setConfig(configuration: AnyConfigurationModel) {
+        self.configuration = configuration
+      },
     }))
     .views(() => ({
       get TooltipComponent() {


### PR DESCRIPTION
This is a breakout from the #1231 branch

Moves sorting from volatile to real track state

This also required updating AlignmentsTrack's autorun to make it capable of reloading the subtrack state

This would allow you to send a "session link" with a sort enabled on it. I like to imagine a screenshot service if that seems kind of unuseful.

Other track states like color scheme, linking reads etc were attempted in #1231 