### PR TITLE
Make add track warning a bit more lenient

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.js
+++ b/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.js
@@ -20,6 +20,23 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+/**
+ * check if a string looks like an abolute URL, e.g. a
+ * full URL e.g. "https://mysite.org/myfile.txt",
+ * implicit protocol URL e.g. "//mysite.org/myfile.txt", or
+ * implicit domain name URL e.g. "/myfile.txt"
+ * @param {String} url URL
+ */
+function isAbsoluteUrl(url) {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url)
+    return true
+  } catch (error) {
+    return url.startsWith('/')
+  }
+}
+
 function ConfirmTrack({
   trackData,
   trackName,
@@ -53,8 +70,8 @@ function ConfirmTrack({
       // check for whether the user entered an absolute URL
       else if (
         !(
-          (indexTrackData.uri && indexTrackData.uri.startsWith('http')) ||
-          trackData.uri.startsWith('http')
+          (indexTrackData.uri && isAbsoluteUrl(indexTrackData.uri)) ||
+          isAbsoluteUrl(trackData.uri)
         )
       ) {
         setError(


### PR DESCRIPTION
This expands what the add track widget is looking for in an absolute URL so things like `/my.bam` and `//mysite.com/my.bam` don't give warnings, since they are valid [absolute URLs](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Absolute_URLs_vs_relative_URLs).