### PR TITLE
Change track selector togglebutton to normal button

### DIFF
--- a/plugins/circular-view/src/CircularView/components/CircularView.js
+++ b/plugins/circular-view/src/CircularView/components/CircularView.js
@@ -23,7 +23,6 @@ export default pluginManager => {
   const IconButton = jbrequire('@material-ui/core/IconButton')
   const MenuItem = jbrequire('@material-ui/core/MenuItem')
   const TextField = jbrequire('@material-ui/core/TextField')
-  const ToggleButton = jbrequire('@material-ui/lab/ToggleButton')
   const { makeStyles } = jbrequire('@material-ui/core/styles')
   const { grey } = jbrequire('@material-ui/core/colors')
 
@@ -103,7 +102,6 @@ export default pluginManager => {
 
   const Controls = observer(({ model, showingFigure }) => {
     const classes = useStyles()
-    const session = getSession(model)
     return (
       <div className={classes.controls}>
         <IconButton

--- a/plugins/circular-view/src/CircularView/components/CircularView.js
+++ b/plugins/circular-view/src/CircularView/components/CircularView.js
@@ -163,20 +163,14 @@ export default pluginManager => {
         </IconButton>
 
         {model.hideTrackSelectorButton ? null : (
-          <ToggleButton
+          <IconButton
             onClick={model.activateTrackSelector}
             title="Open track selector"
-            selected={
-              session.visibleWidget &&
-              session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-              session.visibleWidget.view.id === model.id
-            }
-            value="track_select"
             data-testid="circular_track_select"
             color="secondary"
           >
             <TrackSelectorIcon />
-          </ToggleButton>
+          </IconButton>
         )}
       </div>
     )

--- a/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
@@ -11,7 +11,6 @@ import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 import IconButton from '@material-ui/core/IconButton'
 
 import { observer } from 'mobx-react'
-import { getSession } from '@jbrowse/core/util'
 import { DotplotViewModel } from '../model'
 
 export default () => {
@@ -35,7 +34,6 @@ export default () => {
 
   const Controls = observer(({ model }: { model: DotplotViewModel }) => {
     const classes = useStyles()
-    const session = getSession(model)
     return (
       <div className={classes.controls}>
         <IconButton

--- a/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Controls.tsx
@@ -9,10 +9,9 @@ import ArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
 import ArrowRight from '@material-ui/icons/KeyboardArrowRight'
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 import IconButton from '@material-ui/core/IconButton'
-import ToggleButton from '@material-ui/lab/ToggleButton'
 
 import { observer } from 'mobx-react'
-import { isSessionModelWithWidgets, getSession } from '@jbrowse/core/util'
+import { getSession } from '@jbrowse/core/util'
 import { DotplotViewModel } from '../model'
 
 export default () => {
@@ -97,22 +96,15 @@ export default () => {
           <ZoomIn />
         </IconButton>
 
-        <ToggleButton
+        <IconButton
           onClick={model.activateTrackSelector}
           title="Open track selector"
-          selected={
-            isSessionModelWithWidgets(session) &&
-            session.visibleWidget &&
-            session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-            // @ts-ignore
-            session.visibleWidget.view.id === model.id
-          }
           value="track_select"
           data-testid="circular_track_select"
           color="secondary"
         >
           <TrackSelectorIcon />
-        </ToggleButton>
+        </IconButton>
       </div>
     )
   })

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -447,11 +447,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               {
                 label: 'Open track selector',
                 onClick: self.activateTrackSelector,
-                disabled:
-                  session.visibleWidget &&
-                  session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-                  // @ts-ignore
-                  session.visibleWidget.view.id === self.id,
               },
             ]
           }

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -235,7 +235,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
     }))
     .views(self => ({
       get menuItems(): MenuItem[] {
-        const session = getSession(self)
         const menuItems: MenuItem[] = []
         self.views.forEach((view, idx) => {
           if (view.menuItems) {
@@ -249,12 +248,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
           label: 'Open track selector',
           onClick: self.activateTrackSelector,
           icon: TrackSelectorIcon,
-          disabled:
-            isSessionModelWithWidgets(session) &&
-            session.visibleWidget &&
-            session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-            // @ts-ignore
-            session.visibleWidget.view.id === self.id,
         })
         return menuItems
       },

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -55,10 +55,9 @@ const useStyles = makeStyles(theme => ({
 
 const Controls = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
-  const session = getSession(model)
   return (
     <IconButton
-      onChange={model.activateTrackSelector}
+      onClick={model.activateTrackSelector}
       className={classes.toggleButton}
       title="Open track selector"
       value="track_select"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -6,7 +6,6 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import FormGroup from '@material-ui/core/FormGroup'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
-import IconButton from '@material-ui/core/IconButton'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import React, { useCallback, useRef, useState } from 'react'
@@ -67,7 +66,6 @@ const Controls = observer(({ model }: { model: LGV }) => {
       color="secondary"
     >
       <TrackSelectorIcon className={classes.buttonSpacer} />
-      Open track selector
     </Button>
   )
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -1,12 +1,12 @@
 import { Region } from '@jbrowse/core/util/types'
-import { getSession, isSessionModelWithWidgets } from '@jbrowse/core/util'
+import { getSession } from '@jbrowse/core/util'
 import Button from '@material-ui/core/Button'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import FormGroup from '@material-ui/core/FormGroup'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
-import ToggleButton from '@material-ui/lab/ToggleButton'
+import IconButton from '@material-ui/core/IconButton'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import React, { useCallback, useRef, useState } from 'react'
@@ -57,22 +57,15 @@ const Controls = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
   const session = getSession(model)
   return (
-    <ToggleButton
+    <IconButton
       onChange={model.activateTrackSelector}
       className={classes.toggleButton}
       title="Open track selector"
       value="track_select"
       color="secondary"
-      selected={
-        isSessionModelWithWidgets(session) &&
-        session.visibleWidget &&
-        session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-        // @ts-ignore
-        session.visibleWidget.view.id === model.id
-      }
     >
       <TrackSelectorIcon />
-    </ToggleButton>
+    </IconButton>
   )
 })
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -51,20 +51,24 @@ const useStyles = makeStyles(theme => ({
     border: 'none',
     margin: theme.spacing(0.5),
   },
+  buttonSpacer: {
+    marginRight: theme.spacing(2),
+  },
 }))
 
 const Controls = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
   return (
-    <IconButton
+    <Button
       onClick={model.activateTrackSelector}
       className={classes.toggleButton}
       title="Open track selector"
       value="track_select"
       color="secondary"
     >
-      <TrackSelectorIcon />
-    </IconButton>
+      <TrackSelectorIcon className={classes.buttonSpacer} />
+      Open track selector
+    </Button>
   )
 })
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -81,19 +81,18 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         class="makeStyles-headerBar"
       >
         <button
-          class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton"
-          color="secondary"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-toggleButton MuiButton-textSecondary"
           tabindex="0"
           title="Open track selector"
           type="button"
           value="track_select"
         >
           <span
-            class="MuiToggleButton-label"
+            class="MuiButton-label"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root"
+              class="MuiSvgIcon-root makeStyles-buttonSpacer"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -885,19 +884,18 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         class="makeStyles-headerBar"
       >
         <button
-          class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton"
-          color="secondary"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-toggleButton MuiButton-textSecondary"
           tabindex="0"
           title="Open track selector"
           type="button"
           value="track_select"
         >
           <span
-            class="MuiToggleButton-label"
+            class="MuiButton-label"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root"
+              class="MuiSvgIcon-root makeStyles-buttonSpacer"
               focusable="false"
               viewBox="0 0 24 24"
             >

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1042,14 +1042,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
               label: 'Open track selector',
               onClick: self.activateTrackSelector,
               icon: TrackSelectorIcon,
-              disabled:
-                isSessionModelWithWidgets(session) &&
-                session.visibleWidget &&
-                session.visibleWidget.id === 'hierarchicalTrackSelector' &&
-                // @ts-ignore
-                session.visibleWidget.view &&
-                // @ts-ignore
-                session.visibleWidget.view.id === self.id,
             },
             {
               label: 'Horizontally flip',

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1036,7 +1036,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
       let stringifiedCurrentlyCalculatedStaticBlocks = ''
       return {
         get menuItems(): MenuItem[] {
-          const session = getSession(self)
           const menuItems: MenuItem[] = [
             {
               label: 'Open track selector',

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -239,13 +239,10 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       removeView(view: any) {
-        for (const [id, widget] of self.activeWidgets) {
-          if (
-            id === 'hierarchicalTrackSelector' &&
-            widget.view &&
-            widget.view.id === view.id
-          )
+        for (const [, widget] of self.activeWidgets) {
+          if (widget.view && widget.view.id === view.id) {
             this.hideWidget(widget)
+          }
         }
         self.views.remove(view)
       },

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -160,19 +160,18 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               class="makeStyles-headerBar"
             >
               <button
-                class="MuiButtonBase-root MuiToggleButton-root makeStyles-toggleButton"
-                color="secondary"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-toggleButton MuiButton-textSecondary"
                 tabindex="0"
                 title="Open track selector"
                 type="button"
                 value="track_select"
               >
                 <span
-                  class="MuiToggleButton-label"
+                  class="MuiButton-label"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-buttonSpacer"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -324,13 +324,10 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       removeView(view: any) {
-        for (const [id, widget] of self.activeWidgets) {
-          if (
-            id === 'hierarchicalTrackSelector' &&
-            widget.view &&
-            widget.view.id === view.id
-          )
+        for (const [, widget] of self.activeWidgets) {
+          if (widget.view && widget.view.id === view.id) {
             this.hideWidget(widget)
+          }
         }
         self.views.remove(view)
       },


### PR DESCRIPTION
This code has been a tricky thing to maintain properly since it pokes deeply into the state of the drawerwidget, so I propose removing it. Alternatively we could refactor to extract this, but another area of the code (the "Select tracks" button) removed the toggle state already.

fixes #1411 
fixes #1499 