### PR TITLE
Fix dotplot rendering outside it's allowed bounds

### DIFF
--- a/packages/core/util/Base1DViewModel.test.ts
+++ b/packages/core/util/Base1DViewModel.test.ts
@@ -33,8 +33,8 @@ test('Able to set bpPerPx, width and calculate widths', () => {
   expect(model.totalBp).toEqual(42400)
   // 40000 + (3000 - 600 = 2400) = 42400 / 1 (bpPerPx) = 42400
   expect(model.displayedRegionsTotalPx).toEqual(42400)
-  expect(model.interRegionPaddingWidth).toEqual(2)
-  expect(model.minimumBlockWidth).toEqual(3)
+  expect(model.interRegionPaddingWidth).toEqual(0)
+  expect(model.minimumBlockWidth).toEqual(0)
 })
 
 test('Able to set and showAll Regions', () => {

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -19,8 +19,8 @@ const Base1DView = types
     displayedRegions: types.array(Region),
     bpPerPx: 0,
     offsetPx: 0,
-    interRegionPaddingWidth: types.optional(types.number, 2),
-    minimumBlockWidth: types.optional(types.number, 3),
+    interRegionPaddingWidth: types.optional(types.number, 0),
+    minimumBlockWidth: types.optional(types.number, 0),
   })
   .volatile(() => ({
     features: undefined as undefined | Feature[],

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -306,6 +306,7 @@ function OverviewScaleBar({
   const overview = Base1DView.create({
     displayedRegions: JSON.parse(JSON.stringify(displayedRegions)),
     interRegionPaddingWidth: 0,
+    minimumBlockWidth: model.minimumBlockWidth,
   })
   overview.setVolatileWidth(width)
   overview.showAllRegions()


### PR DESCRIPTION
This is a quick fix for #1792 

There was some indication in https://github.com/GMOD/jbrowse-components/pull/1764

Instead of laboriously making everything worry about the defaults being geared for the LGV, I make it 0 and then lgv specific use cases can override
