### PR TITLE
make rootModel setSession check and attempt to remove undefined MST refs

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -420,7 +420,18 @@ const Renderer = observer(
               )
             }
           } else if (sessionSnapshot) {
-            rootModel.setSession(loader.sessionSnapshot)
+            try {
+              rootModel.setSession(loader.sessionSnapshot)
+            } catch (error) {
+              console.error(error)
+              rootModel.setDefaultSession()
+              const errorMessage = (error.message || '')
+                .replace('[mobx-state-tree] ', '')
+                .replace(/\(.+/, '')
+              rootModel.session?.notify(
+                `Session could not be loaded. ${errorMessage}`,
+              )
+            }
           } else {
             rootModel.setDefaultSession()
           }

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -13,6 +13,17 @@ import {
   getSnapshot,
   SnapshotIn,
   types,
+  IAnyStateTreeNode,
+  Instance,
+  getType,
+  isArrayType,
+  isModelType,
+  isReferenceType,
+  isValidReference,
+  getPropertyMembers,
+  isMapType,
+  getChildType,
+  IAnyType,
 } from 'mobx-state-tree'
 import { observable, autorun } from 'mobx'
 import { UndoManager } from 'mst-middlewares'
@@ -21,6 +32,53 @@ import jbrowseWebFactory from './jbrowseModel'
 // @ts-ignore
 import RenderWorker from './rpc.worker'
 import sessionModelFactory from './sessionModelFactory'
+
+// attempts to remove undefined references from the given MST model. can only actually
+// remove them from arrays and maps. throws MST undefined ref error if it encounters
+// undefined refs in model properties
+function filterSessionInPlace(node: IAnyStateTreeNode, nodeType: IAnyType) {
+  type MSTArray = Instance<ReturnType<typeof types.array>>
+  type MSTMap = Instance<ReturnType<typeof types.map>>
+
+  if (isArrayType(nodeType)) {
+    const array = node as MSTArray
+    const childType = getChildType(node)
+    if (isReferenceType(childType)) {
+      // filter array elements
+      for (let i = 0; i < array.length; ) {
+        if (!isValidReference(() => array[i])) {
+          array.splice(i, 1)
+        } else {
+          i += 1
+        }
+      }
+    }
+    array.forEach(el => {
+      filterSessionInPlace(el, childType)
+    })
+  } else if (isMapType(nodeType)) {
+    const map = node as MSTMap
+    const childType = getChildType(map)
+    if (isReferenceType(childType)) {
+      // filter the map members
+      for (const key in map.keys()) {
+        if (!isValidReference(() => map.get(key))) {
+          map.delete(key)
+        }
+      }
+    }
+    map.forEach(child => {
+      filterSessionInPlace(child, childType)
+    })
+  } else if (isModelType(nodeType)) {
+    // iterate over children
+    const { properties } = getPropertyMembers(node)
+    Object.entries(properties).forEach(([pname, ptype]) => {
+      // @ts-ignore
+      filterSessionInPlace(node[pname], ptype)
+    })
+  }
+}
 
 interface Menu {
   label: string
@@ -142,7 +200,18 @@ export default function RootModel(
         )
       },
       setSession(sessionSnapshot?: SnapshotIn<typeof Session>) {
+        const oldSession = self.session
         self.session = cast(sessionSnapshot)
+        if (self.session) {
+          // validate all references in the session snapshot
+          try {
+            filterSessionInPlace(self.session, getType(self.session))
+          } catch (error) {
+            // throws error if session filtering failed
+            self.session = oldSession
+            throw error
+          }
+        }
       },
       setDefaultSession() {
         const { defaultSession } = self.jbrowse


### PR DESCRIPTION
Attempts to filter out undefined references in sessions at load time as much as possible. It can't get everything, but it does validate all the references at the time that you set the session, so at least you can handle the undefined ref at session load time.

Adds logic in Loader.tsx to handle the new undefined ref errors thrown setSession, which is what actually addresses the problem in #1275.

this is an alternate approach to #1275, but they might possibly be able to work together, could consider testing that.