### PR TITLE
Allow plain json encoding of the session in the URL

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -127,6 +127,10 @@ const SessionLoader = types
       return self.sessionQuery?.startsWith('encoded-')
     },
 
+    get jsonSession() {
+      return self.sessionQuery?.startsWith('json-')
+    },
+
     get localSession() {
       return self.sessionQuery?.startsWith('local-')
     },
@@ -282,8 +286,21 @@ const SessionLoader = types
       )
       self.setSessionSnapshot({ ...session, id: shortid() })
     },
+
+    async decodeJsonUrlSession() {
+      // @ts-ignore
+      const session = JSON.parse(self.sessionQuery.replace('json-', ''))
+      self.setSessionSnapshot({ ...session, id: shortid() })
+    },
+
     async afterCreate() {
-      const { localSession, encodedSession, sharedSession, configPath } = self
+      const {
+        localSession,
+        encodedSession,
+        sharedSession,
+        jsonSession,
+        configPath,
+      } = self
 
       // rename autosave to previousAutosave
       const lastAutosave = localStorage.getItem(`autosave-${configPath}`)
@@ -308,6 +325,8 @@ const SessionLoader = types
                 await this.fetchSharedSession()
               } else if (encodedSession) {
                 await this.decodeEncodedUrlSession()
+              } else if (jsonSession) {
+                await this.decodeJsonUrlSession()
               } else if (localSession) {
                 await this.fetchSessionStorageSession()
               } else if (self.sessionQuery) {


### PR DESCRIPTION
This is a technique that allows a plain JSON string to be put in the session URL

It would look like

http://localhost:3000/?config=test_data%2Fvolvox%2Fconfig.json&session=json-{%22id%22:%22cWzmaLb-c%22,%22name%22:%22Integration%20test%20example%202/3/2021,%207:18:00%20PM%22,%22margin%22:0,%22drawerWidth%22:384,%22views%22:[{%22id%22:%22integration_test%22,%22type%22:%22LinearGenomeView%22,%22offsetPx%22:2000,%22bpPerPx%22:0.05,%22displayedRegions%22:[{%22refName%22:%22ctgA%22,%22start%22:0,%22end%22:50001,%22reversed%22:false,%22assemblyName%22:%22volvox%22}],%22tracks%22:[{%22id%22:%22_XTGJ2EV9%22,%22type%22:%22AlignmentsTrack%22,%22configuration%22:%22volvox-long-reads-sv-bam%22,%22displays%22:[{%22id%22:%22CxRaqiTAM1%22,%22type%22:%22LinearAlignmentsDisplay%22,%22PileupDisplay%22:{%22id%22:%22cY0zxKsHZs%22,%22type%22:%22LinearPileupDisplay%22,%22height%22:100,%22configuration%22:{%22type%22:%22LinearPileupDisplay%22,%22displayId%22:%22volvox-long-reads-sv-bam-LinearAlignmentsDisplay_pileup_xyz%22,%22renderers%22:{%22PileupRenderer%22:{%22type%22:%22PileupRenderer%22},%22SvgFeatureRenderer%22:{%22type%22:%22SvgFeatureRenderer%22}}},%22showSoftClipping%22:false,%22filterBy%22:{%22flagInclude%22:0,%22flagExclude%22:1536}},%22SNPCoverageDisplay%22:{%22id%22:%22dMHjS5-9Dw%22,%22type%22:%22LinearSNPCoverageDisplay%22,%22height%22:45,%22configuration%22:{%22type%22:%22LinearSNPCoverageDisplay%22,%22displayId%22:%22volvox-long-reads-sv-bam-LinearAlignmentsDisplay_snpcoverage_xyz%22,%22renderers%22:{%22SNPCoverageRenderer%22:{%22type%22:%22SNPCoverageRenderer%22}}},%22selectedRendering%22:%22%22,%22resolution%22:1,%22constraints%22:{},%22filterBy%22:{%22flagInclude%22:0,%22flagExclude%22:1536}},%22configuration%22:%22volvox-long-reads-sv-bam-LinearAlignmentsDisplay%22,%22height%22:250,%22showCoverage%22:true,%22showPileup%22:true}]}],%22hideHeader%22:false,%22hideHeaderOverview%22:false,%22trackSelectorType%22:%22hierarchical%22,%22trackLabels%22:%22overlapping%22,%22showCenterLine%22:false}],%22widgets%22:{%22hierarchicalTrackSelector%22:{%22id%22:%22hierarchicalTrackSelector%22,%22type%22:%22HierarchicalTrackSelectorWidget%22,%22collapsed%22:{},%22filterText%22:%22%22,%22view%22:%22integration_test%22}},%22activeWidgets%22:{%22hierarchicalTrackSelector%22:%22hierarchicalTrackSelector%22},%22connectionInstances%22:{},%22sessionTracks%22:[],%22sessionConnections%22:[]}