### PR TITLE
Wait for initialization when setting display

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -19,7 +19,7 @@ import calculateDynamicBlocks from '@jbrowse/core/util/calculateDynamicBlocks'
 import calculateStaticBlocks from '@jbrowse/core/util/calculateStaticBlocks'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 // misc
-import { transaction, autorun } from 'mobx'
+import { transaction, autorun, when } from 'mobx'
 import {
   getSnapshot,
   types,
@@ -603,7 +603,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       setDisplayedRegions(regions: Region[]) {
         self.displayedRegions = cast(regions)
-        self.zoomTo(self.bpPerPx)
+        when(
+          () => self.initialized,
+          () => self.zoomTo(self.bpPerPx),
+        )
       },
 
       activateTrackSelector() {


### PR DESCRIPTION
This fixes a bug in the LGV that I encountered during #1616 . If `setDisplayRegion` before the view is initialized, the region doesn't actually get set. Adding the mobX get ensures that `zoomTo` will be successful.