### PR TITLE
Silence useLayoutEffect warning in tests

### DIFF
--- a/products/jbrowse-web/src/tests/util.js
+++ b/products/jbrowse-web/src/tests/util.js
@@ -88,3 +88,14 @@ export function setup() {
 
 // eslint-disable-next-line no-native-reassign,no-global-assign
 window = Object.assign(window, { innerWidth: 800 })
+
+const originalError = console.error
+
+// this is here to silence a warning related to useStaticRendering
+// xref https://github.com/GMOD/jbrowse-components/issues/1277
+jest.spyOn(console, 'error').mockImplementation((...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('useLayoutEffect')) {
+    return
+  }
+  return originalError.call(console, args)
+})

--- a/products/jbrowse-web/src/tests/util.js
+++ b/products/jbrowse-web/src/tests/util.js
@@ -95,7 +95,7 @@ const originalError = console.error
 // xref https://github.com/GMOD/jbrowse-components/issues/1277
 jest.spyOn(console, 'error').mockImplementation((...args) => {
   if (typeof args[0] === 'string' && args[0].includes('useLayoutEffect')) {
-    return
+    return undefined
   }
   return originalError.call(console, args)
 })


### PR DESCRIPTION
Possible fix for #1277 


This simply silences the warning

The alternatives to this approach could be

(a) Reverting to older mobx-react
(b) Fix mainthreadrendering to not use SSR

