### PR TITLE
Make renderArgs consistent and don't duplicate data

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
@@ -2,24 +2,29 @@
 import { renderToString } from 'react-dom/server'
 import { filter, toArray } from 'rxjs/operators'
 import { Feature } from '../../util/simpleFeature'
-import { BaseFeatureDataAdapter } from '../../data_adapters/BaseAdapter'
 import { checkAbortSignal } from '../../util'
 import { Region } from '../../util/types'
 import RendererType from './RendererType'
-import SerializableFilterChain from './util/serializableFilterChain'
+import {
+  RenderArgs as BaseRenderArgs,
+  RenderArgsSerialized as BaseRenderArgSerialized,
+  RenderArgsDeserialized as BaseRenderArgsDeserialized,
+  ResultsSerialized,
+} from './ServerSideRendererType'
+import RpcManager from '../../rpc/RpcManager'
 
-export interface RenderArgs {
-  blockKey: string
-  sessionId: string
-  signal?: AbortSignal
-  filters?: any
-  dataAdapter: BaseFeatureDataAdapter
-  bpPerPx: number
-  regions?: any
-  config: Record<string, any>
-  renderProps: { displayModel: any }
-  width: number
-  height: number
+export interface RenderArgs extends Omit<BaseRenderArgs, 'displayModel'> {
+  displayModel: {}
+}
+
+interface RenderArgsSerialized
+  extends Omit<BaseRenderArgSerialized, 'displayModel'> {
+  displayModel: {}
+}
+
+interface RenderArgsDeserialized
+  extends Omit<BaseRenderArgsDeserialized, 'displayModel'> {
+  displayModel: {}
 }
 
 export default class ComparativeServerSideRenderer extends RendererType {
@@ -46,7 +51,7 @@ export default class ComparativeServerSideRenderer extends RendererType {
   }
 
   // deserialize some of the results that came back from the worker
-  deserializeResultsInClient(result: { features: any }, args: RenderArgs) {
+  deserializeResultsInClient(result: ResultsSerialized, args: RenderArgs) {
     // @ts-ignore
     result.blockKey = args.blockKey
     return result
@@ -57,7 +62,7 @@ export default class ComparativeServerSideRenderer extends RendererType {
    * inflate arguments as necessary. called in the worker process.
    * @param args - the converted arguments to modify
    */
-  deserializeArgsInWorker(args: Record<string, any>) {
+  deserializeArgsInWorker(args: RenderArgsSerialized) {
     if (this.configSchema) {
       const config = this.configSchema.create(args.config || {})
       args.config = config
@@ -77,7 +82,7 @@ export default class ComparativeServerSideRenderer extends RendererType {
    * Render method called on the client. Serializes args, then
    * calls `render` with the RPC manager.
    */
-  async renderInClient(rpcManager: any, args: RenderArgs) {
+  async renderInClient(rpcManager: RpcManager, args: RenderArgs) {
     const serializedArgs = this.serializeArgsInClient(args)
 
     const result = await rpcManager.call(
@@ -86,8 +91,9 @@ export default class ComparativeServerSideRenderer extends RendererType {
       serializedArgs,
     )
 
-    this.deserializeResultsInClient(result, args)
-    return result
+    // @ts-ignore
+    const deserialized = this.deserializeResultsInClient(result, args)
+    return deserialized
   }
 
   /**
@@ -95,15 +101,13 @@ export default class ComparativeServerSideRenderer extends RendererType {
    * @param feature -
    * @returns true if this feature passes all configured filters
    */
-  featurePassesFilters(renderArgs: RenderArgs, feature: Feature) {
-    const filterChain = new SerializableFilterChain({
-      filters: renderArgs.filters,
-    })
-    return filterChain.passes(feature, renderArgs)
+  featurePassesFilters(renderArgs: RenderArgsDeserialized, feature: Feature) {
+    if (!renderArgs.filters) return true
+    return renderArgs.filters.passes(feature, renderArgs)
   }
 
   // render method called on the worker
-  async renderInWorker(args: RenderArgs) {
+  async renderInWorker(args: RenderArgsSerialized) {
     checkAbortSignal(args.signal)
     this.deserializeArgsInWorker(args)
     checkAbortSignal(args.signal)
@@ -163,7 +167,7 @@ export default class ComparativeServerSideRenderer extends RendererType {
       .toPromise()
   }
 
-  freeResourcesInClient(rpcManager: any, args: RenderArgs) {
+  freeResourcesInClient(rpcManager: RpcManager, args: RenderArgs) {
     const serializedArgs = this.serializeArgsInClient(args)
 
     return rpcManager.call(args.sessionId, 'freeResources', serializedArgs)

--- a/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
@@ -27,7 +27,7 @@ export default class ComparativeServerSideRenderer extends RendererType {
    * directly modifies the render arguments to prepare
    * them to be serialized and sent to the worker.
    *
-   * the base class replaces the `renderProps.displayModel` param
+   * the base class replaces the `displayModel` param
    * (which on the client is a MST model) with a stub
    * that only contains the `selectedFeature`, since
    * this is the only part of the track model that most
@@ -37,11 +37,8 @@ export default class ComparativeServerSideRenderer extends RendererType {
    * @returns the same object
    */
   serializeArgsInClient(args: RenderArgs) {
-    args.renderProps = {
-      ...args.renderProps,
-      // @ts-ignore
-      blockKey: args.blockKey,
-
+    args = {
+      ...args,
       displayModel: {},
     }
 

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.ts
@@ -24,7 +24,6 @@ import RpcManager from '../../rpc/RpcManager'
 import { createJBrowseTheme } from '../../ui'
 
 interface BaseRenderArgs {
-  blockKey: string
   sessionId: string
   signal?: AbortSignal
   dataAdapter: BaseFeatureDataAdapter
@@ -33,16 +32,14 @@ interface BaseRenderArgs {
     by: string
   }
   bpPerPx: number
-  renderProps: {
-    displayModel: { id: string; selectedFeatureId?: string }
-    blockKey: string
-  }
+  displayModel: { id: string; selectedFeatureId?: string }
+  blockKey: string
   regions: Region[]
 }
 
 export interface RenderArgs extends BaseRenderArgs {
   config: SnapshotOrInstance<AnyConfigurationModel>
-  filters: SerializableFilterChain
+  filters: SerializedFilterChain
 }
 
 export interface RenderArgsSerialized extends BaseRenderArgs {
@@ -73,7 +70,7 @@ export default class ServerSideRenderer extends RendererType {
    * directly modifies the render arguments to prepare
    * them to be serialized and sent to the worker.
    *
-   * the base class replaces the `renderProps.displayModel` param
+   * the base class replaces the `displayModel` param
    * (which on the client is a MST model) with a stub
    * that only contains the `selectedFeature`, since
    * this is the only part of the track model that most
@@ -83,11 +80,10 @@ export default class ServerSideRenderer extends RendererType {
    * @returns the same object
    */
   serializeArgsInClient(args: RenderArgs): RenderArgsSerialized {
-    const { displayModel } = args.renderProps
+    const { displayModel } = args
     if (displayModel) {
-      args.renderProps = {
-        ...args.renderProps,
-        blockKey: args.blockKey,
+      args = {
+        ...args,
         displayModel: {
           id: displayModel.id,
           selectedFeatureId: displayModel.selectedFeatureId,
@@ -101,7 +97,6 @@ export default class ServerSideRenderer extends RendererType {
         ? getSnapshot(args.config)
         : args.config,
       regions: JSON.parse(JSON.stringify(args.regions)),
-      filters: args.filters ? args.filters.toJSON().filters : [],
     }
   }
 

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -138,11 +138,14 @@ export class CoreRender extends RpcMethodType {
       this.pluginManager.getRendererType(rendererType),
     )
 
-    const result = await RendererType.renderInWorker({
+    const renderArgs = {
       ...deserializedArgs,
       ...renderProps,
       dataAdapter,
-    })
+    }
+    delete renderArgs.renderProps
+
+    const result = await RendererType.renderInWorker(renderArgs)
 
     checkAbortSignal(signal)
     return result

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -186,9 +186,9 @@ const stateModelFactory = (
                     regions: [region],
                     adapterConfig: self.adapterConfig,
                     rendererType: self.rendererType.name,
-                    renderProps,
                     sessionId: getRpcSessionId(self),
                     timeout: 1000000,
+                    ...renderProps,
                   })
                   self.setReady(true)
                   self.setCurrBpPerPx(view.bpPerPx)

--- a/plugins/circular-view/src/BaseChordDisplay/models/renderReaction.js
+++ b/plugins/circular-view/src/BaseChordDisplay/models/renderReaction.js
@@ -18,7 +18,6 @@ export default ({ jbrequire }) => {
         assemblyName: view.displayedRegions[0]?.assemblyName,
         adapterConfig: JSON.parse(JSON.stringify(display.adapterConfig)),
         rendererType: rendererType.name,
-        renderProps,
         regions: JSON.parse(JSON.stringify(view.displayedRegions)),
         blockDefinitions: view.blockDefinitions,
         sessionId: getRpcSessionId(display),
@@ -38,6 +37,7 @@ export default ({ jbrequire }) => {
       rpcManager,
       cannotBeRenderedReason,
       renderArgs,
+      renderProps,
     } = props
 
     if (cannotBeRenderedReason) {
@@ -61,6 +61,7 @@ export default ({ jbrequire }) => {
 
     const { html, ...data } = await rendererType.renderInClient(rpcManager, {
       ...renderArgs,
+      ...renderProps,
       signal,
     })
 

--- a/plugins/dotplot-view/src/DotplotDisplay/index.ts
+++ b/plugins/dotplot-view/src/DotplotDisplay/index.ts
@@ -159,19 +159,18 @@ function renderBlockData(self: DotplotDisplayModel) {
     return {
       rendererType,
       rpcManager,
-      renderProps,
+      renderProps: {
+        ...renderProps,
+        view: getSnapshot(parent),
+        width: viewWidth,
+        height: viewHeight,
+        borderSize,
+        borderX,
+        borderY,
+      },
       renderArgs: {
         adapterConfig,
         rendererType: rendererType.name,
-        renderProps: {
-          ...renderProps,
-          view: getSnapshot(parent),
-          width: viewWidth,
-          height: viewHeight,
-          borderSize,
-          borderX,
-          borderY,
-        },
         sessionId: getRpcSessionId(self),
         timeout: 1000000, // 10000,
       },
@@ -187,11 +186,14 @@ async function renderBlockEffect(
     throw new Error('cannot render with no props')
   }
 
-  const { rendererType, rpcManager, renderArgs } = props
+  const { rendererType, rpcManager, renderArgs, renderProps } = props
 
   const { html, ...data } = await (rendererType as any).renderInClient(
     rpcManager,
-    renderArgs,
+    {
+      ...renderArgs,
+      ...renderProps,
+    },
   )
 
   return { html, data, renderingComponent: rendererType.ReactComponent }

--- a/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
@@ -36,13 +36,14 @@ export default class ComparativeRender extends RpcMethodType {
   }
 
   async execute(args: ComparativeRenderArgs) {
+    const deserializedArgs = await this.deserializeArguments(args)
     const {
       sessionId,
       adapterConfig,
       rendererType,
       renderProps,
       signal,
-    } = await this.deserializeArguments(args)
+    } = deserializedArgs
     if (!sessionId) throw new Error('must pass a unique session id')
 
     checkAbortSignal(signal)
@@ -73,12 +74,14 @@ export default class ComparativeRender extends RpcMethodType {
         'CoreRender requires a renderer that is a subclass of ServerSideRendererType',
       )
 
-    const result = await RendererType.renderInWorker({
+    const renderArgs = {
+      ...deserializedArgs,
       ...renderProps,
-      sessionId,
       dataAdapter,
-      signal,
-    })
+    }
+    delete renderArgs.renderProps
+
+    const result = await RendererType.renderInWorker(renderArgs)
     checkAbortSignal(signal)
     return result
   }

--- a/plugins/linear-comparative-view/src/LinearComparativeDisplay/index.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeDisplay/index.ts
@@ -151,14 +151,13 @@ function renderBlockData(self: LinearComparativeDisplay) {
   return {
     rendererType,
     rpcManager,
-    renderProps,
+    renderProps: {
+      ...renderProps,
+      view: getSnapshot(parent),
+    },
     renderArgs: {
       adapterConfig,
       rendererType: rendererType.name,
-      renderProps: {
-        ...renderProps,
-        view: getSnapshot(parent),
-      },
       sessionId,
       timeout: 1000000,
     },
@@ -170,12 +169,12 @@ async function renderBlockEffect(props: ReturnType<typeof renderBlockData>) {
     throw new Error('cannot render with no props')
   }
 
-  const { rendererType, rpcManager, renderArgs } = props
+  const { rendererType, rpcManager, renderProps, renderArgs } = props
 
-  const { html, ...data } = await rendererType.renderInClient(
-    rpcManager,
-    renderArgs,
-  )
+  const { html, ...data } = await rendererType.renderInClient(rpcManager, {
+    ...renderArgs,
+    ...renderProps,
+  })
 
   return { html, data, renderingComponent: rendererType.ReactComponent }
 }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -253,7 +253,7 @@ interface ErrorProps {
 
 async function renderBlockEffect(
   props: RenderProps | ErrorProps,
-  _: unknown,
+  signal: AbortSignal,
   self: Instance<BlockStateModel>,
 ) {
   const {
@@ -286,6 +286,7 @@ async function renderBlockEffect(
     {
       ...renderArgs,
       ...renderProps,
+      signal,
     },
   )
   return {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -226,7 +226,6 @@ function renderBlockData(self: Instance<BlockStateModel>) {
         regions: [self.region],
         adapterConfig,
         rendererType: rendererType.name,
-        renderProps,
         sessionId,
         blockKey: self.key,
         timeout: 1000000, // 10000,
@@ -284,7 +283,10 @@ async function renderBlockEffect(
 
   const { html, maxHeightReached, ...data } = await rendererType.renderInClient(
     rpcManager,
-    renderArgs,
+    {
+      ...renderArgs,
+      ...renderProps,
+    },
   )
   return {
     data,


### PR DESCRIPTION
As I was developing the Apollo plugin, I found that sometimes the info I wanted was in `renderArgs` and sometimes it was in `renderArgs.renderProps`. I then noticed that in CoreRender, `renderProps` were getting passed twice, both in `renderArgs.renderProps` and then also spread into the `renderArgs`. After talking with @rbuels, we decided to keep the `renderProps` that were spread and get rid of `renderArgs.renderProps`. This PR does that, and then also unifies how `renderInWorker` and `renderInClient` are called so their arguments are the same.