### PR TITLE
Increase test timeout using jest.setTimeout

### DIFF
--- a/products/jbrowse-cli/src/commands/add-assembly.test.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.test.ts
@@ -26,6 +26,8 @@ const baseSequence = {
   adapter: {},
 }
 
+jest.setTimeout(10000)
+
 describe('add-assembly', () => {
   setup
     .command(['add-assembly', '{}'])


### PR DESCRIPTION
In #1471, it's noted that one of the CLI test files sometimes times out in CI. In `fancy-test` (which is what `oclif-test` is based on), there's a syntax for increasing the timeout for a test that looks like

```ts
const wait = (ms = 10) => new Promise(resolve => setTimeout(resolve, ms))

describe('timeout', () => {
  fancy
  .timeout(50)
  .it('times out after 50ms', async () => {
    await wait(100)
  })
})
```

However, this appears to be dependent on the test running under Mocha and doesn't work when run with Jest. I tried duplicating the behavior with a Jest-specific action, but didn't have any luck, since Jest and Mocha seem to handle timeouts too differently. We can set a longer timeout for all the tests in a single file, though, using `jest.setTimeout()`. I think this works well enough, and may be the best we can do if we want to continue using `oclif-test`.

Fixes #1471 