### PR TITLE
Add list of loaded plugins to the "About widget"

### DIFF
--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -151,6 +151,8 @@ export default class PluginManager {
 
   rootModel?: AbstractRootModel
 
+  corePlugins = [] as string[]
+
   constructor(initialPlugins: Plugin[] = []) {
     // add the core plugin
     this.addPlugin(new CorePlugin())
@@ -190,7 +192,11 @@ export default class PluginManager {
   }
 
   setRootModel(rootModel: AbstractRootModel) {
-    this.rootModel = rootModel
+    this.rootModel = rootModel || []
+  }
+
+  setCorePlugins(list: string[]) {
+    this.corePlugins = list.concat('CorePlugin')
   }
 
   configure() {

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import Typography from '@material-ui/core/Typography'
 import { observer } from 'mobx-react'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
@@ -13,11 +14,30 @@ const useStyles = makeStyles(theme => ({
   subtitle: {
     margin: theme.spacing(),
   },
+  pluginList: {
+    margin: theme.spacing(1),
+  },
 }))
+
+interface BasePlugin {
+  version?: string
+  name: string
+}
 
 function About({ model }: { model: IAnyStateTreeNode }) {
   const classes = useStyles()
-  const session = model ? getSession(model) : { version: '' }
+  const session = model
+    ? getSession(model)
+    : {
+        version: '',
+        pluginManager: {
+          corePlugins: [] as string[],
+          plugins: [] as any[],
+        },
+      }
+  const { pluginManager } = session
+  const { corePlugins, plugins } = pluginManager
+
   return (
     <div className={classes.root}>
       <Typography variant="h4" align="center" color="primary">
@@ -37,15 +57,36 @@ function About({ model }: { model: IAnyStateTreeNode }) {
       <Typography align="center">
         © 2019-2021 The Evolutionary Software Foundation
       </Typography>
-      <ul>
-        {session.pluginManager.plugins.map(plugin => {
-          return (
-            <li>
-              {plugin.name} {plugin.version}
-            </li>
-          )
-        })}
-      </ul>
+      <div className={classes.pluginList}>
+        <Typography>External plugins loaded</Typography>
+        <ul>
+          {plugins
+            .filter((plugin: BasePlugin) => {
+              return !corePlugins.includes(plugin.name)
+            })
+            .map((plugin: BasePlugin) => {
+              return (
+                <li key={plugin.name}>
+                  {plugin.name} {plugin.version}
+                </li>
+              )
+            })}
+        </ul>
+        <Typography>Core plugins loaded</Typography>
+        <ul>
+          {plugins
+            .filter((plugin: BasePlugin) => {
+              return corePlugins.includes(plugin.name)
+            })
+            .map((plugin: BasePlugin) => {
+              return (
+                <li key={plugin.name}>
+                  {plugin.name} {plugin.version}
+                </li>
+              )
+            })}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
@@ -17,14 +17,14 @@ const useStyles = makeStyles(theme => ({
 
 function About({ model }: { model: IAnyStateTreeNode }) {
   const classes = useStyles()
-  const root = model ? getSession(model) : { version: '' }
+  const session = model ? getSession(model) : { version: '' }
   return (
     <div className={classes.root}>
       <Typography variant="h4" align="center" color="primary">
         JBrowse 2
       </Typography>
       <Typography variant="h6" align="center" className={classes.subtitle}>
-        {root.version}
+        {session.version}
       </Typography>
       <Typography align="center" variant="body2">
         JBrowse is a{' '}
@@ -35,19 +35,17 @@ function About({ model }: { model: IAnyStateTreeNode }) {
       </Typography>
       <br />
       <Typography align="center">
-        © 2019 The Evolutionary Software Foundation
+        © 2019-2021 The Evolutionary Software Foundation
       </Typography>
-      {/* <br />
-      <Typography align="center">
-        JBrowse is funded by the{' '}
-        <Link
-          href="https://genome.gov/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          NHGRI
-        </Link>
-      </Typography> */}
+      <ul>
+        {session.pluginManager.plugins.map(plugin => {
+          return (
+            <li>
+              {plugin.name} {plugin.version}
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/plugins/menus/src/AboutWidget/components/__snapshots__/AboutWidget.test.js.snap
+++ b/plugins/menus/src/AboutWidget/components/__snapshots__/AboutWidget.test.js.snap
@@ -32,7 +32,23 @@ exports[`<AboutWidget /> renders 1`] = `
   <p
     class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter"
   >
-    © 2019 The Evolutionary Software Foundation
+    © 2019-2021 The Evolutionary Software Foundation
   </p>
+  <div
+    class="makeStyles-pluginList"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      External plugins loaded
+    </p>
+    <ul />
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Core plugins loaded
+    </p>
+    <ul />
+  </div>
 </div>
 `;

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -416,7 +416,7 @@ const Renderer = observer(
           // error Assuming that the query changes self.sessionError or
           // self.sessionSnapshot or self.blankSession
           const pluginManager = new PluginManager(plugins.map(P => new P()))
-
+          pluginManager.setCorePlugins(corePlugins.map(P => new P().name))
           pluginManager.createPluggableElements()
 
           const JBrowseRootModel = JBrowseRootModelFactory(


### PR DESCRIPTION
This adds a list of currently loaded plugins and their version if available

It also tries to distinguish between corePlugins and non-core plugins which is somewhat awkward, and it could potentially even hide core plugins but currently separates them out