### PR TITLE
Flaky Search RefNameAutocomplete Test

### DIFF
--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
@@ -183,27 +183,23 @@ describe('valid file tests', () => {
     await findByTestId(
       'trackRenderingContainer-integration_test-volvox_alignments',
     )
+    const autocomplete = await findByTestId('autocomplete')
     const inputBox = await findByPlaceholderText('Search for location')
-    const test2 = await findByTestId('autocomplete')
-    inputBox.focus()
+
+    autocomplete.focus()
     fireEvent.change(inputBox, {
-      target: { value: 'ctg' },
+      target: { value: 'ctgB:1..200' },
     })
-    fireEvent.keyDown(test2, { key: 'ArrowDown' })
-    fireEvent.keyDown(test2, { key: 'ArrowDown' })
-    fireEvent.keyDown(test2, { key: 'Enter', code: 'Enter' })
-    expect(state.session.views[0].displayedRegions[0].refName).toEqual('ctgB')
+
+    fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
+    fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+    await wait(() =>
+      expect(state.session.views[0].displayedRegions[0].refName).toEqual(
+        'ctgB',
+      ),
+    )
     expect((await findByPlaceholderText('Search for location')).value).toEqual(
       expect.stringContaining('ctgB'),
     )
-    const test1 = await findByPlaceholderText('Search for location')
-    fireEvent.change(inputBox, {
-      target: { value: 'ctgA:1..120' },
-    })
-    fireEvent.keyDown(test1, { key: 'Enter', code: 'Enter' })
-    expect((await findByPlaceholderText('Search for location')).value).toEqual(
-      expect.stringContaining('ctgA'),
-    )
-    expect(state.session.views[0].displayedRegions[0].refName).toEqual('ctgA')
   })
 })


### PR DESCRIPTION
[Issue 1548 - Flaky Search Test](https://github.com/GMOD/jbrowse-components/issues/1548)

Trying to reduce the amount of steps in the test.
Found flakiness with: ` fireEvent.keyDown(component, { key: 'Enter', code: 'Enter' }) `.
