### PR TITLE
Plugin support

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -65,11 +65,24 @@ export default class PluginLoader {
       await this.loadScript(definition.url)
       const moduleName = definition.name
       const umdName = `JBrowsePlugin${moduleName}`
+      // Based on window-or-global
+      // https://github.com/purposeindustries/window-or-global/blob/322abc71de0010c9e5d9d0729df40959e1ef8775/lib/index.js
+      const scope =
+        (typeof self === 'object' && self.self === self && self) ||
+        (typeof global === 'object' && global.global === global && global) ||
+        this
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const plugin = (window as any)[umdName] as { default: PluginConstructor }
+      let plugin = (scope as any)[umdName] as { default: PluginConstructor }
+      if (!plugin) {
+        // In a web worker, the plugin may be on the global scope or global.window
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        plugin = (scope as any).window[umdName] as {
+          default: PluginConstructor
+        }
+      }
       if (!plugin)
         throw new Error(
-          `plugin ${moduleName} failed to load, window.${umdName} is undefined`,
+          `plugin ${moduleName} failed to load, both ${scope.constructor.name}.${umdName} and ${scope.constructor.name}.window.${umdName} are undefined`,
         )
 
       return plugin.default

--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -7,6 +7,7 @@ export default [
   'prop-types',
 
   '@material-ui/core',
+  '@material-ui/core/styles',
   '@material-ui/lab',
 
   '@jbrowse/core/Plugin',
@@ -29,6 +30,7 @@ export default [
   '@jbrowse/core/util/Base1DViewModel',
   '@jbrowse/core/util/io',
   '@jbrowse/core/util/mst-reflection',
+  '@jbrowse/core/util/rxjs',
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail',
 
   '@jbrowse/core/data_adapters/BaseAdapter',

--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -11,6 +11,7 @@ import * as MUIStyles from '@material-ui/core/styles'
 // @material-ui components
 import * as MUICore from '@material-ui/core'
 import * as MUILab from '@material-ui/lab'
+import MUISvgIcon from '@material-ui/core/SvgIcon'
 import MUIBox from '@material-ui/core/Box'
 import MUIButton from '@material-ui/core/Button'
 import MUIButtonGroup from '@material-ui/core/ButtonGroup'
@@ -69,6 +70,7 @@ import * as coreColor from '../util/color'
 import * as trackUtils from '../util/tracks'
 import * as coreIo from '../util/io'
 import * as coreMstReflection from '../util/mst-reflection'
+import * as rxjs from '../util/rxjs'
 import * as MUIColors from './material-ui-colors'
 import * as mstTypes from '../util/types/mst'
 
@@ -85,6 +87,9 @@ const libs = {
   // material-ui 1st-level components
   '@material-ui/core': MUICore,
   '@material-ui/lab': MUILab,
+
+  // special case so plugins can easily use @material-ui/icons; don't remove
+  '@material-ui/core/SvgIcon': MUISvgIcon,
 
   // material-ui subcomponents, should get rid of these
   '@material-ui/core/colors': MUIColors,
@@ -143,6 +148,7 @@ const libs = {
   '@jbrowse/core/util/Base1DViewModel': Base1DView,
   '@jbrowse/core/util/io': coreIo,
   '@jbrowse/core/util/mst-reflection': coreMstReflection,
+  '@jbrowse/core/util/rxjs': rxjs,
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail': BaseFeatureDetail,
 
   '@jbrowse/core/data_adapters/BaseAdapter': BaseAdapterExports,

--- a/packages/development-tools/src/__snapshots__/build.test.ts.snap
+++ b/packages/development-tools/src/__snapshots__/build.test.ts.snap
@@ -184,6 +184,15 @@ Object {
         "@jbrowse/core/util/mst-reflection",
       ],
     },
+    "@jbrowse/core/util/rxjs": Object {
+      "amd": "@jbrowse/core/util/rxjs",
+      "commonjs": "@jbrowse/core/util/rxjs",
+      "commonjs2": "@jbrowse/core/util/rxjs",
+      "root": Array [
+        "JBrowseExports",
+        "@jbrowse/core/util/rxjs",
+      ],
+    },
     "@jbrowse/core/util/tracks": Object {
       "amd": "@jbrowse/core/util/tracks",
       "commonjs": "@jbrowse/core/util/tracks",
@@ -209,6 +218,15 @@ Object {
       "root": Array [
         "JBrowseExports",
         "@material-ui/core",
+      ],
+    },
+    "@material-ui/core/styles": Object {
+      "amd": "@material-ui/core/styles",
+      "commonjs": "@material-ui/core/styles",
+      "commonjs2": "@material-ui/core/styles",
+      "root": Array [
+        "JBrowseExports",
+        "@material-ui/core/styles",
       ],
     },
     "@material-ui/lab": Object {

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -41,7 +41,10 @@ async function getPluginManager() {
   // Load runtime plugins
   const config = await receiveConfiguration()
   const pluginLoader = new PluginLoader(config.plugins)
+  // Put re-exports on both self and self.window to support various places
+  // plugin bundlers expect them to be
   pluginLoader.installGlobalReExports(self.window)
+  pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()
   const plugins = [...corePlugins, ...runtimePlugins]
   const pluginManager = new PluginManager(plugins.map(P => new P()))


### PR DESCRIPTION
This adds a few things to the plugin architecture to support plugins bundled like in https://github.com/GMOD/jbrowse-plugin-gdc/pull/5. It doesn't remove any existing support for other plugin bundles.