### PR TITLE
Only render "url" file selector on web since "local file" not allowed currently

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -48,7 +48,7 @@ const FileLocationEditor = observer(
     ) => {
       if (newValue === 'url') {
         setFileOrUrlState('url')
-      } else {
+      } else if (isElectron) {
         setFileOrUrlState('file')
       }
     }
@@ -65,13 +65,11 @@ const FileLocationEditor = observer(
               onChange={handleFileOrUrlChange}
               aria-label="file or url picker"
             >
-              <ToggleButton
-                value="file"
-                aria-label="local file"
-                disabled={!isElectron}
-              >
-                File
-              </ToggleButton>
+              {isElectron ? (
+                <ToggleButton value="file" aria-label="local file">
+                  File
+                </ToggleButton>
+              ) : null}
               <ToggleButton value="url" aria-label="url">
                 Url
               </ToggleButton>

--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -37,9 +37,13 @@ const FileLocationEditor = observer(
     setLocation: Function
     name?: string
     description?: string
+    localFileAllowed: boolean
   }) => {
-    const { location, name, description } = props
-    const fileOrUrl = location && isUriLocation(location) ? 'url' : 'file'
+    const { location, name, description, localFileAllowed = isElectron } = props
+    const fileOrUrl =
+      (location && isUriLocation(location)) || !localFileAllowed
+        ? 'url'
+        : 'file'
     const [fileOrUrlState, setFileOrUrlState] = useState(fileOrUrl)
 
     const handleFileOrUrlChange = (
@@ -48,7 +52,7 @@ const FileLocationEditor = observer(
     ) => {
       if (newValue === 'url') {
         setFileOrUrlState('url')
-      } else if (isElectron) {
+      } else if (localFileAllowed) {
         setFileOrUrlState('file')
       }
     }
@@ -65,7 +69,7 @@ const FileLocationEditor = observer(
               onChange={handleFileOrUrlChange}
               aria-label="file or url picker"
             >
-              {isElectron ? (
+              {localFileAllowed ? (
                 <ToggleButton value="file" aria-label="local file">
                   File
                 </ToggleButton>

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -91,21 +91,6 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
             role="group"
           >
             <button
-              aria-label="local file"
-              aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
-              disabled=""
-              tabindex="-1"
-              type="button"
-              value="file"
-            >
-              <span
-                class="MuiToggleButton-label"
-              >
-                File
-              </span>
-            </button>
-            <button
               aria-label="url"
               aria-pressed="true"
               class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
@@ -1835,21 +1820,6 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                 role="group"
               >
                 <button
-                  aria-label="local file"
-                  aria-pressed="false"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
-                  disabled=""
-                  tabindex="-1"
-                  type="button"
-                  value="file"
-                >
-                  <span
-                    class="MuiToggleButton-label"
-                  >
-                    File
-                  </span>
-                </button>
-                <button
                   aria-label="url"
                   aria-pressed="true"
                   class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
@@ -2028,21 +1998,6 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                     class="MuiToggleButtonGroup-root"
                     role="group"
                   >
-                    <button
-                      aria-label="local file"
-                      aria-pressed="false"
-                      class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
-                      disabled=""
-                      tabindex="-1"
-                      type="button"
-                      value="file"
-                    >
-                      <span
-                        class="MuiToggleButton-label"
-                      >
-                        File
-                      </span>
-                    </button>
                     <button
                       aria-label="url"
                       aria-pressed="true"

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
@@ -201,21 +201,6 @@ exports[`<AddTrackWidget /> renders 1`] = `
                         role="group"
                       >
                         <button
-                          aria-label="local file"
-                          aria-pressed="false"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
-                          disabled=""
-                          tabindex="-1"
-                          type="button"
-                          value="file"
-                        >
-                          <span
-                            class="MuiToggleButton-label"
-                          >
-                            File
-                          </span>
-                        </button>
-                        <button
                           aria-label="url"
                           aria-pressed="true"
                           class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/TrackSourceSelect.test.js.snap
@@ -141,21 +141,6 @@ exports[`<TrackSourceSelect /> renders 1`] = `
           role="group"
         >
           <button
-            aria-label="local file"
-            aria-pressed="false"
-            class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-disabled MuiButtonBase-disabled"
-            disabled=""
-            tabindex="-1"
-            type="button"
-            value="file"
-          >
-            <span
-              class="MuiToggleButton-label"
-            >
-              File
-            </span>
-          </button>
-          <button
             aria-label="url"
             aria-pressed="true"
             class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
@@ -92,6 +92,7 @@ export default pluginManager => {
                 <FileSelector
                   location={model.fileSource}
                   setLocation={model.setFileSource}
+                  localFileAllowed
                 />
               </FormGroup>
             </FormControl>


### PR DESCRIPTION
Having the file option but only having it disabled is somewhat difficult to understand. I propose removing the local file option

- except for desktop, where localFileAllowed = isElectron
- except for the SV inspector on web, which manually passes localFileAllowed to the FileSelector component's props


Addresses #694