### PR TITLE
Move loading flag for spreadsheet import wizard to volatile to avoid it persisting across refresh

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -33,7 +33,6 @@ export default (pluginManager: PluginManager) => {
   return types
     .model('SpreadsheetImportWizard', {
       fileType: types.optional(types.enumeration(fileTypes), 'CSV'),
-      loading: false,
       hasColumnNameLine: true,
       columnNameLineNumber: 1,
       selectedAssemblyIdx: 0,
@@ -43,6 +42,7 @@ export default (pluginManager: PluginManager) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fileSource: undefined as any,
       error: undefined as Error | undefined,
+      loading: false,
     }))
     .views(self => ({
       get isReadyToOpen() {


### PR DESCRIPTION
This is a small change to make the spreadsheet loading flag volatile to avoid it accidentally persisting across refreshes