### PR TITLE
Create --branch and --nightly flags for `jbrowse create` and `jbrowse upgrade` commands

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,4 +53,5 @@ jobs:
       - name: Copy branch build to S3
         run: |
           cp products/jbrowse-web/build/test_data/config.json products/jbrowse-web/build/config.json
+          cd products/jbrowse-web/build && zip -r "jbrowse-web-$(echo ${{github.ref}} | cut -d '/' -f3-).zip" . && cd -
           aws s3 sync --delete products/jbrowse-web/build s3://jbrowse.org/code/jb2/$(echo ${{github.ref}} | cut -d "/" -f3-)

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -409,6 +409,8 @@ OPTIONS
 
   -u, --url=url       A direct URL to a JBrowse 2 release
 
+  --nightly=nightly   Download the latest build release off of the master branch
+
 EXAMPLES
   $ jbrowse upgrade # Upgrades current directory to latest jbrowse release
   $ jbrowse upgrade /path/to/jbrowse2/installation

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -327,9 +327,9 @@ OPTIONS
 
   -u, --url=url       A direct URL to a JBrowse 2 release
 
-  --branch=branch     Branch name to fetch from
+  --branch=branch     Download a development build from a named git branch
 
-  --nightly           Get the latest build from master
+  --nightly           Download the latest development build from the master branch
 
 EXAMPLES
   $ jbrowse create /path/to/new/installation
@@ -413,9 +413,9 @@ OPTIONS
 
   -u, --url=url       A direct URL to a JBrowse 2 release
 
-  --branch=branch     Download the latest build release off of the master branch
+  --branch=branch     Download a development build from a named git branch
 
-  --nightly           Get the latest build from master
+  --nightly           Download the latest development build from the master branch
 
 EXAMPLES
   $ jbrowse upgrade # Upgrades current directory to latest jbrowse release

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -329,6 +329,8 @@ OPTIONS
 
   --branch=branch     Branch name to fetch from
 
+  --nightly           Get the latest build from master
+
 EXAMPLES
   $ jbrowse create /path/to/new/installation
   $ jbrowse create /path/to/new/installation --force
@@ -412,6 +414,8 @@ OPTIONS
   -u, --url=url       A direct URL to a JBrowse 2 release
 
   --branch=branch     Download the latest build release off of the master branch
+
+  --nightly           Get the latest build from master
 
 EXAMPLES
   $ jbrowse upgrade # Upgrades current directory to latest jbrowse release

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -327,6 +327,8 @@ OPTIONS
 
   -u, --url=url       A direct URL to a JBrowse 2 release
 
+  --branch=branch     Branch name to fetch from
+
 EXAMPLES
   $ jbrowse create /path/to/new/installation
   $ jbrowse create /path/to/new/installation --force
@@ -409,7 +411,7 @@ OPTIONS
 
   -u, --url=url       A direct URL to a JBrowse 2 release
 
-  --nightly=nightly   Download the latest build release off of the master branch
+  --branch=branch     Download the latest build release off of the master branch
 
 EXAMPLES
   $ jbrowse upgrade # Upgrades current directory to latest jbrowse release

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -251,6 +251,6 @@ export default abstract class JBrowseCommand extends Command {
   }
 
   async getBranch(branch: string) {
-    return `https://s3.amazonaws.com/jbrowse.org/code/jb2/${branch}/jbrowse-${branch}.zip`
+    return `https://s3.amazonaws.com/jbrowse.org/code/jb2/${branch}/jbrowse-web-${branch}.zip`
   }
 }

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -249,4 +249,8 @@ export default abstract class JBrowseCommand extends Command {
       exit: 90,
     })
   }
+
+  async getBranch(branch: string) {
+    return `https://s3.amazonaws.com/jbrowse.org/code/jb2/${branch}/jbrowse-${branch}.zip`
+  }
 }

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -41,6 +41,9 @@ export default class Create extends JBrowseCommand {
     branch: flags.string({
       description: 'Branch name to fetch from',
     }),
+    nightly: flags.boolean({
+      description: 'Get the latest build from master',
+    }),
     url: flags.string({
       char: 'u',
       description: 'A direct URL to a JBrowse 2 release',
@@ -57,7 +60,7 @@ export default class Create extends JBrowseCommand {
     const { localPath: argsPath } = runArgs as { localPath: string }
     this.debug(`Want to install path at: ${argsPath}`)
 
-    const { force, url, listVersions, tag, branch } = runFlags
+    const { force, url, listVersions, tag, branch, nightly } = runFlags
 
     if (listVersions) {
       const versions = (await this.fetchGithubVersions()).map(
@@ -76,6 +79,7 @@ export default class Create extends JBrowseCommand {
 
     const locationUrl =
       url ||
+      (nightly ? await this.getBranch('master') : '') ||
       (branch ? await this.getBranch(branch) : '') ||
       (tag ? await this.getTag(tag) : await this.getLatest())
 

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -39,10 +39,11 @@ export default class Create extends JBrowseCommand {
       description: 'Lists out all versions of JBrowse 2',
     }),
     branch: flags.string({
-      description: 'Branch name to fetch from',
+      description: 'Download a development build from a named git branch',
     }),
     nightly: flags.boolean({
-      description: 'Get the latest build from master',
+      description:
+        'Download the latest development build from the master branch',
     }),
     url: flags.string({
       char: 'u',

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -38,6 +38,9 @@ export default class Create extends JBrowseCommand {
       char: 'l',
       description: 'Lists out all versions of JBrowse 2',
     }),
+    branch: flags.string({
+      description: 'Branch name to fetch from',
+    }),
     url: flags.string({
       char: 'u',
       description: 'A direct URL to a JBrowse 2 release',
@@ -54,7 +57,7 @@ export default class Create extends JBrowseCommand {
     const { localPath: argsPath } = runArgs as { localPath: string }
     this.debug(`Want to install path at: ${argsPath}`)
 
-    const { force, url, listVersions, tag } = runFlags
+    const { force, url, listVersions, tag, branch } = runFlags
 
     if (listVersions) {
       const versions = (await this.fetchGithubVersions()).map(
@@ -72,7 +75,9 @@ export default class Create extends JBrowseCommand {
     }
 
     const locationUrl =
-      url || (tag ? await this.getTag(tag) : await this.getLatest())
+      url ||
+      (branch ? await this.getBranch(branch) : '') ||
+      (tag ? await this.getTag(tag) : await this.getLatest())
 
     this.log(`Fetching ${locationUrl}...`)
     const response = await fetch(locationUrl)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -46,6 +46,9 @@ export default class Upgrade extends JBrowseCommand {
     branch: flags.string({
       description: 'Download the latest build release off of the master branch',
     }),
+    nightly: flags.boolean({
+      description: 'Get the latest build from master',
+    }),
     url: flags.string({
       char: 'u',
       description: 'A direct URL to a JBrowse 2 release',
@@ -56,7 +59,7 @@ export default class Upgrade extends JBrowseCommand {
     const { args: runArgs, flags: runFlags } = this.parse(Upgrade)
     const { localPath: argsPath } = runArgs as { localPath: string }
 
-    const { listVersions, tag, url, branch } = runFlags
+    const { listVersions, tag, url, branch, nightly } = runFlags
 
     if (listVersions) {
       const versions = (await this.fetchGithubVersions()).map(
@@ -81,6 +84,7 @@ export default class Upgrade extends JBrowseCommand {
 
     const locationUrl =
       url ||
+      (nightly ? await this.getBranch('master') : '') ||
       (branch ? await this.getBranch(branch) : '') ||
       (tag ? await this.getTag(tag) : await this.getLatest())
 

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -43,6 +43,9 @@ export default class Upgrade extends JBrowseCommand {
       description:
         'Version of JBrowse 2 to install. Format is v1.0.0.\nDefaults to latest',
     }),
+    nightly: flags.string({
+      description: 'Download the latest build release off of the master branch',
+    }),
     url: flags.string({
       char: 'u',
       description: 'A direct URL to a JBrowse 2 release',

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -43,7 +43,7 @@ export default class Upgrade extends JBrowseCommand {
       description:
         'Version of JBrowse 2 to install. Format is v1.0.0.\nDefaults to latest',
     }),
-    nightly: flags.string({
+    branch: flags.string({
       description: 'Download the latest build release off of the master branch',
     }),
     url: flags.string({
@@ -56,7 +56,7 @@ export default class Upgrade extends JBrowseCommand {
     const { args: runArgs, flags: runFlags } = this.parse(Upgrade)
     const { localPath: argsPath } = runArgs as { localPath: string }
 
-    const { listVersions, tag, url } = runFlags
+    const { listVersions, tag, url, branch } = runFlags
 
     if (listVersions) {
       const versions = (await this.fetchGithubVersions()).map(
@@ -80,7 +80,9 @@ export default class Upgrade extends JBrowseCommand {
     }
 
     const locationUrl =
-      url || (tag ? await this.getTag(tag) : await this.getLatest())
+      url ||
+      (branch ? await this.getBranch(branch) : '') ||
+      (tag ? await this.getTag(tag) : await this.getLatest())
 
     this.log(`Fetching ${locationUrl}...`)
     const response = await fetch(locationUrl)

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -44,10 +44,11 @@ export default class Upgrade extends JBrowseCommand {
         'Version of JBrowse 2 to install. Format is v1.0.0.\nDefaults to latest',
     }),
     branch: flags.string({
-      description: 'Download the latest build release off of the master branch',
+      description: 'Download a development build from a named git branch',
     }),
     nightly: flags.boolean({
-      description: 'Get the latest build from master',
+      description:
+        'Download the latest development build from the master branch',
     }),
     url: flags.string({
       char: 'u',


### PR DESCRIPTION
This re-instates the upload of a jbrowse-web build to the folder where it is being deployed (this existed in travis but was lost in the github move)

Then it also adds a --branch and a --nightly (alias for --branch master) flags to the `jbrowse create` and `jbrowse upgrade` commands

