### PR TITLE
Add spreadsheet filter support for derived columns

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/Spreadsheet.js
@@ -205,13 +205,11 @@ export default pluginManager => {
         </th>
         {columnDisplayOrder.map(colNumber => (
           <td key={colNumber}>
-            {rowModel.cellsWithDerived.length > colNumber ? (
-              <CellData
-                cell={rowModel.cellsWithDerived[colNumber]}
-                spreadsheetModel={spreadsheetModel}
-                columnNumber={colNumber}
-              />
-            ) : null}
+            <CellData
+              cell={rowModel.cellsWithDerived[colNumber]}
+              spreadsheetModel={spreadsheetModel}
+              columnNumber={colNumber}
+            />
           </td>
         ))}
       </tr>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
@@ -136,8 +136,8 @@ export default ({ jbrequire }) => {
 
         const { firstNumber, secondNumber, operation, columnNumber } = self // avoid closing over self
         return function stringPredicate(sheet, row) {
-          const { cells } = row
-          const cell = cells[columnNumber]
+          const { cellsWithDerived } = row
+          const cell = cellsWithDerived[columnNumber]
 
           if (!cell || !cell.text) return false
 

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
@@ -136,9 +136,8 @@ export default pluginManager => {
         }
         const s = stringToFind.toLowerCase() // case insensitive match
         return function stringPredicate(sheet, row) {
-          const { cells } = row
-          const cell = cells[columnNumber]
-          // TODO: add support for derived cells
+          const { cellsWithDerived } = row
+          const cell = cellsWithDerived[columnNumber]
           if (!cell || !cell.text) return false
           const predicate = OPERATION_PREDICATES[operation]
           if (!predicate)

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/FilterControls.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/FilterControls.ts
@@ -25,16 +25,15 @@ export default (pluginManager: PluginManager) => {
         s = s.toLowerCase()
         return function stringPredicate(
           _sheet: unknown,
-          row: { cells: { text: string }[] },
+          row: { cellsWithDerived: { text: string }[] },
         ) {
-          const { cells } = row
+          const { cellsWithDerived } = row
           for (
             let columnNumber = 0;
-            columnNumber < cells.length;
+            columnNumber < cellsWithDerived.length;
             columnNumber += 1
           ) {
-            const cell = cells[columnNumber]
-            // TODO: add support for derived cells
+            const cell = cellsWithDerived[columnNumber]
             // note: case insensitive
             if (cell.text && cell.text.toLowerCase().includes(s)) return true
           }


### PR DESCRIPTION
#1158 introduced derived columns for BED and VCF files. This caused issues with the filtering functionality in the spreadsheet. This PR adds minor fixes to add support for filtering the spreadsheet using these derived columns.