### PR TITLE
Resource list for helpwidget

### DIFF
--- a/plugins/menus/src/HelpWidget/components/HelpWidget.tsx
+++ b/plugins/menus/src/HelpWidget/components/HelpWidget.tsx
@@ -9,6 +9,7 @@ import Link from '@material-ui/core/Link'
 const useStyles = makeStyles(theme => ({
   root: {
     margin: theme.spacing(2),
+    fontSize: '1.2em',
   },
   subtitle: {
     margin: theme.spacing(),
@@ -27,48 +28,48 @@ function Help({ model }: { model?: IAnyStateTreeNode }) {
         {root.version}
       </Typography>
 
-      <Typography>
+      <p>
         Here are some resources to get help. Please report the version number
         above when asking questions. Thanks!
-        <ul>
-          <li>
-            <Link
-              href="https://github.com/GMOD/jbrowse-components/discussions"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Question & answer forum
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Report a bug
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="https://jbrowse.org/jb2/docs/user_guide"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              User guide
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="https://jbrowse.org/jb2/docs/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Documentation
-            </Link>
-          </li>
-        </ul>
-      </Typography>
+      </p>
+      <ul>
+        <li>
+          <Link
+            href="https://github.com/GMOD/jbrowse-components/discussions"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Question & answer forum
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Report a bug
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="https://jbrowse.org/jb2/docs/user_guide"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            User guide
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="https://jbrowse.org/jb2/docs/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Documentation
+          </Link>
+        </li>
+      </ul>
     </div>
   )
 }

--- a/plugins/menus/src/HelpWidget/components/HelpWidget.tsx
+++ b/plugins/menus/src/HelpWidget/components/HelpWidget.tsx
@@ -21,34 +21,53 @@ function Help({ model }: { model?: IAnyStateTreeNode }) {
   return (
     <div className={classes.root}>
       <Typography variant="h4" align="center" color="primary">
-        Help
+        JBrowse 2
       </Typography>
       <Typography variant="h6" align="center" className={classes.subtitle}>
-        JBrowse {root.version}
+        {root.version}
       </Typography>
-      <Typography>Thanks for using JBrowse!</Typography>
+
       <Typography>
-        If you have questions or need help, please post in our{' '}
-        <Link
-          href="https://github.com/GMOD/jbrowse-components/discussions"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          community discussions forum
-        </Link>
-        .
-      </Typography>
-      <Typography>
-        {' '}
-        If you would like to report a bug or request a feature, please{' '}
-        <Link
-          href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          open an issue
-        </Link>{' '}
-        on GitHub.
+        Here are some resources to get help. Please report the version number
+        above when asking questions. Thanks!
+        <ul>
+          <li>
+            <Link
+              href="https://github.com/GMOD/jbrowse-components/discussions"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Question & answer forum
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Report a bug
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="https://jbrowse.org/jb2/docs/user_guide"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              User guide
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="https://jbrowse.org/jb2/docs/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Documentation
+            </Link>
+          </li>
+        </ul>
       </Typography>
     </div>
   )

--- a/plugins/menus/src/HelpWidget/components/__snapshots__/HelpWidget.test.js.snap
+++ b/plugins/menus/src/HelpWidget/components/__snapshots__/HelpWidget.test.js.snap
@@ -7,50 +7,55 @@ exports[`<HelpWidget /> renders 1`] = `
   <h4
     class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary MuiTypography-alignCenter"
   >
-    Help
+    JBrowse 2
   </h4>
   <h6
     class="MuiTypography-root makeStyles-subtitle MuiTypography-h6 MuiTypography-alignCenter"
-  >
-    JBrowse 
-    
-  </h6>
-  <p
-    class="MuiTypography-root MuiTypography-body1"
-  >
-    Thanks for using JBrowse!
+  />
+  <p>
+    Here are some resources to get help. Please report the version number above when asking questions. Thanks!
   </p>
-  <p
-    class="MuiTypography-root MuiTypography-body1"
-  >
-    If you have questions or need help, please post in our
-     
-    <a
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-      href="https://github.com/GMOD/jbrowse-components/discussions"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      community discussions forum
-    </a>
-    .
-  </p>
-  <p
-    class="MuiTypography-root MuiTypography-body1"
-  >
-     
-    If you would like to report a bug or request a feature, please
-     
-    <a
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-      href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      open an issue
-    </a>
-     
-    on GitHub.
-  </p>
+  <ul>
+    <li>
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+        href="https://github.com/GMOD/jbrowse-components/discussions"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Question & answer forum
+      </a>
+    </li>
+    <li>
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+        href="https://github.com/GMOD/jbrowse-components/issues/new/choose"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report a bug
+      </a>
+    </li>
+    <li>
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+        href="https://jbrowse.org/jb2/docs/user_guide"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        User guide
+      </a>
+    </li>
+    <li>
+      <a
+        class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+        href="https://jbrowse.org/jb2/docs/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Documentation
+      </a>
+    </li>
+  </ul>
 </div>
 `;


### PR DESCRIPTION
Screenshot

![localhost_3000_index html_config=test_data%2Fconfig json session=local-ZubbSIjul](https://user-images.githubusercontent.com/6511937/98054800-f6dab780-1e09-11eb-87e9-276654619003.png)


Adds the user guide

Makes the version display similar to the about dialog

Uses less prose when offering links, instead providing a short list
