### PR TITLE
volatile parent Info not accurate - Bug in LGV

### DIFF
--- a/packages/core/util/types/mst.ts
+++ b/packages/core/util/types/mst.ts
@@ -25,11 +25,9 @@ export const NoAssemblyRegion = types
     start: types.number,
     end: types.number,
     reversed: types.optional(types.boolean, false),
+    parentStart: types.optional(types.number, -1),
+    parentEnd: types.optional(types.number, -1),
   })
-  .volatile(() => ({
-    parentStart: -1,
-    parentEnd: -1,
-  }))
   .actions(self => ({
     setRefName(newRefName: string): void {
       self.refName = newRefName

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -201,10 +201,10 @@ export default observer(({ model }: { model: LGV }) => {
 
 const RegionWidth = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
-  const { dynamicBlocks } = model
+  const { coarseTotalBp } = model
   return (
     <Typography variant="body2" color="textSecondary" className={classes.bp}>
-      {`${Math.round(dynamicBlocks.totalBp).toLocaleString('en-US')} bp`}
+      {`${Math.round(coarseTotalBp).toLocaleString('en-US')} bp`}
     </Typography>
   )
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -147,7 +147,7 @@ function PanControls({ model }: { model: LGV }) {
 export default observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
   const theme = useTheme()
-  const { coarseDynamicBlocks: contentBlocks = {}, displayedRegions } = model
+  const { coarseDynamicBlocks: contentBlocks, displayedRegions } = model
 
   const setDisplayedRegion = useCallback(
     (region: Region | undefined) => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -81,7 +81,7 @@ const Search = observer(({ model }: { model: LGV }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const classes = useStyles()
   const theme = useTheme()
-  const { visibleLocStrings } = model
+  const { coarseVisibleLocStrings: visibleLocStrings } = model
   const session = getSession(model)
 
   function navTo(locString: string) {
@@ -147,10 +147,7 @@ function PanControls({ model }: { model: LGV }) {
 export default observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
   const theme = useTheme()
-  const {
-    dynamicBlocks: { contentBlocks },
-    displayedRegions,
-  } = model
+  const { coarseDynamicBlocks: contentBlocks = {}, displayedRegions } = model
 
   const setDisplayedRegion = useCallback(
     (region: Region | undefined) => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles(theme => {
     },
     scaleBarContigForward: {
       backgroundImage: `
-      linear-gradient(-45deg, ${background} 10px, transparent 10px), 
+      linear-gradient(-45deg, ${background} 10px, transparent 10px),
       linear-gradient(-135deg, ${background} 10px, transparent 10px),
       linear-gradient(-45deg, #e4e4e4 11px, transparent 12px),
       linear-gradient(-135deg, #e4e4e4 11px, transparent 12px),
@@ -50,7 +50,7 @@ const useStyles = makeStyles(theme => {
     },
     scaleBarContigReverse: {
       backgroundImage: `
-      linear-gradient(45deg, ${background} 10px, transparent 10px), 
+      linear-gradient(45deg, ${background} 10px, transparent 10px),
       linear-gradient(135deg, ${background} 10px, transparent 10px),
       linear-gradient(45deg, #e4e4e4 11px, transparent 12px),
       linear-gradient(135deg, #e4e4e4 11px, transparent 12px),

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1102,7 +1102,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           return calculateDynamicBlocks(self)
         },
         get visibleLocStrings() {
-          return calculateVisibleLocStrings(this.dynamicBlocks)
+          return calculateVisibleLocStrings(this.dynamicBlocks.contentBlocks)
         },
         get coarseVisibleLocStrings() {
           return calculateVisibleLocStrings(self.coarseDynamicBlocks)

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -14,7 +14,7 @@ import {
   springAnimate,
   isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
-import { BlockSet } from '@jbrowse/core/util/blockTypes'
+import { BlockSet, BaseBlock } from '@jbrowse/core/util/blockTypes'
 import calculateDynamicBlocks from '@jbrowse/core/util/calculateDynamicBlocks'
 import calculateStaticBlocks from '@jbrowse/core/util/calculateStaticBlocks'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
@@ -48,8 +48,7 @@ export interface BpOffset {
   reversed?: boolean
 }
 
-function calculateVisibleLocStrings(dynamicBlocks) {
-  const { contentBlocks } = dynamicBlocks
+function calculateVisibleLocStrings(contentBlocks: BaseBlock[]) {
   if (!contentBlocks.length) {
     return ''
   }
@@ -114,7 +113,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
       scaleFactor: 1,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       trackRefs: {} as { [key: string]: any },
-      coarseDynamicBlocks: { contentBlocks: [] } as any,
+      coarseDynamicBlocks: [] as BaseBlock[],
+      coarseTotalBp: 0,
     }))
     .views(self => ({
       get width(): number {
@@ -1110,17 +1110,20 @@ export function stateModelFactory(pluginManager: PluginManager) {
       }
     })
     .actions(self => ({
-      setCoarseDynamicBlocks(blocks: any) {
-        self.coarseDynamicBlocks = blocks
+      setCoarseDynamicBlocks(blocks: BlockSet) {
+        self.coarseDynamicBlocks = blocks.contentBlocks
+        self.coarseTotalBp = blocks.totalBp
       },
       afterAttach() {
         addDisposer(
           self,
           autorun(
             () => {
-              this.setCoarseDynamicBlocks(self.dynamicBlocks)
+              if (self.initialized) {
+                this.setCoarseDynamicBlocks(self.dynamicBlocks)
+              }
             },
-            { delay: 100 },
+            { delay: 150 },
           ),
         )
       },

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -18,7 +18,7 @@ import { BlockSet } from '@jbrowse/core/util/blockTypes'
 import calculateDynamicBlocks from '@jbrowse/core/util/calculateDynamicBlocks'
 import calculateStaticBlocks from '@jbrowse/core/util/calculateStaticBlocks'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
-import { transaction } from 'mobx'
+import { transaction, autorun } from 'mobx'
 import {
   getSnapshot,
   types,
@@ -26,6 +26,7 @@ import {
   Instance,
   getRoot,
   resolveIdentifier,
+  addDisposer,
 } from 'mobx-state-tree'
 
 import PluginManager from '@jbrowse/core/PluginManager'
@@ -45,6 +46,25 @@ export interface BpOffset {
   end?: number
   coord?: number
   reversed?: boolean
+}
+
+function calculateVisibleLocStrings(dynamicBlocks) {
+  const { contentBlocks } = dynamicBlocks
+  if (!contentBlocks.length) {
+    return ''
+  }
+  const isSingleAssemblyName = contentBlocks.every(
+    block => block.assemblyName === contentBlocks[0].assemblyName,
+  )
+  const locs = contentBlocks.map(block =>
+    assembleLocString({
+      ...block,
+      start: Math.round(block.start),
+      end: Math.round(block.end),
+      assemblyName: isSingleAssemblyName ? undefined : block.assemblyName,
+    }),
+  )
+  return locs.join(';')
 }
 
 export interface NavLocation {
@@ -94,6 +114,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       scaleFactor: 1,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       trackRefs: {} as { [key: string]: any },
+      coarseDynamicBlocks: { contentBlocks: [] } as any,
     }))
     .views(self => ({
       get width(): number {
@@ -1081,27 +1102,29 @@ export function stateModelFactory(pluginManager: PluginManager) {
           return calculateDynamicBlocks(self)
         },
         get visibleLocStrings() {
-          const { contentBlocks } = this.dynamicBlocks
-          if (!contentBlocks.length) {
-            return ''
-          }
-          const isSingleAssemblyName = contentBlocks.every(
-            block => block.assemblyName === contentBlocks[0].assemblyName,
-          )
-          const locs = contentBlocks.map(block =>
-            assembleLocString({
-              ...block,
-              start: Math.round(block.start),
-              end: Math.round(block.end),
-              assemblyName: isSingleAssemblyName
-                ? undefined
-                : block.assemblyName,
-            }),
-          )
-          return locs.join(';')
+          return calculateVisibleLocStrings(this.dynamicBlocks)
+        },
+        get coarseVisibleLocStrings() {
+          return calculateVisibleLocStrings(self.coarseDynamicBlocks)
         },
       }
     })
+    .actions(self => ({
+      setCoarseDynamicBlocks(blocks: any) {
+        self.coarseDynamicBlocks = blocks
+      },
+      afterAttach() {
+        addDisposer(
+          self,
+          autorun(
+            () => {
+              this.setCoarseDynamicBlocks(self.dynamicBlocks)
+            },
+            { delay: 100 },
+          ),
+        )
+      },
+    }))
 
   return types.compose(BaseViewModel, model)
 }


### PR DESCRIPTION
This PR fixes that (with approach # 1)
<img width="1253" alt="correct_zigzag_borders" src="https://user-images.githubusercontent.com/45598764/97755210-fa8ed700-1ab5-11eb-8415-7b390886c259.png">
<img width="1156" alt="incorrect_zigzag_borders" src="https://user-images.githubusercontent.com/45598764/97755213-fbc00400-1ab5-11eb-9b15-f95ae85807aa.png">

Volatile parentStart and parentEnd cause bug when identifying if a region is smaller than its parent region.

Proposal:
Either 
1) move the parentStart and parentEnd back to the model 
2) remove the parent Info from the model and use helper methods to fetch parent Info


