### PR TITLE
Fix ability to add a PAF synteny track with add-track

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -228,7 +228,7 @@ export function guessAdapter(
 
   if (/\.paf/i.test(fileName)) {
     return {
-      type: 'PafAdapter',
+      type: 'PAFAdapter',
       pafLocation: makeLocation(fileName),
     }
   }
@@ -248,7 +248,7 @@ export function guessTrackType(adapterType: string): string {
     TwoBitAdapter: 'ReferenceSequenceTrack',
     VcfTabixAdapter: 'VariantTrack',
     HicAdapter: 'HicTrack',
-    PafAdapter: 'LinearSyntenyTrack',
+    PAFAdapter: 'SyntenyTrack',
   }
   return known[adapterType] || 'FeatureTrack'
 }

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -273,8 +273,8 @@ function HierarchicalTrackSelector({ model }) {
           value={assemblyIdx}
           onChange={handleTabChange}
         >
-          {assemblyNames.map(name => (
-            <Tab key={name} label={name} />
+          {assemblyNames.map((name, index) => (
+            <Tab key={`${name}-${index}`} label={name} />
           ))}
         </Tabs>
       ) : null}

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -168,6 +168,11 @@ export default class AddTrack extends JBrowseCommand {
       !index || isUrl(index) ? index : path.join(subDir, path.basename(index)),
     )
 
+    if (adapter.type === 'PAFAdapter') {
+      // @ts-ignore
+      adapter.assemblyNames = assemblyNames.split(',').map(a => a.trim())
+    }
+
     if (isUrl(location) && load) {
       this.error(
         'The --load flag is used for local files only, but a URL was provided',
@@ -624,7 +629,7 @@ export default class AddTrack extends JBrowseCommand {
 
     if (/\.paf/i.test(fileName)) {
       return {
-        type: 'PafAdapter',
+        type: 'PAFAdapter',
         pafLocation: makeLocation(fileName),
       }
     }
@@ -644,7 +649,7 @@ export default class AddTrack extends JBrowseCommand {
       TwoBitAdapter: 'ReferenceSequenceTrack',
       VcfTabixAdapter: 'VariantTrack',
       HicAdapter: 'HicTrack',
-      PafAdapter: 'LinearSyntenyTrack',
+      PAFAdapter: 'SyntenyTrack',
     }
     return known[adapterType] || 'FeatureTrack'
   }

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -2681,6 +2681,48 @@ Object {
       "trackId": "pOOtg9wxcUC",
       "type": "QuantitativeTrack",
     },
+    Object {
+      "adapter": Object {
+        "assemblyNames": Array [
+          "volvox",
+          "volvox",
+        ],
+        "pafLocation": Object {
+          "uri": "volvox_fake_synteny.paf",
+        },
+        "type": "PAFAdapter",
+      },
+      "assemblyNames": Array [
+        "volvox",
+        "volvox",
+      ],
+      "displays": Array [
+        Object {
+          "displayId": "volvox_fake_synteny-DotplotDisplay",
+          "renderer": Object {
+            "type": "DotplotRenderer",
+          },
+          "type": "DotplotDisplay",
+        },
+        Object {
+          "displayId": "volvox_fake_synteny-LinearComparativeDisplay",
+          "renderer": Object {
+            "type": "SvgFeatureRenderer",
+          },
+          "type": "LinearComparativeDisplay",
+        },
+        Object {
+          "displayId": "volvox_fake_synteny-LinearSyntenyDisplay",
+          "renderer": Object {
+            "type": "LinearSyntenyRenderer",
+          },
+          "type": "LinearSyntenyDisplay",
+        },
+      ],
+      "name": "volvox_fake_synteny",
+      "trackId": "volvox_fake_synteny",
+      "type": "SyntenyTrack",
+    },
   ],
 }
 `;

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1113,6 +1113,19 @@
           "uri": "volvox-sorted.bam.coverage.bw"
         }
       }
+    },
+    {
+      "type": "SyntenyTrack",
+      "trackId": "volvox_fake_synteny",
+      "name": "volvox_fake_synteny",
+      "assemblyNames": ["volvox", "volvox"],
+      "adapter": {
+        "type": "PAFAdapter",
+        "pafLocation": {
+          "uri": "volvox_fake_synteny.paf"
+        },
+        "assemblyNames": ["volvox", "volvox"]
+      }
     }
   ],
   "defaultSession": {


### PR DESCRIPTION
This adds a fake synteny track on volvox, and fixes the ability to specify your own synteny track with PAFAdapter in add-track