### PR TITLE
Add explicit scrollbar

### DIFF
--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -17,11 +17,19 @@ const useStyles = makeStyles(theme => ({
     html: {
       'font-family': 'Roboto',
     },
-    '::-webkit-scrollbar': {
+    /* Based on: https://www.digitalocean.com/community/tutorials/css-scrollbars */
+    /* The emerging W3C standard
+       that is currently Firefox-only */
+    '*': {
+      'scrollbar-width': 'thin',
+      'scrollbar-color': 'rgba(0,0,0,.5) rgba(128,128,128)',
+    },
+    /* Works on Chrome/Edge/Safari */
+    '*::-webkit-scrollbar': {
       '-webkit-appearance': 'none',
       width: '12px',
     },
-    '::-webkit-scrollbar-thumb': {
+    '*::-webkit-scrollbar-thumb': {
       'background-color': 'rgba(0,0,0,.5)',
       '-webkit-box-shadow': '0 0 1px rgba(255,255,255,.5)',
     },

--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -17,6 +17,14 @@ const useStyles = makeStyles(theme => ({
     html: {
       'font-family': 'Roboto',
     },
+    '::-webkit-scrollbar': {
+      '-webkit-appearance': 'none',
+      width: '12px',
+    },
+    '::-webkit-scrollbar-thumb': {
+      'background-color': 'rgba(0,0,0,.5)',
+      '-webkit-box-shadow': '0 0 1px rgba(255,255,255,.5)',
+    },
   },
   root: {
     display: 'grid',

--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles(theme => ({
     /* The emerging W3C standard
        that is currently Firefox-only */
     '*': {
-      'scrollbar-width': 'thin',
+      'scrollbar-width': 'auto',
       'scrollbar-color': 'rgba(0,0,0,.5) rgba(128,128,128)',
     },
     /* Works on Chrome/Edge/Safari */


### PR DESCRIPTION
This closes #1500 by adding explicit CSS to make the scrollbar show up. Works for me, I'd be curious to hear from Linux users  (@garrettjstevens and @cmdcolin )

View:

![image](https://user-images.githubusercontent.com/19295181/100663657-7d03f400-330b-11eb-8f7d-8e4e7fc2713d.png)

Should work on all modern browsers.