### PR TITLE
Allow bgzip imports to the spreadsheet

### DIFF
--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -35,6 +35,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
+    "@gmod/bgzf-filehandle": "^1.3.4",
     "@gmod/vcf": "^4.0.0",
     "@jbrowse/plugin-variants": "^1.0.0",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -40,6 +40,7 @@ export default (pluginManager: PluginManager) => {
     .volatile(() => ({
       fileTypes,
       requiresUnzip: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fileSource: undefined as any,
       error: undefined as Error | undefined,
     }))

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -39,7 +39,6 @@ export default (pluginManager: PluginManager) => {
     })
     .volatile(() => ({
       fileTypes,
-      requiresUnzip: false,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fileSource: undefined as any,
       error: undefined as Error | undefined,
@@ -67,6 +66,19 @@ export default (pluginManager: PluginManager) => {
         }
         return undefined
       },
+
+      get fileName() {
+        return (
+          self.fileSource.uri ||
+          self.fileSource.localPath ||
+          (self.fileSource.blob && self.fileSource.blob.name)
+        )
+      },
+
+      get requiresUnzip() {
+        return this.fileName.endsWith('gz')
+      },
+
       isValidRefName(refName: string, assemblyName?: string) {
         return getSession(self).assemblyManager.isValidRefName(
           refName,
@@ -81,15 +93,9 @@ export default (pluginManager: PluginManager) => {
 
         if (self.fileSource) {
           // try to autodetect the file type, ignore errors
-          const name =
-            self.fileSource.uri ||
-            self.fileSource.localPath ||
-            (self.fileSource.blob && self.fileSource.blob.name)
+          const name = self.fileName
 
           if (name) {
-            if (name.endsWith('.gz')) {
-              self.requiresUnzip = true
-            }
             const match = fileTypesRegexp.exec(name)
             if (match && match[1]) {
               if (match[1] === 'tsv' && name.includes('star-fusion')) {

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/declare.d.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/declare.d.ts
@@ -1,0 +1,1 @@
+declare module '@gmod/bgzf-filehandle'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,7 +3957,7 @@
   resolved "https://registry.yarnpkg.com/@gmod/bed/-/bed-2.0.3.tgz#d4eea0b613b13a197d0465c6e5f22d2cb9f83f05"
   integrity sha512-tV4U9pdyEz5nozGW8FosDgAXVbUfteszNJeeZtDUpQzO7/2OnQHCnAjskGoUnaZ1zRaMNEz7I9dwySeEtTjlcQ==
 
-"@gmod/bgzf-filehandle@^1.2.4", "@gmod/bgzf-filehandle@^1.3.3":
+"@gmod/bgzf-filehandle@^1.2.4", "@gmod/bgzf-filehandle@^1.3.3", "@gmod/bgzf-filehandle@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@gmod/bgzf-filehandle/-/bgzf-filehandle-1.3.4.tgz#89a1e79ee3cdf29e765b7e808412d7266f1d67d7"
   integrity sha512-wv008EwB2cx0ZEel+HB9iohpNFZfMbssukg8W3u5xweogaG22qnLjf57fbluAg3z8+lt0q3Hv4BCQNAMfCTNLg==


### PR DESCRIPTION
This enables opening bgzipped files like vcf.gz in the spreadsheet view

Also makes fileSource volatile because otherwise it is sticky across refresh and confuses the system