### PR TITLE
Display file headers in pre tag in about dialogs and bump @gmod/bam and @gmod/tabix package versions

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -35,8 +35,8 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@gmod/bam": "^1.1.2",
-    "@gmod/cram": "^1.5.6",
+    "@gmod/bam": "^1.1.5",
+    "@gmod/cram": "^1.5.7",
     "@material-ui/icons": "^4.9.1",
     "abortable-promise-cache": "^1.1.3",
     "color": "^3.1.2",

--- a/plugins/alignments/src/BamAdapter/BamAdapter.ts
+++ b/plugins/alignments/src/BamAdapter/BamAdapter.ts
@@ -70,7 +70,8 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
   }
 
   async getHeader(opts?: BaseOptions) {
-    return this.bam.getHeader(opts)
+    const header = await this.bam.getRawHeader(opts)
+    return { header: `<pre>${header}</pre>` }
   }
 
   private async setup(opts?: BaseOptions) {

--- a/plugins/alignments/src/BamAdapter/BamAdapter.ts
+++ b/plugins/alignments/src/BamAdapter/BamAdapter.ts
@@ -70,8 +70,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
   }
 
   async getHeader(opts?: BaseOptions) {
-    const header = await this.bam.getRawHeader(opts)
-    return { header: `<pre>${header}</pre>` }
+    return this.bam.getHeaderText(opts)
   }
 
   private async setup(opts?: BaseOptions) {

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -79,8 +79,7 @@ export class CramAdapter extends BaseFeatureDataAdapter {
   }
 
   async getHeader(opts?: BaseOptions) {
-    const header = await this.cram.cram.getRawHeader(opts)
-    return { header: `<pre>${header}</pre>` }
+    return this.cram.cram.getHeaderText(opts)
   }
 
   private async seqFetch(seqId: number, start: number, end: number) {

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -79,7 +79,8 @@ export class CramAdapter extends BaseFeatureDataAdapter {
   }
 
   async getHeader(opts?: BaseOptions) {
-    return this.cram.cram.getSamHeader(opts)
+    const header = await this.cram.cram.getRawHeader(opts)
+    return { header: `<pre>${header}</pre>` }
   }
 
   private async seqFetch(seqId: number, start: number, end: number) {

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@gmod/bbi": "^1.0.30",
     "@gmod/bed": "^2.0.4",
-    "@gmod/tabix": "^1.4.6"
+    "@gmod/tabix": "^1.5.0"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
+++ b/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
@@ -49,12 +49,7 @@ export default class BedTabixAdapter extends BaseFeatureDataAdapter {
   }
 
   async getHeader() {
-    const header = await this.bed.getHeader()
-    return {
-      header: `<pre>${header
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')}</pre>`,
-    }
+    return this.bed.getHeader()
   }
 
   public getFeatures(query: Region, opts: BaseOptions = {}) {

--- a/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
+++ b/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
@@ -48,6 +48,15 @@ export default class BedTabixAdapter extends BaseFeatureDataAdapter {
     return this.bed.getReferenceSequenceNames(opts)
   }
 
+  async getHeader() {
+    const header = await this.bed.getHeader()
+    return {
+      header: `<pre>${header
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')}</pre>`,
+    }
+  }
+
   public getFeatures(query: Region, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       await this.bed.getLines(query.refName, query.start, query.end, {

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@gmod/gff": "^1.1.2",
-    "@gmod/tabix": "^1.4.6",
+    "@gmod/tabix": "^1.5.0",
     "generic-filehandle": "^2.0.0"
   },
   "peerDependencies": {

--- a/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
@@ -63,12 +63,7 @@ export default class extends BaseFeatureDataAdapter {
   }
 
   public async getHeader() {
-    const header = await this.gff.getHeader()
-    return {
-      header: `<pre>${header
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')}</pre>`,
-    }
+    return this.gff.getHeader()
   }
 
   public getFeatures(query: NoAssemblyRegion, opts: BaseOptions = {}) {

--- a/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
@@ -62,6 +62,15 @@ export default class extends BaseFeatureDataAdapter {
     return this.gff.getReferenceSequenceNames(opts)
   }
 
+  public async getHeader() {
+    const header = await this.gff.getHeader()
+    return {
+      header: `<pre>${header
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')}</pre>`,
+    }
+  }
+
   public getFeatures(query: NoAssemblyRegion, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       const metadata = await this.gff.getMetadata()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/AboutDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/AboutDialog.tsx
@@ -234,7 +234,7 @@ export const Attributes: React.FunctionComponent<AttributeProps> = props => {
   )
 }
 
-type FileInfo = Record<string, unknown>
+type FileInfo = Record<string, unknown> | string
 
 export default function AboutDialog({
   model,
@@ -299,7 +299,17 @@ export default function AboutDialog({
             ) : info === undefined ? (
               'Loading file data...'
             ) : (
-              <Attributes attributes={info} />
+              <Attributes
+                attributes={
+                  typeof info === 'string'
+                    ? {
+                        header: `<pre>${info
+                          .replace(/</g, '&lt;')
+                          .replace(/>/g, '&gt;')}</pre>`,
+                      }
+                    : info
+                }
+              />
             )}
           </BaseCard>
         ) : null}

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -35,7 +35,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@gmod/tabix": "^1.4.6",
+    "@gmod/tabix": "^1.5.0",
     "@gmod/vcf": "^4.0.1",
     "@material-ui/data-grid": "^4.0.0-alpha.10",
     "generic-filehandle": "^2.0.0"

--- a/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
@@ -59,15 +59,11 @@ export default class extends BaseFeatureDataAdapter {
 
   async getHeader() {
     const header = await this.vcf.getHeader()
-    return header
-      .split('\n')
-      .filter(line => line.startsWith('##'))
-      .map(line => {
-        const str = line.slice(2)
-        const index = str.indexOf('=')
-        const [tag, data] = [str.slice(0, index), str.slice(index + 1)]
-        return { tag, data }
-      })
+    return {
+      header: `<pre>${header
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')}</pre>`,
+    }
   }
 
   async getMetadata() {

--- a/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
@@ -58,12 +58,7 @@ export default class extends BaseFeatureDataAdapter {
   }
 
   async getHeader() {
-    const header = await this.vcf.getHeader()
-    return {
-      header: `<pre>${header
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')}</pre>`,
-    }
+    return this.vcf.getHeader()
   }
 
   async getMetadata() {

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -157,5 +157,5 @@ test('looks at about this track dialog', async () => {
   fireEvent.click(await findByTestId('htsTrackEntry-volvox-long-reads-cram'))
   fireEvent.click(await findByTestId('track_menu_icon'))
   fireEvent.click(await findByText('About this track'))
-  await findAllByText('SQ')
+  await findAllByText(/SQ/)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4018,10 +4018,10 @@
     abortable-promise-cache "^1.0.1"
     quick-lru "^4.0.0"
 
-"@gmod/tabix@^1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@gmod/tabix/-/tabix-1.4.6.tgz#eb6ca6a02eb83fbcf8769b1a438c122c9e2fdc2d"
-  integrity sha512-vczsvIn0fYkjACQWL31p28dg4/42+jOLZOzc9L1giWqTqe5Dr47f9YqBipFBw4tV9A2snQbq/sWSmzYP3lyq8Q==
+"@gmod/tabix@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gmod/tabix/-/tabix-1.5.0.tgz#69fb4084eecdf7eb35f24e6b64bd4979d98f1162"
+  integrity sha512-wbiYj+3a3xtL9W5hIAaZ4pDIca2isFVHbA5jIecFAFaui2qOkgWbiRctToZWDHSPLrpVuzf2A0TYjx4nswk9ag==
   dependencies:
     "@babel/runtime-corejs2" "^7.3.1"
     "@gmod/bgzf-filehandle" "^1.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,10 +3921,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@gmod/bam@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.1.2.tgz#52812db06eb0e6506403aad7b2919ae689f60d97"
-  integrity sha512-BvTBE2u9/FYqWRK0r2mAgxkJ5+1AA5PgLI+1vo3MkT0qvFnjyj09CGBcWAld4/PS+Pmoazg6x2sg/e9p4uE7vg==
+"@gmod/bam@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.1.5.tgz#565bcf86105f6a26f8633dde2cbac8866896193f"
+  integrity sha512-/3eu0D+xYE0kXnNdO6ZqD6fk9uuxL9vGhSadau2cuZZ6dognNHDo4z8pBvlj4SJXdFwgkG9qVvR5DabRXq212Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.5.5"
     "@gmod/bgzf-filehandle" "^1.3.3"
@@ -3975,10 +3975,10 @@
   dependencies:
     long "^4.0.0"
 
-"@gmod/cram@^1.5.6":
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.5.6.tgz#6a44e17913fc6431930786f71ec9f4398e81e16d"
-  integrity sha512-Ue8RLzsOG7ykB6dA8SSpbWZMP2YsOaaIb3iLSvyEx1SazTLIMGA/oVRzGYpnIHCQbCe26snFto/rfXo+gXUGeQ==
+"@gmod/cram@^1.5.7":
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.5.7.tgz#f8922081ea37f77fe5f2d167b4e400c22d63799c"
+  integrity sha512-ivGfFSJf/orKeWhLUl2WfiD14ZCW3TaFbEgxSeaOmFr0sLe8sFWAx5V5xAXXhMgFvvou28vd2pXhZcqvEBXiAw==
   dependencies:
     "@babel/runtime-corejs3" "^7.4.5"
     "@gmod/binary-parser" "^1.3.5"


### PR DESCRIPTION
This is a proposal that was started when trying to make gff3tabix track display nice "About this track" header information

The VcfTabixAdapter already has has a "About this track" based on the vcf header, and does mild parsing of the header to make it display using a "feature details" style box

This modifies it to not do parsing of the header, and instead print the raw header using a `<pre>` text box

This then applies across many header types including BAM,CRAM,BEDTabix,GFF3Tabix,VCFTabix

In some situations, this could be better, and in some it could be worse. If the tracks have many thousands of refseqs, then there would be many thousands of not-very-informative header lines. Those can be collapsed when we do the mild parsing approach, but not with this raw approach. Is there any preference? We could also have both mild parsing and raw version...

Any thoughts welcome

This would require updates to BAM and CRAM to have a getRawHeader methods, which are on branches on those respective repos