### PR TITLE
Add some uniprot tracks to demo data

### DIFF
--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@gmod/bbi": "^1.0.30",
-    "@gmod/bed": "^2.0.3",
+    "@gmod/bed": "^2.0.4",
     "@gmod/tabix": "^1.4.6"
   },
   "peerDependencies": {

--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -50,6 +50,13 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
     return Object.keys((await this.bigbed.getHeader()).refsByName)
   }
 
+  async getHeader(opts?: BaseOptions) {
+    const { version, fileType } = await this.bigbed.getHeader(opts)
+    // @ts-ignore
+    const { autoSql } = await this.parser
+    return { version, fileType, autoSql }
+  }
+
   public async refIdToName(refId: number) {
     return ((await this.bigbed.getHeader()).refsByNumber[refId] || {}).name
   }

--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -54,7 +54,12 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
     const { version, fileType } = await this.bigbed.getHeader(opts)
     // @ts-ignore
     const { autoSql } = await this.parser
-    return { version, fileType, autoSql }
+    const { fields, ...rest } = autoSql
+    const f = Object.fromEntries(
+      // @ts-ignore
+      fields.map(({ name, comment }) => [name, comment]),
+    )
+    return { version, fileType, autoSql: { ...rest }, fields: f }
   }
 
   public async refIdToName(refId: number) {

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2122,6 +2122,84 @@
           "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/knownGene.bb"
         }
       }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "snp151.bed4",
+      "name": "snp151.bed4",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/vai/snp151.bed4.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "snp137",
+      "name": "snp137",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/vai/snp137.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "snp151_hg38",
+      "name": "snp151_hg38",
+      "category": ["Variation"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/vai/snp151.bed4.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "gnomad_v2.1_sv.sites",
+      "name": "gnomad_v2.1_sv.sites",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/gnomAD/structuralVariants/gnomad_v2.1_sv.sites.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "missenseConstrained",
+      "name": "missenseConstrained",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/gnomAD/missense/missenseConstrained.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "pliByGene",
+      "name": "pliByGene",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/gnomAD/pLI/pliByGene.bb"
+        }
+      }
     }
   ],
   "connections": [],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2165,7 +2165,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "gnomad_v2.1_sv.sites",
-      "name": "gnomad_v2.1_sv.sites",
+      "name": "Gnomad - v2.1 SVs",
       "category": ["Variation"],
       "assemblyNames": ["hg19"],
       "adapter": {
@@ -2178,7 +2178,7 @@
     {
       "type": "FeatureTrack",
       "trackId": "missenseConstrained",
-      "name": "missenseConstrained",
+      "name": "Gnomad - missense constraint",
       "category": ["Variation"],
       "assemblyNames": ["hg19"],
       "adapter": {
@@ -2191,13 +2191,78 @@
     {
       "type": "FeatureTrack",
       "trackId": "pliByGene",
-      "name": "pliByGene",
+      "name": "Gnomad - probability of loss-of-function intolerant (pLI) by gene",
       "category": ["Variation"],
       "assemblyNames": ["hg19"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
           "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/gnomAD/pLI/pliByGene.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "dgvGold",
+      "name": "dgvGold",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/dgv/dgvGold.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "dgvMerged",
+      "name": "dgvMerged",
+      "category": ["Variation"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/dgv/dgvMerged.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "dgvSupporting",
+      "name": "dgvSupporting",
+      "category": ["Variation"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/dgv/dgvSupporting.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "dgvMerged_hg19",
+      "name": "dgvMerged",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/dgv/dgvMerged.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "dgvSupporting_hg19",
+      "name": "dgvSupporting",
+      "category": ["Variation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/dgv/dgvSupporting.bb"
         }
       }
     }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -1654,6 +1654,474 @@
           "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinGen/clinGenTriplo.bb"
         }
       }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipAliSwissprot",
+      "name": "unipAliSwissprot",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipAliSwissprot.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipAliTrembl",
+      "name": "unipAliTrembl",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipAliTrembl.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipChain",
+      "name": "unipChain",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipChain.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipConflict",
+      "name": "unipConflict",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipConflict.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipDisulfBond",
+      "name": "unipDisulfBond",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipDisulfBond.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipDomain",
+      "name": "unipDomain",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipDomain.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipInterest",
+      "name": "unipInterest",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipInterest.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocCytopl",
+      "name": "unipLocCytopl",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipLocCytopl.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocExtra",
+      "name": "unipLocExtra",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipLocExtra.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocSignal",
+      "name": "unipLocSignal",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipLocSignal.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocTransMemb",
+      "name": "unipLocTransMemb",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipLocTransMemb.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipModif",
+      "name": "unipModif",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipModif.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipMut",
+      "name": "unipMut",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipMut.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipOther",
+      "name": "unipOther",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipOther.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipRepeat",
+      "name": "unipRepeat",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipRepeat.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipSplice",
+      "name": "unipSplice",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipSplice.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipStruct",
+      "name": "unipStruct",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/uniprot/unipStruct.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipAliSwissprot_hg38",
+      "name": "unipAliSwissprot_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipAliSwissprot.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipAliTrembl_hg38",
+      "name": "unipAliTrembl_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipAliTrembl.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipChain_hg38",
+      "name": "unipChain_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipChain.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipConflict_hg38",
+      "name": "unipConflict_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipConflict.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipDisulfBond_hg38",
+      "name": "unipDisulfBond_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipDisulfBond.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipDomain_hg38",
+      "name": "unipDomain_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipDomain.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipInterest_hg38",
+      "name": "unipInterest_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipInterest.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocCytopl_hg38",
+      "name": "unipLocCytopl_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipLocCytopl.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocExtra_hg38",
+      "name": "unipLocExtra_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipLocExtra.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocSignal_hg38",
+      "name": "unipLocSignal_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipLocSignal.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipLocTransMemb_hg38",
+      "name": "unipLocTransMemb_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipLocTransMemb.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipModif_hg38",
+      "name": "unipModif_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipModif.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipMut_hg38",
+      "name": "unipMut_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipMut.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipOther_hg38",
+      "name": "unipOther_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipOther.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipRepeat_hg38",
+      "name": "unipRepeat_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipRepeat.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipSplice_hg38",
+      "name": "unipSplice_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipSplice.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "unipStruct_hg38",
+      "name": "unipStruct_hg38",
+      "category": ["Uniprot"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/uniprot/unipStruct.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "knownGene",
+      "name": "knownGene",
+      "category": ["Annotation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/knownGene.bb"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "knownGene_hg38",
+      "name": "knownGene_hg38",
+      "category": ["Annotation"],
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg38/knownGene.bb"
+        }
+      }
     }
   ],
   "connections": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,10 +3952,10 @@
     quick-lru "^4.0.0"
     rxjs "^6.5.2"
 
-"@gmod/bed@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@gmod/bed/-/bed-2.0.3.tgz#d4eea0b613b13a197d0465c6e5f22d2cb9f83f05"
-  integrity sha512-tV4U9pdyEz5nozGW8FosDgAXVbUfteszNJeeZtDUpQzO7/2OnQHCnAjskGoUnaZ1zRaMNEz7I9dwySeEtTjlcQ==
+"@gmod/bed@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@gmod/bed/-/bed-2.0.4.tgz#44228a731a6b522f8b08502f676867fe09ab957c"
+  integrity sha512-qKwXAdutelLNS2ivSv0RKTsdq9D7GFa89HEn/T6tnZbFPHKYf4piYZvHFhbmamh/9/nouqD7EM8ZL9FfMQoulQ==
 
 "@gmod/bgzf-filehandle@^1.2.4", "@gmod/bgzf-filehandle@^1.3.3", "@gmod/bgzf-filehandle@^1.3.4":
   version "1.3.4"


### PR DESCRIPTION
Just a small proposal to add functional tracks for protein-to-genome mappings

Source
http://genome.ucsc.edu/goldenPath/newsarch.html#120220

Directly linked to bigbeds on the ucsc server

Used script like this to load

```
 while read p; do echo $p; jbrowse add-track $p --out test_data/config_demo.json --category Uniprot --assemblyNames hg38 --trackId `basename $p .bb`_hg38; done < test.txt
```

after creating a text.txt with multiple URLs