### PR TITLE
Add "Show all regions in assembly" to import form and make import form show entire region when refName selected

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -62,6 +62,9 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const newRegion = assemblyRegions.find(r => selectedRegion === r.refName)
     if (newRegion) {
       model.setDisplayedRegions([newRegion])
+      // we use showAllRegions after setDisplayedRegions to make the entire
+      // region visible, xref #1703
+      model.showAllRegions()
     } else {
       try {
         input && model.navToLocString(input, assemblyName)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles(theme => ({
   importFormEntry: {
     minWidth: 180,
   },
+  button: {
+    margin: theme.spacing(2),
+  },
 }))
 
 type LGV = LinearGenomeViewModel
@@ -136,9 +139,10 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
             )
           ) : null}
         </Grid>
-        <Grid item>
+        <Grid item spacing={1}>
           <Button
             disabled={!selectedRegion}
+            className={classes.button}
             onClick={() => {
               if (selectedRegion) {
                 handleSelectedRegion(selectedRegion)
@@ -148,6 +152,17 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
             color="primary"
           >
             Open
+          </Button>
+          <Button
+            disabled={!selectedRegion}
+            className={classes.button}
+            onClick={() => {
+              model.showAllRegionsInAssembly(assemblyName)
+            }}
+            variant="contained"
+            color="secondary"
+          >
+            Show all regions in assembly
           </Button>
         </Grid>
       </Grid>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -139,7 +139,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
             )
           ) : null}
         </Grid>
-        <Grid item spacing={1}>
+        <Grid item>
           <Button
             disabled={!selectedRegion}
             className={classes.button}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -709,7 +709,7 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
       class="MuiGrid-root MuiGrid-item"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-button MuiButton-containedPrimary"
         tabindex="0"
         type="button"
       >
@@ -717,6 +717,20 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
           class="MuiButton-label"
         >
           Open
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-button MuiButton-containedSecondary"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          Show all regions in assembly
         </span>
         <span
           class="MuiTouchRipple-root"

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1137,6 +1137,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
               label: 'Return to import form',
               onClick: () => {
                 self.setDisplayedRegions([])
+                // it is necessary to run these after setting displayed regions
+                // empty or else self.offsetPx gets set to infinity and breaks
+                // mobx-state-tree snapshot
+                self.scrollTo(0)
+                self.zoomTo(10)
               },
               icon: FolderOpenIcon,
             },

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -35,6 +35,7 @@ import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 import SyncAltIcon from '@material-ui/icons/SyncAlt'
 import VisibilityIcon from '@material-ui/icons/Visibility'
 import LabelIcon from '@material-ui/icons/Label'
+import FolderOpenIcon from '@material-ui/icons/FolderOpen'
 import clone from 'clone'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
@@ -1132,6 +1133,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
       return {
         get menuItems(): MenuItem[] {
           const menuItems: MenuItem[] = [
+            {
+              label: 'Return to import form',
+              onClick: () => {
+                self.setDisplayedRegions([])
+              },
+              icon: FolderOpenIcon,
+            },
             {
               label: 'Open track selector',
               onClick: self.activateTrackSelector,


### PR DESCRIPTION
This is a proposal for a couple more navigation features in the lgv

* "Show all regions in assembly" button on importform
* "Return to import form" view menu item
* Add `showAllRegions` after importform navigation. This causes, for example, if LGV refName chr1 is selected, that the entire chr1 is put into view instead of a small window from chr1:1-1000 that we see currently
