### PR TITLE
Add more info about adding a PAF file to the synteny import form

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -141,10 +141,13 @@ export default () => {
 
             <Paper style={{ padding: 12 }}>
               <p style={{ textAlign: 'center' }}>
-                <b>Optional</b>: Add a PAF (pairwise alignment format) file for
-                the dotplot view. Note that the first assembly should be the
-                left column of the PAF and the second assembly should be the
-                right column
+                <b>Optional</b>: Add a PAF{' '}
+                <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">
+                  (pairwise mapping format)
+                </a>{' '}
+                file for the dotplot view. Note that the first assembly should
+                be the left column of the PAF and the second assembly should be
+                the right column
               </p>
               <div style={{ margin: '0 auto' }}>
                 <FileSelector

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import Typography from '@material-ui/core/Typography'
 import { FileSelector } from '@jbrowse/core/ui'
 import { FileLocation } from '@jbrowse/core/util/types'
 import { observer } from 'mobx-react'
@@ -120,7 +119,7 @@ export default () => {
           style={{ width: '50%', margin: '0 auto' }}
         >
           <Grid item>
-            <Paper style={{ padding: 12 }}>
+            <Paper style={{ padding: 12, marginBottom: 10 }}>
               <p style={{ textAlign: 'center' }}>
                 Select assemblies for dotplot view
               </p>
@@ -139,7 +138,7 @@ export default () => {
               ))}
             </Paper>
 
-            <Paper style={{ padding: 12 }}>
+            <Paper style={{ padding: 12, marginBottom: 10 }}>
               <p style={{ textAlign: 'center' }}>
                 <b>Optional</b>: Add a PAF{' '}
                 <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">
@@ -149,14 +148,16 @@ export default () => {
                 be the left column of the PAF and the second assembly should be
                 the right column
               </p>
-              <div style={{ margin: '0 auto' }}>
-                <FileSelector
-                  name="URL"
-                  description=""
-                  location={trackData}
-                  setLocation={loc => setTrackData(loc)}
-                />
-              </div>
+              <Grid container justify="center">
+                <Grid item>
+                  <FileSelector
+                    name="URL"
+                    description=""
+                    location={trackData}
+                    setLocation={loc => setTrackData(loc)}
+                  />
+                </Grid>
+              </Grid>
             </Paper>
           </Grid>
           <Grid item>

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -6,6 +6,7 @@ import { FileLocation } from '@jbrowse/core/util/types'
 import { observer } from 'mobx-react'
 import { getSession } from '@jbrowse/core/util'
 import Button from '@material-ui/core/Button'
+import Paper from '@material-ui/core/Paper'
 import Container from '@material-ui/core/Container'
 import Grid from '@material-ui/core/Grid'
 import MenuItem from '@material-ui/core/MenuItem'
@@ -16,6 +17,7 @@ export default () => {
   const useStyles = makeStyles(theme => ({
     importFormContainer: {
       padding: theme.spacing(4),
+      margin: '0 auto',
     },
     importFormEntry: {
       minWidth: 180,
@@ -110,34 +112,49 @@ export default () => {
 
     return (
       <Container className={classes.importFormContainer}>
-        <Grid container spacing={1} justify="center" alignItems="center">
+        <Grid
+          container
+          spacing={1}
+          justify="center"
+          alignItems="center"
+          style={{ width: '50%', margin: '0 auto' }}
+        >
           <Grid item>
-            <p style={{ textAlign: 'center' }}>
-              Select assemblies for dotplot view
-            </p>
-            {[...new Array(numRows)].map((_, index) => (
-              <FormRow
-                key={`row_${index}_${selected[index]}`}
-                error={error}
-                selected={selected[index]}
-                onChange={val => {
-                  const copy = selected.slice(0)
-                  copy[index] = val
-                  setSelected(copy)
-                }}
-                model={model}
-              />
-            ))}
-          </Grid>
+            <Paper style={{ padding: 12 }}>
+              <p style={{ textAlign: 'center' }}>
+                Select assemblies for dotplot view
+              </p>
+              {[...new Array(numRows)].map((_, index) => (
+                <FormRow
+                  key={`row_${index}_${selected[index]}`}
+                  error={error}
+                  selected={selected[index]}
+                  onChange={val => {
+                    const copy = selected.slice(0)
+                    copy[index] = val
+                    setSelected(copy)
+                  }}
+                  model={model}
+                />
+              ))}
+            </Paper>
 
-          <Grid item>
-            <Typography>Add a PAF file for the dotplot view</Typography>
-            <FileSelector
-              name="URL"
-              description=""
-              location={trackData}
-              setLocation={loc => setTrackData(loc)}
-            />
+            <Paper style={{ padding: 12 }}>
+              <p style={{ textAlign: 'center' }}>
+                <b>Optional</b>: Add a PAF (pairwise alignment format) file for
+                the dotplot view. Note that the first assembly should be the
+                left column of the PAF and the second assembly should be the
+                right column
+              </p>
+              <div style={{ margin: '0 auto' }}>
+                <FileSelector
+                  name="URL"
+                  description=""
+                  location={trackData}
+                  setLocation={loc => setTrackData(loc)}
+                />
+              </div>
+            </Paper>
           </Grid>
           <Grid item>
             <Button onClick={onOpenClick} variant="contained" color="primary">

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
 import { getSession } from '@jbrowse/core/util'
 import Button from '@material-ui/core/Button'
-import Typography from '@material-ui/core/Typography'
 import Container from '@material-ui/core/Container'
 import Grid from '@material-ui/core/Grid'
 import MenuItem from '@material-ui/core/MenuItem'
@@ -11,6 +10,7 @@ import TextField from '@material-ui/core/TextField'
 import { FileLocation } from '@jbrowse/core/util/types'
 import { makeStyles } from '@material-ui/core/styles'
 import { FileSelector } from '@jbrowse/core/ui'
+import { Paper } from '@material-ui/core'
 import { LinearSyntenyViewModel } from '../model'
 
 // the below importsused for multi-way synteny, not implemented yet
@@ -29,6 +29,12 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'center',
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
+  },
+  formPaper: {
+    maxWidth: 600,
+    margin: '0 auto',
+    padding: 12,
+    marginBottom: 10,
   },
 }))
 const FormRow = observer(
@@ -134,36 +140,51 @@ const ImportForm = observer(({ model }: { model: LinearSyntenyViewModel }) => {
 
   return (
     <Container className={classes.importFormContainer}>
-      <Grid container item justify="center" spacing={4} alignItems="center">
-        <Grid item>
+      <Paper className={classes.formPaper}>
+        <Grid container item justify="center" spacing={4} alignItems="center">
+          <Grid item>
+            <p style={{ textAlign: 'center' }}>
+              Select assemblies for synteny view
+            </p>
+            {[...new Array(numRows)].map((_, index) => (
+              <FormRow
+                key={`row_${index}_${selected[index]}`}
+                error={error}
+                selected={selected[index]}
+                onChange={val => {
+                  const copy = selected.slice(0)
+                  copy[index] = val
+                  setSelected(copy)
+                }}
+                model={model}
+              />
+            ))}
+          </Grid>
+        </Grid>
+      </Paper>
+
+      <Paper className={classes.formPaper}>
+        <Grid container justify="center">
           <p style={{ textAlign: 'center' }}>
-            Select assemblies for synteny view
+            <b>Optional</b>: Add a PAF{' '}
+            <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">
+              (pairwise mapping format)
+            </a>{' '}
+            file for the linear synteny view. Note that the first assembly
+            should be the left column of the PAF and the second assembly should
+            be the right column
           </p>
-          {[...new Array(numRows)].map((_, index) => (
-            <FormRow
-              key={`row_${index}_${selected[index]}`}
-              error={error}
-              selected={selected[index]}
-              onChange={val => {
-                const copy = selected.slice(0)
-                copy[index] = val
-                setSelected(copy)
-              }}
-              model={model}
+          <Grid item>
+            <FileSelector
+              name="URL"
+              description=""
+              location={trackData}
+              setLocation={loc => setTrackData(loc)}
             />
-          ))}
+          </Grid>
         </Grid>
-
-        <Grid item>
-          <Typography>Add a PAF file for the synteny view</Typography>
-          <FileSelector
-            name="URL"
-            description=""
-            location={trackData}
-            setLocation={loc => setTrackData(loc)}
-          />
-        </Grid>
-
+      </Paper>
+      <Grid container justify="center">
         <Grid item>
           <Button onClick={onOpenClick} variant="contained" color="primary">
             Open


### PR DESCRIPTION
This was a carry over from #1539 to try to improve the synteny import form

Screenshot here
![localhost_3000__config=test_data%2Fconfig json session=local-k4_vfnJfl](https://user-images.githubusercontent.com/6511937/101807463-23f24800-3ae3-11eb-8420-2f04e472a750.png)


Makes it clear that PAF is optional, that PAF is "pairwise mapping format", and details about how the assemblies you pick correspond to the columns in the paf