### PR TITLE
Remove savedSessions from configs

### DIFF
--- a/test_data/breakpoint/config.json
+++ b/test_data/breakpoint/config.json
@@ -93,114 +93,109 @@
     }
   ],
   "defaultSession": {
-    "name": "New Session"
-  },
-  "savedSessions": [
-    {
-      "name": "Human Example (hg19)",
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "BreakpointSplitView",
-          "headerHeight": 44,
-          "height": 400,
-          "displayName": "pbsv.BND.3:186700648-6:56758392 split detail",
-          "trackSelectorType": "hierarchical",
-          "views": [
-            {
-              "id": "AcZl9Uifbv",
-              "type": "LinearGenomeView",
-              "offsetPx": 18669656.00687344,
-              "bpPerPx": 10,
-              "displayedRegions": [
-                {
-                  "refName": "3",
-                  "start": 0,
-                  "end": 186700647,
-                  "assemblyName": "hg19"
-                },
-                {
-                  "refName": "3",
-                  "start": 186700647,
-                  "end": 198022430,
-                  "assemblyName": "hg19"
-                }
-              ],
-              "tracks": [
-                {
-                  "type": "AlignmentsTrack",
-                  "height": 100,
-                  "configuration": "pacbio_hg002_breakpoints",
-                  "selectedRendering": ""
-                },
-                {
-                  "type": "VariantTrack",
-                  "height": 100,
-                  "configuration": "pacbio_vcf",
-                  "selectedRendering": ""
-                }
-              ],
-              "hideControls": false,
-              "hideHeader": true,
-              "trackSelectorType": "hierarchical"
-            },
-            {
-              "id": "0Q9aAu1h7g",
-              "type": "LinearGenomeView",
-              "offsetPx": 5675435.581319785,
-              "bpPerPx": 10,
-              "displayedRegions": [
-                {
-                  "refName": "6",
-                  "start": 0,
-                  "end": 56758391,
-                  "assemblyName": "hg19"
-                },
-                {
-                  "refName": "6",
-                  "start": 56758391,
-                  "end": 171115067,
-                  "assemblyName": "hg19"
-                }
-              ],
-              "tracks": [
-                {
-                  "type": "AlignmentsTrack",
-                  "height": 100,
-                  "configuration": "pacbio_hg002_breakpoints",
-                  "selectedRendering": ""
-                },
-                {
-                  "type": "VariantTrack",
-                  "height": 100,
-                  "configuration": "pacbio_vcf",
-                  "selectedRendering": ""
-                }
-              ],
-              "hideControls": false,
-              "hideHeader": true,
-              "trackSelectorType": "hierarchical"
-            }
-          ]
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
+    "name": "Human Example (hg19)",
+    "drawerWidth": 384,
+    "views": [
+      {
+        "id": "MiDMyyWpp",
+        "type": "BreakpointSplitView",
+        "headerHeight": 44,
+        "height": 400,
+        "displayName": "pbsv.BND.3:186700648-6:56758392 split detail",
+        "trackSelectorType": "hierarchical",
+        "views": [
+          {
+            "id": "AcZl9Uifbv",
+            "type": "LinearGenomeView",
+            "offsetPx": 18669656.00687344,
+            "bpPerPx": 10,
+            "displayedRegions": [
+              {
+                "refName": "3",
+                "start": 0,
+                "end": 186700647,
+                "assemblyName": "hg19"
+              },
+              {
+                "refName": "3",
+                "start": 186700647,
+                "end": 198022430,
+                "assemblyName": "hg19"
+              }
+            ],
+            "tracks": [
+              {
+                "type": "AlignmentsTrack",
+                "height": 100,
+                "configuration": "pacbio_hg002_breakpoints",
+                "selectedRendering": ""
+              },
+              {
+                "type": "VariantTrack",
+                "height": 100,
+                "configuration": "pacbio_vcf",
+                "selectedRendering": ""
+              }
+            ],
+            "hideControls": false,
+            "hideHeader": true,
+            "trackSelectorType": "hierarchical"
+          },
+          {
+            "id": "0Q9aAu1h7g",
+            "type": "LinearGenomeView",
+            "offsetPx": 5675435.581319785,
+            "bpPerPx": 10,
+            "displayedRegions": [
+              {
+                "refName": "6",
+                "start": 0,
+                "end": 56758391,
+                "assemblyName": "hg19"
+              },
+              {
+                "refName": "6",
+                "start": 56758391,
+                "end": 171115067,
+                "assemblyName": "hg19"
+              }
+            ],
+            "tracks": [
+              {
+                "type": "AlignmentsTrack",
+                "height": 100,
+                "configuration": "pacbio_hg002_breakpoints",
+                "selectedRendering": ""
+              },
+              {
+                "type": "VariantTrack",
+                "height": 100,
+                "configuration": "pacbio_vcf",
+                "selectedRendering": ""
+              }
+            ],
+            "hideControls": false,
+            "hideHeader": true,
+            "trackSelectorType": "hierarchical"
+          }
+        ]
+      }
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": ""
       },
-      "activeWidgets": {},
-      "connections": {}
-    }
-  ],
+      "sessionManager": {
+        "id": "sessionManager",
+        "type": "SessionManager"
+      }
+    },
+    "activeWidgets": {},
+    "connections": {}
+  },
   "connections": [
     {
       "type": "JBrowse1Connection",

--- a/test_data/config.json
+++ b/test_data/config.json
@@ -344,6 +344,5 @@
   ],
   "defaultSession": {
     "name": "New Session"
-  },
-  "savedSessions": []
+  }
 }

--- a/test_data/config_chrom_sizes_test.json
+++ b/test_data/config_chrom_sizes_test.json
@@ -84,7 +84,6 @@
       "hierarchicalTrackSelector": "hierarchicalTrackSelector"
     }
   },
-  "savedSessions": [],
   "configuration": {
     "rpc": {
       "defaultDriver": "MainThreadRpcDriver"

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -1819,6 +1819,5 @@
   "connections": [],
   "defaultSession": {
     "name": "New Session"
-  },
-  "savedSessions": []
+  }
 }

--- a/test_data/config_dotplot.json
+++ b/test_data/config_dotplot.json
@@ -172,54 +172,5 @@
       }
     ],
     "connections": {}
-  },
-  "savedSessions": [
-    {
-      "name": "Grape vs Peach",
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "DotplotView",
-          "assemblyNames": ["peach", "grape"],
-          "hview": {
-            "displayedRegions": [],
-            "bpPerPx": 100000,
-            "offsetPx": 0
-          },
-          "vview": {
-            "displayedRegions": [],
-            "bpPerPx": 100000,
-            "offsetPx": 0
-          },
-          "tracks": [
-            {
-              "type": "DotplotTrack",
-              "configuration": "dotplot_track"
-            }
-          ],
-          "displayName": "Grape vs Peach dotplot",
-          "trackSelectorType": "hierarchical"
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
-      },
-      "activeWidgets": {},
-      "menuBars": [
-        {
-          "type": "MainMenuBar"
-        }
-      ],
-      "connections": {}
-    }
-  ]
+  }
 }

--- a/test_data/config_human_dotplot.json
+++ b/test_data/config_human_dotplot.json
@@ -35,59 +35,49 @@
   ],
   "tracks": [],
   "defaultSession": {
-    "name": "New Session",
+    "name": "hg19 vs hg38",
+    "width": 1850,
+    "drawerWidth": 384,
+    "views": [
+      {
+        "id": "MiDMyyWpp",
+        "type": "DotplotView",
+        "assemblyNames": ["hg38", "hg19"],
+        "hview": {
+          "displayedRegions": [],
+          "bpPerPx": 100000,
+          "offsetPx": 0
+        },
+        "vview": {
+          "displayedRegions": [],
+          "bpPerPx": 200000,
+          "offsetPx": 0
+        },
+        "headerHeight": 44,
+        "width": 1850,
+        "height": 600,
+        "displayName": "hg19 vs hg38 dotplot",
+        "trackSelectorType": "hierarchical"
+      }
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": ""
+      },
+      "sessionManager": {
+        "id": "sessionManager",
+        "type": "SessionManager"
+      }
+    },
+    "activeWidgets": {},
     "menuBars": [
       {
         "type": "MainMenuBar"
       }
-    ]
-  },
-  "savedSessions": [
-    {
-      "name": "hg19 vs hg38",
-      "width": 1850,
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "DotplotView",
-          "assemblyNames": ["hg38", "hg19"],
-          "hview": {
-            "displayedRegions": [],
-            "bpPerPx": 100000,
-            "offsetPx": 0
-          },
-          "vview": {
-            "displayedRegions": [],
-            "bpPerPx": 200000,
-            "offsetPx": 0
-          },
-          "headerHeight": 44,
-          "width": 1850,
-          "height": 600,
-          "displayName": "hg19 vs hg38 dotplot",
-          "trackSelectorType": "hierarchical"
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
-      },
-      "activeWidgets": {},
-      "menuBars": [
-        {
-          "type": "MainMenuBar"
-        }
-      ],
-      "connections": {}
-    }
-  ]
+    ],
+    "connections": {}
+  }
 }

--- a/test_data/config_longread.json
+++ b/test_data/config_longread.json
@@ -78,84 +78,74 @@
     }
   ],
   "defaultSession": {
-    "name": "New Session",
+    "name": "SKBR3 PacBio vs Ref",
+    "width": 1850,
+    "drawerWidth": 384,
+    "views": [
+      {
+        "id": "MiDMyyWpp",
+        "type": "DotplotView",
+        "assemblyNames": ["longread", "hg19"],
+        "hview": {
+          "displayedRegions": [
+            {
+              "refName": "m150119_155609_00118_c100767352550000001823169407221597_s1_p0/48046/0_23941",
+              "start": 0,
+              "end": 24000,
+              "assemblyName": "longread"
+            }
+          ],
+          "bpPerPx": 30,
+          "offsetPx": 0
+        },
+        "vview": {
+          "displayedRegions": [
+            {
+              "refName": "chr5",
+              "start": 69291433,
+              "end": 69302081,
+              "assemblyName": "hg19"
+            },
+            {
+              "refName": "chr1",
+              "start": 858506,
+              "end": 881099,
+              "assemblyName": "hg19"
+            }
+          ],
+          "bpPerPx": 100,
+          "offsetPx": 0
+        },
+        "tracks": [
+          {
+            "type": "DotplotTrack",
+            "configuration": "dotplot_track"
+          }
+        ],
+        "headerHeight": 44,
+        "height": 500,
+        "name": "SKBR3 PacBio vs Ref",
+        "trackSelectorType": "hierarchical"
+      }
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": ""
+      },
+      "sessionManager": {
+        "id": "sessionManager",
+        "type": "SessionManager"
+      }
+    },
+    "activeWidgets": {},
     "menuBars": [
       {
         "type": "MainMenuBar"
       }
-    ]
-  },
-  "savedSessions": [
-    {
-      "name": "SKBR3 PacBio vs Ref",
-      "width": 1850,
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "DotplotView",
-          "assemblyNames": ["longread", "hg19"],
-          "hview": {
-            "displayedRegions": [
-              {
-                "refName": "m150119_155609_00118_c100767352550000001823169407221597_s1_p0/48046/0_23941",
-                "start": 0,
-                "end": 24000,
-                "assemblyName": "longread"
-              }
-            ],
-            "bpPerPx": 30,
-            "offsetPx": 0
-          },
-          "vview": {
-            "displayedRegions": [
-              {
-                "refName": "chr5",
-                "start": 69291433,
-                "end": 69302081,
-                "assemblyName": "hg19"
-              },
-              {
-                "refName": "chr1",
-                "start": 858506,
-                "end": 881099,
-                "assemblyName": "hg19"
-              }
-            ],
-            "bpPerPx": 100,
-            "offsetPx": 0
-          },
-          "tracks": [
-            {
-              "type": "DotplotTrack",
-              "configuration": "dotplot_track"
-            }
-          ],
-          "headerHeight": 44,
-          "height": 500,
-          "name": "SKBR3 PacBio vs Ref",
-          "trackSelectorType": "hierarchical"
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
-      },
-      "activeWidgets": {},
-      "menuBars": [
-        {
-          "type": "MainMenuBar"
-        }
-      ],
-      "connections": {}
-    }
-  ]
+    ],
+    "connections": {}
+  }
 }

--- a/test_data/config_longread_linear.json
+++ b/test_data/config_longread_linear.json
@@ -149,88 +149,78 @@
     }
   ],
   "defaultSession": {
-    "name": "New Session",
+    "name": "SKBR3 PacBio vs Ref",
+    "width": 1850,
+    "drawerWidth": 384,
+    "views": [
+      {
+        "id": "MiDMyyWpp",
+        "type": "LinearSyntenyView",
+        "assemblyNames": ["longread", "hg19"],
+        "views": [
+          {
+            "type": "LinearGenomeView",
+            "displayedRegions": [
+              {
+                "refName": "m150119_155609_00118_c100767352550000001823169407221597_s1_p0/48046/0_23941",
+                "start": 0,
+                "end": 24000,
+                "assemblyName": "longread"
+              }
+            ],
+            "bpPerPx": 30,
+            "offsetPx": 0
+          },
+          {
+            "type": "LinearGenomeView",
+            "displayedRegions": [
+              {
+                "refName": "chr5",
+                "start": 70166510,
+                "end": 70177159,
+                "assemblyName": "hg19"
+              },
+              {
+                "refName": "chr1",
+                "start": 858506,
+                "end": 881099,
+                "assemblyName": "hg19"
+              }
+            ],
+            "bpPerPx": 100,
+            "offsetPx": 0
+          }
+        ],
+        "tracks": [
+          {
+            "type": "LinearSyntenyTrack",
+            "configuration": "dotplot_track"
+          }
+        ],
+        "headerHeight": 44,
+        "height": 500,
+        "name": "SKBR3 PacBio vs Ref",
+        "trackSelectorType": "hierarchical"
+      }
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": ""
+      },
+      "sessionManager": {
+        "id": "sessionManager",
+        "type": "SessionManager"
+      }
+    },
+    "activeWidgets": {},
     "menuBars": [
       {
         "type": "MainMenuBar"
       }
-    ]
-  },
-  "savedSessions": [
-    {
-      "name": "SKBR3 PacBio vs Ref",
-      "width": 1850,
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "LinearSyntenyView",
-          "assemblyNames": ["longread", "hg19"],
-          "views": [
-            {
-              "type": "LinearGenomeView",
-              "displayedRegions": [
-                {
-                  "refName": "m150119_155609_00118_c100767352550000001823169407221597_s1_p0/48046/0_23941",
-                  "start": 0,
-                  "end": 24000,
-                  "assemblyName": "longread"
-                }
-              ],
-              "bpPerPx": 30,
-              "offsetPx": 0
-            },
-            {
-              "type": "LinearGenomeView",
-              "displayedRegions": [
-                {
-                  "refName": "chr5",
-                  "start": 70166510,
-                  "end": 70177159,
-                  "assemblyName": "hg19"
-                },
-                {
-                  "refName": "chr1",
-                  "start": 858506,
-                  "end": 881099,
-                  "assemblyName": "hg19"
-                }
-              ],
-              "bpPerPx": 100,
-              "offsetPx": 0
-            }
-          ],
-          "tracks": [
-            {
-              "type": "LinearSyntenyTrack",
-              "configuration": "dotplot_track"
-            }
-          ],
-          "headerHeight": 44,
-          "height": 500,
-          "name": "SKBR3 PacBio vs Ref",
-          "trackSelectorType": "hierarchical"
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
-      },
-      "activeWidgets": {},
-      "menuBars": [
-        {
-          "type": "MainMenuBar"
-        }
-      ],
-      "connections": {}
-    }
-  ]
+    ],
+    "connections": {}
+  }
 }

--- a/test_data/config_synteny_grape_peach.json
+++ b/test_data/config_synteny_grape_peach.json
@@ -1,104 +1,94 @@
 {
   "defaultSession": {
-    "name": "New Session",
-    "menuBars": [
+    "name": "Grape vs Peach Demo",
+    "drawerWidth": 384,
+    "views": [
       {
-        "type": "MainMenuBar"
+        "type": "LinearSyntenyView",
+        "id": "test1",
+        "headerHeight": 44,
+        "datasetName": "grape_vs_peach_dataset",
+        "tracks": [
+          {
+            "type": "LinearSyntenyTrack",
+            "height": 100,
+            "configuration": "grape_peach_synteny_mcscan"
+          }
+        ],
+        "height": 400,
+        "displayName": "Grape vs Peach",
+        "trackSelectorType": "hierarchical",
+        "views": [
+          {
+            "type": "LinearGenomeView",
+            "id": "test1_1",
+            "offsetPx": 28249,
+            "bpPerPx": 1000,
+            "displayedRegions": [
+              {
+                "refName": "Pp01",
+                "assemblyName": "peach",
+                "start": 0,
+                "end": 100000000
+              }
+            ],
+            "tracks": [
+              {
+                "type": "BasicTrack",
+                "height": 100,
+                "configuration": "peach_genes",
+                "selectedRendering": ""
+              }
+            ],
+            "hideControls": false,
+            "hideHeader": true,
+            "hideCloseButton": true,
+            "trackSelectorType": "hierarchical"
+          },
+          {
+            "type": "LinearGenomeView",
+            "id": "test1_2",
+            "offsetPx": 0,
+            "bpPerPx": 1000,
+            "displayedRegions": [
+              {
+                "refName": "chr1",
+                "assemblyName": "grape",
+                "start": 0,
+                "end": 100000000
+              }
+            ],
+            "tracks": [
+              {
+                "type": "BasicTrack",
+                "height": 100,
+                "configuration": "grape_genes",
+                "selectedRendering": ""
+              }
+            ],
+            "hideControls": false,
+            "hideHeader": true,
+            "hideCloseButton": true,
+            "trackSelectorType": "hierarchical"
+          }
+        ]
       }
-    ]
-  },
-  "savedSessions": [
-    {
-      "name": "Grape vs Peach Demo",
-      "drawerWidth": 384,
-      "views": [
-        {
-          "type": "LinearSyntenyView",
-          "id": "test1",
-          "headerHeight": 44,
-          "datasetName": "grape_vs_peach_dataset",
-          "tracks": [
-            {
-              "type": "LinearSyntenyTrack",
-              "height": 100,
-              "configuration": "grape_peach_synteny_mcscan"
-            }
-          ],
-          "height": 400,
-          "displayName": "Grape vs Peach",
-          "trackSelectorType": "hierarchical",
-          "views": [
-            {
-              "type": "LinearGenomeView",
-              "id": "test1_1",
-              "offsetPx": 28249,
-              "bpPerPx": 1000,
-              "displayedRegions": [
-                {
-                  "refName": "Pp01",
-                  "assemblyName": "peach",
-                  "start": 0,
-                  "end": 100000000
-                }
-              ],
-              "tracks": [
-                {
-                  "type": "BasicTrack",
-                  "height": 100,
-                  "configuration": "peach_genes",
-                  "selectedRendering": ""
-                }
-              ],
-              "hideControls": false,
-              "hideHeader": true,
-              "hideCloseButton": true,
-              "trackSelectorType": "hierarchical"
-            },
-            {
-              "type": "LinearGenomeView",
-              "id": "test1_2",
-              "offsetPx": 0,
-              "bpPerPx": 1000,
-              "displayedRegions": [
-                {
-                  "refName": "chr1",
-                  "assemblyName": "grape",
-                  "start": 0,
-                  "end": 100000000
-                }
-              ],
-              "tracks": [
-                {
-                  "type": "BasicTrack",
-                  "height": 100,
-                  "configuration": "grape_genes",
-                  "selectedRendering": ""
-                }
-              ],
-              "hideControls": false,
-              "hideHeader": true,
-              "hideCloseButton": true,
-              "trackSelectorType": "hierarchical"
-            }
-          ]
-        }
-      ],
-      "widgets": {
-        "hierarchicalTrackSelector": {
-          "id": "hierarchicalTrackSelector",
-          "type": "HierarchicalTrackSelectorWidget",
-          "collapsed": {},
-          "filterText": ""
-        },
-        "sessionManager": {
-          "id": "sessionManager",
-          "type": "SessionManager"
-        }
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": ""
       },
-      "activeWidgets": {},
-      "connections": {}
-    }
-  ],
+      "sessionManager": {
+        "id": "sessionManager",
+        "type": "SessionManager"
+      }
+    },
+    "activeWidgets": {},
+    "connections": {}
+  },
   "assemblies": [
     {
       "name": "grape",

--- a/test_data/yeast_synteny/config.json
+++ b/test_data/yeast_synteny/config.json
@@ -35,9 +35,6 @@
   ],
   "configuration": {},
   "connections": [],
-  "defaultSession": {
-    "name": "New Session"
-  },
   "tracks": [
     {
       "type": "DotplotTrack",
@@ -57,46 +54,36 @@
     }
   ],
   "defaultSession": {
-    "name": "New Session",
-    "menuBars": [
+    "name": "R64 vs YJM1447",
+    "width": 1850,
+    "drawerWidth": 384,
+    "views": [
       {
-        "type": "MainMenuBar"
+        "id": "MiDMyyWpp",
+        "type": "DotplotView",
+        "assemblyNames": ["R64", "YJM1447"],
+        "hview": {
+          "displayedRegions": [],
+          "bpPerPx": 100000,
+          "offsetPx": 0
+        },
+        "vview": {
+          "displayedRegions": [],
+          "bpPerPx": 100000,
+          "offsetPx": 0
+        },
+        "tracks": [
+          {
+            "type": "DotplotTrack",
+            "configuration": "dotplot_track"
+          }
+        ],
+        "headerHeight": 44,
+        "width": 1850,
+        "height": 600,
+        "displayName": "R64 vs YJM1447 dotplot",
+        "trackSelectorType": "hierarchical"
       }
     ]
-  },
-  "savedSessions": [
-    {
-      "name": "R64 vs YJM1447",
-      "width": 1850,
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "DotplotView",
-          "assemblyNames": ["R64", "YJM1447"],
-          "hview": {
-            "displayedRegions": [],
-            "bpPerPx": 100000,
-            "offsetPx": 0
-          },
-          "vview": {
-            "displayedRegions": [],
-            "bpPerPx": 100000,
-            "offsetPx": 0
-          },
-          "tracks": [
-            {
-              "type": "DotplotTrack",
-              "configuration": "dotplot_track"
-            }
-          ],
-          "headerHeight": 44,
-          "width": 1850,
-          "height": 600,
-          "displayName": "R64 vs YJM1447 dotplot",
-          "trackSelectorType": "hierarchical"
-        }
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
`savedSessions` no longer gets loaded from the config file after #1240. This removes references to it in demo configs, and moves a saved session to `defaultSession` where applicable.