### PR TITLE
New website

### DIFF
--- a/products/website/docusaurus.config.js
+++ b/products/website/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'JBrowse',
   tagline: 'Next generation genome browser',
   url: 'https://jbrowse.com',
-  baseUrl: '/jb2/',
+  baseUrl: '/',
   favicon: 'img/favicon.ico',
   organizationName: 'GMOD', // Usually your GitHub org/user name.
   projectName: 'jbrowse-components', // Usually your repo name.

--- a/products/website/docusaurus.config.js
+++ b/products/website/docusaurus.config.js
@@ -92,6 +92,10 @@ module.exports = {
               label: 'GitHub',
               href: 'https://github.com/GMOD/jbrowse-components',
             },
+            {
+              label: 'Looking for JBrowse 1?',
+              href: 'https://jbrowse.org/jbrowse1.html',
+            },
           ],
         },
       ],


### PR DESCRIPTION
This is a proposal for making the jb2 website go live. We remove the /jb2/ prefix and link to jbrowse1.html.

It is paired with this jbrowse 1 PR

https://github.com/GMOD/jbrowse/pull/1550

For #1250 