### PR TITLE
Remove the TextDecoder/TextEncoder polyfill

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -15,7 +15,6 @@ import { AnyConfigurationModel } from '@jbrowse/core/configuration/configuration
 import { types, Instance, SnapshotOut } from 'mobx-state-tree'
 import { PluginConstructor } from '@jbrowse/core/Plugin'
 import { FatalErrorDialog } from '@jbrowse/core/ui'
-import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import 'fontsource-roboto'
 import 'requestidlecallback-polyfill'
 import 'core-js/stable'
@@ -34,12 +33,6 @@ import packagedef from '../package.json'
 import factoryReset from './factoryReset'
 import StartScreen from './StartScreen'
 
-if (!window.TextEncoder) {
-  window.TextEncoder = TextEncoder
-}
-if (!window.TextDecoder) {
-  window.TextDecoder = TextDecoder
-}
 function NoConfigMessage() {
   const s = window.location.search
   const links = [

--- a/products/jbrowse-web/src/tests/util.js
+++ b/products/jbrowse-web/src/tests/util.js
@@ -1,6 +1,5 @@
 import rangeParser from 'range-parser' // eslint-disable-line import/no-extraneous-dependencies
 import PluginManager from '@jbrowse/core/PluginManager'
-import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import JBrowseRootModelFactory from '../rootModel'
 import configSnapshot from '../../test_data/volvox/config.json'
 import corePlugins from '../corePlugins'
@@ -67,9 +66,6 @@ export function generateReadBuffer(getFileFunction) {
 }
 
 export function setup() {
-  if (!window.TextEncoder) window.TextEncoder = TextEncoder
-  if (!window.TextDecoder) window.TextDecoder = TextDecoder
-
   window.requestIdleCallback = cb => cb()
   window.cancelIdleCallback = () => {}
   window.requestAnimationFrame = cb => setTimeout(cb)


### PR DESCRIPTION
Fixes #1553 by removing the TextDecoder polyfill we were using

It has different behavior to what exists on the proper https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder

Hard exactly to tell why but the TextDecoder object we were receiving was not a proper instance of a TextDecoder

Possibly related to how this module allows multiple different ways of importing the module
https://github.com/anonyco/FastestSmallestTextEncoderDecoder

Note that caniuse says that all our browsers we target are ok without this https://caniuse.com/textencoder