### PR TITLE
Increase pileup maxHeight

### DIFF
--- a/plugins/alignments/src/PileupRenderer/configSchema.ts
+++ b/plugins/alignments/src/PileupRenderer/configSchema.ts
@@ -39,7 +39,7 @@ export default ConfigurationSchema(
     maxHeight: {
       type: 'integer',
       description: 'the maximum height to be used in a pileup rendering',
-      defaultValue: 600,
+      defaultValue: 1200,
     },
     maxClippingSize: {
       type: 'integer',


### PR DESCRIPTION
This is a small proposal to increase pileup maxheight

As part of this, we could also consider

a) making a track menu item to increase maxheight
b) potentially increase maxheight across the board
c) remove the existance of maxheight entirely?