### PR TITLE
Remove dense from MuiInputLabel

### DIFF
--- a/packages/core/ui/theme.test.ts
+++ b/packages/core/ui/theme.test.ts
@@ -56,12 +56,12 @@ describe('theme utils', () => {
     const muiPaperProps = { variant: 'outlined' as 'outlined' }
     const theme = createJBrowseTheme({ props: { MuiPaper: muiPaperProps } })
     expect(theme.props?.MuiPaper).toEqual(muiPaperProps)
-    expect(Object.keys(theme.props || {}).length).toBe(18)
+    expect(Object.keys(theme.props || {}).length).toBe(17)
   })
   it('allows modifying a prop override', () => {
     const muiButtonProps = { size: 'medium' as 'medium' }
     const theme = createJBrowseTheme({ props: { MuiButton: muiButtonProps } })
     expect(theme.props?.MuiButton).toEqual(muiButtonProps)
-    expect(Object.keys(theme.props || {}).length).toBe(17)
+    expect(Object.keys(theme.props || {}).length).toBe(16)
   })
 })

--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -62,9 +62,6 @@ export function createJBrowseDefaultProps(/* palette: PaletteOptions = {} */) {
     MuiInputBase: {
       margin: 'dense' as 'dense',
     },
-    MuiInputLabel: {
-      margin: 'dense' as 'dense',
-    },
     MuiList: {
       dense: true,
     },


### PR DESCRIPTION
Tiny PR, removes dense from MuiInputLabel

before
![t1234](https://user-images.githubusercontent.com/6511937/95880352-6a2a6580-0d45-11eb-9e3e-3f1cce8be445.png)
after
![t123](https://user-images.githubusercontent.com/6511937/95880354-6ac2fc00-0d45-11eb-8eaf-1aff2feafe79.png)
