### PR TITLE
Collaborative release announcement editing 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,11 @@ the monorepo to NPM and trigger the creation of a release on GitHub. To run this
 script:
 
 - Ensure that there is a file for this release in
-  `website/release_announcement_drafts/` for this release. Usually this includes
-  an overview of the major bugfixes and/or features being released. The release
-  script will automatically add download and detailed changelog information to
-  this post. You can see examples at https://jbrowse.org/jb2/blog.
+  `website/release_announcement_drafts/` containing a an overview or the major
+  features and bugfixes in the release, with as many nice screenshots or movies
+  as possible. The release script will automatically add download and detailed
+  changelog information to this post. You can see examples of the finished
+  posts at https://jbrowse.org/jb2/blog.
 
 - Make sure you have a GitHub access token with public_repo scope. To generate
   one, go to https://github.com/settings/tokens, click "Generate new token,"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,11 @@ There is a script `scripts/release.sh` that will publish the public packages in
 the monorepo to NPM and trigger the creation of a release on GitHub. To run this
 script:
 
-- Create a file outside the monorepo with a blog post about the release.
-  Usually this includes an overview of the major bugfixes and/or features being
-  released. The release script will automatically add download and detailed
-  changelog information to this post. You can see examples at
-  https://jbrowse.org/jb2/blog.
+- Ensure that there is a file for this release in
+  `website/release_announcement_drafts/` for this release. Usually this includes
+  an overview of the major bugfixes and/or features being released. The release
+  script will automatically add download and detailed changelog information to
+  this post. You can see examples at https://jbrowse.org/jb2/blog.
 
 - Make sure you have a GitHub access token with public_repo scope. To generate
   one, go to https://github.com/settings/tokens, click "Generate new token,"
@@ -86,7 +86,7 @@ script:
 Run the script like this:
 
 ```
-scripts/release.sh /path/to/blogpost.md myGitHubAuthToken versionIncreaseLevel
+scripts/release.sh myGitHubAuthToken versionIncreaseLevel
 ```
 
 If you don't provide `versionIncreaseLevel`, it will default to "patch".

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 
-## Usage scripts/release.sh blogpost.md githubAuthToken <prerelease/patch/minor/major>
-# The first argument blogpost.md is published to the jbrowse 2 blog. The second
-# argument is a personal access token for the GitHub API with `public_repo`
+## Usage scripts/release.sh githubAuthToken <prerelease/patch/minor/major>
+# The first argument is a personal access token for the GitHub API with `public_repo`
 # scope. You can generate a token at https://github.com/settings/tokens
-# The third optional argument is a flag for the publishing command for version
+# The second optional argument is a flag for the publishing command for version
 # bump. If not provided, it will default to "patch".
 
 ## Precautionary bash tags
 set -e
 set -o pipefail
 
-[[ -n "$1" ]] || { echo "No blogpost file provided" && exit 1; }
-[[ -n "$2" ]] || { echo "No GITHUB_AUTH token provided" && exit 1; }
-[[ -n "$3" ]] && SEMVER_LEVEL="$3" || SEMVER_LEVEL="patch"
+[[ -n "$1" ]] || { echo "No GITHUB_AUTH token provided" && exit 1; }
+GITHUB_AUTH=$1
+[[ -n "$2" ]] && SEMVER_LEVEL="$2" || SEMVER_LEVEL="patch"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 [[ "$BRANCH" != "master" ]] && { echo "Current branch is not master, please switch to master branch" && exit 1; }
@@ -34,6 +33,10 @@ PREVIOUS_VERSION=$(node --print "const lernaJson = require('./lerna.json'); lern
 VERSION=$(yarn --silent semver --increment "$SEMVER_LEVEL" "$PREVIOUS_VERSION")
 RELEASE_TAG=v$VERSION
 
+# make sure the blogpost draft is present
+BLOGPOST_DRAFT=website/release_announcement_drafts/$RELEASE_TAG.md
+[[ -f $BLOGPOST_DRAFT ]] || { echo "No blogpost draft found at $BLOGPOST_DRAFT, please write one." && exit 1; }
+
 # Updates the "Browse demo instance" link on the homepage
 INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$RELEASE_TAG/index.html
 INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
@@ -43,7 +46,7 @@ mv tmp.json website/docusaurus.config.json
 CHANGED=$(yarn --silent lerna changed --all --json)
 # Generates a changelog with a section added listing the packages that were
 # included in this release
-CHANGELOG=$(GITHUB_AUTH="$2" node scripts/changelog.js "$CHANGED" "$VERSION")
+CHANGELOG=$(GITHUB_AUTH="$GITHUB_AUTH" node scripts/changelog.js "$CHANGED" "$VERSION")
 # Add the changelog to the top of CHANGELOG.md
 echo "$CHANGELOG" >tmp.md
 echo "" >>tmp.md
@@ -51,7 +54,7 @@ cat CHANGELOG.md >>tmp.md
 mv tmp.md CHANGELOG.md
 
 # Blog post text
-NOTES=$(cat "$1")
+NOTES=$(cat "$BLOGPOST_DRAFT")
 DATE=$(date +"%Y-%m-%d")
 ## Blogpost run after lerna version, to get the accurate tags
 BLOGPOST_FILENAME=website/blog/${DATE}-${RELEASE_TAG}-release.md

--- a/website/release_announcement_drafts/v1.0.4.md
+++ b/website/release_announcement_drafts/v1.0.4.md
@@ -1,0 +1,23 @@
+This release of JBrowse Web includes a _great_ many small improvements and bug fixes, see the full changelog below.
+
+Some particularly salient improvements include:
+
+## Linear view sequence fetching
+
+Users can now download regions of sequence by selecting a region in the linear genome view and clicking "get sequence". See the demonstration video below:
+
+A long-requested feature, implemented in [#1588](https://github.com/GMOD/jbrowse-components/pull/1588) by [@teresam856](https://github.com/teresam856)!
+
+## Enhanced navigation of paired end reads and BND/TRA breakends
+
+Feature details of paired-end alignment reads and variants now contain links to open new views to help understand the regions or reads that they are related to.
+
+Aligned reads with information on "supplementary" alignments, such as most paired-end reads, now contain special links in their feature details that open a new linear genome view showing the other read(s) in the group.
+
+![localhost_3000__config=test_data%2Fconfig_demo json session=local-bHWWb4AhO](https://user-images.githubusercontent.com/6511937/107866463-8f7fcb00-6e2e-11eb-847f-0084939a9bfd.png)
+
+Similarly, feature details for `BND` and `TRA` breakpoints in variant tracks have links to open new breakpoint split views, allowing users to visualize both sides of the breakend or translocation.
+
+![localhost_3000__config=test_data%2Fconfig_demo json session=local-mlN3tEAII](https://user-images.githubusercontent.com/6511937/108010771-e4ece100-6fc2-11eb-8fc0-2b04be2891ae.png)
+
+Implemented by [@cmdcolin](https://github.com/cmdcolin) in [#1701](https://github.com/GMOD/jbrowse-components/pull/1701).


### PR DESCRIPTION
This PR makes the release.sh script take release blogpost drafts from `website/release_announcement_drafts` so that we can write them collaboratively with PRs before the release, to make sure everybody is happy with them.