### PR TITLE
Add track menu options for autoscale, log scale, histogram fill, setting min/max score, and zoom level/resolution for wiggle/snpcoverage tracks

### DIFF
--- a/config/jest/console.js
+++ b/config/jest/console.js
@@ -4,7 +4,11 @@ const originalWarn = console.warn
 // this is here to silence a warning related to useStaticRendering
 // xref https://github.com/GMOD/jbrowse-components/issues/1277
 jest.spyOn(console, 'error').mockImplementation((...args) => {
-  if (typeof args[0] === 'string' && args[0].includes('useLayoutEffect')) {
+  if (
+    typeof args[0] === 'string' &&
+    (args[0].includes('useLayoutEffect') ||
+      args[0].includes('useResizeContainer'))
+  ) {
     return undefined
   }
   return originalError.call(console, args)

--- a/config/jest/console.js
+++ b/config/jest/console.js
@@ -4,18 +4,13 @@ const originalWarn = console.warn
 // this is here to silence a warning related to useStaticRendering
 // xref https://github.com/GMOD/jbrowse-components/issues/1277
 jest.spyOn(console, 'error').mockImplementation((...args) => {
-  if (
-    typeof args[0] === 'string' &&
-    (args[0].includes('useLayoutEffect') ||
-      args[0].includes('useResizeContainer'))
-  ) {
+  if (typeof args[0] === 'string' && args[0].includes('useLayoutEffect')) {
     return undefined
   }
   return originalError.call(console, args)
 })
 
-// this is here to silence a warning related to @material-ui/data-grid
-// not precisely sure why it warns but this error is silenced during test
+// this is here to silence a warning related to useResizeContainer for @material-ui/data-grid
 jest.spyOn(console, 'warn').mockImplementation((...args) => {
   if (typeof args[0] === 'string' && args[0].includes('useResizeContainer')) {
     return undefined

--- a/config/jest/console.js
+++ b/config/jest/console.js
@@ -10,7 +10,8 @@ jest.spyOn(console, 'error').mockImplementation((...args) => {
   return originalError.call(console, args)
 })
 
-// this is here to silence a warning related to useResizeContainer for @material-ui/data-grid
+// this is here to silence a warning related to @material-ui/data-grid
+// not precisely sure why it warns but this error is silenced during test
 jest.spyOn(console, 'warn').mockImplementation((...args) => {
   if (typeof args[0] === 'string' && args[0].includes('useResizeContainer')) {
     return undefined

--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -52,7 +52,7 @@ function idMaker(args: any, id = '') {
 export abstract class BaseFeatureDataAdapter {
   public id: string
 
-  static capabilities = []
+  static capabilities = [] as string[]
 
   constructor(args: unknown = {}) {
     // note: we use switch on jest here for more simple feature IDs

--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -52,6 +52,8 @@ function idMaker(args: any, id = '') {
 export abstract class BaseFeatureDataAdapter {
   public id: string
 
+  static capabilities = []
+
   constructor(args: unknown = {}) {
     // note: we use switch on jest here for more simple feature IDs
     // in test environment

--- a/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
+++ b/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
@@ -14,7 +14,7 @@ export const BaseDisplay = types
   })
   .volatile(() => ({
     rendererTypeName: '',
-    error: undefined as Error | string | undefined,
+    error: undefined as Error | undefined,
   }))
   .views(self => ({
     get RenderingComponent(): React.FC<{
@@ -106,8 +106,8 @@ export const BaseDisplay = types
     },
   }))
   .actions(self => ({
-    setError(e: string) {
-      self.error = e
+    setError(error?: Error) {
+      self.error = error
     },
     // base display reload does nothing, see specialized displays for details
     reload() {},

--- a/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
+++ b/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
@@ -36,13 +36,15 @@ export function createBaseTrackModel(
     .volatile(() => ({
       showAbout: false,
       DialogComponent: undefined as React.FC | undefined,
+      DialogDisplay: undefined as any,
     }))
     .actions(self => ({
       setShowAbout(show: boolean) {
         self.showAbout = show
       },
-      setDialogComponent(dlg: any) {
+      setDialogComponent(dlg: any, context?: any) {
         self.DialogComponent = dlg
+        self.DialogDisplay = context
       },
     }))
     .views(self => ({

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -18,6 +18,7 @@ import {
   TypeTestedByPredicate,
   isSessionModel,
   isViewModel,
+  isTrackModel,
   Region,
   AssemblyManager,
 } from './types'
@@ -244,6 +245,15 @@ export function getContainingView(node: IAnyStateTreeNode) {
     return findParentThatIs(node, isViewModel)
   } catch (e) {
     throw new Error('no containing view found')
+  }
+}
+
+/** get the state model of the view in the state tree that contains the given node */
+export function getContainingTrack(node: IAnyStateTreeNode) {
+  try {
+    return findParentThatIs(node, isTrackModel)
+  } catch (e) {
+    throw new Error('no containing track found')
   }
 }
 

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -126,6 +126,20 @@ export function isViewModel(thing: unknown): thing is AbstractViewModel {
     'setWidth' in thing
   )
 }
+
+export interface AbstractTrackModel {
+  setDialogComponent(dlg: unknown, display?: unknown): void
+}
+export function isTrackModel(thing: unknown): thing is AbstractTrackModel {
+  return (
+    typeof thing === 'object' &&
+    thing !== null &&
+    'configuration' in thing &&
+    //@ts-ignore
+    thing.configuration.trackId
+  )
+}
+
 export interface TrackViewModel extends AbstractViewModel {
   showTrack(trackId: string): void
   hideTrack(trackId: string): void

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -135,7 +135,7 @@ export function isTrackModel(thing: unknown): thing is AbstractTrackModel {
     typeof thing === 'object' &&
     thing !== null &&
     'configuration' in thing &&
-    //@ts-ignore
+    // @ts-ignore
     thing.configuration.trackId
   )
 }

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -41,7 +41,6 @@
     "abortable-promise-cache": "^1.1.3",
     "color": "^3.1.2",
     "copy-to-clipboard": "^3.3.1",
-    "d3-scale": "^3.2.1",
     "deep-equal": "^2.0.3",
     "generic-filehandle": "^2.0.0",
     "json-stable-stringify": "^1.0.1",

--- a/plugins/alignments/src/LinearPileupDisplay/components/ColorByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/ColorByTag.tsx
@@ -8,7 +8,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -23,11 +22,11 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function ColorByTagDlg(props: {
-  model: AnyConfigurationModel
+  display: any
   handleClose: () => void
 }) {
   const classes = useStyles()
-  const { model, handleClose } = props
+  const { display, handleClose } = props
   const [tag, setTag] = useState('')
   const validTag = tag.match(/^[A-Za-z][A-Za-z0-9]$/)
 
@@ -80,8 +79,7 @@ export default function ColorByTagDlg(props: {
               type="submit"
               style={{ marginLeft: 20 }}
               onClick={() => {
-                const display = model.displays[0]
-                ;(display.PileupDisplay || display).setColorScheme({
+                display.setColorScheme({
                   type: 'tag',
                   tag,
                 })

--- a/plugins/alignments/src/LinearPileupDisplay/components/ColorByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/ColorByTag.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function ColorByTagDlg(props: {
-  display: any
+  display: { setColorScheme: Function }
   handleClose: () => void
 }) {
   const classes = useStyles()

--- a/plugins/alignments/src/LinearPileupDisplay/components/FilterByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/FilterByTag.tsx
@@ -81,16 +81,14 @@ function Bitmask(props: { flag: number; setFlag: Function }) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default observer((props: { model: any; handleClose: () => void }) => {
-  const { model, handleClose } = props
+export default observer((props: { display: any; handleClose: () => void }) => {
+  const { display, handleClose } = props
   const classes = useStyles()
-  const display = model.displays[0]
-  const effectiveDisplay = display.PileupDisplay || display
-  const filter = effectiveDisplay.filterBy
-  const [flagInclude, setFlagInclude] = useState(filter?.flagInclude)
-  const [flagExclude, setFlagExclude] = useState(filter?.flagExclude)
-  const [tag, setTag] = useState(filter?.tagFilter?.tag || '')
-  const [tagValue, setTagValue] = useState(filter?.tagFilter?.value || '')
+  const { filterBy } = display
+  const [flagInclude, setFlagInclude] = useState(filterBy?.flagInclude)
+  const [flagExclude, setFlagExclude] = useState(filterBy?.flagExclude)
+  const [tag, setTag] = useState(filterBy?.tagFilter?.tag || '')
+  const [tagValue, setTagValue] = useState(filterBy?.tagFilter?.value || '')
   const validTag = tag.match(/^[A-Za-z][A-Za-z0-9]$/)
 
   const site = 'https://broadinstitute.github.io/picard/explain-flags.html'
@@ -167,7 +165,7 @@ export default observer((props: { model: any; handleClose: () => void }) => {
               variant="contained"
               color="primary"
               onClick={() => {
-                effectiveDisplay.setFilterBy({
+                display.setFilterBy({
                   flagInclude,
                   flagExclude,
                   tagFilter:

--- a/plugins/alignments/src/LinearPileupDisplay/components/FilterByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/FilterByTag.tsx
@@ -47,8 +47,8 @@ const flagNames = [
   'supplementary alignment',
 ]
 
-function Bitmask(props: { flag: number; setFlag: Function }) {
-  const { flag, setFlag } = props
+function Bitmask(props: { flag?: number; setFlag: Function }) {
+  const { flag = 0, setFlag } = props
   return (
     <>
       <TextField
@@ -80,110 +80,121 @@ function Bitmask(props: { flag: number; setFlag: Function }) {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default observer((props: { display: any; handleClose: () => void }) => {
-  const { display, handleClose } = props
-  const classes = useStyles()
-  const { filterBy } = display
-  const [flagInclude, setFlagInclude] = useState(filterBy?.flagInclude)
-  const [flagExclude, setFlagExclude] = useState(filterBy?.flagExclude)
-  const [tag, setTag] = useState(filterBy?.tagFilter?.tag || '')
-  const [tagValue, setTagValue] = useState(filterBy?.tagFilter?.value || '')
-  const validTag = tag.match(/^[A-Za-z][A-Za-z0-9]$/)
+export default observer(
+  (props: {
+    display: {
+      filterBy?: {
+        flagExclude: number
+        flagInclude: number
+        tagFilter?: { tag: string; value: string }
+      }
+      setFilterBy: Function
+    }
+    handleClose: () => void
+  }) => {
+    const { display, handleClose } = props
+    const classes = useStyles()
+    const { filterBy } = display
+    const [flagInclude, setFlagInclude] = useState(filterBy?.flagInclude)
+    const [flagExclude, setFlagExclude] = useState(filterBy?.flagExclude)
+    const [tag, setTag] = useState(filterBy?.tagFilter?.tag || '')
+    const [tagValue, setTagValue] = useState(filterBy?.tagFilter?.value || '')
+    const validTag = tag.match(/^[A-Za-z][A-Za-z0-9]$/)
 
-  const site = 'https://broadinstitute.github.io/picard/explain-flags.html'
+    const site = 'https://broadinstitute.github.io/picard/explain-flags.html'
 
-  return (
-    <Dialog
-      open
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">
-        Filter options
-        <IconButton
-          aria-label="close"
-          className={classes.closeButton}
-          onClick={handleClose}
-        >
-          <CloseIcon />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent>
-        <Typography>
-          Set filter bitmask options. Refer to <Link href={site}>{site}</Link>{' '}
-          for details
-        </Typography>
-        <div className={classes.root}>
-          <form>
-            <Paper className={classes.paper} variant="outlined">
-              <div style={{ display: 'flex' }}>
-                <div>
-                  <Typography>Read must have ALL these flags</Typography>
-                  <Bitmask flag={flagInclude} setFlag={setFlagInclude} />
+    return (
+      <Dialog
+        open
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Filter options
+          <IconButton
+            aria-label="close"
+            className={classes.closeButton}
+            onClick={handleClose}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Typography>
+            Set filter bitmask options. Refer to <Link href={site}>{site}</Link>{' '}
+            for details
+          </Typography>
+          <div className={classes.root}>
+            <form>
+              <Paper className={classes.paper} variant="outlined">
+                <div style={{ display: 'flex' }}>
+                  <div>
+                    <Typography>Read must have ALL these flags</Typography>
+                    <Bitmask flag={flagInclude} setFlag={setFlagInclude} />
+                  </div>
+                  <div>
+                    <Typography>Read must have NONE of these flags</Typography>
+                    <Bitmask flag={flagExclude} setFlag={setFlagExclude} />
+                  </div>
                 </div>
-                <div>
-                  <Typography>Read must have NONE of these flags</Typography>
-                  <Bitmask flag={flagExclude} setFlag={setFlagExclude} />
-                </div>
-              </div>
-            </Paper>
-            <Paper className={classes.paper} variant="outlined">
-              <Typography>Filter by tag name and value (optional)</Typography>
-              <TextField
-                className={classes.field}
-                value={tag}
-                onChange={event => {
-                  setTag(event.target.value)
+              </Paper>
+              <Paper className={classes.paper} variant="outlined">
+                <Typography>Filter by tag name and value (optional)</Typography>
+                <TextField
+                  className={classes.field}
+                  value={tag}
+                  onChange={event => {
+                    setTag(event.target.value)
+                  }}
+                  placeholder="Enter tag name"
+                  inputProps={{
+                    maxLength: 2,
+                    'data-testid': 'color-tag-name-input',
+                  }}
+                  error={tag.length === 2 && !validTag}
+                  helperText={
+                    tag.length === 2 && !validTag ? 'Not a valid tag' : ''
+                  }
+                  data-testid="color-tag-name"
+                />
+                <TextField
+                  className={classes.field}
+                  value={tagValue}
+                  onChange={event => {
+                    setTagValue(event.target.value)
+                  }}
+                  placeholder="Enter tag value"
+                  inputProps={{
+                    'data-testid': 'color-tag-name-input',
+                  }}
+                  data-testid="color-tag-value"
+                />
+              </Paper>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => {
+                  display.setFilterBy({
+                    flagInclude,
+                    flagExclude,
+                    tagFilter:
+                      tag !== ''
+                        ? {
+                            tag,
+                            value: tagValue,
+                          }
+                        : undefined,
+                  })
+                  handleClose()
                 }}
-                placeholder="Enter tag name"
-                inputProps={{
-                  maxLength: 2,
-                  'data-testid': 'color-tag-name-input',
-                }}
-                error={tag.length === 2 && !validTag}
-                helperText={
-                  tag.length === 2 && !validTag ? 'Not a valid tag' : ''
-                }
-                data-testid="color-tag-name"
-              />
-              <TextField
-                className={classes.field}
-                value={tagValue}
-                onChange={event => {
-                  setTagValue(event.target.value)
-                }}
-                placeholder="Enter tag value"
-                inputProps={{
-                  'data-testid': 'color-tag-name-input',
-                }}
-                data-testid="color-tag-value"
-              />
-            </Paper>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={() => {
-                display.setFilterBy({
-                  flagInclude,
-                  flagExclude,
-                  tagFilter:
-                    tag !== ''
-                      ? {
-                          tag,
-                          value: tagValue,
-                        }
-                      : undefined,
-                })
-                handleClose()
-              }}
-            >
-              Submit
-            </Button>
-          </form>
-        </div>
-      </DialogContent>
-    </Dialog>
-  )
-})
+              >
+                Submit
+              </Button>
+            </form>
+          </div>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)

--- a/plugins/alignments/src/LinearPileupDisplay/components/SortByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/SortByTag.tsx
@@ -8,7 +8,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -24,11 +23,11 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function ColorByTagDlg(props: {
-  model: AnyConfigurationModel
+  display: any
   handleClose: () => void
 }) {
   const classes = useStyles()
-  const { model, handleClose } = props
+  const { display, handleClose } = props
   const [tag, setTag] = useState('')
   const validTag = tag.match(/^[A-Za-z][A-Za-z0-9]$/)
   return (
@@ -73,8 +72,7 @@ export default function ColorByTagDlg(props: {
               variant="contained"
               color="primary"
               onClick={() => {
-                const display = model.displays[0]
-                ;(display.PileupDisplay || display).setSortedBy('tag', tag)
+                display.setSortedBy('tag', tag)
                 handleClose()
               }}
             >

--- a/plugins/alignments/src/LinearPileupDisplay/components/SortByTag.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/SortByTag.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function ColorByTagDlg(props: {
-  display: any
+  display: { setSortedBy: Function }
   handleClose: () => void
 }) {
   const classes = useStyles()

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -7,6 +7,7 @@ import {
   getSession,
   isSessionModelWithWidgets,
   getContainingView,
+  getContainingTrack,
 } from '@jbrowse/core/util'
 
 import { BlockSet } from '@jbrowse/core/util/blockTypes'
@@ -404,7 +405,10 @@ const stateModelFactory = (
                 {
                   label: 'Sort by tag...',
                   onClick: () =>
-                    getParent(self, 3).setDialogComponent(SortByTagDlg),
+                    getContainingTrack(self).setDialogComponent(
+                      SortByTagDlg,
+                      self,
+                    ),
                 },
                 {
                   label: 'Clear sort',
@@ -455,7 +459,10 @@ const stateModelFactory = (
                 {
                   label: 'Color by tag...',
                   onClick: () => {
-                    getParent(self, 3).setDialogComponent(ColorByTagDlg)
+                    getContainingTrack(self).setDialogComponent(
+                      ColorByTagDlg,
+                      self,
+                    )
                   },
                 },
               ],
@@ -464,7 +471,10 @@ const stateModelFactory = (
               label: 'Filter by',
               icon: FilterListIcon,
               onClick: () => {
-                getParent(self, 3).setDialogComponent(FilterByTagDlg)
+                getContainingTrack(self).setDialogComponent(
+                  FilterByTagDlg,
+                  self,
+                )
               },
             },
           ]

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -17,7 +17,7 @@ import {
   LinearGenomeViewModel,
   BaseLinearDisplay,
 } from '@jbrowse/plugin-linear-genome-view'
-import { cast, types, addDisposer, getParent, Instance } from 'mobx-state-tree'
+import { cast, types, addDisposer, Instance } from 'mobx-state-tree'
 import copy from 'copy-to-clipboard'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { Feature } from '@jbrowse/core/util/simpleFeature'

--- a/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
+++ b/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
@@ -40,6 +40,8 @@ interface BaseInfo {
 }
 
 export default class SNPCoverageRenderer extends WiggleBaseRenderer {
+  // note: the snps are drawn on linear scale even if the data is drawn in log scape
+  // hence the two different scales being used
   draw(ctx: CanvasRenderingContext2D, props: SNPCoverageRendererProps) {
     const {
       features,
@@ -52,12 +54,11 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
     const theme = createJBrowseTheme(configTheme)
 
     const [region] = regions
-    const viewScale = getScale({ ...scaleOpts, range: [0, height] })
-    const snpViewScale = getScale({
-      ...scaleOpts,
-      scaleType: 'linear',
-      range: [0, height],
-    })
+    const opts = { ...scaleOpts, range: [0, height] }
+
+    const viewScale = getScale(opts)
+    const snpViewScale = getScale({ ...opts, scaleType: 'linear' })
+
     const originY = getOrigin(scaleOpts.scaleType)
     const snpOriginY = getOrigin('linear')
 
@@ -65,14 +66,11 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
       height - viewScale(rawscore) - curr
     const snpToY = (rawscore: number, curr = 0) =>
       height - snpViewScale(rawscore) - curr
-
     const toHeight = (rawscore: number, curr = 0) =>
       toY(originY) - toY(rawscore, curr)
-
     const snpToHeight = (rawscore: number, curr = 0) =>
       snpToY(snpOriginY) - snpToY(rawscore, curr)
 
-    const insRegex = /^ins.[A-Za-z0-9]/
     const colorForBase: { [key: string]: string } = {
       A: theme.palette.bases.A.main,
       C: theme.palette.bases.C.main,
@@ -83,31 +81,26 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
 
     // Use two pass rendering, which helps in visualizing the SNPs at higher bpPerPx
     // First pass: draw the gray background
-    // Second pass: draw the SNP data, and add a minimum feature width of 1px which can be wider than the actual bpPerPx
-    // This reduces overdrawing of the grey background over the SNPs
     for (const feature of features.values()) {
       const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
       const score = feature.get('score') as number
-      // console.log(score, toHeight(score))
-
-      // draw total
       ctx.fillStyle = colorForBase.total
       const w = rightPx - leftPx + 0.3
       ctx.fillRect(leftPx, toY(score), w, toHeight(score))
     }
+
+    // Second pass: draw the SNP data, and add a minimum feature width of 1px which can be wider than the actual bpPerPx
+    // This reduces overdrawing of the grey background over the SNPs
     for (const feature of features.values()) {
       const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
       const w = Math.max(rightPx - leftPx + 0.3, 1)
-      // grab array with nestedtable's info, draw mismatches
-      const infoArray = feature.get('snpinfo') || []
+      const infoArray: BaseInfo[] = feature.get('snpinfo') || []
       let curr = 0
-      infoArray.forEach(function iterate(info: BaseInfo) {
+      infoArray.forEach(info => {
         if (!info || info.base === 'reference' || info.base === 'total') {
           return
         }
-        ctx.fillStyle = info.base.match(insRegex)
-          ? 'darkgrey'
-          : colorForBase[info.base]
+        ctx.fillStyle = colorForBase[info.base]
         ctx.fillRect(
           leftPx,
           snpToY(info.score + curr),

--- a/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
+++ b/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
@@ -53,11 +53,24 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
 
     const [region] = regions
     const viewScale = getScale({ ...scaleOpts, range: [0, height] })
+    const snpViewScale = getScale({
+      ...scaleOpts,
+      scaleType: 'linear',
+      range: [0, height],
+    })
     const originY = getOrigin(scaleOpts.scaleType)
+    const snpOriginY = getOrigin('linear')
+
     const toY = (rawscore: number, curr = 0) =>
       height - viewScale(rawscore) - curr
+    const snpToY = (rawscore: number, curr = 0) =>
+      height - snpViewScale(rawscore) - curr
+
     const toHeight = (rawscore: number, curr = 0) =>
       toY(originY) - toY(rawscore, curr)
+
+    const snpToHeight = (rawscore: number, curr = 0) =>
+      snpToY(snpOriginY) - snpToY(rawscore, curr)
 
     const insRegex = /^ins.[A-Za-z0-9]/
     const colorForBase: { [key: string]: string } = {
@@ -95,7 +108,12 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
         ctx.fillStyle = info.base.match(insRegex)
           ? 'darkgrey'
           : colorForBase[info.base]
-        ctx.fillRect(leftPx, toY(info.score + curr), w, toHeight(info.score))
+        ctx.fillRect(
+          leftPx,
+          snpToY(info.score + curr),
+          w,
+          snpToHeight(info.score),
+        )
         curr += info.score
       })
     }

--- a/plugins/alignments/src/index.ts
+++ b/plugins/alignments/src/index.ts
@@ -95,7 +95,10 @@ export default class AlignmentsPlugin extends Plugin {
       return new DisplayType({
         name: 'LinearSNPCoverageDisplay',
         configSchema,
-        stateModel: linearSNPCoverageDisplayModelFactory(configSchema),
+        stateModel: linearSNPCoverageDisplayModelFactory(
+          pluginManager,
+          configSchema,
+        ),
         trackType: 'AlignmentsTrack',
         viewType: 'LinearGenomeView',
         ReactComponent: LinearWiggleDisplayReactComponent,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -42,11 +42,6 @@ const LinearGenomeView = observer((props: { model: LGV }) => {
   // the dialog scrolls the LGV
   const aboutTrack = model.tracks.find(track => track.showAbout)
   const dialogTrack = model.tracks.find(track => track.DialogComponent)
-  // const ret = track.displays.find(display => display.DialogComponent)
-  // console.log('ret', ret)
-  // return ret
-  // })
-  // console.log(dialogTrack)
 
   return !initialized ? (
     <ImportForm model={model} />
@@ -61,8 +56,11 @@ const LinearGenomeView = observer((props: { model: LGV }) => {
 
       {dialogTrack ? (
         <dialogTrack.DialogComponent
-          model={dialogTrack}
-          handleClose={() => dialogTrack.setDialogComponent(undefined)}
+          track={dialogTrack}
+          display={dialogTrack.DialogDisplay}
+          handleClose={() =>
+            dialogTrack.setDialogComponent(undefined, undefined)
+          }
         />
       ) : null}
       {!hideHeader ? (

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -138,7 +138,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const assembliesInitialized = this.assemblyNames.every(assemblyName => {
           if (
             assemblyManager.assemblyList
-              .map((asm: { name: string }) => asm.name)
+              ?.map((asm: { name: string }) => asm.name)
               .includes(assemblyName)
           ) {
             return (assemblyManager.get(assemblyName) || {}).initialized

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@gmod/bbi": "^1.0.30",
+    "@material-ui/icons": "^4.11.2",
     "abortable-promise-cache": "^1.1.3",
     "color": "^3.1.1",
     "d3-scale": "^3.2.3",

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -38,7 +38,7 @@
     "@gmod/bbi": "^1.0.30",
     "abortable-promise-cache": "^1.1.3",
     "color": "^3.1.1",
-    "d3-scale": "^3.0.0",
+    "d3-scale": "^3.2.3",
     "json-stable-stringify": "^1.0.1",
     "react-d3-axis": "^0.1.2"
   },

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -29,6 +29,12 @@ export default class BigWigAdapter
   implements DataAdapterWithGlobalStats {
   private bigwig: BigWig
 
+  public static capabilities = [
+    'hasResolution',
+    'hasLocalStats',
+    'hasGlobalStats',
+  ]
+
   public constructor(config: Instance<typeof configSchema>) {
     super(config)
     this.bigwig = new BigWig({

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -100,14 +100,14 @@ export default class BigWigAdapter
     })
   }
 
-  public getFeatures(region: NoAssemblyRegion, opts?: BaseOptions) {
+  public getFeatures(region: NoAssemblyRegion, opts: BaseOptions = {}) {
     const { refName, start, end } = region
-    const { bpPerPx, signal, statusCallback = () => {} } = opts || {}
+    const { bpPerPx, signal, statusCallback = () => {} } = opts
     return ObservableCreate<Feature>(async observer => {
       statusCallback('Downloading bigwig data')
       const ob = await this.bigwig.getFeatureStream(refName, start, end, {
         ...opts,
-        basesPerSpan: bpPerPx,
+        basesPerSpan: (bpPerPx || 0) / 100,
       })
       ob.pipe(
         mergeAll(),

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -20,6 +20,10 @@ import {
 
 import configSchema from './configSchema'
 
+interface WiggleOptions extends BaseOptions {
+  resolution?: number
+}
+
 export default class BigWigAdapter
   extends BaseFeatureDataAdapter
   implements DataAdapterWithGlobalStats {
@@ -100,14 +104,19 @@ export default class BigWigAdapter
     })
   }
 
-  public getFeatures(region: NoAssemblyRegion, opts: BaseOptions = {}) {
+  public getFeatures(region: NoAssemblyRegion, opts: WiggleOptions = {}) {
     const { refName, start, end } = region
-    const { bpPerPx, signal, statusCallback = () => {} } = opts
+    const {
+      bpPerPx = 0,
+      signal,
+      resolution = 1,
+      statusCallback = () => {},
+    } = opts
     return ObservableCreate<Feature>(async observer => {
       statusCallback('Downloading bigwig data')
       const ob = await this.bigwig.getFeatureStream(refName, start, end, {
         ...opts,
-        basesPerSpan: (bpPerPx || 0) / 100,
+        basesPerSpan: bpPerPx / resolution,
       })
       ob.pipe(
         mergeAll(),

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetMinMaxDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetMinMaxDialog.tsx
@@ -8,7 +8,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
 const useStyles = makeStyles(theme => ({
   root: {},
@@ -21,8 +20,12 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function SetMinMaxDlg(props: {
-  track: AnyConfigurationModel
-  display: any
+  display: {
+    minScore: number
+    maxScore: number
+    setMinScore: Function
+    setMaxScore: Function
+  }
   handleClose: () => void
 }) {
   const classes = useStyles()

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetMinMaxDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetMinMaxDialog.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
+import TextField from '@material-ui/core/TextField'
+import Typography from '@material-ui/core/Typography'
+import Dialog from '@material-ui/core/Dialog'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import IconButton from '@material-ui/core/IconButton'
+import CloseIcon from '@material-ui/icons/Close'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+
+const useStyles = makeStyles(theme => ({
+  root: {},
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}))
+
+export default function SetMinMaxDlg(props: {
+  track: AnyConfigurationModel
+  display: any
+  handleClose: () => void
+}) {
+  const classes = useStyles()
+  const { display, handleClose } = props
+  const { minScore, maxScore } = display
+
+  const [min, setMin] = useState(
+    `${minScore !== Number.MIN_VALUE ? minScore : ''}`,
+  )
+  const [max, setMax] = useState(
+    `${maxScore !== Number.MAX_VALUE ? maxScore : ''}`,
+  )
+
+  return (
+    <Dialog
+      open
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">
+        Set min/max score for track
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={handleClose}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent style={{ overflowX: 'hidden' }}>
+        <div className={classes.root}>
+          <Typography>Enter min/max score: </Typography>
+
+          <TextField
+            value={min}
+            onChange={event => {
+              setMin(event.target.value)
+            }}
+            placeholder="Enter min score"
+          />
+          <TextField
+            value={max}
+            onChange={event => {
+              setMax(event.target.value)
+            }}
+            placeholder="Enter max score"
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            type="submit"
+            style={{ marginLeft: 20 }}
+            onClick={() => {
+              display.setMinScore(
+                min !== '' && !Number.isNaN(+min) ? +min : undefined,
+              )
+              display.setMaxScore(
+                max !== '' && !Number.isNaN(+max) ? +max : undefined,
+              )
+              handleClose()
+            }}
+          >
+            Submit
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -13,8 +13,7 @@ for (let i = -20; i < 20; i += 1) {
 
 export const YScaleBar = observer(
   ({ model }: { model: WiggleDisplayModel }) => {
-    const { domain, height } = model
-    const scaleType = getConf(model, 'scaleType')
+    const { domain, height, scaleType } = model
     const scale = getScale({
       scaleType,
       domain,

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -6,11 +6,6 @@ import { Axis, axisPropsFromTickScale, RIGHT } from 'react-d3-axis'
 import { getScale } from '../../util'
 import { WiggleDisplayModel } from '../models/model'
 
-const powersOfTen: number[] = []
-for (let i = -20; i < 20; i += 1) {
-  powersOfTen.push(10 ** i)
-}
-
 export const YScaleBar = observer(
   ({ model }: { model: WiggleDisplayModel }) => {
     const { domain, height, scaleType } = model
@@ -22,10 +17,7 @@ export const YScaleBar = observer(
     })
     const ticks = height < 50 ? 2 : 4
     const axisProps = axisPropsFromTickScale(scale, ticks)
-    const values =
-      scaleType === 'log'
-        ? axisProps.values.filter((s: number) => powersOfTen.includes(s))
-        : axisProps.values
+    const { values } = axisProps
 
     return (
       <svg

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -1,6 +1,6 @@
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseLinearDisplayComponent } from '@jbrowse/plugin-linear-genome-view'
-import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import { observer } from 'mobx-react'
 import React from 'react'
 import { Axis, axisPropsFromTickScale, RIGHT } from 'react-d3-axis'
 import { getScale } from '../../util'
@@ -41,7 +41,7 @@ export const YScaleBar = observer(
   },
 )
 
-function WiggleDisplayComponent(props: { model: WiggleDisplayModel }) {
+export default observer((props: { model: WiggleDisplayModel }) => {
   const { model } = props
   const { ready, stats, needsScalebar } = model
   return (
@@ -49,10 +49,4 @@ function WiggleDisplayComponent(props: { model: WiggleDisplayModel }) {
       {ready && stats && needsScalebar ? <YScaleBar model={model} /> : null}
     </BaseLinearDisplayComponent>
   )
-}
-
-WiggleDisplayComponent.propTypes = {
-  model: MobxPropTypes.observableObject.isRequired,
-}
-
-export default observer(WiggleDisplayComponent)
+})

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -218,6 +218,7 @@ const stateModelFactory = (
           const { AdapterClass } = pluginManager.getAdapterType(
             this.adapterTypeName,
           )
+          // @ts-ignore
           return AdapterClass.capabilities.includes('hasResolution')
         },
 

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -106,11 +106,7 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
         },
 
         get adapterTypeName() {
-          let curr = self
-          while (!curr.configuration || !curr.configuration.trackId) {
-            curr = getParent(curr)
-          }
-          return getConf(curr, ['adapter', 'type'])
+          return self.adapterConfig.type
         },
 
         get rendererTypeName() {

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -138,6 +138,11 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
             bounds: [minScore, maxScore],
           })
 
+          // avoid weird scalebar if log value and empty region displayed
+          if (this.scaleType === 'log' && ret[1] === Number.MIN_VALUE) {
+            return [0, Number.MIN_VALUE]
+          }
+
           // uses a heuristic to just give some extra headroom on bigwig scores
           if (maxScore !== Number.MIN_VALUE && ret[1] > 1.0) {
             ret[1] = round(ret[1])
@@ -146,9 +151,11 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
             ret[0] = round(ret[0])
           }
 
+          // avoid returning a new object if it matches the old value
           if (JSON.stringify(oldDomain) !== JSON.stringify(ret)) {
             oldDomain = ret
           }
+
           return oldDomain
         },
 

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -218,7 +218,6 @@ const stateModelFactory = (
           const { AdapterClass } = pluginManager.getAdapterType(
             this.adapterTypeName,
           )
-          // @ts-ignore
           return AdapterClass.capabilities.includes('hasResolution')
         },
 

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -106,7 +106,11 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
         },
 
         get adapterTypeName() {
-          return getConf(getParent(self, 2), ['adapter', 'type'])
+          let curr = self
+          while (!curr.configuration || !curr.configuration.trackId) {
+            curr = getParent(curr)
+          }
+          return getConf(curr, ['adapter', 'type'])
         },
 
         get rendererTypeName() {

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -1,4 +1,8 @@
-import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
+import {
+  ConfigurationReference,
+  getConf,
+  readConfObject,
+} from '@jbrowse/core/configuration'
 import {
   isAbortException,
   getSession,
@@ -130,9 +134,9 @@ const stateModelFactory = (
         },
 
         get filled() {
-          return typeof self.fill === 'undefined'
+          return typeof self.fill !== 'undefined'
             ? self.fill
-            : getConf(this.rendererConfig, 'filled')
+            : readConfObject(this.rendererConfig, 'filled')
         },
 
         get domain() {
@@ -214,6 +218,7 @@ const stateModelFactory = (
           const { AdapterClass } = pluginManager.getAdapterType(
             this.adapterTypeName,
           )
+          // @ts-ignore
           return AdapterClass.capabilities.includes('hasResolution')
         },
 
@@ -243,11 +248,11 @@ const stateModelFactory = (
             ...(this.canHaveFill
               ? [
                   {
-                    label: self.fill
+                    label: this.filled
                       ? 'Turn off histogram fill'
                       : 'Turn on histogram fill',
                     onClick: () => {
-                      self.setFill(!self.fill)
+                      self.setFill(!this.filled)
                     },
                   },
                 ]

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -83,11 +83,10 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
         self.fill = fill
       },
       toggleLogScale() {
-        console.log(self.scale)
-        if (self.scale === 'log') {
-          self.scale = 'linear'
-        } else {
+        if (self.scale !== 'log') {
           self.scale = 'log'
+        } else {
+          self.scale = 'linear'
         }
       },
       setAutoscale(val: string) {
@@ -136,7 +135,7 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
           const ret = getNiceDomain({
             domain: [self.stats.scoreMin, self.stats.scoreMax],
             scaleType: this.scaleType,
-            bounds: [minScore, 100],
+            bounds: [minScore, maxScore],
           })
 
           // uses a heuristic to just give some extra headroom on bigwig scores

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -175,6 +175,15 @@ const stateModelFactory = (
             self.rendererTypeName === 'LinePlotRenderer'
           )
         },
+        get scaleOpts() {
+          return {
+            domain: this.domain,
+            stats: self.stats,
+            autoscaleType: this.autoscaleType,
+            scaleType: this.scaleType,
+            inverted: getConf(self, 'inverted'),
+          }
+        },
 
         get canHaveFill() {
           return self.rendererTypeName === 'XYPlotRenderer'
@@ -202,13 +211,7 @@ const stateModelFactory = (
             notReady: !self.ready,
             displayModel: self,
             config: this.rendererConfig,
-            scaleOpts: {
-              domain: this.domain,
-              stats: self.stats,
-              autoscaleType: this.autoscaleType,
-              scaleType: this.scaleType,
-              inverted: getConf(self, 'inverted'),
-            },
+            scaleOpts: this.scaleOpts,
             resolution: self.resolution,
             height: self.height,
           }

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -14,13 +14,7 @@ import {
   LinearGenomeViewModel,
 } from '@jbrowse/plugin-linear-genome-view'
 import { autorun, observable } from 'mobx'
-import {
-  addDisposer,
-  isAlive,
-  getParent,
-  types,
-  Instance,
-} from 'mobx-state-tree'
+import { addDisposer, isAlive, types, Instance } from 'mobx-state-tree'
 import React from 'react'
 
 import { getNiceDomain } from '../../util'

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -188,52 +188,57 @@ const stateModelFactory = (configSchema: ReturnType<typeof ConfigSchemaF>) =>
         },
 
         get composedTrackMenuItems() {
-          return this.adapterTypeName === 'BigWigAdapter'
-            ? [
-                {
-                  label: 'Finer BigWig resolution',
-                  onClick: () => {
-                    self.setResolution(self.resolution * 5)
+          const bigWigOptions =
+            this.adapterTypeName === 'BigWigAdapter'
+              ? [
+                  {
+                    label: 'Finer resolution',
+                    onClick: () => {
+                      self.setResolution(self.resolution * 5)
+                    },
                   },
-                },
-                {
-                  label: 'Coarser BigWig resolution',
-                  onClick: () => {
-                    self.setResolution(self.resolution / 5)
+                  {
+                    label: 'Coarser resolution',
+                    onClick: () => {
+                      self.setResolution(self.resolution / 5)
+                    },
                   },
-                },
-                {
-                  label: self.fill
-                    ? 'Turn off histogram fill'
-                    : 'Turn on histogram fill',
-                  onClick: () => {
-                    self.setFill(!self.fill)
+                ]
+              : []
+
+          const otherOptions = [
+            {
+              label: self.fill
+                ? 'Turn off histogram fill'
+                : 'Turn on histogram fill',
+              onClick: () => {
+                self.setFill(!self.fill)
+              },
+            },
+            {
+              label: self.logScale ? 'Set linear scale' : 'Set log scale',
+              onClick: () => {
+                self.setLogScale(!self.logScale)
+              },
+            },
+            {
+              label: 'Autoscale type',
+              subMenu: [
+                ['local', 'Local'],
+                ['global', 'Global'],
+                ['globalsd', 'Global within +/- 3SD'],
+                ['localsd', 'Local within +/- 3SD'],
+              ].map(([val, label]) => {
+                return {
+                  label,
+                  onClick() {
+                    self.setAutoscale(val)
                   },
-                },
-                {
-                  label: self.logScale ? 'Set linear scale' : 'Set log scale',
-                  onClick: () => {
-                    self.setLogScale(!self.logScale)
-                  },
-                },
-                {
-                  label: 'Autoscale type',
-                  subMenu: [
-                    ['local', 'Local'],
-                    ['global', 'Global'],
-                    ['globalsd', 'Global within +/- 3SD'],
-                    ['localsd', 'Local within +/- 3SD'],
-                  ].map(([val, label]) => {
-                    return {
-                      label,
-                      onClick() {
-                        self.setAutoscale(val)
-                      },
-                    }
-                  }),
-                },
-              ]
-            : []
+                }
+              }),
+            },
+          ]
+          return [...bigWigOptions, ...otherOptions]
         },
 
         get trackMenuItems() {

--- a/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
+++ b/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
@@ -41,7 +41,7 @@ export default class XYPlotRenderer extends WiggleBaseRenderer {
 
       const lowClipping = score < niceMin
       const highClipping = score > niceMax
-      const w = rightPx - leftPx + 0.3 // fudge factor for subpixel rendering
+      const w = rightPx - leftPx + 0.4 // fudge factor for subpixel rendering
 
       const c = colorCallback(feature)
       if (summaryScoreMode === 'max') {
@@ -56,12 +56,24 @@ export default class XYPlotRenderer extends WiggleBaseRenderer {
         // max
         if (maxr !== undefined) {
           ctx.fillStyle = Color(c).lighten(0.6).toString()
-          ctx.fillRect(leftPx, toY(maxr), w, filled ? toHeight(maxr) : 1)
+          ctx.fillRect(
+            leftPx,
+            toY(maxr),
+            w - 0.1,
+            filled ? toHeight(maxr) - toHeight(score) : 1,
+          )
         }
 
         // normal
         ctx.fillStyle = c
-        ctx.fillRect(leftPx, toY(score), w, filled ? toHeight(score) : 1)
+        ctx.fillRect(
+          leftPx,
+          toY(score),
+          w - 0.1,
+          filled
+            ? toHeight(score) - (minr !== undefined ? toHeight(minr) : 0)
+            : 1,
+        )
         // min
         if (minr !== undefined) {
           ctx.fillStyle = Color(c).darken(0.6).toString()

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -60,7 +60,10 @@ export default class extends Plugin {
       return new DisplayType({
         name: 'LinearWiggleDisplay',
         configSchema,
-        stateModel: linearWiggleDisplayModelFactory(configSchema),
+        stateModel: linearWiggleDisplayModelFactory(
+          pluginManager,
+          configSchema,
+        ),
         trackType: 'QuantitativeTrack',
         viewType: 'LinearGenomeView',
         ReactComponent: LinearWiggleDisplayReactComponent,

--- a/plugins/wiggle/src/util.test.js
+++ b/plugins/wiggle/src/util.test.js
@@ -13,7 +13,7 @@ test('log scale', () => {
   const domain = [1, 100]
   const range = [0, 100]
   const scale = getScale({ scaleType, domain, range })
-  expect(scale.domain()).toEqual(domain)
+  expect(scale.domain()).toEqual([1, 128])
 })
 
 test('test inverted', () => {
@@ -22,7 +22,7 @@ test('test inverted', () => {
   const domain = [1, 100]
   const range = [0, 100]
   const scale = getScale({ scaleType, domain, range, inverted })
-  expect(scale.domain()).toEqual(domain)
+  expect(scale.domain()).toEqual([1, 128])
   expect(scale.range()).toEqual(range.reverse())
 })
 

--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -34,12 +34,14 @@ export function getScale({
     scale = scaleLinear()
   } else if (scaleType === 'log') {
     scale = scaleLog()
+    scale.base(2)
   } else if (scaleType === 'quantize') {
     scale = scaleQuantize()
   } else {
     throw new Error('undefined scaleType')
   }
   scale.domain(pivotValue !== undefined ? [min, pivotValue, max] : [min, max])
+  // console.log('before', scale.domain())
   scale.nice()
 
   const [rangeMin, rangeMax] = range
@@ -47,6 +49,8 @@ export function getScale({
     throw new Error('invalid range')
   }
   scale.range(inverted ? range.slice().reverse() : range)
+
+  // console.log('after', scale.domain())
   return scale
 }
 /**
@@ -123,7 +127,9 @@ export function getNiceDomain({
       return scaleLinear()
     }
     if (type === 'log') {
-      return scaleLog()
+      const scale = scaleLog()
+      scale.base(2)
+      return scale
     }
     if (type === 'quantize') {
       return scaleQuantize()

--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -27,7 +27,9 @@ export function getScale({
 }: ScaleOpts) {
   let scale
   const [min, max] = domain
-  if (min === undefined || max === undefined) throw new Error('invalid domain')
+  if (min === undefined || max === undefined) {
+    throw new Error('invalid domain')
+  }
   if (scaleType === 'linear') {
     scale = scaleLinear()
   } else if (scaleType === 'log') {

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -229,7 +229,7 @@ export default function RootModel(
         this.setSession(autosavedSession)
       },
 
-      setError(error: Error) {
+      setError(error?: Error) {
         self.error = error
       },
     }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,6 +5224,13 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/lab@^4.0.0-alpha.45":
   version "4.0.0-alpha.56"
   resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz#ff63080949b55b40625e056bbda05e130d216d34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11059,50 +11059,50 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-"d3-array@1.2.0 - 2":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
-  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
+d3-array@^2.3.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.9.1.tgz#f355cc72b46c8649b3f9212029e2d681cb5b9643"
+  integrity sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg==
 
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+"d3-color@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
 
-d3-format@1:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
-  integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
+"d3-format@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
+  integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
-d3-interpolate@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
-  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+"d3-interpolate@1.2.0 - 2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
   dependencies:
-    d3-color "1"
+    d3-color "1 - 2"
 
-d3-scale@^3.0.0, d3-scale@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.1.tgz#da1684adce7261b4bc7a76fe193d887f0e909e69"
-  integrity sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==
+d3-scale@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.3.tgz#be380f57f1f61d4ff2e6cbb65a40593a51649cfd"
+  integrity sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==
   dependencies:
-    d3-array "1.2.0 - 2"
-    d3-format "1"
-    d3-interpolate "^1.2.0"
-    d3-time "1"
-    d3-time-format "2"
+    d3-array "^2.3.0"
+    d3-format "1 - 2"
+    d3-interpolate "1.2.0 - 2"
+    d3-time "1 - 2"
+    d3-time-format "2 - 3"
 
-d3-time-format@2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
-  integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
+"d3-time-format@2 - 3":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-3.0.0.tgz#df8056c83659e01f20ac5da5fdeae7c08d5f1bb6"
+  integrity sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==
   dependencies:
-    d3-time "1"
+    d3-time "1 - 2"
 
-d3-time@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
-  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+"d3-time@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
+  integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
 
 d@1, d@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This enables a toggle option for the view to make "Show all regions" into "Show all regions in assembly"


Also allows the user to toggle filled histograms on and off, set log scale, and control bigwig coarseness

This helps enable the screenshot in the cancer demo e.g. puts this screenshot into any users grasp who can open a bigwig file 
![image](https://user-images.githubusercontent.com/6511937/101403619-7e04ca80-38a3-11eb-887c-b16a81d997d4.png)


