### PR TITLE
Fix "Add track" workflow with local files on desktop and make a bit more testing of this widget

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
@@ -1,13 +1,13 @@
 import { readConfObject } from '@jbrowse/core/configuration'
 import { getSession } from '@jbrowse/core/util'
-import { guessAdapter, UNKNOWN } from '@jbrowse/core/util/tracks'
 import Link from '@material-ui/core/Link'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import { observer } from 'mobx-react'
-import React, { useEffect } from 'react'
+import React from 'react'
+import { UNKNOWN } from '@jbrowse/core/util/tracks'
 import { AddTrackModel } from '../model'
 
 const useStyles = makeStyles(theme => ({
@@ -20,26 +20,7 @@ function ConfirmTrack({ model }: { model: AddTrackModel }) {
   const classes = useStyles()
   const session = getSession(model)
   let error = ''
-  const {
-    trackName,
-    trackData,
-    trackAdapter,
-    trackType,
-    indexTrackData,
-    assembly,
-  } = model
-
-  useEffect(() => {
-    if (trackData?.uri) {
-      const adapter = guessAdapter(trackData.uri, 'uri', indexTrackData.uri)
-      model.setTrackAdapter(adapter)
-    }
-
-    if (trackData.localPath) {
-      const adapter = guessAdapter(trackData.localPath, 'localPath')
-      model.setTrackAdapter(adapter)
-    }
-  }, [model, trackData, indexTrackData])
+  const { trackName, trackData, trackAdapter, trackType, assembly } = model
 
   if (model.isFtp) {
     error = `Warning: JBrowse cannot access files using the ftp protocol`

--- a/plugins/data-management/src/AddTrackWidget/index.test.jsx
+++ b/plugins/data-management/src/AddTrackWidget/index.test.jsx
@@ -12,8 +12,10 @@ function setWindowLoc(loc) {
   delete window.location
   window.location = new URL(loc)
 }
-const FakeViewModel = types.model({
+const FakeViewModel = types.model('FakeView', {
+  id: types.identifier,
   type: types.literal('FakeView'),
+  assemblyNames: types.array(types.string),
 })
 
 // register a true fake view plugin because the widget.view is a true
@@ -38,13 +40,19 @@ describe('tests on an LGV type system with view.assemblyNames, using URL', () =>
     const pluginManager = new PluginManager([new FakeViewPlugin()])
     pluginManager.createPluggableElements()
     pluginManager.configure()
+
     const SessionModel = types.model({
       view: FakeViewModel,
       widget: stateModelFactory(pluginManager),
     })
 
+    // assemblyNames is defined on the view, which is done in LGV for example
+    // this is really just used for convenience to automatically fill in the
+    // assembly field in the form
+
     session = SessionModel.create({
       view: {
+        id: 'testing',
         type: 'FakeView',
         assemblyNames: ['volvox'],
       },
@@ -59,19 +67,21 @@ describe('tests on an LGV type system with view.assemblyNames, using URL', () =>
     window.location = realLocation
   })
 
-  it('adds url', () => {
+  it('adds relative URL', () => {
     const { widget } = session
     widget.setTrackData({ uri: 'volvox-sorted.bam' })
     expect(widget.trackName).toBe('volvox-sorted.bam')
     expect(widget.isFtp).toBe(false)
     expect(widget.isRelativeUrl).toBe(true)
+    expect(widget.assembly).toBe('volvox')
   })
 
-  it('adds url from wrong protocol', () => {
+  it('adds full URL', () => {
     const { widget } = session
     widget.setTrackData({ uri: 'http://google.com/volvox-sorted.bam' })
     expect(widget.trackName).toBe('volvox-sorted.bam')
     expect(widget.isRelativeUrl).toBe(false)
+    expect(widget.assembly).toBe('volvox')
   })
 
   it('test wrongProtocol returning false', () => {
@@ -101,8 +111,13 @@ describe('tests on an view without view.assemblyNames', () => {
       widget: stateModelFactory(pluginManager),
     })
 
+    // no assemblyNames on the view, just in case some view does not implement
+    // this
     session = SessionModel.create({
-      view: { type: 'FakeView' },
+      view: {
+        type: 'FakeView',
+        id: 'testing',
+      },
       widget: {
         type: 'AddTrackWidget',
         view: 'testing',

--- a/plugins/data-management/src/AddTrackWidget/index.test.jsx
+++ b/plugins/data-management/src/AddTrackWidget/index.test.jsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { types } from 'mobx-state-tree'
+import PluginManager from '@jbrowse/core/PluginManager'
+import Plugin from '@jbrowse/core/Plugin'
+import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
+import stateModelFactory from './model'
+
+const realLocation = window.location
+
+// https://stackoverflow.com/a/60110508/2129219
+function setWindowLoc(loc) {
+  delete window.location
+  window.location = new URL(loc)
+}
+const FakeViewModel = types.model({
+  type: types.literal('FakeView'),
+})
+
+// register a true fake view plugin because the widget.view is a true
+// safeReference to a pluginManager.pluggableMstType('view', 'stateModel')
+class FakeViewPlugin extends Plugin {
+  name = 'FakeViewPlugin'
+
+  install(pluginManager) {
+    pluginManager.addViewType(() => {
+      return new ViewType({
+        name: 'FakeView',
+        stateModel: FakeViewModel,
+        ReactComponent: () => <div>Hello world</div>,
+      })
+    })
+  }
+}
+
+describe('tests on an LGV type system with view.assemblyNames, using URL', () => {
+  let session
+  beforeEach(() => {
+    const pluginManager = new PluginManager([new FakeViewPlugin()])
+    pluginManager.createPluggableElements()
+    pluginManager.configure()
+    const SessionModel = types.model({
+      view: FakeViewModel,
+      widget: stateModelFactory(pluginManager),
+    })
+
+    session = SessionModel.create({
+      view: {
+        type: 'FakeView',
+        assemblyNames: ['volvox'],
+      },
+      widget: {
+        type: 'AddTrackWidget',
+        view: 'testing',
+      },
+    })
+  })
+
+  afterEach(() => {
+    window.location = realLocation
+  })
+
+  it('adds url', () => {
+    const { widget } = session
+    widget.setTrackData({ uri: 'volvox-sorted.bam' })
+    expect(widget.trackName).toBe('volvox-sorted.bam')
+    expect(widget.isFtp).toBe(false)
+    expect(widget.isRelativeUrl).toBe(true)
+  })
+
+  it('adds url from wrong protocol', () => {
+    const { widget } = session
+    widget.setTrackData({ uri: 'http://google.com/volvox-sorted.bam' })
+    expect(widget.trackName).toBe('volvox-sorted.bam')
+    expect(widget.isRelativeUrl).toBe(false)
+  })
+
+  it('test wrongProtocol returning false', () => {
+    const { widget } = session
+    widget.setTrackData({ uri: 'http://google.com/volvox-sorted.bam' })
+    setWindowLoc('http://google.com')
+
+    expect(widget.wrongProtocol).toBe(false)
+  })
+
+  it('test wrongProtocol returning true', () => {
+    const { widget } = session
+    widget.setTrackData({ uri: 'http://google.com/volvox-sorted.bam' })
+    setWindowLoc('https://google.com')
+    expect(widget.wrongProtocol).toBe(true)
+  })
+})
+
+describe('tests on an view without view.assemblyNames', () => {
+  let session
+  beforeEach(() => {
+    const pluginManager = new PluginManager([new FakeViewPlugin()])
+    pluginManager.createPluggableElements()
+    pluginManager.configure()
+    const SessionModel = types.model({
+      view: FakeViewModel,
+      widget: stateModelFactory(pluginManager),
+    })
+
+    session = SessionModel.create({
+      view: { type: 'FakeView' },
+      widget: {
+        type: 'AddTrackWidget',
+        view: 'testing',
+      },
+    })
+  })
+
+  it('adds url', () => {
+    const { widget } = session
+    widget.setTrackData({ uri: 'volvox-sorted.bam' })
+    expect(widget.trackName).toBe('volvox-sorted.bam')
+    expect(widget.isRelativeUrl).toBe(true)
+    expect(widget.assembly).toBe(undefined)
+  })
+})

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -107,12 +107,8 @@ export default function f(pluginManager: PluginManager) {
       },
 
       get assembly() {
-        return (
-          self.altAssemblyName ||
-          (self.view.displayedRegions && self.view.displayedRegions.length > 0
-            ? self.view.displayedRegions[0].assemblyName
-            : '')
-        )
+        console.log(self.view)
+        return self.altAssemblyName || self.view.assemblyNames?.[0]
       },
 
       get trackType() {

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -2,7 +2,11 @@
 import { types, Instance } from 'mobx-state-tree'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { ElementId } from '@jbrowse/core/util/types/mst'
-import { guessTrackType, UNSUPPORTED } from '@jbrowse/core/util/tracks'
+import {
+  guessAdapter,
+  guessTrackType,
+  UNSUPPORTED,
+} from '@jbrowse/core/util/tracks'
 
 function isAbsoluteUrl(url: string) {
   try {
@@ -33,11 +37,11 @@ export default function f(pluginManager: PluginManager) {
       altTrackName: '',
       altTrackType: '',
 
-      trackAdapter: {} as any,
+      altTrackAdapter: {} as any,
     }))
     .actions(self => ({
       setTrackAdapter(obj: any) {
-        self.trackAdapter = obj
+        self.altTrackAdapter = obj
       },
       setTrackSource(str: string) {
         self.trackSource = str
@@ -60,36 +64,51 @@ export default function f(pluginManager: PluginManager) {
 
       clearData() {
         self.trackSource = ''
-        self.trackAdapter = {}
+        self.altTrackAdapter = {}
         self.indexTrackData = { uri: '' }
         self.trackData = { uri: '' }
         self.altTrackName = ''
         self.altTrackType = ''
         self.altAssemblyName = ''
+        self.altTrackAdapter = {}
       },
     }))
     .views(self => ({
+      get trackAdapter() {
+        const { trackData, indexTrackData } = self
+        if (trackData?.uri) {
+          return guessAdapter(trackData.uri, 'uri', indexTrackData.uri)
+        }
+
+        if (trackData.localPath) {
+          return guessAdapter(trackData.localPath, 'localPath')
+        }
+        return self.altTrackAdapter
+      },
+
       get trackName() {
         // @ts-ignore
         const uri = self.trackData?.uri
+        const localPath = self.trackData?.localPath
         return (
           self.altTrackName ||
-          (uri ? uri.slice(uri.lastIndexOf('/') + 1) : null)
+          (uri ? uri.slice(uri.lastIndexOf('/') + 1) : null) ||
+          (localPath ? localPath.slice(localPath.lastIndexOf('/') + 1) : null)
         )
       },
 
       get isFtp() {
-        return (
-          (self.indexTrackData.uri &&
-            self.indexTrackData.uri.startsWith('ftp://')) ||
-          self.trackData.uri.startsWith('ftp://')
+        const { trackData, indexTrackData } = self
+        return !!(
+          (indexTrackData.uri && indexTrackData.uri.startsWith('ftp://')) ||
+          (trackData.uri && trackData.uri.startsWith('ftp://'))
         )
       },
 
       get isRelativeUrl() {
         return !(
           (self.indexTrackData.uri && isAbsoluteUrl(self.indexTrackData.uri)) ||
-          isAbsoluteUrl(self.trackData.uri)
+          (self.trackData.uri && isAbsoluteUrl(self.trackData.uri))
         )
       },
 
@@ -103,16 +122,15 @@ export default function f(pluginManager: PluginManager) {
       },
 
       get unsupported() {
-        return self.trackAdapter.type === UNSUPPORTED
+        return this.trackAdapter.type === UNSUPPORTED
       },
 
       get assembly() {
-        console.log(self.view)
         return self.altAssemblyName || self.view.assemblyNames?.[0]
       },
 
       get trackType() {
-        return self.altTrackType || guessTrackType(self.trackAdapter.type)
+        return self.altTrackType || guessTrackType(this.trackAdapter.type)
       },
     }))
 }


### PR DESCRIPTION
The AddTrack MST refactor in #1414 introduced some bugs with local files from jbrowse-desktop

This fixes that issue and also creates some unit tests to help cover more cases

Issue did not affect any "releases" yet but a desktop user from Keiran Raine's collaboration found this issue on desktop