### PR TITLE
Fix CLI to allow jbrowse create to download newer monorepo tag format

### DIFF
--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -208,7 +208,7 @@ export default abstract class JBrowseCommand extends Command {
       }
     }
 
-    throw new Error('no @jbrowse/web tags found')
+    throw new Error('no tags found')
   }
 
   async *fetchVersions() {
@@ -224,9 +224,7 @@ export default abstract class JBrowseCommand extends Command {
         // eslint-disable-next-line no-await-in-loop
         result = (await response.json()) as GithubRelease[]
 
-        yield result.filter(release =>
-          release.tag_name.startsWith('@jbrowse/web'),
-        )
+        yield result.filter(release => release.tag_name.startsWith('v'))
         page++
       } else {
         throw new Error(`${response.statusText}`)

--- a/products/jbrowse-cli/src/commands/create.test.ts
+++ b/products/jbrowse-cli/src/commands/create.test.ts
@@ -11,7 +11,7 @@ const fsPromises = fs.promises
 
 const releaseArray = [
   {
-    tag_name: '@jbrowse/web@v0.0.1',
+    tag_name: 'v0.0.1',
     prerelease: false,
     assets: [
       {
@@ -23,15 +23,13 @@ const releaseArray = [
 
 function mockTagFail(gitHubApi: Scope) {
   return gitHubApi
-    .get(
-      '/repos/GMOD/jbrowse-components/releases/tags/@jbrowse/web@v999.999.999',
-    )
+    .get('/repos/GMOD/jbrowse-components/releases/tags/v999.999.999')
     .reply(404, {})
 }
 
 function mockTagSuccess(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases/tags/@jbrowse/web@v0.0.1')
+    .get('/repos/GMOD/jbrowse-components/releases/tags/v0.0.1')
     .reply(200, releaseArray[0])
 }
 
@@ -127,7 +125,7 @@ describe('create', () => {
   setup
     .nock('https://api.github.com', mockTagSuccess)
     .nock('https://example.com', mockZip)
-    .command(['create', 'jbrowse', '--tag', '@jbrowse/web@v0.0.1', '--force'])
+    .command(['create', 'jbrowse', '--tag', 'v0.0.1', '--force'])
     .it(
       'overwrites and succeeds in downloading JBrowse in a non-empty directory with version #',
       async ctx => {
@@ -138,13 +136,7 @@ describe('create', () => {
     )
   setup
     .nock('https://api.github.com', mockTagFail)
-    .command([
-      'create',
-      'jbrowse',
-      '--tag',
-      '@jbrowse/web@v999.999.999',
-      '--force',
-    ])
+    .command(['create', 'jbrowse', '--tag', 'v999.999.999', '--force'])
     .catch(/Could not find version/)
     .it('fails to download a version that does not exist')
   setup
@@ -160,7 +152,7 @@ describe('create', () => {
     .catch(/0/)
     .it('lists versions', ctx => {
       expect(ctx.stdoutWrite).toHaveBeenCalledWith(
-        'All JBrowse versions:\n@jbrowse/web@v0.0.1\n',
+        'All JBrowse versions:\nv0.0.1\n',
       )
     })
 })

--- a/products/jbrowse-cli/src/commands/upgrade.test.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.test.ts
@@ -11,7 +11,7 @@ const fsPromises = fs.promises
 
 const releaseArray = [
   {
-    tag_name: '@jbrowse/web@v0.0.2',
+    tag_name: 'v0.0.2',
     prerelease: false,
     assets: [
       {
@@ -20,7 +20,7 @@ const releaseArray = [
     ],
   },
   {
-    tag_name: '@jbrowse/web@v0.0.1',
+    tag_name: 'v0.0.1',
     prerelease: false,
     assets: [
       {
@@ -32,15 +32,13 @@ const releaseArray = [
 
 function mockTagFail(gitHubApi: Scope) {
   return gitHubApi
-    .get(
-      '/repos/GMOD/jbrowse-components/releases/tags/@jbrowse/web@v999.999.999',
-    )
+    .get('/repos/GMOD/jbrowse-components/releases/tags/v999.999.999')
     .reply(404, {})
 }
 
 function mockTagSuccess(gitHubApi: Scope) {
   return gitHubApi
-    .get('/repos/GMOD/jbrowse-components/releases/tags/@jbrowse/web@v0.0.1')
+    .get('/repos/GMOD/jbrowse-components/releases/tags/v0.0.1')
     .reply(200, releaseArray[1])
 }
 
@@ -104,7 +102,7 @@ describe('upgrade', () => {
   setup
     .nock('https://api.github.com', mockTagSuccess)
     .nock('https://example.com', mockV1Zip)
-    .command(['upgrade', '--tag', '@jbrowse/web@v0.0.1'])
+    .command(['upgrade', '--tag', 'v0.0.1'])
     .it('upgrades a directory with a specific version', async ctx => {
       expect(await fsPromises.readdir(ctx.dir)).toContain('manifest.json')
     })
@@ -116,7 +114,7 @@ describe('upgrade', () => {
     })
   setup
     .nock('https://api.github.com', mockTagFail)
-    .command(['upgrade', '--tag', '@jbrowse/web@v999.999.999'])
+    .command(['upgrade', '--tag', 'v999.999.999'])
     .catch(/Could not find version/)
     .it('fails to upgrade if version does not exist')
   setup


### PR DESCRIPTION
This is a possible fix for the jbrowse CLI to move to the new tagging style