### PR TITLE
Remove some animation effects

### DIFF
--- a/packages/core/ui/Drawer.js
+++ b/packages/core/ui/Drawer.js
@@ -1,5 +1,4 @@
 import Paper from '@material-ui/core/Paper'
-import Slide from '@material-ui/core/Slide'
 import { makeStyles } from '@material-ui/core/styles'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'

--- a/packages/core/ui/Drawer.js
+++ b/packages/core/ui/Drawer.js
@@ -22,26 +22,23 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-function Drawer({ children, open, session }) {
+function Drawer({ children, session }) {
   const classes = useStyles()
 
   return (
-    <Slide in={open} direction="left">
-      <Paper className={classes.paper} elevation={16} square>
-        <ResizeHandle
-          onDrag={session.resizeDrawer}
-          className={classes.resizeHandle}
-          vertical
-        />
-        {children}
-      </Paper>
-    </Slide>
+    <Paper className={classes.paper} elevation={16} square>
+      <ResizeHandle
+        onDrag={session.resizeDrawer}
+        className={classes.resizeHandle}
+        vertical
+      />
+      {children}
+    </Paper>
   )
 }
 
 Drawer.propTypes = {
   children: PropTypes.node,
-  open: PropTypes.bool.isRequired,
   session: MobxPropTypes.observableObject.isRequired,
 }
 

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -1,14 +1,19 @@
-import Divider from '@material-ui/core/Divider'
-import ListItemIcon from '@material-ui/core/ListItemIcon'
-import ListItemText from '@material-ui/core/ListItemText'
-import ListSubheader from '@material-ui/core/ListSubheader'
-import { MenuProps as MUIMenuProps } from '@material-ui/core/Menu'
-import MenuItem, { MenuItemProps } from '@material-ui/core/MenuItem'
-import MenuList from '@material-ui/core/MenuList'
-import Paper from '@material-ui/core/Paper'
-import Popover, { PopoverProps } from '@material-ui/core/Popover'
-import { SvgIconProps } from '@material-ui/core/SvgIcon'
-import { makeStyles } from '@material-ui/core/styles'
+import {
+  Divider,
+  Grow,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  MenuProps as MUIMenuProps,
+  MenuItem,
+  MenuItemProps,
+  MenuList,
+  Paper,
+  Popover,
+  PopoverProps,
+  SvgIconProps,
+  makeStyles,
+} from '@material-ui/core'
 import ArrowRightIcon from '@material-ui/icons/ArrowRight'
 import CheckBoxIcon from '@material-ui/icons/CheckBox'
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
@@ -178,7 +183,7 @@ function findPreviousValidIdx(menuItems: MenuItem[], currentIdx: number) {
   )
 }
 
-const MenuPage = (props: MenuPageProps) => {
+const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
   const [subMenuAnchorEl, setSubMenuAnchorEl] = useState<null | HTMLElement>(
     null,
   )
@@ -384,20 +389,18 @@ const MenuPage = (props: MenuPageProps) => {
   }
 
   return (
-    <>
-      {open ? (
-        <Paper
-          elevation={8}
-          ref={paperRef}
-          className={classes.paper}
-          style={{ ...position }}
-        >
-          {ListContents}
-        </Paper>
-      ) : null}
-    </>
+    <Grow in={open} style={{ transformOrigin: '0 0 0' }} ref={ref}>
+      <Paper
+        elevation={8}
+        ref={paperRef}
+        className={classes.paper}
+        style={{ ...position }}
+      >
+        {ListContents}
+      </Paper>
+    </Grow>
   )
-}
+})
 
 interface MenuProps extends PopoverProps {
   menuItems: MenuItem[]
@@ -409,6 +412,7 @@ interface MenuProps extends PopoverProps {
 
 function Menu(props: MenuProps) {
   const { open, onClose, menuItems, onMenuItemClick, ...other } = props
+
   return (
     <Popover
       transitionDuration={0}

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -1,5 +1,4 @@
 import Divider from '@material-ui/core/Divider'
-import Grow from '@material-ui/core/Grow'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListSubheader from '@material-ui/core/ListSubheader'
@@ -179,7 +178,7 @@ function findPreviousValidIdx(menuItems: MenuItem[], currentIdx: number) {
   )
 }
 
-const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
+const MenuPage = (props: MenuPageProps) => {
   const [subMenuAnchorEl, setSubMenuAnchorEl] = useState<null | HTMLElement>(
     null,
   )
@@ -385,18 +384,20 @@ const MenuPage = React.forwardRef((props: MenuPageProps, ref) => {
   }
 
   return (
-    <Grow in={open} style={{ transformOrigin: '0 0 0' }} ref={ref}>
-      <Paper
-        elevation={8}
-        ref={paperRef}
-        className={classes.paper}
-        style={{ ...position }}
-      >
-        {ListContents}
-      </Paper>
-    </Grow>
+    <>
+      {open ? (
+        <Paper
+          elevation={8}
+          ref={paperRef}
+          className={classes.paper}
+          style={{ ...position }}
+        >
+          {ListContents}
+        </Paper>
+      ) : null}
+    </>
   )
-})
+}
 
 interface MenuProps extends PopoverProps {
   menuItems: MenuItem[]
@@ -410,6 +411,7 @@ function Menu(props: MenuProps) {
   const { open, onClose, menuItems, onMenuItemClick, ...other } = props
   return (
     <Popover
+      transitionDuration={0}
       open={open}
       onClose={onClose}
       BackdropProps={{ invisible: true }}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -58,53 +58,51 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
     : []
 
   return (
-
-      <div className={classes.track}>
-        <Tooltip title={titleText} placement="left" enterDelay={500}>
-          <FormControlLabel
-            className={classes.formControlLabel}
-            control={
-              <Checkbox
-                inputProps={{
-                  'data-testid': `htsTrackEntry-${trackId}`,
-                }}
-                className={classes.checkbox}
-              />
-            }
-            label={
-              assemblyName ? `Reference Sequence (${assemblyName})` : trackName
-            }
-            checked={model.view.tracks.some(t => t.configuration === trackConf)}
-            onChange={() => model.view.toggleTrack(trackConf.trackId)}
-            disabled={disabled || unsupported}
-          />
-        </Tooltip>
-        {menuItems.length ? (
-          <IconButton
-            className={classes.configureButton}
-            onClick={event => {
-              setAnchorEl(event.currentTarget)
-            }}
-            color="secondary"
-            data-testid={`htsTrackEntryMenu-${trackId}`}
-          >
-            <HorizontalDots />
-          </IconButton>
-        ) : null}
-        <Menu
-          anchorEl={anchorEl}
-          onMenuItemClick={(_, callback) => {
-            callback()
-            setAnchorEl(null)
-          }}
-          open={Boolean(anchorEl)}
-          onClose={() => {
-            setAnchorEl(null)
-          }}
-          menuItems={menuItems}
+    <div className={classes.track}>
+      <Tooltip title={titleText} placement="left" enterDelay={500}>
+        <FormControlLabel
+          className={classes.formControlLabel}
+          control={
+            <Checkbox
+              inputProps={{
+                'data-testid': `htsTrackEntry-${trackId}`,
+              }}
+              className={classes.checkbox}
+            />
+          }
+          label={
+            assemblyName ? `Reference Sequence (${assemblyName})` : trackName
+          }
+          checked={model.view.tracks.some(t => t.configuration === trackConf)}
+          onChange={() => model.view.toggleTrack(trackConf.trackId)}
+          disabled={disabled || unsupported}
         />
-      </div>
-
+      </Tooltip>
+      {menuItems.length ? (
+        <IconButton
+          className={classes.configureButton}
+          onClick={event => {
+            setAnchorEl(event.currentTarget)
+          }}
+          color="secondary"
+          data-testid={`htsTrackEntryMenu-${trackId}`}
+        >
+          <HorizontalDots />
+        </IconButton>
+      ) : null}
+      <Menu
+        anchorEl={anchorEl}
+        onMenuItemClick={(_, callback) => {
+          callback()
+          setAnchorEl(null)
+        }}
+        open={Boolean(anchorEl)}
+        onClose={() => {
+          setAnchorEl(null)
+        }}
+        menuItems={menuItems}
+      />
+    </div>
   )
 }
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/TrackEntry.js
@@ -3,7 +3,6 @@ import { readConfObject } from '@jbrowse/core/configuration'
 import { getSession } from '@jbrowse/core/util'
 import { Menu } from '@jbrowse/core/ui'
 import Checkbox from '@material-ui/core/Checkbox'
-import Fade from '@material-ui/core/Fade'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
@@ -59,7 +58,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
     : []
 
   return (
-    <Fade in>
+
       <div className={classes.track}>
         <Tooltip title={titleText} placement="left" enterDelay={500}>
           <FormControlLabel
@@ -105,7 +104,7 @@ function TrackEntry({ model, disabled, trackConf, assemblyName }) {
           menuItems={menuItems}
         />
       </div>
-    </Fade>
+
   )
 }
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -60,7 +60,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
   >
     <div
       class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
         class="MuiFormControlLabel-root makeStyles-formControlLabel"
@@ -197,7 +196,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
               >
                 <div
                   class="makeStyles-track"
-                  style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
                 >
                   <label
                     class="MuiFormControlLabel-root makeStyles-formControlLabel"
@@ -329,7 +327,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
                           >
                             <div
                               class="makeStyles-track"
-                              style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
                             >
                               <label
                                 class="MuiFormControlLabel-root makeStyles-formControlLabel"
@@ -496,7 +493,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
   >
     <div
       class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
         class="MuiFormControlLabel-root makeStyles-formControlLabel"
@@ -571,7 +567,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
   >
     <div
       class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
         class="MuiFormControlLabel-root makeStyles-formControlLabel"
@@ -640,7 +635,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
     </div>
     <div
       class="makeStyles-track"
-      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
     >
       <label
         class="MuiFormControlLabel-root makeStyles-formControlLabel"


### PR DESCRIPTION
I sometimes get the sense that the drawer slide-in animations feels laggy

We can remove this animation, and to me, this produces the feeling of the app being faster and snappier. Note that we have a slide in but not a slide out currently so this basically just makes it more even also

Similar things can be done for the menu. Currently, it does a growing expansion that isn't necessarily that laggy but to me, it feels (and is) faster if the menu appears instantly

My operating system menus do not have any delay for example, so it feels more native