### PR TITLE
Update developer guide to cover displays, and highlight working external plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,3 +212,18 @@ genomic translocations
 
 This is a "superview" type that contains a circular and spreadsheet view as
 child views
+
+## Internal plugin build system
+
+Plugins may be built as separate packages that can be distributed on NPM. In
+order to streamline development and avoid having to build every plugin before
+developing on e.g. JBrowse Web, however, the `package.json`'s "main" entry for
+plugins in this monorepo by default points to the un-built code (e.g.
+`src/index.ts`). JBrowse Web then takes care of building the plugins itself (see
+`products/jbrowse-web/rescripts/yarnWorkspacesRescript.js`).
+
+When you want to use a built plugin, you can run `yarn useDist` in the plugin's
+`package.json`, and then run `yarn useSrc` to restore it when you're done. As an
+example, the root-level `yarn build` that builds all the packages does this to
+build all the plugins and then build JBrowse Web and JBrowse Desktop using the
+built plugins.

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -2784,6 +2784,45 @@ Object {
       "trackId": "volvox_wrong_assembly",
       "type": "QuantitativeTrack",
     },
+    Object {
+      "adapter": Object {
+        "index": Object {
+          "location": Object {
+            "uri": "volvox.filtered.vcf.gz.tbi",
+          },
+        },
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": Object {
+          "uri": "volvox.filtered.vcf.gz",
+        },
+      },
+      "assemblyNames": Array [
+        "volvox",
+      ],
+      "category": Array [
+        "VCF",
+      ],
+      "displays": Array [
+        Object {
+          "displayId": "volvox_filtered_vcf_color-ChordVariantDisplay",
+          "renderer": Object {
+            "type": "StructuralVariantChordRenderer",
+          },
+          "type": "ChordVariantDisplay",
+        },
+        Object {
+          "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
+          "renderer": Object {
+            "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'",
+            "type": "SvgFeatureRenderer",
+          },
+          "type": "LinearVariantDisplay",
+        },
+      ],
+      "name": "volvox filtered vcf (green snp, purple indel)",
+      "trackId": "variant_colors",
+      "type": "VariantTrack",
+    },
   ],
 }
 `;

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1186,6 +1186,41 @@
           "uri": "volvox.bw.nonexist"
         }
       }
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variant_colors",
+      "name": "volvox filtered vcf (green snp, purple indel)",
+      "category": ["VCF"],
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "volvox.filtered.vcf.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "volvox.filtered.vcf.gz.tbi"
+          }
+        }
+      },
+      "displays": [
+        {
+          "type": "ChordVariantDisplay",
+          "displayId": "volvox_filtered_vcf_color-ChordVariantDisplay",
+          "renderer": {
+            "type": "StructuralVariantChordRenderer"
+          }
+        },
+        {
+          "type": "LinearVariantDisplay",
+          "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
+          "renderer": {
+            "type": "SvgFeatureRenderer",
+            "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'"
+          }
+        }
+      ]
     }
   ],
   "defaultSession": {

--- a/website/docs/developer_guide.md
+++ b/website/docs/developer_guide.md
@@ -883,11 +883,11 @@ class MyAdapter extends BaseFeatureDataAdapter {
     return ObservableCreate(async observer => {
       try {
         const { refName, start, end } = region
-        const myapi = await fetch(
+        const response = await fetch(
           'http://myservice/genes/${refName}/${start}-${end}',
           options,
         )
-        if (result.ok) {
+        if (response.ok) {
           const features = await result.json()
           features.forEach(feature => {
             observer.next(

--- a/website/docs/developer_guide.md
+++ b/website/docs/developer_guide.md
@@ -42,6 +42,34 @@ command-line tool implemented with [OCLIF](https://oclif.io/).
 This figure summarizes the general architecture of our state model and React
 component tree
 
+## Example plugins
+
+You can follow this guide for developing plugins, but you might also want to
+refer to working versions of plugins on the web now
+
+This repo contains a template for creating new plugins
+https://github.com/GMOD/jbrowse-plugin-template.
+
+Here are some examples of working plugins.
+
+- [jbrowse-plugin-ucsc-api](https://github.com/cmdcolin/jbrowse-plugin-ucsc-api) - probably the simplest plugin example, it demonstrates accessing data from
+  UCSC REST API
+- [jbrowse-plugin-gwas](https://github.com/cmdcolin/jbrowse-plugin-gwas) - a
+  custom plugin to display manhattan plot GWAS data
+- [jbrowse-plugin-biothings-api](https://github.com/cmdcolin/jbrowse-plugin-biothings-api) - demonstrates accessing data from mygene.info, part of the "biothings API"
+  family
+- [jbrowse-plugin-msaview](https://github.com/GMOD/jbrowse-plugin-msaview) -
+  demonstrates creating a custom view type that doesn't use any conventional
+  tracks
+- [jbrowse-plugin-gdc](https://github.com/GMOD/jbrowse-plugin-gdc) -
+  demonstrates accessing GDC cancer data GraphQL API, plus a custom drawer and
+  track type for coloring variants by impact score
+
+You can use these to see how plugins are generally structured, and can use the
+pluggable elements in them as templates for your own pluggable elements.
+
+We will go over what plugins do and what is in them now
+
 ## What's in a plugin
 
 A plugin is an independently distributed package of code that is designed to
@@ -75,6 +103,7 @@ The pluggable types that we have in JBrowse 2 are
 - Renderer types
 - Widgets
 - RPC calls
+- Display types
 - View types
 
 In additional to creating plugins that create new adapters, track types,
@@ -102,6 +131,26 @@ multiple adapter types
   uses getSubAdapter to instantiate it
 - `SNPCoverageAdapter` - this adapter takes a `BamAdapter` or `CramAdapter` as a
   subadapter, and calculates feature coverage from it
+
+### Displays
+
+A display is a method for displaying a particular track in a particular view
+
+For example, we have a notion of a synteny track type, and the synteny track
+type has two display models
+
+- DotplotDisplay, which is used in the dotplot view
+- LinearSyntenyDisplay, which is used in the linear synteny view
+
+This enables a single track entry to be used in multiple view types e.g. if I
+run jbrowse add-track myfile.paf, this automatically creates a synteny track
+that can be opened in both a dotplot and a linear synteny view.
+
+Most track types only have a "linear" display available, but one more example
+is the VariantTrack, which has two display methods
+
+- LinearVariantDisplay - used in linear genome view
+- ChordVariantDisplay - used in the circular view
 
 ### Renderers
 
@@ -440,6 +489,34 @@ types
   }))
 ```
 
+Note that it is also common to use this scenario, because the base display may
+implement track menu items so this is like getting the superclasses track menu
+items
+
+```js
+types
+  .model({
+    // model
+  })
+  .views(self => {
+    const { trackMenuitems } = self
+    return {
+      get composedTrackMenuItems() {
+        return [
+          {
+            label: 'Menu Item',
+            icon: AddIcon,
+            onClick: () => {},
+          },
+        ]
+      },
+      get trackMenuItems() {
+        return [...trackMenuItems, ...this.composedTrackMenuItems]
+      },
+    }
+  })
+```
+
 ### Adding track context-menu items
 
 When you right-click in a linear track, a context menu will appear if there are
@@ -493,21 +570,6 @@ class SomePlugin extends Plugin {
   }
 }
 ```
-
-### Plugin build system
-
-Plugins may be built as separate packages that can be distributed on NPM. In
-order to streamline development and avoid having to build every plugin before
-developing on e.g. JBrowse Web, however, the `package.json`'s "main" entry for
-plugins in this monorepo by default points to the un-built code (e.g.
-`src/index.ts`). JBrowse Web then takes care of building the plugins itself (see
-`products/jbrowse-web/rescripts/yarnWorkspacesRescript.js`).
-
-When you want to use a built plugin, you can run `yarn useDist` in the plugin's
-`package.json`, and then run `yarn useSrc` to restore it when you're done. As an
-example, the root-level `yarn build` that builds all the packages does this to
-build all the plugins and then build JBrowse Web and JBrowse Desktop using the
-built plugins.
 
 ## Configuration model concepts
 
@@ -610,39 +672,47 @@ various feature attributes
 
 ### Example of a config callback
 
+We currently use jexl to express callbacks. This is more limited than arbitrary
+javascript, but can be expressive
+
+See https://github.com/TomFrost/Jexl for more details
+
 If you had an variant track in your config, and wanted to make a custom config
 callback for color, it might look like this
 
 ```json
 {
   "type": "VariantTrack",
-  "trackId": "myvcf",
-  "name": "My variants",
-  "assemblyNames": ["h19"],
+  "trackId": "variant_colors",
+  "name": "volvox filtered vcf (green snp, purple indel)",
   "category": ["VCF"],
+  "assemblyNames": ["volvox"],
   "adapter": {
     "type": "VcfTabixAdapter",
     "vcfGzLocation": {
-      "uri": "test_data/volvox/volvox.filtered.vcf.gz"
+      "uri": "volvox.filtered.vcf.gz"
     },
     "index": {
       "location": {
-        "uri": "test_data/volvox/volvox.filtered.vcf.gz.tbi"
+        "uri": "volvox.filtered.vcf.gz.tbi"
       }
     }
   },
-  "renderers": {
-    "SvgFeatureRenderer": {
-      "type": "SvgFeatureRenderer",
-      "color": "feat|getData('type')=='SNV'?'green':'purple'"
+  "displays": [
+    {
+      "type": "LinearVariantDisplay",
+      "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
+      "renderer": {
+        "type": "SvgFeatureRenderer",
+        "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'"
+      }
     }
-  }
+  ]
 }
 ```
 
 This draws all SNV (single nucleotide variants) as green, and other types as
-purple (insertion, deletion, other structural variant). Note that JSON format
-doesn't allow fancy multiline
+purple (insertion, deletion, other structural variant).
 
 ### Configuration internals
 
@@ -710,6 +780,16 @@ Reading the sub-config schema is as follows
 const indexType = readConfObject(config, ['index', 'indexType'])
 ```
 
+Alternatively can use
+
+```js
+const indexConf = readConfObject(config, ['index'])
+indexConf.indexType
+```
+
+However, this may miss default values from the slot, the readConfObject has
+special logic to fill in the default value
+
 ## Creating adapters
 
 ### What is an adapter
@@ -747,6 +827,9 @@ with your adapter.
   alias for "1". An example of this in JBrowse is an adapter for
   (alias files)[http://software.broadinstitute.org/software/igv/LoadData/#aliasfile]
 
+Note about refname alias adapter: the first column must match what is seen in
+your FASTA file
+
 ### Skeleton of a feature adapter
 
 A basic feature adapter might look like this (with implementation omitted for
@@ -769,9 +852,9 @@ class MyAdapter extends BaseFeatureDataAdapter {
 }
 ```
 
-So to make a feature adapter, you implement the getRefNames function (optional),
-the getFeatures function (returns an rxjs observable stream of features,
-discussed below) and freeResources (optional)
+So to make a feature adapter, you implement the getRefNames function
+(optional), the getFeatures function (returns an rxjs observable stream of
+features, discussed below) and freeResources (optional)
 
 ### Example feature adapter
 
@@ -786,35 +869,40 @@ import { readConfObject } from '@jbrowse/core/configuration'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 
 class MyAdapter extends BaseFeatureDataAdapter {
-  // @param config - a configuration object
-  // @param getSubAdapter - function to initialize additional subadapters
+  // your constructor gets a config object that you can read with readConfObject
+  // if you use "subadapters" then you can initialize those with getSubAdapter
   constructor(config, getSubAdapter) {
     const fileLocation = readConfObject(config, 'fileLocation')
     const subadapter = readConfObject(config, 'sequenceAdapter')
     const sequenceAdapter = getSubAdapter(subadapter)
   }
 
-  // @param region - { refName:string, start:number, end:number}
-  // @param options - { signal: AbortSignal, bpPerPx: number }
-  // @return an rxjs Observable
+  // use rxjs observer.next(new SimpleFeature(...your feature data....) for each
+  // feature you want to return
   getFeatures(region, options) {
     return ObservableCreate(async observer => {
       try {
+        const { refName, start, end } = region
         const myapi = await fetch(
           'http://myservice/genes/${refName}/${start}-${end}',
+          options,
         )
-        if (result.ok) const features = await result.json()
-        features.forEach(feature => {
-          observer.next(
-            new SimpleFeature({
-              uniqueID: `${feature.chr}-${feature.start}-${feature.end}`,
-              refName: feature.chr,
-              start: feature.start,
-              end: feature.end,
-            }),
-          )
-        })
-        observer.complete()
+        if (result.ok) {
+          const features = await result.json()
+          features.forEach(feature => {
+            observer.next(
+              new SimpleFeature({
+                uniqueID: `${feature.refName}-${feature.start}-${feature.end}`,
+                refName: feature.refName,
+                start: feature.start,
+                end: feature.end,
+              }),
+            )
+          })
+          observer.complete()
+        } else {
+          throw new Error(`${response.status} - ${response.statusText}`)
+        }
       } catch (e) {
         observer.error(e)
       }
@@ -850,9 +938,11 @@ renaming](config_guide#configuring-reference-renaming)
 #### getFeatures
 
 A function that returns features from the file given a genomic
-range query e.g. getFeatures(region, options), where region is an object like
+range query e.g.
 
-The region contains
+`getFeatures(region, options)`
+
+The region parameter contains
 
 ```typescript
 interface Region {
@@ -864,7 +954,17 @@ interface Region {
 }
 ```
 
-The options can contain any number of things
+The refName, start, end specify a simple genomic range. The "assemblyName" is
+used to query a specific assembly if your adapter responds to multiple
+assemblies e.g. for a synteny data file or a REST API that queries a backend
+with multiple assemblies.
+
+The "originalRefName" are also passed, where originalRefName is the queried
+refname before ref renaming e.g. in BamAdapter, if the BAM file uses chr1, and
+your reference genome file uses 1, then originalRefName will be 1 and refName
+will be chr1
+
+The options parameter to getFeatures can contain any number of things
 
 ```typescript
 interface Options {
@@ -875,18 +975,18 @@ interface Options {
 }
 ```
 
-- bpPerPx - number: resolution of the genome browser when the features were
+- `bpPerPx` - number: resolution of the genome browser when the features were
   fetched
-- signal - can be used to abort a fetch request when it is no longer needed,
+- `signal` - can be used to abort a fetch request when it is no longer needed,
   from AbortController
-- statusCallback - not implemented yet but in the future may allow you to
+- `statusCallback` - not implemented yet but in the future may allow you to
   report the status of your loading operations
-- headers - set of HTTP headers as a JSON object
+- `headers` - set of HTTP headers as a JSON object
 
-We return an rxjs Observable. This is similar to a JBrowse 1 getFeatures call,
-where we pass each feature to a featureCallback, tell it when we are done with
-finishCallback, and send errors to errorCallback, except we do all those things
-with the Observable
+We return an rxjs Observable from getFeatures. This is similar to a JBrowse 1
+getFeatures call, where we pass each feature to a featureCallback, tell it when
+we are done with finishCallback, and send errors to errorCallback, except we do
+all those things with the Observable
 
 Here is a "conversion" of JBrowse 1 getFeatures callbacks to JBrowse 2
 observable calls
@@ -902,27 +1002,7 @@ This is uncommonly used, so most adapters make this an empty function
 Most adapters in fact use an LRU cache to make resources go away over time
 instead of manually cleaning up resources
 
-## Creating a new plugin
-
-You can use this template to create a new JBrowse plugin:
-https://github.com/GMOD/jbrowse-plugin-template.
-
-Here are some examples of plugins. You can use these to see how plugins are
-generally structured, and can use the pluggable elements in them as templates
-for your own pluggable elements.
-
-- https://github.com/GMOD/jbrowse-plugin-gdc - demonstrates accessing GDC
-  cancer data GraphQL API, plus a custom drawer and track type for coloring
-  variants by impact score
-- https://github.com/cmdcolin/jbrowse-plugin-biothings-api - demonstrates
-  accessing data from mygene.info, part of the "biothings API" family
-- https://github.com/cmdcolin/jbrowse-plugin-ucsc-api - demonstrates accessing
-  data from UCSC
-
-We will go over in detail some of these steps. Note that the best practices
-may be found by looking at the above plugins source code directly.
-
-### Intro to plugins
+### Writing your own plugin
 
 JBrowse 2 plugins can be used to add new pluggable elements (views, tracks,
 adapters, etc), and to modify behavior of the application by adding code
@@ -1044,16 +1124,13 @@ track.json
 
 ```json
 {
-  "type": "BasicTrack",
+  "type": "FeatureTrack",
   "trackId": "genehancer_ucsc",
   "name": "UCSC GeneHancer",
   "assemblyNames": ["hg38"],
   "adapter": {
     "type": "UCSCAdapter",
     "track": "geneHancerInteractionsDoubleElite"
-  },
-  "renderer": {
-    "type": "SvgFeatureRenderer"
   }
 }
 ```
@@ -1484,149 +1561,12 @@ instead of a track, but here are some reasons you might want a custom track
   automatically initialized rather than the BasicTrack (which combines any
   adapter and renderer)
 
-### What does creating a track look like
+For examples of custom track types, refer to things like
 
-When you create your plugin, you will add a cCreating a custom track is
-basically looks like this
-
-You have your config schema
-
-```js
-import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { BasicTrackConfig } from '@jbrowse/plugin-linear-genome-view'
-
-const configSchema = ConfigurationSchema(
-  'MyTrack',
-  {
-    color: {
-      type: 'string',
-      description: 'the color to use on my special features',
-      defaultValue: 'green',
-    },
-  },
-  { baseConfiguration: BasicTrackConfig, explicitlyTyped: true },
-)
-```
-
-### What are the details of configSchema and stateModel
-
-- stateModel - a mobx-state-tree object that manages track logic
-- configSchema - a combination of a "stateModel" and a "configSchema"
-
-The state model is often implemented as a composition of the "base track" and
-some custom logic
-
-```js
-import { observer } from 'mobx-react'
-import { types } from 'mobx-state-tree'
-import { BlockBasedTrack } from '@jbrowse/plugin-linear-genome-view'
-
-// A component which changes color when you click on it
-// Note that this track is an observer, so it automatically re-renders
-// when something inside the track model changes e.g. model.hasTheBellRung
-const BackgroundChangeTrack = observer(props => {
-  const { model } = props
-  return (
-    <div
-      style={{ backgroundColor: model.hasTheBellRung ? 'red' : 'green' }}
-      onClick={() => model.ringTheBell()}
-    >
-      <BlockBasedTrack {...props} />
-    </div>
-  )
-})
-
-// A track state model that implements the logic for changing the
-// background color on user click
-return types.compose(
-  'BackgroundChangeTrack',
-  BaseTrack,
-  types
-    .model({
-      hasTheBellRung: false,
-    })
-    .volatile(() => ({
-      ReactComponent: MyComponent,
-    }))
-    .actions(self => ({
-      ringTheBell() {
-        self.hasTheBellRung = true
-      },
-    })),
-)
-```
-
-This custom track type is fairly silly, but it shows us that our "track" can
-really be any React component that we want it to, and that we can control some
-logical state of the track by using mobx-state-tree
-
-### Putting it all together
-
-Here is a complete plugin that creates it's ReactComponent, configSchema,
-stateModel, and Plugin class in a single file. You are of course welcome to
-split things up into different files in your own plugins :)
-
-src/index.js
-
-```js
-import { observer } from 'mobx-react'
-import { types } from 'mobx-state-tree'
-import { BlockBasedTrack } from '@jbrowse/plugin-linear-genome-view'
-import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { BasicTrackConfig } from '@jbrowse/plugin-linear-genome-view'
-import Plugin from '@jbrowse/core/Plugin'
-
-const BackgroundChangeTrack = observer(props => {
-  const { model } = props
-  return (
-    <div
-      style={{ backgroundColor: model.hasTheBellRung ? 'red' : 'green' }}
-      onClick={() => model.ringTheBell()}
-    >
-      <BlockBasedTrack {...props} />
-    </div>
-  )
-})
-
-const stateModel = types.compose(
-  'BackgroundChangeTrack',
-  BaseTrack,
-  types
-    .model({
-      hasTheBellRung: false,
-    })
-    .volatile(() => ({
-      ReactComponent: MyComponent,
-    }))
-    .actions(self => ({
-      ringTheBell() {
-        self.hasTheBellRung = true
-      },
-    })),
-)
-
-const configSchema = ConfigurationSchema(
-  'MyTrack',
-  {
-    color: {
-      type: 'string',
-      description: 'the color to use on my special features',
-      defaultValue: 'green',
-    },
-  },
-  { baseConfiguration: BasicTrackConfig, explicitlyTyped: true },
-)
-
-export default class MyPlugin extends Plugin {
-  install(pluginManager) {
-    pluginManager.addTrackType(() => {
-      return new TrackType({
-        name: 'MyTrack',
-        compatibleView: 'LinearGenomeView', // this is the default
-        configSchema,
-        stateModel,
-      })
-    })
-  }
-}
-```
+- HicTrack, which uses a custom HicRenderer to draw contact matrix
+- GDCPlugin, which has a custom track type that registers custom feature detail
+  widgets
+- VariantTrack, which also registers custom widgets, and has
+  ChordVariantDisplay and LinearVariantDisplay
+- SyntenyTrack, which can be displayed with DotplotDisplay or
+  LinearSyntenyDisplay


### PR DESCRIPTION
This does not address anything about making factory functions because we have seen that it is unnecessary

In order to try to most accurately direct people to the right place, it puts currently working external plugin links  at the top

Then it also

1) Removes completely the "ring the bell" track type example. Although fun, I could not get it to work, and it was non-functional as written
2) Moves a specific internal codebase example to our CONTRIBUTING guide
3) Fixes a color callback example in jexl, and adds it to volvox just so we can see results easily

