### PR TITLE
Add true breakend ALT strings to the feature details panel

### DIFF
--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.test.js
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.test.js
@@ -26,7 +26,7 @@ describe('VariantTrack widget', () => {
       end: 177,
       name: 'rs123',
       REF: 'A',
-      ALT: '<TRA>',
+      ALT: ['<TRA>'],
       QUAL: 10.4,
       INFO: {
         MQ: 5,

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -21,6 +21,19 @@ import {
   BaseCard,
 } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
 import BreakendOptionDialog from './BreakendOptionDialog'
+import { Breakend } from '../VcfTabixAdapter/VcfFeature'
+
+// from vcf-js
+function toString(feat: string | Breakend) {
+  if (typeof feat === 'string') {
+    return feat
+  }
+  const char = feat.MateDirection === 'left' ? ']' : '['
+  if (feat.Join === 'left') {
+    return `${char}${feat.MatePosition}${char}${feat.Replacement}`
+  }
+  return `${feat.Replacement}${char}${feat.MatePosition}${char}`
+}
 
 function VariantSamples(props: any) {
   const [filter, setFilter] = useState<any>({})
@@ -220,7 +233,10 @@ function VariantFeatureDetails(props: any) {
   return (
     <Paper data-testid="variant-side-drawer">
       <FeatureDetails
-        feature={rest}
+        feature={{
+          ...rest,
+          ALT: rest.ALT?.map((alt: string | Breakend) => toString(alt)),
+        }}
         descriptions={{ ...basicDescriptions, ...descriptions }}
         {...props}
       />


### PR DESCRIPTION
This renders the true ALT breakend strings. Using our "MatePosition/JoinDirection" json representation may not be familiar to people, while the breakend syntax can be learned to be read...it is also more succinct and faithful to the datafile

Also adds curlies to VcfFeature, makes some multiline things a single line a bit shorter using object destructuring, and changes the order of resolving data to prioritize this.data instead of this.variant in toJSON and get