### PR TITLE
Use fontsource-roboto instead of typeface-roboto

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -67,6 +67,7 @@
     "electron-better-ipc-extra": "garrettjstevens/electron-better-ipc-extra#c8648bdea088312107ffc4d176cc5e6ae67a7cfd",
     "electron-debug": "^3.0.1",
     "electron-is-dev": "^1.1.0",
+    "fontsource-roboto": "3.0.3",
     "json-stable-stringify": "^1.0.1",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",
@@ -79,8 +80,7 @@
     "react-dom": "^16.8.0",
     "react-error-boundary": "^1.2.5",
     "react-sizeme": "^2.6.7",
-    "rxjs": "^6.5.2",
-    "typeface-roboto": "^0.0.54"
+    "rxjs": "^6.5.2"
   },
   "browserslist": [
     "last 1 chrome version"

--- a/products/jbrowse-desktop/src/index.js
+++ b/products/jbrowse-desktop/src/index.js
@@ -2,7 +2,7 @@ import { FatalErrorDialog } from '@jbrowse/core/ui'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import ErrorBoundary from 'react-error-boundary'
-import 'typeface-roboto'
+import 'fontsource-roboto'
 import factoryReset from './factoryReset'
 import Loader from './Loader'
 

--- a/products/jbrowse-protein-widget/package.json
+++ b/products/jbrowse-protein-widget/package.json
@@ -24,14 +24,14 @@
     "@jbrowse/plugin-protein": "^0.0.1-beta.13",
     "@jbrowse/plugin-svg": "^0.0.1-beta.14",
     "@material-ui/core": "^4.9.5",
+    "fontsource-roboto": "3.0.3",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "rxjs": "^6.5.2",
-    "typeface-roboto": "^0.0.54"
+    "rxjs": "^6.5.2"
   },
   "unpkg": "umd/jbrowse-protein-viewer.js",
   "private": true

--- a/products/jbrowse-protein-widget/src/Viewer.js
+++ b/products/jbrowse-protein-widget/src/Viewer.js
@@ -5,7 +5,7 @@ import { transaction } from 'mobx'
 import { Provider } from 'mobx-react'
 import { types } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
-import 'typeface-roboto'
+import 'fontsource-roboto'
 
 import PluginManager from '@jbrowse/core/PluginManager'
 import { ConfigurationSchema } from '@jbrowse/core/configuration'

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -45,6 +45,7 @@
     "clsx": "^1.0.4",
     "core-js": "^3.2.1",
     "fastestsmallesttextencoderdecoder": "^1.0.14",
+    "fontsource-roboto": "3.0.3",
     "json-stable-stringify": "^1.0.1",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",
@@ -60,7 +61,6 @@
     "react-sizeme": "^2.6.7",
     "requestidlecallback-polyfill": "^1.0.2",
     "rxjs": "^6.5.2",
-    "typeface-roboto": "^0.0.54",
     "use-query-params": "^1.1.3"
   },
   "devDependencies": {

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -16,7 +16,7 @@ import { SnapshotOut } from 'mobx-state-tree'
 import { PluginConstructor } from '@jbrowse/core/Plugin'
 import { FatalErrorDialog } from '@jbrowse/core/ui'
 import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
-import 'typeface-roboto'
+import 'fontsource-roboto'
 import 'requestidlecallback-polyfill'
 import 'core-js/stable'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11448,6 +11448,11 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.0.0"
 
+fontsource-roboto@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fontsource-roboto/-/fontsource-roboto-3.0.3.tgz#99c312babeabce22b3e933b3edf2951d4508f4f7"
+  integrity sha512-kfsC9qAP6XhwnSDAhg2lhWeaUJfLGXZh7GcLxFiz/4lXdkV2pVhWv2Xp9ES3b3BHdc9UuPrWXXLOphzHIStcOw==
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -21991,11 +21996,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typeface-roboto@^0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.54.tgz#8f02c9a18d1cfa7f49381a6ff0d21ff061f38ad2"
-  integrity sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ==
 
 typescript@^3.0.0, typescript@^3.7.3:
   version "3.9.7"


### PR DESCRIPTION
Just a small change. [typeface-roboto](https://www.npmjs.com/package/typeface-roboto) is now deprecated, and they suggest [fontsource-roboto](https://www.npmjs.com/package/fontsource-roboto) as a drop-in replacement.