### PR TITLE
Create separate config schema for ReferenceSequenceTrack

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -11,7 +11,7 @@ export function getTrackAssemblyNames(
 ) {
   const trackConf = track.configuration
   const trackAssemblyNames = readConfObject(trackConf, 'assemblyNames')
-  if (trackAssemblyNames[0] === 'assemblyName') {
+  if (!trackAssemblyNames) {
     // Check if it's an assembly sequence track
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parent = getParent<any>(track.configuration)

--- a/plugins/sequence/src/index.ts
+++ b/plugins/sequence/src/index.ts
@@ -1,9 +1,5 @@
-import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
-import {
-  createBaseTrackConfig,
-  createBaseTrackModel,
-} from '@jbrowse/core/pluggableElementTypes/models'
+import { createBaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
 import ServerSideRendererType from '@jbrowse/core/pluggableElementTypes/renderers/ServerSideRendererType'
 import TrackType from '@jbrowse/core/pluggableElementTypes/TrackType'
 import Plugin from '@jbrowse/core/Plugin'
@@ -33,6 +29,7 @@ import {
   AdapterClass as TwoBitAdapterClass,
   configSchema as twoBitAdapterConfigSchema,
 } from './TwoBitAdapter'
+import { createReferenceSeqTrackConfig } from './referenceSeqTrackConfig'
 
 export default class SequencePlugin extends Plugin {
   name = 'SequencePlugin'
@@ -75,14 +72,8 @@ export default class SequencePlugin extends Plugin {
     )
 
     pluginManager.addTrackType(() => {
-      const configSchema = ConfigurationSchema(
-        'ReferenceSequenceTrack',
-        {},
-        {
-          baseConfiguration: createBaseTrackConfig(pluginManager),
-          explicitIdentifier: 'trackId',
-        },
-      )
+      const configSchema = createReferenceSeqTrackConfig(pluginManager)
+
       return new TrackType({
         name: 'ReferenceSequenceTrack',
         configSchema,

--- a/plugins/sequence/src/referenceSeqTrackConfig.ts
+++ b/plugins/sequence/src/referenceSeqTrackConfig.ts
@@ -4,7 +4,7 @@ import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 
 /*
-Note: this is primarily a copy of createBaseTrackModel, except with a subset
+Note: this is primarily a copy of createBaseTrackConfig, except with a subset
 of the config slots, to avoid including fields that don't make sense for the
 ReferenceSequenceTrack
 */

--- a/plugins/sequence/src/referenceSeqTrackConfig.ts
+++ b/plugins/sequence/src/referenceSeqTrackConfig.ts
@@ -3,6 +3,11 @@ import { types } from 'mobx-state-tree'
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 
+/*
+Note: this is primarily a copy of createBaseTrackModel, except with a subset
+of the config slots, to avoid including fields that don't make sense for the
+ReferenceSequenceTrack
+*/
 export function createReferenceSeqTrackConfig(pluginManager: PluginManager) {
   return ConfigurationSchema(
     'ReferenceSequenceTrack',

--- a/plugins/sequence/src/referenceSeqTrackConfig.ts
+++ b/plugins/sequence/src/referenceSeqTrackConfig.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { types } from 'mobx-state-tree'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import PluginManager from '@jbrowse/core/PluginManager'
+
+export function createReferenceSeqTrackConfig(pluginManager: PluginManager) {
+  return ConfigurationSchema(
+    'ReferenceSequenceTrack',
+    {
+      adapter: pluginManager.pluggableConfigSchemaType('adapter'),
+      displays: types.array(pluginManager.pluggableConfigSchemaType('display')),
+      metadata: {
+        type: 'frozen',
+        description: 'anything to add about this track',
+        defaultValue: {},
+      },
+    },
+    {
+      preProcessSnapshot: s => {
+        const snap = JSON.parse(JSON.stringify(s))
+        const displayTypes = new Set()
+        const { displays = [] } = snap
+        if (snap.trackId !== 'placeholderId') {
+          // Gets the displays on the track snapshot and the possible displays
+          // from the track type and adds any missing possible displays to the
+          // snapshot
+          displays.forEach((d: any) => d && displayTypes.add(d.type))
+          const trackType = pluginManager.getTrackType(snap.type)
+          trackType.displayTypes.forEach(displayType => {
+            if (!displayTypes.has(displayType.name)) {
+              displays.push({
+                displayId: `${snap.trackId}-${displayType.name}`,
+                type: displayType.name,
+              })
+            }
+          })
+        }
+        return { ...snap, displays }
+      },
+      explicitIdentifier: 'trackId',
+      explicitlyTyped: true,
+      actions: (self: any) => ({
+        addDisplayConf(displayConf: { type: string; displayId: string }) {
+          const { type } = displayConf
+          if (!type) throw new Error(`unknown display type ${type}`)
+          const display = self.displays.find(
+            (d: any) => d && d.displayId === displayConf.displayId,
+          )
+          if (display) {
+            return display
+          }
+          const length = self.displays.push(displayConf)
+          return self.displays[length - 1]
+        },
+      }),
+    },
+  )
+}


### PR DESCRIPTION
I noticed that after the (awesome) changes to the display methods, there were some fields that seemed unnecessary for the ReferenceSequenceTrack config schema.

For example, this is the config editor after the changes:

![image](https://user-images.githubusercontent.com/19295181/98837464-d60cf600-23f7-11eb-91ec-56b7c79f38ad.png)

Probably not useful graphically, or in the config in general. In pairing, @garrettjstevens and I created a smaller base config schema for the ReferenceSequenceTrack.

Now, the slots look like this:

![image](https://user-images.githubusercontent.com/19295181/98837818-4582e580-23f8-11eb-8b8d-908b425d8f6e.png)

Removing some of the unnecessary slots for a ReferenceSequenceTrack.