### PR TITLE
Clear tracks when using "Return to import form"

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1279,9 +1279,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       // this "clears the view" and makes the view return to the import form
       clearView() {
         self.setDisplayedRegions([])
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        self.tracks = [] as any
+        self.tracks.clear()
         // it is necessary to run these after setting displayed regions empty
         // or else model.offsetPx gets set to Infinity and breaks
         // mobx-state-tree snapshot

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -1279,6 +1279,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
       // this "clears the view" and makes the view return to the import form
       clearView() {
         self.setDisplayedRegions([])
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        self.tracks = [] as any
         // it is necessary to run these after setting displayed regions empty
         // or else model.offsetPx gets set to Infinity and breaks
         // mobx-state-tree snapshot


### PR DESCRIPTION
Reported by https://github.com/li153348734 in the gitter chat, this is a small fix where the tracks remained after using "Return to import form" and changing assemblies but the tracks weren't cleared out https://files.gitter.im/5c59cb65d73408ce4fb6f58e/BIz5/image.png


I checked other options in the linear-genome-view state that might also need to be "cleared" but didn't see any. Any further update that might need clearing can go into "clearView"