### PR TITLE
Add requestidlecallback ponyfill in @jbrowse/core/util

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -856,3 +856,12 @@ export const complement = (() => {
     return seqString.replace(complementRegex, m => complementTable[m] || '')
   }
 })()
+
+// requires immediate execution in jest environment, because (hypothesis) it
+// otherwise listens for prerendered_canvas but reads empty pixels, and doesn't
+// get the contents of the canvas
+export const rIC =
+  window.requestIdleCallback ||
+  (typeof jest === 'undefined'
+    ? (cb: Function) => setTimeout(() => cb(), 1)
+    : (cb: Function) => cb())

--- a/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
+++ b/plugins/circular-view/src/BaseChordDisplay/components/RpcRenderedSvgGroup.js
@@ -4,6 +4,7 @@ export default ({ jbrequire }) => {
   const { useEffect, useRef } = React
   const { observer, PropTypes: MobxPropTypes } = jbrequire('mobx-react')
   const { unmountComponentAtNode, hydrate } = jbrequire('react-dom')
+  const { rIC } = jbrequire('@jbrowse/core/util')
 
   function RpcRenderedSvgGroup({ model }) {
     const { data, html, filled, renderProps, renderingComponent } = model
@@ -23,14 +24,14 @@ export default ({ jbrequire }) => {
           // use requestIdleCallback to defer main-thread rendering
           // and hydration for when we have some free time. helps
           // keep the framerate up.
-          requestIdleCallback(() => {
+          rIC(() => {
             if (!isAlive(model)) return
             const mainThreadRendering = React.createElement(
               renderingComponent,
               { ...data, ...renderProps },
               null,
             )
-            requestIdleCallback(() => {
+            rIC(() => {
               if (!isAlive(model)) return
               hydrate(mainThreadRendering, domNode)
             })

--- a/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedContent.tsx
@@ -1,6 +1,6 @@
 import { getConf } from '@jbrowse/core/configuration'
 import { createJBrowseTheme } from '@jbrowse/core/ui'
-import { getSession } from '@jbrowse/core/util'
+import { getSession, rIC } from '@jbrowse/core/util'
 import { BlockModel } from '@jbrowse/plugin-linear-genome-view'
 import { ThemeProvider } from '@material-ui/core/styles'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
@@ -16,7 +16,6 @@ interface ErrorBoundaryState {
   hasError: boolean
   error?: Error
 }
-
 class RenderErrorBoundary extends Component<{}, ErrorBoundaryState> {
   // eslint-disable-next-line react/static-property-placement
   static propTypes = {
@@ -81,7 +80,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         // a long continuous scroll, it forces it to evaluate because
         // otherwise the continuous scroll would never give it time to do
         // so
-        requestIdleCallback(
+        rIC(
           () => {
             if (!isAlive(model)) {
               return

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedContent.tsx
@@ -1,6 +1,6 @@
 import { getConf } from '@jbrowse/core/configuration'
 import { createJBrowseTheme } from '@jbrowse/core/ui'
-import { getSession } from '@jbrowse/core/util'
+import { getSession, rIC } from '@jbrowse/core/util'
 import { ThemeProvider } from '@material-ui/core/styles'
 import { observer, PropTypes } from 'mobx-react'
 import { getSnapshot, isAlive, isStateTreeNode } from 'mobx-state-tree'
@@ -38,7 +38,7 @@ function ServerSideRenderedContent(props: { model: BlockModel }) {
         // a long continuous scroll, it forces it to evaluate because
         // otherwise the continuous scroll would never give it time to do
         // so
-        requestIdleCallback(
+        rIC(
           () => {
             if (!isAlive(model)) {
               return


### PR DESCRIPTION
Added a really basic rIC ponyfill that performs setTimeout(cb,1) for @jbrowse/core/util, used it throughout the codebase where needed

The alternative I can think of is adding the requestidlecallback-polyfill to jbrowse-react-linear-genome-view specifically but probably just better to do this
https://github.com/GMOD/jbrowse-components/tree/ric_polyfill

For compatibility with Safari mostly

Fixes #1659