### PR TITLE
Make SV inspector breakpoint split view onClick waitForAssembly if necessary

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -8,7 +8,10 @@ import BreakpointSplitViewComponent from './components/BreakpointSplitView'
 import BreakpointSplitViewModel from './model'
 
 class BreakpointSplitViewType extends ViewType {
-  snapshotFromBreakendFeature(feature: Feature, view: LinearGenomeViewModel) {
+  async snapshotFromBreakendFeature(
+    feature: Feature,
+    view: LinearGenomeViewModel,
+  ) {
     const breakendSpecification = (feature.get('ALT') || [])[0]
     const startPos = feature.get('start')
     let endPos
@@ -16,7 +19,9 @@ class BreakpointSplitViewType extends ViewType {
 
     // TODO: Figure this out for multiple assembly names
     const { assemblyName } = view.displayedRegions[0]
-    const assembly = getSession(view).assemblyManager.get(assemblyName)
+    const assembly = await getSession(view).assemblyManager.waitForAssembly(
+      assemblyName,
+    )
     const { getCanonicalRefName } = assembly as Assembly
     const featureRefName = getCanonicalRefName(feature.get('refName'))
 

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -8,7 +8,7 @@ import BreakpointSplitViewComponent from './components/BreakpointSplitView'
 import BreakpointSplitViewModel from './model'
 
 class BreakpointSplitViewType extends ViewType {
-  isBreakendFeature(feature) {
+  isBreakendFeature(feature: Feature) {
     const breakendSpecification = (feature.get('ALT') || [])[0]
     if (breakendSpecification) {
       // a VCF breakend feature
@@ -22,6 +22,7 @@ class BreakpointSplitViewType extends ViewType {
     if (feature.get('mate')) {
       return true
     }
+    return false
   }
 
   async snapshotFromBreakendFeature(

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -8,6 +8,22 @@ import BreakpointSplitViewComponent from './components/BreakpointSplitView'
 import BreakpointSplitViewModel from './model'
 
 class BreakpointSplitViewType extends ViewType {
+  isBreakendFeature(feature) {
+    const breakendSpecification = (feature.get('ALT') || [])[0]
+    if (breakendSpecification) {
+      // a VCF breakend feature
+      if (breakendSpecification === '<TRA>') {
+        return true
+      }
+      if (breakendSpecification.MatePosition) {
+        return true
+      }
+    }
+    if (feature.get('mate')) {
+      return true
+    }
+  }
+
   async snapshotFromBreakendFeature(
     feature: Feature,
     view: LinearGenomeViewModel,

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
@@ -2,7 +2,7 @@ import { readConfObject } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { MenuItem } from '@jbrowse/core/ui'
 import { SnapshotIn, Instance } from 'mobx-state-tree'
-import { InstanceOfModelReturnedBy } from '@jbrowse/core/util'
+import { getSession, InstanceOfModelReturnedBy } from '@jbrowse/core/util'
 import DoneIcon from '@material-ui/icons/Done'
 import Spreadsheet from './Spreadsheet'
 import ImportWizard from './ImportWizard'
@@ -38,7 +38,7 @@ const defaultRowMenuItems: MenuItemWithDisabledCallback[] = [
 export default (pluginManager: PluginManager) => {
   const { lib, load } = pluginManager
   const { mobx } = lib
-  const { types, getParent, getRoot, getEnv } = lib['mobx-state-tree']
+  const { types, getParent, getEnv } = lib['mobx-state-tree']
   const BaseViewModel = lib['@jbrowse/core/BaseViewModel']
 
   const SpreadsheetModel = load(Spreadsheet)
@@ -83,6 +83,15 @@ export default (pluginManager: PluginManager) => {
       rowMenuItems: mobx.observable(defaultRowMenuItems),
     }))
     .views(self => ({
+      get initialized() {
+        const { assemblyManager } = getSession(self)
+        const assemblyName = this.assembly
+        if (assemblyName) {
+          const assembly = assemblyManager.get(assemblyName)
+          return Boolean(assembly && assembly.refNameAliases)
+        }
+        return true
+      },
       get readyToDisplay() {
         return !!self.spreadsheet && self.spreadsheet.isLoaded
       },
@@ -102,8 +111,9 @@ export default (pluginManager: PluginManager) => {
 
       get assembly() {
         if (self.spreadsheet && self.spreadsheet.assemblyName) {
+          const session = getSession(self)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const assemblies = getRoot(self).jbrowse.assemblies as any[]
+          const assemblies = session.assemblies as any[]
           const assembly = (assemblies || []).find(
             asm =>
               readConfObject(asm, 'name') === self.spreadsheet?.assemblyName,

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -41,7 +41,7 @@ function defaultOnChordClick(feature, chordTrack, pluginManager) {
     })
     .catch(e => {
       console.error(e)
-      session.notify('${e}')
+      session.notify(`${e}`)
     })
 }
 

--- a/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
@@ -97,9 +97,7 @@ export default pluginManager => {
     if (featureData) {
       const viewType = pluginManager.getViewType('BreakpointSplitView')
       const feature = new SimpleFeature(featureData)
-      const ret = viewType.isBreakendFeature(feature)
-      console.log({ ret })
-      return ret
+      return viewType.isBreakendFeature(feature)
     }
 
     return false

--- a/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
@@ -55,14 +55,14 @@ export default pluginManager => {
     return undefined
   }
 
-  function openBreakpointSplitViewFromTableRow(
+  async function openBreakpointSplitViewFromTableRow(
     svInspectorView,
     spreadsheetView,
     spreadsheet,
     row,
     rowNumber,
   ) {
-    const viewSnapshot = breakpointSplitViewSnapshotFromTableRow(
+    const viewSnapshot = await breakpointSplitViewSnapshotFromTableRow(
       svInspectorView,
       spreadsheetView,
       spreadsheet,

--- a/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
@@ -87,20 +87,22 @@ export default pluginManager => {
     row,
     rowNumber,
   ) {
-    try {
-      const featureData = getSerializedFeatureForRow(
-        session,
-        spreadsheet,
-        row,
-        rowNumber,
-      )
-      if (featureData) {
-        const viewType = pluginManager.getViewType('BreakpointSplitView')
-        return viewType.isBreakendFeature(feature)
-      }
-    } catch (e) {
-      return false
+    const session = getSession(spreadsheetView)
+    const featureData = getSerializedFeatureForRow(
+      session,
+      spreadsheet,
+      row,
+      rowNumber,
+    )
+    if (featureData) {
+      const viewType = pluginManager.getViewType('BreakpointSplitView')
+      const feature = new SimpleFeature(featureData)
+      const ret = viewType.isBreakendFeature(feature)
+      console.log({ ret })
+      return ret
     }
+
+    return false
   }
 
   return {

--- a/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
@@ -27,7 +27,7 @@ export default pluginManager => {
     return undefined
   }
 
-  function breakpointSplitViewSnapshotFromTableRow(
+  async function breakpointSplitViewSnapshotFromTableRow(
     svInspectorView,
     spreadsheetView,
     spreadsheet,
@@ -46,7 +46,7 @@ export default pluginManager => {
       session.setSelection(feature)
       const viewType = pluginManager.getViewType('BreakpointSplitView')
       const { circularView } = svInspectorView
-      const viewSnapshot = viewType.snapshotFromBreakendFeature(
+      const viewSnapshot = await viewType.snapshotFromBreakendFeature(
         feature,
         circularView,
       )
@@ -88,14 +88,16 @@ export default pluginManager => {
     rowNumber,
   ) {
     try {
-      const viewSnapshot = breakpointSplitViewSnapshotFromTableRow(
-        svInspectorView,
-        spreadsheetView,
+      const featureData = getSerializedFeatureForRow(
+        session,
         spreadsheet,
         row,
         rowNumber,
       )
-      return Boolean(viewSnapshot)
+      if (featureData) {
+        const viewType = pluginManager.getViewType('BreakpointSplitView')
+        return viewType.isBreakendFeature(feature)
+      }
     } catch (e) {
       return false
     }


### PR DESCRIPTION
This contains fixes addressing #1399

1) a fix for the refnamealiasing/resolution for ref seqs that do not provide a refname adapter, yet more fallout from #1350 but hopefully in a good place after this. this is an important one
2) make the breakpointsplitview click make sure assembly with assemblyManager.waitForAssembly
3) fixup some async/await related to that and then the chord click can not use async/await 
since assemblies load via a webworker there can be noticeable delays all over the place with this


http://localhost:3000/?config=test_data%2Fconfig.json&session=share-bahnH-jeo1&password=mCPxk

Here is a config.json containing the worm assembly and the hg19+hg38

The share URL above can be tested on master and this branch to see

```
{
  "assemblies": [
    {
      "name": "hg19",
      "aliases": ["GRCh37"],
      "sequence": {
        "type": "ReferenceSequenceTrack",
        "trackId": "Pd8Wh30ei9R",
        "adapter": {
          "type": "BgzipFastaAdapter",
          "fastaLocation": {
            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
          },
          "faiLocation": {
            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
          },
          "gziLocation": {
            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
          }
        },
        "rendering": {
          "type": "DivSequenceRenderer"
        }
      },
      "refNameAliases": {
        "adapter": {
          "type": "RefNameAliasAdapter",
          "location": {
            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt"
          }
        }
      }
    },
    {
      "name": "hg38",
      "aliases": ["GRCh38"],
      "sequence": {
        "type": "ReferenceSequenceTrack",
        "trackId": "P6R5xbRqRr",
        "adapter": {
          "type": "BgzipFastaAdapter",
          "fastaLocation": {
            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
          },
          "faiLocation": {
            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
          },
          "gziLocation": {
            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
          }
        },
        "rendering": {
          "type": "DivSequenceRenderer"
        }
      },
      "refNameAliases": {
        "adapter": {
          "type": "RefNameAliasAdapter",
          "location": {
            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
          }
        }
      }
    },
    {
      "name": "PRJNA13758.current.genomic",
      "sequence": {
        "type": "ReferenceSequenceTrack",
        "trackId": "PRJNA13758.current.genomic-ReferenceSequenceTrack",
        "adapter": {
          "type": "BgzipFastaAdapter",
          "fastaLocation": {
            "uri": "https://s3.amazonaws.com/wormbase-modencode/fasta/current/c_elegans.PRJNA13758.WS278.genomic.fa.gz"
          },
          "faiLocation": {
            "uri": "https://s3.amazonaws.com/wormbase-modencode/fasta/current/c_elegans.PRJNA13758.WS278.genomic.fa.gz.fai"
          },
          "gziLocation": {
            "uri": "https://s3.amazonaws.com/wormbase-modencode/fasta/current/c_elegans.PRJNA13758.WS278.genomic.fa.gz.gzi"
          }
        }
      }
    }
  ],
  "configuration": {},
  "connections": [
    {
      "type": "JBrowse1Connection",
      "connectionId": "COSMIC_connection_grch37",
      "name": "COSMIC (GRCh37)",
      "assemblyName": "hg19",
      "dataDirLocation": {
        "uri": "https://cancer.sanger.ac.uk/jbrowse/data/json/grch37/v90/cosmic"
      }
    },
    {
      "type": "JBrowse1Connection",
      "connectionId": "COSMIC_connection_grch38",
      "name": "COSMIC (GRCh38)",
      "assemblyName": "hg38",
      "dataDirLocation": {
        "uri": "https://cancer.sanger.ac.uk/jbrowse/data/json/grch38/v90/cosmic"
      }
    }
  ],
  "defaultSession": {
    "name": "New Session"
  },
  "tracks": [
    {
      "type": "BasicTrack",
      "trackId": "repeats_hg19",
      "name": "Repeats",
      "assemblyNames": ["hg19"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://jbrowse.org/genomes/hg19/repeats.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "nclist_genes_hg19",
      "name": "Gencode v19",
      "assemblyNames": ["hg19"],
      "category": ["Annotation"],
      "adapter": {
        "type": "NCListAdapter",
        "rootUrlTemplate": {
          "uri": "https://jbrowse.org/genomes/hg19/gencode/{refseq}/trackData.json"
        },
        "refNames": [
          "chr1",
          "chr2",
          "chr3",
          "chr4",
          "chr5",
          "chr6",
          "chr7",
          "chr8",
          "chr9",
          "chr10",
          "chr11",
          "chr12",
          "chr13",
          "chr14",
          "chr15",
          "chr16",
          "chr17",
          "chr18",
          "chr19",
          "chr20",
          "chr21",
          "chr22",
          "chr23",
          "chrX",
          "chrY",
          "chrMT"
        ]
      },
      "renderer": {
        "type": "SvgFeatureRenderer",
        "labels": {
          "description": "function(feature) { return feature.get('gene_name') }"
        }
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "hg19_gaps",
      "name": "Gaps",
      "assemblyNames": ["hg19"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://jbrowse.org/genomes/hg19/gaps.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "clinvar_cnv_hg19",
      "name": "Clinvar CNV",
      "assemblyNames": ["hg19"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarCnv.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "clinvar_hg19",
      "name": "Clinvar variants",
      "assemblyNames": ["hg19"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "repeats_hg38",
      "name": "Repeats",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://jbrowse.org/genomes/GRCh38/repeats.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "gencode_nclist_hg38",
      "name": "Gencode v32",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "NCListAdapter",
        "rootUrlTemplate": {
          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/gencode/{refseq}/trackData.jsonz"
        },
        "refNames": [
          "chr1",
          "chr2",
          "chr3",
          "chr4",
          "chr5",
          "chr6",
          "chr7",
          "chr8",
          "chr9",
          "chr10",
          "chr11",
          "chr12",
          "chr13",
          "chr14",
          "chr15",
          "chr16",
          "chr17",
          "chr18",
          "chr19",
          "chr20",
          "chr21",
          "chr22",
          "chr23",
          "chrX",
          "chrY",
          "chrMT"
        ]
      },
      "renderer": {
        "type": "SvgFeatureRenderer",
        "labels": {
          "description": "function(feature) { return feature.get('gene_name') }"
        }
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "clinvar_cnv_hg38",
      "name": "Clinvar CNV",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "clinvar_hg38",
      "name": "Clinvar variants",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "mane_hg38",
      "name": "MANE 0.6",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/mane/mane.0.6.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer",
        "labels": {
          "description": "function(feature) { return feature.get('geneName2') }"
        }
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "gdc_features",
      "name": "GDC Cancer",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/gdcCancer/gdcCancer.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    },
    {
      "type": "BasicTrack",
      "trackId": "hg38_gaps",
      "name": "Gaps",
      "assemblyNames": ["hg38"],
      "category": ["Annotation"],
      "adapter": {
        "type": "BigBedAdapter",
        "bigBedLocation": {
          "uri": "https://jbrowse.org/genomes/GRCh38/gaps.bb"
        }
      },
      "renderer": {
        "type": "SvgFeatureRenderer"
      }
    }
  ]
}

```