### PR TITLE
Move jbrowse/react-linear-genome-view storybook to lgv subdirectory

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -79,5 +79,5 @@ jobs:
       - name: Deploy Storybook for branch to S3
         run: |
           pwd
-          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/$(echo ${{github.ref}} | cut -d "/" -f3-)
+          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/lgv/$(echo ${{github.ref}} | cut -d "/" -f3-)
         working-directory: products/jbrowse-react-linear-genome-view

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -8,7 +8,6 @@ import {
   ThemeProvider,
 } from '../src'
 import volvoxConfig from '../public/test_data/volvox/config.json'
-import humanConfig from '../public/test_data/config.json'
 import volvoxSession from '../public/volvox-session.json'
 
 export default {
@@ -163,7 +162,35 @@ export const WithRuntimePlugins = () => {
   }
 
   const state = createViewState({
-    assembly: humanConfig.assemblies[0],
+    assembly: {
+      name: 'hg19',
+      aliases: ['GRCh37'],
+      sequence: {
+        type: 'ReferenceSequenceTrack',
+        trackId: 'Pd8Wh30ei9R',
+        adapter: {
+          type: 'BgzipFastaAdapter',
+          fastaLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
+          },
+          faiLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
+          },
+          gziLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
+          },
+        },
+      },
+      refNameAliases: {
+        adapter: {
+          type: 'RefNameAliasAdapter',
+          location: {
+            uri:
+              'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
+          },
+        },
+      },
+    },
     plugins,
     tracks: [
       {

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -8,6 +8,7 @@ import {
   ThemeProvider,
 } from '../src'
 import volvoxConfig from '../public/test_data/volvox/config.json'
+import humanConfig from '../public/test_data/config.json'
 import volvoxSession from '../public/volvox-session.json'
 
 export default {
@@ -146,12 +147,11 @@ export const WithRuntimePlugins = () => {
   useEffect(() => {
     async function getPlugins() {
       const loadedPlugins = await loadPlugins([
-        /* array of plugin definitions like:
         {
-          "name": "GDC",
-          "url": "http://localhost:9000/plugin.js"
-        }
-        */
+          name: 'UCSC',
+          url:
+            'https://unpkg.com/jbrowse-plugin-ucsc@^1/dist/jbrowse-plugin-ucsc.umd.production.min.js',
+        },
       ])
       setPlugins(loadedPlugins)
     }
@@ -163,11 +163,60 @@ export const WithRuntimePlugins = () => {
   }
 
   const state = createViewState({
-    assembly,
-    tracks,
-    defaultSession,
-    location: 'ctgA:1105..1221',
+    assembly: humanConfig.assemblies[0],
     plugins,
+    tracks: [
+      {
+        type: 'FeatureTrack',
+        trackId: 'segdups_ucsc_hg19',
+        name: 'UCSC SegDups',
+        category: ['Annotation'],
+        assemblyNames: ['hg19'],
+        adapter: {
+          type: 'UCSCAdapter',
+          track: 'genomicSuperDups',
+        },
+      },
+    ],
+    location: '1:2,467,681..2,667,681',
+    defaultSession: {
+      name: 'Runtime plugins',
+      view: {
+        id: 'aU9Nqje1U',
+        type: 'LinearGenomeView',
+        offsetPx: 22654,
+        bpPerPx: 108.93300653594771,
+        displayedRegions: [
+          {
+            refName: '1',
+            start: 0,
+            end: 249250621,
+            reversed: false,
+            assemblyName: 'hg19',
+          },
+        ],
+        tracks: [
+          {
+            id: 'MbiRphmDa',
+            type: 'FeatureTrack',
+            configuration: 'segdups_ucsc_hg19',
+            displays: [
+              {
+                id: '8ovhuA5cFM',
+                type: 'LinearBasicDisplay',
+                height: 100,
+                configuration: 'segdups_ucsc_hg19-LinearBasicDisplay',
+              },
+            ],
+          },
+        ],
+        hideHeader: false,
+        hideHeaderOverview: false,
+        trackSelectorType: 'hierarchical',
+        trackLabels: 'overlapping',
+        showCenterLine: false,
+      },
+    },
   })
   return (
     <ThemeProvider theme={theme}>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -40,14 +40,11 @@ function Home() {
   const { currentLink } = siteConfig.customFields
   const pathArray = currentLink.split('/')
   const currentVersion = pathArray[pathArray.length - 2]
-  const storybookLink = `https://jbrowse.org/storybook/${currentVersion}/`
+  const storybookLink = `https://jbrowse.org/storybook/lgv/${currentVersion}/`
   const classes = useStyles()
 
   return (
-    <Layout
-      title={`${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
-    >
+    <Layout title={`${siteConfig.title}`}>
       <div className={classes.body}>
         <div className={classes.container}>
           <div style={{ flexBasis: '50%' }}>
@@ -64,28 +61,22 @@ function Home() {
             <ul>
               <li>
                 {' '}
-                <Link href="/jb2/blog" variant="contained">
-                  Download latest web release
-                </Link>
+                <Link href="/jb2/blog">Download latest web release</Link>
               </li>
               <li>
-                <Link href={currentLink} variant="contained">
-                  Browse web demo instance
-                </Link>
+                <Link href={currentLink}>Browse web demo instance</Link>
               </li>
             </ul>
             <h3>Embedded</h3>
             <ul>
               <li>
-                <Link href={storybookLink} variant="contained">
+                <Link href="https://www.npmjs.com/package/@jbrowse/react-linear-genome-view">
                   Linear genome view React component on <tt>npm</tt>
-                </Link>
+                </Link>{' '}
+                <Link href={storybookLink}>(example usages)</Link>
               </li>
               <li>
-                <Link
-                  href="https://gmod.github.io/JBrowseR/"
-                  variant="contained"
-                >
+                <Link href="https://gmod.github.io/JBrowseR/">
                   JBrowseR R package on <tt>CRAN</tt>
                 </Link>
               </li>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -73,7 +73,7 @@ function Home() {
                 <Link href="https://www.npmjs.com/package/@jbrowse/react-linear-genome-view">
                   Linear genome view React component on <tt>npm</tt>
                 </Link>{' '}
-                <Link href={storybookLink}>(example usages)</Link>
+                <Link href={storybookLink}>(docs)</Link>
               </li>
               <li>
                 <Link href="https://gmod.github.io/JBrowseR/">


### PR DESCRIPTION
This is a silly PR but it proposes moving the storybook generated to jbrowse.org/storybook/lgv/master instead of jbrowse.org/storybook/master

This allows us to use the same directory for other components if needed

Also makes it so that storybook is a supplementary link on the homepage