### PR TITLE
Wait on assemblies that are being tracked by the assemblyManager only

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -129,11 +129,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
     }))
     .views(self => ({
       get initialized() {
-        const { assemblyNames } = this
         const { assemblyManager } = getSession(self)
-        const assembliesInitialized = assemblyNames.every(
-          asm => assemblyManager.get(asm)?.initialized,
-        )
+
+        // if the assemblyManager is tracking a given assembly name, wait for
+        // it to be loaded
+        const assembliesInitialized = this.assemblyNames.every(assemblyName => {
+          const assembly = assemblyManager.get(assemblyName)
+          return assembly ? assembly.initialized : true
+        })
+
         return (
           self.volatileWidth !== undefined &&
           self.displayedRegions.length > 0 &&


### PR DESCRIPTION
Fixes #1467 

Related to the #1438 because it made linear-genome-view become initialized only after the assembly manager says it's assemblies were loaded, but the "read assembly" never is added to the assembly manager proper (which i think is a valid thing...just a contextual assembly that bypasses assemblyManager)