### PR TITLE
Add clickable navigation links to supplementary alignments/paired ends locations and BND/TRA endpoints in detail widgets

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -260,7 +260,7 @@ export const BaseCoreDetails = (props: BaseProps) => {
 interface AttributeProps {
   attributes: Record<string, any>
   omit?: string[]
-  formatter?: (val: unknown) => JSX.Element
+  formatter?: (val: unknown, key: string) => JSX.Element
   descriptions?: Record<string, React.ReactNode>
   prefix?: string
 }
@@ -384,7 +384,7 @@ export const Attributes: FunctionComponent<AttributeProps> = props => {
             <SimpleValue
               key={key}
               name={key}
-              value={formatter(value)}
+              value={formatter(value, key)}
               description={description}
               prefix={prefix}
             />
@@ -407,7 +407,7 @@ export interface BaseInputProps extends BaseCardProps {
   omit?: string[]
   model: any
   descriptions?: Record<string, React.ReactNode>
-  formatter?: (val: unknown) => JSX.Element
+  formatter?: (val: unknown, key: string) => JSX.Element
 }
 
 const Subfeature = (props: BaseProps) => {

--- a/packages/core/BaseFeatureWidget/index.test.js
+++ b/packages/core/BaseFeatureWidget/index.test.js
@@ -1,10 +1,15 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { stateModel } from '.'
+import PluginManager from '../PluginManager'
+import { stateModelFactory } from '.'
 import { BaseFeatureDetails as ReactComponent } from './BaseFeatureDetail'
 
 test('open up a widget', () => {
-  const model = stateModel.create({ type: 'BaseFeatureWidget' })
+  console.warn = jest.fn()
+  const pluginManager = new PluginManager([])
+  const model = stateModelFactory(pluginManager).create({
+    type: 'BaseFeatureWidget',
+  })
   const { container, getByText } = render(<ReactComponent model={model} />)
   model.setFeatureData({
     start: 2,

--- a/packages/core/BaseFeatureWidget/index.ts
+++ b/packages/core/BaseFeatureWidget/index.ts
@@ -1,5 +1,5 @@
 import { types } from 'mobx-state-tree'
-import PluginManager from '@jbrowse/core/PluginManager'
+import PluginManager from '../PluginManager'
 import { ConfigurationSchema } from '../configuration'
 import { ElementId } from '../util/types/mst'
 

--- a/packages/core/BaseFeatureWidget/index.ts
+++ b/packages/core/BaseFeatureWidget/index.ts
@@ -1,23 +1,29 @@
 import { types } from 'mobx-state-tree'
+import PluginManager from '@jbrowse/core/PluginManager'
 import { ConfigurationSchema } from '../configuration'
 import { ElementId } from '../util/types/mst'
 
 const configSchema = ConfigurationSchema('BaseFeatureWidget', {})
 
-const stateModel = types
-  .model('BaseFeatureWidget', {
-    id: ElementId,
-    type: types.literal('BaseFeatureWidget'),
-    featureData: types.frozen(),
-  })
-  .actions(self => ({
-    setFeatureData(data: Record<string, unknown>) {
-      self.featureData = data
-    },
-    clearFeatureData() {
-      self.featureData = undefined
-    },
-  }))
+export default function stateModelFactory(pluginManager: PluginManager) {
+  return types
+    .model('BaseFeatureWidget', {
+      id: ElementId,
+      type: types.literal('BaseFeatureWidget'),
+      featureData: types.frozen(),
+      view: types.safeReference(
+        pluginManager.pluggableMstType('view', 'stateModel'),
+      ),
+    })
+    .actions(self => ({
+      setFeatureData(data: Record<string, unknown>) {
+        self.featureData = data
+      },
+      clearFeatureData() {
+        self.featureData = undefined
+      },
+    }))
+}
 
-export { configSchema, stateModel }
+export { configSchema, stateModelFactory }
 export { BaseFeatureDetails as ReactComponent } from './BaseFeatureDetail'

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -116,7 +116,7 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
                     } else {
                       session.notify(
                         'No view associated with this feature detail panel anymore',
-                        'warn',
+                        'warning',
                       )
                     }
                   }}

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -100,13 +100,23 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
             const extra = Math.floor(saLength / 5)
             const start = +saStart
             const end = +saStart + saLength
-            const locString = `${saRef}:${start - extra}-${end + extra}`
+            const locString = `${saRef}:${Math.max(1, start - extra)}-${
+              end + extra
+            }`
             const displayString = `${saRef}:${start}-${end} (${saStrand})`
             return (
               <li key={`${SA}-${index}`}>
                 <Link
                   onClick={() => {
-                    session.views[0].navToLocString(locString)
+                    const { view } = model
+                    if (view) {
+                      view.navToLocString(locString)
+                    } else {
+                      session.notify(
+                        'No view associated with this feature detail panel anymore',
+                        'warn',
+                      )
+                    }
                   }}
                   href="#"
                 >

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -12,6 +12,7 @@ import { parseCigar } from '../BamAdapter/MismatchParser'
 
 const omit = ['clipPos', 'flags']
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function AlignmentFlags(props: { feature: any }) {
   const classes = useStyles()
   const { feature } = props
@@ -84,6 +85,7 @@ function getLengthOnRef(cigar: string) {
   return lengthOnRef
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function SupplementaryAlignments(props: { tag: string; model: any }) {
   const { tag, model } = props
   const session = getSession(model)
@@ -130,6 +132,7 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
   )
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function AlignmentFeatureDetails(props: { model: any }) {
   const { model } = props
   const feat = JSON.parse(JSON.stringify(model.featureData))

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -107,7 +107,7 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
             }`
             const displayString = `${saRef}:${start}-${end} (${saStrand})`
             return (
-              <li key={`${SA}-${index}`}>
+              <li key={`${locString}-${index}`}>
                 <Link
                   onClick={() => {
                     const { view } = model

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -133,6 +133,29 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function PairLink({ locString, model }: { locString: string; model: any }) {
+  const session = getSession(model)
+  return (
+    <Link
+      onClick={() => {
+        const { view } = model
+        if (view) {
+          view.navToLocString(locString)
+        } else {
+          session.notify(
+            'No view associated with this feature detail panel anymore',
+            'warning',
+          )
+        }
+      }}
+      href="#"
+    >
+      {locString}
+    </Link>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function AlignmentFeatureDetails(props: { model: any }) {
   const { model } = props
   const feat = JSON.parse(JSON.stringify(model.featureData))
@@ -142,7 +165,13 @@ function AlignmentFeatureDetails(props: { model: any }) {
       <BaseFeatureDetails
         {...props}
         omit={omit}
-        formatter={(value: unknown) => <Formatter value={value} />}
+        formatter={(value: unknown, key: string) => {
+          return key === 'next_segment_position' ? (
+            <PairLink model={model} locString={value as string} />
+          ) : (
+            <Formatter value={value} />
+          )
+        }}
       />
       {SA ? <SupplementaryAlignments model={model} tag={SA} /> : null}
       <AlignmentFlags feature={feat} {...props} />

--- a/plugins/alignments/src/AlignmentsFeatureDetail/index.js
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/index.js
@@ -4,20 +4,25 @@ import { types } from 'mobx-state-tree'
 
 const configSchema = ConfigurationSchema('AlignmentsFeatureWidget', {})
 
-const stateModel = types
-  .model('AlignmentsFeatureWidget', {
-    id: ElementId,
-    type: types.literal('AlignmentsFeatureWidget'),
-    featureData: types.frozen(),
-  })
-  .actions(self => ({
-    setFeatureData(data) {
-      self.featureData = data
-    },
-    clearFeatureData() {
-      self.featureData = undefined
-    },
-  }))
+export default function stateModelFactory(pluginManager) {
+  return types
+    .model('AlignmentsFeatureWidget', {
+      id: ElementId,
+      type: types.literal('AlignmentsFeatureWidget'),
+      featureData: types.frozen(),
+      view: types.safeReference(
+        pluginManager.pluggableMstType('view', 'stateModel'),
+      ),
+    })
+    .actions(self => ({
+      setFeatureData(data) {
+        self.featureData = data
+      },
+      clearFeatureData() {
+        self.featureData = undefined
+      },
+    }))
+}
 
-export { configSchema, stateModel }
+export { configSchema, stateModelFactory }
 export { default as ReactComponent } from './AlignmentsFeatureDetail'

--- a/plugins/alignments/src/AlignmentsFeatureDetail/index.test.js
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/index.test.js
@@ -1,10 +1,15 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { stateModel } from '.'
+import PluginManager from '@jbrowse/core/PluginManager'
+import { stateModelFactory } from '.'
 import ReactComponent from './AlignmentsFeatureDetail'
 
 test('open up a widget', () => {
-  const model = stateModel.create({ type: 'AlignmentsFeatureWidget' })
+  console.warn = jest.fn()
+  const pluginManager = new PluginManager([])
+  const model = stateModelFactory(pluginManager).create({
+    type: 'AlignmentsFeatureWidget',
+  })
   model.setFeatureData({
     seq:
       'TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG',

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -210,7 +210,7 @@ const stateModelFactory = (
           const featureWidget = session.addWidget(
             'AlignmentsFeatureWidget',
             'alignmentFeature',
-            { featureData: feature.toJSON() },
+            { featureData: feature.toJSON(), view: getContainingView(self) },
           )
           session.showWidget(featureWidget)
         }

--- a/plugins/alignments/src/index.test.ts
+++ b/plugins/alignments/src/index.test.ts
@@ -4,6 +4,7 @@ import { getSnapshot } from 'mobx-state-tree'
 import ThisPlugin from '.'
 
 test('plugin in a stock JBrowse', () => {
+  console.warn = jest.fn()
   const pluginManager = new PluginManager([new ThisPlugin(), new SVG()])
   pluginManager.createPluggableElements()
   pluginManager.configure()

--- a/plugins/alignments/src/index.ts
+++ b/plugins/alignments/src/index.ts
@@ -14,7 +14,7 @@ import { LinearWiggleDisplayReactComponent } from '@jbrowse/plugin-wiggle'
 import {
   configSchema as alignmentsFeatureDetailConfigSchema,
   ReactComponent as AlignmentsFeatureDetailReactComponent,
-  stateModel as alignmentsFeatureDetailStateModel,
+  stateModelFactory as alignmentsFeatureDetailStateModelFactory,
 } from './AlignmentsFeatureDetail'
 import BamAdapterF from './BamAdapter'
 import * as MismatchParser from './BamAdapter/MismatchParser'
@@ -126,7 +126,7 @@ export default class AlignmentsPlugin extends Plugin {
           name: 'AlignmentsFeatureWidget',
           heading: 'Feature Details',
           configSchema: alignmentsFeatureDetailConfigSchema,
-          stateModel: alignmentsFeatureDetailStateModel,
+          stateModel: alignmentsFeatureDetailStateModelFactory(pluginManager),
           ReactComponent: AlignmentsFeatureDetailReactComponent,
         }),
     )

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -16,11 +16,11 @@ class BreakpointSplitViewType extends ViewType {
 
     // TODO: Figure this out for multiple assembly names
     const { assemblyName } = view.displayedRegions[0]
-    const assembly = getSession(view).assemblyManager.get(assemblyName)
+    const { assemblyManager } = getSession(view)
+    const assembly = assemblyManager.get(assemblyName)
     const { getCanonicalRefName } = assembly as Assembly
     const featureRefName = getCanonicalRefName(feature.get('refName'))
-
-    const topRegion = view.displayedRegions.find(
+    const topRegion = assembly.regions.find(
       f => f.refName === String(featureRefName),
     )
 
@@ -61,7 +61,7 @@ class BreakpointSplitViewType extends ViewType {
       return {}
     }
 
-    const bottomRegion = view.displayedRegions.find(
+    const bottomRegion = assembly.regions.find(
       f => f.refName === String(mateRefName),
     )
 

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -18,6 +18,13 @@ class BreakpointSplitViewType extends ViewType {
     const { assemblyName } = view.displayedRegions[0]
     const { assemblyManager } = getSession(view)
     const assembly = assemblyManager.get(assemblyName)
+
+    if (!assembly) {
+      throw new Error(`assembly ${assemblyName} not found`)
+    }
+    if (!assembly.regions) {
+      throw new Error(`assembly ${assemblyName} regions not loaded`)
+    }
     const { getCanonicalRefName } = assembly as Assembly
     const featureRefName = getCanonicalRefName(feature.get('refName'))
     const topRegion = assembly.regions.find(

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.test.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.test.js
@@ -82,6 +82,7 @@ describe('ConfigurationEditor widget', () => {
   })
 
   it('renders with defaults of the PileupTrack schema', () => {
+    console.warn = jest.fn()
     const pluginManager = new PluginManager([new Alignments(), new SVG()])
     pluginManager.createPluggableElements()
     pluginManager.configure()

--- a/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
@@ -195,7 +195,6 @@ export default class extends BaseFeatureDataAdapter {
 
   private featureData(data: FeatureLoc) {
     const f: Record<string, unknown> = { ...data }
-
     ;(f.start as number) -= 1 // convert to interbase
     f.strand = { '+': 1, '-': -1, '.': 0, '?': undefined }[data.strand] // convert strand
     f.phase = Number(data.phase)

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/index.test.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/index.test.ts
@@ -3,6 +3,7 @@ import { configSchemaFactory } from './index'
 import ThisPlugin from '..'
 
 test('create config', () => {
+  console.warn = jest.fn()
   const pluginManager = new PluginManager([new ThisPlugin()])
   expect(() =>
     configSchemaFactory(pluginManager).create({

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -263,7 +263,7 @@ export const BaseLinearDisplay = types
         const featureWidget = session.addWidget(
           'BaseFeatureWidget',
           'baseFeature',
-          { featureData: feature.toJSON() },
+          { featureData: feature.toJSON(), view: getContainingView(self) },
         )
         session.showWidget(featureWidget)
       }

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -1,7 +1,7 @@
 import {
   configSchema as baseFeatureWidgetConfigSchema,
   ReactComponent as BaseFeatureWidgetReactComponent,
-  stateModel as baseFeatureWidgetStateModel,
+  stateModelFactory as baseFeatureWidgetStateModelFactory,
 } from '@jbrowse/core/BaseFeatureWidget'
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import {
@@ -89,7 +89,7 @@ export default class LinearGenomeViewPlugin extends Plugin {
           name: 'BaseFeatureWidget',
           heading: 'Feature Details',
           configSchema: baseFeatureWidgetConfigSchema,
-          stateModel: baseFeatureWidgetStateModel,
+          stateModel: baseFeatureWidgetStateModelFactory(pluginManager),
           ReactComponent: BaseFeatureWidgetReactComponent,
         }),
     )

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -44,10 +44,10 @@ function defaultOnChordClick(feature, chordTrack, pluginManager) {
 
 export default pluginManager => {
   const { jbrequire } = pluginManager
-  const { autorun, reaction } = jbrequire('mobx')
-  const { types, getParent, addDisposer, getSnapshot } = jbrequire(
-    'mobx-state-tree',
-  )
+  const { autorun, reaction } = pluginManager.lib.mobx
+  const { types, getParent, addDisposer, getSnapshot } = pluginManager.lib[
+    'mobx-state-tree'
+  ]
   const { BaseViewModel } = jbrequire(
     '@jbrowse/core/pluggableElementTypes/models',
   )
@@ -83,7 +83,8 @@ export default pluginManager => {
 
       onlyDisplayRelevantRegionsInCircularView: false,
 
-      // switch specifying whether we are showing the import wizard or the spreadsheet in our viewing area
+      // switch specifying whether we are showing the import wizard or the
+      // spreadsheet in our viewing area
       mode: types.optional(
         types.enumeration('SvInspectorViewMode', ['import', 'display']),
         'import',

--- a/plugins/variants/src/LinearVariantDisplay/model.ts
+++ b/plugins/variants/src/LinearVariantDisplay/model.ts
@@ -1,6 +1,10 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
-import { getSession, isSessionModelWithWidgets } from '@jbrowse/core/util'
+import {
+  getSession,
+  getContainingView,
+  isSessionModelWithWidgets,
+} from '@jbrowse/core/util'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
 import { types } from 'mobx-state-tree'
@@ -29,7 +33,7 @@ export default (configSchema: LinearVariantDisplayConfigModel) =>
           const featureWidget = session.addWidget(
             'VariantFeatureWidget',
             'variantFeature',
-            { featureData: feature.toJSON() },
+            { featureData: feature.toJSON(), view: getContainingView(self) },
           )
           session.showWidget(featureWidget)
         }
@@ -45,8 +49,9 @@ export default (configSchema: LinearVariantDisplayConfigModel) =>
       get rendererTypeName() {
         const viewName = getConf(self, 'defaultRendering')
         const rendererType = rendererTypes.get(viewName)
-        if (!rendererType)
+        if (!rendererType) {
           throw new Error(`unknown alignments view name ${viewName}`)
+        }
         return rendererType
       },
 

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -9,13 +9,16 @@ Link,
   TextField,
   Typography,
 } from '@material-ui/core'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
+import SimpleFeature, {
+  SimpleFeatureSerialized,
+} from '@jbrowse/core/util/simpleFeature'
 import { DataGrid } from '@material-ui/data-grid'
 import { observer } from 'mobx-react'
 import {
   BaseFeatureDetails,
   BaseCard,
 } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
+import { getSession } from '@jbrowse/core/util'
 
 function VariantSamples(props: any) {
   const [filter, setFilter] = useState<any>({})
@@ -109,16 +112,17 @@ function VariantSamples(props: any) {
   )
 }
 
+
 function BreakendPanel(props: {
   locStrings: string[]
   model: any
-  feature: Feature
+  feature: SimpleFeatureSerialized
 }) {
-  const { model, locStrings } = props
+  const { model, locStrings, feature } = props
   const session = getSession(model)
   return (
     <BaseCard {...props} title="Breakends">
-      <Typography>Link to breakend endpoint</Typography>
+      <Typography>Link to linear view of breakend endpoints</Typography>
       <ul>
         {locStrings.map((locString, index) => {
           return (
@@ -137,7 +141,39 @@ function BreakendPanel(props: {
                   }
                 }}
               >
-                {locString}
+                {`LGV - ${locString}`}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+      <Typography>
+        Launch split views with breakend source and target
+      </Typography>
+      <ul>
+        {locStrings.map((locString, index) => {
+          return (
+            <li key={`${JSON.stringify(locString)}-${index}`}>
+              <Link
+                href="#"
+                onClick={() => {
+                  const { pluginManager } = session
+                  const viewType = pluginManager.getViewType(
+                    'BreakpointSplitView',
+                  )
+                  const { view } = model
+                  // @ts-ignore
+                  const viewSnapshot = viewType.snapshotFromBreakendFeature(
+                    new SimpleFeature(feature),
+                    view,
+                  )
+                  viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
+                  viewSnapshot.views[1].offsetPx -= view.width / 2 + 100
+                  viewSnapshot.featureData = feature
+                  session.addView('BreakpointSplitView', viewSnapshot)
+                }}
+              >
+                {`${feature.refName}:${feature.start} // ${locString} (split view)`}
               </Link>
             </li>
           )

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react'
 import {
   Divider,
-Link,
+  Link,
   Paper,
   FormControlLabel,
   Checkbox,
@@ -112,7 +112,6 @@ function VariantSamples(props: any) {
   )
 }
 
-
 function BreakendPanel(props: {
   locStrings: string[]
   model: any
@@ -120,6 +119,13 @@ function BreakendPanel(props: {
 }) {
   const { model, locStrings, feature } = props
   const session = getSession(model)
+  const { pluginManager } = session
+  let viewType: any
+  try {
+    viewType = pluginManager.getViewType('BreakpointSplitView')
+  } catch (e) {
+    // plugin not added
+  }
   return (
     <BaseCard {...props} title="Breakends">
       <Typography>Link to linear view of breakend endpoints</Typography>
@@ -132,7 +138,7 @@ function BreakendPanel(props: {
                 onClick={() => {
                   const { view } = model
                   if (view) {
-                    view.navToLocString(locString)
+                    view.navToLocString?.(locString)
                   } else {
                     session.notify(
                       'No view associated with this feature detail panel anymore',
@@ -147,38 +153,38 @@ function BreakendPanel(props: {
           )
         })}
       </ul>
-      <Typography>
-        Launch split views with breakend source and target
-      </Typography>
-      <ul>
-        {locStrings.map((locString, index) => {
-          return (
-            <li key={`${JSON.stringify(locString)}-${index}`}>
-              <Link
-                href="#"
-                onClick={() => {
-                  const { pluginManager } = session
-                  const viewType = pluginManager.getViewType(
-                    'BreakpointSplitView',
-                  )
-                  const { view } = model
-                  // @ts-ignore
-                  const viewSnapshot = viewType.snapshotFromBreakendFeature(
-                    new SimpleFeature(feature),
-                    view,
-                  )
-                  viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
-                  viewSnapshot.views[1].offsetPx -= view.width / 2 + 100
-                  viewSnapshot.featureData = feature
-                  session.addView('BreakpointSplitView', viewSnapshot)
-                }}
-              >
-                {`${feature.refName}:${feature.start} // ${locString} (split view)`}
-              </Link>
-            </li>
-          )
-        })}
-      </ul>
+      {viewType ? (
+        <>
+          <Typography>
+            Launch split views with breakend source and target
+          </Typography>
+          <ul>
+            {locStrings.map((locString, index) => {
+              return (
+                <li key={`${JSON.stringify(locString)}-${index}`}>
+                  <Link
+                    href="#"
+                    onClick={() => {
+                      const { view } = model
+                      // @ts-ignore
+                      const viewSnapshot = viewType.snapshotFromBreakendFeature(
+                        new SimpleFeature(feature),
+                        view,
+                      )
+                      viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
+                      viewSnapshot.views[1].offsetPx -= view.width / 2 + 100
+                      viewSnapshot.featureData = feature
+                      session.addView('BreakpointSplitView', viewSnapshot)
+                    }}
+                  >
+                    {`${feature.refName}:${feature.start} // ${locString} (split view)`}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      ) : null}
     </BaseCard>
   )
 }
@@ -213,7 +219,7 @@ function VariantFeatureDetails(props: any) {
       {feat.type === 'breakend' ? (
         <BreakendPanel
           feature={feat}
-          locStrings={feat.ALT.map(alt => alt.MatePosition)}
+          locStrings={feat.ALT.map((alt: any) => alt.MatePosition)}
           model={model}
         />
       ) : null}

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -109,17 +109,20 @@ function VariantSamples(props: any) {
   )
 }
 
-function TranslocationPanel(props: { feature: any; model: any }) {
-  const { model, feature } = props
+function BreakendPanel(props: {
+  locStrings: string[]
+  model: any
+  feature: Feature
+}) {
+  const { model, locStrings } = props
   const session = getSession(model)
   return (
     <BaseCard {...props} title="Breakends">
-      <Typography>List of breakend endpoints</Typography>
+      <Typography>Link to breakend endpoint</Typography>
       <ul>
-        {feature.ALT.map((alt: { MatePosition: string }, index: number) => {
-          const locString = alt.MatePosition
+        {locStrings.map((locString, index) => {
           return (
-            <li key={`${JSON.stringify(alt)}-index`}>
+            <li key={`${JSON.stringify(locString)}-${index}`}>
               <Link
                 href="#"
                 onClick={() => {
@@ -172,7 +175,18 @@ function VariantFeatureDetails(props: any) {
       />
       <Divider />
       {feat.type === 'breakend' ? (
-        <TranslocationPanel feature={feat} model={model} />
+        <BreakendPanel
+          feature={feat}
+          locStrings={feat.ALT.map(alt => alt.MatePosition)}
+          model={model}
+        />
+      ) : null}
+      {feat.type === 'translocation' ? (
+        <BreakendPanel
+          feature={feat}
+          model={model}
+          locStrings={[`${feat.INFO.CHR2[0]}:${feat.INFO.END}`]}
+        />
       ) : null}
       <VariantSamples feature={feat} {...props} />
     </Paper>

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -2,13 +2,14 @@
 import React, { useState } from 'react'
 import {
   Divider,
+Link,
   Paper,
   FormControlLabel,
   Checkbox,
   TextField,
   Typography,
 } from '@material-ui/core'
-
+import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { DataGrid } from '@material-ui/data-grid'
 import { observer } from 'mobx-react'
 import {
@@ -108,6 +109,41 @@ function VariantSamples(props: any) {
   )
 }
 
+function TranslocationPanel(props: { feature: any; model: any }) {
+  const { model, feature } = props
+  const session = getSession(model)
+  return (
+    <BaseCard {...props} title="Breakends">
+      <Typography>List of breakend endpoints</Typography>
+      <ul>
+        {feature.ALT.map((alt: { MatePosition: string }, index: number) => {
+          const locString = alt.MatePosition
+          return (
+            <li key={`${JSON.stringify(alt)}-index`}>
+              <Link
+                href="#"
+                onClick={() => {
+                  const { view } = model
+                  if (view) {
+                    view.navToLocString(locString)
+                  } else {
+                    session.notify(
+                      'No view associated with this feature detail panel anymore',
+                      'warning',
+                    )
+                  }
+                }}
+              >
+                {locString}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </BaseCard>
+  )
+}
+
 function VariantFeatureDetails(props: any) {
   const { model } = props
   const feat = JSON.parse(JSON.stringify(model.featureData))
@@ -135,6 +171,9 @@ function VariantFeatureDetails(props: any) {
         {...props}
       />
       <Divider />
+      {feat.type === 'breakend' ? (
+        <TranslocationPanel feature={feat} model={model} />
+      ) : null}
       <VariantSamples feature={feat} {...props} />
     </Paper>
   )

--- a/plugins/variants/src/VariantFeatureWidget/index.js
+++ b/plugins/variants/src/VariantFeatureWidget/index.js
@@ -4,7 +4,7 @@ import { types } from 'mobx-state-tree'
 
 export const configSchema = ConfigurationSchema('VariantFeatureWidget', {})
 
-export default function stateModelFactory(pluginManager) {
+export function stateModelFactory(pluginManager) {
   return types
     .model('VariantFeatureWidget', {
       id: ElementId,

--- a/plugins/variants/src/VariantFeatureWidget/index.js
+++ b/plugins/variants/src/VariantFeatureWidget/index.js
@@ -3,19 +3,25 @@ import { ElementId } from '@jbrowse/core/util/types/mst'
 import { types } from 'mobx-state-tree'
 
 export const configSchema = ConfigurationSchema('VariantFeatureWidget', {})
-export const stateModel = types
-  .model('VariantFeatureWidget', {
-    id: ElementId,
-    type: types.literal('VariantFeatureWidget'),
-    featureData: types.frozen(),
-  })
-  .actions(self => ({
-    setFeatureData(data) {
-      self.featureData = data
-    },
-    clearFeatureData() {
-      self.featureData = undefined
-    },
-  }))
+
+export default function stateModelFactory(pluginManager) {
+  return types
+    .model('VariantFeatureWidget', {
+      id: ElementId,
+      type: types.literal('VariantFeatureWidget'),
+      featureData: types.frozen(),
+      view: types.safeReference(
+        pluginManager.pluggableMstType('view', 'stateModel'),
+      ),
+    })
+    .actions(self => ({
+      setFeatureData(data) {
+        self.featureData = data
+      },
+      clearFeatureData() {
+        self.featureData = undefined
+      },
+    }))
+}
 
 export { default as ReactComponent } from './VariantFeatureWidget'

--- a/plugins/variants/src/index.test.js
+++ b/plugins/variants/src/index.test.js
@@ -5,6 +5,7 @@ import { getSnapshot } from 'mobx-state-tree'
 import ThisPlugin from '.'
 
 test('plugin in a stock JBrowse', () => {
+  console.warn = jest.fn()
   const pluginManager = new PluginManager([
     new ThisPlugin(),
     new Alignments(),

--- a/plugins/variants/src/index.ts
+++ b/plugins/variants/src/index.ts
@@ -19,7 +19,7 @@ import StructuralVariantChordRendererFactory from './StructuralVariantChordRende
 import {
   configSchema as variantFeatureWidgetConfigSchema,
   ReactComponent as VariantFeatureWidgetReactComponent,
-  stateModel as variantFeatureWidgetStateModel,
+  stateModelFactory as variantFeatureWidgetStateModelFactory,
 } from './VariantFeatureWidget'
 import {
   AdapterClass as VcfTabixAdapterClass,
@@ -83,7 +83,7 @@ export default class VariantsPlugin extends Plugin {
           name: 'VariantFeatureWidget',
           heading: 'Feature Details',
           configSchema: variantFeatureWidgetConfigSchema,
-          stateModel: variantFeatureWidgetStateModel,
+          stateModel: variantFeatureWidgetStateModelFactory(pluginManager),
           ReactComponent: VariantFeatureWidgetReactComponent,
         }),
     )


### PR DESCRIPTION
This creates "clickable locstrings" for supplementary alignments in the AlignmentFeatureDetails, and for breakends/translocations on VariantFeatureDetails

Example
![localhost_3000__config=test_data%2Fconfig_demo json session=local-bHWWb4AhO](https://user-images.githubusercontent.com/6511937/107866463-8f7fcb00-6e2e-11eb-847f-0084939a9bfd.png)


