### PR TITLE
Remove softclip and hardclip from snpcov

### DIFF
--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -285,7 +285,12 @@ export default (pluginManager: PluginManager) => {
                       bin.getNested(base).decrement('reference', overlap)
                     }
 
-                    if (base && base !== '*' && base !== 'skip') {
+                    if (
+                      base &&
+                      base !== '*' &&
+                      base !== 'skip' &&
+                      base !== 'softclip'
+                    ) {
                       bin.getNested(base).increment(strand, overlap)
                     }
                   },


### PR DESCRIPTION
This removes soft/hard clipping from the snpcoverage

Currently it incorrectly draws softclip in the SNPCoverageRenderer using the color that was used to draw the SNP before it

Before, the clipping increases the count in a base which does not actually have an increased count, and colors it sort of randomly with red because it was what is in the ctx.fillStyle from another SNP
![localhost_3000__config=test_data%2Fconfig_demo json session=local-yh38NOn5j (1)](https://user-images.githubusercontent.com/6511937/102254363-83cb6300-3ed6-11eb-91db-6c98d6398ffc.png)



After, no softclipping into in the coverage, no coloring of it
![localhost_3000__config=test_data%2Fconfig_demo json session=local-yh38NOn5j](https://user-images.githubusercontent.com/6511937/102254276-6bf3df00-3ed6-11eb-81b3-3a7219120bd0.png)


This is a bit anti-thetical to goals like #815 but the way it is being done right now on master is sort of incorrect