### PR TITLE
Volatile error for spreadsheet/import wizard

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
@@ -207,10 +207,7 @@ export default pluginManager => {
       <>
         {model.error ? (
           <Container className={classes.errorContainer}>
-            <ErrorDisplay
-              errorMessage={String(model.error.message)}
-              stackTrace={model.error.stackTrace}
-            />
+            <ErrorDisplay errorMessage={`${model.error}`} />
           </Container>
         ) : null}
         <ImportForm model={model} />

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -38,10 +38,10 @@ export default (pluginManager: PluginManager) => {
       columnNameLineNumber: 1,
 
       selectedAssemblyIdx: 0,
-      error: types.maybe(types.model({ message: '', stackTrace: '' })),
     })
     .volatile(() => ({
       fileTypes,
+      error: undefined as Error | undefined,
     }))
     .views(self => ({
       get isReadyToOpen() {
@@ -117,10 +117,7 @@ export default (pluginManager: PluginManager) => {
       setError(error: Error) {
         console.error(error)
         self.loading = false
-        self.error = {
-          message: String(error),
-          stackTrace: String(error.stack || ''),
-        }
+        self.error = error
       },
 
       setLoaded() {


### PR DESCRIPTION
This is a tiny PR for suggesting that the error be a volatile state for spreadsheet/sv inspector import wizards

Any error during import persists across refreshes. I can't think of a great reason why that would be a good thing to do