### PR TITLE
Display error message from dynamodb session sharing error

### DIFF
--- a/products/jbrowse-web/src/ShareButton.tsx
+++ b/products/jbrowse-web/src/ShareButton.tsx
@@ -264,9 +264,7 @@ const ShareDialog = observer(
             <DialogContent>
               {currentSetting === 'short' ? (
                 error ? (
-                  <Typography color="error">
-                    Failed to generate short URL: {`${error}`}
-                  </Typography>
+                  <Typography color="error">{`${error}`}</Typography>
                 ) : loading ? (
                   <Typography>Generating short URL...</Typography>
                 ) : (

--- a/products/jbrowse-web/src/sessionSharing.ts
+++ b/products/jbrowse-web/src/sessionSharing.ts
@@ -23,6 +23,15 @@ const decrypt = (text: string, password: string) => {
   const bytes = AES.decrypt(text, password)
   return bytes.toString(Utf8)
 }
+
+function getErrorMsg(err: string) {
+  try {
+    const obj = JSON.parse(err)
+    return obj.message
+  } catch (e) {
+    return err
+  }
+}
 // writes the encrypted session, current datetime, and referer to DynamoDB
 export async function shareSessionToDynamo(
   session: Record<string, unknown>,
@@ -45,7 +54,8 @@ export async function shareSessionToDynamo(
   })
 
   if (!response.ok) {
-    throw new Error(`Error sharing session ${response.statusText}`)
+    const err = await response.text()
+    throw new Error(getErrorMsg(err))
   }
   const json = await response.json()
   return {
@@ -69,17 +79,10 @@ export async function readSessionFromDynamo(
   })
 
   if (!response.ok) {
-    console.error({ response, url })
-    throw new Error(
-      `Unable to fetch session ${sessionId}\n${response.statusText}`,
-    )
+    const err = await response.text()
+    throw new Error(getErrorMsg(err))
   }
 
-  // TODO: shouldn't get a 200 back for this
-  const text = await response.text()
-  if (!text) {
-    throw new Error(`Unable to fetch session ${sessionId}`)
-  }
-  const json = JSON.parse(text)
+  const json = await response.json()
   return decrypt(json.session, password)
 }

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ErrorBoundary, { FallbackProps } from 'react-error-boundary'
-import { render } from '@testing-library/react'
+import { render, wait } from '@testing-library/react'
 import { TextDecoder, TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import { LocalFile } from 'generic-filehandle'
 import rangeParser from 'range-parser'
@@ -119,7 +119,7 @@ describe('<Loader />', () => {
       </QueryParamProvider>,
     )
 
-    expect(await findByText('Help')).toBeTruthy()
+    await findByText('Help')
   })
 
   it('can use config from a url with shared session ', async () => {
@@ -134,9 +134,11 @@ describe('<Loader />', () => {
         <Loader initialTimestamp={initialTimestamp} />
       </QueryParamProvider>,
     )
-    expect(await findByText('Help')).toBeTruthy()
 
-    expect(sessionStorage.length).toBeGreaterThan(0)
+    await findByText('Help')
+    await wait(() => {
+      expect(sessionStorage.length).toBeGreaterThan(0)
+    })
   })
 
   it('can use config from a url with nonexistent share param ', async () => {
@@ -153,7 +155,7 @@ describe('<Loader />', () => {
         </QueryParamProvider>
       </ErrorBoundary>,
     )
-    await findAllByText(/Unable to fetch session/)
+    await findAllByText(/Error/)
   }, 10000)
 
   it('can catch error from loading a bad config', async () => {


### PR DESCRIPTION
I observed an error during sharing session, but the error message I got did not have details about the cause

![Screenshot from 2021-01-11 17-30-31](https://user-images.githubusercontent.com/6511937/104251498-7b167000-5435-11eb-830b-a16c74d38e6e.png)

This is a possible approach that parse the error message from the JSON form and if that fails, display it as is

Alternatively, we could simplify our return from our dynamodb API to not return json formatted errors, but this may be ok as is here
