### PR TITLE
Fix the display of trackhub registry results

### DIFF
--- a/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
+++ b/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
@@ -8,6 +8,7 @@ import RadioGroup from '@material-ui/core/RadioGroup'
 import { makeStyles } from '@material-ui/core/styles'
 import Tooltip from '@material-ui/core/Tooltip'
 import Typography from '@material-ui/core/Typography'
+import SanitizedHTML from '@jbrowse/core/ui/SanitizedHTML'
 import { PropTypes as MobxPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
@@ -278,14 +279,14 @@ function TrackHubRegistrySelect({ model, setModelReady }) {
                     <Wire key={id} value={id}>
                       {formControlProps => (
                         <Tooltip
-                          title={error || longLabel}
+                          title={error || <SanitizedHTML html={longLabel} />}
                           placement="left"
                           interactive
                         >
                           <FormControlLabel
                             key={id}
                             value={id}
-                            label={shortLabel}
+                            label={<SanitizedHTML html={shortLabel} />}
                             disabled={Boolean(error)}
                             control={<Radio />}
                             {...formControlProps}

--- a/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
+++ b/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
@@ -11,7 +11,6 @@ import Typography from '@material-ui/core/Typography'
 import { PropTypes as MobxPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
-import DOMPurify from 'dompurify'
 import HubDetails from './HubDetails'
 import SelectBox from './SelectBox'
 
@@ -270,34 +269,24 @@ function TrackHubRegistrySelect({ model, setModelReady }) {
                     hub.assembly.synonyms.includes(selectedAssembly),
                 )
                 .map(hub => {
-                  const disabled = Boolean(hub.error)
-                  const cleanShortLabel = (
-                    <div
-                      __dangerouslySetInnerHTML={{
-                        __html: DOMPurify.sanitize(hub.hub.shortLabel),
-                      }}
-                    />
-                  )
-                  const cleanLongLabel = (
-                    <div
-                      __dangerouslySetInnerHTML={{
-                        __html: DOMPurify.sanitize(hub.hub.longLabel),
-                      }}
-                    />
-                  )
+                  const {
+                    error,
+                    id,
+                    hub: { shortLabel, longLabel },
+                  } = hub
                   return (
-                    <Wire key={hub.id} value={hub.id}>
+                    <Wire key={id} value={id}>
                       {formControlProps => (
                         <Tooltip
-                          title={disabled ? hub.error : cleanLongLabel}
+                          title={error || longLabel}
                           placement="left"
                           interactive
                         >
                           <FormControlLabel
-                            key={hub.id}
-                            value={hub.id}
-                            label={cleanShortLabel}
-                            disabled={disabled}
+                            key={id}
+                            value={id}
+                            label={shortLabel}
+                            disabled={Boolean(error)}
                             control={<Radio />}
                             {...formControlProps}
                           />


### PR DESCRIPTION
Currently on master the trackhub registry names don't display properly

Not sure the regression but I removed the sanitize html element and it worked ok

If we need to actually render html in the labels we could restore the html sanitizer but otherwise works fine without it

On master:
![s3 amazonaws com_jbrowse org_code_jb2_master_index html_session=local-QRaSifM9h](https://user-images.githubusercontent.com/6511937/103561902-3cf2dc80-4e88-11eb-9586-438c0e83bd6d.png)


After:
![localhost_3000__config=test_data%2Fconfig json session=local-mz0KoOMqV](https://user-images.githubusercontent.com/6511937/103562157-9824cf00-4e88-11eb-8515-55c4a4b0c686.png)
