### PR TITLE
Fix allRefNames on assembly

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -155,13 +155,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         if (!(this.refNames && self.refNameAliases)) {
           return undefined
         }
-        const aliases: string[] = []
-        self.refNameAliases.forEach((_canonicalName, alias) => {
-          if (this.refNames && !this.refNames.includes(alias)) {
-            aliases.push(alias)
-          }
-        })
-        return [...this.refNames, ...aliases]
+        return Array.from(self.refNameAliases.keys())
       },
       get rpcManager() {
         return getParent(self, 2).rpcManager

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -155,9 +155,11 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         if (!(this.refNames && self.refNameAliases)) {
           return undefined
         }
-        let aliases: string[] = []
-        self.refNameAliases.forEach(aliasList => {
-          aliases = aliases.concat(aliasList)
+        const aliases: string[] = []
+        self.refNameAliases.forEach((_canonicalName, alias) => {
+          if (this.refNames && !this.refNames.includes(alias)) {
+            aliases.push(alias)
+          }
         })
         return [...this.refNames, ...aliases]
       },


### PR DESCRIPTION
Restores previous functionality to return a list of all refNames and aliases.