### PR TITLE
Replace 'show all regions' with 'show all regions in assembly'

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -269,13 +269,13 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             />
             <input
               type="hidden"
-              value="332.1928094887362"
+              value="284.799690655495"
             />
             <span
               aria-orientation="horizontal"
               aria-valuemax="564.3856189774724"
-              aria-valuemin="332.1928094887362"
-              aria-valuenow="332.1928094887362"
+              aria-valuemin="284.799690655495"
+              aria-valuenow="284.799690655495"
               class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
               data-index="0"
               role="slider"
@@ -961,7 +961,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             />
             <span
               class="MuiSlider-track"
-              style="left: 0%; width: 2.3783941938133566%;"
+              style="left: 0%; width: 9.774680693120512%;"
             />
             <input
               type="hidden"
@@ -970,12 +970,12 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             <span
               aria-orientation="horizontal"
               aria-valuemax="564.3856189774724"
-              aria-valuemin="-13.750352374993502"
+              aria-valuemin="-61.143471208234715"
               aria-valuenow="0"
               class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
               data-index="0"
               role="slider"
-              style="left: 2.3783941938133566%;"
+              style="left: 9.774680693120512%;"
               tabindex="0"
             />
           </span>

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -1,5 +1,6 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
+import { Region } from '@jbrowse/core/util/types/mst'
 import {
   createBaseTrackConfig,
   createBaseTrackModel,
@@ -49,6 +50,18 @@ stubManager.createPluggableElements()
 stubManager.configure()
 const LinearGenomeModel = stateModelFactory(stubManager)
 
+const Assembly = types
+  .model({
+    regions: types.array(Region),
+  })
+  .views(self => ({
+    getCanonicalRefName(refName: string) {
+      if (refName === 'contigA') {
+        return 'ctgA'
+      }
+      return refName
+    },
+  }))
 const Session = types
   .model({
     name: 'testSession',
@@ -66,32 +79,24 @@ const Session = types
     assemblyManager: new Map([
       [
         'volvox',
-        {
-          getCanonicalRefName(refName: string) {
-            if (refName === 'contigA') {
-              return 'ctgA'
-            }
-            return refName
-          },
-          get regions() {
-            return [
-              {
-                assemblyName: 'volvox',
-                start: 0,
-                end: 50001,
-                refName: 'ctgA',
-                reversed: false,
-              },
-              {
-                assemblyName: 'volvox',
-                start: 0,
-                end: 6079,
-                refName: 'ctgB',
-                reversed: false,
-              },
-            ]
-          },
-        },
+        Assembly.create({
+          regions: [
+            {
+              assemblyName: 'volvox',
+              start: 0,
+              end: 50001,
+              refName: 'ctgA',
+              reversed: false,
+            },
+            {
+              assemblyName: 'volvox',
+              start: 0,
+              end: 6079,
+              refName: 'ctgB',
+              reversed: false,
+            },
+          ],
+        }),
       ],
     ]),
   }))

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -54,7 +54,7 @@ const Assembly = types
   .model({
     regions: types.array(Region),
   })
-  .views(self => ({
+  .views(() => ({
     getCanonicalRefName(refName: string) {
       if (refName === 'contigA') {
         return 'ctgA'

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -126,11 +126,11 @@ test('can instantiate a model that lets you navigate', () => {
       tracks: [{ name: 'foo track', type: 'FeatureTrack' }],
     }),
   )
+  model.setWidth(800)
   model.setDisplayedRegions([
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
   ])
-  model.setWidth(800)
-  expect(model.maxBpPerPx).toEqual(10)
+  expect(model.maxBpPerPx).toBeCloseTo(13.888)
   model.setNewView(0.02, 0)
 
   expect(model.scaleBarHeight).toEqual(20)
@@ -172,12 +172,12 @@ test('can instantiate a model that has multiple displayed regions', () => {
       tracks: [{ name: 'foo track', type: 'FeatureTrack' }],
     }),
   )
+  model.setWidth(800)
   model.setDisplayedRegions([
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgB' },
   ])
-  model.setWidth(800)
-  expect(model.maxBpPerPx).toEqual(20)
+  expect(model.maxBpPerPx).toBeCloseTo(27.777)
   model.setNewView(0.02, 0)
 
   expect(model.offsetPx).toEqual(0)
@@ -204,7 +204,7 @@ test('can instantiate a model that tests navTo/moveTo', async () => {
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgA' },
     { assemblyName: 'volvox', start: 0, end: 10000, refName: 'ctgB' },
   ])
-  expect(model.maxBpPerPx).toEqual(20)
+  expect(model.maxBpPerPx).toBeCloseTo(27.7777)
 
   model.navTo({ refName: 'ctgA', start: 0, end: 100 })
   expect(model.offsetPx).toBe(0)
@@ -362,16 +362,10 @@ describe('Zoom to selected displayed regions', () => {
         refName: 'ctgB',
       },
     )
-    // 15000 + 10000 + 1 = 25001 / 800 - 8 = 28
-    // this is the newBpPerPx ~ 28
-    // minBpPerPx = 0.2 & max is 28
-    //  extrabp = 0
-    //  bpToStart 464 / 28
-    // expect(model.scrollTo(16.58)).toEqual(0)
-    // This should be 28
+
     largestBpPerPx = model.bpPerPx
     expect(model.offsetPx).toEqual(0)
-    expect(model.bpPerPx).toEqual(28)
+    expect(model.bpPerPx).toBeCloseTo(31.408)
   })
 
   it('can select if start and end object are swapped', () => {
@@ -395,7 +389,7 @@ describe('Zoom to selected displayed regions', () => {
       },
     )
     expect(model.offsetPx).toEqual(0)
-    expect(model.bpPerPx).toEqual(28)
+    expect(model.bpPerPx).toBeCloseTo(31.408)
   })
 
   it('can select over one refSeq', () => {
@@ -452,7 +446,7 @@ describe('Zoom to selected displayed regions', () => {
   it('can select over two regions in the same reference sequence', () => {
     model.setWidth(800)
     model.showAllRegions()
-    expect(model.bpPerPx).toBe(28)
+    expect(model.bpPerPx).toBeCloseTo(38.8888)
     // totalBp = 28000 / 1000 = 28 as maxBpPerPx
     model.zoomToDisplayedRegions(
       {
@@ -485,8 +479,9 @@ describe('Zoom to selected displayed regions', () => {
     ])
     model.setWidth(800)
     model.showAllRegions()
-    // totalBo 15000 + 3000 + 35000 = 53000 / 800 = 66.25 but maxBp is 53000/ 1000  thus 53
-    expect(model.bpPerPx).toBe(53)
+    // totalBp 15000 + 3000 + 35000 = 53000
+    // then 53000 / (width*0.9) = 73.6111
+    expect(model.bpPerPx).toBeCloseTo(73.61111)
     model.zoomToDisplayedRegions(
       {
         start: 5000,
@@ -554,7 +549,7 @@ test('can instantiate a model that >2 regions', () => {
   expect(model.offsetPx).toEqual(10000 / model.bpPerPx + 2)
   expect(model.displayedRegionsTotalPx).toEqual(30000 / model.bpPerPx)
   model.showAllRegions()
-  expect(model.offsetPx).toEqual(100)
+  expect(model.offsetPx).toEqual(-40)
 
   expect(model.bpToPx({ refName: 'ctgA', coord: 100 })).toEqual({
     index: 0,

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -677,3 +677,23 @@ test('can perform pxToBp on human genome things with ellided blocks (zoomed out)
   expect(model.pxToBp(1500).refName).toBe('Y_KI270740v1_random')
   expect(model.pxToBp(1500).oob).toBeTruthy()
 })
+
+test('can showAllRegionsInAssembly', async () => {
+  const session = Session.create({
+    configuration: {},
+  })
+  const width = 800
+  const model = session.setView(
+    LinearGenomeModel.create({
+      id: 'test4',
+      type: 'LinearGenomeView',
+      tracks: [{ name: 'foo track', type: 'FeatureTrack' }],
+    }),
+  )
+  model.setWidth(width)
+  model.showAllRegionsInAssembly('volvox')
+  expect(model.displayedRegions.map(reg => reg.refName)).toEqual([
+    'ctgA',
+    'ctgB',
+  ])
+})

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -25,7 +25,6 @@ import {
   cast,
   Instance,
   getRoot,
-  isStateTreeNode,
   resolveIdentifier,
   addDisposer,
 } from 'mobx-state-tree'
@@ -193,7 +192,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
 
       get maxBpPerPx() {
-        return this.totalBp / 1000
+        return this.totalBp / (self.width * 0.9)
       },
 
       get minBpPerPx() {
@@ -1025,10 +1024,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         }
         const assembly = assemblyManager.get(assemblyName)
         if (assembly) {
-          // isStateTreeNode is used in test where assembly is not an STN
-          const { regions } = isStateTreeNode(assembly)
-            ? getSnapshot(assembly)
-            : assembly
+          const { regions } = getSnapshot(assembly)
           if (regions) {
             this.setDisplayedRegions(regions)
             self.zoomTo(self.maxBpPerPx)

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   />
                   <span
                     class="MuiSlider-track"
-                    style="left: 0%; width: 48.86084055306146%;"
+                    style="left: 0%; width: 56.78411120929245%;"
                   />
                   <input
                     type="hidden"
@@ -355,12 +355,12 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   <span
                     aria-orientation="horizontal"
                     aria-valuemax="564.3856189774724"
-                    aria-valuemin="305.8893689053569"
+                    aria-valuemin="258.49625007211563"
                     aria-valuenow="432.19280948873626"
                     class="MuiSlider-thumb MuiSlider-thumbColorPrimary"
                     data-index="0"
                     role="slider"
-                    style="left: 48.86084055306146%;"
+                    style="left: 56.78411120929245%;"
                     tabindex="0"
                   />
                 </span>


### PR DESCRIPTION
This is a break out from #1531 

This adds a new behavior where we can "Show all regions in assembly" and also changes a behavior so that maxBpPerPx is conditional on totalBp/(self.width*0.9) rather than totalBp/1000

That means on a wide monitor, the behavior for "Show all regions in assembly" would use more of those horizontal pixels than just choosing to squish everything down to 1000