### PR TITLE
Fix VCF crash with null ALT field

### DIFF
--- a/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
@@ -83,10 +83,14 @@ export default class VCFFeature implements Feature {
       variant.REF,
       variant.ALT,
     )
-    const isTRA = variant.ALT.some((f: string | Breakend) => f === '<TRA>')
-    const isSymbolic = variant.ALT.some(
-      (f: string | Breakend) => typeof f === 'string' && f.indexOf('<') !== -1,
-    )
+    const isTRA =
+      variant.ALT && variant.ALT.some((f: string | Breakend) => f === '<TRA>')
+    const isSymbolic =
+      variant.ALT &&
+      variant.ALT.some(
+        (f: string | Breakend) =>
+          typeof f === 'string' && f.indexOf('<') !== -1,
+      )
     const featureData: FeatureData = {
       refName: variant.CHROM,
       start,

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -159,7 +159,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_cnv_hg19",
-      "name": "Clinvar CNV (UCSC)",
+      "name": "ClinVar CNV (UCSC)",
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
@@ -172,7 +172,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_hg19",
-      "name": "Clinvar variants (UCSC)",
+      "name": "ClinVar variants (UCSC)",
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
@@ -185,7 +185,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_ncbi",
-      "name": "Clinvar variants (NCBI)",
+      "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
@@ -203,7 +203,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_ncbi_hg38",
-      "name": "Clinvar variants (NCBI)",
+      "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {
@@ -287,7 +287,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_cnv_hg38",
-      "name": "Clinvar CNV (UCSC)",
+      "name": "ClinVar CNV (UCSC)",
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {
@@ -300,7 +300,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_hg38",
-      "name": "Clinvar variants (UCSC)",
+      "name": "ClinVar variants (UCSC)",
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {
@@ -1574,6 +1574,84 @@
             "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/mappability/wgEncodeDacMapabilityConsensusExcludable.bed.gz.tbi"
           },
           "indexType": "TBI"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenGeneDisease",
+      "name": "ClinGen Gene-Disease mapping",
+      "assemblyNames": ["hg38"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinGen/clinGenGeneDisease.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenHaplo",
+      "name": "ClinGen haplosensitivity",
+      "assemblyNames": ["hg38"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinGen/clinGenHaplo.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenTriplo",
+      "name": "ClinGen triplosensitivity",
+      "assemblyNames": ["hg38"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinGen/clinGenTriplo.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenDiesease_hg19",
+      "name": "ClinGen Gene-Disease mapping",
+      "assemblyNames": ["hg19"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinGen/clinGenGeneDisease.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenHaplo_hg19",
+      "name": "ClinGen haplosensitivity",
+      "assemblyNames": ["hg19"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinGen/clinGenHaplo.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinGenTriplo_hg19",
+      "name": "ClinGen triplosensitivity",
+      "assemblyNames": ["hg19"],
+      "category": ["ClinGen"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinGen/clinGenTriplo.bb"
         }
       }
     }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -183,7 +183,7 @@
       }
     },
     {
-      "type": "FeatureTrack",
+      "type": "VariantTrack",
       "trackId": "clinvar_ncbi",
       "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg19"],
@@ -201,7 +201,7 @@
       }
     },
     {
-      "type": "FeatureTrack",
+      "type": "VariantTrack",
       "trackId": "clinvar_ncbi_hg38",
       "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg38"],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -159,7 +159,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_cnv_hg19",
-      "name": "Clinvar CNV",
+      "name": "Clinvar CNV (UCSC)",
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
@@ -172,13 +172,49 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_hg19",
-      "name": "Clinvar variants",
+      "name": "Clinvar variants (UCSC)",
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
           "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinvar_ncbi",
+      "name": "Clinvar variants (NCBI)",
+      "assemblyNames": ["hg19"],
+      "category": ["Annotation"],
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi"
+          }
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinvar_ncbi_hg38",
+      "name": "Clinvar variants (NCBI)",
+      "assemblyNames": ["hg38"],
+      "category": ["Annotation"],
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi"
+          }
         }
       }
     },
@@ -251,7 +287,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_cnv_hg38",
-      "name": "Clinvar CNV",
+      "name": "Clinvar CNV (UCSC)",
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {
@@ -264,7 +300,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "clinvar_hg38",
-      "name": "Clinvar variants",
+      "name": "Clinvar variants (UCSC)",
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {


### PR DESCRIPTION
This fixes a crash that occured loading the NCBI clinvar vcf. The ALT is null

It is some question to me whether replacing '.' with null is the proper behavior, because we also in many places render the literal string null in our feature dialogs

However, this fixes the code as is

It adds the NCBI clinvar vcf as a track here

I also just for fun added some more cool tracks from UCSC (ClinGen)