### PR TITLE
Pagination starts at page 1, and also filter out jbrowse/web tags

### DIFF
--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -196,13 +196,9 @@ export default abstract class JBrowseCommand extends Command {
 
   async getLatest() {
     for await (const versions of this.fetchVersions()) {
-      const jb2webreleases = versions.filter(release =>
-        release.tag_name.startsWith('@jbrowse/web'),
-      )
-
       // if a release was just uploaded, or an erroneous build was made
       // then it might have no build asset
-      const nonprereleases = jb2webreleases
+      const nonprereleases = versions
         .filter(release => release.prerelease === false)
         .filter(release => release.assets && release.assets.length > 0)
 
@@ -216,7 +212,7 @@ export default abstract class JBrowseCommand extends Command {
   }
 
   async *fetchVersions() {
-    let page = 0
+    let page = 1
     let result
 
     do {
@@ -227,7 +223,10 @@ export default abstract class JBrowseCommand extends Command {
       if (response.ok) {
         // eslint-disable-next-line no-await-in-loop
         result = await response.json()
-        yield result as GithubRelease[]
+
+        yield result.filter(release =>
+          release.tag_name.startsWith('@jbrowse/web'),
+        )
         page++
       } else {
         throw new Error(`${result.statusText}`)

--- a/products/jbrowse-cli/src/commands/create.test.ts
+++ b/products/jbrowse-cli/src/commands/create.test.ts
@@ -37,15 +37,15 @@ function mockTagSuccess(gitHubApi: Scope) {
 
 function mockReleases(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases?page=0')
+    .get('/repos/GMOD/jbrowse-components/releases?page=1')
     .reply(200, releaseArray)
 }
 
 function mockReleasesListVersions(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases?page=0')
-    .reply(200, releaseArray)
     .get('/repos/GMOD/jbrowse-components/releases?page=1')
+    .reply(200, releaseArray)
+    .get('/repos/GMOD/jbrowse-components/releases?page=2')
     .reply(200, [])
 }
 

--- a/products/jbrowse-cli/src/commands/upgrade.test.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.test.ts
@@ -46,7 +46,7 @@ function mockTagSuccess(gitHubApi: Scope) {
 
 function mockReleases(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases?page=0')
+    .get('/repos/GMOD/jbrowse-components/releases?page=1')
     .reply(200, releaseArray)
 }
 


### PR DESCRIPTION
I didn't fully test this but it looks like their pagination system has numbering starting from 1 where we attempted to start from 0, resulting in the duplication. Also filter out @jbrowse/web tags only #1415 