### PR TITLE
disable 'copy to clipboard' while loading

### DIFF
--- a/products/jbrowse-web/src/ShareButton.tsx
+++ b/products/jbrowse-web/src/ShareButton.tsx
@@ -309,6 +309,7 @@ const ShareDialog = observer(
               }}
               color="primary"
               startIcon={<ContentCopyIcon />}
+              disabled={currentSetting === 'short' && loading}
             >
               Copy URL to Clipboard
             </Button>


### PR DESCRIPTION
Simple fix, disable button from being pressed while short link is being generated, closes #1586 