### PR TITLE
Improve typescript for mobx-state-tree reexports

### DIFF
--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -3,6 +3,7 @@ import React from 'react'
 import * as ReactDom from 'react-dom'
 import * as mobx from 'mobx'
 import * as mst from 'mobx-state-tree'
+import { types } from 'mobx-state-tree'
 import * as mxreact from 'mobx-react'
 import PropTypes from 'prop-types'
 
@@ -78,7 +79,7 @@ import ReExportsList from './list'
 
 const libs = {
   mobx,
-  'mobx-state-tree': mst,
+  'mobx-state-tree': { ...mst, types },
   react: React,
   'react-dom': ReactDom,
   'mobx-react': mxreact,


### PR DESCRIPTION
Currently plugin development does not appear to get the types for mobx-state-tree and all imports produce type `any`


Can be reproduced with

```
mkdir test
cd test
yarn add @jbrowse/core
```

then make a index.ts file

```
import PluginManager from "@jbrowse/core/PluginManager";

export default function (pm: PluginManager) {
  const { types } = pm.lib["mobx-state-tree"];
  const model = types.model({
    value: types.string,
  });

  return model;
}
```

The `types` variable is of type any, which makes it a bit more difficult to properly typescript the code

This PR manually augments the reexports to try to help this. Possibly it could go even further than this but it may help by itself

Before
![Screenshot from 2021-02-01 21-24-52](https://user-images.githubusercontent.com/6511937/106552572-d1c31700-64d4-11eb-955e-6ca5d5df5f97.png)

After
![Screenshot from 2021-02-01 21-29-41](https://user-images.githubusercontent.com/6511937/106552589-d8ea2500-64d4-11eb-8452-0a4590d439e3.png)

