### PR TITLE
Bug:  search box disappears from LGV header on smaller widths

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -180,7 +180,7 @@ export default observer(({ model }: { model: LGV }) => {
     <div className={classes.headerBar}>
       <Controls model={model} />
       <div className={classes.spacer} />
-      <FormGroup row>
+      <FormGroup row style={{ flexWrap: 'nowrap' }}>
         <PanControls model={model} />
         <RefNameAutocomplete
           onSelect={setDisplayedRegion}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -111,6 +111,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         />
         <div
           class="MuiFormGroup-root MuiFormGroup-row"
+          style="flex-wrap: nowrap;"
         >
           <button
             class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
@@ -914,6 +915,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         />
         <div
           class="MuiFormGroup-root MuiFormGroup-row"
+          style="flex-wrap: nowrap;"
         >
           <button
             class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"


### PR DESCRIPTION
[Issue 1419](https://github.com/GMOD/jbrowse-components/issues/1419)
Before
<img width="522" alt="LGV Header Bug before" src="https://user-images.githubusercontent.com/45598764/99295021-b7dd3680-27f9-11eb-94bf-bb324261c3fd.png">
Now
<img width="542" alt="LGV Header Bug after" src="https://user-images.githubusercontent.com/45598764/99295037-bf9cdb00-27f9-11eb-8993-0c1472a431d9.png">


Also working in Safari
