### PR TITLE
Avoid large object hash on SV inspector load

### DIFF
--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -1,6 +1,5 @@
 import { Observable, merge } from 'rxjs'
 import { takeUntil } from 'rxjs/operators'
-import objectHash from 'object-hash'
 import { isStateTreeNode, getSnapshot } from 'mobx-state-tree'
 import { ObservableCreate } from '../util/rxjs'
 import { checkAbortSignal, observeAbortSignal } from '../util'
@@ -29,6 +28,7 @@ export type AnyDataAdapter = BaseFeatureDataAdapter | BaseRefNameAliasAdapter
 
 // generates a short "id fingerprint" from the config passed to the base
 // feature adapter by recursively enumerating props up to an ID of length 100
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function idMaker(args: any, id = '') {
   const keys = Object.keys(args)
   for (let i = 0; i < keys.length; i++) {

--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -27,6 +27,24 @@ export interface AdapterConstructor {
 
 export type AnyDataAdapter = BaseFeatureDataAdapter | BaseRefNameAliasAdapter
 
+// generates a short "id fingerprint" from the config passed to the base
+// feature adapter by recursively enumerating props up to an ID of length 100
+function idMaker(args: any, id = '') {
+  const keys = Object.keys(args)
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    if (id.length > 100) {
+      break
+    }
+    if (typeof args[key] === 'object') {
+      id += idMaker(args[key], id)
+    } else {
+      id += `${key}-${args[key]};`
+    }
+  }
+  return id.slice(0, 100)
+}
+
 /**
  * Base class for feature adapters to extend. Defines some methods that
  * subclasses must implement.
@@ -39,7 +57,7 @@ export abstract class BaseFeatureDataAdapter {
     // in test environment
     if (typeof jest === 'undefined') {
       const data = isStateTreeNode(args) ? getSnapshot(args) : args
-      this.id = objectHash(data, { ignoreUnknown: true }).slice(0, 5)
+      this.id = idMaker(data)
     } else {
       this.id = 'test'
     }


### PR DESCRIPTION
Found with @elliothershberg on #1518 

The SV inspector makes a FromConfigAdapter of the features in the spreadsheet, but the BaseAdapter calculates a adapter ID using objectHash of the constructor's args (comment in diff explains purpose of that id)


We saw that the objectHash was consuming an endlessly large amount of memory (2gb, at which point it seemed to be struggling, which is good to know maybe....probably keeping whole app memory under 2gb is a good marker) basically with the large config.features input


This uses math.random just out of convenience but could use shortid, etc.


