### PR TITLE
Bugfix(?) - `this hasn't been initialised - super() hasn't been called`

### DIFF
--- a/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
@@ -15,16 +15,11 @@ import LRU from '@gmod/jbrowse-core/util/QuickLRU'
 export default class extends BaseFeatureDataAdapter implements RegionsAdapter {
   protected fasta: typeof IndexedFasta
 
-  private seqCache = new AbortablePromiseCache({
-    cache: new LRU({ maxSize: 200 }),
-    fill: async (
-      args: { refName: string; start: number; end: number },
-      // abortSignal?: AbortSignal,
-    ) => {
-      const { refName, start, end } = args
-      return this.fasta.getSequence(refName, start, end)
-    },
-  })
+  private seqCache: AbortablePromiseCache<
+    { refName: string; start: number; end: number },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  >
 
   public constructor(config: AnyConfigurationModel) {
     super(config)
@@ -41,6 +36,16 @@ export default class extends BaseFeatureDataAdapter implements RegionsAdapter {
       fai: openLocation(faiLocation as FileLocation),
     }
 
+    this.seqCache = new AbortablePromiseCache({
+      cache: new LRU({ maxSize: 200 }),
+      fill: async (
+        args: { refName: string; start: number; end: number },
+        // abortSignal?: AbortSignal,
+      ) => {
+        const { refName, start, end } = args
+        return this.fasta.getSequence(refName, start, end)
+      },
+    })
     this.fasta = new IndexedFasta(fastaOpts)
   }
 


### PR DESCRIPTION
Currently if I go the the deployed master branch at https://s3.amazonaws.com/jbrowse.org/code/jb2/alpha/master/index.html and do `File -> Add -> Linear genome view`, it crashes with the following error:

```
rpc.worker.ts:60 rpc-error 1 CoreGetRegions ReferenceError: this hasn't been initialised - super() hasn't been called
    at r (assertThisInitialized.js:3)
    at new n (IndexedFastaAdapter.ts:25)
    at n.<anonymous> (createSuper.js:11)
    at new n (BgzipFastaAdapter.ts:11)
    at dr (dataAdapterCache.ts:62)
    at n.<anonymous> (coreRpcMethods.ts:28)
    at u (runtime.js:63)
    at Generator._invoke (runtime.js:293)
    at Generator.next (runtime.js:118)
    at r (asyncToGenerator.js:3)
    at s (asyncToGenerator.js:25)
mg @ rpc.worker.ts:60
(anonymous) @ rpc.worker.ts:95
Promise.catch (async)
(anonymous) @ rpc.worker.ts:79
Promise.then (async)
b.handler @ web-rpc.js:321
```

If I build master locally, though, this error does not happen. It appears to be an error in calling `this` in a class member before the class is initialized, which I try to address in this PR. I'm not sure if this will actually fix it, though, since I can't reproduce it locally. I'll wait for this branch to build and deploy and then test then.