### PR TITLE
Bold insertion indicator for large insertions on pileup track

### DIFF
--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -481,15 +481,26 @@ export default class PileupRenderer extends BoxRendererType {
       } else if (mismatch.type === 'insertion') {
         ctx.fillStyle = 'purple'
         const pos = mismatchLeftPx - 1
-        ctx.fillRect(pos, topPx + 1, w, heightPx - 2)
-        ctx.fillRect(pos - w, topPx, w * 3, 1)
-        ctx.fillRect(pos - w, topPx + heightPx - 1, w * 3, 1)
-        if (1 / bpPerPx >= charWidth && heightPx >= charHeight - 2) {
-          ctx.fillText(
-            `(${mismatch.base})`,
-            mismatchLeftPx + 2,
-            topPx + heightPx,
-          )
+
+        const len = +mismatch.base || mismatch.length
+
+        if (len < 10) {
+          ctx.fillRect(pos, topPx + 1, w, heightPx - 2)
+          ctx.fillRect(pos - w, topPx, w * 3, 1)
+          ctx.fillRect(pos - w, topPx + heightPx - 1, w * 3, 1)
+          if (1 / bpPerPx >= charWidth && heightPx >= charHeight - 2) {
+            ctx.fillText(
+              `(${mismatch.base})`,
+              mismatchLeftPx + 2,
+              topPx + heightPx,
+            )
+          }
+        } else {
+          const txt = `(${len})`
+          const rect = ctx.measureText(txt)
+          ctx.fillRect(mismatchLeftPx - 2, topPx, rect.width + 4, heightPx)
+          ctx.fillStyle = 'white'
+          ctx.fillText(txt, mismatchLeftPx, topPx + heightPx)
         }
       } else if (mismatch.type === 'hardclip' || mismatch.type === 'softclip') {
         ctx.fillStyle = mismatch.type === 'hardclip' ? 'red' : 'blue'

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -496,11 +496,17 @@ export default class PileupRenderer extends BoxRendererType {
             )
           }
         } else {
-          const txt = `(${len})`
+          const txt = `${len}`
           const rect = ctx.measureText(txt)
-          ctx.fillRect(mismatchLeftPx - 2, topPx, rect.width + 4, heightPx)
+          const padding = 5
+          ctx.fillRect(
+            mismatchLeftPx - rect.width / 2 - padding,
+            topPx,
+            rect.width + 2 * padding,
+            heightPx,
+          )
           ctx.fillStyle = 'white'
-          ctx.fillText(txt, mismatchLeftPx, topPx + heightPx)
+          ctx.fillText(txt, mismatchLeftPx - rect.width / 2, topPx + heightPx)
         }
       } else if (mismatch.type === 'hardclip' || mismatch.type === 'softclip') {
         ctx.fillStyle = mismatch.type === 'hardclip' ? 'red' : 'blue'

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2524,6 +2524,25 @@
           }
         }
       ]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "nstd175.GRCh37.variant_call.vcf",
+      "name": "nstd175.GRCh37.variant_call.vcf",
+      "category": ["GIAB"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/data/Homo_sapiens/by_study/vcf/nstd175.GRCh37.variant_call.vcf.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/data/Homo_sapiens/by_study/vcf/nstd175.GRCh37.variant_call.vcf.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      }
     }
   ],
   "connections": [],


### PR DESCRIPTION
Sort of tangential but related goals to elucidating insertions as #1687 

Adds similar insertion indicator seen in igv

Ref fig S2 https://static-content.springer.com/esm/art%3A10.1186%2Fs13059-020-02107-y/MediaObjects/13059_2020_2107_MOESM1_ESM.docx from https://genomebiology.biomedcentral.com/articles/10.1186/s13059-020-02107-y#Sec22

![Screenshot from 2021-02-10 20-44-22](https://user-images.githubusercontent.com/6511937/107600357-cb255580-6be0-11eb-9464-c0759857f6dd.png)
The insertion signal for the 6000bp insertion is dispersed by complicated mapping, but can be pieced together from the large numbers

I arbitrarily thresholded it so that len<10 it draws line indicator, and larger than than it makes the bold indicator which draws it as wide as needed to accommodate the number

