### PR TITLE
Fix session sharing when using cross origin config

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -175,9 +175,6 @@ const SessionLoader = types
     setSessionTriaged(args?: { snap: unknown; origin: string }) {
       self.sessionTriaged = args
     },
-    setShareWarningOpen(flag: boolean) {
-      self.shareWarningOpen = flag
-    },
   }))
   .actions(self => ({
     async fetchPlugins(config: { plugins: PluginDefinition[] }) {
@@ -206,7 +203,6 @@ const SessionLoader = types
         // cross origin config check
         if (configUri.hostname !== window.location.hostname) {
           self.setSessionTriaged({ snap: config, origin: 'config' })
-          self.setShareWarningOpen(true)
         } else {
           self.setConfigSnapshot(config)
         }
@@ -274,7 +270,6 @@ const SessionLoader = types
       const hasCallbacks = await scanSharedSessionForCallbacks(session)
       if (hasCallbacks) {
         self.setSessionTriaged({ snap: session, origin: 'share' })
-        self.setShareWarningOpen(true)
       } else {
         self.setSessionSnapshot({ ...session, id: shortid() })
       }
@@ -546,7 +541,7 @@ const Renderer = observer(
       )
     }
 
-    if (shareWarningOpen) {
+    if (loader.sessionTriaged) {
       return (
         <SessionWarningModal
           loader={loader}

--- a/products/jbrowse-web/src/sessionWarningModal.tsx
+++ b/products/jbrowse-web/src/sessionWarningModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from '@material-ui/core/Button'
 import { makeStyles } from '@material-ui/core/styles'
 import Dialog from '@material-ui/core/Dialog'
@@ -33,68 +33,65 @@ export default function SessionWarningModal({
   sessionTriaged: { snap: IAnyStateTreeNode; origin: string }
 }) {
   const classes = useStyles()
-  const [open, setOpen] = useState(true)
 
   const session = JSON.parse(JSON.stringify(sessionTriaged.snap))
 
   const handleClose = () => {
-    loader.setShareWarningOpen(false)
-    setOpen(false)
+    loader.setSessionTriaged(undefined)
   }
   return (
-    <>
-      <Dialog
-        maxWidth="xl"
-        open={open}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-        data-testid="session-warning-modal"
-        className={classes.main}
-      >
-        <DialogTitle id="alert-dialog-title">Warning</DialogTitle>
-        <Divider />
-        <div>
-          <WarningIcon fontSize="large" />
-          <DialogContent>
-            <DialogContentText>
-              External sessions can contain code that runs.
-            </DialogContentText>
-            <DialogContentText>
-              Please ensure and confirm you trust the source of this session.
-            </DialogContentText>
-          </DialogContent>
-          <div className={classes.buttons}>
-            <Button
-              color="primary"
-              variant="contained"
-              style={{ marginRight: 5 }}
-              onClick={() => {
-                sessionTriaged.origin === 'share'
-                  ? loader.setSessionSnapshot({
-                      ...session,
-                      id: shortid(),
-                    })
-                  : loader.setConfigSnapshot({
-                      ...session,
-                      id: shortid(),
-                    })
-                handleClose()
-              }}
-            >
-              Confirm
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => {
-                loader.setBlankSession(true)
-                handleClose()
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
+    <Dialog
+      open
+      maxWidth="xl"
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      data-testid="session-warning-modal"
+      className={classes.main}
+    >
+      <DialogTitle id="alert-dialog-title">Warning</DialogTitle>
+      <Divider />
+      <div>
+        <WarningIcon fontSize="large" />
+        <DialogContent>
+          <DialogContentText>
+            External sessions can contain code that runs.
+          </DialogContentText>
+          <DialogContentText>
+            Please ensure and confirm you trust the source of this session.
+          </DialogContentText>
+        </DialogContent>
+        <div className={classes.buttons}>
+          <Button
+            color="primary"
+            variant="contained"
+            style={{ marginRight: 5 }}
+            onClick={() => {
+              console.log(sessionTriaged)
+              sessionTriaged.origin === 'share'
+                ? loader.setSessionSnapshot({
+                    ...session,
+                    id: shortid(),
+                  })
+                : loader.setSessionSnapshot({
+                    ...session,
+                    id: shortid(),
+                  })
+              handleClose()
+            }}
+          >
+            Confirm
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              loader.setBlankSession(true)
+              handleClose()
+            }}
+          >
+            Cancel
+          </Button>
         </div>
-      </Dialog>
-    </>
+      </div>
+    </Dialog>
   )
 }

--- a/products/jbrowse-web/src/sessionWarningModal.tsx
+++ b/products/jbrowse-web/src/sessionWarningModal.tsx
@@ -66,13 +66,12 @@ export default function SessionWarningModal({
             variant="contained"
             style={{ marginRight: 5 }}
             onClick={() => {
-              console.log(sessionTriaged)
               sessionTriaged.origin === 'share'
                 ? loader.setSessionSnapshot({
                     ...session,
                     id: shortid(),
                   })
-                : loader.setSessionSnapshot({
+                : loader.setConfigSnapshot({
                     ...session,
                     id: shortid(),
                   })


### PR DESCRIPTION
Currently if a session is shared with a cross origin config, it produces a warning about that but then fails to load the requested session

The session loading needs the config to be loaded first, so it needs to wait for the config to be "untriaged" using the wording of the PR

This PR adds an autorun so when we get the config is untriaged, then processes the session

Only exists sense the merger of #1632