### PR TITLE
Improve mobx-state-tree type validation errors

### DIFF
--- a/products/jbrowse-desktop/rescripts/webpackRescript.js
+++ b/products/jbrowse-desktop/rescripts/webpackRescript.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -19,6 +20,14 @@ module.exports = {
       new HtmlWebpackPlugin({
         chunks: ['rpc'],
         filename: 'worker.html',
+      }),
+    )
+    config.plugins.unshift(
+      new webpack.DefinePlugin({
+        // Global mobx-state-tree configuration.
+        // Force type checking in production for easier debugging:
+        // xref https://github.com/GMOD/jbrowse-components/pull/1575
+        'process.env.ENABLE_TYPE_CHECK': '"true"',
       }),
     )
     // Not sure why, but have to change this or the rpc entrypoint won't run

--- a/products/jbrowse-desktop/rescripts/webpackRescript.js
+++ b/products/jbrowse-desktop/rescripts/webpackRescript.js
@@ -1,4 +1,5 @@
 const path = require('path')
+// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const HtmlWebpackPlugin = require('html-webpack-plugin')

--- a/products/jbrowse-web/rescripts/webpackRescript.js
+++ b/products/jbrowse-web/rescripts/webpackRescript.js
@@ -1,6 +1,20 @@
+const webpack = require('webpack')
+
 module.exports = {
   devServer: config => {
     config.staticOptions = { fallthrough: false }
+    return config
+  },
+
+  webpack: config => {
+    config.plugins.unshift(
+      new webpack.DefinePlugin({
+        // Global mobx-state-tree configuration.
+        // Force type checking in production for easier debugging:
+        // xref https://github.com/GMOD/jbrowse-components/pull/1575
+        'process.env.ENABLE_TYPE_CHECK': '"true"',
+      }),
+    )
     return config
   },
 }

--- a/products/jbrowse-web/rescripts/webpackRescript.js
+++ b/products/jbrowse-web/rescripts/webpackRescript.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack')
 
 module.exports = {

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -482,7 +482,13 @@ const Renderer = observer(
                 <>
                   {' '}
                   ... Failed element had snapshot:
-                  <pre>
+                  <pre
+                    style={{
+                      background: 'lightgrey',
+                      border: '1px solid black',
+                      margin: 20,
+                    }}
+                  >
                     {JSON.stringify(JSON.parse(snapshotError), null, 2)}
                   </pre>
                 </>

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -470,7 +470,8 @@ const Renderer = observer(
             <div
               style={{
                 border: '1px solid black',
-
+                overflow: 'auto',
+                maxHeight: 200,
                 padding: 2,
                 margin: 2,
                 backgroundColor: '#ff8888',

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -155,4 +155,21 @@ describe('<Loader />', () => {
     )
     await findAllByText(/Unable to fetch session/)
   }, 10000)
+
+  it('can catch error from loading a bad config', async () => {
+    const { findAllByText } = render(
+      <ErrorBoundary FallbackComponent={({ error }) => <div>{`${error}`}</div>}>
+        <QueryParamProvider
+          // @ts-ignore
+          location={{
+            search:
+              '?config=test_data/bad_config_for_testing_error_catcher.json',
+          }}
+        >
+          <Loader initialTimestamp={initialTimestamp} />
+        </QueryParamProvider>
+      </ErrorBoundary>,
+    )
+    await findAllByText(/Failed to load/)
+  }, 10000)
 })

--- a/test_data/bad_config_for_testing_error_catcher.json
+++ b/test_data/bad_config_for_testing_error_catcher.json
@@ -1,0 +1,22 @@
+{
+  "tracks": [
+    {
+      "type": "VariantTrack",
+      "trackId": "volvox_sv_test",
+      "name": "volvox structural variant test",
+      "category": ["VCF"],
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "Garbage",
+        "vcfGzLocation": {
+          "uri": "volvox.dup.vcf.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "volvox.dup.vcf.gz.tbi"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is an attempt to improve the loader error

Fixes #1515 

Note that this issue of the infinite CPU only happens due to react-error-overlay in dev but is now fixed by this and attempts to additionally improve the situation by providing a slightly more readable abbreviated error message than the default

Screenshot

![localhost_3000__config=test_data_volvox_config json (1)](https://user-images.githubusercontent.com/6511937/102703819-01c69b80-4242-11eb-911a-fe45be5d914c.png)


This helps us understand potentially the track the failed to load, and the "path" e.g. it is the first track