### PR TITLE
Support plugins using material-ui/icons >= 4.11.2

### DIFF
--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -8,6 +8,7 @@ export default [
 
   '@material-ui/core',
   '@material-ui/core/SvgIcon',
+  '@material-ui/core/utils',
   '@material-ui/lab',
 
   '@jbrowse/core/Plugin',

--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -10,6 +10,7 @@ import * as MUIStyles from '@material-ui/core/styles'
 
 // @material-ui components
 import * as MUICore from '@material-ui/core'
+import * as MUIUtils from '@material-ui/core/utils'
 import MUISvgIcon from '@material-ui/core/SvgIcon'
 import * as MUILab from '@material-ui/lab'
 import MUIBox from '@material-ui/core/Box'
@@ -88,6 +89,8 @@ const libs = {
   '@material-ui/core': MUICore,
   // special case so plugins can easily use @material-ui/icons; don't remove
   '@material-ui/core/SvgIcon': MUISvgIcon,
+  '@material-ui/core/utils': MUIUtils,
+  // end special case
   '@material-ui/lab': MUILab,
 
   // material-ui subcomponents, should get rid of these


### PR DESCRIPTION
There was a change in how material-ui exports its icons between 4.9.1 and 4.11.2. This adds one more special case name to the re-exports that allows plugins to bundle material-ui/icons using the new versions. Also works with the most recent beta of material-ui 5 (5.0.0-alpha.24).

xref https://github.com/GMOD/jbrowse-plugin-msaview/issues/6