### PR TITLE
Fix for navigation past end of chromosome

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -102,24 +102,24 @@ export default observer(({ model }: { model: LGV }) => {
 
   const setDisplayedRegion = useCallback(
     (newRegionValue: string | undefined) => {
-      if (newRegionValue) {
-        const newRegion: Region | undefined = model.displayedRegions.find(
-          region => newRegionValue === region.refName,
-        )
-        // navigate to region or if region not found try navigating to locstring
-        if (newRegion) {
-          model.setDisplayedRegions([newRegion])
-          // we use showAllRegions after setDisplayedRegions to make the entire
-          // region visible, xref #1703
-          model.showAllRegions()
-        } else {
-          try {
+      try {
+        if (newRegionValue) {
+          const newRegion: Region | undefined = model.displayedRegions.find(
+            region => newRegionValue === region.refName,
+          )
+          // navigate to region or if region not found try navigating to locstring
+          if (newRegion) {
+            model.setDisplayedRegions([newRegion])
+            // we use showAllRegions after setDisplayedRegions to make the entire
+            // region visible, xref #1703
+            model.showAllRegions()
+          } else {
             newRegionValue && model.navToLocString(newRegionValue)
-          } catch (e) {
-            console.warn(e)
-            session.notify(`${e}`, 'warning')
           }
         }
+      } catch (e) {
+        console.warn(e)
+        session.notify(`${e}`, 'warning')
       }
     },
     [model, session],

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -113,18 +113,20 @@ const Polygon = observer(
   }) => {
     const theme = useTheme()
     const classes = useStyles()
-    const { offsetPx, dynamicBlocks: visibleRegions } = model
+    const {
+      offsetPx,
+      dynamicBlocks: { contentBlocks, totalWidthPxWithoutBorders },
+    } = model
 
     const polygonColor = theme.palette.tertiary
       ? theme.palette.tertiary.light
       : theme.palette.primary.light
 
-    if (!visibleRegions.contentBlocks.length) {
+    if (!contentBlocks.length) {
       return null
     }
-    const firstBlock = visibleRegions.contentBlocks[0]
-    const lastBlock =
-      visibleRegions.contentBlocks[visibleRegions.contentBlocks.length - 1]
+    const firstBlock = contentBlocks[0]
+    const lastBlock = contentBlocks[contentBlocks.length - 1]
     const topLeft = overview.bpToPx({
       refName: firstBlock.refName,
       coord: firstBlock.reversed ? firstBlock.end : firstBlock.start,
@@ -139,8 +141,8 @@ const Polygon = observer(
     const startPx = Math.max(0, -offsetPx)
     const endPx =
       startPx +
-      visibleRegions.totalWidthPxWithoutBorders +
-      (visibleRegions.contentBlocks.length * model.interRegionPaddingWidth) / 2
+      totalWidthPxWithoutBorders +
+      (contentBlocks.length * model.interRegionPaddingWidth) / 2
 
     const points = [
       [startPx, HEADER_BAR_HEIGHT],
@@ -185,6 +187,9 @@ const ScaleBar = observer(
     const gridPitch = chooseGridPitch(scale, 120, 15)
     const { dynamicBlocks: overviewVisibleRegions } = overview
 
+    if (!visibleRegions.contentBlocks.length) {
+      return null
+    }
     const firstBlock = visibleRegions.contentBlocks[0]
     const firstOverviewPx =
       overview.bpToPx({

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -690,11 +690,20 @@ export function stateModelFactory(pluginManager: PluginManager) {
           )
           if (newDisplayedRegion) {
             this.setDisplayedRegions([getSnapshot(newDisplayedRegion)])
-          } else {
-            throw new Error(
-              `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
-            )
+
+            this.navTo({
+              ...parsedLocString,
+              start: Math.min(
+                parsedLocString?.start || 0,
+                newDisplayedRegion.end,
+              ),
+              end: Math.min(parsedLocString?.end || 1, newDisplayedRegion.end),
+            })
+            return
           }
+          throw new Error(
+            `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
+          )
         }
         this.navTo(parsedLocString)
       },


### PR DESCRIPTION
Fixes #1718


This adds a redundancy that avoids an all out crash, and then fixes the navigation so it clamps to the end of the newly navigating displayed region


This is just a general observation but our logic for navigating is fairly complex...I think it is likely that a refactoring probably along the time that name indexing comes around is likely in order