### PR TITLE
Add wormbase example with connection to jbrowse 1 data directory 

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -52,6 +52,7 @@ function NoConfigMessage() {
     ['test_data/yeast_synteny/config.json', 'Yeast synteny'],
     ['test_data/config_many_contigs.json', 'Many contigs'],
     ['test_data/config_honeybee.json', 'Honeybee'],
+    ['test_data/config_wormbase.json', 'Wormbase'],
   ]
   return (
     <div>

--- a/test_data/config_wormbase.json
+++ b/test_data/config_wormbase.json
@@ -1,0 +1,39 @@
+{
+  "assemblies": [
+    {
+      "name": "C. elegans (N2)",
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "GCF_000002985.6_WBcel235_genomic-ReferenceSequenceTrack",
+        "metadata": {
+          "source": "https://www.ncbi.nlm.nih.gov/assembly/GCF_000002985.6/",
+          "strain": "Bristol N2"
+        },
+        "adapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/wormbase/c_elegans/fasta/GCF_000002985.6_WBcel235_genomic.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/wormbase/c_elegans/fasta/GCF_000002985.6_WBcel235_genomic.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/wormbase/c_elegans/fasta/GCF_000002985.6_WBcel235_genomic.fa.gz.gzi"
+          }
+        }
+      }
+    }
+  ],
+  "configuration": {},
+  "connections": [
+    {
+      "type": "JBrowse1Connection",
+      "connectionId": "JBrowse1Connection-GCF_000002985.6_WBcel235_genomic-1616618478254",
+      "name": "wormbase",
+      "assemblyName": "C. elegans (N2)",
+      "dataDirLocation": {
+        "uri": "https://wormbase.org/tools/genome/jbrowse-simple/data/c_elegans_PRJNA13758"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Example link when built

s3.amazonaws.com/jbrowse.org/code/jb2/add_wormbase_example/index.html?config=test_data/config_wormbase.json

Needs tracklist optimizations since it has many tracks, but it does at least partially load