### PR TITLE
Improve zoomed-out display of quantitative displays tracks when bicolor pivot is active

### DIFF
--- a/plugins/wiggle/src/LinePlotRenderer/LinePlotRenderer.js
+++ b/plugins/wiggle/src/LinePlotRenderer/LinePlotRenderer.js
@@ -7,23 +7,18 @@ export default class extends WiggleBaseRenderer {
   draw(ctx, props) {
     const { features, regions, bpPerPx, scaleOpts, height, config } = props
     const [region] = regions
-    const pivotValue = readConfObject(config, 'bicolorPivotValue')
-    const negColor = readConfObject(config, 'negColor')
-    const posColor = readConfObject(config, 'posColor')
     const clipColor = readConfObject(config, 'clipColor')
     const highlightColor = readConfObject(config, 'highlightColor')
     const scale = getScale({ ...scaleOpts, range: [0, height] })
     const [niceMin, niceMax] = scale.domain()
     const toY = rawscore => height - scale(rawscore)
-    let colorCallback
-    if (readConfObject(config, 'color') === '#f0f') {
-      colorCallback = feature =>
-        feature.get('score') < pivotValue ? negColor : posColor
-    } else {
-      colorCallback = feature => readConfObject(config, 'color', [feature])
-    }
-    let lastVal
+    const colorCallback =
+      readConfObject(config, 'color') === '#f0f'
+        ? // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          feature => 'grey'
+        : feature => readConfObject(config, 'color', [feature])
 
+    let lastVal
     for (const feature of features.values()) {
       const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
       const score = feature.get('score')

--- a/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
+++ b/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
@@ -19,110 +19,79 @@ export default class XYPlotRenderer extends WiggleBaseRenderer {
     const clipColor = readConfObject(config, 'clipColor')
     const highlightColor = readConfObject(config, 'highlightColor')
     const summaryScoreMode = readConfObject(config, 'summaryScoreMode')
+
     const scale = getScale({ ...scaleOpts, range: [0, height] })
     const originY = getOrigin(scaleOpts.scaleType)
     const [niceMin, niceMax] = scale.domain()
-    const toY = (rawscore: number) => height - scale(rawscore)
-    const toHeight = (rawscore: number) => toY(originY) - toY(rawscore)
-    let colorCallback
-    if (readConfObject(config, 'color') === '#f0f') {
-      colorCallback = (feature: Feature) =>
-        feature.get('score') < pivotValue ? negColor : posColor
-    } else {
-      colorCallback = (feature: Feature) =>
-        readConfObject(config, 'color', [feature])
-    }
-    const crossingOrigin = niceMin < 0 && niceMax > 0
 
+    const toY = (n: number) => height - scale(n)
+    const toHeight = (n: number) => toY(originY) - toY(n)
+
+    const colorCallback =
+      readConfObject(config, 'color') === '#f0f'
+        ? (_: Feature, score: number) =>
+            score < pivotValue ? negColor : posColor
+        : (feature: Feature, _score: number) =>
+            readConfObject(config, 'color', [feature])
+
+    const crossingOrigin = niceMin < pivotValue && niceMax > pivotValue
     for (const feature of features.values()) {
       const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
       let score = feature.get('score')
       const maxr = feature.get('maxScore')
       const minr = feature.get('minScore')
-      const summary = feature.get('summary')
 
       const lowClipping = score < niceMin
       const highClipping = score > niceMax
       const w = rightPx - leftPx + 0.4 // fudge factor for subpixel rendering
 
-      const c = colorCallback(feature)
+      const summary = feature.get('summary')
+
       if (summaryScoreMode === 'max') {
-        score = maxr === undefined ? score : maxr
-        ctx.fillStyle = c
+        score = summary ? maxr : score
+        ctx.fillStyle = colorCallback(feature, score)
         ctx.fillRect(leftPx, toY(score), w, filled ? toHeight(score) : 1)
       } else if (summaryScoreMode === 'min') {
-        score = minr === undefined ? score : minr
-        ctx.fillStyle = c
+        score = summary ? minr : score
+        ctx.fillStyle = colorCallback(feature, score)
         ctx.fillRect(leftPx, toY(score), w, filled ? toHeight(score) : 1)
       } else if (summaryScoreMode === 'whiskers') {
-        if (crossingOrigin) {
-          if (summary) {
-            ctx.fillStyle = maxr < pivotValue ? negColor : posColor
-            ctx.fillRect(
-              leftPx,
-              toY(maxr),
-              w - 0.1,
-              filled ? toHeight(maxr) - toHeight(0) : 1,
-            )
-
-            // avg
-            ctx.fillStyle = 'purple'
-            ctx.fillRect(
-              leftPx,
-              toY(score),
-              w - 0.1,
-              filled ? toHeight(score) - toHeight(0) : 1,
-            )
-
-            ctx.fillStyle = minr < pivotValue ? negColor : posColor
-            ctx.fillRect(
-              leftPx,
-              filled ? toY(0) : toY(minr),
-              w,
-              filled ? toHeight(-minr) : 1,
-            )
-          } else {
-            // normal
-            ctx.fillStyle = c
-            ctx.fillRect(
-              leftPx,
-              toY(score),
-              w - 0.1,
-              filled
-                ? toHeight(score) - (minr !== undefined ? toHeight(minr) : 0)
-                : 1,
-            )
-          }
-        } else {
-          // max
-          if (maxr !== undefined) {
-            ctx.fillStyle = Color(c).lighten(0.6).toString()
-            ctx.fillRect(
-              leftPx,
-              toY(maxr),
-              w - 0.1,
-              filled ? toHeight(maxr) - toHeight(score) : 1,
-            )
-          }
-
-          // normal
-          ctx.fillStyle = c
+        const c = colorCallback(feature, score)
+        if (summary) {
+          ctx.fillStyle = crossingOrigin
+            ? colorCallback(feature, maxr)
+            : Color(c).lighten(0.6).toString()
           ctx.fillRect(
             leftPx,
-            toY(score),
-            w - 0.1,
-            filled
-              ? toHeight(score) - (minr !== undefined ? toHeight(minr) : 0)
-              : 1,
+            toY(maxr),
+            w,
+            filled ? toHeight(maxr) - toHeight(score) : 1,
           )
-          // min
-          if (minr !== undefined) {
-            ctx.fillStyle = Color(c).darken(0.6).toString()
-            ctx.fillRect(leftPx, toY(minr), w, filled ? toHeight(minr) : 1)
-          }
+        }
+
+        // normal
+        ctx.fillStyle =
+          crossingOrigin && summary
+            ? Color(colorCallback(feature, maxr)).mix(
+                Color(colorCallback(feature, minr)),
+              )
+            : c
+        ctx.fillRect(
+          leftPx,
+          toY(score),
+          w,
+          filled ? toHeight(score) - (summary ? toHeight(minr) : 0) : 1,
+        )
+
+        // min
+        if (summary) {
+          ctx.fillStyle = crossingOrigin
+            ? colorCallback(feature, minr)
+            : Color(c).darken(0.6).toString()
+          ctx.fillRect(leftPx, toY(minr), w, filled ? toHeight(minr) : 1)
         }
       } else {
-        ctx.fillStyle = c
+        ctx.fillStyle = colorCallback(feature, score)
         ctx.fillRect(leftPx, toY(score), w, filled ? toHeight(score) : 1)
       }
 

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2545,6 +2545,26 @@
     },
     {
       "type": "QuantitativeTrack",
+      "trackId": "hg19.100way.phyloP100way_density",
+      "name": "hg19.100way.phyloP100way (density)",
+      "category": ["Conservation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "http://hgdownload.cse.ucsc.edu/goldenpath/hg19/phyloP100way/hg19.100way.phyloP100way.bw"
+        }
+      },
+      "displays": [
+        {
+          "type": "LinearWiggleDisplay",
+          "displayId": "hg19.100way.phyloP100way_density",
+          "defaultRendering": "density"
+        }
+      ]
+    },
+    {
+      "type": "QuantitativeTrack",
       "trackId": "hg19.100way.phyloP100way",
       "name": "hg19.100way.phyloP100way",
       "category": ["Conservation"],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2545,6 +2545,26 @@
     },
     {
       "type": "QuantitativeTrack",
+      "trackId": "hg19.100way.phyloP100way_line",
+      "name": "hg19.100way.phyloP100way (line)",
+      "category": ["Conservation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "http://hgdownload.cse.ucsc.edu/goldenpath/hg19/phyloP100way/hg19.100way.phyloP100way.bw"
+        }
+      },
+      "displays": [
+        {
+          "type": "LinearWiggleDisplay",
+          "displayId": "hg19.100way.phyloP100way_line",
+          "defaultRendering": "line"
+        }
+      ]
+    },
+    {
+      "type": "QuantitativeTrack",
       "trackId": "hg19.100way.phyloP100way_density",
       "name": "hg19.100way.phyloP100way (density)",
       "category": ["Conservation"],


### PR DESCRIPTION
currently the default code "whiskers" which renders the min and max in the summary bins looks sort of weird when rendered on things with bicolorPivot

the code could possibly be made clearer but I think there is a need for this change, demoing the phyloP conservation track


before
histogram on
![localhost_3000__config=test_data%2Fconfig_demo json session=local-FyERkHy7k](https://user-images.githubusercontent.com/6511937/107840388-985d9780-6d6f-11eb-8d21-769eb6060995.png)
histogram off
![localhost_3000__config=test_data%2Fconfig_demo json session=local-FyERkHy7k (1)](https://user-images.githubusercontent.com/6511937/107840395-a6abb380-6d6f-11eb-9f67-c9b4b5ecbe11.png)


after
histogram on
![localhost_3000__config=test_data%2Fconfig_demo json session=local--vAl-WUBd (7)](https://user-images.githubusercontent.com/6511937/107840403-b925ed00-6d6f-11eb-8c0e-98e6971c0180.png)
various histogram off resolutions
![localhost_3000__config=test_data%2Fconfig_demo json session=local--vAl-WUBd (4)](https://user-images.githubusercontent.com/6511937/107840404-ba571a00-6d6f-11eb-8378-71bd1a6c563d.png)
![localhost_3000__config=test_data%2Fconfig_demo json session=local--vAl-WUBd (3)](https://user-images.githubusercontent.com/6511937/107840405-bb884700-6d6f-11eb-98e4-064fe95afc71.png)
![localhost_3000__config=test_data%2Fconfig_demo json session=local--vAl-WUBd (2)](https://user-images.githubusercontent.com/6511937/107840407-bc20dd80-6d6f-11eb-96a4-ec66dc780bed.png)
