### PR TITLE
Add solid border on hierarchical panels to emphasize nested

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Category.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/Category.js
@@ -45,7 +45,7 @@ function Category({
 
   return (
     <Accordion
-      style={{ marginTop: '4px' }}
+      style={{ marginTop: 4, border: '1px solid #444' }}
       expanded={!model.collapsed.get(pathName)}
       onChange={() => model.toggleCategory(pathName)}
     >

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -135,7 +135,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
   />
   <div
     class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
-    style="margin-top: 4px;"
+    style="margin-top: 4px; border: 1px solid #444;"
   >
     <div
       aria-disabled="false"
@@ -268,7 +268,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
               </div>
               <div
                 class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
-                style="margin-top: 4px;"
+                style="margin-top: 4px; border: 1px solid #444;"
               >
                 <div
                   aria-disabled="false"


### PR DESCRIPTION
In order to emphasize nestedness of categories, adding a strong border color helps them stand out. This is the first thing I think could help this, more spacing could help but we are very tightly constrained in the drawer so probably avoid it if possible

Before

![localhost_3000__config=test_data%2Fvolvox%2Fconfig json session=local-C0PfYHoz3](https://user-images.githubusercontent.com/6511937/107839118-f20d9400-6d66-11eb-901c-61358f6eb64f.png)
After
![localhost_3000__config=test_data%2Fvolvox_config json](https://user-images.githubusercontent.com/6511937/107839120-f33ec100-6d66-11eb-9925-12ac3106b6f5.png)
