### PR TITLE
Auto-remove tracks with non valid config references in view->afterAttach

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -90,6 +90,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.tracks = cast(arr)
       },
       afterAttach() {
+        // used to remove tracks whose config has been deleted
         this.setTracks(
           self.tracks.filter(track =>
             isValidReference(() => track.configuration),

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -86,8 +86,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
       showCenterLine: false,
     })
     .actions(self => ({
-      setTracks(arr: any) {
-        self.tracks = arr
+      setTracks(arr: unknown[]) {
+        self.tracks = cast(arr)
       },
       afterAttach() {
         this.setTracks(

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -26,6 +26,7 @@ import { transaction } from 'mobx'
 import {
   getSnapshot,
   types,
+  isValidReference,
   cast,
   Instance,
   getRoot,
@@ -84,6 +85,18 @@ export function stateModelFactory(pluginManager: PluginManager) {
       trackLabels: 'overlapping' as 'overlapping' | 'hidden' | 'offset',
       showCenterLine: false,
     })
+    .actions(self => ({
+      setTracks(arr: any) {
+        self.tracks = arr
+      },
+      afterAttach() {
+        this.setTracks(
+          self.tracks.filter(track =>
+            isValidReference(() => track.configuration),
+          ),
+        )
+      },
+    }))
     .volatile(() => ({
       volatileWidth: undefined as number | undefined,
       minimumBlockWidth: 20,


### PR DESCRIPTION

Ref
https://github.com/GMOD/jbrowse-components/issues/560

Procedure to test

Open a couple tracks
Delete one of those tracks from the config.json
Refresh the page

Expect: The track that was deleted will not be present on the refreshed page

Note that "all views would need to implement this functionality" as implemented here