### PR TITLE
Make hasWidget check hidden widgets

### DIFF
--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -284,7 +284,9 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           } catch (err1) {
             // ignore
           }
-          if (this.hasWidget(node)) {
+
+          // @ts-ignore
+          if (self.widgets.has(node.id)) {
             // If a configuration editor widget has the track config
             // open, close the widget
             const type = 'configuration editor widget(s)'

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -214,7 +214,9 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           } catch (err1) {
             // ignore
           }
-          if (this.hasWidget(node)) {
+
+          // @ts-ignore
+          if (self.widgets.has(node.id)) {
             // If a configuration editor widget has the track config
             // open, close the widget
             const type = 'configuration editor widget(s)'
@@ -420,7 +422,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       hasWidget(widget: any) {
-        return self.widgets.has(widget.id)
+        return self.activeWidgets.has(widget.id)
       },
 
       hideWidget(widget: any) {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -420,7 +420,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       hasWidget(widget: any) {
-        return self.activeWidgets.has(widget.id)
+        return self.widgets.has(widget.id)
       },
 
       hideWidget(widget: any) {


### PR DESCRIPTION
Currently the removeReferring uses hasWidget to check if anything is referring to a track. This searches all widgets including hidden ones from self.widgets in the session

This would fix #1342 


Alternative fixes might involve not keeping track of hidden widgets
