### PR TITLE
Update admin-server log message

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -37,6 +37,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
+    "boxen": "^4.2.0",
+    "chalk": "^4.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "json-parse-better-errors": "^1.0.2",

--- a/products/jbrowse-cli/src/commands/admin-server.test.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.test.ts
@@ -125,7 +125,7 @@ describe('admin-server', () => {
     })
     .it('uses port 9090 if not specified', async ctx => {
       expect(ctx.stdoutWrite.mock.calls[0][0]).toMatch(
-        /Navigate to http:\/\/localhost:9090\?adminKey=[a-zA-Z0-9]{10,12} to configure your JBrowse installation graphically\./,
+        /http:\/\/localhost:9090\?adminKey=[a-zA-Z0-9]{10,12}/,
       )
     })
   setupWithCreate

--- a/yarn.lock
+++ b/yarn.lock
@@ -7081,6 +7081,14 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-case@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.1.tgz#d5005709275952e7963fed7b91e4f9fdb6180afa"


### PR DESCRIPTION
Inspired by [serve](https://www.npmjs.com/package/serve), this tries to make the admin-server message a bit more readable.

**Before:**

![image](https://user-images.githubusercontent.com/25592344/98181491-a83c2480-1ec0-11eb-8ca8-32230f41ee8a.png)

**After:**

![image](https://user-images.githubusercontent.com/25592344/98181454-922e6400-1ec0-11eb-95c4-43574ec70935.png)
