### PR TITLE
Avoid errors from breakpoint split view related to getBoundingClientRect

### DIFF
--- a/plugins/breakpoint-split-view/src/util.ts
+++ b/plugins/breakpoint-split-view/src/util.ts
@@ -14,7 +14,8 @@ function heightFromSpecificLevel(
   trackConfigId: string,
   level: number,
 ) {
-  return views[level].trackRefs[trackConfigId].getBoundingClientRect().top
+  const track = views[level].trackRefs[trackConfigId]
+  return track?.getBoundingClientRect().top || 0
 }
 
 export function getPxFromCoordinate(


### PR DESCRIPTION
![s3 amazonaws com_jbrowse org_code_jb2_v1 0 2_index html_session=local-Go9biLRff](https://user-images.githubusercontent.com/6511937/102025520-84dd8280-3d66-11eb-8d48-c7c074b56b37.png)

Seen on master while flipping through SV inspector and launching breakpoint split views