### PR TITLE
New assembly manager

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -245,6 +245,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         makeAbortableReaction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           self as any,
+          // @ts-ignore
           loadAssemblyData,
           loadAssemblyReaction,
           { name: `${self.name} assembly loading`, fireImmediately: true },
@@ -368,6 +369,7 @@ async function loadAssemblyReaction(
       refNameAliases[refNameAlias.refName] = refNameAlias.aliases
     })
   }
+  // eslint-disable-next-line consistent-return
   return { adapterRegionsWithAssembly, refNameAliases }
 }
 export type Assembly = Instance<ReturnType<typeof assemblyFactory>>

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -120,6 +120,9 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
       },
     }))
     .actions(self => ({
+      removeAssembly(asm: Instance<typeof Assembly>) {
+        self.assemblies.remove(asm)
+      },
       afterAttach() {
         addDisposer(
           self,
@@ -130,6 +133,11 @@ export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
               assemblyConfigs: Instance<typeof Assembly> &
                 AnyConfigurationModel[],
             ) => {
+              self.assemblies.forEach(asm => {
+                if (!asm.configuration) {
+                  this.removeAssembly(asm)
+                }
+              })
               assemblyConfigs.forEach(assemblyConfig => {
                 const existingAssemblyIdx = self.assemblies.findIndex(
                   assembly =>

--- a/plugins/data-management/src/AssemblyManager/AssemblyAddForm.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyAddForm.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import { observer } from 'mobx-react'
+import TextField from '@material-ui/core/TextField'
+import { Container, Grid } from '@material-ui/core'
+import Button from '@material-ui/core/Button'
+import AddIcon from '@material-ui/icons/Add'
+
+const AssemblyAddForm = observer(
+  ({
+    rootModel,
+    setFormOpen,
+    setIsAssemblyBeingEdited,
+    setAssemblyBeingEdited,
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rootModel: any
+    setFormOpen: Function
+    setIsAssemblyBeingEdited(arg: boolean): void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setAssemblyBeingEdited(arg: any): void
+  }) => {
+    const [assemblyName, setAssemblyName] = useState('')
+
+    function createAssembly() {
+      if (assemblyName === '') {
+        rootModel.session.notify("Can't create an assembly without a name")
+      } else {
+        // alert(`Entered: ${assemblyName}`)
+        setFormOpen(false)
+        setIsAssemblyBeingEdited(true)
+        setAssemblyBeingEdited(
+          rootModel.jbrowse.addAssemblyConf({ name: assemblyName }),
+        )
+      }
+    }
+
+    return (
+      <Container>
+        <Grid container spacing={1} justify="center" alignItems="center">
+          <Grid item>
+            <TextField
+              id="assembly-name"
+              label="Assembly Name"
+              variant="outlined"
+              value={assemblyName}
+              onChange={event => setAssemblyName(event.target.value)}
+            />
+          </Grid>
+          <Grid item>
+            <Button
+              variant="contained"
+              color="secondary"
+              startIcon={<AddIcon />}
+              onClick={createAssembly}
+            >
+              Create New Assembly
+            </Button>
+          </Grid>
+        </Grid>
+      </Container>
+    )
+  },
+)
+
+export default AssemblyAddForm

--- a/plugins/data-management/src/AssemblyManager/AssemblyEditor.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyEditor.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { ConfigurationEditor } from '@jbrowse/plugin-config'
+
+const AssemblyEditor = observer(
+  ({
+    assembly,
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assembly: any
+  }) => {
+    return <ConfigurationEditor model={{ target: assembly }} />
+  },
+)
+
+export default AssemblyEditor

--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import AssemblyManager from './AssemblyManager'
+
+const mockRootModel = {
+  jbrowse: {
+    assemblies: [
+      {
+        name: 'testAssembly',
+        sequence: {
+          type: 'testSequenceTrack',
+          trackId: '',
+          adapter: {
+            type: 'testSeqAdapter',
+            twoBitLocation: {
+              uri: 'test.2bit',
+            },
+          },
+        },
+      },
+    ],
+    addAssemblyConf: jest.fn(),
+    removeAssemblyConf: jest.fn(),
+  },
+  session: {
+    notify: jest.fn(),
+  },
+}
+
+describe('AssemblyManager GUI', () => {
+  it('renders succesfully', () => {
+    const { getByText } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={() => {}} />,
+    )
+    expect(getByText('Assembly Manager')).toBeTruthy()
+  })
+
+  it('opens up the Add Assembly Form when clicked', () => {
+    const { getByText } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={() => {}} />,
+    )
+    fireEvent.click(getByText('Add New Assembly'))
+    expect(getByText('Create New Assembly')).toBeTruthy()
+  })
+
+  it('calls addAssemblyConf from the Add Assembly form', () => {
+    const { getByText, getByRole } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={() => {}} />,
+    )
+    fireEvent.click(getByText('Add New Assembly'))
+
+    // enter a new assembly and submit
+    fireEvent.change(getByRole('textbox'), {
+      target: {
+        value: 'ce11',
+      },
+    })
+    fireEvent.click(getByText('Create New Assembly'))
+
+    expect(mockRootModel.jbrowse.addAssemblyConf).toHaveBeenCalledTimes(1)
+  })
+
+  it("prompts the user for a name when adding assembly if they don't", () => {
+    const { getByText } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={() => {}} />,
+    )
+    fireEvent.click(getByText('Add New Assembly'))
+    fireEvent.click(getByText('Create New Assembly'))
+    expect(mockRootModel.session.notify).toHaveBeenCalledWith(
+      "Can't create an assembly without a name",
+    )
+  })
+
+  it('deletes an assembly when delete button clicked', () => {
+    const { getByTestId } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={() => {}} />,
+    )
+    fireEvent.click(getByTestId('testAssembly-delete'))
+    expect(mockRootModel.jbrowse.removeAssemblyConf).toHaveBeenCalledWith(
+      'testAssembly',
+    )
+  })
+
+  it('closes when the return button is clicked', () => {
+    const onClose = jest.fn()
+    const { getByText } = render(
+      <AssemblyManager rootModel={mockRootModel} open onClose={onClose} />,
+    )
+    fireEvent.click(getByText('Return'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react'
+import { observer } from 'mobx-react'
+import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import AddIcon from '@material-ui/icons/Add'
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos'
+import { IconButton } from '@material-ui/core/'
+
+import AssemblyTable from './AssemblyTable'
+import AssemblyAddForm from './AssemblyAddForm'
+import AssemblyEditor from './AssemblyEditor'
+
+const useStyles = makeStyles(() => ({
+  titleBox: {
+    color: '#FFFFFF',
+    backgroundColor: '#0D233F',
+    textAlign: 'center',
+  },
+  dialogContent: {
+    width: 600,
+  },
+  backButton: {
+    color: '#FFFFFF',
+  },
+}))
+
+const AssemblyManager = observer(
+  ({
+    rootModel,
+    open,
+    onClose,
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rootModel: any
+    open: boolean
+    onClose: Function
+  }) => {
+    const classes = useStyles()
+    const [isFormOpen, setFormOpen] = useState(false)
+    const [isAssemblyBeingEdited, setIsAssemblyBeingEdited] = useState(false)
+    const [assemblyBeingEdited, setAssemblyBeingEdited] = useState()
+
+    const showAssemblyTable = !isFormOpen && !isAssemblyBeingEdited
+
+    return (
+      <Dialog open={open}>
+        <DialogTitle className={classes.titleBox}>
+          {showAssemblyTable ? <p>Assembly Manager</p> : null}
+          {isFormOpen ? (
+            <>
+              <div style={{ textAlign: 'left' }}>
+                <IconButton
+                  aria-label="back"
+                  className={classes.backButton}
+                  onClick={() => setFormOpen(false)}
+                >
+                  <ArrowBackIosIcon />
+                </IconButton>
+              </div>
+              <p>Add New Assembly</p>
+            </>
+          ) : null}
+          {isAssemblyBeingEdited ? (
+            <>
+              <div style={{ textAlign: 'left' }}>
+                <IconButton
+                  aria-label="back"
+                  className={classes.backButton}
+                  onClick={() => setIsAssemblyBeingEdited(false)}
+                >
+                  <ArrowBackIosIcon />
+                </IconButton>
+              </div>
+              <p>{returnAssemblyName(assemblyBeingEdited)}</p>
+            </>
+          ) : null}
+        </DialogTitle>
+        <DialogContent>
+          <div className={classes.dialogContent}>
+            {showAssemblyTable ? (
+              <AssemblyTable
+                rootModel={rootModel}
+                setIsAssemblyBeingEdited={setIsAssemblyBeingEdited}
+                setAssemblyBeingEdited={setAssemblyBeingEdited}
+              />
+            ) : null}
+            {isAssemblyBeingEdited ? (
+              <AssemblyEditor assembly={assemblyBeingEdited} />
+            ) : null}
+            {isFormOpen ? (
+              <AssemblyAddForm
+                rootModel={rootModel}
+                setFormOpen={setFormOpen}
+                setIsAssemblyBeingEdited={setIsAssemblyBeingEdited}
+                setAssemblyBeingEdited={setAssemblyBeingEdited}
+              />
+            ) : null}
+          </div>
+        </DialogContent>
+        <DialogActions>
+          {showAssemblyTable ? (
+            <>
+              <Button
+                color="secondary"
+                variant="contained"
+                onClick={() => {
+                  onClose(false)
+                }}
+              >
+                Return
+              </Button>
+              <Button
+                variant="contained"
+                color="secondary"
+                startIcon={<AddIcon />}
+                onClick={() => {
+                  setFormOpen(true)
+                }}
+              >
+                Add New Assembly
+              </Button>
+            </>
+          ) : null}
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function returnAssemblyName(assembly: any) {
+  if (assembly !== undefined) {
+    return assembly.name
+  }
+  return null
+}
+
+export default AssemblyManager

--- a/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { makeStyles } from '@material-ui/core/styles'
+import { IconButton } from '@material-ui/core'
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import TableCell from '@material-ui/core/TableCell'
+import TableContainer from '@material-ui/core/TableContainer'
+import TableHead from '@material-ui/core/TableHead'
+import TableRow from '@material-ui/core/TableRow'
+import Paper from '@material-ui/core/Paper'
+import CreateIcon from '@material-ui/icons/Create'
+import DeleteIcon from '@material-ui/icons/Delete'
+
+// local
+import { readConfObject } from '@jbrowse/core/configuration'
+
+const useStyles = makeStyles(() => ({
+  table: {
+    minWidth: 650,
+  },
+  buttonCell: {
+    padding: 3,
+  },
+  button: {
+    display: 'inline-block',
+    padding: 3,
+    minHeight: 0,
+    minWidth: 0,
+  },
+
+  dialogContent: {
+    width: 600,
+  },
+}))
+
+const AssemblyTable = observer(
+  ({
+    rootModel,
+    setIsAssemblyBeingEdited,
+    setAssemblyBeingEdited,
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rootModel: any
+    setIsAssemblyBeingEdited(arg: boolean): void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setAssemblyBeingEdited(arg: any): void
+  }) => {
+    const classes = useStyles()
+
+    function removeAssembly(name: string) {
+      rootModel.jbrowse.removeAssemblyConf(name)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = rootModel.jbrowse.assemblies.map((assembly: any) => {
+      const name = readConfObject(assembly, 'name')
+      const aliases = readConfObject(assembly, 'aliases')
+      return (
+        <TableRow key={name}>
+          <TableCell>{name}</TableCell>
+          <TableCell>{aliases ? aliases.toString() : ''}</TableCell>
+          <TableCell className={classes.buttonCell}>
+            <IconButton
+              data-testid={`${name}-edit`}
+              className={classes.button}
+              onClick={() => {
+                setIsAssemblyBeingEdited(true)
+                setAssemblyBeingEdited(assembly)
+              }}
+            >
+              <CreateIcon color="primary" />
+            </IconButton>
+            <IconButton
+              data-testid={`${name}-delete`}
+              className={classes.button}
+              onClick={() => {
+                removeAssembly(name)
+              }}
+            >
+              <DeleteIcon color="error" />
+            </IconButton>
+          </TableCell>
+        </TableRow>
+      )
+    })
+
+    return (
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Aliases</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>{rows}</TableBody>
+        </Table>
+      </TableContainer>
+    )
+  },
+)
+
+export default AssemblyTable

--- a/plugins/data-management/src/AssemblyManager/index.ts
+++ b/plugins/data-management/src/AssemblyManager/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AssemblyManager'

--- a/plugins/data-management/src/index.ts
+++ b/plugins/data-management/src/index.ts
@@ -24,9 +24,14 @@ import {
   stateModelFactory as HierarchicalTrackSelectorStateModelFactory,
   configSchema as HierarchicalTrackSelectorConfigSchema,
 } from './HierarchicalTrackSelectorWidget'
+import AssemblyManager from './AssemblyManager'
 
 export default class extends Plugin {
   name = 'DataManagementPlugin'
+
+  exports = {
+    AssemblyManager,
+  }
 
   install(pluginManager: PluginManager) {
     pluginManager.addConnectionType(

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -58,7 +58,7 @@ const JBrowse = observer(({ pluginManager }) => {
   }, [jbrowse, session, adminKey])
 
   if (error) {
-    throw new Error(error)
+    throw error
   }
 
   const theme = getConf(rootModel.jbrowse, 'theme')

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -72,13 +72,15 @@ const JBrowse = observer(({ pluginManager }) => {
         session={session}
         HeaderButtons={<ShareButton session={session} />}
       />
-      <AssemblyManager
-        rootModel={rootModel}
-        open={rootModel.isAssemblyEditing}
-        onClose={() => {
-          rootModel.setAssemblyEditing(false)
-        }}
-      />
+      {adminKey ? (
+        <AssemblyManager
+          rootModel={rootModel}
+          open={rootModel.isAssemblyEditing}
+          onClose={() => {
+            rootModel.setAssemblyEditing(false)
+          }}
+        />
+      ) : null}
     </ThemeProvider>
   )
 })

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -62,12 +62,22 @@ const JBrowse = observer(({ pluginManager }) => {
   }
 
   const theme = getConf(rootModel.jbrowse, 'theme')
+  const { AssemblyManager } = pluginManager.getPlugin(
+    'DataManagementPlugin',
+  ).exports
   return (
     <ThemeProvider theme={createJBrowseTheme(theme)}>
       <CssBaseline />
       <App
         session={session}
         HeaderButtons={<ShareButton session={session} />}
+      />
+      <AssemblyManager
+        rootModel={rootModel}
+        open={rootModel.isAssemblyEditing}
+        onClose={() => {
+          rootModel.setAssemblyEditing(false)
+        }}
       />
     </ThemeProvider>
   )

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -21,25 +21,6 @@ Array [
       },
     ],
   },
-  Object {
-    "label": "Admin",
-    "menuItems": Array [
-      Object {
-        "icon": Object {
-          "$$typeof": Symbol(react.memo),
-          "compare": null,
-          "displayName": "SettingsIcon",
-          "muiName": "SvgIcon",
-          "type": Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          },
-        },
-        "label": "Open Assembly Manager",
-        "onClick": [Function],
-      },
-    ],
-  },
 ]
 `;
 
@@ -60,25 +41,6 @@ Array [
           },
         },
         "label": "New session",
-        "onClick": [Function],
-      },
-    ],
-  },
-  Object {
-    "label": "Admin",
-    "menuItems": Array [
-      Object {
-        "icon": Object {
-          "$$typeof": Symbol(react.memo),
-          "compare": null,
-          "displayName": "SettingsIcon",
-          "muiName": "SvgIcon",
-          "type": Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          },
-        },
-        "label": "Open Assembly Manager",
         "onClick": [Function],
       },
     ],

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -21,6 +21,25 @@ Array [
       },
     ],
   },
+  Object {
+    "label": "Admin",
+    "menuItems": Array [
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "displayName": "SettingsIcon",
+          "muiName": "SvgIcon",
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Open Assembly Manager",
+        "onClick": [Function],
+      },
+    ],
+  },
 ]
 `;
 
@@ -41,6 +60,25 @@ Array [
           },
         },
         "label": "New session",
+        "onClick": [Function],
+      },
+    ],
+  },
+  Object {
+    "label": "Admin",
+    "menuItems": Array [
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "displayName": "SettingsIcon",
+          "muiName": "SvgIcon",
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Open Assembly Manager",
         "onClick": [Function],
       },
     ],

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -75,6 +75,14 @@ export default function JBrowseWeb(
         const length = self.assemblies.push(assemblyConf)
         return self.assemblies[length - 1]
       },
+      removeAssemblyConf(assemblyName) {
+        const toRemove = self.assemblies.find(
+          assembly => assembly.name === assemblyName,
+        )
+        if (toRemove) {
+          self.assemblies.remove(toRemove)
+        }
+      },
       addTrackConf(trackConf) {
         const { type } = trackConf
         if (!type) throw new Error(`unknown track type ${type}`)

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -52,12 +52,12 @@ export default function RootModel(
       configPath: types.maybe(types.string),
       session: types.maybe(Session),
       assemblyManager: assemblyManagerType,
-      error: types.maybe(types.string),
       version: types.maybe(types.string),
       isAssemblyEditing: false,
     })
     .volatile(() => ({
       savedSessionsVolatile: observable.map({}),
+      error: undefined as undefined | Error,
     }))
     .views(self => ({
       get savedSessions() {
@@ -220,8 +220,8 @@ export default function RootModel(
         this.setSession(autosavedSession)
       },
 
-      setError(errorMessage: string) {
-        self.error = errorMessage
+      setError(error: Error) {
+        self.error = error
       },
     }))
     .volatile(self => ({

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -7,12 +7,14 @@ import RpcManager from '@jbrowse/core/rpc/RpcManager'
 import { MenuItem } from '@jbrowse/core/ui'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import AddIcon from '@material-ui/icons/Add'
+import SettingsIcon from '@material-ui/icons/Settings'
 import {
   addDisposer,
   cast,
   getSnapshot,
   SnapshotIn,
   types,
+  getParent,
 } from 'mobx-state-tree'
 import { observable, autorun } from 'mobx'
 import { UndoManager } from 'mst-middlewares'
@@ -52,6 +54,7 @@ export default function RootModel(
       assemblyManager: assemblyManagerType,
       error: types.maybe(types.string),
       version: types.maybe(types.string),
+      isAssemblyEditing: false,
     })
     .volatile(() => ({
       savedSessionsVolatile: observable.map({}),
@@ -144,6 +147,9 @@ export default function RootModel(
       setSession(sessionSnapshot?: SnapshotIn<typeof Session>) {
         self.session = cast(sessionSnapshot)
       },
+      setAssemblyEditing(flag: boolean) {
+        self.isAssemblyEditing = flag
+      },
       setDefaultSession() {
         const { defaultSession } = self.jbrowse
         const newSession = {
@@ -234,6 +240,20 @@ export default function RootModel(
                   localStorage.setItem(self.previousAutosaveId, lastAutosave)
                 }
                 session.setDefaultSession()
+              },
+            },
+          ],
+        },
+        {
+          label: 'Admin',
+          menuItems: [
+            {
+              label: 'Open Assembly Manager',
+              icon: SettingsIcon,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              onClick: (session: any) => {
+                const rootModel = getParent(session)
+                rootModel.setAssemblyEditing(true)
               },
             },
           ],

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -244,20 +244,24 @@ export default function RootModel(
             },
           ],
         },
-        {
-          label: 'Admin',
-          menuItems: [
-            {
-              label: 'Open Assembly Manager',
-              icon: SettingsIcon,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              onClick: (session: any) => {
-                const rootModel = getParent(session)
-                rootModel.setAssemblyEditing(true)
+        ...(adminMode
+          ? [
+              {
+                label: 'Admin',
+                menuItems: [
+                  {
+                    label: 'Open Assembly Manager',
+                    icon: SettingsIcon,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    onClick: (session: any) => {
+                      const rootModel = getParent(session)
+                      rootModel.setAssemblyEditing(true)
+                    },
+                  },
+                ],
               },
-            },
-          ],
-        },
+            ]
+          : []),
       ] as Menu[],
       rpcManager: new RpcManager(
         pluginManager,


### PR DESCRIPTION
This is a PR with the new location for the AssemblyManager GUI, for #513 . @rbuels and I moved the components into the `data-management` plugin, and use it from there.

I still want to do some more manual testing and look through the previous commit history to make sure nothing was missed. For example, need to grab the logic for making it only available in admin mode, and make sure it works fine from there.

Would be curious to get thoughts from @garrettjstevens  and @cmdcolin 