### PR TITLE
Add another heuristic for returning gene features from BigBed

### DIFF
--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -126,7 +126,13 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
                   refName,
                 },
               })
-              return f.get('thickStart') && f.get('blockCount')
+
+              // collection of heuristics for suggesting that this feature
+              // should be converted to a gene, CNV bigbed has many gene like
+              // features including thickStart and blockCount but no strand
+              return f.get('thickStart') &&
+                f.get('blockCount') &&
+                f.get('strand') !== 0
                 ? ucscProcessedTranscript(f)
                 : f
             },


### PR DESCRIPTION
Currently the ClinVar CNV bigbed file classifies features as "mRNA" because it uses both thickStart and blockCount (just 1 block, but single exon genes also only have 1 block)

These are heuristics to classify the feature as an mRNA and convert to processed feature

There is nothing really that bad about this, but it tries to show the "CDS" sequence for this feature from #1758 

This adds another heuristic to also have strand not be 0 in order to convert a feature into a gene

It may not be perfect but it is hopefully keeps the current status quo