### PR TITLE
Fix connection tracks not showing up in track selector

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -110,7 +110,18 @@ export default pluginManager =>
         const trackConfigurations = connection.tracks
 
         const relevantTrackConfigurations = trackConfigurations.filter(
-          conf => conf.viewType === self.view.type,
+          trackConf => {
+            const viewType = pluginManager.getViewType(self.view.type)
+            const compatibleDisplays = viewType.displayTypes.map(
+              displayType => displayType.name,
+            )
+            for (const display of trackConf.displays) {
+              if (compatibleDisplays.includes(display.type)) {
+                return true
+              }
+            }
+            return false
+          },
         )
         return relevantTrackConfigurations
       },


### PR DESCRIPTION
Fixes a bug introduced in #1398. This makes the connection track filtering logic the same as the regular track filtering.

Fixes #1424 