### PR TITLE
Fix usage of aliases for isValidRefName

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -192,11 +192,11 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         return self.refNameColors[idx % self.refNameColors.length]
       },
       isValidRefName(refName: string) {
-        if (!self.allRefNames)
+        if (!self.refNameAliases)
           throw new Error(
             'isValidRefName cannot be called yet, the assembly has not finished loading',
           )
-        return self.allRefNames.includes(refName)
+        return !!this.getCanonicalRefName(refName)
       },
     }))
     .actions(self => ({


### PR DESCRIPTION
Currently on master searching chr5:1-100 does not work since chr5 is an alias

This fixes that.. This is a knock on from #1369 

Note that having an integration test for this would be great. Have tried to do this here recently but didn't get it completed https://github.com/GMOD/jbrowse-components/compare/search_test