### PR TITLE
Fix horizontally flipped translation frames position

### DIFF
--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -366,6 +366,7 @@ function Sequence(props: MyProps) {
               region={region}
               theme={theme}
               height={height}
+              reverse={region.reversed}
             />
           ))
         : null}
@@ -408,7 +409,7 @@ function Sequence(props: MyProps) {
               region={region}
               theme={theme}
               height={height}
-              reverse
+              reverse={!region.reversed}
             />
           ))
         : null}


### PR DESCRIPTION
Small fix to make it so that the translation frames flip from top to bottom when horizontally flipped. A last minute change on the sequence branch (making it so that it packs the position towards y=0 when certain things are hidden) made this get missed