### PR TITLE
Change jexl callback helpers for features to use more functions and less transforms

### DIFF
--- a/packages/core/configuration/configurationSlot.test.ts
+++ b/packages/core/configuration/configurationSlot.test.ts
@@ -46,13 +46,13 @@ test('can convert a stringArray slot to and from a callback', () => {
 test('can convert a slot with a default function value to a scalar value', () => {
   const model = ConfigSlot('tester', {
     type: 'string',
-    defaultValue: 'jexl:feature|getData("foo")',
+    defaultValue: 'jexl:get(feature,"foo")',
   })
   const instance = model.create()
-  expect(instance.value).toBe('jexl:feature|getData("foo")')
+  expect(instance.value).toBe('jexl:get(feature,"foo")')
   expect(() => instance.expr.evalSync()).toThrow()
   instance.convertToCallback()
-  expect(instance.value).toBe('jexl:feature|getData("foo")')
+  expect(instance.value).toBe('jexl:get(feature,"foo")')
   expect(() => instance.expr.evalSync()).toThrow()
   instance.convertToValue()
   expect(instance.value).not.toContain('jexl:')

--- a/packages/core/util/jexl.ts
+++ b/packages/core/util/jexl.ts
@@ -6,27 +6,28 @@ type JexlWithAddFunction = typeof jexl & {
 }
 type JexlNonBuildable = Omit<typeof jexl, 'Jexl'>
 
-function createJexlInstance(/* config?: any*/): JexlNonBuildable {
-  const jexlInstance = new jexl.Jexl()
-  // someday will make sure all of configs callbacks are added in, including ones passed in
+export default function (/* config?: any*/): JexlNonBuildable {
+  const j = new jexl.Jexl() as JexlWithAddFunction
+  // someday will make sure all of configs callbacks are added in, including
+  // ones passed in
 
   // below are core functions
-  jexlInstance.addTransform('getData', (feature: Feature, data: string) => {
+  j.addFunction('get', (feature: Feature, data: string) => {
     return feature.get(data)
   })
 
-  jexlInstance.addTransform('getId', (feature: Feature) => {
+  j.addFunction('id', (feature: Feature) => {
     return feature.id()
   })
 
   // let user cast a jexl type into a javascript type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  jexlInstance.addTransform('cast', (arg: any) => {
+  j.addFunction('cast', (arg: any) => {
     return arg
   })
 
   // logging
-  jexlInstance.addTransform('log', (thing: unknown) => {
+  j.addFunction('log', (thing: unknown) => {
     // eslint-disable-next-line no-console
     console.log(thing)
     return thing
@@ -34,105 +35,82 @@ function createJexlInstance(/* config?: any*/): JexlNonBuildable {
 
   // math
   // addfunction added in jexl 2.3 but types/jexl still on 2.2
-  ;(jexlInstance as JexlWithAddFunction).addFunction('max', Math.max)
-  ;(jexlInstance as JexlWithAddFunction).addFunction('min', Math.min)
-  jexlInstance.addTransform('sqrt', Math.sqrt)
-  jexlInstance.addTransform('ceil', Math.ceil)
-  jexlInstance.addTransform('floor', Math.floor)
-  jexlInstance.addTransform('round', Math.round)
-  jexlInstance.addTransform('abs', Math.abs)
+  j.addFunction('max', Math.max)
+  j.addFunction('min', Math.min)
+  j.addFunction('sqrt', Math.sqrt)
+  j.addFunction('ceil', Math.ceil)
+  j.addFunction('floor', Math.floor)
+  j.addFunction('round', Math.round)
+  j.addFunction('abs', Math.abs)
 
   // string
-  jexlInstance.addTransform('split', (str: string, char: string) =>
-    str.split(char),
-  )
-  jexlInstance.addTransform('charAt', (str: string, index: number) =>
-    str.charAt(index),
-  )
-  jexlInstance.addTransform('charCodeAt', (str: string, index: number) =>
+  j.addFunction('split', (str: string, char: string) => str.split(char))
+  j.addFunction('charAt', (str: string, index: number) => str.charAt(index))
+  j.addFunction('charCodeAt', (str: string, index: number) =>
     str.charCodeAt(index),
   )
-  jexlInstance.addTransform('codePointAt', (str: string, pos: number) =>
+  j.addFunction('codePointAt', (str: string, pos: number) =>
     str.codePointAt(pos),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'endsWith',
-    (str: string, searchStr: string, length?: number | undefined) => {
-      str.endsWith(searchStr, length)
-    },
+    (str: string, searchStr: string, length?: number | undefined) =>
+      str.endsWith(searchStr, length),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'padEnd',
-    (str: string, targetLength: number, padString?: string | undefined) => {
-      str.padEnd(targetLength, padString)
-    },
+    (str: string, targetLength: number, padString?: string | undefined) =>
+      str.padEnd(targetLength, padString),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'padStart',
-    (str: string, targetLength: number, fillString?: string | undefined) => {
-      str.padStart(targetLength, fillString)
-    },
+    (str: string, targetLength: number, fillString?: string | undefined) =>
+      str.padStart(targetLength, fillString),
   )
-  jexlInstance.addTransform('repeat', (str: string, count: number) => {
-    str.repeat(count)
-  })
-  jexlInstance.addTransform(
-    'replace',
-    (str: string, match: string, newSubStr: string) => {
-      str.replace(match, newSubStr)
-    },
+  j.addFunction('repeat', (str: string, count: number) => str.repeat(count))
+  j.addFunction('replace', (str: string, match: string, newSubStr: string) =>
+    str.replace(match, newSubStr),
   )
-  jexlInstance.addTransform(
-    'replaceAll',
-    (str: string, match: string, newSubStr: string) => {
-      str.replaceAll(match, newSubStr)
-    },
+  j.addFunction('replaceAll', (str: string, match: string, newSubStr: string) =>
+    str.replaceAll(match, newSubStr),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'slice',
-    (str: string, start: number, end?: number | undefined) => {
-      str.slice(start, end)
-    },
+    (str: string, start: number, end?: number | undefined) =>
+      str.slice(start, end),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'startsWith',
-    (str: string, searchStr: string, position?: number | undefined) => {
-      str.startsWith(searchStr, position)
-    },
+    (str: string, searchStr: string, position?: number | undefined) =>
+      str.startsWith(searchStr, position),
   )
-  jexlInstance.addTransform(
+  j.addFunction(
     'substring',
-    (str: string, start: number, end?: number | undefined) => {
-      str.substring(start, end)
-    },
+    (str: string, start: number, end?: number | undefined) =>
+      str.substring(start, end),
   )
-  jexlInstance.addTransform('toLowerCase', (str: string) => {
-    str.toLowerCase()
-  })
-  jexlInstance.addTransform('toUpperCase', (str: string) => {
-    str.toUpperCase()
-  })
-  jexlInstance.addTransform('trim', (str: string) => {
+  j.addFunction('toLowerCase', (str: string) => str.toLowerCase())
+  j.addFunction('toUpperCase', (str: string) => str.toUpperCase())
+  j.addFunction('trim', (str: string) => {
     str.trim()
   })
-  jexlInstance.addTransform('trimEnd', (str: string) => {
-    str.trimEnd()
-  })
-  jexlInstance.addTransform('trimStart', (str: string) => {
-    str.trimStart()
-  })
+  j.addFunction('trimEnd', (str: string) => str.trimEnd())
+  j.addFunction('trimStart', (str: string) => str.trimStart())
 
-  jexlInstance.addTransform('hashcode', (str: string) => {
-    return str
+  j.addFunction('hashcode', (str: string) =>
+    str
       .split('')
       .map(c => c.charCodeAt(0))
-      .reduce((a, b) => a + b, 0)
+      .reduce((a, b) => a + b, 0),
+  )
+
+  j.addFunction('getTag', (feature: Feature, str: string) => {
+    const tags = feature.get('tags')
+    return tags ? tags[str] : feature.get(str)
   })
 
   // eslint-disable-next-line no-bitwise
-  jexlInstance.addBinaryOp('&', 15, (a: number, b: number) => a & b)
+  j.addBinaryOp('&', 15, (a: number, b: number) => a & b)
 
-  return jexlInstance
+  return j
 }
-
-export default createJexlInstance

--- a/packages/core/util/jexl.ts
+++ b/packages/core/util/jexl.ts
@@ -53,6 +53,11 @@ export default function (/* config?: any*/): JexlNonBuildable {
     str.codePointAt(pos),
   )
   j.addFunction(
+    'startsWith',
+    (str: string, searchStr: string, length?: number | undefined) =>
+      str.startsWith(searchStr, length),
+  )
+  j.addFunction(
     'endsWith',
     (str: string, searchStr: string, length?: number | undefined) =>
       str.endsWith(searchStr, length),
@@ -96,13 +101,6 @@ export default function (/* config?: any*/): JexlNonBuildable {
   })
   j.addFunction('trimEnd', (str: string) => str.trimEnd())
   j.addFunction('trimStart', (str: string) => str.trimStart())
-
-  j.addFunction('hashcode', (str: string) =>
-    str
-      .split('')
-      .map(c => c.charCodeAt(0))
-      .reduce((a, b) => a + b, 0),
-  )
 
   j.addFunction('getTag', (feature: Feature, str: string) => {
     const tags = feature.get('tags')

--- a/packages/core/util/jexlStrings.test.js
+++ b/packages/core/util/jexlStrings.test.js
@@ -27,18 +27,18 @@ describe('function string parsing', () => {
       end: 9,
     })
     expect(
-      stringToJexlExpression(`jexl:feature|getData('score')`).evalSync({
+      stringToJexlExpression(`jexl:get(feature,'score')`).evalSync({
         feature,
       }),
     ).toEqual(10)
     expect(
-      stringToJexlExpression(`jexl:feature|getData('uniqueId')`).evalSync({
+      stringToJexlExpression(`jexl:get(feature,'uniqueId')`).evalSync({
         feature,
       }),
     ).toBe('jexlFeature')
     expect(
       stringToJexlExpression(
-        `jexl:feature|getData('end') - feature|getData('start') == 8`,
+        `jexl:get(feature,'end') - get(feature,'start') == 8`,
       ).evalSync({ feature }),
     ).toBe(true)
   })

--- a/packages/core/util/jexlStrings.ts
+++ b/packages/core/util/jexlStrings.ts
@@ -17,7 +17,7 @@ export function stringToJexlExpression(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   jexl?: any,
 ) {
-  const cacheKey = `${'nosig'}|${str}`
+  const cacheKey = `nosig|${str}`
   if (!compilationCache[cacheKey]) {
     const match = str.startsWith('jexl:')
     if (!match) {

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -378,18 +378,17 @@ const stateModelFactory = (
           if (self.filterBy) {
             const { flagInclude, flagExclude } = self.filterBy
             filters = [
-              `jexl:((feature|getData('flags')&${flagInclude})==${flagInclude}) && !(feature|getData('flags')&${flagExclude})`,
+              `jexl:((get(feature,'flags')&${flagInclude})==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
             ]
             if (self.filterBy.tagFilter) {
               const { tag, value } = self.filterBy.tagFilter
               filters.push(
-                `jexl:"${value}" =='*' ? (feature|getData('tags) ? feature|getData('tags)["${tag}"] : feature|getData("${tag}")) != undefined\n
-                : feature|getData('tags') ? feature|getData('tags')["${tag}"] : feature|getData("${tag}")) == "${value}")`,
+                `jexl:"${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}")`,
               )
             }
             if (self.filterBy.readName) {
               const { readName } = self.filterBy
-              filters.push(`jexl:feature|getData('name') == "${readName}"`)
+              filters.push(`jexl:get(feature,'name') == "${readName}"`)
             }
           }
           return filters

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -148,20 +148,19 @@ const stateModelFactory = (
           if (self.filterBy) {
             const { flagInclude, flagExclude } = self.filterBy
             filters = [
-              `jexl:feature|getData('snpinfo') != undefined ? true : ((feature|getData('flags')&${flagInclude})==${flagInclude}) && !(feature|getData('flags')&${flagExclude})`,
+              `jexl:get(feature,'snpinfo') != undefined ? true : ((get(feature,'flags')&${flagInclude})==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
             ]
 
             if (self.filterBy.tagFilter) {
               const { tag, value } = self.filterBy.tagFilter
               filters.push(
-                `jexl:feature|getData('snpinfo') ? true : "${value}" =='*' ? (feature|getData('tags') ? feature|getData('tags')["${tag}"] : feature|getData("${tag}")) != undefined\n
-                : (feature|getData('tags') ? feature|getData('tags')["${tag}"] : feature|getData("${tag}")) == "${value}")`,
+                `jexl:get(feature,'snpinfo') ? true : "${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}")`,
               )
             }
             if (self.filterBy.readName) {
               const { readName } = self.filterBy
               filters.push(
-                `jexl:feature|getData('snpinfo') ? true : feature|getData('name') == "${readName}"`,
+                `jexl:get(feature,'snpinfo') ? true : get(feature,'name') == "${readName}"`,
               )
             }
           }

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -777,13 +777,13 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
             spellcheck="false"
             style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-size: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
           >
-            feature|getData('name')
+            get(feature,'name')
           </textarea>
           <pre
             aria-hidden="true"
             style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-size: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: relative; pointer-events: none; padding: 10px 10px 10px 10px;"
           >
-            feature|getData('name')
+            get(feature,'name')
             <br />
           </pre>
           <style

--- a/plugins/filtering/src/LinearFilteringDisplay/model.js
+++ b/plugins/filtering/src/LinearFilteringDisplay/model.js
@@ -9,7 +9,7 @@ function makeFilters(displayModel) {
   for (const attrName of filterOut.keys()) {
     for (const value of filterOut.get(attrName).keys()) {
       if (filterOut.get(attrName).get(value)) {
-        filters.push(`jexl:feature|getData('${attrName}') != '${value}'`)
+        filters.push(`jexl:get(feature,'${attrName}') != '${value}'`)
       }
     }
   }

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/configSchema.ts
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/configSchema.ts
@@ -9,7 +9,7 @@ export default function configSchemaFactory(pluginManager: PluginManager) {
       mouseover: {
         type: 'string',
         description: 'what to display in a given mouseover',
-        defaultValue: `jexl:feature|getData('name')`,
+        defaultValue: `jexl:get(feature,'name')`,
 
         contextVariable: ['feature'],
       },

--- a/plugins/lollipop/src/LollipopRenderer/configSchema.ts
+++ b/plugins/lollipop/src/LollipopRenderer/configSchema.ts
@@ -24,14 +24,14 @@ export default ConfigurationSchema(
     radius: {
       type: 'number',
       description: 'radius in pixels of each lollipop body',
-      defaultValue: `jexl:max(3, (feature|getData('score')*10)/3.14)|sqrt`,
+      defaultValue: `jexl:sqrt(max(3, (get(feature,'score')*10)/3.14))`,
       contextVariable: ['feature'],
     },
     caption: {
       type: 'string',
       description:
         'the tooltip caption displayed when the mouse hovers over a lollipop',
-      defaultValue: `jexl:feature|getData('name')`,
+      defaultValue: `jexl:get(feature,'name')`,
       contextVariable: ['feature'],
     },
     minStickLength: {
@@ -55,7 +55,7 @@ export default ConfigurationSchema(
       type: 'number',
       description:
         'the "score" of each lollipop, displayed as a number in the center of the circle',
-      defaultValue: `jexl:feature|getData('score')`,
+      defaultValue: `jexl:get(feature,'score')`,
       contextVariable: ['feature'],
     },
   },

--- a/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
@@ -39,7 +39,7 @@ export default ConfigurationSchema(
         type: 'string',
         description:
           'the primary name of the feature to show, if space is available',
-        defaultValue: `jexl:feature|getData('name') || feature|getData('id')`,
+        defaultValue: `jexl:get(feature,'name') || get(feature,'id')`,
         contextVariable: ['feature'],
       },
       nameColor: {
@@ -51,7 +51,7 @@ export default ConfigurationSchema(
       description: {
         type: 'string',
         description: 'the text description to show, if space is available',
-        defaultValue: `jexl:feature|getData('note') || feature|getData('description')`,
+        defaultValue: `jexl:get(feature,'note') || get(feature,'description')`,
         contextVariable: ['feature'],
       },
       descriptionColor: {

--- a/products/jbrowse-react-linear-genome-view/public/nextstrain_covid.json
+++ b/products/jbrowse-react-linear-genome-view/public/nextstrain_covid.json
@@ -132,7 +132,7 @@
           "displayId": "nextstrain-color-display",
           "renderer": {
             "type": "SvgFeatureRenderer",
-            "color1": "feature|getData('fill') || 'black'"
+            "color1": "jexl:get(feature,'fill') || 'black'"
           }
         }
       ]

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -2813,7 +2813,7 @@ Object {
         Object {
           "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
           "renderer": Object {
-            "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'",
+            "color1": "jexl:get(feature,'type')=='SNV'?'green':'purple'",
             "type": "SvgFeatureRenderer",
           },
           "type": "LinearVariantDisplay",

--- a/test_data/config.json
+++ b/test_data/config.json
@@ -118,7 +118,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -223,7 +223,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -274,7 +274,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('geneName2')"
+              "description": "jexl:get(feature,'geneName2')"
             }
           }
         }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -155,7 +155,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -256,9 +256,9 @@
           "type": "LinearGDCDisplay",
           "displayId": "gdc_plugin_track_linear",
           "renderer": {
-            "color1": "jexl:{LOW: 'blue', MODIFIER: 'goldenrod', MODERATE: 'orange', HIGH: 'red'}|cast[feature|getData('consequence').hits.edges[.node.transcript.is_canonical == true][0].node.transcript.annotation.vep_impact] || 'lightgray'",
+            "color1": "jexl:cast({LOW: 'blue', MODIFIER: 'goldenrod', MODERATE: 'orange', HIGH: 'red'})[get(feature,'consequence').hits.edges[.node.transcript.is_canonical == true][0].node.transcript.annotation.vep_impact] || 'lightgray'",
             "labels": {
-              "name": "jexl:feature|getData('genomicDnaChange')"
+              "name": "jexl:get(feature,'genomicDnaChange')"
             },
             "type": "SvgFeatureRenderer"
           }
@@ -374,7 +374,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -425,7 +425,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('geneName2')"
+              "description": "jexl:get(feature,'geneName2')"
             }
           }
         }
@@ -2487,7 +2487,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -2518,7 +2518,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -3084,7 +3084,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "f|getData('ucscLabel')"
+              "description": "jexl:get(feature,'ucscLabel')"
             }
           }
         }

--- a/test_data/config_honeybee.json
+++ b/test_data/config_honeybee.json
@@ -34,7 +34,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }
@@ -64,7 +64,7 @@
           "renderer": {
             "type": "SvgFeatureRenderer",
             "labels": {
-              "description": "jexl:feature|getData('gene_name')"
+              "description": "jexl:get(feature,'gene_name')"
             }
           }
         }

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1217,7 +1217,7 @@
           "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
-            "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'"
+            "color1": "jexl:get(feature,'type')=='SNV'?'green':'purple'"
           }
         }
       ]

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -1127,11 +1127,10 @@ For example:
 
 ### Configuration callbacks
 
-We use jexl (see https://github.com/TomFrost/Jexl) for defining configuration
-callbacks. This is more limited than allowing arbitrary javascript in our
-configs, but helps prevent things like XSS.
+We use Jexl (see https://github.com/TomFrost/Jexl) for defining configuration
+callbacks.
 
-An example of a jexl configuration callback might look like this
+An example of a Jexl configuration callback might look like this
 
     "color": "jexl:get(feature,'strand')==-1?'red':'blue'"
 
@@ -1169,8 +1168,8 @@ String functions
 jexl:charAt('abc',2) // c
 jexl:charCodeAt(' ',0) // 32
 jexl:codePointAt(' ',0) // 32
+jexl:startsWith('kittycat','kit') // true
 jexl:endsWith('kittycat','cat') // true
-jexl:hashcode('kittycat') // random number, in this case, 877
 jexl:padStart('cat', 8, 'kitty') // kittycat
 jexl:padEnd('kitty', 8, 'cat') // kittycat
 jexl:replace('kittycat','cat','') // kitty

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -1124,3 +1124,90 @@ For example:
   }
 }
 ```
+
+### Configuration callbacks
+
+We use jexl (see https://github.com/TomFrost/Jexl) for defining configuration
+callbacks. This is more limited than allowing arbitrary javascript in our
+configs, but helps prevent things like XSS.
+
+An example of a jexl configuration callback might look like this
+
+    "color": "jexl:get(feature,'strand')==-1?'red':'blue'"
+
+The notation get(feature,'strand') is the same as feature.get('strand') in
+javascript code.
+
+We have a number of other functions such as
+
+Feature operations - get
+
+```
+
+jexl:get(feature,'start') // start coordinate, 0-based half open
+jexl:get(feature,'end') // end coordinate, 0-based half open
+jexl:get(feature,'refName') // chromosome or reference sequence name
+jexl:get(feature,'CIGAR') // BAM or CRAM feature CIGAR string
+jexl:get(feature,'seq') // BAM or CRAM feature sequence
+jexl:get(feature,'type') // feature type e.g. mRNA or gene
+
+```
+
+Feature operations - getTag
+
+The getTag function smooths over slight differences in BAM and CRAM features to access their tags
+
+```
+jexl:getTag(feature, 'MD') // fetches MD string from BAM or CRAM feature
+jexl:getTag(feature, 'HP') // fetches haplotype tag from BAM or CRAM feature
+
+```
+
+String functions
+
+```
+jexl:charAt('abc',2) // c
+jexl:charCodeAt(' ',0) // 32
+jexl:codePointAt(' ',0) // 32
+jexl:endsWith('kittycat','cat') // true
+jexl:hashcode('kittycat') // random number, in this case, 877
+jexl:padStart('cat', 8, 'kitty') // kittycat
+jexl:padEnd('kitty', 8, 'cat') // kittycat
+jexl:replace('kittycat','cat','') // kitty
+jexl:replaceAll('kittycatcat','cat','') // kitty
+jexl:slice('kittycat',5) // cat
+jexl:substring('kittycat',0,5) // kitty
+jexl:trim('  kitty ') // kitty, whitespace trimmed
+jexl:trimStart('  kitty ') // kitty, starting whitespace trimmed
+jexl:trimEnd('  kitty ') // kitty, ending whitespace trimmed
+jexl:toUpperCase('kitty') // KITTY
+jexl:toLowerCase('KITTY') // kitty
+```
+
+Math functions
+
+```
+
+jexl:min(0,2)
+jexl:max(0,2)
+jexl:abs(-5)
+jexl:ceil(0.5)
+jexl:floor(0.5)
+jexl:round(0.5)
+
+```
+
+Console logging
+
+```
+
+jexl:log(feature) // console.logs output and returns value
+jexl:cast({'mRNA':'green','pseudogene':'purple'})[get(feature,'type')] // returns either green or purple depending on feature type
+
+```
+
+Binary operators
+
+```
+jexl:get(feature,'flags')&2 // bitwise and to check if BAM or CRAM feature flags has 2 set
+```

--- a/website/docs/developer_guide.md
+++ b/website/docs/developer_guide.md
@@ -672,10 +672,7 @@ various feature attributes
 
 ### Example of a config callback
 
-We currently use jexl to express callbacks. This is more limited than arbitrary
-javascript, but can be expressive
-
-See https://github.com/TomFrost/Jexl for more details
+We use Jexl to express callbacks. See https://github.com/TomFrost/Jexl for more details.
 
 If you had an variant track in your config, and wanted to make a custom config
 callback for color, it might look like this

--- a/website/docs/developer_guide.md
+++ b/website/docs/developer_guide.md
@@ -610,7 +610,7 @@ export default ConfigurationSchema('PileupRenderer', {
   color: {
     type: 'color',
     description: 'the color of each feature in a pileup alignment',
-    defaultValue: `jexl:feature|getData('strand') == - 1 ? '#8F8FD8' : '#EC8B8B'`,
+    defaultValue: `jexl:get(feature,'strand') == - 1 ? '#8F8FD8' : '#EC8B8B'`,
     contextVariable: ['feature'],
   },
   displayMode: {
@@ -704,7 +704,7 @@ callback for color, it might look like this
       "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
       "renderer": {
         "type": "SvgFeatureRenderer",
-        "color1": "jexl:feature|getData('type')=='SNV'?'green':'purple'"
+        "color1": "jexl:get(feature,'type')=='SNV'?'green':'purple'"
       }
     }
   ]


### PR DESCRIPTION
This is a proposal to change our syntax for jexl callbacks

It is based on a belief that the use of transforms, with the bar | syntax, will appear more unfamiliar than simply making everything functions

I propose making a function "get(feature, attribute)" where I can type

    get(feature, 'start')

This is similar to

    feature.get('start')

And replaces the current feature|getData(attribute)

Some other helper functions are changed from transforms to functions also

I add a section for documenting jexl to the configuration guide also

![localhost_3000_jb2_docs_config_guide (1)](https://user-images.githubusercontent.com/6511937/112254785-8953ea00-8c37-11eb-93ee-b970c85d9a16.png)
