### PR TITLE
Release and workflow updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,1 @@
+'needs label triage': '*'

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,0 +1,19 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    if: |
+      !(
+        contains(github.event.pull_request.labels.*.name, "breaking") ||
+        contains(github.event.pull_request.labels.*.name, "enhancement") ||
+        contains(github.event.pull_request.labels.*.name, "bug") ||
+        contains(github.event.pull_request.labels.*.name, "documentation") ||
+        contains(github.event.pull_request.labels.*.name, "internal")
+      )
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
-      - name: Install deps and build (with cache)
+      - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Test codebase
         run: yarn test-ci
@@ -30,16 +30,19 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
-      - name: Install deps and build (with cache)
+      - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build codebase
         run: yarn build
       - name: Test build
         run: BUILT_TESTS=1 yarn built-test-ci
+      - name: Install website deps (with cache)
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: website
       - name: Build website
         run: |
           cd website/
-          yarn
           yarn build
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/README.md
+++ b/README.md
@@ -46,11 +46,39 @@ Either cd to products/jbrowse-web or products/jbrowse-desktop and run `yarn star
 
 ## Developers
 
-To make a release of jbrowse-components tools, run the following
+### Releasing/publishing
 
-```sh
-scripts/release.sh blogpost.txt
+There is a script `scripts/release.sh` that will publish the public packages in
+the monorepo to NPM and trigger the creation of a release on GitHub. To run this
+script:
+
+- Create a file outside the monorepo with a blog post about the release. Usually
+  this includes an overview of the major bugfixes and/or features being
+  released. The release script will automatically add download and detailed
+  changelog information to this post. You can see examples at
+  https://jbrowse.org/jb2/blog.
+- Make sure you have a GitHub access token with public_repo scope. To generate
+  one, go to https://github.com/settings/tokens, click "Generate new token," add
+  a note describing what you want the token to be for, select the "public_repo"
+  checkbox (under "repo"), and then click "Generate token." Make sure to save
+  this token in a safe place to use for future releases as you won't be able to
+  see it again. If you do lose your token, delete/revoke the token you lost and
+  generate a new one.
+- Decide if the release should have a major, minor, or patch level version
+  increase. All packages that are published will get the same version number.
+
+Run the script like this:
+
+```
+scripts/release.sh /path/to/blogpost.md myGitHubAuthToken versionIncreaseLevel
 ```
 
-This will analyze which packages have changed, and prompt you to publish each
-package in the monorepo individually.
+If you don't provide `versionIncreaseLevel`, it will default to "patch".
+
+This will trigger a GitHub workflow that will build JBrowse Web and create a
+draft release on GitHub. Once the draft release has been created (you can look
+for it [here](https://github.com/GMOD/jbrowse-components/releases)), go to the
+release and click "Edit," then add a description to the release. Usually you can
+copy the content of the blog post that was generated (it will be named something
+like `website/blog/${DATE}-${RELEASE_TAG}-release.md`), removing the "Downloads"
+section. Finally, click "Publish release."

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "requestidlecallback-polyfill": "^1.0.2",
     "rimraf": "^3.0.2",
     "rxjs": "^6.0.0",
+    "semver": "^7.3.4",
     "standard-changelog": "^2.0.7",
     "ts-loader": "^7.0.5",
     "ts-node": "^8",

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -10,7 +10,11 @@
   "license": "Apache-2.0",
   "homepage": "https://jbrowse.org",
   "bugs": "https://github.com/GMOD/jbrowse-components/issues",
-  "repository": "https://github.com/GMOD/jbrowse-components.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GMOD/jbrowse-components.git",
+    "directory": "products/jbrowse-cli"
+  },
   "author": "JBrowse Team",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -2,10 +2,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const spawn = require('cross-spawn')
 
-function main(changed) {
-  const lernaChangelog = spawn.sync('yarn', ['--silent', 'lerna-changelog'], {
-    encoding: 'utf8',
-  }).stdout
+function main(changed, version) {
+  const lernaChangelog = spawn.sync(
+    'yarn',
+    ['--silent', 'lerna-changelog', '--next-version', version],
+    { encoding: 'utf8' },
+  ).stdout
   const changelogLines = lernaChangelog.split('\n')
   const changedPackages = JSON.parse(changed)
   const updatesTable = ['| Package | Download |', '| --- | --- |']
@@ -34,4 +36,8 @@ const changed = process.argv[2]
 if (!changed) {
   throw new Error('No list of changed packages provided')
 }
-main(changed)
+const version = process.argv[3]
+if (!version) {
+  throw new Error('No new version provided')
+}
+main(changed, version)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,23 +5,20 @@
 # argument is a personal access token for the GitHub API with `public_repo`
 # scope. You can generate a token at https://github.com/settings/tokens
 # The third optional argument is a flag for the publishing command for version
-# bump. If not provided, the publishing command will prompt you.
+# bump. If not provided, it will default to "patch".
 
 ## Precautionary bash tags
 set -e
 set -o pipefail
 
-# Blog post text
-NOTES=$(cat "$1")
-DATE=$(date +"%Y-%m-%d")
-# Packages that have changed and will have their version bumped
-CHANGED=$(yarn --silent lerna changed --all --json)
+[[ -n "$1" ]] || { echo "No blogpost file provided" && exit 1; }
+[[ -n "$2" ]] || { echo "No GITHUB_AUTH token provided" && exit 1; }
+[[ -n "$3" ]] && SEMVER_LEVEL="$3" || SEMVER_LEVEL="patch"
 
-# Run lerna version first, publish after changelog and blog post have been created
-yarn lerna version --no-push --message "[update docs] %s" "$3"
-
-# Get the new version after versioning from lerna.json
-VERSION=$(node --print "const lernaJson = require('./lerna.json'); lernaJson.version")
+# Get the version before release from lerna.json
+PREVIOUS_VERSION=$(node --print "const lernaJson = require('./lerna.json'); lernaJson.version")
+# Use semver to get the new version from the semver level
+VERSION=$(yarn --silent semver --increment "$SEMVER_LEVEL" "$PREVIOUS_VERSION")
 RELEASE_TAG=v$VERSION
 
 # Updates the "Browse demo instance" link on the homepage
@@ -29,19 +26,26 @@ INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$RELEASE_TAG/index.html
 INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
 mv tmp.json website/docusaurus.config.json
 
+# Packages that have changed and will have their version bumped
+CHANGED=$(yarn --silent lerna changed --all --json)
 # Generates a changelog with a section added listing the packages that were
 # included in this release
-CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$CHANGED")
+CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$CHANGED" "$VERSION")
 # Add the changelog to the top of CHANGELOG.md
 echo "$CHANGELOG" >tmp.md
+echo "" >tmp.md
 cat CHANGELOG.md >>tmp.md
 mv tmp.md CHANGELOG.md
 
+# Blog post text
+NOTES=$(cat "$1")
+DATE=$(date +"%Y-%m-%d")
 ## Blogpost run after lerna version, to get the accurate tags
 BLOGPOST_FILENAME=website/blog/${DATE}-${RELEASE_TAG}-release.md
 RELEASE_TAG=$RELEASE_TAG DATE=$DATE NOTES=$NOTES CHANGELOG=$CHANGELOG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
 
 git add .
-git commit --amend --no-edit
-yarn lerna publish from-git
-git push --follow-tags
+git commit --message "Prepare for $RELEASE_TAG release"
+
+# Run lerna version first, publish after changelog and blog post have been created
+yarn lerna publish "$SEMVER_LEVEL" --message "[update docs] %s"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22384,6 +22384,13 @@ semver@^7.1.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
These are some adjustments to the release process determined after releasing v1.0.2. The biggest change is that the release script uses `semver` to get the new version number before `yarn lerna publish` is run. That way it can generate the blog post and changelog with the new version number and commit them before tagging and publishing the release.

Also includes a couple GitHub workflow updates:

- update the build job to install the website deps with a cache to help it be a bit faster
- add a new workflow that will add a "needs label triage" label to a PR if it doesn't have a changelog label

