### PR TITLE
Add blank FORMAT column for spreadsheet view VcfImporter if none exists

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
@@ -30,6 +30,10 @@ function vcfRecordToRow(vcfParser: any, line: string, lineNumber: number): Row {
   })
 
   const data = line.split('\t').map(d => (d === '.' ? '' : d))
+  // no format column, add blank
+  if (data.length === 8) {
+    data.push('')
+  }
   const row: Row = {
     id: String(lineNumber + 1),
     extendedData: { vcfFeature: vcfFeature.toJSON() },


### PR DESCRIPTION
If a VCF that is uploaded to the spreadsheet view has no FORMAT then it crashes

This avoids the crash by making a fake FORMAT column