### PR TITLE
Add option for configs to be ephemeral

### DIFF
--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -87,6 +87,7 @@ function makeConfigurationSchemaModel<
   // now assemble the MST model of the configuration schema
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const modelDefinition: Record<string, any> = {}
+  modelDefinition.ephemeral = false
   let identifier
 
   if (options.explicitlyTyped) {
@@ -203,6 +204,9 @@ function makeConfigurationSchemaModel<
         newSnap[key] = value
       }
     })
+    if (!newSnap.ephemeral) {
+      delete newSnap.ephemeral
+    }
     return newSnap
   })
 

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -174,6 +174,25 @@ export default function JBrowseWeb(
         }
       }
       removeAttr(snapshot, 'baseUri')
+      function removeEphemeral(obj) {
+        if (Array.isArray(obj)) {
+          obj = obj.filter(value => !value.ephemeral)
+          obj.forEach(value => {
+            if (typeof value === 'object') {
+              removeEphemeral(value)
+            }
+          })
+        } else {
+          for (const prop in obj) {
+            if (prop.ephemeral) {
+              delete obj[prop]
+            } else if (typeof obj[prop] === 'object') {
+              removeEphemeral(obj[prop])
+            }
+          }
+        }
+      }
+      removeEphemeral(snapshot)
       return snapshot
     },
   })


### PR DESCRIPTION
This is a draft PR for config schemas that are "ephemeral", i.e. they get omitted when a snapshot is made of the jbrowse config. This was discussed as a possible approach toward making #1444 possible. This way, configs can be added that will never be written to disk in admin mode, so e.g. a connection can write assembly configs that don't persist, so they are restored from the connection each time they are used.

If this approach is acceptable, this will need some tests added.