### PR TITLE
Change usage of window

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -46,7 +46,7 @@ export async function watchWorker(worker: WorkerHandle, pingTime: number) {
 
 function detectHardwareConcurrency() {
   const mainThread = typeof window !== 'undefined'
-  const canDetect = 'hardwareConcurrency' in window.navigator
+  const canDetect = mainThread && 'hardwareConcurrency' in window.navigator
   if (mainThread && canDetect) {
     return window.navigator.hardwareConcurrency
   }

--- a/packages/core/rpc/ElectronRpcDriver.ts
+++ b/packages/core/rpc/ElectronRpcDriver.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-await-in-loop,@typescript-eslint/no-explicit-any */
+/* eslint-disable no-await-in-loop */
 import shortid from 'shortid'
 import BaseRpcDriver from './BaseRpcDriver'
 import PluginManager from '../PluginManager'
@@ -13,6 +13,7 @@ declare global {
   }
 }
 const { electronBetterIpc = {}, electron } =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   typeof window !== 'undefined' ? window : ({} as any)
 
 async function wait(ms: number) {

--- a/packages/core/rpc/ElectronRpcDriver.ts
+++ b/packages/core/rpc/ElectronRpcDriver.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-await-in-loop */
+/* eslint-disable no-await-in-loop,@typescript-eslint/no-explicit-any */
 import shortid from 'shortid'
 import BaseRpcDriver from './BaseRpcDriver'
 import PluginManager from '../PluginManager'
@@ -12,7 +12,8 @@ declare global {
     electron?: import('electron').AllElectron
   }
 }
-const { electronBetterIpc = {}, electron } = window
+const { electronBetterIpc = {}, electron } =
+  typeof window !== 'undefined' ? window : ({} as any)
 
 async function wait(ms: number) {
   return new Promise(resolve => {

--- a/packages/core/util/calculateStaticBlocks.ts
+++ b/packages/core/util/calculateStaticBlocks.ts
@@ -24,8 +24,9 @@ export default function calculateStaticBlocks(
 
   // on the main thread, window.innerWidth is used because this reduces
   // recalculating the blocks, otherwise, model.width for cases such as
-  // off-main-thread
-  width = window.innerWidth || model.width,
+  // off-main-thread. also this is not a ternary because our window.innerWidth
+  // might be undefined on off-main-thread, so instead use || model.width
+  width = (typeof window !== 'undefined' && window.innerWidth) || model.width,
 ) {
   const {
     offsetPx,

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -861,10 +861,12 @@ export const complement = (() => {
 // otherwise listens for prerendered_canvas but reads empty pixels, and doesn't
 // get the contents of the canvas
 export const rIC =
-  window.requestIdleCallback ||
-  (typeof jest === 'undefined'
-    ? (cb: Function) => setTimeout(() => cb(), 1)
-    : (cb: Function) => cb())
+  // eslint-disable-next-line no-nested-ternary
+  typeof jest === 'undefined'
+    ? typeof window !== 'undefined'
+      ? window.requestIdleCallback
+      : (cb: Function) => setTimeout(() => cb(), 1)
+    : (cb: Function) => cb()
 
 // xref https://gist.github.com/tophtucker/62f93a4658387bb61e4510c37e2e97cf
 export function measureText(str: string, fontSize = 10) {

--- a/packages/core/util/io/ElectronLocalFile.ts
+++ b/packages/core/util/io/ElectronLocalFile.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { GenericFilehandle, FilehandleOptions } from 'generic-filehandle'
 
 declare global {
@@ -5,7 +6,7 @@ declare global {
     electron?: import('electron').AllElectron
   }
 }
-const { electron } = window
+const { electron } = typeof window !== 'undefined' ? window : ({} as any)
 
 type PathLike = import('fs').PathLike
 type Stats = import('fs').Stats

--- a/packages/core/util/io/ElectronLocalFile.ts
+++ b/packages/core/util/io/ElectronLocalFile.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { GenericFilehandle, FilehandleOptions } from 'generic-filehandle'
 
 declare global {
@@ -6,6 +5,8 @@ declare global {
     electron?: import('electron').AllElectron
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const { electron } = typeof window !== 'undefined' ? window : ({} as any)
 
 type PathLike = import('fs').PathLike

--- a/packages/core/util/io/ElectronRemoteFile.ts
+++ b/packages/core/util/io/ElectronRemoteFile.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any,no-underscore-dangle */
+/* eslint-disable no-underscore-dangle */
 import uri2path from 'file-uri-to-path'
 import {
   Fetcher,
@@ -15,6 +15,8 @@ declare global {
     electron?: import('electron').AllElectron
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const { electron } = typeof window !== 'undefined' ? window : ({} as any)
 
 class ElectronRemoteFileError extends Error {

--- a/packages/core/util/io/ElectronRemoteFile.ts
+++ b/packages/core/util/io/ElectronRemoteFile.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/no-explicit-any,no-underscore-dangle */
 import uri2path from 'file-uri-to-path'
 import {
   Fetcher,
@@ -15,7 +15,7 @@ declare global {
     electron?: import('electron').AllElectron
   }
 }
-const { electron } = window
+const { electron } = typeof window !== 'undefined' ? window : ({} as any)
 
 class ElectronRemoteFileError extends Error {
   public status: number | undefined


### PR DESCRIPTION
This is a tiny PR takes some of the logic out of #1125 that changes how `window` is used. This is to help with running JB2 in other contexts than the browser, where `window` might not be defined.

This is related to #1786 . I'm looking into how our React LGV works inside of a vanilla Next.js app, and have run into issues with `window` not being defined.