### PR TITLE
Fix rendering cigar with = sign matches

### DIFF
--- a/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
@@ -93,7 +93,7 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
               const prevX = currX
               const prevY = currY
 
-              if (op === 'M') {
+              if (op === 'M' || op === '=') {
                 currX += val / hview.bpPerPx
                 currY += val / vview.bpPerPx
               } else if (op === 'D' || op === 'N') {

--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -174,7 +174,7 @@ function LinearSyntenyRendering(props: {
               const prevX1 = currX1
               const prevX2 = currX2
 
-              if (op === 'M') {
+              if (op === 'M' || op === '=') {
                 ctx.fillStyle = '#f003'
                 currX1 += (val / views[0].bpPerPx) * rev1
                 currX2 += (val / views[1].bpPerPx) * rev2


### PR DESCRIPTION
This fixes rendering of read vs ref when the reads use = to represent matches instead of M in the cigar string (seen in 11kb pacbio sample data track)