### PR TITLE
Fix global autoscale selection in linearwiggledisplay

### DIFF
--- a/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
+++ b/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
@@ -40,7 +40,7 @@ export class WiggleGetGlobalStats extends RpcMethodType {
     if (
       dataAdapter instanceof BaseFeatureDataAdapter &&
       // @ts-ignore
-      dataAdapter.capabilities.includes('hasGlobalStats')
+      dataAdapter.constructor.capabilities.includes('hasGlobalStats')
     ) {
       // @ts-ignore
       return dataAdapter.getGlobalStats(deserializedArgs)

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -1073,7 +1073,14 @@
         "bigWigLocation": {
           "uri": "https://www.encodeproject.org/files/ENCFF303QSJ/@@download/ENCFF303QSJ.bigWig"
         }
-      }
+      },
+      "displays": [
+        {
+          "type": "LinearWiggleDisplay",
+          "displayId": "wiggle_global_autoscale-LinearWiggleDisplay",
+          "autoscale": "global"
+        }
+      ]
     },
     {
       "type": "QuantitativeTrack",


### PR DESCRIPTION
This fixes the use of the global autoscaling selection in #1664 

Static parameters can't be accessed on a instance of the object e.g. can't use  `instance.staticField`, but can use  `instance.constructor.staticField`


For some reason this issue has only existed after the merger of #1629 but the MDN as Garrett found out explains this https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static#using_static_members_in_classes