### PR TITLE
Rename jbrowse cli add-track --type to --trackType

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -265,7 +265,7 @@ describe('add-track', () => {
       'customTrackId',
       '--description',
       'new description',
-      '--type',
+      '--trackType',
       'CustomTrackType',
       '--category',
       'newcategory',

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -39,7 +39,7 @@ export default class AddTrack extends JBrowseCommand {
     '$ jbrowse add-track /path/to/my.bam --load copy',
     '$ jbrowse add-track /path/to/my.bam --target /path/to/jbrowse2/installation/config.json --load symlink',
     '$ jbrowse add-track https://mywebsite.com/my.bam',
-    `$ jbrowse add-track /path/to/my.bam --type AlignmentsTrack --name 'New Track' --load move`,
+    `$ jbrowse add-track /path/to/my.bam --trackType AlignmentsTrack --name 'New Track' --load move`,
     `$ jbrowse add-track /path/to/my.bam --trackId AlignmentsTrack1 --load inPlace --overwrite`,
     `$ jbrowse add-track /path/to/my.bam --config '{"defaultRendering": "density"}'`,
   ]
@@ -53,7 +53,7 @@ export default class AddTrack extends JBrowseCommand {
   ]
 
   static flags = {
-    type: flags.string({
+    trackType: flags.string({
       char: 't',
       description: `Type of track, by default inferred from track file`,
     }),

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -143,7 +143,7 @@ export default class AddTrack extends JBrowseCommand {
     const isDir = (await fsPromises.lstat(output)).isDirectory()
     this.target = isDir ? `${output}/config.json` : output
 
-    let { type, trackId, name, assemblyNames } = runFlags
+    let { trackType, trackId, name, assemblyNames } = runFlags
 
     const configDirectory = path.dirname(this.target)
     if (!argsTrack) {
@@ -208,7 +208,7 @@ export default class AddTrack extends JBrowseCommand {
     }
 
     // set up the track information
-    type = type || this.guessTrackType(adapter.type)
+    const type = trackType || this.guessTrackType(adapter.type)
     trackId = trackId || path.basename(location, path.extname(location))
     name = name || trackId
     assemblyNames = assemblyNames || configContents.assemblies[0].name


### PR DESCRIPTION
Renames the current --type option to --trackType

In reference to
https://github.com/GMOD/jbrowse-components/discussions/1545

We could also consider adding an adapterType that overrides guessAdapterType, but that is currently difficult because every data adapter is kind of different (there is no standard based on supplying just urlTemplate...)