### PR TITLE
Make spreadsheet view wait for assembly to be loaded

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -142,6 +142,9 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
       refNameAliases: types.maybe(types.map(types.string)),
     })
     .views(self => ({
+      get initialized() {
+        return Boolean(self.refNameAliases)
+      },
       get name(): string {
         return readConfObject(self.configuration, 'name')
       },
@@ -152,7 +155,7 @@ export default function assemblyFactory(assemblyConfigType: IAnyType) {
         return self.regions && self.regions.map(region => region.refName)
       },
       get allRefNames() {
-        if (!(this.refNames && self.refNameAliases)) {
+        if (!self.refNameAliases) {
           return undefined
         }
         return Array.from(self.refNameAliases.keys())

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
@@ -351,7 +351,7 @@ export default pluginManager => {
 
     return (
       <div className={classes.root} style={{ height }}>
-        {model && model.rowSet && model.rowSet.isLoaded ? (
+        {model && model.rowSet && model.rowSet.isLoaded && model.initialized ? (
           <DataTable model={model} />
         ) : (
           <div>Loading...</div>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
@@ -1,4 +1,5 @@
 import FolderOpenIcon from '@material-ui/icons/FolderOpen'
+import { CircularProgress } from '@material-ui/core'
 import ImportWizardFactory from './ImportWizard'
 import SpreadsheetFactory from './Spreadsheet'
 import GlobalFilterControlsFactory from './GlobalFilterControls'

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.js
@@ -1,5 +1,4 @@
 import FolderOpenIcon from '@material-ui/icons/FolderOpen'
-import { CircularProgress } from '@material-ui/core'
 import ImportWizardFactory from './ImportWizard'
 import SpreadsheetFactory from './Spreadsheet'
 import GlobalFilterControlsFactory from './GlobalFilterControls'

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/Spreadsheet.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/Spreadsheet.ts
@@ -70,6 +70,15 @@ export default (pluginManager: PluginManager) => {
       isLoaded: false,
     }))
     .views(self => ({
+      get initialized() {
+        const session = getSession(self)
+        const name = self.assemblyName
+        if (name) {
+          const asm = session.assemblyManager.get(name)
+          return asm && asm.initialized
+        }
+        return true
+      },
       get hideRowSelection() {
         // just delegates to parent
         return getParent(self).hideRowSelection

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
@@ -2,7 +2,7 @@ import { readConfObject } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { MenuItem } from '@jbrowse/core/ui'
 import { SnapshotIn, Instance } from 'mobx-state-tree'
-import { InstanceOfModelReturnedBy } from '@jbrowse/core/util'
+import { getSession, InstanceOfModelReturnedBy } from '@jbrowse/core/util'
 import DoneIcon from '@material-ui/icons/Done'
 import Spreadsheet from './Spreadsheet'
 import ImportWizard from './ImportWizard'
@@ -38,7 +38,7 @@ const defaultRowMenuItems: MenuItemWithDisabledCallback[] = [
 export default (pluginManager: PluginManager) => {
   const { lib, load } = pluginManager
   const { mobx } = lib
-  const { types, getParent, getRoot, getEnv } = lib['mobx-state-tree']
+  const { types, getParent, getEnv } = lib['mobx-state-tree']
   const { BaseViewModel } = lib['@jbrowse/core/pluggableElementTypes/models']
 
   const SpreadsheetModel = load(Spreadsheet)
@@ -103,7 +103,7 @@ export default (pluginManager: PluginManager) => {
       get assembly() {
         if (self.spreadsheet && self.spreadsheet.assemblyName) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const assemblies = getRoot(self).jbrowse.assemblies as any[]
+          const assemblies = getSession(self).assemblies as any[]
           const assembly = (assemblies || []).find(
             asm =>
               readConfObject(asm, 'name') === self.spreadsheet?.assemblyName,


### PR DESCRIPTION
Alternative version of #1400 

This waits for assembly to be initialized before loading, and avoids some of the async complications of #1400