### PR TITLE
Window Session and rootModel do not get set after Splash Screen 

### DIFF
--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -30,7 +30,11 @@ const JBrowse = observer(({ pluginManager }) => {
 
   useEffect(() => {
     setSessionId(`local-${currentSessionId}`)
-  }, [currentSessionId, setSessionId])
+    // @ts-ignore
+    window.JBrowseRootModel = rootModel
+    // @ts-ignore
+    window.JBrowseSession = session
+  }, [currentSessionId, rootModel, session, setSessionId])
 
   useEffect(() => {
     onSnapshot(jbrowse, async snapshot => {

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -430,9 +430,9 @@ const Renderer = observer(
           // window.MODEL.views[0] in devtools
 
           // @ts-ignore
-          window.SESSION = rootModel.session
+          window.JBrowseSession = rootModel.session
           // @ts-ignore
-          window.ROOTMODEL = rootModel
+          window.JBrowseRootModel = rootModel
 
           pluginManager.setRootModel(rootModel)
 

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -426,13 +426,15 @@ const Renderer = observer(
           // rootModel.setHistory(
           //   UndoManager.create({}, { targetStore: rootModel.session }),
           // )
-
           // make some things available globally for testing e.g.
           // window.MODEL.views[0] in devtools
-          // @ts-ignore
-          window.MODEL = rootModel.session
-          // @ts-ignore
-          window.ROOTMODEL = rootModel
+          if (inDevelopment) {
+            // @ts-ignore
+            window.MODEL = rootModel.session
+            // @ts-ignore
+            window.ROOTMODEL = rootModel
+          }
+
           pluginManager.setRootModel(rootModel)
 
           pluginManager.configure()

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -426,16 +426,7 @@ const Renderer = observer(
           // rootModel.setHistory(
           //   UndoManager.create({}, { targetStore: rootModel.session }),
           // )
-          // make some things available globally for testing e.g.
-          // window.MODEL.views[0] in devtools
-
-          // @ts-ignore
-          window.JBrowseSession = rootModel.session
-          // @ts-ignore
-          window.JBrowseRootModel = rootModel
-
           pluginManager.setRootModel(rootModel)
-
           pluginManager.configure()
           setPluginManager(pluginManager)
 

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -428,12 +428,11 @@ const Renderer = observer(
           // )
           // make some things available globally for testing e.g.
           // window.MODEL.views[0] in devtools
-          if (inDevelopment) {
-            // @ts-ignore
-            window.MODEL = rootModel.session
-            // @ts-ignore
-            window.ROOTMODEL = rootModel
-          }
+
+          // @ts-ignore
+          window.SESSION = rootModel.session
+          // @ts-ignore
+          window.ROOTMODEL = rootModel
 
           pluginManager.setRootModel(rootModel)
 


### PR DESCRIPTION
 ~[Issue 1417](https://github.com/GMOD/jbrowse-components/issues/1417)~

Issue: Window session object did not get set after going through the splash screen. Kept the JBrowseRootModel and JBrowseSession in prod for debugging purposes.