### PR TITLE
Add hic aborting and fix remoteAbort signal propagation

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.test.ts
+++ b/packages/core/rpc/BaseRpcDriver.test.ts
@@ -1,4 +1,5 @@
 import PluginManager from '../PluginManager'
+import { checkAbortSignal } from '../util'
 import BaseRpcDriver, { watchWorker } from './BaseRpcDriver'
 import RpcMethodType from '../pluggableElementTypes/RpcMethodType'
 
@@ -18,20 +19,19 @@ class MockWorkerHandle {
   async call(
     name: string,
     _args = [],
-    opts: { timeout: number } = { timeout: 3000 },
+    opts: { timeout: number; signal?: AbortSignal },
   ) {
     const start = Date.now()
     if (name === 'ping') {
       while (this.busy) {
-        if (opts.timeout < Date.now() - start) {
+        if (opts.timeout < +Date.now() - start) {
           throw new Error('timeout')
         }
 
         // eslint-disable-next-line no-await-in-loop
         await timeout(50)
       }
-    }
-    if (name === 'doWorkShortPingTime') {
+    } else if (name === 'doWorkShortPingTime') {
       this.busy = true
       await timeout(50)
       this.busy = false
@@ -43,24 +43,22 @@ class MockWorkerHandle {
       this.busy = true
       await timeout(50)
       this.busy = false
-    }
-
-    if (name === 'doWorkLongPingTime') {
+    } else if (name === 'doWorkLongPingTime') {
       this.busy = true
-      await timeout(500)
+      await timeout(1000)
+      checkAbortSignal(opts.signal)
       this.busy = false
-      await timeout(500)
+      await timeout(1000)
+      checkAbortSignal(opts.signal)
       this.busy = true
-      await timeout(500)
+      await timeout(1000)
+      checkAbortSignal(opts.signal)
       this.busy = false
-    }
-    if (name === 'MockRenderTimeout') {
+    } else if (name === 'MockRenderTimeout') {
       this.busy = true
       await timeout(10000)
       this.busy = false
-    }
-
-    if (name === 'MockRenderShort') {
+    } else if (name === 'MockRenderShort') {
       this.busy = true
       await timeout(100)
       this.busy = false
@@ -70,12 +68,32 @@ class MockWorkerHandle {
 test('watch worker with long ping, generates timeout', async () => {
   const worker = new MockWorkerHandle()
 
+  expect.assertions(1)
   try {
     const workerWatcher = watchWorker(worker, 200)
-    const result = worker.call('doWorkLongPingTime')
+    const result = worker.call('doWorkLongPingTime', undefined, {
+      timeout: 100,
+    })
     await Promise.race([result, workerWatcher])
   } catch (e) {
     expect(e.message).toMatch(/timeout/)
+  }
+})
+
+test('test worker abort', async () => {
+  const worker = new MockWorkerHandle()
+  expect.assertions(1)
+
+  try {
+    const controller = new AbortController()
+    const resultP = worker.call('doWorkLongPingTime', undefined, {
+      signal: controller.signal,
+      timeout: 2000,
+    })
+    controller.abort()
+    await resultP
+  } catch (e) {
+    expect(e.message).toMatch(/abort/)
   }
 })
 

--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -138,7 +138,7 @@ export default abstract class BaseRpcDriver {
     signalId: number,
   ) {
     const worker = this.getWorker(sessionId, pluginManager)
-    worker.call(functionName, signalId, { timeout: 1000000 })
+    worker.call(functionName, { signalId }, { timeout: 1000000 })
   }
 
   createWorkerPool(): LazyWorker[] {

--- a/packages/core/rpc/remoteAbortSignals.ts
+++ b/packages/core/rpc/remoteAbortSignals.ts
@@ -74,9 +74,13 @@ export function deserializeAbortSignal({
  *
  * @param abortSignalId -
  */
-export function remoteAbort(abortSignalId: number) {
+export function remoteAbort(props: { signalId: number }) {
+  const { signalId: abortSignalId } = props
   const surrogateAbortController = surrogateAbortControllers.get(abortSignalId)
-  if (surrogateAbortController) surrogateAbortController.abort()
+
+  if (surrogateAbortController) {
+    surrogateAbortController.abort()
+  }
 }
 
 export function remoteAbortRpcHandler() {

--- a/packages/core/util/aborting.ts
+++ b/packages/core/util/aborting.ts
@@ -28,6 +28,23 @@ export function checkAbortSignal(signal?: AbortSignal): void {
   }
 }
 
+function timeout(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+/**
+ * Skips to the next tick, then runs `checkAbortSignal`.
+ * Await this to inside an otherwise synchronous loop to
+ * provide a place to break when an abort signal is received.
+ */
+export async function abortBreakPoint(signal?: AbortSignal) {
+  // it was observed that an actual timeout is needed to get the aborting (wrap
+  // hicrenderer in a try catch, console.error the error, and rethrow the error
+  // to see). using await Promise.resolve() did not appear to allow aborting to
+  // occur
+  await timeout(1)
+  checkAbortSignal(signal)
+}
+
 export function makeAbortError() {
   if (typeof DOMException !== 'undefined') {
     return new DOMException('aborted', 'AbortError')

--- a/plugins/hic/src/HicRenderer/HicRenderer.ts
+++ b/plugins/hic/src/HicRenderer/HicRenderer.ts
@@ -12,6 +12,7 @@ import {
   createCanvas,
   createImageBitmap,
 } from '@jbrowse/core/util/offscreenCanvasPonyfill'
+import { checkAbortSignal } from '@jbrowse/core/util'
 import React from 'react'
 import { toArray } from 'rxjs/operators'
 import { readConfObject } from '@jbrowse/core/configuration'
@@ -51,52 +52,64 @@ export default class HicRenderer extends ServerSideRendererType {
       bpPerPx,
       highResolutionScaling = 1,
       dataAdapter,
+      signal,
     } = props
     const [region] = regions
     const width = (region.end - region.start) / bpPerPx
     const height = readConfObject(config, 'maxHeight')
     const res = await dataAdapter.getResolution(bpPerPx)
-
-    if (!(width > 0) || !(height > 0)) {
-      return { height: 0, width: 0, maxHeightReached: false }
-    }
-
-    const canvas = createCanvas(
-      Math.ceil(width * highResolutionScaling),
-      height * highResolutionScaling,
-    )
-    const w = res / (bpPerPx * Math.sqrt(2))
-    const ctx = canvas.getContext('2d')
-    ctx.scale(highResolutionScaling, highResolutionScaling)
-    const baseColor = Color(readConfObject(config, 'baseColor'))
-    if (features.length) {
-      const offset = features[0].bin1
-      let maxScore = 0
-      let minBin = 0
-      let maxBin = 0
-      for (let i = 0; i < features.length; i++) {
-        const { bin1, bin2, counts } = features[i]
-        maxScore = Math.max(counts, maxScore)
-        minBin = Math.min(Math.min(bin1, bin2), minBin)
-        maxBin = Math.max(Math.max(bin1, bin2), maxBin)
+    console.log({ signal })
+    try {
+      console.time('test')
+      if (!(width > 0) || !(height > 0)) {
+        return { height: 0, width: 0, maxHeightReached: false }
       }
-      ctx.rotate(-Math.PI / 4)
-      for (let i = 0; i < features.length; i++) {
-        const { bin1, bin2, counts } = features[i]
-        ctx.fillStyle = readConfObject(config, 'color', [
-          counts,
-          maxScore,
-          baseColor,
-        ])
-        ctx.fillRect((bin1 - offset) * w, (bin2 - offset) * w, w, w)
-      }
-    }
 
-    const imageData = await createImageBitmap(canvas)
-    return {
-      imageData,
-      height,
-      width,
+      const canvas = createCanvas(
+        Math.ceil(width * highResolutionScaling),
+        height * highResolutionScaling,
+      )
+      const w = res / (bpPerPx * Math.sqrt(2))
+      const ctx = canvas.getContext('2d')
+      ctx.scale(highResolutionScaling, highResolutionScaling)
+      const baseColor = Color(readConfObject(config, 'baseColor'))
+      if (features.length) {
+        const offset = features[0].bin1
+        let maxScore = 0
+        let minBin = 0
+        let maxBin = 0
+        checkAbortSignal(signal)
+        for (let i = 0; i < features.length; i++) {
+          const { bin1, bin2, counts } = features[i]
+          maxScore = Math.max(counts, maxScore)
+          minBin = Math.min(Math.min(bin1, bin2), minBin)
+          maxBin = Math.max(Math.max(bin1, bin2), maxBin)
+        }
+        checkAbortSignal(signal)
+        ctx.rotate(-Math.PI / 4)
+        for (let i = 0; i < features.length; i++) {
+          const { bin1, bin2, counts } = features[i]
+          ctx.fillStyle = readConfObject(config, 'color', [
+            counts,
+            maxScore,
+            baseColor,
+          ])
+          ctx.fillRect((bin1 - offset) * w, (bin2 - offset) * w, w, w)
+          if (i % 10000 === 0) {
+            checkAbortSignal(signal)
+          }
+        }
+      }
+
+      const imageData = await createImageBitmap(canvas)
+      console.timeEnd('test')
+      return {
+        imageData,
+        height,
+        width,
+      }
+    } catch (e) {
+      console.error(e)
     }
   }
 

--- a/plugins/hic/src/HicRenderer/HicRenderer.ts
+++ b/plugins/hic/src/HicRenderer/HicRenderer.ts
@@ -12,7 +12,7 @@ import {
   createCanvas,
   createImageBitmap,
 } from '@jbrowse/core/util/offscreenCanvasPonyfill'
-import { checkAbortSignal } from '@jbrowse/core/util'
+import { abortBreakPoint } from '@jbrowse/core/util'
 import React from 'react'
 import { toArray } from 'rxjs/operators'
 import { readConfObject } from '@jbrowse/core/configuration'
@@ -43,9 +43,7 @@ export interface PileupRenderProps {
     by: string
   }
 }
-function timeout(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
+
 export default class HicRenderer extends ServerSideRendererType {
   async makeImageData(props: PileupRenderProps) {
     const {
@@ -78,16 +76,14 @@ export default class HicRenderer extends ServerSideRendererType {
       let maxScore = 0
       let minBin = 0
       let maxBin = 0
-      await timeout(1)
-      checkAbortSignal(signal)
+      await abortBreakPoint(signal)
       for (let i = 0; i < features.length; i++) {
         const { bin1, bin2, counts } = features[i]
         maxScore = Math.max(counts, maxScore)
         minBin = Math.min(Math.min(bin1, bin2), minBin)
         maxBin = Math.max(Math.max(bin1, bin2), maxBin)
       }
-      await timeout(1)
-      checkAbortSignal(signal)
+      await abortBreakPoint(signal)
       ctx.rotate(-Math.PI / 4)
       let start = Date.now()
       for (let i = 0; i < features.length; i++) {
@@ -99,9 +95,8 @@ export default class HicRenderer extends ServerSideRendererType {
         ])
         ctx.fillRect((bin1 - offset) * w, (bin2 - offset) * w, w, w)
         if (+Date.now() - start > 400) {
-          checkAbortSignal(signal)
           // eslint-disable-next-line no-await-in-loop
-          await timeout(1)
+          await abortBreakPoint(signal)
           start = +Date.now()
         }
       }


### PR DESCRIPTION
This fixes a bug in the remoteAbort call where the signalId was not being passed at all (it was calling {...1} which is just {}, the signal wasn't given a name on the object)

Then it adds a couple points in the hic code where it checks the abort signal, using a timeout to yield to the webworker to process the abortsignal RPC calls