### PR TITLE
Updates to release process

### DIFF
--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -41,6 +41,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./products/jbrowse-web/build/jbrowse-web-${RELEASE_VERSION}.zip
-          asset_name: jbrowse-web-${RELEASE_VERSION}.zip
+          asset_path: ./products/jbrowse-web/build/jbrowse-web-${{env.RELEASE_VERSION}}.zip
+          asset_name: jbrowse-web-${{env.RELEASE_VERSION}}.zip
           asset_content_type: application/zip

--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          draft: false
+          # This allows us to manually edit the release body text before publishing
+          draft: true
           prerelease: false
       - name: Upload jbrowse-web build
         id: upload-release-asset

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,11 +18,13 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
-      - name: Install deps
-        run: yarn
-      - run: |
+      - name: Install deps (with cache)
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: website
+      - name: Build website
+        run: |
           cd website/
-          yarn
           yarn build
           cd docs/
           make pdf # generate the pdfcombined.md, run pandoc in docker in the next step
@@ -31,9 +33,16 @@ jobs:
           cp listings.tex ../../
           cd ../../
           ln -s website/docs/img
+          cat <<EOF > entrypoint.sh
+          #!/bin/sh -l
+          /opt/texlive/texdir/bin/x86_64-linuxmusl/tlmgr install pmboxdraw
+          /usr/bin/pandoc --pdf-engine /opt/texlive/texdir/bin/x86_64-linuxmusl/pdflatex --listings -H listings.tex --toc -o website/jbrowse2.pdf website/docs/titlemod.md pdfcombined.md
+          EOF
+          chmod +x entrypoint.sh
+          cat entrypoint.sh
       - uses: docker://pandoc/latex:2.9
         with:
-          args: --listings -H listings.tex --toc -o website/jbrowse2.pdf website/docs/titlemod.md pdfcombined.md
+          entrypoint: /github/workspace/entrypoint.sh
       - name: Upload
         run: |
           cd website/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "changelog": "lerna-changelog",
     "useDist": "lerna run useDist --scope \"@jbrowse/plugin*\"",
     "useSrc": "lerna run useSrc --scope \"@jbrowse/plugin*\"",
-    "lerna-publish": "lerna publish --no-push",
+    "lerna-publish": "lerna publish",
     "lint": "eslint --report-unused-disable-directives --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
     "format": "prettier --write .",
     "check-format": "prettier --check .",

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -44,5 +44,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -322,7 +322,7 @@ OPTIONS
   -h, --help          show CLI help
   -l, --listVersions  Lists out all versions of JBrowse 2
 
-  -t, --tag=tag       Version of JBrowse 2 to install. Format is @jbrowse/web@0.0.1.
+  -t, --tag=tag       Version of JBrowse 2 to install. Format is v1.0.0.
                       Defaults to latest
 
   -u, --url=url       A direct URL to a JBrowse 2 release
@@ -331,7 +331,7 @@ EXAMPLES
   $ jbrowse create /path/to/new/installation
   $ jbrowse create /path/to/new/installation --force
   $ jbrowse create /path/to/new/installation --url url.com/directjbrowselink.zip
-  $ jbrowse create /path/to/new/installation --tag @jbrowse/web@0.0.1
+  $ jbrowse create /path/to/new/installation --tag v1.0.0
   $ jbrowse create --listVersions # Lists out all available versions of JBrowse 2
 ```
 
@@ -404,7 +404,7 @@ OPTIONS
   -h, --help          show CLI help
   -l, --listVersions  Lists out all versions of JBrowse 2
 
-  -t, --tag=tag       Version of JBrowse 2 to install. Format is @jbrowse/web@0.0.1.
+  -t, --tag=tag       Version of JBrowse 2 to install. Format is v1.0.0.
                       Defaults to latest
 
   -u, --url=url       A direct URL to a JBrowse 2 release
@@ -412,7 +412,7 @@ OPTIONS
 EXAMPLES
   $ jbrowse upgrade # Upgrades current directory to latest jbrowse release
   $ jbrowse upgrade /path/to/jbrowse2/installation
-  $ jbrowse upgrade /path/to/jbrowse2/installation --tag @jbrowse/web@0.0.1
+  $ jbrowse upgrade /path/to/jbrowse2/installation --tag v1.0.0
   $ jbrowse upgrade --listVersions # Lists out all available versions of JBrowse 2
   $ jbrowse upgrade --url https://sample.com/jbrowse2.zip
 ```

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -208,7 +208,7 @@ export default abstract class JBrowseCommand extends Command {
       }
     }
 
-    throw new Error('no tags found')
+    throw new Error('no version tags found')
   }
 
   async *fetchVersions() {

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -14,7 +14,7 @@ export default class Create extends JBrowseCommand {
     '$ jbrowse create /path/to/new/installation',
     '$ jbrowse create /path/to/new/installation --force',
     '$ jbrowse create /path/to/new/installation --url url.com/directjbrowselink.zip',
-    '$ jbrowse create /path/to/new/installation --tag @jbrowse/web@0.0.1',
+    '$ jbrowse create /path/to/new/installation --tag v1.0.0',
     '$ jbrowse create --listVersions # Lists out all available versions of JBrowse 2',
   ]
 
@@ -45,7 +45,7 @@ export default class Create extends JBrowseCommand {
     tag: flags.string({
       char: 't',
       description:
-        'Version of JBrowse 2 to install. Format is @jbrowse/web@0.0.1.\nDefaults to latest',
+        'Version of JBrowse 2 to install. Format is v1.0.0.\nDefaults to latest',
     }),
   }
 

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -11,7 +11,7 @@ export default class Upgrade extends JBrowseCommand {
   static examples = [
     '$ jbrowse upgrade # Upgrades current directory to latest jbrowse release',
     '$ jbrowse upgrade /path/to/jbrowse2/installation',
-    '$ jbrowse upgrade /path/to/jbrowse2/installation --tag @jbrowse/web@0.0.1',
+    '$ jbrowse upgrade /path/to/jbrowse2/installation --tag v1.0.0',
     '$ jbrowse upgrade --listVersions # Lists out all available versions of JBrowse 2',
     '$ jbrowse upgrade --url https://sample.com/jbrowse2.zip',
   ]
@@ -41,7 +41,7 @@ export default class Upgrade extends JBrowseCommand {
     tag: flags.string({
       char: 't',
       description:
-        'Version of JBrowse 2 to install. Format is @jbrowse/web@0.0.1.\nDefaults to latest',
+        'Version of JBrowse 2 to install. Format is v1.0.0.\nDefaults to latest',
     }),
     url: flags.string({
       char: 'u',

--- a/scripts/blog_template.txt
+++ b/scripts/blog_template.txt
@@ -1,5 +1,5 @@
 ---
-title: ${VERSION} Release
+title: ${RELEASE_TAG} Release
 date: ${DATE}
 tags: ['release','jbrowse 2']
 ---
@@ -8,7 +8,7 @@ ${NOTES}
 
 ## Downloads
 
-- [${JBROWSE_WEB_TAG}](https://github.com/GMOD/jbrowse-components/releases/tag/${JBROWSE_WEB_TAG})
+- [${RELEASE_TAG}](https://github.com/GMOD/jbrowse-components/releases/tag/${RELEASE_TAG})
 
 To install JBrowse 2 for the web, you can download the link above, or you can
 use the JBrowse CLI to automatically download the latest version. See the

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -2,12 +2,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const spawn = require('cross-spawn')
 
-function main(version, changed) {
-  const lernaChangelog = spawn.sync(
-    'yarn',
-    ['--silent', 'lerna-changelog', '--next-version', version],
-    { encoding: 'utf8' },
-  ).stdout
+function main(changed) {
+  const lernaChangelog = spawn.sync('yarn', ['--silent', 'lerna-changelog'], {
+    encoding: 'utf8',
+  }).stdout
   const changelogLines = lernaChangelog.split('\n')
   const changedPackages = JSON.parse(changed)
   const updatesTable = ['| Package | Download |', '| --- | --- |']
@@ -32,12 +30,8 @@ function main(version, changed) {
   console.log(`${changelogLines.join('\n')}\n`)
 }
 
-const version = process.argv[2]
-if (!version) {
-  throw new Error('No version provided')
-}
-const changed = process.argv[3]
+const changed = process.argv[2]
 if (!changed) {
   throw new Error('No list of changed packages provided')
 }
-main(version, changed)
+main(changed)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,44 +17,31 @@ DATE=$(date +"%Y-%m-%d")
 # Packages that have changed and will have their version bumped
 CHANGED=$(yarn --silent lerna changed --all --json)
 
-# Run lerna publish --no-push
-yarn run lerna-publish "$3"
+# Run lerna version first, publish after changelog and blog post have been created
+yarn lerna version --no-push --message "[update docs] %s" "$3"
 
-# Get the new after publishing from lerna.json
+# Get the new version after versioning from lerna.json
 VERSION=$(node --print "const lernaJson = require('./lerna.json'); lernaJson.version")
+RELEASE_TAG=v$VERSION
 
-# Get the latest JBrowse Web tag. If JBrowse Web was not in CHANGED, this tag
-# will be from a previous version.
-# Have to avoid overlap with @jbrowse/website
-JBROWSE_WEB_TAG=$(git tag --sort=-creatordate --list "@jbrowse/web@*" | head --lines 1)
-
-# If JBrowse Web was in the list of changed packages
-if grep --quiet "@jbrowse/web" <<<"$CHANGED"; then
-  ## This pushes only the @jbrowse/web tag first because a flood of tags causes
-  ## the CI system to skip the build
-  git push origin tag "@jbrowse/web*"
-  echo "Waiting while the new jbrowse-web tag is processed on github actions before pushing the rest of the tags"
-  sleep 30
-
-  # Updates the "Browse demo instance" link on the homepage
-  INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$JBROWSE_WEB_TAG/index.html
-  INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
-  mv tmp.json website/docusaurus.config.json
-fi
+# Updates the "Browse demo instance" link on the homepage
+INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$RELEASE_TAG/index.html
+INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
+mv tmp.json website/docusaurus.config.json
 
 # Generates a changelog with a section added listing the packages that were
 # included in this release
-CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$VERSION" "$CHANGED")
+CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$CHANGED")
 # Add the changelog to the top of CHANGELOG.md
 echo "$CHANGELOG" >tmp.md
 cat CHANGELOG.md >>tmp.md
 mv tmp.md CHANGELOG.md
 
-## Blogpost run after lerna publish, to get the accurate tags
-BLOGPOST_FILENAME=website/blog/${DATE}-${VERSION}-release.md
-VERSION=$VERSION DATE=$DATE NOTES=$NOTES CHANGELOG=$CHANGELOG JBROWSE_WEB_TAG=$JBROWSE_WEB_TAG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
+## Blogpost run after lerna version, to get the accurate tags
+BLOGPOST_FILENAME=website/blog/${DATE}-${RELEASE_TAG}-release.md
+RELEASE_TAG=$RELEASE_TAG DATE=$DATE NOTES=$NOTES CHANGELOG=$CHANGELOG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
 
 git add .
-git commit --message "[update docs] release"
-## Push the rest of the tags
+git commit --amend --no-edit
+yarn lerna publish from-git
 git push --follow-tags


### PR DESCRIPTION
These are some more changes to the release process after learning some things doing the last release. Using our new synchronized versioning scheme, lerna just does one tag for each version and not a tag for each package. Big changes:

- Build jbrowse-web for each version tag, even if internally the jbrowse-web package doesn't change
- Make workflow-generated GitHub release a draft so we can manually change the description (e.g. add changelog) before publishing
- Fix website build (was missing a texlive package)
- Publish `@jbrowse/plugin-circular-view` (see #1502)