### PR TITLE
Remove mobx-run-in-reactive-context runner

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -34,7 +34,6 @@
     "deep-equal": "^2.0.3",
     "generic-filehandle": "^2.0.0",
     "json-stable-stringify": "^1.0.1",
-    "mobx-run-in-reactive-context": "^1.0.1",
     "react-d3-axis": "^0.1.2"
   },
   "peerDependencies": {

--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -3,7 +3,6 @@ import { PrerenderedCanvas } from '@gmod/jbrowse-core/ui'
 import { bpSpanPx } from '@gmod/jbrowse-core/util'
 import { observer } from 'mobx-react'
 import React, { MouseEvent, useRef, useState, useEffect } from 'react'
-import runner from 'mobx-run-in-reactive-context'
 import type { BlockBasedTrackModel } from '@gmod/jbrowse-plugin-linear-genome-view'
 
 function PileupRendering(props: {
@@ -185,15 +184,15 @@ function PileupRendering(props: {
         style={{ position: 'absolute', left: 0, top: 0 }}
         className="highlightOverlayCanvas"
         ref={highlightOverlayCanvas}
-        onMouseDown={event => runner(() => onMouseDown(event))}
-        onMouseEnter={event => runner(() => onMouseEnter(event))}
-        onMouseOut={event => runner(() => onMouseOut(event))}
-        onMouseOver={event => runner(() => onMouseOver(event))}
-        onMouseUp={event => runner(() => onMouseUp(event))}
-        onMouseLeave={event => runner(() => onMouseLeave(event))}
-        onMouseMove={event => runner(() => mouseMove(event))}
-        onClick={event => runner(() => onClick(event))}
-        onContextMenu={event => runner(() => onContextMenu(event))}
+        onMouseDown={event => onMouseDown(event)}
+        onMouseEnter={event => onMouseEnter(event)}
+        onMouseOut={event => onMouseOut(event)}
+        onMouseOver={event => onMouseOver(event)}
+        onMouseUp={event => onMouseUp(event)}
+        onMouseLeave={event => onMouseLeave(event)}
+        onMouseMove={event => mouseMove(event)}
+        onClick={event => onClick(event)}
+        onContextMenu={event => onContextMenu(event)}
         onFocus={() => {}}
         onBlur={() => {}}
       />

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -30,7 +30,6 @@
     "clsx": "^1.1.0",
     "generic-filehandle": "^2.0.1",
     "json-stable-stringify": "^1.0.1",
-    "mobx-run-in-reactive-context": "^1.0.1",
     "react-sizeme": "^2.6.12"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15766,19 +15766,12 @@ mobx-react@^6.0.0:
   dependencies:
     mobx-react-lite "^2.2.0"
 
-mobx-run-in-reactive-context@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mobx-run-in-reactive-context/-/mobx-run-in-reactive-context-1.0.1.tgz#f12f94f57dc965a576e5293472ebd0edc12fd075"
-  integrity sha512-M2Ri1TEH9dT3x8RMqibIdVePY1kLAYIs762mMZ15Ciem+fxHGZuRpIX/beffIAjTrD8TBLwSPQjnDAtANoniKw==
-  dependencies:
-    mobx "*"
-
 mobx-state-tree@3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/mobx-state-tree/-/mobx-state-tree-3.14.1.tgz#0a523876b87817f5c8553a162e71b38044f0c9da"
   integrity sha512-cmwO1jvYPgaJTGJtqId0Qod4cDqcJEWWCwSu/Uns7jFT+kWKzLFhzb9jxPub8YM3HSXg7HPGpKiLe970he9FOw==
 
-mobx@*, mobx@^5.0.0, mobx@^5.10.1:
+mobx@^5.0.0, mobx@^5.10.1:
   version "5.15.4"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.4.tgz#9da1a84e97ba624622f4e55a0bf3300fb931c2ab"
   integrity sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw==


### PR DESCRIPTION
I can't remember what this was for. Originally was probably having some trouble with something related to reactivity in the PileupRenderer. Doesn't seem affected when removed