### PR TITLE
Don't crash app when live editing assembly

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -212,7 +212,9 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         this.setRefNameAliases(refNameAliases)
       },
       setError(error: Error) {
-        getParent(self, 3).setError(error)
+        if (!getParent(self, 3).isAssemblyEditing) {
+          getParent(self, 3).setError(error)
+        }
       },
       setRegions(regions: Region[]) {
         self.regions = cast(regions)


### PR DESCRIPTION
This is a small change that checks if the Assembly Manager GUI is open before cascading errors loading an assembly up to the root model of the app and crashing it. This fixes issues with live editing values using the config editor for assemblies (#1375 ).

I'm going to open a separate PR with an improved form for adding assemblies, but think this should go in now, depending on how long creating the new form takes me.