### PR TITLE
Fix memory leak when side scrolling LGV blocks

### DIFF
--- a/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
+++ b/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
@@ -13,10 +13,9 @@ export default ({ jbrequire }) => {
 
     useEffect(() => {
       const domNode = ssrContainerNode.current
-      const isHydrated = hydrated.current
       function doHydrate() {
         if (domNode && filled) {
-          if (domNode && domNode.innerHTML && isHydrated) {
+          if (domNode && domNode.innerHTML && hydrated.current) {
             domNode.style.display = 'none'
             requestIdleCallback(() => unmountComponentAtNode(domNode))
           }
@@ -40,6 +39,11 @@ export default ({ jbrequire }) => {
         }
       }
       doHydrate()
+      return () => {
+        if (hydrated.current && domNode) {
+          unmountComponentAtNode(domNode)
+        }
+      }
     })
 
     return <g ref={ssrContainerNode} />

--- a/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
+++ b/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
@@ -9,15 +9,14 @@ export default ({ jbrequire }) => {
     const { data, html, filled, renderProps, renderingComponent } = model
 
     const ssrContainerNode = useRef(null)
-    const hydrated = useRef(false)
 
     useEffect(() => {
       const domNode = ssrContainerNode.current
       function doHydrate() {
         if (domNode && filled) {
-          if (domNode && domNode.innerHTML && hydrated.current) {
+          if (domNode && domNode.innerHTML) {
             domNode.style.display = 'none'
-            requestIdleCallback(() => unmountComponentAtNode(domNode))
+            unmountComponentAtNode(domNode)
           }
           domNode.style.display = 'inline'
           domNode.innerHTML = html
@@ -40,7 +39,7 @@ export default ({ jbrequire }) => {
       }
       doHydrate()
       return () => {
-        if (hydrated.current && domNode) {
+        if (domNode) {
           unmountComponentAtNode(domNode)
         }
       }

--- a/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
@@ -62,7 +62,6 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
 
   useEffect(() => {
     const domNode = ssrContainerNode.current
-    const isHydrated = hydrated.current
     function doHydrate() {
       const {
         data,
@@ -71,7 +70,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         renderingComponent: RenderingComponent,
       } = model
       if (domNode && model.filled) {
-        if (isHydrated && domNode) {
+        if (hydrated.current && domNode) {
           unmountComponentAtNode(domNode)
         }
         domNode.innerHTML = html
@@ -106,7 +105,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
     doHydrate()
 
     return () => {
-      if (domNode && isHydrated) {
+      if (domNode && hydrated.current) {
         unmountComponentAtNode(domNode)
       }
     }

--- a/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
@@ -54,7 +54,6 @@ class RenderErrorBoundary extends Component<{}, ErrorBoundaryState> {
 
 function ServerSideRenderedContent(props: { model: BlockModel }) {
   const ssrContainerNode = useRef<HTMLDivElement>(null)
-  const hydrated = useRef(false)
 
   const { model } = props
   const session = getSession(model)
@@ -70,7 +69,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         renderingComponent: RenderingComponent,
       } = model
       if (domNode && model.filled) {
-        if (hydrated.current && domNode) {
+        if (domNode) {
           unmountComponentAtNode(domNode)
         }
         domNode.innerHTML = html
@@ -95,7 +94,6 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
               </ThemeProvider>,
               domNode,
             )
-            hydrated.current = true
           },
           { timeout: 300 },
         )
@@ -105,7 +103,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
     doHydrate()
 
     return () => {
-      if (domNode && hydrated.current) {
+      if (domNode) {
         unmountComponentAtNode(domNode)
       }
     }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -74,7 +74,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
     doHydrate()
 
     return () => {
-      if (domNode && isHydrated) {
+      if (domNode && hydrated.current) {
         unmountComponentAtNode(domNode)
       }
     }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -10,7 +10,6 @@ import type { BlockModel } from '../models/serverSideRenderedBlock'
 
 function ServerSideRenderedContent(props: { model: BlockModel }) {
   const ssrContainerNode = useRef<HTMLDivElement>(null)
-  const hydrated = useRef(false)
 
   const { model } = props
   const session = getSession(model)
@@ -27,7 +26,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         renderingComponent: RenderingComponent,
       } = model
       if (domNode && filled) {
-        if (hydrated.current && domNode) {
+        if (domNode) {
           unmountComponentAtNode(domNode)
         }
         domNode.innerHTML = html
@@ -63,7 +62,6 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
               </ThemeProvider>,
               domNode,
             )
-            hydrated.current = true
           },
           { timeout: 300 },
         )
@@ -73,7 +71,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
     doHydrate()
 
     return () => {
-      if (domNode && hydrated.current) {
+      if (domNode) {
         unmountComponentAtNode(domNode)
       }
     }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -18,7 +18,6 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
 
   useEffect(() => {
     const domNode = ssrContainerNode.current
-    const isHydrated = hydrated.current
     function doHydrate() {
       const {
         data,
@@ -28,7 +27,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         renderingComponent: RenderingComponent,
       } = model
       if (domNode && filled) {
-        if (isHydrated && domNode) {
+        if (hydrated.current && domNode) {
           unmountComponentAtNode(domNode)
         }
         domNode.innerHTML = html


### PR DESCRIPTION
There was possibly a memory leak from side scrolling blocks. I saw memory increasing pretty high from sidescrolling lgv

I looked and this code was not called for example


```
diff --git a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.t>
index efd6e3600..66dd4de57 100644
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -75,6 +75,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {

     return () => {
       if (domNode && isHydrated) {
+        console.log('here')
         unmountComponentAtNode(domNode)
       }
     }
lines 1-12/12 (END)


```
We could adjust the use of the isHydrated variable but also it seems this fix on this branch is a simpler approach: always unmount because it is a do nothing if not mounted https://reactjs.org/docs/react-dom.html#unmountcomponentatnode
