### PR TITLE
Add warning dialog in LGV before returning to import form to prevent accidentally losing the current view

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -58,6 +58,12 @@ const LinearGenomeView = observer((props: { model: LGV }) => {
           handleClose={() => aboutTrack.setShowAbout(false)}
         />
       ) : null}
+      {model.DialogComponent ? (
+        <model.DialogComponent
+          model={model}
+          handleClose={() => model.setDialogComponent(undefined)}
+        />
+      ) : null}
 
       {dialogTrack ? (
         <dialogTrack.DialogComponent

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
@@ -11,7 +11,6 @@ import {
   IconButton,
 } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
-import { LinearGenomeViewModel } from '..'
 
 const useStyles = makeStyles(theme => ({
   loadingMessage: {
@@ -35,28 +34,19 @@ function ReturnToImportFormDialog({
   model,
   handleClose,
 }: {
-  model: LinearGenomeViewModel
+  model: { clearView: Function }
   handleClose: () => void
 }) {
   const classes = useStyles()
   return (
-    <Dialog
-      data-testid="sequence-dialog"
-      maxWidth="xl"
-      open
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">
+    <Dialog maxWidth="xl" open onClose={handleClose}>
+      <DialogTitle>
         Reference sequence
         {handleClose ? (
           <IconButton
-            data-testid="close-seqDialog"
             className={classes.closeButton}
             onClick={() => {
               handleClose()
-              model.setOffsets(undefined, undefined)
             }}
           >
             <CloseIcon />
@@ -72,12 +62,7 @@ function ReturnToImportFormDialog({
       <DialogActions>
         <Button
           onClick={() => {
-            model.setDisplayedRegions([])
-            // it is necessary to run these after setting displayed regions
-            // empty or else model.offsetPx gets set to infinity and breaks
-            // mobx-state-tree snapshot
-            model.scrollTo(0)
-            model.zoomTo(10)
+            model.clearView()
             handleClose()
           }}
           variant="contained"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+import { LinearGenomeViewModel } from '..'
+
+const useStyles = makeStyles(theme => ({
+  loadingMessage: {
+    padding: theme.spacing(5),
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+  dialogContent: {
+    width: '80em',
+  },
+  textAreaFont: {
+    fontFamily: 'Courier New',
+  },
+}))
+
+function ReturnToImportFormDialog({
+  model,
+  handleClose,
+}: {
+  model: LinearGenomeViewModel
+  handleClose: () => void
+}) {
+  const classes = useStyles()
+  return (
+    <Dialog
+      data-testid="sequence-dialog"
+      maxWidth="xl"
+      open
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">
+        Reference sequence
+        {handleClose ? (
+          <IconButton
+            data-testid="close-seqDialog"
+            className={classes.closeButton}
+            onClick={() => {
+              handleClose()
+              model.setOffsets(undefined, undefined)
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : null}
+      </DialogTitle>
+      <Divider />
+
+      <DialogContent>
+        Are you sure you want to return to the import form? This will lose your
+        current view
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            model.setDisplayedRegions([])
+            // it is necessary to run these after setting displayed regions
+            // empty or else model.offsetPx gets set to infinity and breaks
+            // mobx-state-tree snapshot
+            model.scrollTo(0)
+            model.zoomTo(10)
+            handleClose()
+          }}
+          variant="contained"
+          color="primary"
+          autoFocus
+        >
+          OK
+        </Button>
+        <Button
+          onClick={() => {
+            handleClose()
+          }}
+          color="secondary"
+          variant="contained"
+          autoFocus
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default observer(ReturnToImportFormDialog)

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -40,6 +40,7 @@ import clone from 'clone'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
 import Base1DView from '@jbrowse/core/util/Base1DViewModel'
+import ReturnToImportFormDlg from './components/ReturnToImportFormDialog'
 
 export { default as ReactComponent } from './components/LinearGenomeView'
 
@@ -124,6 +125,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
       coarseTotalBp: 0,
       leftOffset: undefined as undefined | BpOffset,
       rightOffset: undefined as undefined | BpOffset,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      DialogComponent: undefined as React.FC<any> | undefined,
     }))
     .views(self => ({
       get width(): number {
@@ -439,6 +442,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions(self => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setDialogComponent(comp?: React.FC<any>) {
+        self.DialogComponent = comp
+      },
       setWidth(newWidth: number) {
         self.volatileWidth = newWidth
       },
@@ -1156,12 +1163,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             {
               label: 'Return to import form',
               onClick: () => {
-                self.setDisplayedRegions([])
-                // it is necessary to run these after setting displayed regions
-                // empty or else self.offsetPx gets set to infinity and breaks
-                // mobx-state-tree snapshot
-                self.scrollTo(0)
-                self.zoomTo(10)
+                self.setDialogComponent(ReturnToImportFormDlg)
               },
               icon: FolderOpenIcon,
             },

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -125,8 +125,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
       coarseTotalBp: 0,
       leftOffset: undefined as undefined | BpOffset,
       rightOffset: undefined as undefined | BpOffset,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      DialogComponent: undefined as React.FC<any> | undefined,
+      DialogComponent: undefined as
+        | React.FC<{ handleClose: () => void; model: { clearView: Function } }>
+        | undefined,
     }))
     .views(self => ({
       get width(): number {
@@ -435,15 +436,18 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
 
       get centerLineInfo() {
-        const centerLineInfo = self.displayedRegions.length
+        return self.displayedRegions.length
           ? this.pxToBp(self.width / 2)
           : undefined
-        return centerLineInfo
       },
     }))
     .actions(self => ({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      setDialogComponent(comp?: React.FC<any>) {
+      setDialogComponent(
+        comp?: React.FC<{
+          handleClose: () => void
+          model: { clearView: Function }
+        }>,
+      ) {
         self.DialogComponent = comp
       },
       setWidth(newWidth: number) {
@@ -1272,6 +1276,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
       }
     })
     .actions(self => ({
+      // this "clears the view" and makes the view return to the import form
+      clearView() {
+        self.setDisplayedRegions([])
+        // it is necessary to run these after setting displayed regions empty
+        // or else model.offsetPx gets set to Infinity and breaks
+        // mobx-state-tree snapshot
+        self.scrollTo(0)
+        self.zoomTo(10)
+      },
       setCoarseDynamicBlocks(blocks: BlockSet) {
         self.coarseDynamicBlocks = blocks.contentBlocks
         self.coarseTotalBp = blocks.totalBp


### PR DESCRIPTION
Currently there is a "return to import form" helper on the linear genome view, however if it is used accidentally you can lose your current view

This adds a dialog prompt to check if you are sure

It creates a model state for tracking whether a dialog is open