### PR TITLE
Instrument navToLocString tests in the LGV and fix refname navigation

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -679,6 +679,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const canonicalRefName = assembly.getCanonicalRefName(
           parsedLocString.refName,
         )
+
         if (!canonicalRefName) {
           throw new Error(
             `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
@@ -690,22 +691,33 @@ export function stateModelFactory(pluginManager: PluginManager) {
           )
           if (newDisplayedRegion) {
             this.setDisplayedRegions([getSnapshot(newDisplayedRegion)])
-
-            this.navTo({
-              ...parsedLocString,
-              start: Math.min(
-                parsedLocString?.start || 0,
-                newDisplayedRegion.end,
-              ),
-              end: Math.min(parsedLocString?.end || 1, newDisplayedRegion.end),
-            })
-            return
+          } else {
+            throw new Error(
+              `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
+            )
           }
-          throw new Error(
-            `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,
-          )
         }
-        this.navTo(parsedLocString)
+        const displayedRegion = regions.find(
+          region => region.refName === canonicalRefName,
+        )
+        if (displayedRegion) {
+          const start = clamp(
+            parsedLocString?.start ?? 0,
+            0,
+            displayedRegion.end,
+          )
+          const end = clamp(
+            parsedLocString?.end ?? displayedRegion.end,
+            0,
+            displayedRegion.end,
+          )
+
+          this.navTo({
+            ...parsedLocString,
+            start,
+            end,
+          })
+        }
       },
 
       /**
@@ -747,7 +759,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
         let s = start
         let e = end
         let refNameMatched = false
-
         const predicate = (r: Region) => {
           if (refName === r.refName) {
             refNameMatched = true


### PR DESCRIPTION
This tries to instrument some simple navToLocString tests for the LGV for easier testing of corner cases

There is likely more that can be done to ensure reliability but I hope these tests could be a starting point for simulating end-user behavior of using locstring inputs


Fixes #1740 