### PR TITLE
Fix for track using assembly alias not displaying

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -155,8 +155,13 @@ export default function assemblyFactory(
       get name(): string {
         return readConfObject(self.configuration, 'name')
       },
+
       get aliases(): string[] {
         return readConfObject(self.configuration, 'aliases')
+      },
+
+      get allAliases() {
+        return [this.name, ...this.aliases]
       },
       get refNames() {
         return self.regions && self.regions.map(region => region.refName)

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -160,6 +160,10 @@ export default function assemblyFactory(
         return readConfObject(self.configuration, 'aliases')
       },
 
+      hasName(name: string) {
+        return this.name === name || this.aliases.includes(name)
+      },
+
       get allAliases() {
         return [this.name, ...this.aliases]
       },

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -26,27 +26,13 @@ export default function assemblyManagerFactory(
     })
     .views(self => ({
       get(assemblyName: string) {
-        const canonicalName = this.aliasMap.get(assemblyName)
-        return self.assemblies.find(
-          assembly => assembly.name === (canonicalName || assemblyName),
-        )
+        return self.assemblies.find(assembly => assembly.hasName(assemblyName))
       },
 
       get assemblyList() {
         return getParent(self).jbrowse.assemblies.slice()
       },
 
-      get aliasMap() {
-        const aliases: Map<string, string> = new Map()
-        self.assemblies.forEach(assembly => {
-          if (assembly.aliases.length) {
-            assembly.aliases.forEach(assemblyAlias => {
-              aliases.set(assemblyAlias, assembly.name)
-            })
-          }
-        })
-        return aliases
-      },
       get rpcManager() {
         return getParent(self).rpcManager
       },
@@ -71,10 +57,7 @@ export default function assemblyManagerFactory(
         if (!assemblyName) {
           throw new Error('no assembly name supplied to waitForAssembly')
         }
-        const canonicalName = self.aliasMap.get(assemblyName)
-        const assembly = self.assemblies.find(
-          asm => asm.name === (canonicalName || assemblyName),
-        )
+        const assembly = self.get(assemblyName)
         if (assembly) {
           await when(() => Boolean(assembly.regions && assembly.refNameAliases))
           return assembly

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@gmod/ucsc-hub": "^0.1.3",
     "@material-ui/icons": "^4.9.1",
+    "array-intersection": "^0.1.2",
     "object-hash": "^1.3.1",
     "pluralize": "^8.0.0"
   },

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -109,21 +109,13 @@ export default pluginManager =>
         }
         const trackConfigurations = connection.tracks
 
-        const relevantTrackConfigurations = trackConfigurations.filter(
-          trackConf => {
-            const viewType = pluginManager.getViewType(self.view.type)
-            const compatibleDisplays = viewType.displayTypes.map(
-              displayType => displayType.name,
-            )
-            for (const display of trackConf.displays) {
-              if (compatibleDisplays.includes(display.type)) {
-                return true
-              }
-            }
-            return false
-          },
-        )
-        return relevantTrackConfigurations
+        // filter out tracks that don't match the current display types
+        return trackConfigurations.filter(conf => {
+          const { displayTypes } = pluginManager.getViewType(self.view.type)
+          const compatibleDisplays = displayTypes.map(display => display.name)
+          const trackDisplays = conf.displays.map(display => display.type)
+          return intersect(compatibleDisplays, trackDisplays).length > 0
+        })
       },
 
       hierarchy(assemblyName) {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -56,13 +56,23 @@ export default pluginManager =>
           return []
         }
 
+        const session = getSession(self)
+        const { assemblyManager } = session
+        const assembly = assemblyManager.get(assemblyName)
+        if (!assembly) {
+          return []
+        }
         const relevantTrackConfigurations = trackConfigurations.filter(
           trackConf => {
             const trackConfAssemblies = readConfObject(
               trackConf,
               'assemblyNames',
             )
-            if (!trackConfAssemblies.includes(assemblyName)) {
+            const { name, aliases } = assembly
+            const overlappingRefNames = [name, ...aliases].filter(refName =>
+              trackConfAssemblies.includes(refName),
+            )
+            if (!overlappingRefNames.length) {
               return false
             }
             const viewType = pluginManager.getViewType(self.view.type)

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -189,7 +189,11 @@ function renderBlockData(self: Instance<BlockStateModel>) {
       let matchFound = false
       assemblyNames.forEach((assemblyName: string) => {
         const assembly = assemblyManager.get(assemblyName)
-        if (assembly && assembly.aliases.includes(self.region.assemblyName))
+        if (
+          assembly &&
+          (assembly.name === self.region.assemblyName ||
+            assembly.aliases.includes(self.region.assemblyName))
+        )
           matchFound = true
       })
       if (!matchFound) {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -189,12 +189,9 @@ function renderBlockData(self: Instance<BlockStateModel>) {
       let matchFound = false
       assemblyNames.forEach((assemblyName: string) => {
         const assembly = assemblyManager.get(assemblyName)
-        if (
-          assembly &&
-          (assembly.name === self.region.assemblyName ||
-            assembly.aliases.includes(self.region.assemblyName))
-        )
+        if (assembly && assembly.hasName(assemblyName)) {
           matchFound = true
+        }
       })
       if (!matchFound) {
         cannotBeRenderedReason = `region assembly (${self.region.assemblyName}) does not match track assemblies (${assemblyNames})`

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -12,6 +12,7 @@ import { TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import { clearCache } from '@jbrowse/core/util/io/rangeFetcher'
 import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
 import * as sessionSharing from '../sessionSharing'
+import volvoxConfigSnapshot from '../../test_data/volvox/config.json'
 import chromeSizesConfig from '../../test_data/config_chrom_sizes_test.json'
 import JBrowse from '../JBrowse'
 import { setup, getPluginManager, generateReadBuffer } from './util'
@@ -95,6 +96,32 @@ test('variant track test - opens feature detail view', async () => {
   fireEvent.click(await findByText('Open feature details'))
   expect(await findByTestId('variant-side-drawer')).toBeInTheDocument()
 }, 10000)
+
+describe('assembly aliases', () => {
+  it('allow a track with an alias assemblyName to display', async () => {
+    const variantTrack = volvoxConfigSnapshot.tracks.find(
+      track => track.trackId === 'volvox_filtered_vcf',
+    )
+    const assemblyAliasVariantTrack = JSON.parse(JSON.stringify(variantTrack))
+    assemblyAliasVariantTrack.assemblyNames = ['vvx']
+    const pluginManager = getPluginManager({
+      ...volvoxConfigSnapshot,
+      tracks: [assemblyAliasVariantTrack],
+    })
+    const state = pluginManager.rootModel
+    const { findByTestId, findByText } = render(
+      <JBrowse pluginManager={pluginManager} />,
+    )
+    await findByText('Help')
+    state.session.views[0].setNewView(0.05, 5000)
+    fireEvent.click(await findByTestId('htsTrackEntry-volvox_filtered_vcf'))
+    state.session.views[0].tracks[0].displays[0].setFeatureIdUnderMouse(
+      'test-vcf-604452',
+    )
+    const feat = await findByTestId('test-vcf-604452', {}, { timeout: 10000 })
+    expect(feat).toBeTruthy()
+  }, 10000)
+})
 
 describe('nclist track test with long name', () => {
   it('see that a feature gets ellipses', async () => {


### PR DESCRIPTION
Found this as part of other work, but am submitting it separately since it's a self-contained bug fix.

In the case where e.g. as assembly had a `name` of `"hg19"` and `aliases` of `["GRCh37"]`, if a track configuration used `"assemblyNames": ["GRCh37"]`, the track would not show up in the track selector, even though it was using a valid assembly alias.

Fixing that then revealed that the track would not display in the LinearGenomeView because the check comparing the track and displayedRegion assembly names was not being performed properly.

Fixes both bugs and adds a test to confirm the proper behavior.