### PR TITLE
Add Support to new track types in TrackHub spec + fallback for unsupported types

### DIFF
--- a/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -96,6 +96,8 @@ function makeTrackConfig(
     }
   else bigDataLocation = { localPath: track.get('bigDataUrl') }
   let bigDataIndexLocation
+
+  // bigGenePred falls into the default case, make a case for bigGenePred and return the correct config
   switch (baseTrackType) {
     case 'bam':
       if (trackDbFileLocation.uri)
@@ -158,6 +160,17 @@ function makeTrackConfig(
         categories,
       )
     case 'bigBed':
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+      }
+    case 'bigGenePred':
       return {
         type: 'FeatureTrack',
         name: track.get('shortLabel'),
@@ -262,6 +275,12 @@ function makeTrackConfig(
         baseTrackType,
         categories,
       )
+    case 'bigNarrowPeak':
+      return generateUnsupportedTrackConf(
+        track.get('shortLabel'),
+        baseTrackType,
+        categories,
+      )
     case 'peptideMapping':
       return generateUnsupportedTrackConf(
         track.get('shortLabel'),
@@ -310,6 +329,24 @@ function makeTrackConfig(
         baseTrackType,
         categories,
       )
+    case 'hic':
+      return {
+        type: 'HicTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'HicAdapter',
+          hicLocation: bigDataLocation,
+        },
+      }
+    case 'halSnake':
+      return generateUnsupportedTrackConf(
+        track.get('shortLabel'),
+        baseTrackType,
+        categories,
+      )
+
     default:
       throw new Error(`Unsupported track type: ${baseTrackType}`)
   }

--- a/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -97,7 +97,6 @@ function makeTrackConfig(
   else bigDataLocation = { localPath: track.get('bigDataUrl') }
   let bigDataIndexLocation
 
-  // bigGenePred falls into the default case, make a case for bigGenePred and return the correct config
   switch (baseTrackType) {
     case 'bam':
       if (trackDbFileLocation.uri)
@@ -348,6 +347,10 @@ function makeTrackConfig(
       )
 
     default:
-      throw new Error(`Unsupported track type: ${baseTrackType}`)
+      return generateUnsupportedTrackConf(
+        track.get('shortLabel'),
+        baseTrackType,
+        categories,
+      )
   }
 }

--- a/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -1,7 +1,10 @@
 import objectHash from 'object-hash'
 import { GenomesFile, HubFile, TrackDbFile } from '@gmod/ucsc-hub'
 import { openLocation } from '@jbrowse/core/util/io'
-import { generateUnsupportedTrackConf } from '@jbrowse/core/util/tracks'
+import {
+  generateUnsupportedTrackConf,
+  generateUnknownTrackConf,
+} from '@jbrowse/core/util/tracks'
 import ucscAssemblies from './ucscAssemblies'
 
 export { ucscAssemblies }
@@ -275,11 +278,16 @@ function makeTrackConfig(
         categories,
       )
     case 'bigNarrowPeak':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+      }
     case 'peptideMapping':
       return generateUnsupportedTrackConf(
         track.get('shortLabel'),
@@ -347,7 +355,7 @@ function makeTrackConfig(
       )
 
     default:
-      return generateUnsupportedTrackConf(
+      return generateUnknownTrackConf(
         track.get('shortLabel'),
         baseTrackType,
         categories,

--- a/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -156,11 +156,19 @@ function makeTrackConfig(
         categories,
       )
     case 'bigBarChart':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+        renderer: {
+          type: 'SvgFeatureRenderer',
+        },
+      }
     case 'bigBed':
       return {
         type: 'FeatureTrack',
@@ -184,29 +192,61 @@ function makeTrackConfig(
         },
       }
     case 'bigChain':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+        renderer: {
+          type: 'SvgFeatureRenderer',
+        },
+      }
     case 'bigInteract':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+        renderer: {
+          type: 'SvgFeatureRenderer',
+        },
+      }
     case 'bigMaf':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+        renderer: {
+          type: 'SvgFeatureRenderer',
+        },
+      }
     case 'bigPsl':
-      return generateUnsupportedTrackConf(
-        track.get('shortLabel'),
-        baseTrackType,
-        categories,
-      )
+      return {
+        type: 'FeatureTrack',
+        name: track.get('shortLabel'),
+        description: track.get('longLabel'),
+        category: categories,
+        adapter: {
+          type: 'BigBedAdapter',
+          bigBedLocation: bigDataLocation,
+        },
+        renderer: {
+          type: 'SvgFeatureRenderer',
+        },
+      }
     case 'bigWig':
       return {
         type: 'QuantitativeTrack',


### PR DESCRIPTION
Added support for new track types added to trackhub spec recently seen here https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html

types added
- bigGenePred: opens a bb track
- hic: opens a hic track
- bigNarrowPeak: opens an unsupported track
- halSnake: opens an unsupported track

also fixes another issue that came up in #1426, if it is an unlisted unsupported track, the default case will make an unsupportedTrackConf instead of throwing an error so it doesn't break loading the trackHub on any unsupported track