### PR TITLE
Don't use abort signal for refnamemap

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -268,7 +268,6 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
             self: self as Assembly,
             options: rest,
           } as CacheData,
-          signal,
           statusCallback,
         )
       },


### PR DESCRIPTION
This is a shortfix that helps with #1232 

Currently on every side scroll the refnamemap is evicted from the cache, can add a console log and see it hits this eviction on many side scrolls https://github.com/rbuels/abortable-promise-cache/blob/master/src/AbortablePromiseCache.ts#L97

The shortfix is to just not have aborting here

The longfix is to identify what is going on with AbortablePromiseCache here and then also reduce CPU usage that made loadRefNameMap get noticed in the first place