### PR TITLE
Fix CLI add-track --load inPlace to put exact contents into the config, add better CLI example docs

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.test.ts
+++ b/products/jbrowse-cli/src/commands/add-track.test.ts
@@ -126,6 +126,86 @@ describe('add-track', () => {
 
   setup
     .do(initctx)
+    .command(['add-track', '/testing/in/place.bam', '--load', 'inPlace'])
+    .it('adds a track with load inPlace', async ctx => {
+      const contents = await fsPromises.readFile(
+        path.join(ctx.dir, 'config.json'),
+        { encoding: 'utf8' },
+      )
+
+      expect(JSON.parse(contents).tracks).toEqual([
+        {
+          type: 'AlignmentsTrack',
+          trackId: 'place',
+          name: 'place',
+          assemblyNames: ['testAssembly'],
+          adapter: {
+            type: 'BamAdapter',
+            bamLocation: {
+              uri: '/testing/in/place.bam',
+            },
+            index: {
+              indexType: 'BAI',
+              location: {
+                uri: '/testing/in/place.bam.bai',
+              },
+            },
+            sequenceAdapter: {
+              type: 'testSeqAdapter',
+              twoBitLocation: {
+                uri: 'test.2bit',
+              },
+            },
+          },
+        },
+      ])
+    })
+  setup
+    .do(initctx)
+    .command([
+      'add-track',
+      '/testing/in/place.bam',
+      '--load',
+      'inPlace',
+      '--indexFile',
+      '/something/else/random.bai',
+    ])
+    .it('adds a track with load inPlace', async ctx => {
+      const contents = await fsPromises.readFile(
+        path.join(ctx.dir, 'config.json'),
+        { encoding: 'utf8' },
+      )
+
+      expect(JSON.parse(contents).tracks).toEqual([
+        {
+          type: 'AlignmentsTrack',
+          trackId: 'place',
+          name: 'place',
+          assemblyNames: ['testAssembly'],
+          adapter: {
+            type: 'BamAdapter',
+            bamLocation: {
+              uri: '/testing/in/place.bam',
+            },
+            index: {
+              indexType: 'BAI',
+              location: {
+                uri: '/something/else/random.bai',
+              },
+            },
+            sequenceAdapter: {
+              type: 'testSeqAdapter',
+              twoBitLocation: {
+                uri: 'test.2bit',
+              },
+            },
+          },
+        },
+      ])
+    })
+
+  setup
+    .do(initctx)
     .command([
       'add-track',
       simpleBam,


### PR DESCRIPTION
This fixes the usage of --inPlace tag to put the exact config without using file.basename(filename) into the config

It also adds some "helpful comments" above each example usage to try to explain what happens in each use case