### PR TITLE
Add console.error log in block setError

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -122,6 +122,7 @@ const blockState = types
         renderInProgress = undefined
       },
       setError(error: Error) {
+        console.error(error)
         if (renderInProgress && !renderInProgress.signal.aborted) {
           renderInProgress.abort()
         }
@@ -177,65 +178,59 @@ export type BlockModel = Instance<BlockStateModel>
 // not using a flow for this, because the flow doesn't
 // work with autorun
 function renderBlockData(self: Instance<BlockStateModel>) {
-  try {
-    const { assemblyManager, rpcManager } = getSession(self)
-    let display = getParent(self)
-    while (!(display.configuration && getConf(display, 'displayId'))) {
-      display = getParent(display)
-    }
-    const assemblyNames = getTrackAssemblyNames(display.parentTrack)
-    let cannotBeRenderedReason
-    if (!assemblyNames.includes(self.region.assemblyName)) {
-      let matchFound = false
-      assemblyNames.forEach((assemblyName: string) => {
-        const assembly = assemblyManager.get(assemblyName)
-        if (assembly && assembly.hasName(assemblyName)) {
-          matchFound = true
-        }
-      })
-      if (!matchFound) {
-        cannotBeRenderedReason = `region assembly (${self.region.assemblyName}) does not match track assemblies (${assemblyNames})`
+  const { assemblyManager, rpcManager } = getSession(self)
+  let display = getParent(self)
+  while (!(display.configuration && getConf(display, 'displayId'))) {
+    display = getParent(display)
+  }
+  const assemblyNames = getTrackAssemblyNames(display.parentTrack)
+  let cannotBeRenderedReason
+  if (!assemblyNames.includes(self.region.assemblyName)) {
+    let matchFound = false
+    assemblyNames.forEach((assemblyName: string) => {
+      const assembly = assemblyManager.get(assemblyName)
+      if (assembly && assembly.hasName(assemblyName)) {
+        matchFound = true
       }
+    })
+    if (!matchFound) {
+      cannotBeRenderedReason = `region assembly (${self.region.assemblyName}) does not match track assemblies (${assemblyNames})`
     }
-    if (!cannotBeRenderedReason) {
-      cannotBeRenderedReason = display.regionCannotBeRendered(self.region)
-    }
-    const { renderProps } = display
-    const { rendererType } = display
-    const { config } = renderProps
-    // This line is to trigger the mobx reaction when the config changes
-    // It won't trigger the reaction if it doesn't think we're accessing it
-    readConfObject(config)
+  }
+  if (!cannotBeRenderedReason) {
+    cannotBeRenderedReason = display.regionCannotBeRendered(self.region)
+  }
+  const { renderProps } = display
+  const { rendererType } = display
+  const { config } = renderProps
+  // This line is to trigger the mobx reaction when the config changes
+  // It won't trigger the reaction if it doesn't think we're accessing it
+  readConfObject(config)
 
-    const { adapterConfig } = display
+  const { adapterConfig } = display
 
-    const sessionId = getRpcSessionId(display)
+  const sessionId = getRpcSessionId(display)
 
-    return {
-      rendererType,
-      rpcManager,
-      renderProps,
-      cannotBeRenderedReason,
-      displayError: display.error,
-      renderArgs: {
-        statusCallback: (message: string) => {
-          if (isAlive(self)) {
-            self.setStatus(message)
-          }
-        },
-        assemblyName: self.region.assemblyName,
-        regions: [self.region],
-        adapterConfig,
-        rendererType: rendererType.name,
-        sessionId,
-        blockKey: self.key,
-        timeout: 1000000, // 10000,
+  return {
+    rendererType,
+    rpcManager,
+    renderProps,
+    cannotBeRenderedReason,
+    displayError: display.error,
+    renderArgs: {
+      statusCallback: (message: string) => {
+        if (isAlive(self)) {
+          self.setStatus(message)
+        }
       },
-    }
-  } catch (error) {
-    return {
-      displayError: error,
-    }
+      assemblyName: self.region.assemblyName,
+      regions: [self.region],
+      adapterConfig,
+      rendererType: rendererType.name,
+      sessionId,
+      blockKey: self.key,
+      timeout: 1000000, // 10000,
+    },
   }
 }
 


### PR DESCRIPTION
https://github.com/GMOD/jbrowse-components/compare/better_console_warn?w=1

This is minor but there are some cases where if an issue arises a console.error with the exception is not printed, which makes it difficult to debug. This adds a console.error in setError

It also makes it unnecessary to do try/catch in the serverSideRenderedBlock->renderBlockData

See whitespace-ignored-diff here https://github.com/GMOD/jbrowse-components/compare/better_console_warn?w=1

Possibly some error messages could get duplicate printed by this but hopefully better than none, and more reliable than sprinkling errors everywhere

The alternative is sprinkling console.error closer to the source e.g. could do it in the catch handler of makeAbortableReaction but that is a little presumptive