### PR TITLE
Updates to improve scalebar tooltips, overview scalebar plotting, and refName label positioning

### DIFF
--- a/packages/core/util/Base1DViewModel.test.ts
+++ b/packages/core/util/Base1DViewModel.test.ts
@@ -34,7 +34,7 @@ test('Able to set bpPerPx, width and calculate widths', () => {
   // 40000 + (3000 - 600 = 2400) = 42400 / 1 (bpPerPx) = 42400
   expect(model.displayedRegionsTotalPx).toEqual(42400)
   expect(model.interRegionPaddingWidth).toEqual(2)
-  expect(model.minimumBlockWidth).toEqual(20)
+  expect(model.minimumBlockWidth).toEqual(3)
 })
 
 test('Able to set and showAll Regions', () => {

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -19,6 +19,8 @@ const Base1DView = types
     displayedRegions: types.array(Region),
     bpPerPx: 0,
     offsetPx: 0,
+    interRegionPaddingWidth: types.optional(types.number, 2),
+    minimumBlockWidth: types.optional(types.number, 3),
   })
   .volatile(() => ({
     features: undefined as undefined | Feature[],
@@ -59,12 +61,6 @@ const Base1DView = types
       return self.displayedRegions
         .map(a => a.end - a.start)
         .reduce((a, b) => a + b, 0)
-    },
-    get interRegionPaddingWidth() {
-      return 2
-    },
-    get minimumBlockWidth() {
-      return 3
     },
     /**
      * calculates the Px at which coord is found.

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -64,7 +64,7 @@ const Base1DView = types
       return 2
     },
     get minimumBlockWidth() {
-      return 20
+      return 3
     },
     /**
      * calculates the Px at which coord is found.

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -62,6 +62,7 @@ const Base1DView = types
         .map(a => a.end - a.start)
         .reduce((a, b) => a + b, 0)
     },
+
     /**
      * calculates the Px at which coord is found.
      *

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -81,6 +81,7 @@ const Base1DView = types
     }) {
       let offsetBp = 0
 
+      const interRegionPaddingBp = self.interRegionPaddingWidth * self.bpPerPx
       const index = self.displayedRegions.findIndex((r, idx) => {
         if (refName === r.refName && coord >= r.start && coord <= r.end) {
           // using optional parameter ,regionNumber, as additional requirement to find
@@ -90,7 +91,7 @@ const Base1DView = types
             return true
           }
         }
-        offsetBp += r.end - r.start
+        offsetBp += r.end - r.start + interRegionPaddingBp
         return false
       })
       const foundRegion = self.displayedRegions[index]

--- a/packages/core/util/__snapshots__/calculateDynamicBlocks.test.ts.snap
+++ b/packages/core/util/__snapshots__/calculateDynamicBlocks.test.ts.snap
@@ -27,6 +27,16 @@ Array [
 
 exports[`four 1`] = `
 Array [
+  InterRegionPaddingBlock {
+    "assemblyName": undefined,
+    "end": undefined,
+    "key": "{test}ctgA:1..250-0-beforeFirstRegion",
+    "offsetPx": -100,
+    "refName": undefined,
+    "start": undefined,
+    "variant": "boundary",
+    "widthPx": 100,
+  },
   ContentBlock {
     "assemblyName": "test",
     "end": 250,
@@ -51,6 +61,16 @@ Array [
 
 exports[`one 1`] = `
 Array [
+  InterRegionPaddingBlock {
+    "assemblyName": undefined,
+    "end": undefined,
+    "key": "{test}ctgA:1..200-0-beforeFirstRegion",
+    "offsetPx": 0,
+    "refName": undefined,
+    "start": undefined,
+    "variant": "boundary",
+    "widthPx": -0,
+  },
   ContentBlock {
     "assemblyName": "test",
     "end": 200,
@@ -75,6 +95,16 @@ Array [
 
 exports[`three 1`] = `
 Array [
+  InterRegionPaddingBlock {
+    "assemblyName": undefined,
+    "end": undefined,
+    "key": "{test}ctgA:49,901..50,000-0-reversed-beforeFirstRegion",
+    "offsetPx": -100,
+    "refName": undefined,
+    "start": undefined,
+    "variant": "boundary",
+    "widthPx": 100,
+  },
   ContentBlock {
     "assemblyName": "test",
     "end": 50000,
@@ -100,6 +130,16 @@ Array [
 
 exports[`two 1`] = `
 Array [
+  InterRegionPaddingBlock {
+    "assemblyName": undefined,
+    "end": undefined,
+    "key": "{test}ctgA:49,801..50,000-0-reversed-beforeFirstRegion",
+    "offsetPx": 0,
+    "refName": undefined,
+    "start": undefined,
+    "variant": "boundary",
+    "widthPx": -0,
+  },
   ContentBlock {
     "assemblyName": "test",
     "end": 50000,

--- a/packages/core/util/__snapshots__/calculateDynamicBlocks.test.ts.snap
+++ b/packages/core/util/__snapshots__/calculateDynamicBlocks.test.ts.snap
@@ -27,16 +27,6 @@ Array [
 
 exports[`four 1`] = `
 Array [
-  InterRegionPaddingBlock {
-    "assemblyName": undefined,
-    "end": undefined,
-    "key": "{test}ctgA:1..250-0-beforeFirstRegion",
-    "offsetPx": -100,
-    "refName": undefined,
-    "start": undefined,
-    "variant": "boundary",
-    "widthPx": 100,
-  },
   ContentBlock {
     "assemblyName": "test",
     "end": 250,
@@ -61,16 +51,6 @@ Array [
 
 exports[`one 1`] = `
 Array [
-  InterRegionPaddingBlock {
-    "assemblyName": undefined,
-    "end": undefined,
-    "key": "{test}ctgA:1..200-0-beforeFirstRegion",
-    "offsetPx": 0,
-    "refName": undefined,
-    "start": undefined,
-    "variant": "boundary",
-    "widthPx": -0,
-  },
   ContentBlock {
     "assemblyName": "test",
     "end": 200,
@@ -95,16 +75,6 @@ Array [
 
 exports[`three 1`] = `
 Array [
-  InterRegionPaddingBlock {
-    "assemblyName": undefined,
-    "end": undefined,
-    "key": "{test}ctgA:49,901..50,000-0-reversed-beforeFirstRegion",
-    "offsetPx": -100,
-    "refName": undefined,
-    "start": undefined,
-    "variant": "boundary",
-    "widthPx": 100,
-  },
   ContentBlock {
     "assemblyName": "test",
     "end": 50000,
@@ -130,16 +100,6 @@ Array [
 
 exports[`two 1`] = `
 Array [
-  InterRegionPaddingBlock {
-    "assemblyName": undefined,
-    "end": undefined,
-    "key": "{test}ctgA:49,801..50,000-0-reversed-beforeFirstRegion",
-    "offsetPx": 0,
-    "refName": undefined,
-    "start": undefined,
-    "variant": "boundary",
-    "widthPx": -0,
-  },
   ContentBlock {
     "assemblyName": "test",
     "end": 50000,

--- a/packages/core/util/__snapshots__/calculateStaticBlocks.test.ts.snap
+++ b/packages/core/util/__snapshots__/calculateStaticBlocks.test.ts.snap
@@ -331,7 +331,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "{test}ctgB:1,025..2,048-1",
-      "offsetPx": 1226,
+      "offsetPx": 1224,
       "parentRegion": Object {
         "assemblyName": "test",
         "end": 10000000,
@@ -350,7 +350,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "{test}ctgB:2,049..3,072-1",
-      "offsetPx": 2250,
+      "offsetPx": 2248,
       "parentRegion": Object {
         "assemblyName": "test",
         "end": 10000000,
@@ -542,7 +542,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": true,
       "isRightEndOfDisplayedRegion": false,
       "key": "{test}ctgA:9,201..10,000-1-reversed",
-      "offsetPx": 3,
+      "offsetPx": 1,
       "parentRegion": Object {
         "assemblyName": "test",
         "end": 10000,
@@ -562,7 +562,7 @@ BlockSet {
       "isLeftEndOfDisplayedRegion": false,
       "isRightEndOfDisplayedRegion": false,
       "key": "{test}ctgA:8,401..9,200-1-reversed",
-      "offsetPx": 803,
+      "offsetPx": 801,
       "parentRegion": Object {
         "assemblyName": "test",
         "end": 10000,

--- a/packages/core/util/blockTypes.ts
+++ b/packages/core/util/blockTypes.ts
@@ -47,6 +47,15 @@ export class BlockSet {
       : 0
   }
 
+  get totalWidthPxWithoutBorders() {
+    return this.blocks.length
+      ? this.blocks
+          .filter(block => block.variant !== 'boundary')
+          .map(blocks => blocks.widthPx)
+          .reduce((a, b) => a + b)
+      : 0
+  }
+
   get offsetPx() {
     return this.blocks.length ? this.blocks[0].offsetPx : 0
   }

--- a/packages/core/util/calculateDynamicBlocks.ts
+++ b/packages/core/util/calculateDynamicBlocks.ts
@@ -146,6 +146,7 @@ export default function calculateDynamicBlocks(
               offsetPx: blockData.offsetPx + blockData.widthPx,
             }),
           )
+          displayedRegionLeftPx += interRegionPaddingWidth
         }
         if (
           regionNumber === displayedRegions.length - 1 &&
@@ -160,10 +161,10 @@ export default function calculateDynamicBlocks(
               variant: 'boundary',
             }),
           )
+          displayedRegionLeftPx += interRegionPaddingWidth
         }
       }
     }
-    displayedRegionLeftPx += interRegionPaddingWidth
     displayedRegionLeftPx += (regionEnd - regionStart) / bpPerPx
   })
   return blocks

--- a/packages/core/util/calculateDynamicBlocks.ts
+++ b/packages/core/util/calculateDynamicBlocks.ts
@@ -115,6 +115,17 @@ export default function calculateDynamicBlocks(
         reversed ? '-reversed' : ''
       }`
 
+      if (padding && blocks.length === 0 && isLeftEndOfDisplayedRegion) {
+        blocks.push(
+          new InterRegionPaddingBlock({
+            key: `${blockData.key}-beforeFirstRegion`,
+            widthPx: -offsetPx,
+            offsetPx: blockData.offsetPx + offsetPx,
+            variant: 'boundary',
+          }),
+        )
+      }
+
       if (elision && regionWidthPx < minimumBlockWidth) {
         blocks.push(new ElidedBlock(blockData))
       } else {
@@ -136,6 +147,21 @@ export default function calculateDynamicBlocks(
             }),
           )
           displayedRegionLeftPx += interRegionPaddingWidth
+        }
+
+        if (
+          regionNumber === displayedRegions.length - 1 &&
+          blockData.isRightEndOfDisplayedRegion
+        ) {
+          blockOffsetPx = blockData.offsetPx + blockData.widthPx
+          blocks.push(
+            new InterRegionPaddingBlock({
+              key: `${blockData.key}-afterLastRegion`,
+              widthPx: width - blockOffsetPx + offsetPx,
+              offsetPx: blockOffsetPx,
+              variant: 'boundary',
+            }),
+          )
         }
       }
     }

--- a/packages/core/util/calculateDynamicBlocks.ts
+++ b/packages/core/util/calculateDynamicBlocks.ts
@@ -115,17 +115,6 @@ export default function calculateDynamicBlocks(
         reversed ? '-reversed' : ''
       }`
 
-      if (padding && blocks.length === 0 && isLeftEndOfDisplayedRegion) {
-        blocks.push(
-          new InterRegionPaddingBlock({
-            key: `${blockData.key}-beforeFirstRegion`,
-            widthPx: -offsetPx,
-            offsetPx: blockData.offsetPx + offsetPx,
-            variant: 'boundary',
-          }),
-        )
-      }
-
       if (elision && regionWidthPx < minimumBlockWidth) {
         blocks.push(new ElidedBlock(blockData))
       } else {
@@ -144,21 +133,6 @@ export default function calculateDynamicBlocks(
               key: `${blockData.key}-rightpad`,
               widthPx: interRegionPaddingWidth,
               offsetPx: blockData.offsetPx + blockData.widthPx,
-            }),
-          )
-          displayedRegionLeftPx += interRegionPaddingWidth
-        }
-        if (
-          regionNumber === displayedRegions.length - 1 &&
-          blockData.isRightEndOfDisplayedRegion
-        ) {
-          blockOffsetPx = blockData.offsetPx + blockData.widthPx
-          blocks.push(
-            new InterRegionPaddingBlock({
-              key: `${blockData.key}-afterLastRegion`,
-              widthPx: width - blockOffsetPx + offsetPx,
-              offsetPx: blockOffsetPx,
-              variant: 'boundary',
             }),
           )
           displayedRegionLeftPx += interRegionPaddingWidth

--- a/packages/core/util/calculateStaticBlocks.ts
+++ b/packages/core/util/calculateStaticBlocks.ts
@@ -128,6 +128,7 @@ export default function calculateStaticBlocks(
           blockData.isRightEndOfDisplayedRegion &&
           regionNumber < displayedRegions.length - 1
         ) {
+          regionBpOffset += interRegionPaddingWidth * bpPerPx
           blocks.push(
             new InterRegionPaddingBlock({
               key: `${blockData.key}-rightpad`,
@@ -140,6 +141,7 @@ export default function calculateStaticBlocks(
           regionNumber === displayedRegions.length - 1 &&
           blockData.isRightEndOfDisplayedRegion
         ) {
+          regionBpOffset += interRegionPaddingWidth * bpPerPx
           blocks.push(
             new InterRegionPaddingBlock({
               key: `${blockData.key}-afterLastRegion`,
@@ -151,7 +153,6 @@ export default function calculateStaticBlocks(
         }
       }
     }
-    regionBpOffset += interRegionPaddingWidth * bpPerPx
     regionBpOffset += regionEnd - regionStart
   })
   return blocks

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -780,10 +780,9 @@ export function stringify({
   refName: string
   oob?: boolean
 }) {
-  return (
-    `${refName}:${coord.toLocaleString('en-US')}` +
-    (oob ? ' (out of bounds)' : '')
-  )
+  return `${refName}:${coord.toLocaleString('en-US')}${
+    oob ? ' (out of bounds)' : ''
+  }`
 }
 
 export const isElectron =

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -771,8 +771,19 @@ export function minmax(a: number, b: number) {
   return [Math.min(a, b), Math.max(a, b)]
 }
 
-export function stringify(offset: { coord: number; refName: string }) {
-  return `${offset.refName}:${offset.coord.toLocaleString('en-US')}`
+export function stringify({
+  refName,
+  coord,
+  oob,
+}: {
+  coord: number
+  refName: string
+  oob?: boolean
+}) {
+  return (
+    `${refName}:${coord.toLocaleString('en-US')}` +
+    (oob ? ' (out of bounds)' : '')
+  )
 }
 
 export const isElectron =

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -38,12 +38,6 @@ export const Dotplot1DView = Base1DView.extend(self => {
   const scaleFactor = observable.box(1)
   return {
     views: {
-      get interRegionPaddingWidth() {
-        return 0
-      },
-      get minimumBlockWidth() {
-        return 0
-      },
       get dynamicBlocks() {
         return calculateDynamicBlocks(self, false, false)
       },
@@ -380,8 +374,16 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             const [x1, x2, y1, y2] = result
             const session = getSession(self)
 
-            const d1 = Dotplot1DView.create(getSnapshot(self.hview))
-            const d2 = Dotplot1DView.create(getSnapshot(self.vview))
+            const d1 = Dotplot1DView.create({
+              ...getSnapshot(self.hview),
+              minimumBlockWidth: 0,
+              interRegionPaddingWidth: 0,
+            })
+            const d2 = Dotplot1DView.create({
+              ...getSnapshot(self.vview),
+              minimumBlockWidth: 0,
+              interRegionPaddingWidth: 0,
+            })
             d1.setVolatileWidth(self.hview.width)
             d2.setVolatileWidth(self.vview.width)
             d1.moveTo(x1, x2)

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -20,8 +20,8 @@ const useStyles = makeStyles({
     whiteSpace: 'nowrap',
     textAlign: 'left',
     position: 'absolute',
-    display: 'flex',
     minHeight: '100%',
+    display: 'flex',
   },
   heightOverflowed: {
     position: 'absolute',

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -78,6 +78,7 @@ const LinearGenomeView = observer((props: { model: LGV }) => {
                   variant="contained"
                   color="primary"
                   onClick={model.activateTrackSelector}
+                  style={{ zIndex: 1000 }}
                 >
                   <TrackSelectorIcon className={classes.spacer} />
                   Open track selector

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -118,15 +118,16 @@ const Polygon = observer(
   }) => {
     const theme = useTheme()
     const classes = useStyles()
-    const { offsetPx, width, bpPerPx, dynamicBlocks: visibleRegions } = model
+    const { offsetPx, width, dynamicBlocks: visibleRegions } = model
 
-    const blocks = visibleRegions.getBlocks()
     const polygonColor = theme.palette.tertiary
       ? theme.palette.tertiary.light
       : theme.palette.primary.light
 
+    if (!visibleRegions.contentBlocks.length) {
+      return null
+    }
     const firstBlock = visibleRegions.contentBlocks[0]
-    // contentBlocks[0]
     const lastBlock =
       visibleRegions.contentBlocks[visibleRegions.contentBlocks.length - 1]
     const topLeft = overview.bpToPx({
@@ -141,11 +142,11 @@ const Polygon = observer(
     })
 
     const startPx = Math.max(0, -offsetPx)
-    const lastVisible = blocks[blocks.length - 1]
     const endPx =
-      lastVisible instanceof InterRegionPaddingBlock
-        ? lastVisible.offsetPx - offsetPx
-        : width
+      startPx +
+      visibleRegions.totalWidthPx +
+      (visibleRegions.contentBlocks.length * model.interRegionPaddingWidth) / 2
+
     const points = [
       [startPx, HEADER_BAR_HEIGHT],
       [endPx, HEADER_BAR_HEIGHT],

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -147,8 +147,8 @@ const Polygon = observer(
         ? lastVisible.offsetPx - offsetPx
         : width
     const points = [
-      [startPx, HEADER_BAR_HEIGHT - 10],
-      [endPx, HEADER_BAR_HEIGHT - 10],
+      [startPx, HEADER_BAR_HEIGHT],
+      [endPx, HEADER_BAR_HEIGHT],
       [topRight, 0],
       [topLeft, 0],
     ]

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -5,12 +5,7 @@ import { getSession } from '@jbrowse/core/util'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import LinearProgress from '@material-ui/core/LinearProgress'
-import {
-  BlockSet,
-  ContentBlock,
-  ElidedBlock,
-  InterRegionPaddingBlock,
-} from '@jbrowse/core/util/blockTypes'
+import { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
 import React from 'react'
@@ -118,7 +113,7 @@ const Polygon = observer(
   }) => {
     const theme = useTheme()
     const classes = useStyles()
-    const { offsetPx, width, dynamicBlocks: visibleRegions } = model
+    const { offsetPx, dynamicBlocks: visibleRegions } = model
 
     const polygonColor = theme.palette.tertiary
       ? theme.palette.tertiary.light

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -139,7 +139,7 @@ const Polygon = observer(
     const startPx = Math.max(0, -offsetPx)
     const endPx =
       startPx +
-      visibleRegions.totalWidthPx +
+      visibleRegions.totalWidthPxWithoutBorders +
       (visibleRegions.contentBlocks.length * model.interRegionPaddingWidth) / 2
 
     const points = [

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -118,15 +118,17 @@ const Polygon = observer(
   }) => {
     const theme = useTheme()
     const classes = useStyles()
-    const { offsetPx, bpPerPx, dynamicBlocks: visibleRegions } = model
+    const { offsetPx, width, bpPerPx, dynamicBlocks: visibleRegions } = model
 
-    const blocks = visibleRegions.getBlocks().filter(block => !!block.refName)
+    const blocks = visibleRegions.getBlocks()
     const polygonColor = theme.palette.tertiary
       ? theme.palette.tertiary.light
       : theme.palette.primary.light
 
-    const firstBlock = blocks[0]
-    const lastBlock = blocks[blocks.length - 1]
+    const firstBlock = visibleRegions.contentBlocks[0]
+    // contentBlocks[0]
+    const lastBlock =
+      visibleRegions.contentBlocks[visibleRegions.contentBlocks.length - 1]
     const topLeft = overview.bpToPx({
       refName: firstBlock.refName,
       coord: firstBlock.reversed ? firstBlock.end : firstBlock.start,
@@ -138,12 +140,13 @@ const Polygon = observer(
       regionNumber: lastBlock.regionNumber,
     })
 
-    const startPx = firstBlock.offsetPx - offsetPx
+    const startPx = Math.max(0, -offsetPx)
+    const lastVisible = blocks[blocks.length - 1]
+    const lastVisible2 = blocks[blocks.length - 2]
     const endPx =
-      startPx +
-      visibleRegions.totalBp / bpPerPx +
-      model.interRegionPaddingWidth * blocks.length
-
+      lastVisible instanceof InterRegionPaddingBlock
+        ? lastVisible2.offsetPx + lastVisible2.widthPx - offsetPx
+        : width
     const points = [
       [startPx, HEADER_BAR_HEIGHT],
       [endPx, HEADER_BAR_HEIGHT],

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -142,14 +142,13 @@ const Polygon = observer(
 
     const startPx = Math.max(0, -offsetPx)
     const lastVisible = blocks[blocks.length - 1]
-    const lastVisible2 = blocks[blocks.length - 2]
     const endPx =
       lastVisible instanceof InterRegionPaddingBlock
-        ? lastVisible2.offsetPx + lastVisible2.widthPx - offsetPx
+        ? lastVisible.offsetPx - offsetPx
         : width
     const points = [
-      [startPx, HEADER_BAR_HEIGHT],
-      [endPx, HEADER_BAR_HEIGHT],
+      [startPx, HEADER_BAR_HEIGHT - 10],
+      [endPx, HEADER_BAR_HEIGHT - 10],
       [topRight, 0],
       [topLeft, 0],
     ]

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -185,13 +185,15 @@ const ScaleBar = observer(
     const gridPitch = chooseGridPitch(scale, 120, 15)
     const { dynamicBlocks: overviewVisibleRegions } = overview
 
-    const firstBlock = visibleRegions.blocks[0]
+    const firstBlock = visibleRegions.contentBlocks[0]
     const firstOverviewPx =
       overview.bpToPx({
         refName: firstBlock.refName,
         coord: firstBlock.reversed ? firstBlock.end : firstBlock.start,
       }) || 0
-    const lastBlock = visibleRegions.blocks[visibleRegions.blocks.length - 1]
+
+    const lastBlock =
+      visibleRegions.contentBlocks[visibleRegions.contentBlocks.length - 1]
     const lastOverviewPx =
       overview.bpToPx({
         refName: lastBlock.refName,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -16,8 +16,12 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           class="makeStyles-scaleBar"
         >
           <div
-            class="MuiPaper-root makeStyles-scaleBarContig makeStyles-scaleBarContigForward MuiPaper-outlined MuiPaper-rounded"
-            style="min-width: 800px; border-color: rgb(153, 102, 0);"
+            class="makeStyles-scaleBarVisibleRegion"
+            style="width: 800px; left: 0px;"
+          />
+          <div
+            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
+            style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -25,10 +29,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             >
               ctgA
             </p>
-            <div
-              class="makeStyles-scaleBarVisibleRegion"
-              style="width: 800px; left: -1px; pointer-events: none;"
-            />
             <div
               class="makeStyles-scaleBarLabel"
               style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
@@ -73,7 +73,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       >
         <polygon
           fill="rgba(121, 134, 203, 0.3)"
-          points="0,48,100,48,800,0,0,0"
+          points="0,48,101,48,800,0,0,0"
           stroke="rgba(121, 134, 203, 0.8)"
         />
       </svg>
@@ -688,8 +688,12 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           class="makeStyles-scaleBar"
         >
           <div
-            class="MuiPaper-root makeStyles-scaleBarContig makeStyles-scaleBarContigForward MuiPaper-outlined MuiPaper-rounded"
-            style="min-width: 72.54545454545455px; margin-right: 2px; border-color: rgb(153, 102, 0);"
+            class="makeStyles-scaleBarVisibleRegion"
+            style="width: 580px; left: 0px;"
+          />
+          <div
+            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
+            style="left: 0px; width: 72.72727272727273px; border-color: rgb(153, 102, 0);"
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -697,24 +701,20 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             >
               ctgA
             </p>
-            <div
-              class="makeStyles-scaleBarVisibleRegion"
-              style="width: 72.54545454545455px; left: -1px; pointer-events: none;"
-            />
           </div>
           <div
-            class="MuiPaper-root makeStyles-scaleBarContig makeStyles-scaleBarContigForward MuiPaper-outlined MuiPaper-rounded"
-            style="min-width: 725.4545454545454px;"
+            class="makeStyles-scaleBarContig"
+            style="width: 0px; left: 72.72727272727273px; background-color: rgb(153, 153, 153);"
+          />
+          <div
+            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
+            style="left: 72.72727272727273px; width: 727.2727272727273px;"
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
             >
               ctgB
             </p>
-            <div
-              class="makeStyles-scaleBarVisibleRegion"
-              style="width: 506.36727272727273px; left: -1px; pointer-events: none;"
-            />
             <div
               class="makeStyles-scaleBarLabel"
               style="left: 145.0909090909091px; pointer-events: none;"
@@ -759,7 +759,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       >
         <polygon
           fill="rgba(121, 134, 203, 0.3)"
-          points="0,48,800,48,580,0,0,0"
+          points="0,48,802,48,580,0,0,0"
           stroke="rgba(121, 134, 203, 0.8)"
         />
       </svg>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -20,6 +20,10 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             style="width: 800px; left: 0px;"
           />
           <div
+            class="makeStyles-scaleBarContig"
+            style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
+          />
+          <div
             class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
             style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
           >
@@ -60,6 +64,10 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               100
             </div>
           </div>
+          <div
+            class="makeStyles-scaleBarContig"
+            style="width: 0px; left: 800px; background-color: rgb(153, 153, 153);"
+          />
         </div>
       </div>
     </div>
@@ -692,6 +700,10 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             style="width: 580px; left: 0px;"
           />
           <div
+            class="makeStyles-scaleBarContig"
+            style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
+          />
+          <div
             class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
             style="left: 0px; width: 72.72727272727273px; border-color: rgb(153, 102, 0);"
           >
@@ -746,6 +758,10 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               2,000
             </div>
           </div>
+          <div
+            class="makeStyles-scaleBarContig"
+            style="width: 0px; left: 800px; background-color: rgb(153, 153, 153);"
+          />
         </div>
       </div>
     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/hg38DisplayedRegions.json
+++ b/plugins/linear-genome-view/src/LinearGenomeView/hg38DisplayedRegions.json
@@ -1,0 +1,3187 @@
+[
+  {
+    "refName": "1",
+    "start": 0,
+    "end": 248956422,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2",
+    "start": 0,
+    "end": 242193529,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3",
+    "start": 0,
+    "end": 198295559,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4",
+    "start": 0,
+    "end": 190214555,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5",
+    "start": 0,
+    "end": 181538259,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6",
+    "start": 0,
+    "end": 170805979,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7",
+    "start": 0,
+    "end": 159345973,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8",
+    "start": 0,
+    "end": 145138636,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9",
+    "start": 0,
+    "end": 138394717,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "10",
+    "start": 0,
+    "end": 133797422,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11",
+    "start": 0,
+    "end": 135086622,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12",
+    "start": 0,
+    "end": 133275309,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13",
+    "start": 0,
+    "end": 114364328,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14",
+    "start": 0,
+    "end": 107043718,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15",
+    "start": 0,
+    "end": 101991189,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16",
+    "start": 0,
+    "end": 90338345,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17",
+    "start": 0,
+    "end": 83257441,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18",
+    "start": 0,
+    "end": 80373285,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19",
+    "start": 0,
+    "end": 58617616,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "20",
+    "start": 0,
+    "end": 64444167,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21",
+    "start": 0,
+    "end": 46709983,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22",
+    "start": 0,
+    "end": 50818468,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270721v1_random",
+    "start": 0,
+    "end": 100316,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_GL000009v2_random",
+    "start": 0,
+    "end": 201709,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_GL000225v1_random",
+    "start": 0,
+    "end": 211173,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270722v1_random",
+    "start": 0,
+    "end": 194050,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_GL000194v1_random",
+    "start": 0,
+    "end": 191469,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270723v1_random",
+    "start": 0,
+    "end": 38115,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270724v1_random",
+    "start": 0,
+    "end": 39555,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270725v1_random",
+    "start": 0,
+    "end": 172810,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270726v1_random",
+    "start": 0,
+    "end": 43739,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270727v1_random",
+    "start": 0,
+    "end": 448248,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_KI270728v1_random",
+    "start": 0,
+    "end": 1872759,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL000205v2_random",
+    "start": 0,
+    "end": 185591,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270729v1_random",
+    "start": 0,
+    "end": 280839,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270730v1_random",
+    "start": 0,
+    "end": 112551,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270706v1_random",
+    "start": 0,
+    "end": 175055,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270707v1_random",
+    "start": 0,
+    "end": 32032,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270708v1_random",
+    "start": 0,
+    "end": 127682,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270709v1_random",
+    "start": 0,
+    "end": 66860,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270710v1_random",
+    "start": 0,
+    "end": 40176,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270711v1_random",
+    "start": 0,
+    "end": 42210,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270712v1_random",
+    "start": 0,
+    "end": 176043,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270713v1_random",
+    "start": 0,
+    "end": 40745,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270714v1_random",
+    "start": 0,
+    "end": 41717,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270731v1_random",
+    "start": 0,
+    "end": 150754,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270732v1_random",
+    "start": 0,
+    "end": 41543,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270733v1_random",
+    "start": 0,
+    "end": 179772,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270734v1_random",
+    "start": 0,
+    "end": 165050,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270735v1_random",
+    "start": 0,
+    "end": 42811,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270736v1_random",
+    "start": 0,
+    "end": 181920,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270737v1_random",
+    "start": 0,
+    "end": 103838,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270738v1_random",
+    "start": 0,
+    "end": 99375,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270739v1_random",
+    "start": 0,
+    "end": 73985,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270715v1_random",
+    "start": 0,
+    "end": 161471,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270716v1_random",
+    "start": 0,
+    "end": 153799,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_GL000221v1_random",
+    "start": 0,
+    "end": 155397,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_GL000008v2_random",
+    "start": 0,
+    "end": 209709,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL000208v1_random",
+    "start": 0,
+    "end": 92689,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_KI270717v1_random",
+    "start": 0,
+    "end": 40062,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_KI270718v1_random",
+    "start": 0,
+    "end": 38054,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_KI270719v1_random",
+    "start": 0,
+    "end": 176845,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_KI270720v1_random",
+    "start": 0,
+    "end": 39050,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270762v1_alt",
+    "start": 0,
+    "end": 354444,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270766v1_alt",
+    "start": 0,
+    "end": 256271,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270760v1_alt",
+    "start": 0,
+    "end": 109528,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270765v1_alt",
+    "start": 0,
+    "end": 185285,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_GL383518v1_alt",
+    "start": 0,
+    "end": 182439,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_GL383519v1_alt",
+    "start": 0,
+    "end": 110268,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_GL383520v2_alt",
+    "start": 0,
+    "end": 366580,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270764v1_alt",
+    "start": 0,
+    "end": 50258,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270763v1_alt",
+    "start": 0,
+    "end": 911658,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270759v1_alt",
+    "start": 0,
+    "end": 425601,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270761v1_alt",
+    "start": 0,
+    "end": 165834,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270770v1_alt",
+    "start": 0,
+    "end": 136240,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270773v1_alt",
+    "start": 0,
+    "end": 70887,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270774v1_alt",
+    "start": 0,
+    "end": 223625,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270769v1_alt",
+    "start": 0,
+    "end": 120616,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_GL383521v1_alt",
+    "start": 0,
+    "end": 143390,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270772v1_alt",
+    "start": 0,
+    "end": 133041,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270775v1_alt",
+    "start": 0,
+    "end": 138019,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270771v1_alt",
+    "start": 0,
+    "end": 110395,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270768v1_alt",
+    "start": 0,
+    "end": 110099,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_GL582966v2_alt",
+    "start": 0,
+    "end": 96131,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_GL383522v1_alt",
+    "start": 0,
+    "end": 123821,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270776v1_alt",
+    "start": 0,
+    "end": 174166,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270767v1_alt",
+    "start": 0,
+    "end": 161578,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_JH636055v2_alt",
+    "start": 0,
+    "end": 173151,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270783v1_alt",
+    "start": 0,
+    "end": 109187,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270780v1_alt",
+    "start": 0,
+    "end": 224108,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_GL383526v1_alt",
+    "start": 0,
+    "end": 180671,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270777v1_alt",
+    "start": 0,
+    "end": 173649,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270778v1_alt",
+    "start": 0,
+    "end": 248252,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270781v1_alt",
+    "start": 0,
+    "end": 113034,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270779v1_alt",
+    "start": 0,
+    "end": 205312,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270782v1_alt",
+    "start": 0,
+    "end": 162429,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270784v1_alt",
+    "start": 0,
+    "end": 184404,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270790v1_alt",
+    "start": 0,
+    "end": 220246,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_GL383528v1_alt",
+    "start": 0,
+    "end": 376187,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270787v1_alt",
+    "start": 0,
+    "end": 111943,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_GL000257v2_alt",
+    "start": 0,
+    "end": 586476,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270788v1_alt",
+    "start": 0,
+    "end": 158965,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_GL383527v1_alt",
+    "start": 0,
+    "end": 164536,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270785v1_alt",
+    "start": 0,
+    "end": 119912,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270789v1_alt",
+    "start": 0,
+    "end": 205944,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270786v1_alt",
+    "start": 0,
+    "end": 244096,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270793v1_alt",
+    "start": 0,
+    "end": 126136,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270792v1_alt",
+    "start": 0,
+    "end": 179043,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270791v1_alt",
+    "start": 0,
+    "end": 195710,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL383532v1_alt",
+    "start": 0,
+    "end": 82728,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL949742v1_alt",
+    "start": 0,
+    "end": 226852,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270794v1_alt",
+    "start": 0,
+    "end": 164558,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL339449v2_alt",
+    "start": 0,
+    "end": 1612928,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL383530v1_alt",
+    "start": 0,
+    "end": 101241,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270796v1_alt",
+    "start": 0,
+    "end": 172708,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_GL383531v1_alt",
+    "start": 0,
+    "end": 173459,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270795v1_alt",
+    "start": 0,
+    "end": 131892,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000250v2_alt",
+    "start": 0,
+    "end": 4672374,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270800v1_alt",
+    "start": 0,
+    "end": 175808,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270799v1_alt",
+    "start": 0,
+    "end": 152148,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL383533v1_alt",
+    "start": 0,
+    "end": 124736,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270801v1_alt",
+    "start": 0,
+    "end": 870480,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270802v1_alt",
+    "start": 0,
+    "end": 75005,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KB021644v2_alt",
+    "start": 0,
+    "end": 185823,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270797v1_alt",
+    "start": 0,
+    "end": 197536,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270798v1_alt",
+    "start": 0,
+    "end": 271782,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270804v1_alt",
+    "start": 0,
+    "end": 157952,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270809v1_alt",
+    "start": 0,
+    "end": 209586,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270806v1_alt",
+    "start": 0,
+    "end": 158166,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_GL383534v2_alt",
+    "start": 0,
+    "end": 119183,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270803v1_alt",
+    "start": 0,
+    "end": 1111570,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270808v1_alt",
+    "start": 0,
+    "end": 271455,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270807v1_alt",
+    "start": 0,
+    "end": 126434,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270805v1_alt",
+    "start": 0,
+    "end": 209988,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270818v1_alt",
+    "start": 0,
+    "end": 145606,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270812v1_alt",
+    "start": 0,
+    "end": 282736,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270811v1_alt",
+    "start": 0,
+    "end": 292436,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270821v1_alt",
+    "start": 0,
+    "end": 985506,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270813v1_alt",
+    "start": 0,
+    "end": 300230,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270822v1_alt",
+    "start": 0,
+    "end": 624492,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270814v1_alt",
+    "start": 0,
+    "end": 141812,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270810v1_alt",
+    "start": 0,
+    "end": 374415,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270819v1_alt",
+    "start": 0,
+    "end": 133535,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270820v1_alt",
+    "start": 0,
+    "end": 36640,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270817v1_alt",
+    "start": 0,
+    "end": 158983,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270816v1_alt",
+    "start": 0,
+    "end": 305841,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270815v1_alt",
+    "start": 0,
+    "end": 132244,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_GL383539v1_alt",
+    "start": 0,
+    "end": 162988,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_GL383540v1_alt",
+    "start": 0,
+    "end": 71551,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_GL383541v1_alt",
+    "start": 0,
+    "end": 171286,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_GL383542v1_alt",
+    "start": 0,
+    "end": 60032,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "9_KI270823v1_alt",
+    "start": 0,
+    "end": 439082,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "10_GL383545v1_alt",
+    "start": 0,
+    "end": 179254,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "10_KI270824v1_alt",
+    "start": 0,
+    "end": 181496,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "10_GL383546v1_alt",
+    "start": 0,
+    "end": 309802,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "10_KI270825v1_alt",
+    "start": 0,
+    "end": 188315,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270832v1_alt",
+    "start": 0,
+    "end": 210133,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270830v1_alt",
+    "start": 0,
+    "end": 177092,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270831v1_alt",
+    "start": 0,
+    "end": 296895,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270829v1_alt",
+    "start": 0,
+    "end": 204059,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_GL383547v1_alt",
+    "start": 0,
+    "end": 154407,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_JH159136v1_alt",
+    "start": 0,
+    "end": 200998,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_JH159137v1_alt",
+    "start": 0,
+    "end": 191409,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270827v1_alt",
+    "start": 0,
+    "end": 67707,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270826v1_alt",
+    "start": 0,
+    "end": 186169,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL877875v1_alt",
+    "start": 0,
+    "end": 167313,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL877876v1_alt",
+    "start": 0,
+    "end": 408271,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270837v1_alt",
+    "start": 0,
+    "end": 40090,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL383549v1_alt",
+    "start": 0,
+    "end": 120804,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270835v1_alt",
+    "start": 0,
+    "end": 238139,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL383550v2_alt",
+    "start": 0,
+    "end": 169178,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL383552v1_alt",
+    "start": 0,
+    "end": 138655,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL383553v2_alt",
+    "start": 0,
+    "end": 152874,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270834v1_alt",
+    "start": 0,
+    "end": 119498,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_GL383551v1_alt",
+    "start": 0,
+    "end": 184319,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270833v1_alt",
+    "start": 0,
+    "end": 76061,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270836v1_alt",
+    "start": 0,
+    "end": 56134,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270840v1_alt",
+    "start": 0,
+    "end": 191684,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270839v1_alt",
+    "start": 0,
+    "end": 180306,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270843v1_alt",
+    "start": 0,
+    "end": 103832,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270841v1_alt",
+    "start": 0,
+    "end": 169134,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270838v1_alt",
+    "start": 0,
+    "end": 306913,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "13_KI270842v1_alt",
+    "start": 0,
+    "end": 37287,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270844v1_alt",
+    "start": 0,
+    "end": 322166,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270847v1_alt",
+    "start": 0,
+    "end": 1511111,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270845v1_alt",
+    "start": 0,
+    "end": 180703,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "14_KI270846v1_alt",
+    "start": 0,
+    "end": 1351393,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270852v1_alt",
+    "start": 0,
+    "end": 478999,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270851v1_alt",
+    "start": 0,
+    "end": 263054,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270848v1_alt",
+    "start": 0,
+    "end": 327382,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_GL383554v1_alt",
+    "start": 0,
+    "end": 296527,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270849v1_alt",
+    "start": 0,
+    "end": 244917,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_GL383555v2_alt",
+    "start": 0,
+    "end": 388773,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270850v1_alt",
+    "start": 0,
+    "end": 430880,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_KI270854v1_alt",
+    "start": 0,
+    "end": 134193,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_KI270856v1_alt",
+    "start": 0,
+    "end": 63982,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_KI270855v1_alt",
+    "start": 0,
+    "end": 232857,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_KI270853v1_alt",
+    "start": 0,
+    "end": 2659700,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_GL383556v1_alt",
+    "start": 0,
+    "end": 192462,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "16_GL383557v1_alt",
+    "start": 0,
+    "end": 89672,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL383563v3_alt",
+    "start": 0,
+    "end": 375691,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270862v1_alt",
+    "start": 0,
+    "end": 391357,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270861v1_alt",
+    "start": 0,
+    "end": 196688,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270857v1_alt",
+    "start": 0,
+    "end": 2877074,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_JH159146v1_alt",
+    "start": 0,
+    "end": 278131,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_JH159147v1_alt",
+    "start": 0,
+    "end": 70345,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL383564v2_alt",
+    "start": 0,
+    "end": 133151,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL000258v2_alt",
+    "start": 0,
+    "end": 1821992,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL383565v1_alt",
+    "start": 0,
+    "end": 223995,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270858v1_alt",
+    "start": 0,
+    "end": 235827,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270859v1_alt",
+    "start": 0,
+    "end": 108763,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_GL383566v1_alt",
+    "start": 0,
+    "end": 90219,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270860v1_alt",
+    "start": 0,
+    "end": 178921,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_KI270864v1_alt",
+    "start": 0,
+    "end": 111737,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383567v1_alt",
+    "start": 0,
+    "end": 289831,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383570v1_alt",
+    "start": 0,
+    "end": 164789,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383571v1_alt",
+    "start": 0,
+    "end": 198278,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383568v1_alt",
+    "start": 0,
+    "end": 104552,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383569v1_alt",
+    "start": 0,
+    "end": 167950,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_GL383572v1_alt",
+    "start": 0,
+    "end": 159547,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_KI270863v1_alt",
+    "start": 0,
+    "end": 167999,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270868v1_alt",
+    "start": 0,
+    "end": 61734,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270865v1_alt",
+    "start": 0,
+    "end": 52969,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL383573v1_alt",
+    "start": 0,
+    "end": 385657,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL383575v2_alt",
+    "start": 0,
+    "end": 170222,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL383576v1_alt",
+    "start": 0,
+    "end": 188024,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL383574v1_alt",
+    "start": 0,
+    "end": 155864,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270866v1_alt",
+    "start": 0,
+    "end": 43156,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270867v1_alt",
+    "start": 0,
+    "end": 233762,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949746v1_alt",
+    "start": 0,
+    "end": 987716,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "20_GL383577v2_alt",
+    "start": 0,
+    "end": 128386,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "20_KI270869v1_alt",
+    "start": 0,
+    "end": 118774,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "20_KI270871v1_alt",
+    "start": 0,
+    "end": 58661,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "20_KI270870v1_alt",
+    "start": 0,
+    "end": 183433,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_GL383578v2_alt",
+    "start": 0,
+    "end": 63917,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_KI270874v1_alt",
+    "start": 0,
+    "end": 166743,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_KI270873v1_alt",
+    "start": 0,
+    "end": 143900,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_GL383579v2_alt",
+    "start": 0,
+    "end": 201197,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_GL383580v2_alt",
+    "start": 0,
+    "end": 74653,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_GL383581v2_alt",
+    "start": 0,
+    "end": 116689,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "21_KI270872v1_alt",
+    "start": 0,
+    "end": 82692,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270875v1_alt",
+    "start": 0,
+    "end": 259914,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270878v1_alt",
+    "start": 0,
+    "end": 186262,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270879v1_alt",
+    "start": 0,
+    "end": 304135,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270876v1_alt",
+    "start": 0,
+    "end": 263666,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270877v1_alt",
+    "start": 0,
+    "end": 101331,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_GL383583v2_alt",
+    "start": 0,
+    "end": 96924,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_GL383582v2_alt",
+    "start": 0,
+    "end": 162811,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "X_KI270880v1_alt",
+    "start": 0,
+    "end": 284869,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "X_KI270881v1_alt",
+    "start": 0,
+    "end": 144206,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270882v1_alt",
+    "start": 0,
+    "end": 248807,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270883v1_alt",
+    "start": 0,
+    "end": 170399,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270884v1_alt",
+    "start": 0,
+    "end": 157053,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270885v1_alt",
+    "start": 0,
+    "end": 171027,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270886v1_alt",
+    "start": 0,
+    "end": 204239,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270887v1_alt",
+    "start": 0,
+    "end": 209512,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270888v1_alt",
+    "start": 0,
+    "end": 155532,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270889v1_alt",
+    "start": 0,
+    "end": 170698,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270890v1_alt",
+    "start": 0,
+    "end": 184499,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270891v1_alt",
+    "start": 0,
+    "end": 170680,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "1_KI270892v1_alt",
+    "start": 0,
+    "end": 162212,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270894v1_alt",
+    "start": 0,
+    "end": 214158,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "2_KI270893v1_alt",
+    "start": 0,
+    "end": 161218,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270895v1_alt",
+    "start": 0,
+    "end": 162896,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270896v1_alt",
+    "start": 0,
+    "end": 378547,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270897v1_alt",
+    "start": 0,
+    "end": 1144418,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "5_KI270898v1_alt",
+    "start": 0,
+    "end": 130957,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000251v2_alt",
+    "start": 0,
+    "end": 4795265,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "7_KI270899v1_alt",
+    "start": 0,
+    "end": 190869,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270901v1_alt",
+    "start": 0,
+    "end": 136959,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270900v1_alt",
+    "start": 0,
+    "end": 318687,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270902v1_alt",
+    "start": 0,
+    "end": 106711,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270903v1_alt",
+    "start": 0,
+    "end": 214625,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "12_KI270904v1_alt",
+    "start": 0,
+    "end": 572349,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270906v1_alt",
+    "start": 0,
+    "end": 196384,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "15_KI270905v1_alt",
+    "start": 0,
+    "end": 5161414,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270907v1_alt",
+    "start": 0,
+    "end": 137721,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270910v1_alt",
+    "start": 0,
+    "end": 157099,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270909v1_alt",
+    "start": 0,
+    "end": 325800,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_JH159148v1_alt",
+    "start": 0,
+    "end": 88070,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "17_KI270908v1_alt",
+    "start": 0,
+    "end": 1423190,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_KI270912v1_alt",
+    "start": 0,
+    "end": 174061,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "18_KI270911v1_alt",
+    "start": 0,
+    "end": 157710,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949747v2_alt",
+    "start": 0,
+    "end": 729520,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KB663609v1_alt",
+    "start": 0,
+    "end": 74013,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "X_KI270913v1_alt",
+    "start": 0,
+    "end": 274009,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270914v1_alt",
+    "start": 0,
+    "end": 205194,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270915v1_alt",
+    "start": 0,
+    "end": 170665,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270916v1_alt",
+    "start": 0,
+    "end": 184516,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270917v1_alt",
+    "start": 0,
+    "end": 190932,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270918v1_alt",
+    "start": 0,
+    "end": 123111,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270919v1_alt",
+    "start": 0,
+    "end": 170701,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270920v1_alt",
+    "start": 0,
+    "end": 198005,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270921v1_alt",
+    "start": 0,
+    "end": 282224,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270922v1_alt",
+    "start": 0,
+    "end": 187935,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270923v1_alt",
+    "start": 0,
+    "end": 189352,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270924v1_alt",
+    "start": 0,
+    "end": 166540,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "4_KI270925v1_alt",
+    "start": 0,
+    "end": 555799,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000252v2_alt",
+    "start": 0,
+    "end": 4604811,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "8_KI270926v1_alt",
+    "start": 0,
+    "end": 229282,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "11_KI270927v1_alt",
+    "start": 0,
+    "end": 218612,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949748v2_alt",
+    "start": 0,
+    "end": 1064304,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "22_KI270928v1_alt",
+    "start": 0,
+    "end": 176103,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270929v1_alt",
+    "start": 0,
+    "end": 186203,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270930v1_alt",
+    "start": 0,
+    "end": 200773,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270931v1_alt",
+    "start": 0,
+    "end": 170148,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270932v1_alt",
+    "start": 0,
+    "end": 215732,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270933v1_alt",
+    "start": 0,
+    "end": 170537,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL000209v2_alt",
+    "start": 0,
+    "end": 177381,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270934v1_alt",
+    "start": 0,
+    "end": 163458,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000253v2_alt",
+    "start": 0,
+    "end": 4677643,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949749v2_alt",
+    "start": 0,
+    "end": 1091841,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270935v1_alt",
+    "start": 0,
+    "end": 197351,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000254v2_alt",
+    "start": 0,
+    "end": 4827813,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949750v2_alt",
+    "start": 0,
+    "end": 1066390,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270936v1_alt",
+    "start": 0,
+    "end": 164170,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000255v2_alt",
+    "start": 0,
+    "end": 4606388,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949751v2_alt",
+    "start": 0,
+    "end": 1002683,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "3_KI270937v1_alt",
+    "start": 0,
+    "end": 165607,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_GL000256v2_alt",
+    "start": 0,
+    "end": 4929269,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949752v1_alt",
+    "start": 0,
+    "end": 987100,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "6_KI270758v1_alt",
+    "start": 0,
+    "end": 76752,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_GL949753v2_alt",
+    "start": 0,
+    "end": 796479,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "19_KI270938v1_alt",
+    "start": 0,
+    "end": 1066800,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "M",
+    "start": 0,
+    "end": 16569,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270302v1",
+    "start": 0,
+    "end": 2274,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270304v1",
+    "start": 0,
+    "end": 2165,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270303v1",
+    "start": 0,
+    "end": 1942,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270305v1",
+    "start": 0,
+    "end": 1472,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270322v1",
+    "start": 0,
+    "end": 21476,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270320v1",
+    "start": 0,
+    "end": 4416,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270310v1",
+    "start": 0,
+    "end": 1201,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270316v1",
+    "start": 0,
+    "end": 1444,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270315v1",
+    "start": 0,
+    "end": 2276,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270312v1",
+    "start": 0,
+    "end": 998,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270311v1",
+    "start": 0,
+    "end": 12399,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270317v1",
+    "start": 0,
+    "end": 37690,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270412v1",
+    "start": 0,
+    "end": 1179,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270411v1",
+    "start": 0,
+    "end": 2646,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270414v1",
+    "start": 0,
+    "end": 2489,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270419v1",
+    "start": 0,
+    "end": 1029,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270418v1",
+    "start": 0,
+    "end": 2145,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270420v1",
+    "start": 0,
+    "end": 2321,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270424v1",
+    "start": 0,
+    "end": 2140,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270417v1",
+    "start": 0,
+    "end": 2043,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270422v1",
+    "start": 0,
+    "end": 1445,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270423v1",
+    "start": 0,
+    "end": 981,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270425v1",
+    "start": 0,
+    "end": 1884,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270429v1",
+    "start": 0,
+    "end": 1361,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270442v1",
+    "start": 0,
+    "end": 392061,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270466v1",
+    "start": 0,
+    "end": 1233,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270465v1",
+    "start": 0,
+    "end": 1774,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270467v1",
+    "start": 0,
+    "end": 3920,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270435v1",
+    "start": 0,
+    "end": 92983,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270438v1",
+    "start": 0,
+    "end": 112505,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270468v1",
+    "start": 0,
+    "end": 4055,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270510v1",
+    "start": 0,
+    "end": 2415,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270509v1",
+    "start": 0,
+    "end": 2318,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270518v1",
+    "start": 0,
+    "end": 2186,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270508v1",
+    "start": 0,
+    "end": 1951,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270516v1",
+    "start": 0,
+    "end": 1300,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270512v1",
+    "start": 0,
+    "end": 22689,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270519v1",
+    "start": 0,
+    "end": 138126,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270522v1",
+    "start": 0,
+    "end": 5674,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270511v1",
+    "start": 0,
+    "end": 8127,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270515v1",
+    "start": 0,
+    "end": 6361,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270507v1",
+    "start": 0,
+    "end": 5353,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270517v1",
+    "start": 0,
+    "end": 3253,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270529v1",
+    "start": 0,
+    "end": 1899,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270528v1",
+    "start": 0,
+    "end": 2983,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270530v1",
+    "start": 0,
+    "end": 2168,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270539v1",
+    "start": 0,
+    "end": 993,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270538v1",
+    "start": 0,
+    "end": 91309,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270544v1",
+    "start": 0,
+    "end": 1202,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270548v1",
+    "start": 0,
+    "end": 1599,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270583v1",
+    "start": 0,
+    "end": 1400,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270587v1",
+    "start": 0,
+    "end": 2969,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270580v1",
+    "start": 0,
+    "end": 1553,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270581v1",
+    "start": 0,
+    "end": 7046,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270579v1",
+    "start": 0,
+    "end": 31033,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270589v1",
+    "start": 0,
+    "end": 44474,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270590v1",
+    "start": 0,
+    "end": 4685,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270584v1",
+    "start": 0,
+    "end": 4513,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270582v1",
+    "start": 0,
+    "end": 6504,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270588v1",
+    "start": 0,
+    "end": 6158,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270593v1",
+    "start": 0,
+    "end": 3041,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270591v1",
+    "start": 0,
+    "end": 5796,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270330v1",
+    "start": 0,
+    "end": 1652,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270329v1",
+    "start": 0,
+    "end": 1040,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270334v1",
+    "start": 0,
+    "end": 1368,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270333v1",
+    "start": 0,
+    "end": 2699,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270335v1",
+    "start": 0,
+    "end": 1048,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270338v1",
+    "start": 0,
+    "end": 1428,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270340v1",
+    "start": 0,
+    "end": 1428,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270336v1",
+    "start": 0,
+    "end": 1026,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270337v1",
+    "start": 0,
+    "end": 1121,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270363v1",
+    "start": 0,
+    "end": 1803,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270364v1",
+    "start": 0,
+    "end": 2855,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270362v1",
+    "start": 0,
+    "end": 3530,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270366v1",
+    "start": 0,
+    "end": 8320,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270378v1",
+    "start": 0,
+    "end": 1048,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270379v1",
+    "start": 0,
+    "end": 1045,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270389v1",
+    "start": 0,
+    "end": 1298,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270390v1",
+    "start": 0,
+    "end": 2387,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270387v1",
+    "start": 0,
+    "end": 1537,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270395v1",
+    "start": 0,
+    "end": 1143,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270396v1",
+    "start": 0,
+    "end": 1880,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270388v1",
+    "start": 0,
+    "end": 1216,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270394v1",
+    "start": 0,
+    "end": 970,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270386v1",
+    "start": 0,
+    "end": 1788,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270391v1",
+    "start": 0,
+    "end": 1484,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270383v1",
+    "start": 0,
+    "end": 1750,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270393v1",
+    "start": 0,
+    "end": 1308,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270384v1",
+    "start": 0,
+    "end": 1658,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270392v1",
+    "start": 0,
+    "end": 971,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270381v1",
+    "start": 0,
+    "end": 1930,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270385v1",
+    "start": 0,
+    "end": 990,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270382v1",
+    "start": 0,
+    "end": 4215,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270376v1",
+    "start": 0,
+    "end": 1136,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270374v1",
+    "start": 0,
+    "end": 2656,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270372v1",
+    "start": 0,
+    "end": 1650,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270373v1",
+    "start": 0,
+    "end": 1451,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270375v1",
+    "start": 0,
+    "end": 2378,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270371v1",
+    "start": 0,
+    "end": 2805,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270448v1",
+    "start": 0,
+    "end": 7992,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270521v1",
+    "start": 0,
+    "end": 7642,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000195v1",
+    "start": 0,
+    "end": 182896,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000219v1",
+    "start": 0,
+    "end": 179198,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000220v1",
+    "start": 0,
+    "end": 161802,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000224v1",
+    "start": 0,
+    "end": 179693,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270741v1",
+    "start": 0,
+    "end": 157432,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000226v1",
+    "start": 0,
+    "end": 15008,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000213v1",
+    "start": 0,
+    "end": 164239,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270743v1",
+    "start": 0,
+    "end": 210658,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270744v1",
+    "start": 0,
+    "end": 168472,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270745v1",
+    "start": 0,
+    "end": 41891,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270746v1",
+    "start": 0,
+    "end": 66486,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270747v1",
+    "start": 0,
+    "end": 198735,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270748v1",
+    "start": 0,
+    "end": 93321,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270749v1",
+    "start": 0,
+    "end": 158759,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270750v1",
+    "start": 0,
+    "end": 148850,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270751v1",
+    "start": 0,
+    "end": 150742,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270752v1",
+    "start": 0,
+    "end": 27745,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270753v1",
+    "start": 0,
+    "end": 62944,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270754v1",
+    "start": 0,
+    "end": 40191,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270755v1",
+    "start": 0,
+    "end": 36723,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270756v1",
+    "start": 0,
+    "end": 79590,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270757v1",
+    "start": 0,
+    "end": 71251,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000214v1",
+    "start": 0,
+    "end": 137718,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_KI270742v1",
+    "start": 0,
+    "end": 186739,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000216v2",
+    "start": 0,
+    "end": 176608,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Un_GL000218v1",
+    "start": 0,
+    "end": 161147,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "X",
+    "start": 0,
+    "end": 156040895,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Y",
+    "start": 0,
+    "end": 57227415,
+    "reversed": false,
+    "assemblyName": "hg38"
+  },
+  {
+    "refName": "Y_KI270740v1_random",
+    "start": 0,
+    "end": 37240,
+    "reversed": false,
+    "assemblyName": "hg38"
+  }
+]

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -619,9 +619,8 @@ test('can perform bpToPx in a way that makes sense on things that happen outside
 // determined objectively by looking at
 // http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-Se2K5q_Jog&password=qT9on
 //
-// this test is important because this is after a chunk of ellided blocks and
-// is zoomed in, and pxToBp has to take into account only interRegionPadding
-// for things in the view
+// this test is important because interregionpadding blocks outside the current
+// view should not be taken into account
 test('can perform pxToBp on human genome things with ellided blocks (zoomed in)', () => {
   const session = Session.create({
     configuration: {},
@@ -643,6 +642,9 @@ test('can perform pxToBp on human genome things with ellided blocks (zoomed in)'
 })
 
 // determined objectively from looking at http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-TUJdqKI2c9&password=01tan
+//
+// this tests some places on hg38 when zoomed to whole genome, so inter-region
+// padding blocks and elided blocks matter
 test('can perform pxToBp on human genome things with ellided blocks (zoomed out)', () => {
   const session = Session.create({
     configuration: {},

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -557,7 +557,7 @@ test('can instantiate a model that >2 regions', () => {
 
   expect(model.bpToPx({ refName: 'ctgB', coord: 100 })).toEqual({
     index: 1,
-    offsetPx: Math.round(10100 / model.bpPerPx),
+    offsetPx: Math.round(10100 / model.bpPerPx) + model.interRegionPaddingWidth,
   })
 })
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -10,6 +10,7 @@ import { Instance, types } from 'mobx-state-tree'
 import { LinearGenomeViewStateModel, stateModelFactory } from '.'
 import { BaseLinearDisplayComponent } from '..'
 import { stateModelFactory as LinearBasicDisplayStateModelFactory } from '../LinearBasicDisplay'
+import hg38DisplayedRegions from './hg38DisplayedRegions.json'
 
 // a stub linear genome view state model that only accepts base track types.
 // used in unit tests.
@@ -613,4 +614,64 @@ test('can perform bpToPx in a way that makes sense on things that happen outside
   model.toggleHeaderOverview()
   model.setError(Error('pxToBp failed to map to a region'))
   expect(model.error?.message).toEqual('pxToBp failed to map to a region')
+})
+
+// determined objectively by looking at
+// http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-Se2K5q_Jog&password=qT9on
+//
+// this test is important because this is after a chunk of ellided blocks and
+// is zoomed in, and pxToBp has to take into account only interRegionPadding
+// for things in the view
+test('can perform pxToBp on human genome things with ellided blocks (zoomed in)', () => {
+  const session = Session.create({
+    configuration: {},
+  })
+  const model = session.setView(
+    LinearGenomeModel.create({
+      id: 'test6',
+      type: 'LinearGenomeView',
+      tracks: [{ name: 'foo track', type: 'FeatureTrack' }],
+    }),
+  )
+  const width = 800
+  model.setWidth(width)
+  model.setDisplayedRegions(hg38DisplayedRegions)
+  model.setNewView(6359.273152497633, 503862)
+  expect(model.pxToBp(0).refName).toBe('Y')
+  expect(model.pxToBp(400).refName).toBe('Y')
+  expect(model.pxToBp(800).refName).toBe('Y_KI270740v1_random')
+})
+
+// determined objectively from looking at http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-TUJdqKI2c9&password=01tan
+test('can perform pxToBp on human genome things with ellided blocks (zoomed out)', () => {
+  const session = Session.create({
+    configuration: {},
+  })
+  const model = session.setView(
+    LinearGenomeModel.create({
+      id: 'test6',
+      type: 'LinearGenomeView',
+      tracks: [{ name: 'foo track', type: 'FeatureTrack' }],
+    }),
+  )
+  const width = 800
+  model.setWidth(width)
+  model.setDisplayedRegions(hg38DisplayedRegions)
+  model.setNewView(3209286.105, -225.5083315372467)
+  // chr1 to the left
+  expect(model.pxToBp(0).refName).toBe('1')
+  expect(model.pxToBp(0).oob).toBeTruthy()
+  // chr10 in the middle, tests a specific coord but should just be probably
+  // somewhat around here
+  expect(model.pxToBp(800).coord).toBe(111057351)
+  expect(model.pxToBp(800).refName).toBe('10')
+
+  // chrX after an ellided block, this tests a specific coord but should just be
+  // probably somewhat around here
+  expect(model.pxToBp(1228).coord).toBe(99349155)
+  expect(model.pxToBp(1228).refName).toBe('X')
+
+  // chrY_random at the end
+  expect(model.pxToBp(1500).refName).toBe('Y_KI270740v1_random')
+  expect(model.pxToBp(1500).oob).toBeTruthy()
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -280,6 +280,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       }) {
         let offsetBp = 0
 
+        const interRegionPaddingBp = this.interRegionPaddingWidth * self.bpPerPx
         const index = self.displayedRegions.findIndex((r, idx) => {
           if (refName === r.refName && coord >= r.start && coord <= r.end) {
             if (regionNumber ? regionNumber === idx : true) {
@@ -287,7 +288,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
               return true
             }
           }
-          offsetBp += r.end - r.start
+          offsetBp += r.end - r.start + interRegionPaddingBp
           return false
         })
         const foundRegion = self.displayedRegions[index]

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -363,7 +363,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
             index: n - 1,
           }
         }
-        return { coord: '', refName: '' }
+        return {
+          coord: 0,
+          index: 0,
+          refName: '',
+          oob: true,
+          assemblyName: '',
+          offset: 0,
+          reversed: false,
+        }
       },
 
       getTrack(id: string) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -330,8 +330,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
         for (let index = 0; index < self.displayedRegions.length; index += 1) {
           const region = self.displayedRegions[index]
           const len = region.end - region.start
+          const offset = bp - bpSoFar
           if (len + bpSoFar > bp && bpSoFar <= bp) {
-            const offset = bp - bpSoFar
             return {
               ...getSnapshot(region),
               oob: false,
@@ -342,7 +342,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
               index,
             }
           }
-          if (region.end - region.start > interRegionPaddingBp) {
+
+          // add the interRegionPaddingWidth if the boundary is in the screen e.g. offset>0 && offset<width
+          if (
+            region.end - region.start > interRegionPaddingBp &&
+            offset > 0 &&
+            offset < self.width
+          ) {
             bpSoFar += len + interRegionPaddingBp
           } else {
             bpSoFar += len

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -344,10 +344,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
           }
 
           // add the interRegionPaddingWidth if the boundary is in the screen e.g. offset>0 && offset<width
+          //
           if (
             region.end - region.start > interRegionPaddingBp &&
-            offset > 0 &&
-            offset < self.width
+            offset / self.bpPerPx > 0 &&
+            offset / self.bpPerPx < self.width
           ) {
             bpSoFar += len + interRegionPaddingBp
           } else {

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -323,20 +323,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
             index: 0,
           }
         }
-        if (bp >= this.totalBp) {
-          const region = self.displayedRegions[n - 1]
-          const len = region.end - region.start
-          const offset = bp - this.totalBp + len
-          return {
-            ...getSnapshot(region),
-            oob: true,
-            offset,
-            coord: region.reversed
-              ? Math.floor(region.end - offset) + 1
-              : Math.floor(region.start + offset) + 1,
-            index: n - 1,
-          }
-        }
 
         const interRegionPaddingBp = this.interRegionPaddingWidth * self.bpPerPx
 
@@ -359,6 +345,21 @@ export function stateModelFactory(pluginManager: PluginManager) {
             bpSoFar += len + interRegionPaddingBp
           } else {
             bpSoFar += len
+          }
+        }
+
+        if (bp >= bpSoFar) {
+          const region = self.displayedRegions[n - 1]
+          const len = region.end - region.start
+          const offset = bp - bpSoFar + len
+          return {
+            ...getSnapshot(region),
+            oob: true,
+            offset,
+            coord: region.reversed
+              ? Math.floor(region.end - offset) + 1
+              : Math.floor(region.start + offset) + 1,
+            index: n - 1,
           }
         }
         return { coord: '', refName: '' }

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -93,6 +93,10 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   style="width: 267px; left: 0px;"
                 />
                 <div
+                  class="makeStyles-scaleBarContig"
+                  style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
+                />
+                <div
                   class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
                   style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
                 >
@@ -139,6 +143,10 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     120
                   </div>
                 </div>
+                <div
+                  class="makeStyles-scaleBarContig"
+                  style="width: 0px; left: 800px; background-color: rgb(153, 153, 153);"
+                />
               </div>
             </div>
           </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -89,8 +89,12 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="makeStyles-scaleBar"
               >
                 <div
-                  class="MuiPaper-root makeStyles-scaleBarContig makeStyles-scaleBarContigForward MuiPaper-outlined MuiPaper-rounded"
-                  style="min-width: 800px; border-color: rgb(153, 102, 0);"
+                  class="makeStyles-scaleBarVisibleRegion"
+                  style="width: 267px; left: 0px;"
+                />
+                <div
+                  class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward"
+                  style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
                 >
                   <p
                     class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
@@ -98,10 +102,6 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     ctgA
                   </p>
-                  <div
-                    class="makeStyles-scaleBarVisibleRegion"
-                    style="width: 266.6666666666667px; left: -1px; pointer-events: none;"
-                  />
                   <div
                     class="makeStyles-scaleBarLabel"
                     style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
@@ -152,7 +152,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
             >
               <polygon
                 fill="rgba(121, 134, 203, 0.3)"
-                points="0,48,800,48,267,0,0,0"
+                points="0,48,801,48,267,0,0,0"
                 stroke="rgba(121, 134, 203, 0.8)"
               />
             </svg>


### PR DESCRIPTION
With this change

#1556 
#1532 
Also see refname label positioning issue (X not flush with boundary) in #1556

I also make the minimum block width smaller to make it so realistically human sized chromosomes such as 20-22 of human are displayed even when zoomed out



The refname label positioning  was fixed by updates to calculateStaticBlocks/calculateDynamicBlocks: only needs to add interregionpaddingwidth when it is a content block

This PR also adds ellided blocks to the overview bar so that we avoid rainbow-of-small-displayed regions, and changes it from paper with margins to exact width divs

![localhost_3000__config=test_data%2Fconfig_demo json session=local-Mj1xyxkZX (2)](https://user-images.githubusercontent.com/6511937/103037289-7c8d0080-4539-11eb-8f94-feefb4bbe0dc.png)


Note that this is still not perfect: it is visible from the screenshot that the chr1 overview scale bar polygon does not match up perfectly with the end of the display and the chr1 displays some negative offsets in an actually visible region

However, these changes do improve the general situation