### PR TITLE
Min node 10.4

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -24,7 +24,7 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.4.0"
   },
   "scripts": {
     "build": "cp ../../yarn.lock . && oclif-dev pack && rm yarn.lock",

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -9,7 +9,7 @@ In this guide, we'll get an instance of JBrowse running on your computer.
 ## Pre-requisites
 
 - Ability to run commands on the command line
-- Node.js 10+
+- Node.js 10.4+
 
 :::caution
 


### PR DESCRIPTION
Unfortunately this isn't properly testable (noting issues in #1461)

But we can set a minimum node 10.4 in the jbrowse-cli engines, and then still run add-assembly subcommand



