### PR TITLE
Restructure demo page and release cancer demo

### DIFF
--- a/website/src/pages/demos.md
+++ b/website/src/pages/demos.md
@@ -1,15 +1,17 @@
 # JBrowse 2 demos
 
-## Current versions
+## [Current demo (cancer genomics)](http://jbrowse.org/demos/current/)
 
+We have prepared several demos showing the new capabilities and features of
+JBrowse 2.
+The demos contain examples of new workflows and views in JBrowse 2, with links
+to live sessions in order for you to be able to experience the app yourself.
+The link above will always direct to the most recent demo that has been released.
+Enjoy!
+
+- [Cancer genomics demo](http://jbrowse.org/demos/cancer-demo-2020/)
 - [jbrowse-web@1.0.0 release](http://jbrowse.org/demos/1.0.0/)
-- [current](http://jbrowse.org/demos/current/)
-
-## Conference demos
-
-Here are some live demos and screenshots showing capabilities and features of
-JBrowse 2
-
-- Demos presented at [ASHG2020](http://jbrowse.org/demos/ashg2020/)
-- Demos presented at [ITCR2020](http://jbrowse.org/demos/itcr2020/)
-- Demos presented at [BOG2020](http://jbrowse.org/demos/bog2020/)
+- Conference demos:
+  - [ASHG2020](http://jbrowse.org/demos/ashg2020/)
+  - [ITCR2020](http://jbrowse.org/demos/itcr2020/)
+  - [BOG2020](http://jbrowse.org/demos/bog2020/)


### PR DESCRIPTION
This PR adds the cancer genomics demo to the list of JB2 demos. (closes #1322 )

Also, after talking w/ @rbuels , did some clean up and restructuring of the demo page to make it easier to understand.

Before:

![image](https://user-images.githubusercontent.com/19295181/102951455-c1edf700-4481-11eb-983d-7ce94174a349.png)

After:

![image](https://user-images.githubusercontent.com/19295181/102951485-cfa37c80-4481-11eb-8969-b00e5849947d.png)
