### PR TITLE
Keep existing slot attributes when setting URI

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
@@ -330,11 +330,17 @@ const stringEnumEditor = observer(({ slot, slotSchema }) => {
   )
 })
 
+function createSetLocation(slot) {
+  return location => {
+    slot.set({ ...slot.value, ...location })
+  }
+}
+
 const FileSelectorWrapper = observer(({ slot }) => {
   return (
     <FileSelector
       location={slot.value}
-      setLocation={slot.set}
+      setLocation={createSetLocation(slot)}
       name={slot.name}
       description={slot.description}
     />


### PR DESCRIPTION
Fixes #1341. @elliothershberg and I ran into the bug during our pairing and found this fix. The slot editor was getting rid of the baseUri when setting a new URI.