### PR TITLE
Standardized sentence casing on drawer widget titles

### DIFF
--- a/plugins/alignments/src/index.ts
+++ b/plugins/alignments/src/index.ts
@@ -124,7 +124,7 @@ export default class AlignmentsPlugin extends Plugin {
       () =>
         new WidgetType({
           name: 'AlignmentsFeatureWidget',
-          heading: 'Feature Details',
+          heading: 'Feature details',
           configSchema: alignmentsFeatureDetailConfigSchema,
           stateModel: alignmentsFeatureDetailStateModelFactory(pluginManager),
           ReactComponent: AlignmentsFeatureDetailReactComponent,

--- a/plugins/breakpoint-split-view/src/index.ts
+++ b/plugins/breakpoint-split-view/src/index.ts
@@ -19,7 +19,7 @@ export default class BreakpointSplitViewPlugin extends Plugin {
       () =>
         new WidgetType({
           name: 'BreakpointAlignmentsWidget',
-          heading: 'Breakpoint Feature Details',
+          heading: 'Breakpoint feature details',
           configSchema: alignmentsFeatureDetailConfigSchema,
           stateModel: alignmentsFeatureDetailStateModel,
           ReactComponent: AlignmentsFeatureDetailReactComponent,

--- a/plugins/config/src/ConfigurationEditorWidget/index.js
+++ b/plugins/config/src/ConfigurationEditorWidget/index.js
@@ -8,12 +8,12 @@ export const configSchema = ConfigurationSchema('ConfigurationEditorWidget', {})
 export const HeadingComponent = observer(({ model }) => {
   if (model && model.target) {
     if (model.target.type) {
-      return `${model.target.type} Settings`
+      return `${model.target.type} settings`
     }
     if (isStateTreeNode(model.target)) {
       const type = getType(model.target)
       if (type && type.name) {
-        return `${type.name.replace('ConfigurationSchema', '')} Settings`
+        return `${type.name.replace('ConfigurationSchema', '')} settings`
       }
     }
   }

--- a/plugins/data-management/src/index.ts
+++ b/plugins/data-management/src/index.ts
@@ -51,7 +51,7 @@ export default class extends Plugin {
     pluginManager.addWidgetType(() => {
       return new WidgetType({
         name: 'HierarchicalTrackSelectorWidget',
-        heading: 'Available Tracks',
+        heading: 'Available tracks',
         configSchema: HierarchicalTrackSelectorConfigSchema,
         stateModel: HierarchicalTrackSelectorStateModelFactory(pluginManager),
         ReactComponent: HierarchicalTrackSelectorReactComponent,

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -124,7 +124,7 @@ export default class LinearGenomeViewPlugin extends Plugin {
       () =>
         new WidgetType({
           name: 'BaseFeatureWidget',
-          heading: 'Feature Details',
+          heading: 'Feature details',
           configSchema: baseFeatureWidgetConfigSchema,
           stateModel: baseFeatureWidgetStateModelFactory(pluginManager),
           ReactComponent: BaseFeatureWidgetReactComponent,

--- a/plugins/variants/src/index.ts
+++ b/plugins/variants/src/index.ts
@@ -81,7 +81,7 @@ export default class VariantsPlugin extends Plugin {
       () =>
         new WidgetType({
           name: 'VariantFeatureWidget',
-          heading: 'Feature Details',
+          heading: 'Feature details',
           configSchema: variantFeatureWidgetConfigSchema,
           stateModel: variantFeatureWidgetStateModelFactory(pluginManager),
           ReactComponent: VariantFeatureWidgetReactComponent,


### PR DESCRIPTION
This is a nitpicky change but I thought I would propose to use sentence casing on drawer titles

Seeing a list of items in the new select box makes it more obvious when we are not consistent

Note that "Add a track" and "Add a connection" are currently sentence case so this is more consistent with those examples
