### PR TITLE
Have assembly manager get plugin manager from factory function args

### DIFF
--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -13,9 +13,13 @@ import { readConfObject } from '../configuration'
 import { AnyConfigurationModel } from '../configuration/configurationSchema'
 
 import assemblyFactory from './assembly'
+import PluginManager from '../PluginManager'
 
-export default function assemblyManagerFactory(assemblyConfigType: IAnyType) {
-  const Assembly = assemblyFactory(assemblyConfigType)
+export default function assemblyManagerFactory(
+  assemblyConfigType: IAnyType,
+  pluginManager: PluginManager,
+) {
+  const Assembly = assemblyFactory(assemblyConfigType, pluginManager)
   return types
     .model({
       assemblies: types.array(Assembly),

--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -21,7 +21,7 @@ export interface BaseOptions {
 export interface AdapterConstructor {
   new (
     config: AnyConfigurationModel,
-    getSubAdapter: getSubAdapterType,
+    getSubAdapter?: getSubAdapterType,
   ): AnyDataAdapter
 }
 

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -40,7 +40,7 @@ export class CramAdapter extends BaseFeatureDataAdapter {
 
   public constructor(
     config: AnyConfigurationModel,
-    getSubAdapter: getSubAdapterType,
+    getSubAdapter?: getSubAdapterType,
   ) {
     super(config)
 
@@ -65,9 +65,9 @@ export class CramAdapter extends BaseFeatureDataAdapter {
       'type',
     ])
 
-    const { dataAdapter } = getSubAdapter(
+    const dataAdapter = getSubAdapter?.(
       readConfObject(config, 'sequenceAdapter'),
-    )
+    ).dataAdapter
     // TODO: BaseFeatureDataAdapter is different inside of the plugin build, needs to be gotten from pluginManager.lib
     if (dataAdapter instanceof BaseFeatureDataAdapter) {
       this.sequenceAdapter = dataAdapter

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -70,11 +70,12 @@ export default (pluginManager: PluginManager) => {
 
     public constructor(
       config: Instance<typeof MyConfigSchema>,
-      getSubAdapter: getSubAdapterType,
+      getSubAdapter?: getSubAdapterType,
     ) {
       super(config)
 
-      const { dataAdapter } = getSubAdapter(getSnapshot(config.subadapter))
+      const dataAdapter = getSubAdapter?.(getSnapshot(config.subadapter))
+        .dataAdapter
 
       if (dataAdapter instanceof BaseFeatureDataAdapter) {
         this.subadapter = dataAdapter

--- a/plugins/linear-comparative-view/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
+++ b/plugins/linear-comparative-view/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
@@ -48,7 +48,7 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
 
   public constructor(
     config: Instance<typeof MyConfigSchema>,
-    getSubAdapter: getSubAdapterType,
+    getSubAdapter?: getSubAdapterType,
   ) {
     super(config)
     const subadapters = readConfObject(config, 'subadapters')
@@ -57,9 +57,13 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
       readConfObject(config, 'mcscanAnchorsLocation') as FileLocation,
     )
 
-    this.subadapters = subadapters.map(
-      (subadapter: any) => getSubAdapter(subadapter).dataAdapter,
-    )
+    this.subadapters = subadapters.map((subadapter: any) => {
+      const dataAdapter = getSubAdapter?.(subadapter).dataAdapter
+      if (dataAdapter instanceof BaseFeatureDataAdapter) {
+        return dataAdapter
+      }
+      throw new Error(`invalid subadapter type '${config.subadapter.type}'`)
+    })
 
     this.assemblyNames = assemblyNames
   }

--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -36,7 +36,10 @@ export default function RootModel(pluginManager: PluginManager) {
     { dispatcher },
     ...assemblyConfigSchemas,
   )
-  const assemblyManagerType = assemblyManagerFactory(assemblyConfigSchemasType)
+  const assemblyManagerType = assemblyManagerFactory(
+    assemblyConfigSchemasType,
+    pluginManager,
+  )
   return types
     .model('Root', {
       jbrowse: JBrowseDesktop(

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -42,7 +42,10 @@ export default function RootModel(
     { dispatcher },
     ...assemblyConfigSchemas,
   )
-  const assemblyManagerType = assemblyManagerFactory(assemblyConfigSchemasType)
+  const assemblyManagerType = assemblyManagerFactory(
+    assemblyConfigSchemasType,
+    pluginManager,
+  )
   return types
     .model('Root', {
       jbrowse: jbrowseWebFactory(


### PR DESCRIPTION
After #1438, the React Linear Genome View wasn't working. It turned out to be because the assembly manager was looking for the plugin manager on the root model, which doesn't exist in the React Linear Genome View. I thought about adding `pluginManager` to `AbstractRootModel`, but that caused typescript errors elsewhere. Instead, I decided to pass the plugin manager as an arg when creating the assembly manager model, which is similar to the way a session model is created.

This seems to work fine, but it led to `pluginManager` being correctly typed in `assembly.ts` (before this it was implicitly `any`), which required some typescript fixes. Basically what it amounted to was that `getSubAdapter` was marked as required in `AdapterConstructor`, but from what I understand, it should actually be optional. Changing it to optional required changing a few adapters that use that interface.