### PR TITLE
Updates to release workflow

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
-  "version": "independent",
+  "version": "1.0.0",
   "npmClient": "yarn",
-  "useWorkspaces": true,
-  "independent": true
+  "useWorkspaces": true
 }

--- a/scripts/blog_template.txt
+++ b/scripts/blog_template.txt
@@ -1,14 +1,21 @@
 ---
-title: jbrowse-web ${JBROWSE_WEB_VERSION}
+title: ${VERSION} Release
 date: ${DATE}
 tags: ['release','jbrowse 2']
 ---
 
 ${NOTES}
 
+## Downloads
+
 - [${JBROWSE_WEB_TAG}](https://github.com/GMOD/jbrowse-components/releases/tag/${JBROWSE_WEB_TAG})
 
-To install, you can download the link above, or you can use the jbrowse CLI
-tool to automatically download the latest version. See the [jbrowse 2
-quick-start guide](https://jbrowse.org/jb2/docs/quickstart_web) for more info
+To install JBrowse 2, you can download the link above, or you can use the
+JBrowse CLI to automatically download the latest version. See the
+[JBrowse web quick start](https://jbrowse.org/jb2/docs/quickstart_web) for more
+details.
 
+See "Packages in this release" in the changelog for links to packages published
+on NPM.
+
+${CHANGELOG}

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const spawn = require('cross-spawn')
+
+function main(version, changed) {
+  const lernaChangelog = spawn.sync(
+    'yarn',
+    ['--silent', 'lerna-changelog', '--next-version', version],
+    { encoding: 'utf8' },
+  ).stdout
+  const changelogLines = lernaChangelog.split('\n')
+  const changedPackages = JSON.parse(changed)
+  const updatesTable = ['| Package | Download |', '| --- | --- |']
+  changedPackages.forEach(changedPackage => {
+    const { name } = changedPackage
+    const link = changedPackage.private
+      ? ''
+      : `https://www.npmjs.com/package/${name}`
+    updatesTable.push(`| ${name} | ${link} |`)
+  })
+  const updatesDetails = [
+    '<details><summary>Packages in this release</summary>',
+    '<p>',
+    '',
+    ...updatesTable,
+    '',
+    '</p>',
+    '</details>',
+    '',
+  ]
+  changelogLines.splice(3, 0, ...updatesDetails)
+  console.log(`${changelogLines.join('\n')}\n`)
+}
+
+const version = process.argv[2]
+if (!version) {
+  throw new Error('No version provided')
+}
+const changed = process.argv[3]
+if (!changed) {
+  throw new Error('No list of changed packages provided')
+}
+main(version, changed)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,42 +1,60 @@
 #!/usr/bin/env bash
 
-## Usage scripts/release.sh blogpost.txt <prerelease/patch/minor/major>
-# The first argument blogpost.txt is published to the jbrowse 2 blog. The
-# second argument is a flag for the publishing command for version bump, by
-# default it is none and will prompt
+## Usage scripts/release.sh blogpost.md githubAuthToken <prerelease/patch/minor/major>
+# The first argument blogpost.md is published to the jbrowse 2 blog. The second
+# argument is a personal access token for the GitHub API with `public_repo`
+# scope. You can generate a token at https://github.com/settings/tokens
+# The third optional argument is a flag for the publishing command for version
+# bump. If not provided, the publishing command will prompt you.
 
 ## Precautionary bash tags
 set -e
 set -o pipefail
 
+# Blog post text
 NOTES=$(cat "$1")
 DATE=$(date +"%Y-%m-%d")
+# Packages that have changed and will have their version bumped
+CHANGED=$(yarn --silent lerna changed --all --json)
 
-yarn run lerna-publish "$2"
+# Run lerna publish --no-push
+yarn run lerna-publish "$3"
 
-## This pushes only the @jbrowse/web tag first because a flood of tags causes
-## the CI system to skip the build
-git push origin tag "@jbrowse/web*"
-echo "Waiting while the new jbrowse-web tag is processed on github actions before pushing the rest of the tags"
-sleep 30
-## Push the rest of the tags
-git push --follow-tags
+# Get the new after publishing from lerna.json
+VERSION=$(node --print "const lernaJson = require('./lerna.json'); lernaJson.version")
+
+# Get the latest JBrowse Web tag. If JBrowse Web was not in CHANGED, this tag
+# will be from a previous version.
+# Have to avoid overlap with @jbrowse/website
+JBROWSE_WEB_TAG=$(git tag --sort=-creatordate --list "@jbrowse/web@*" | head --lines 1)
+
+# If JBrowse Web was in the list of changed packages
+if grep --quiet "@jbrowse/web" <<<"$CHANGED"; then
+  ## This pushes only the @jbrowse/web tag first because a flood of tags causes
+  ## the CI system to skip the build
+  git push origin tag "@jbrowse/web*"
+  echo "Waiting while the new jbrowse-web tag is processed on github actions before pushing the rest of the tags"
+  sleep 30
+
+  # Updates the "Browse demo instance" link on the homepage
+  INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$JBROWSE_WEB_TAG/index.html
+  INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
+  mv tmp.json website/docusaurus.config.json
+fi
+
+# Generates a changelog with a section added listing the packages that were
+# included in this release
+CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$VERSION" "$CHANGED")
+# Add the changelog to the top of CHANGELOG.md
+echo "$CHANGELOG" >tmp.md
+cat CHANGELOG.md >>tmp.md
+mv tmp.md CHANGELOG.md
 
 ## Blogpost run after lerna publish, to get the accurate tags
-
-## Have to avoid overlap with @jbrowse/website
-JBROWSE_WEB_TAG=$(git tag --sort=-creatordate -l "@jbrowse/web@*" | head -n1)
-
-JBROWSE_WEB_VERSION=${JBROWSE_WEB_TAG:13}
-BLOGPOST_FILENAME=website/blog/$(date +"%Y-%m-%d")-jbrowse-web-${JBROWSE_WEB_VERSION}-release.md
-
-JBROWSE_DESKTOP_TAG=$(git tag --sort=-creatordate -l "@jbrowse/desktop*" | head -n1)
-INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$JBROWSE_WEB_TAG/index.html
-JBROWSE_WEB_VERSION=$JBROWSE_WEB_VERSION JBROWSE_WEB_TAG=$JBROWSE_WEB_TAG JBROWSE_DESKTOP_TAG=$JBROWSE_DESKTOP_TAG DATE=$DATE NOTES=$NOTES perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
-
-INSTANCE=$INSTANCE node -p "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
-mv tmp.json website/docusaurus.config.json
+BLOGPOST_FILENAME=website/blog/${DATE}-${VERSION}-release.md
+VERSION=$VERSION DATE=$DATE NOTES=$NOTES CHANGELOG=$CHANGELOG JBROWSE_WEB_TAG=$JBROWSE_WEB_TAG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
 
 git add .
-git commit -m "[update docs] release"
-git push
+git commit --message "[update docs] release"
+## Push the rest of the tags
+git push --follow-tags

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Usage scripts/release.sh blogpost.txt <prerelease/patch/minor/major>
 # The first argument blogpost.txt is published to the jbrowse 2 blog. The
@@ -9,11 +9,10 @@
 set -e
 set -o pipefail
 
-NOTES=`cat $1`
+NOTES=$(cat "$1")
 DATE=$(date +"%Y-%m-%d")
-FRONTPAGE_FILENAME=website/src/pages/index.js
 
-yarn run lerna-publish $2
+yarn run lerna-publish "$2"
 
 ## This pushes only the @jbrowse/web tag first because a flood of tags causes
 ## the CI system to skip the build
@@ -26,20 +25,17 @@ git push --follow-tags
 ## Blogpost run after lerna publish, to get the accurate tags
 
 ## Have to avoid overlap with @jbrowse/website
-JBROWSE_WEB_TAG=$(git tag --sort=-creatordate -l "@jbrowse/web@*"|head -n1)
+JBROWSE_WEB_TAG=$(git tag --sort=-creatordate -l "@jbrowse/web@*" | head -n1)
 
 JBROWSE_WEB_VERSION=${JBROWSE_WEB_TAG:13}
 BLOGPOST_FILENAME=website/blog/$(date +"%Y-%m-%d")-jbrowse-web-${JBROWSE_WEB_VERSION}-release.md
 
-
-JBROWSE_DESKTOP_TAG=$(git tag --sort=-creatordate -l "@jbrowse/desktop*"|head -n1)
+JBROWSE_DESKTOP_TAG=$(git tag --sort=-creatordate -l "@jbrowse/desktop*" | head -n1)
 INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$JBROWSE_WEB_TAG/index.html
-JBROWSE_WEB_VERSION=$JBROWSE_WEB_VERSION JBROWSE_WEB_TAG=$JBROWSE_WEB_TAG JBROWSE_DESKTOP_TAG=$JBROWSE_DESKTOP_TAG DATE=$DATE NOTES=$NOTES perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' < scripts/blog_template.txt > $BLOGPOST_FILENAME
+JBROWSE_WEB_VERSION=$JBROWSE_WEB_VERSION JBROWSE_WEB_TAG=$JBROWSE_WEB_TAG JBROWSE_DESKTOP_TAG=$JBROWSE_DESKTOP_TAG DATE=$DATE NOTES=$NOTES perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
 
-
-INSTANCE=$INSTANCE node -p "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" > tmp.json
+INSTANCE=$INSTANCE node -p "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
 mv tmp.json website/docusaurus.config.json
-
 
 git add .
 git commit -m "[update docs] release"

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -72,7 +72,7 @@ In the directory where you would like to download JBrowse 2, run this command
 jbrowse create jbrowse2
 ```
 
-### Downloading using the JBrowse CLI
+### Downloading manually
 
 You can also download JBrowse 2 manually. Go to the
 [releases page](https://github.com/GMOD/jbrowse-components/releases/) of the


### PR DESCRIPTION
While trying to integrate changelog generation into the release process, I was having trouble making things clear to someone looking at the changelog. The biggest problem was that usually changelogs are grouped under a version number, but since all our packages are versioned independently, and the changelog is for the whole repository, that didn't work. Also, not every package is published during every release. Packages that have no changes are not published and don't have their versions bumped. I tried creating a table in the changelog of all the packages that were changed, what their new version is, if they are published to NPM or not, etc., but it got a bit complicated. It also seems like it would be difficult to decide individually for every package in each release whether the changes deserve a minor or patch bump.

That leads me to the biggest proposal in this PR: **Use lerna to lock all packages to the same version**. That way a changelog can refer to a specific version number, and it's easy to see which changes happened in which versions. Lerna will still only publish the packages that have changed if done this way, so not everything will be published under every version number. I know we decided on independent versioning at some point, but I couldn't remember the exact reason why. I thought this might be a good chance to reconsider that, since we just synchronized everything at 1.0.0, and it would be a straightforward switch.

The other problem I ran into is that some releases may not include a release of JBrowse Web. This could happen if, for example, after a release we found a critical bug in another product, like JBrowse Desktop, that we needed to publish a fix for quickly. If only JBrowse Desktop is changed, and not JBrowse Web, then the release would not include JBrowse Web. I had to change the release script and the automatic blog post to account for this.