### PR TITLE
Fix alignment track ability to remember the height of the SNPCoverage subtrack on refresh

### DIFF
--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -106,7 +106,7 @@ export class CramAdapter extends BaseFeatureDataAdapter {
 
     const trimmed: string[] = []
     seqChunks
-      .sort((a: Feature, b: Feature) => a.get('start') - b.get('start'))
+      .sort((a, b) => a.get('start') - b.get('start'))
       .forEach((chunk: Feature) => {
         const chunkStart = chunk.get('start')
         const chunkEnd = chunk.get('end')

--- a/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
@@ -1,17 +1,11 @@
 import { observer } from 'mobx-react'
 import { getConf } from '@jbrowse/core/configuration'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { ResizeHandle } from '@jbrowse/core/ui'
 import { AlignmentsDisplayModel } from '../models/model'
 
 export default observer(({ model }: { model: AlignmentsDisplayModel }) => {
   const { PileupDisplay, SNPCoverageDisplay, showPileup, showCoverage } = model
-
-  // determine height of the model when toggling pileupdisplay
-  useEffect(() => {
-    SNPCoverageDisplay.setHeight(!showPileup ? model.height : 45)
-  }, [SNPCoverageDisplay, model, showPileup])
-
   return (
     <div
       data-testid={`display-${getConf(model, 'displayId')}`}

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.ts
@@ -12,6 +12,7 @@ import {
   Instance,
   types,
 } from 'mobx-state-tree'
+import { getContainingTrack } from '@jbrowse/core/util'
 import { AlignmentsConfigModel } from './configSchema'
 
 const minDisplayHeight = 20
@@ -30,6 +31,7 @@ const stateModelFactory = (
         SNPCoverageDisplay: types.maybe(
           pluginManager.getDisplayType('LinearSNPCoverageDisplay').stateModel,
         ),
+        snpCovHeight: 45,
         type: types.literal('LinearAlignmentsDisplay'),
         configuration: ConfigurationReference(configSchema),
         height: 250,
@@ -50,12 +52,16 @@ const stateModelFactory = (
       setScrollTop(scrollTop: number) {
         self.scrollTop = scrollTop
       },
+      setSNPCoverageHeight(n: number) {
+        self.snpCovHeight = n
+      },
     }))
     .views(self => {
       const { trackMenuItems } = self
       return {
         get pileupDisplayConfig() {
           const conf = getConf(self)
+          const track = getContainingTrack(self)
           const { SNPCoverageRenderer, ...rest } = conf.renderers
           return {
             ...conf,
@@ -63,7 +69,7 @@ const stateModelFactory = (
               ...rest,
             },
             type: 'LinearPileupDisplay',
-            name: `${getConf(getParent(self, 2), 'name')} pileup`,
+            name: `${getConf(track, 'name')} pileup`,
             displayId: `${self.configuration.displayId}_pileup_xyz`, // xyz to avoid someone accidentally naming the displayId similar to this
           }
         },
@@ -114,12 +120,36 @@ const stateModelFactory = (
       }
     })
     .actions(self => ({
+      setSNPCoverageDisplay(displayConfig: AnyConfigurationModel) {
+        self.SNPCoverageDisplay = {
+          type: 'LinearSNPCoverageDisplay',
+          configuration: displayConfig,
+          height: self.snpCovHeight,
+        }
+      },
+      setPileupDisplay(displayConfig: AnyConfigurationModel) {
+        self.PileupDisplay = {
+          type: 'LinearPileupDisplay',
+          configuration: displayConfig,
+        }
+      },
+      setHeight(displayHeight: number) {
+        if (displayHeight > minDisplayHeight) self.height = displayHeight
+        else self.height = minDisplayHeight
+        return self.height
+      },
+      resizeHeight(distance: number) {
+        const oldHeight = self.height
+        const newHeight = this.setHeight(self.height + distance)
+        return newHeight - oldHeight
+      },
+    }))
+    .actions(self => ({
       afterAttach() {
         addDisposer(
           self,
           autorun(() => {
             if (!self.SNPCoverageDisplay) {
-              // @ts-ignore
               self.setSNPCoverageDisplay(self.snpCoverageDisplayConfig)
             } else if (
               !deepEqual(
@@ -127,11 +157,11 @@ const stateModelFactory = (
                 getSnapshot(self.SNPCoverageDisplay.configuration),
               )
             ) {
+              self.SNPCoverageDisplay.setHeight(self.snpCovHeight)
               self.SNPCoverageDisplay.setConfig(self.snpCoverageDisplayConfig)
             }
 
             if (!self.PileupDisplay) {
-              // @ts-ignore
               self.setPileupDisplay(self.pileupDisplayConfig)
             } else if (
               !deepEqual(
@@ -157,29 +187,12 @@ const stateModelFactory = (
             }
           }),
         )
-      },
-      setSNPCoverageDisplay(displayConfig: AnyConfigurationModel) {
-        self.SNPCoverageDisplay = {
-          type: 'LinearSNPCoverageDisplay',
-          configuration: displayConfig,
-          height: 45,
-        }
-      },
-      setPileupDisplay(displayConfig: AnyConfigurationModel) {
-        self.PileupDisplay = {
-          type: 'LinearPileupDisplay',
-          configuration: displayConfig,
-        }
-      },
-      setHeight(displayHeight: number) {
-        if (displayHeight > minDisplayHeight) self.height = displayHeight
-        else self.height = minDisplayHeight
-        return self.height
-      },
-      resizeHeight(distance: number) {
-        const oldHeight = self.height
-        const newHeight = this.setHeight(self.height + distance)
-        return newHeight - oldHeight
+        addDisposer(
+          self,
+          autorun(() => {
+            self.setSNPCoverageHeight(self.SNPCoverageDisplay.height)
+          }),
+        )
       },
     }))
 }


### PR DESCRIPTION
Currently changing the snpcov subtrack height is not remembered on refresh

This fixes that. There is an old useEffect thing that was hacky that was causing reset to height:45 along with a couple other things

The autorun that propagates state from alignments display model to the SNPCoverage display model is kind of awkward and could be evaluated, but this fixes the particular issue of setting the subtrack height in track state