### PR TITLE
Bug volatile parentinfo

### DIFF
--- a/packages/core/util/types/mst.ts
+++ b/packages/core/util/types/mst.ts
@@ -25,8 +25,6 @@ export const NoAssemblyRegion = types
     start: types.number,
     end: types.number,
     reversed: types.optional(types.boolean, false),
-    parentStart: types.optional(types.number, -1),
-    parentEnd: types.optional(types.number, -1),
   })
   .actions(self => ({
     setRefName(newRefName: string): void {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -216,8 +216,10 @@ const ScaleBar = observer(({ model, scale }: { model: LGV; scale: number }) => {
         }
         const regionLength = seq.end - seq.start
         // boolean if displayed region length is smaller than its parent's
-        const incompleteRegion =
-          seq.parentEnd - seq.parentStart > seq.end - seq.start
+        const parent = model.parentRegion(seq.assemblyName, seq.refName)
+        const incompleteRegion = parent
+          ? parent.end - parent.start > seq.end - seq.start
+          : false
         // number of labels to draw in the overview scale bar
         const numLabels = Math.floor(regionLength / gridPitch.majorPitch)
         // calculating the number labels

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -520,11 +520,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       setDisplayedRegions(regions: Region[]) {
         self.displayedRegions = cast(regions)
-        self.displayedRegions.forEach(r => {
-          const parent = self.parentRegion(r.assemblyName, r.refName)
-          r.parentStart = parent ? parent.start : -1
-          r.parentEnd = parent ? parent.end : -1
-        })
         self.zoomTo(self.bpPerPx)
       },
 


### PR DESCRIPTION
[Issue: 1367 ](https://github.com/GMOD/jbrowse-components/issues/1367)
(with approach # 1 in this [pr](https://github.com/GMOD/jbrowse-components/pull/1363))
This PR fixes that (with approach # 2)
<img width="1253" alt="correct_zigzag_borders" src="https://user-images.githubusercontent.com/45598764/97755210-fa8ed700-1ab5-11eb-8415-7b390886c259.png">
<img width="1156" alt="incorrect_zigzag_borders" src="https://user-images.githubusercontent.com/45598764/97755213-fbc00400-1ab5-11eb-9b15-f95ae85807aa.png">

Volatile parentStart and parentEnd cause bug when identifying if a region is smaller than its parent region.

Proposal:
Either 
1) move the parentStart and parentEnd back to the model 
2) remove the parent Info from the model and use helper methods to fetch parent Info
3) discuss other options