### PR TITLE
Add ability to use admin-server in dev mode

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -37,6 +37,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "json-parse-better-errors": "^1.0.2",
     "node-fetch": "^2.6.0",

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -2,6 +2,7 @@ import { flags } from '@oclif/command'
 import fs, { promises as fsPromises } from 'fs'
 import crypto from 'crypto'
 import express from 'express'
+import cors from 'cors'
 import JBrowseCommand, { Config } from '../base'
 
 function isValidPort(port: number) {
@@ -76,6 +77,7 @@ export default class AdminServer extends JBrowseCommand {
     // @ts-ignore
     const app = express()
     app.use(express.static('.'))
+    app.use(cors())
 
     // POST route to save config
     app.use(express.json())
@@ -115,7 +117,7 @@ export default class AdminServer extends JBrowseCommand {
     const adminKey = generateKey()
     const server = app.listen(port)
     this.log(
-      `Navigate to http://localhost:${port}?adminKey=${adminKey} to configure your JBrowse installation graphically.`,
+      `Navigate to http://localhost:${port}?adminKey=${adminKey} to configure your JBrowse installation graphically.\n\nIf you are running yarn start you can launch http://localhost:3000?adminKey=${adminKey}&adminServer=http://localhost:${port}/updateConfig`,
     )
   }
 }

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -22,6 +22,7 @@ function deleteBaseUris(config) {
 
 const JBrowse = observer(({ pluginManager }) => {
   const [adminKey] = useQueryParam('adminKey', StringParam)
+  const [adminServer] = useQueryParam('adminServer', StringParam)
   const [, setSessionId] = useQueryParam('session', StringParam)
   const { rootModel } = pluginManager
   const { error, jbrowse, session } = rootModel || {}
@@ -35,10 +36,10 @@ const JBrowse = observer(({ pluginManager }) => {
     onSnapshot(jbrowse, async snapshot => {
       if (adminKey) {
         const config = JSON.parse(JSON.stringify(snapshot))
-        deleteBaseUris(snapshot)
+        deleteBaseUris(config)
         const payload = { adminKey, config }
 
-        const response = await fetch('/updateConfig', {
+        const response = await fetch(adminServer || `/updateConfig`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -55,7 +56,7 @@ const JBrowse = observer(({ pluginManager }) => {
         }
       }
     })
-  }, [jbrowse, session, adminKey])
+  }, [jbrowse, session, adminKey, adminServer])
 
   if (error) {
     throw error

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -39,6 +39,21 @@ if (!window.TextDecoder) {
   window.TextDecoder = TextDecoder
 }
 function NoConfigMessage() {
+  const s = window.location.search
+  const links = [
+    ['test_data/volvox/config.json', 'Volvox sample data'],
+    ['test_data/config.json', 'Human basic'],
+    ['test_data/config_demo.json', 'Human sample data'],
+    ['test_data/tomato/config.json', 'Tomato SVs'],
+    ['test_data/breakpoint/config.json', 'Breakpoint'],
+    ['test_data/config_dotplot.json', 'Grape/Peach dotplot'],
+    ['test_data/config_synteny_grape_peach.json', 'Grape/Peach synteny'],
+    ['test_data/yeast_synteny/config.json', 'Yeast synteny'],
+    ['test_data/config_longread.json', 'Long read vs. ref (dotplot)'],
+    ['test_data/config_longread_linear.json', 'Long read vs. ref (linear)'],
+    ['test_data/config_many_contigs.json', 'Many contigs'],
+    ['test_data/config_honeybee.json', 'Honeybee'],
+  ]
   return (
     <div>
       <h4>
@@ -57,59 +72,11 @@ function NoConfigMessage() {
         <>
           <div>Sample JBrowse configs:</div>
           <ul>
-            <li>
-              <a href="?config=test_data/config.json">Human basic</a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_demo.json">Human sample data</a>
-            </li>
-            <li>
-              <a href="?config=test_data/tomato/config.json">Tomato SVs</a>
-            </li>
-            <li>
-              <a href="?config=test_data/volvox/config.json">Volvox</a>
-            </li>
-            <li>
-              <a href="?config=test_data/breakpoint/config.json">Breakpoint</a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_dotplot.json">
-                Grape/Peach Dotplot
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_human_dotplot.json">
-                hg19/hg38 Dotplot
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_synteny_grape_peach.json">
-                Grape/Peach Synteny
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/yeast_synteny/config.json">
-                Yeast Synteny
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_longread.json">
-                Long Read vs. Reference Dotplot
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_longread_linear.json">
-                Long Read vs. Reference Linear
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_many_contigs.json">
-                Many Contigs
-              </a>
-            </li>
-            <li>
-              <a href="?config=test_data/config_honeybee.json">Honeybee</a>
-            </li>
+            {links.map(([link, name]) => (
+              <li>
+                <a href={`${s}${s ? '&' : '?'}config=${link}`}>{name}</a>
+              </li>
+            ))}
           </ul>
         </>
       ) : (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7925,6 +7925,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -15307,7 +15315,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -20622,7 +20630,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
This attempts to help with the issue #1297 


The admin-server prints out a message for how to run it in dev mode e.g. when yarn start is running on port 3000 and the admin server is running on port 9000

The URL format looks like

http://localhost:3000/?adminKey=ebcd0bd95f&adminServer=http%3A%2F%2Flocalhost%3A9090%2FupdateConfig&config=test_data%2Fvolvox%2Fconfig.json&session=local-WlWepLIjl

To work with volvox I run

cd test_data/volvox
../../products/jbrowse-cli/bin/run admin-server
http://localhost:3000?adminKey=320ffbf8eb&adminServer=http://localhost:9090/updateConfig


