### PR TITLE
Add plugin top-level configuration

### DIFF
--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -9,6 +9,8 @@ export default abstract class Plugin {
   install(_pluginManager: PluginManager): void {}
 
   configure(_pluginManager: PluginManager): void {}
+
+  configuration: AnyConfigurationSchemaType | undefined = undefined
 }
 
 export type PluginConstructor = new (...args: unknown[]) => Plugin

--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -1,4 +1,5 @@
 import PluginManager from './PluginManager'
+import { AnyConfigurationSchemaType } from './configuration/configurationSchema'
 
 /**
  * base class for a JBrowse plugin

--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -11,7 +11,7 @@ export default abstract class Plugin {
 
   configure(_pluginManager: PluginManager): void {}
 
-  configuration: AnyConfigurationSchemaType | undefined = undefined
+  configurationSchema: AnyConfigurationSchemaType | undefined = undefined
 }
 
 export type PluginConstructor = new (...args: unknown[]) => Plugin

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -164,7 +164,7 @@ export default class PluginManager {
   pluginConfigurationSchemas() {
     const configurationSchema = {}
     this.plugins.forEach(plugin => {
-      console.log(plugin.name)
+      // console.log(plugin.name)
       if (plugin.configuration) {
         configurationSchema[plugin.name] = plugin.configuration
       }

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -164,7 +164,6 @@ export default class PluginManager {
   pluginConfigurationSchemas() {
     const configurationSchema: { [key: string]: unknown } = {}
     this.plugins.forEach(plugin => {
-      // console.log(plugin.name)
       if (plugin.configuration) {
         configurationSchema[plugin.name] = plugin.configuration
       }

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -162,13 +162,13 @@ export default class PluginManager {
   }
 
   pluginConfigurationSchemas() {
-    const configurationSchema: { [key: string]: unknown } = {}
+    const configurationSchemas: { [key: string]: unknown } = {}
     this.plugins.forEach(plugin => {
-      if (plugin.configuration) {
-        configurationSchema[plugin.name] = plugin.configuration
+      if (plugin.configurationSchema) {
+        configurationSchemas[plugin.name] = plugin.configurationSchema
       }
     })
-    return configurationSchema
+    return configurationSchemas
   }
 
   addPlugin(plugin: Plugin) {

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -161,6 +161,17 @@ export default class PluginManager {
     })
   }
 
+  pluginConfigurationSchemas() {
+    const configurationSchema = {}
+    this.plugins.forEach(plugin => {
+      console.log(plugin.name)
+      if (plugin.configuration) {
+        configurationSchema[plugin.name] = plugin.configuration
+      }
+    })
+    return configurationSchema
+  }
+
   addPlugin(plugin: Plugin) {
     if (this.configured) {
       throw new Error('JBrowse already configured, cannot add plugins')

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -162,7 +162,7 @@ export default class PluginManager {
   }
 
   pluginConfigurationSchemas() {
-    const configurationSchema = {}
+    const configurationSchema: { [key: string]: unknown } = {}
     this.plugins.forEach(plugin => {
       // console.log(plugin.name)
       if (plugin.configuration) {

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -42,6 +42,10 @@ export default class LinearGenomeViewPlugin extends Plugin {
     baseLinearDisplayConfigSchema,
   }
 
+  configuration = ConfigurationSchema('LinearGenomeViewPlugin', {
+    topLevelExample: 'top-level-config',
+  })
+
   install(pluginManager: PluginManager) {
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -42,10 +42,6 @@ export default class LinearGenomeViewPlugin extends Plugin {
     baseLinearDisplayConfigSchema,
   }
 
-  configuration = ConfigurationSchema('LinearGenomeViewPlugin', {
-    topLevelExample: 'top-level-config',
-  })
-
   install(pluginManager: PluginManager) {
     pluginManager.addTrackType(() => {
       const configSchema = ConfigurationSchema(

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -39,6 +39,7 @@ export default function JBrowseWeb(
           defaultValue: false,
         },
         theme: { type: 'frozen', defaultValue: {} },
+        ...pluginManager.pluginConfigurationSchemas(),
       }),
       plugins: types.frozen(),
       assemblies: types.array(assemblyConfigSchemasType),

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -11,6 +11,7 @@ import { TextEncoder } from 'fastestsmallesttextencoderdecoder'
 // locals
 import { clearCache } from '@jbrowse/core/util/io/rangeFetcher'
 import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import { readConfObject, getConf } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import JBrowseRootModelFactory from '../rootModel'
 import corePlugins from '../corePlugins'
@@ -83,9 +84,12 @@ test('toplevel configuration', () => {
   pluginManager.setRootModel(rootModel)
   pluginManager.configure()
   const state = pluginManager.rootModel
-  const { configuration } = state.session
-  expect(configuration.TestPlugin).toBeTruthy()
-  expect(configuration.TestPlugin.topLevelTest).toBeTruthy()
+  const { jbrowse } = state
+  const { configuration } = jbrowse
+  const test = getConf(jbrowse, ['TestPlugin', 'topLevelTest'])
+  const test2 = readConfObject(configuration, ['TestPlugin', 'topLevelTest'])
+  expect(test).toEqual('test works')
+  expect(test2).toEqual('test works')
 })
 
 test('variant track test - opens feature detail view', async () => {

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -86,6 +86,7 @@ test('toplevel configuration', () => {
   const state = pluginManager.rootModel
   const { jbrowse } = state
   const { configuration } = jbrowse
+  // test reading top level configurations added by Test Plugin
   const test = getConf(jbrowse, ['TestPlugin', 'topLevelTest'])
   const test2 = readConfObject(configuration, ['TestPlugin', 'topLevelTest'])
   expect(test).toEqual('test works')

--- a/products/jbrowse-web/src/tests/JBrowse.test.js
+++ b/products/jbrowse-web/src/tests/JBrowse.test.js
@@ -11,11 +11,15 @@ import { TextEncoder } from 'fastestsmallesttextencoderdecoder'
 // locals
 import { clearCache } from '@jbrowse/core/util/io/rangeFetcher'
 import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import PluginManager from '@jbrowse/core/PluginManager'
+import JBrowseRootModelFactory from '../rootModel'
+import corePlugins from '../corePlugins'
 import * as sessionSharing from '../sessionSharing'
 import volvoxConfigSnapshot from '../../test_data/volvox/config.json'
 import chromeSizesConfig from '../../test_data/config_chrom_sizes_test.json'
 import JBrowse from '../JBrowse'
 import { setup, getPluginManager, generateReadBuffer } from './util'
+import TestPlugin from './TestPlugin'
 
 window.TextEncoder = TextEncoder
 
@@ -63,6 +67,25 @@ test('lollipop track test', async () => {
 
   await findByTestId('display-lollipop_track_linear')
   await expect(findByTestId('three')).resolves.toBeTruthy()
+})
+
+test('toplevel configuration', () => {
+  const pluginManager = new PluginManager(
+    corePlugins.concat([TestPlugin]).map(P => new P()),
+  )
+  pluginManager.createPluggableElements()
+  const JBrowseRootModel = JBrowseRootModelFactory(pluginManager, true)
+  const rootModel = JBrowseRootModel.create({
+    jbrowse: volvoxConfigSnapshot,
+    assemblyManager: {},
+  })
+  rootModel.setDefaultSession()
+  pluginManager.setRootModel(rootModel)
+  pluginManager.configure()
+  const state = pluginManager.rootModel
+  const { configuration } = state.session
+  expect(configuration.TestPlugin).toBeTruthy()
+  expect(configuration.TestPlugin.topLevelTest).toBeTruthy()
 })
 
 test('variant track test - opens feature detail view', async () => {

--- a/products/jbrowse-web/src/tests/TestPlugin.ts
+++ b/products/jbrowse-web/src/tests/TestPlugin.ts
@@ -4,7 +4,7 @@ import { ConfigurationSchema } from '@jbrowse/core/configuration'
 export default class TestPlugin extends Plugin {
   name = 'TestPlugin'
 
-  configuration = ConfigurationSchema('TestPlugin', {
+  configurationSchema = ConfigurationSchema('TestPlugin', {
     topLevelTest: {
       description: 'Test for top level configuration',
       type: 'string',

--- a/products/jbrowse-web/src/tests/TestPlugin.ts
+++ b/products/jbrowse-web/src/tests/TestPlugin.ts
@@ -1,0 +1,10 @@
+import Plugin from '@jbrowse/core/Plugin'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default class TestPlugin extends Plugin {
+  name = 'TestPlugin'
+
+  configuration = ConfigurationSchema('TestPlugin', {
+    topLevelTest: 'top-level-config',
+  })
+}

--- a/products/jbrowse-web/src/tests/TestPlugin.ts
+++ b/products/jbrowse-web/src/tests/TestPlugin.ts
@@ -5,6 +5,12 @@ export default class TestPlugin extends Plugin {
   name = 'TestPlugin'
 
   configuration = ConfigurationSchema('TestPlugin', {
-    topLevelTest: 'top-level-config',
+    topLevelTest: {
+      description: 'Test for top level configuration',
+      type: 'string',
+      defaultValue: 'test works',
+    },
   })
+
+  configure() {}
 }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -2575,4 +2575,3 @@
     "name": "New Session"
   }
 }
-


### PR DESCRIPTION
Proposal for [issue 1535](https://github.com/GMOD/jbrowse-components/issues/1535)

Adds method to PluginManager that retrieves plugin's configuration objects if they exist
Modifies the Jbrowse Model to add the plugin's configurations 
Adds optional configuration param to the base class for a JBrowse plugin 
Adds a test and a test plugin to verify we are able to read and get from the configuration