### PR TITLE
Make the variant display derive from the feature display

### DIFF
--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -150,6 +150,8 @@ export {
   BaseLinearDisplay,
   baseLinearDisplayConfigSchema,
   linearBasicDisplayConfigSchemaFactory,
+  featuresTrackConfigSchema,
+  featuresTrackModelFactory,
 }
 
 export type { LinearGenomeViewModel, LinearGenomeViewStateModel, BlockModel }

--- a/plugins/variants/src/LinearVariantDisplay/configSchema.ts
+++ b/plugins/variants/src/LinearVariantDisplay/configSchema.ts
@@ -1,33 +1,17 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { types, Instance } from 'mobx-state-tree'
+import { Instance } from 'mobx-state-tree'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { baseLinearDisplayConfigSchema } from '@jbrowse/plugin-linear-genome-view'
+import { featuresTrackConfigSchema } from '@jbrowse/plugin-linear-genome-view'
 
 export function LinearVariantDisplayConfigFactory(
   pluginManager: PluginManager,
 ) {
-  const PileupRendererConfigSchema = pluginManager.getRendererType(
-    'PileupRenderer',
-  ).configSchema
-  const SvgFeatureRendererConfigSchema = pluginManager.getRendererType(
-    'SvgFeatureRenderer',
-  ).configSchema
+  const configSchema = featuresTrackConfigSchema(pluginManager)
 
   return ConfigurationSchema(
     'LinearVariantDisplay',
-    {
-      defaultRendering: {
-        type: 'stringEnum',
-        model: types.enumeration('Rendering', ['pileup', 'svg']),
-        defaultValue: 'svg',
-      },
-
-      renderers: ConfigurationSchema('RenderersConfiguration', {
-        PileupRenderer: PileupRendererConfigSchema,
-        SvgFeatureRenderer: SvgFeatureRendererConfigSchema,
-      }),
-    },
-    { baseConfiguration: baseLinearDisplayConfigSchema, explicitlyTyped: true },
+    {},
+    { baseConfiguration: configSchema, explicitlyTyped: true },
   )
 }
 

--- a/plugins/variants/src/LinearVariantDisplay/model.ts
+++ b/plugins/variants/src/LinearVariantDisplay/model.ts
@@ -1,26 +1,19 @@
-import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
-import { getParentRenderProps } from '@jbrowse/core/util/tracks'
+import { ConfigurationReference } from '@jbrowse/core/configuration'
 import {
   getSession,
   getContainingView,
   isSessionModelWithWidgets,
 } from '@jbrowse/core/util'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
-import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
+import { featuresTrackModelFactory } from '@jbrowse/plugin-linear-genome-view'
 import { types } from 'mobx-state-tree'
 import { LinearVariantDisplayConfigModel } from './configSchema'
 
-// using a map because it preserves order
-const rendererTypes = new Map([
-  ['pileup', 'PileupRenderer'],
-  ['svg', 'SvgFeatureRenderer'],
-])
-
-export default (configSchema: LinearVariantDisplayConfigModel) =>
-  types
+export default function (configSchema: LinearVariantDisplayConfigModel) {
+  return types
     .compose(
       'LinearVariantDisplay',
-      BaseLinearDisplay,
+      featuresTrackModelFactory(configSchema),
       types.model({
         type: types.literal('LinearVariantDisplay'),
         configuration: ConfigurationReference(configSchema),
@@ -41,34 +34,4 @@ export default (configSchema: LinearVariantDisplayConfigModel) =>
         session.setSelection(feature)
       },
     }))
-    .views(self => ({
-      /**
-       * the renderer type name is based on the "view"
-       * selected in the UI: pileup, coverage, etc
-       */
-      get rendererTypeName() {
-        const viewName = getConf(self, 'defaultRendering')
-        const rendererType = rendererTypes.get(viewName)
-        if (!rendererType) {
-          throw new Error(`unknown alignments view name ${viewName}`)
-        }
-        return rendererType
-      },
-
-      /**
-       * the react props that are passed to the Renderer when data
-       * is rendered in this display
-       */
-      get renderProps() {
-        // view -> track -> [displays] -> [blocks]
-        const config = self.rendererType.configSchema.create(
-          getConf(self, ['renderers', self.rendererTypeName]) || {},
-        )
-        return {
-          ...self.composedRenderProps,
-          ...getParentRenderProps(self),
-          config,
-          displayModel: self,
-        }
-      },
-    }))
+}

--- a/plugins/variants/src/__snapshots__/index.test.js.snap
+++ b/plugins/variants/src/__snapshots__/index.test.js.snap
@@ -21,13 +21,8 @@ Object {
     },
     Object {
       "displayId": "trackId0-LinearVariantDisplay",
-      "renderers": Object {
-        "PileupRenderer": Object {
-          "type": "PileupRenderer",
-        },
-        "SvgFeatureRenderer": Object {
-          "type": "SvgFeatureRenderer",
-        },
+      "renderer": Object {
+        "type": "StructuralVariantChordRenderer",
       },
       "type": "LinearVariantDisplay",
     },

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -152,13 +152,8 @@ Object {
         },
         Object {
           "displayId": "volvox_sv_test-LinearVariantDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
+          "renderer": Object {
+            "type": "SvgFeatureRenderer",
           },
           "type": "LinearVariantDisplay",
         },
@@ -195,13 +190,8 @@ Object {
         },
         Object {
           "displayId": "volvox_sv_test_renamed-LinearVariantDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
+          "renderer": Object {
+            "type": "SvgFeatureRenderer",
           },
           "type": "LinearVariantDisplay",
         },
@@ -989,13 +979,8 @@ Object {
         },
         Object {
           "displayId": "volvox_test_vcf-LinearVariantDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
+          "renderer": Object {
+            "type": "SvgFeatureRenderer",
           },
           "type": "LinearVariantDisplay",
         },
@@ -2145,13 +2130,8 @@ Object {
         },
         Object {
           "displayId": "volvox_filtered_vcf-LinearVariantDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
+          "renderer": Object {
+            "type": "SvgFeatureRenderer",
           },
           "type": "LinearVariantDisplay",
         },


### PR DESCRIPTION
This proposes to make the LinearVariantDisplay derive from the LinearFeatureDisplay

This gives it the ability to hide feature labels via the track menu, and other similar things


The current version has the ability to choose PileupRenderer as its renderer but I think this is probably unneeded