### PR TITLE
Fix rendering null

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -107,7 +107,7 @@ export const BaseCoreDetails = (props: BaseProps) => {
       {coreRenderedDetails.map(key => {
         const value = displayedDetails[key.toLowerCase()]
         const strValue = String(value)
-        return value ? (
+        return value !== null && value !== undefined ? (
           <div className={classes.field} key={key}>
             <div className={classes.fieldName}>{key}</div>
             <div className={classes.fieldValue}>
@@ -156,7 +156,7 @@ export const Attributes: FunctionComponent<AttributeProps> = props => {
 
   const SimpleValue = ({ name, value }: { name: string; value: any }) => {
     const description = descriptions && descriptions[name]
-    return (
+    return value ? (
       <div style={{ display: 'flex' }}>
         {description ? (
           <Tooltip title={description} placement="left">
@@ -167,7 +167,7 @@ export const Attributes: FunctionComponent<AttributeProps> = props => {
         )}
         <div className={classes.fieldValue}>{formatter(value)}</div>
       </div>
-    )
+    ) : null
   }
   const ArrayValue = ({ name, value }: { name: string; value: any[] }) => {
     const description = descriptions && descriptions[name]

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.js
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.js
@@ -82,7 +82,7 @@ function VariantSamples(props) {
                     </TableCell>
                     {infoFields.map(f => (
                       <TableCell className={classes.valueCell} key={f}>
-                        {String(value[f])}
+                        {value === null ? '.' : String(value[f])}
                       </TableCell>
                     ))}
                   </TableRow>


### PR DESCRIPTION
Avoids rendering null and undefined values in the feature details widget

Also restores the '.' notation in the genotype table for variantfeaturedetails, because there, the '.' sort of has a meaning e.g. "no call"