### PR TITLE
Fix add track relative urls

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -227,6 +227,8 @@ OPTIONS
 
   --overwrite                           Overwrites existing track if it shares the same trackId
 
+  --protocol=protocol                   [default: uri] Force protocol to a specific value
+
   --skipCheck                           Skip check for whether or not the file or URL exists or if you are in a JBrowse
                                         directory
 

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -230,6 +230,8 @@ OPTIONS
   --skipCheck                           Skip check for whether or not the file or URL exists or if you are in a JBrowse
                                         directory
 
+  --subDir=subDir                       when using --load a file, output to a subdirectory of the target dir
+
   --target=target                       path to config file in JB2 installation to write out to.
 
   --trackId=trackId                     trackId for the track, by default inferred from filename, must be unique

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -95,38 +95,6 @@ interface GithubRelease {
 export default abstract class JBrowseCommand extends Command {
   async init() {}
 
-  async checkLocation(location: string) {
-    let manifestJson: string
-    try {
-      manifestJson = await fsPromises.readFile(
-        path.join(location, 'manifest.json'),
-        {
-          encoding: 'utf8',
-        },
-      )
-    } catch (error) {
-      this.error(
-        'Could not find the file "manifest.json". Please make sure you are in the top level of a JBrowse 2 installation.',
-        { exit: 10 },
-      )
-    }
-    let manifest: { name?: string } = {}
-    try {
-      manifest = parseJSON(manifestJson)
-    } catch (error) {
-      this.error(
-        'Could not parse the file "manifest.json". Please make sure you are in the top level of a JBrowse 2 installation.',
-        { exit: 20 },
-      )
-    }
-    if (manifest.name !== 'JBrowse') {
-      this.error(
-        '"name" in file "manifest.json" is not "JBrowse". Please make sure you are in the top level of a JBrowse 2 installation.',
-        { exit: 30 },
-      )
-    }
-  }
-
   async readFile(location: string) {
     return fsPromises.readFile(location, { encoding: 'utf8' })
   }

--- a/products/jbrowse-cli/src/commands/add-connection.test.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.test.ts
@@ -88,28 +88,6 @@ describe('add-connection', () => {
     ])
     .exit(130)
     .it('fails if not a matching assembly name')
-  setup
-    .do(async () => {
-      await fsPromises.unlink('manifest.json')
-    })
-    .command(['add-connection', 'https://example.com'])
-    .exit(10)
-    .it('fails if no manifest.json found in cwd')
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', 'This Is Invalid JSON')
-    })
-    .command(['add-connection', 'https://example.com'])
-    .exit(20)
-    .it("fails if it can't parse manifest.json")
-
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', '{"name":"NotJBrowse"}')
-    })
-    .command(['add-connection', 'https://example.com'])
-    .exit(30)
-    .it('fails if "name" in manifest.json is not "JBrowse"')
 
   setupWithDateMock
     .nock('https://mysite.com', site => site.head('/data/hub.txt').reply(200))

--- a/products/jbrowse-cli/src/commands/add-connection.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.ts
@@ -98,11 +98,6 @@ export default class AddConnection extends JBrowseCommand {
     }
     const { config } = runFlags
     let { type, name, connectionId, assemblyName } = runFlags
-
-    if (!(runFlags.skipCheck || runFlags.force)) {
-      await this.checkLocation(path.dirname(this.target))
-    }
-
     const url = await this.resolveURL(
       argsPath,
       !(runFlags.skipCheck || runFlags.force),

--- a/products/jbrowse-cli/src/commands/add-track-json.ts
+++ b/products/jbrowse-cli/src/commands/add-track-json.ts
@@ -48,8 +48,6 @@ export default class AddTrackJson extends JBrowseCommand {
 
     this.debug(`Sequence location is: ${inputtedTrack}`)
     const { update } = runFlags
-    await this.checkLocation(path.dirname(this.target))
-
     const config: Config = await this.readJsonFile(this.target)
     this.debug(`Found existing config file ${this.target}`)
 

--- a/products/jbrowse-cli/src/commands/add-track-json.ts
+++ b/products/jbrowse-cli/src/commands/add-track-json.ts
@@ -1,6 +1,5 @@
 import { flags } from '@oclif/command'
 import { promises as fsPromises } from 'fs'
-import path from 'path'
 import JBrowseCommand, { Config } from '../base'
 
 export default class AddTrackJson extends JBrowseCommand {

--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -40,28 +40,7 @@ describe('add-track', () => {
     ])
     .exit(100)
     .it('fails if URL with load flag is passed')
-  setup
-    .do(async () => {
-      await fsPromises.unlink('manifest.json')
-    })
-    .command(['add-track', simpleBam])
-    .exit(10)
-    .it('fails if no manifest.json found in cwd')
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', 'This Is Invalid JSON')
-    })
-    .command(['add-track', simpleBam])
-    .exit(20)
-    .it("fails if it can't parse manifest.json")
 
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', '{"name":"NotJBrowse"}')
-    })
-    .command(['add-track', simpleBam])
-    .exit(30)
-    .it('fails if "name" in manifest.json is not "JBrowse"')
   setup
     .do(async ctx => {
       await fsPromises.copyFile(

--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -20,10 +20,7 @@ const testConfig = path.join(
 )
 
 describe('add-track', () => {
-  setup
-    .command(['add-track'])
-    .exit(2)
-    .it('fails if no track is specified')
+  setup.command(['add-track']).exit(2).it('fails if no track is specified')
   setup
     .command(['add-track', simpleBam])
     .exit(110)

--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -21,17 +21,14 @@ const testConfig = path.join(
 
 describe('add-track', () => {
   setup
-    .command(['add-track', '{}'])
-    .exit(180)
-    .it('fails if no data directory is specified')
+    .command(['add-track'])
+    .exit(2)
+    .it('fails if no track is specified')
   setup
     .command(['add-track', simpleBam])
     .exit(110)
-    .it('fails if load flag isnt passed')
+    .it('fails if load flag isnt passed in for a localFile')
   setup
-    .nock('https://mysite.com', site =>
-      site.head('/data/simple.bam').reply(200),
-    )
     .command([
       'add-track',
       'https://mysite.com/data/simple.bam',
@@ -198,9 +195,6 @@ describe('add-track', () => {
         path.join(ctx.dir, 'config.json'),
       )
     })
-    .nock('https://mysite.com', site =>
-      site.head('/data/simple.bam').replyWithFile(200, simpleBam),
-    )
     .command(['add-track', 'https://mysite.com/data/simple.bam'])
     .it('adds a track from a url', async ctx => {
       const contents = await fsPromises.readFile(

--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -19,7 +19,7 @@ const testConfig = path.join(
   'test_config.json',
 )
 
-async function initctx(ctx: any) {
+async function initctx(ctx: { dir: string }) {
   await fsPromises.copyFile(
     testConfig,
     path.join(ctx.dir, path.basename(testConfig)),
@@ -30,7 +30,7 @@ async function initctx(ctx: any) {
     path.join(ctx.dir, 'config.json'),
   )
 }
-async function init2bit(ctx: any) {
+async function init2bit(ctx: { dir: string }) {
   const simple2bit = path.join(
     __dirname,
     '..',

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -28,6 +28,10 @@ interface LocalPathLocation {
   localPath: string
 }
 
+function basename(path: string) {
+  return path.startsWith('http') ? path : path.basename(path)
+}
+
 export default class AddTrack extends JBrowseCommand {
   // @ts-ignore
   target: string
@@ -110,6 +114,10 @@ export default class AddTrack extends JBrowseCommand {
       char: 'f',
       description: 'Equivalent to `--skipCheck --overwrite`',
     }),
+    protocol: flags.string({
+      description: 'Force protocol to a specific value',
+      default: 'uri',
+    }),
   }
 
   async run() {
@@ -126,6 +134,7 @@ export default class AddTrack extends JBrowseCommand {
       load,
       subDir,
       target,
+      protocol,
       out,
     } = runFlags
 
@@ -144,10 +153,8 @@ export default class AddTrack extends JBrowseCommand {
       }
     }
     const location = argsTrack
-    const protocol = argsTrack.startsWith('http') ? 'uri' : 'localPath'
-
     const adapter = this.guessAdapter(
-      path.join(subDir, path.basename(location)),
+      path.join(subDir, basename(location)),
       protocol,
     )
     if (adapter.type === 'UNKNOWN') {
@@ -330,83 +337,6 @@ export default class AddTrack extends JBrowseCommand {
       } ${this.target}`,
     )
   }
-
-  //   async resolveFileLocationWithProtocol(
-  //     location: string,
-  //     inPlace: boolean,
-  //     subDir = '',
-  //     check = true,
-  //   ) {
-  //     let locationUrl: URL | undefined
-  //     let locationPath: string | undefined
-  //     let locationObj: {
-  //       location: string
-  //       protocol: 'uri' | 'localPath'
-  //       local: boolean
-  //     }
-  //     try {
-  //       locationUrl = new URL(location)
-  //     } catch (error) {
-  //       // ignore
-  //     }
-  //     if (locationUrl) {
-  //       let response
-  //       try {
-  //         if (check) {
-  //           response = await fetch(locationUrl, { method: 'HEAD' })
-  //         }
-  //         if (!response || response.ok) {
-  //           locationObj = {
-  //             location: locationUrl.href,
-  //             protocol: 'uri',
-  //             local: false,
-  //           }
-  //           return locationObj
-  //         }
-  //       } catch (error) {
-  //         // ignore
-  //       }
-  //     }
-  //     try {
-  //       locationPath = await fsPromises.realpath(location)
-  //     } catch (e) {
-  //       // ignore
-  //     }
-  //     if (locationPath) {
-  //       // if the inPlace argument ends up being upwards from the directory from
-  //       // the target directory, output a warning
-  //       if (
-  //         check &&
-  //         inPlace &&
-  //         path.relative(this.target, locationPath).startsWith('..')
-  //       ) {
-  //         this.warn(
-  //           `The argument "${locationPath}" is not not in the same directory as
-  //           "${this.target}". We will trust this since --load inPlace was used,
-  //           but please check that this is at the least inside a web-accessible
-  //           server directory (e.g. absolute locations on the filesystem should
-  //           not be used with inPlace, instead a --load copy or something should
-  //           be used to copy the filesystem location to where the config is). Use
-  //           --skipCheck to silence this warning.`,
-  //         )
-  //       }
-
-  //       // if using inPlace, output *locationPath* (the original argument)
-  //       // directly, else output subDir+the basename(filepath) because that is
-  //       // where the file(s) will later be copied into the target directory
-  //       locationObj = {
-  //         location: inPlace
-  //           ? locationPath
-  //           : path.join(subDir, path.basename(locationPath)),
-  //         protocol: 'uri',
-  //         local: true,
-  //       }
-  //       return locationObj
-  //     }
-  //     return this.error(`Could not resolve to a file or a URL: "${location}"`, {
-  //       exit: 180,
-  //     })
-  //   }
 
   guessFileNames(fileName: string) {
     if (/\.bam$/i.test(fileName)) {

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -154,19 +154,19 @@ export default class AddTrack extends JBrowseCommand {
       }
     }
     const location = argsTrack
+
+    const isUrl = location.match(/^https?:\/\//)
     const adapter = this.guessAdapter(
-      location.startsWith('http')
-        ? location
-        : path.join(subDir, path.basename(location)),
+      isUrl ? location : path.join(subDir, path.basename(location)),
       protocol as 'uri' | 'localPath',
     )
 
-    if (location.startsWith('http') && load) {
+    if (isUrl && load) {
       this.error(
-        'The --load flag is used for local files only, but a URL was provided to add-track',
+        'The --load flag is used for local files only, but a URL was provided',
         { exit: 100 },
       )
-    } else if (!location.startsWith('http') && !load) {
+    } else if (!isUrl && !load) {
       this.error(
         `The --load flag should be used if a local file is used, example --load
         copy to copy the file into the config directory. Options for load are

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -2,7 +2,6 @@
 import { flags } from '@oclif/command'
 import fs, { promises as fsPromises } from 'fs'
 import path from 'path'
-import fetch from 'node-fetch'
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
 

--- a/products/jbrowse-cli/src/commands/admin-server.test.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.test.ts
@@ -84,13 +84,6 @@ async function killExpress(ctx: { stdoutWrite: jest.Mock }, port: number) {
 
 describe('admin-server', () => {
   setupWithCreate
-    .do(async () => {
-      await fsPromises.unlink('manifest.json')
-    })
-    .command(['admin-server'])
-    .exit(10)
-    .it('fails if no manifest.json found in cwd')
-  setupWithCreate
     .command(['admin-server', '--port', '9091'])
     .finally(async ctx => {
       await killExpress(ctx, 9091)

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -47,10 +47,6 @@ export default class AdminServer extends JBrowseCommand {
     const isDir = (await fsPromises.lstat(output)).isDirectory()
     this.target = isDir ? `${output}/config.json` : output
 
-    if (!runFlags.skipCheck) {
-      await this.checkLocation(path.dirname(this.target))
-    }
-
     // check if the config file exists, if none exists write default
     const defaultConfig: Config = {
       assemblies: [],

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -1,7 +1,6 @@
 import { flags } from '@oclif/command'
 import fs, { promises as fsPromises } from 'fs'
 import crypto from 'crypto'
-import path from 'path'
 import express from 'express'
 import JBrowseCommand, { Config } from '../base'
 

--- a/products/jbrowse-cli/src/commands/set-default-session.test.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.test.ts
@@ -154,28 +154,7 @@ describe('set-default-session', () => {
     .command(['set-default-session', '--session', simpleBam])
     .exit(160)
     .it('fails when file is does not have a default session to read')
-  setup
-    .do(async () => {
-      await fsPromises.unlink('manifest.json')
-    })
-    .command(['set-default-session', '--session', simpleDefaultSession])
-    .exit(10)
-    .it('fails if no manifest.json found in cwd')
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', 'This Is Invalid JSON')
-    })
-    .command(['set-default-session', '--session', simpleDefaultSession])
-    .exit(20)
-    .it("fails if it can't parse manifest.json")
 
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', '{"name":"NotJBrowse"}')
-    })
-    .command(['set-default-session', '--session', simpleDefaultSession])
-    .exit(30)
-    .it('fails if "name" in manifest.json is not "JBrowse"')
   setupWithAddTrack
     .do(async ctx => {
       await fsPromises.copyFile(

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -1,6 +1,5 @@
 import { flags } from '@oclif/command'
 import { promises as fsPromises } from 'fs'
-import path from 'path'
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
 

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -83,9 +83,6 @@ export default class SetDefaultSession extends JBrowseCommand {
     const output = runFlags.target || runFlags.out || '.'
     const isDir = (await fsPromises.lstat(output)).isDirectory()
     this.target = isDir ? `${output}/config.json` : output
-
-    await this.checkLocation(path.dirname(this.target))
-
     const configContents: Config = await this.readJsonFile(this.target)
 
     // if user passes current session flag, print out and exit

--- a/products/jbrowse-cli/src/commands/upgrade.test.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.test.ts
@@ -89,22 +89,6 @@ describe('upgrade', () => {
     .command(['upgrade', 'jbrowse'])
     .exit(10)
     .it('fails if user selects a directory that does not exist')
-
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', 'This Is Invalid JSON')
-    })
-    .command(['upgrade'])
-    .exit(20)
-    .it("fails if it can't parse manifest.json")
-
-  setup
-    .do(async () => {
-      await fsPromises.writeFile('manifest.json', '{"name":"NotJBrowse"}')
-    })
-    .command(['upgrade'])
-    .exit(30)
-    .it('fails if "name" in manifest.json is not "JBrowse"')
   setup
     .nock('https://api.github.com', mockReleases)
     .nock('https://example.com', mockV2Zip)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -61,9 +61,6 @@ export default class Upgrade extends JBrowseCommand {
       this.exit()
     }
     this.debug(`Want to upgrade at: ${argsPath}`)
-
-    await this.checkLocation(argsPath)
-
     const locationUrl =
       url || (tag ? await this.getTag(tag) : await this.getLatest())
 

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -1,4 +1,6 @@
 import { flags } from '@oclif/command'
+import fs from 'fs'
+import path from 'path'
 import fetch from 'node-fetch'
 import unzip from 'unzipper'
 import JBrowseCommand from '../base'
@@ -60,7 +62,20 @@ export default class Upgrade extends JBrowseCommand {
       this.log(`All JBrowse versions:\n${versions.join('\n')}`)
       this.exit()
     }
+
     this.debug(`Want to upgrade at: ${argsPath}`)
+    if (!argsPath) {
+      this.error(`No directory supplied`, { exit: 100 })
+    }
+
+    if (!fs.existsSync(path.join(argsPath, 'manifest.json'))) {
+      this.error(
+        `No manifest.json found in this directory, are you sure it is an
+        existing jbrowse 2 installation?`,
+        { exit: 10 },
+      )
+    }
+
     const locationUrl =
       url || (tag ? await this.getTag(tag) : await this.getLatest())
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -38,6 +38,7 @@ that can be built on.
 - Interactively edit the configuration using the GUI
 - Circular, dotplot, stacked synteny views
 - SV inspector, that gives spreadsheet and circos overview of data in a single view
+- Linear genome view can be reverse complemented
 
 #### Can the linear genome view be reverse complemented
 
@@ -110,16 +111,13 @@ sure to run the command inside your current jbrowse2 folder e.g.
 /var/www/html/jbrowse2 or wherever you are currently setting up a config.json
 (you can have multiple configs)
 
-To add a BAM track, try
-
-    jbrowse add-track myfile.bam -i myfile.bam.bai -a hg19
-
 Note that you can also use remote URLs
 
-    jbrowse add-track http://yourremote
+    jbrowse add-track http://yourremote/myfile.bam
 
 The add-track command will do as much as possible to infer from the file
-extension how to configure this track
+extension how to configure this track, and automatically infer the index to be
+myfile.bam.bai
 
 ### Curiosities
 


### PR DESCRIPTION
This PR

- Removes the checkLocation concept (e.g. checking for a manifest.json) except for in the case of jbrowse upgrade which should supply a path with a manifest.json
- Removes resolveFileLocationWithProtocol in add-track replacing it with an inline logic
- Removes the live-checking that a URL exists before adding it. If this is really desirable, we can add it back but I think it's better to let the tool be something that just does stuff rather than validate everything down to whether a url that they supplied is valid
- Adds --subDir argument to add-track so that when I say --load copy --subDir bam then it copies the file to a bam subdirectory near target
- Adds a --protocol argument that allows the user to manually specify the protocol used for the user to manually supply this, since it's not really able to be automatically determined. uri is used by default

Finally it fixes #1337 by making the file path that is written to the config.json generated via guessAdapter different from the actual file locations that are generated by guessFileNames