### PR TITLE
Add color picker and choice of summary score style for wiggle track

### DIFF
--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -41,6 +41,7 @@
     "color": "^3.1.1",
     "d3-scale": "^3.2.3",
     "json-stable-stringify": "^1.0.1",
+    "react-color": "^2.19.3",
     "react-d3-axis": "^0.1.2"
   },
   "peerDependencies": {

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Button,
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+import { CompactPicker, Color, RGBColor } from 'react-color'
+
+const useStyles = makeStyles(theme => ({
+  root: {},
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}))
+
+// this is needed because passing a entire color object into the react-color
+// for alpha, can't pass in an rgba string for example
+function serializeColor(color: Color) {
+  if (color instanceof Object) {
+    const { r, g, b, a } = color as RGBColor
+    return `rgb(${r},${g},${b},${a})`
+  }
+  return color
+}
+
+export default function SetColorDialog(props: {
+  display: {
+    color: number
+    setColor: Function
+  }
+  handleClose: () => void
+}) {
+  const classes = useStyles()
+  const { display, handleClose } = props
+
+  return (
+    <Dialog
+      open
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">
+        Select a color
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={handleClose}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent style={{ overflowX: 'hidden' }}>
+        <div className={classes.root}>
+          <CompactPicker
+            onChange={event => {
+              display.setColor(serializeColor(event.rgb))
+            }}
+          />
+          <br />
+          <div style={{ margin: 20 }}>
+            <Button
+              onClick={() => {
+                display.setColor(undefined)
+              }}
+              color="secondary"
+              variant="contained"
+            >
+              Restore default from config
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              onClick={() => {
+                handleClose()
+              }}
+            >
+              Submit
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -356,6 +356,15 @@ const stateModelFactory = (
                       },
                     ],
                   },
+                  {
+                    label: 'Summary score mode',
+                    subMenu: ['min', 'max', 'avg', 'whiskers'].map(elt => {
+                      return {
+                        label: elt,
+                        onClick: () => self.setSummaryScoreMode(elt),
+                      }
+                    }),
+                  },
                 ]
               : []),
             ...(self.canHaveFill
@@ -385,15 +394,7 @@ const stateModelFactory = (
                 self.toggleCrossHatches()
               },
             },
-            {
-              label: 'Summary score mode',
-              subMenu: ['min', 'max', 'avg', 'whiskers'].map(elt => {
-                return {
-                  label: elt,
-                  onClick: () => self.setSummaryScoreMode(elt),
-                }
-              }),
-            },
+
             ...(getConf(self, 'renderers').length > 1
               ? [
                   {

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -32,6 +32,7 @@ import { getNiceDomain, getScale } from '../../util'
 
 import Tooltip from '../components/Tooltip'
 import SetMinMaxDlg from '../components/SetMinMaxDialog'
+import SetColorDlg from '../components/SetColorDialog'
 
 // fudge factor for making all labels on the YScalebar visible
 export const YSCALEBAR_LABEL_OFFSET = 5
@@ -66,6 +67,8 @@ const stateModelFactory = (
         selectedRendering: types.optional(types.string, ''),
         resolution: types.optional(types.number, 1),
         fill: types.maybe(types.boolean),
+        color: types.maybe(types.string),
+        summaryScoreMode: types.maybe(types.string),
         rendererTypeNameState: types.maybe(types.string),
         scale: types.maybe(types.string),
         autoscale: types.maybe(types.string),
@@ -90,6 +93,9 @@ const stateModelFactory = (
         self.stats.scoreMin = stats.scoreMin
         self.stats.scoreMax = stats.scoreMax
         self.ready = true
+      },
+      setColor(color: string) {
+        self.color = color
       },
 
       setLoading(aborter: AbortController) {
@@ -123,6 +129,10 @@ const stateModelFactory = (
         } else {
           self.scale = 'linear'
         }
+      },
+
+      setSummaryScoreMode(val: string) {
+        self.summaryScoreMode = val
       },
 
       setAutoscale(val: string) {
@@ -197,12 +207,20 @@ const stateModelFactory = (
           filled: self.fill,
           scaleType: this.scaleType,
           displayCrossHatches: self.displayCrossHatches,
+          summaryScoreMode: self.summaryScoreMode,
+          color: self.color,
         })
       },
     }))
     .views(self => {
       let oldDomain: [number, number] = [0, 0]
       return {
+        get summaryScoreModeSetting() {
+          return (
+            self.summaryScoreMode ||
+            readConfObject(self.rendererConfig, 'summaryScoreMode')
+          )
+        },
         get domain() {
           const { stats, scaleType, minScore, maxScore } = self
 
@@ -367,6 +385,15 @@ const stateModelFactory = (
                 self.toggleCrossHatches()
               },
             },
+            {
+              label: 'Summary score mode',
+              subMenu: ['min', 'max', 'avg', 'whiskers'].map(elt => {
+                return {
+                  label: elt,
+                  onClick: () => self.setSummaryScoreMode(elt),
+                }
+              }),
+            },
             ...(getConf(self, 'renderers').length > 1
               ? [
                   {
@@ -402,6 +429,12 @@ const stateModelFactory = (
               label: 'Set min/max score',
               onClick: () => {
                 getContainingTrack(self).setDialogComponent(SetMinMaxDlg, self)
+              },
+            },
+            {
+              label: 'Set color',
+              onClick: () => {
+                getContainingTrack(self).setDialogComponent(SetColorDlg, self)
               },
             },
           ]


### PR DESCRIPTION
This adds a simple color picker for the wiggle track

This is almost going too far in a way, and I believe is starting to call into question the duplication of config items into state

I believe the user experience of having to clone a track and use our config editor is not ideal, and I think the track state and track menu helps, but it is causing duplication of code.

However, I also see that the continued use of track state as a way to open up a new opportunity: it offers a conceptually nice way to get config layers:I can simply say something like

    // using concept from @teresam856 for top level config
    getConf(getSession(self).WigglePluginSettings, 'someSetting')

Then I can get a "global setting" to apply to all my wiggle tracks a la config layers. This would be otherwise difficult to setup on every individual wiggle track

So there are tradeoffs here, but open to ideas.

Note that other track types like FeatureTrack could enjoy a color picker also