### PR TITLE
Use itemRgb/reserved for feature color

### DIFF
--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -113,6 +113,9 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
               if (r.uniqueId === undefined) {
                 throw new Error('invalid bbi feature')
               }
+              delete data.chromStart
+              delete data.chromEnd
+              delete data.chrom
 
               const f = new SimpleFeature({
                 id: `${this.id}-${r.uniqueId}`,

--- a/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
@@ -7,7 +7,12 @@ export default ConfigurationSchema(
     color1: {
       type: 'color',
       description: 'the main color of each feature',
-      defaultValue: 'goldenrod',
+      defaultValue: `function(f) {
+  const parent = f.parent();
+  const itemRgb = parent?parent.get("itemRgb"):f.get("itemRgb");
+  const reserved = parent?parent.get("reserved"):f.get("reserved");
+  const rgb = itemRgb||reserved;
+  return rgb?"rgb("+rgb+")":"goldenrod"; }`,
       functionSignature: ['feature'],
     },
     color2: {

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -130,8 +130,10 @@ describe('test configuration editor', () => {
     fireEvent.click(await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf'))
     fireEvent.click(await findByText('Settings'))
     await expect(findByTestId('configEditor')).resolves.toBeTruthy()
-    const input = await findByDisplayValue('goldenrod')
-    fireEvent.change(input, { target: { value: 'green' } })
+    const input = await findByDisplayValue(/goldenrod/)
+    fireEvent.change(input, {
+      target: { value: 'function(f) { return "green" }' },
+    })
     await waitFor(async () => {
       const feats = await findAllByTestId('box-test-vcf-604452')
       expect(feats[0]).toHaveAttribute('fill', 'green')

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2493,6 +2493,34 @@
           "indexType": "TBI"
         }
       }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "encodeCcreCombined",
+      "name": "ENCODE cis-regulatory elements (all cell types)",
+      "category": ["Annotation"],
+      "metadata": {
+        "source": "http://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=1020236289_HOhuYmfogKvSVWee06A1OECtrgLq&c=chrX&g=encodeCcreCombined"
+      },
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "http://hgdownload.soe.ucsc.edu/gbdb/hg38/encode3/ccre/encodeCcreCombined.bb"
+        }
+      },
+      "displays": [
+        {
+          "type": "LinearBasicDisplay",
+          "displayId": "testing1",
+          "renderer": {
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "description": "function(f) { return f.get('ucscLabel') }"
+            }
+          }
+        }
+      ]
     }
   ],
   "connections": [],


### PR DESCRIPTION

BigBed tracks often contain an encoded itemRgb or reserved field that contains rgb color. Note that sometimes this exists on a parent feature so parent feature is checked too.

We could enable rendering this by default in our SvgFeatureRenderer color callback

![localhost_3000__config=test_data%2Fconfig_demo json session=local-vGn3hp2jX](https://user-images.githubusercontent.com/6511937/106670299-18af1c00-656a-11eb-99fc-39a6f0fcf38e.png)

They aren't great about documenting the legend unless one goes to the UCSC page of interest, but it could help some cases and provide more rich visualization(e.g. the CNV is apparently blue for loss, red for gain https://genome.ucsc.edu/cgi-bin/hgTrackUi?db=hg38&g=iscaComposite) 

Enabling this by default makes it easier for any end user using the system to not have to make any custom code for this

Also deletes chromStart,chromEnd,chrom from feature details because those display 0 based coords when we want to display 1 based, and are basically duplicate attributes.