### PR TITLE
Add extra timeout to color change test

### DIFF
--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -159,10 +159,13 @@ describe('test configuration editor', () => {
     await expect(findByTestId('configEditor')).resolves.toBeTruthy()
     const input = await findByDisplayValue('goldenrod')
     fireEvent.change(input, { target: { value: 'green' } })
-    await waitFor(async () => {
-      const feats = await findAllByTestId('box-test-vcf-604452')
-      expect(feats[0]).toHaveAttribute('fill', 'green')
-    })
+    await waitFor(
+      async () => {
+        const feats = await findAllByTestId('box-test-vcf-604452')
+        expect(feats[0]).toHaveAttribute('fill', 'green')
+      },
+      { timeout: 10000 },
+    )
   }, 10000)
 })
 


### PR DESCRIPTION
Seen on master
https://github.com/GMOD/jbrowse-components/runs/1873190103?check_suite_focus=true#step:5:37


Started in  #1682 but should just be due to flakiness or timeout