### PR TITLE
Split alignments track menu items into "Pileup" and "SNPCoverage" submenus

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.ts
@@ -113,8 +113,19 @@ const stateModelFactory = (
         get trackMenuItems(): MenuItem[] {
           return [
             ...trackMenuItems,
-            ...self.PileupDisplay.composedTrackMenuItems,
-            ...self.SNPCoverageDisplay.composedTrackMenuItems,
+            {
+              type: 'subMenu',
+              label: 'Pileup settings',
+              subMenu: self.PileupDisplay.composedTrackMenuItems,
+            },
+            {
+              type: 'subMenu',
+              label: 'SNPCoverage settings',
+              subMenu: [
+                ...self.SNPCoverageDisplay.composedTrackMenuItems,
+                ...self.SNPCoverageDisplay.extraTrackMenuItems,
+              ],
+            },
           ]
         },
       }

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -527,20 +527,20 @@ const stateModelFactory = (
               ],
             },
             {
-              label: 'Set feature height',
-              onClick: () => {
-                getContainingTrack(self).setDialogComponent(
-                  SetFeatureHeightDlg,
-                  self,
-                )
-              },
-            },
-            {
               label: 'Filter by',
               icon: FilterListIcon,
               onClick: () => {
                 getContainingTrack(self).setDialogComponent(
                   FilterByTagDlg,
+                  self,
+                )
+              },
+            },
+            {
+              label: 'Set feature height',
+              onClick: () => {
+                getContainingTrack(self).setDialogComponent(
+                  SetFeatureHeightDlg,
                   self,
                 )
               },

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -177,28 +177,28 @@ const stateModelFactory = (
         return filters
       },
 
-      get scaleOpts() {
-        return {
-          domain: self.domain,
-          stats: self.stats,
-          autoscaleType: getConf(self, 'autoscale'),
-          scaleType: getConf(self, 'scaleType'),
-          inverted: getConf(self, 'inverted'),
-        }
-      },
+      // get scaleOpts() {
+      //   return {
+      //     domain: self.domain,
+      //     stats: self.stats,
+      //     autoscaleType: getConf(self, 'autoscale'),
+      //     scaleType: getConf(self, 'scaleType'),
+      //     inverted: getConf(self, 'inverted'),
+      //   }
+      // },
 
-      get renderProps() {
-        return {
-          ...self.composedRenderProps,
-          ...getParentRenderProps(self),
-          notReady: !self.ready,
-          height: self.height,
-          displayModel: self,
-          scaleOpts: this.scaleOpts,
-          filters: self.filters,
-          config: self.rendererConfig,
-        }
-      },
+      // get renderProps() {
+      //   return {
+      //     ...self.composedRenderProps,
+      //     ...getParentRenderProps(self),
+      //     notReady: !self.ready,
+      //     height: self.height,
+      //     displayModel: self,
+      //     scaleOpts: this.scaleOpts,
+      //     filters: self.filters,
+      //     config: self.rendererConfig,
+      //   }
+      // },
     }))
 
 export type SNPCoverageDisplayModel = ReturnType<typeof stateModelFactory>

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -115,26 +115,20 @@ const stateModelFactory = (
       get extraTrackMenuItems() {
         return [
           {
-            type: 'subMenu',
-            label: 'SNPCoverageTrack settings',
-            subMenu: [
-              {
-                label: 'Draw insertion/clipping indicators',
-                type: 'checkbox',
-                checked: self.drawIndicatorsSetting,
-                onClick: () => {
-                  self.toggleDrawIndicators()
-                },
-              },
-              {
-                label: 'Draw insertion/clipping counts',
-                type: 'checkbox',
-                checked: self.drawInterbaseCountsSetting,
-                onClick: () => {
-                  self.toggleDrawInterbaseCounts()
-                },
-              },
-            ],
+            label: 'Draw insertion/clipping indicators',
+            type: 'checkbox',
+            checked: self.drawIndicatorsSetting,
+            onClick: () => {
+              self.toggleDrawIndicators()
+            },
+          },
+          {
+            label: 'Draw insertion/clipping counts',
+            type: 'checkbox',
+            checked: self.drawInterbaseCountsSetting,
+            onClick: () => {
+              self.toggleDrawInterbaseCounts()
+            },
           },
         ]
       },

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -112,7 +112,7 @@ const stateModelFactory = (
         return []
       },
 
-      get composedTrackMenuItems() {
+      get extraTrackMenuItems() {
         return [
           {
             type: 'subMenu',

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -1,6 +1,5 @@
 import { types, cast } from 'mobx-state-tree'
 import { getConf, readConfObject } from '@jbrowse/core/configuration'
-import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import { linearWiggleDisplayModelFactory } from '@jbrowse/plugin-wiggle'
 import {
   AnyConfigurationSchemaType,
@@ -170,29 +169,6 @@ const stateModelFactory = (
         }
         return filters
       },
-
-      // get scaleOpts() {
-      //   return {
-      //     domain: self.domain,
-      //     stats: self.stats,
-      //     autoscaleType: getConf(self, 'autoscale'),
-      //     scaleType: getConf(self, 'scaleType'),
-      //     inverted: getConf(self, 'inverted'),
-      //   }
-      // },
-
-      // get renderProps() {
-      //   return {
-      //     ...self.composedRenderProps,
-      //     ...getParentRenderProps(self),
-      //     notReady: !self.ready,
-      //     height: self.height,
-      //     displayModel: self,
-      //     scaleOpts: this.scaleOpts,
-      //     filters: self.filters,
-      //     config: self.rendererConfig,
-      //   }
-      // },
     }))
 
 export type SNPCoverageDisplayModel = ReturnType<typeof stateModelFactory>

--- a/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.test.js
+++ b/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.test.js
@@ -54,6 +54,7 @@ test('several features', async () => {
     highResolutionScaling: 1,
     height: 100,
     config: {},
+    ticks: { values: [0, 100] },
   })
 
   expect(result).toMatchSnapshot({

--- a/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
+++ b/plugins/alignments/src/SNPCoverageRenderer/SNPCoverageRenderer.ts
@@ -27,6 +27,8 @@ interface SNPCoverageRendererProps {
   sessionId: string
   signal: AbortSignal
   theme: ThemeOptions
+  ticks: { values: number[] }
+  displayCrossHatches: boolean
 }
 
 interface BaseInfo {
@@ -49,6 +51,8 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
       height: unadjustedHeight,
       theme: configTheme,
       config: cfg,
+      displayCrossHatches,
+      ticks: { values },
     } = props
     const theme = createJBrowseTheme(configTheme)
     const [region] = regions
@@ -173,6 +177,17 @@ export default class SNPCoverageRenderer extends WiggleBaseRenderer {
           ctx.fill()
         }
       }
+    }
+
+    if (displayCrossHatches) {
+      ctx.lineWidth = 1
+      ctx.strokeStyle = 'rgba(140,140,140,0.8)'
+      values.forEach(tick => {
+        ctx.beginPath()
+        ctx.moveTo(0, Math.round(toY(tick)))
+        ctx.lineTo(width, Math.round(toY(tick)))
+        ctx.stroke()
+      })
     }
   }
 }

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -297,6 +297,7 @@ const stateModelFactory = (
             height: self.height,
             ticks: this.ticks,
             displayCrossHatches: self.displayCrossHatches,
+            filters: self.filters,
           }
         },
 
@@ -366,13 +367,17 @@ const stateModelFactory = (
                 self.toggleCrossHatches()
               },
             },
-            {
-              label: 'Renderer type',
-              subMenu: [...rendererTypes.keys()].map(key => ({
-                label: key,
-                onClick: () => self.setRendererType(key),
-              })),
-            },
+            ...(getConf(self, 'renderers').length > 1
+              ? [
+                  {
+                    label: 'Renderer type',
+                    subMenu: [...rendererTypes.keys()].map(key => ({
+                      label: key,
+                      onClick: () => self.setRendererType(key),
+                    })),
+                  },
+                ]
+              : []),
             {
               label: 'Autoscale type',
               subMenu: [


### PR DESCRIPTION
This was sort of inspired by #1754 but does not fix it

I split the long list of track menu items for the combined snpcov+pileup alignments track into submenus, one for pileup, one for snpcoverage options

It also added a custom getter called "extraTrackMenuItems" instead of overriding composedTrackMenuItems in the SNPCoverageDisplay model because it was not possible to properly override composedTrackMenuItems and preserve the wiggle options

![localhost_3001__config=test_data%2Fvolvox%2Fconfig json session=local-QB2XB3ssB (1)](https://user-images.githubusercontent.com/6511937/109737437-4dbb8800-7b83-11eb-91ad-5328ee998b14.png)
