### PR TITLE
1674 open track bug

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -117,6 +117,8 @@ export interface AbstractViewModel {
   type: string
   width: number
   setWidth(width: number): void
+  displayedRegions?: Region[]
+  initialized?: boolean
 }
 export function isViewModel(thing: unknown): thing is AbstractViewModel {
   return (

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -107,9 +107,7 @@ export default function f(pluginManager: PluginManager) {
       },
 
       get assembly() {
-        return (
-          self.altAssemblyName || self.view.displayedRegions[0].assemblyName
-        )
+        return self.altAssemblyName
       },
 
       get trackType() {

--- a/plugins/data-management/src/index.ts
+++ b/plugins/data-management/src/index.ts
@@ -88,12 +88,12 @@ export default class extends Plugin {
           if (session.views.length === 0) {
             session.notify('Please open a view to add a track first')
           } else if (session.views.length >= 1) {
-            const assemblyInitialized =
-              session.views[0]?.assemblyNames ||
-              session.views[0]?.displayedRegions ||
-              session.views[0]?.assemblyName ||
-              []
-            if (assemblyInitialized.length > 0) {
+            // TODO: universal way of knowing wether view is initialized or not
+            const assemblyInitialized = session.views[0]?.displayedRegions || []
+            if (
+              assemblyInitialized.length > 0 ||
+              session.views[0].initialized
+            ) {
               const widget = session.addWidget(
                 'AddTrackWidget',
                 'addTrackWidget',

--- a/plugins/data-management/src/index.ts
+++ b/plugins/data-management/src/index.ts
@@ -88,16 +88,25 @@ export default class extends Plugin {
           if (session.views.length === 0) {
             session.notify('Please open a view to add a track first')
           } else if (session.views.length >= 1) {
-            const widget = session.addWidget(
-              'AddTrackWidget',
-              'addTrackWidget',
-              { view: session.views[0].id },
-            )
-            session.showWidget(widget)
-            if (session.views.length > 1) {
-              session.notify(
-                `This will add a track to the first view. Note: if you want to open a track in a specific view open the track selector for that view and use the add track (plus icon) in the bottom right`,
+            const assemblyInitialized =
+              session.views[0]?.assemblyNames ||
+              session.views[0]?.displayedRegions ||
+              session.views[0]?.assemblyName ||
+              []
+            if (assemblyInitialized.length > 0) {
+              const widget = session.addWidget(
+                'AddTrackWidget',
+                'addTrackWidget',
+                { view: session.views[0].id },
               )
+              session.showWidget(widget)
+              if (session.views.length > 1) {
+                session.notify(
+                  `This will add a track to the first view. Note: if you want to open a track in a specific view open the track selector for that view and use the add track (plus icon) in the bottom right`,
+                )
+              }
+            } else {
+              session.notify(`Please open a view to add a track first`)
             }
           }
         },

--- a/products/jbrowse-web/src/tests/CircularView.test.js
+++ b/products/jbrowse-web/src/tests/CircularView.test.js
@@ -50,6 +50,9 @@ describe('circular views', () => {
     } = render(<JBrowse pluginManager={pluginManager} />)
     // wait for the UI to be loaded
     await findByText('Help')
+    // try opening a track before opening the actual view
+    fireEvent.click(await findByText('File'))
+    fireEvent.click(await findByText('Open track'))
 
     fireEvent.click(await findByText('Open'))
 


### PR DESCRIPTION
Proposal to fix bug [1674](https://github.com/GMOD/jbrowse-components/issues/1674)
Jbrowse web currently crashes when we click File -> Open Track while an import form is being rendered due to 

This PR
- Removes retrieving assemblyName from displayedRegions in the addTrackWidget model.ts. Not all views have displayedRegions @ session.views[0] (e.g synteny which has them @ session.views[0].views) which causes 'TypeError: Cannot read property 'assemblyName' of undefined'. DisplayedRegions can also be undefined when opening a view (import form) but displayedRegions are still yet to be defined which will throw the same error. 

- Small test in CircularView. Tests being able to click `Open Track` from circular view set up wizard without crashing Jbrowse web.

Can remove utilizing the  `self.view.displayedRegions[0].assemblyName` in the addTrackWidget `get assembly()` or maybe add more options for retrieving the assemblyName. 