### PR TITLE
Improve sorting and filtering in variant detail widget

### DIFF
--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@gmod/tabix": "^1.5.0",
     "@gmod/vcf": "^4.0.1",
-    "@material-ui/data-grid": "^4.0.0-alpha.10",
+    "@material-ui/data-grid": "^4.0.0-alpha.20",
     "generic-filehandle": "^2.0.0"
   },
   "peerDependencies": {

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -62,7 +62,7 @@
     "@jbrowse/plugin-wiggle": "^1.0.3",
     "@librpc/web": "rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0",
     "@material-ui/core": "^4.9.5",
-    "@material-ui/data-grid": "^4.0.0-alpha.11",
+    "@material-ui/data-grid": "^4.0.0-alpha.20",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.45",
     "clsx": "^1.0.4",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -41,7 +41,7 @@
     "@jbrowse/plugin-wiggle": "^1.0.3",
     "@librpc/web": "rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0",
     "@material-ui/core": "^4.9.5",
-    "@material-ui/data-grid": "^4.0.0-alpha.11",
+    "@material-ui/data-grid": "^4.0.0-alpha.20",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "clsx": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5218,15 +5218,14 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
-"@material-ui/data-grid@^4.0.0-alpha.10", "@material-ui/data-grid@^4.0.0-alpha.11":
-  version "4.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@material-ui/data-grid/-/data-grid-4.0.0-alpha.11.tgz#ad3a8acd663d2256d1165b257165be342db5285d"
-  integrity sha512-OYgA1zNoFDHwA0KG7GoGCH3PnEuhbWL6EZbaVf2y+7biFaubHSIPiE5YOC4PBI+XJaIgESJhEjxc+ruhoSEc2w==
+"@material-ui/data-grid@^4.0.0-alpha.20":
+  version "4.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@material-ui/data-grid/-/data-grid-4.0.0-alpha.20.tgz#5fe8df438f5a9718636dc3bfaf268267cc87f17e"
+  integrity sha512-YqTTGs61zf3kT/5LuWWxwfTWwjXXJfP8nR7JiX30cMQXlOeIihQXHqbRrm7IHQRVWYQ5YxI95QLWtLHBIm2h0w==
   dependencies:
     "@material-ui/utils" "^5.0.0-alpha.14"
     prop-types "^15.7.2"
     reselect "^4.0.0"
-    tslib "^2.0.0"
 
 "@material-ui/icons@^4.0.0", "@material-ui/icons@^4.9.1":
   version "4.9.1"


### PR DESCRIPTION
Currently on master, sorting the table for the genotype column is broken because the data passed to the genotype column is an array instead of a string

This stringifies columns before they are passed to the table

It also adds a "show sample filters" checkbox because sometimes all those filters are overwhelming, and thus allows you to hide them, and also gives a helper text to get all non-zero alleles for example

![localhost_3000__config=test_data%2Fvolvox%2Fconfig json session=local-HpOQGowBg (1)](https://user-images.githubusercontent.com/6511937/108246300-83d22400-710e-11eb-85e3-30e9301db4e7.png)
