### PR TITLE
Avoid stale region reference in block hydrate

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -22,12 +22,12 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
     function doHydrate() {
       const {
         data,
-        region,
         html,
+        filled,
         renderProps,
         renderingComponent: RenderingComponent,
       } = model
-      if (domNode && model.filled) {
+      if (domNode && filled) {
         if (isHydrated && domNode) {
           unmountComponentAtNode(domNode)
         }
@@ -42,7 +42,15 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         // so
         requestIdleCallback(
           () => {
-            if (!isAlive(model) || !isAlive(region)) return
+            if (!isAlive(model)) {
+              return
+            }
+
+            const { region } = model
+            if (!isAlive(region)) {
+              return
+            }
+
             const serializedRegion = isStateTreeNode(region)
               ? getSnapshot(region)
               : region


### PR DESCRIPTION
Fixes #1447 
Pretty minor warning but thought it'd be a reasonable fix. This defers unboxing the model.region

The warning appeared to come from even destructuring region from model at the start of doHydrate but this defers it a little