### PR TITLE
Use jbrowse.org link for the alias files to fix CORS errors

### DIFF
--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -24,7 +24,7 @@
         "adapter": {
           "type": "RefNameAliasAdapter",
           "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt"
+            "uri": "https://jbrowse.org/genomes/hg19/hg19_aliases.txt"
           }
         }
       }
@@ -52,7 +52,7 @@
         "adapter": {
           "type": "RefNameAliasAdapter",
           "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
+            "uri": "https://jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
           }
         }
       }


### PR DESCRIPTION
Currently, every time I load up the app I get a CORS error for this file

![Screenshot from 2020-11-30 15-52-21](https://user-images.githubusercontent.com/6511937/100663289-10492380-3324-11eb-801b-5a0b3e930482.png)

This is the whole screenshot I see almost every app load

```
Access to fetch at 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
rangeFetcher.ts:13 GET https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt net::ERR_FAILED
getfetch @ rangeFetcher.ts:13


```

It has been hypothesized that this is due to weird amazon throttling, because it is intermittent and doesn't affect all users

Ian also ran into this for a VCF file once, which makes it somewhat concerning that it would affect other users

This change would specifically help me, because the cloudfront'ed file has no issue, hence this tiny change.


It is some question of whether this should be done to more of our files. I don't know the details or implications of making cloudfront host giant files that we range request against (could be expensive)



