### PR TITLE
Fix website build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "plugins/*"
   ],
   "scripts": {
-    "build": "yarn useDist && node scripts/build.js && yarn useSrc",
+    "build": "yarn useDist && node scripts/build.js && yarn useSrc && cd website && yarn build",
     "useDist": "lerna run useDist --scope \"@jbrowse/plugin*\"",
     "useSrc": "lerna run useSrc --scope \"@jbrowse/plugin*\"",
     "lerna-publish": "lerna publish --no-push",

--- a/website/docs/quickstart_desktop.md
+++ b/website/docs/quickstart_desktop.md
@@ -52,7 +52,7 @@ Reference
 https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac
 
 ![](./img/installation_mac_protect2.png)
-The "open app from unauthorized developer" after right-clicking and selecting "open"
+The 'open app from unauthorized developer' after right-clicking and selecting 'open'
 
 #### Installing on Windows
 

--- a/website/docs/quickstart_gui.md
+++ b/website/docs/quickstart_gui.md
@@ -70,14 +70,14 @@ In order to do this, use the navigation bar to open up the Assembly Manager
 This opens up a table which can be used to create, edit, and delete assemblies
 in your application
 
-![](./img/assembly_manager.png)
+![Assembly manger](./img/assembly_manager.png)
 
 Let's add the hg38 human reference genome to our JBrowse 2 application.
 
 Press the "Add New Assembly" button, and enter `hg38` as the assembly name in
 the text field
 
-![](./img/add_hg38_assembly.png)
+![Assembly manager page for adding an assembly](./img/add_hg38_assembly.png)
 
 Click on "Create New Assembly". Great, we've added an assembly! Now, in the
 configuration editor, add an alias, and configure the adapter to point the hg38
@@ -87,12 +87,12 @@ genome hosted by JBrowse:
 - fasta index: `https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai`
 - gzi: `https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi`
 
-![](./img/configure_hg38_assembly.png) Figure showing the settings
+![Figure showing the settings](./img/configure_hg38_assembly.png)
 
 After clicking the back arrow to return to the table of assemblies, we see that
 we have successfully added the hg38 assembly.
 
-![](./img/hg38_assembly_table.png) Figure showing the assembly manager
+![Figure showing the assembly manager](./img/hg38_assembly_table.png)
 
 The assembly can be edited or deleted, but for now we will return to the
 application.
@@ -145,7 +145,7 @@ First we will open a Linear Genome View using the navigation bar
 The configuration settings are accessible by clicking on the ellipses by each
 track.
 
-![](./img/admin_settings_access.png) Figure showing the configuration editor
+![Figure showing the configuration editor](./img/admin_settings_access.png)
 
 Open the configuration editor for the track by clicking on the "Settings" button
 shown above. You can use the configuration editor to live-edit any configurable

--- a/website/docs/quickstart_gui.md
+++ b/website/docs/quickstart_gui.md
@@ -70,7 +70,7 @@ In order to do this, use the navigation bar to open up the Assembly Manager
 This opens up a table which can be used to create, edit, and delete assemblies
 in your application
 
-![Assembly manger](./img/assembly_manager.png)
+![Assembly manager](./img/assembly_manager.png)
 
 Let's add the hg38 human reference genome to our JBrowse 2 application.
 

--- a/website/docs/tex_parser.js
+++ b/website/docs/tex_parser.js
@@ -33,22 +33,23 @@ let caption = ''
       }
       continue
     }
-    if (line.startsWith('![')) {
+    if (line.startsWith('![]')) {
       const res = line.match(/\(([^)]+)\)/)
       if (res) {
         figure = res[1].replace('/jb2', '..')
         continue
       }
     }
-    if (figure && line.trim() !== '') {
-      caption += `${line} `
-      continue
-    }
-    if (figure && caption) {
-      console.log(`![${caption}](${figure})\n\n`)
-      figure = ''
-      caption = ''
-      continue
+    if (figure) {
+      if (line.trim() !== '') {
+        caption += `${line} `
+        continue
+      } else {
+        console.log(`![${caption}](${figure})\n\n`)
+        figure = ''
+        caption = ''
+        continue
+      }
     }
     if (readingHeader === false) {
       console.log(line)

--- a/website/docs/user_guide.md
+++ b/website/docs/user_guide.md
@@ -46,13 +46,13 @@ the form for adding a track:
 File->Open Track
 
 ![](img/add_track_form.png)
-The "Add track form"
+The 'Add track form'
 
 Note: There is also a circular "+" button inside the track selector menu that
 can also be used to access the "Add track" form.
 
 ![](img/add_track_tracklist.png)
-The "Add track button" in the tracklist
+The 'Add track button' in the tracklist
 
 In the "Add track" form, you can provide a URL to a file to load. Opening files
 from your local machine is not supported currently in the jbrowse-web app
@@ -114,7 +114,7 @@ Currently, in order to edit a track config, you have to make a copy of the track
 
 ![](img/copy_track.png)
 Figure showing how to copy a track, note that settings button is disabled
-because we don't "own this track" as a non-privileged user
+because we don't 'own this track' as a non-privileged user
 
 After you have copied the track, you can edit the track settings
 
@@ -245,7 +245,7 @@ http://localhost:3001/?config=test_data%2Fvolvox%2Fconfig.json&session=eJzNVU1vm
 ![](./img/alignments_center_line.png)
 Illustrates before and after turning on the center line. The center line is an
 indicator that shows what base pair underlies the center of the view. Note that
-this is used in the "Sort by" option discussed below; the sort is performed
+this is used in the 'Sort by' option discussed below; the sort is performed
 using properties of the feature or even exact base pair underlying the center
 line
 
@@ -265,7 +265,7 @@ http://localhost:3001/?config=test_data%2Fvolvox%2Fconfig.json&session=eJzNVcFO2
 
 ![](./img/alignments_sort_by_base.png)
 Illustrating the pileup re-ordering that happens when turning on the
-"Sort by"->"Base pair". The sorting is done by specifically what letter of each
+'Sort by'->'Base pair'. The sorting is done by specifically what letter of each
 read underlies the current center line position (the center line is 1bp wide,
 so sorted by that exact letter)
 
@@ -351,7 +351,7 @@ genome by
 Example of a dotplot of a long read vs the reference genome
 
 ![](./img/linear_longread.png)
-Example of a "synteny" view of a long read vs the reference genome
+Example of a 'synteny' view of a long read vs the reference genome
 
 ## Hi-C tracks
 


### PR DESCRIPTION
The website currently won't build. This fixes the build and adds the website build to the root `yarn build` command so that if it breaks again it will show up in CI (website used to be built in CI before https://github.com/GMOD/jbrowse-components/pull/1336).

Some fixes are because there seems to a bug in docusaurus that if a markdown image alt-text has double quotes (like this: `![alt text with "quotes"!](../static/img/logo.svg)`), the build breaks: https://github.com/facebook/docusaurus/issues/3751

Another fix updates `tex_parser.md` so that it only tries to extract a caption for an image if there is no alt-text, and only extracts the caption if it's on the next line (no blank lines after it).