### PR TITLE
Alternative fsPromises usage

### DIFF
--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -1,7 +1,9 @@
 import { flags } from '@oclif/command'
-import fs, { promises as fsPromises } from 'fs'
+import fs from 'fs'
 import path from 'path'
 import JBrowseCommand, { Assembly, Sequence, Config } from '../base'
+
+const fsPromises = fs.promises
 
 function isValidJSON(string: string) {
   try {

--- a/products/jbrowse-cli/src/commands/add-connection.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.ts
@@ -1,10 +1,11 @@
 import { flags } from '@oclif/command'
 import fetch from 'node-fetch'
-import { promises as fsPromises } from 'fs'
+import fs from 'fs'
 import path from 'path'
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
 
+const fsPromises = fs.promises
 interface Connection {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -1,9 +1,11 @@
 /* eslint curly:error */
 import { flags } from '@oclif/command'
-import fs, { promises as fsPromises } from 'fs'
+import fs from 'fs'
 import path from 'path'
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
+
+const fsPromises = fs.promises
 
 interface Track {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -1,5 +1,5 @@
 import { flags } from '@oclif/command'
-import fs, { promises as fsPromises } from 'fs'
+import fs from 'fs'
 import crypto from 'crypto'
 import boxen from 'boxen'
 import chalk from 'chalk'
@@ -7,6 +7,8 @@ import os from 'os'
 import express from 'express'
 import cors from 'cors'
 import JBrowseCommand, { Config } from '../base'
+
+const fsPromises = fs.promises
 
 function isValidPort(port: number) {
   return port > 0 && port < 65535

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -1,9 +1,11 @@
 /* eslint curly:error */
 import { flags } from '@oclif/command'
-import { promises as fsPromises } from 'fs'
+import fs from 'fs'
 import fetch from 'node-fetch'
 import unzip from 'unzipper'
 import JBrowseCommand from '../base'
+
+const fsPromises = fs.promises
 
 export default class Create extends JBrowseCommand {
   static description = 'Downloads and installs the latest JBrowse 2 release'

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -1,7 +1,10 @@
 import { flags } from '@oclif/command'
-import { promises as fsPromises } from 'fs'
+import fs from 'fs'
+
 import parseJSON from 'json-parse-better-errors'
 import JBrowseCommand from '../base'
+
+const fsPromises = fs.promises
 
 interface DefaultSession {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #1440 

This is kind of a weird one but

```
nvm install 10.9
yarn
cd products/jbrowse-cli
bin/run create t1
bin/run add-assembly volvox.fa --out t1
```

This fails with the lstat error described in #1440 

With this PR though it is fixed

Note that `yarn test products/jbrowse-cli` does not pass with node 10.9 still due to something weird about testUtil, full error

```

    TypeError: Patterns must be a string or an array of strings



      at assertPatternsInput (node_modules/globby/index.js:17:9)
      at generateGlobTasks (node_modules/globby/index.js:42:2)
      at Object.<anonymous>.module.exports (node_modules/globby/index.js:116:20)
      at Object.<anonymous>.module.exports (node_modules/del/index.js:66:23)
      at _callee2$ (products/jbrowse-cli/src/testUtil.ts:128:37)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:293:22)
      at Generator.next (node_modules/regenerator-runtime/runtime.js:118:21)
      at asyncGeneratorStep (node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
      at node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
      at node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12
      at products/jbrowse-cli/src/testUtil.ts:144:18
      at Object.finally (node_modules/fancy-test/lib/base.js:112:117)
      at Object.run (node_modules/fancy-test/lib/base.js:79:36)


```

That goes back to something in the del command/package I think
