### PR TITLE
Add length limit on error message from session loading

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -463,7 +463,11 @@ const Renderer = observer(
                   .replace('[mobx-state-tree] ', '')
                   .replace(/\(.+/, '')
                 rootModel.session?.notify(
-                  `Session could not be loaded. ${errorMessage}`,
+                  `Session could not be loaded. ${
+                    errorMessage.length > 1000
+                      ? `${errorMessage.slice(0, 1000)}...see more in console`
+                      : errorMessage
+                  }`,
                 )
               }
             } else {


### PR DESCRIPTION
Simple approach to fix #1749...chop the error message length at 1000 chars which is pretty sizeable length but shouldn't overflow the screen