### PR TITLE
Make sure the dotplot view creates views with interRegionPaddingWidth: 0 and minimumBlockWidth: 0

### DIFF
--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -245,6 +245,8 @@ export default class DotplotPlugin extends Plugin {
                   hview: {
                     offsetPx: 0,
                     bpPerPx: refLength / 800,
+                    minimumBlockWidth: 0,
+                    interRegionPaddingWidth: 0,
                     displayedRegions: features.map(f => {
                       return {
                         start: f.start,
@@ -257,6 +259,8 @@ export default class DotplotPlugin extends Plugin {
                   vview: {
                     offsetPx: 0,
                     bpPerPx: totalLength / 400,
+                    minimumBlockWidth: 0,
+                    interRegionPaddingWidth: 0,
                     displayedRegions: [
                       {
                         assemblyName: readAssembly,


### PR DESCRIPTION
There might be a better way to make sure the derived Dotplot1DView sets these by default to 0, but currently any instantiation of Dotplot1DView should manually set these to 0

