### PR TITLE
Add download page in website header and new super-quick-start guide

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,7 +39,7 @@ BLOGPOST_DRAFT=website/release_announcement_drafts/$RELEASE_TAG.md
 
 # Updates the "Browse demo instance" link on the homepage
 INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$RELEASE_TAG/index.html
-INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; JSON.stringify(config,0,2)" >tmp.json
+RELEASE_TAG=$RELEASE_TAG INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; config.customFields.currentVersion = process.env.RELEASE_TAG; JSON.stringify(config,0,2)" >tmp.json
 mv tmp.json website/docusaurus.config.json
 
 # Packages that have changed and will have their version bumped

--- a/test_data/yeast_synteny/config.json
+++ b/test_data/yeast_synteny/config.json
@@ -1,33 +1,33 @@
 {
   "assemblies": [
     {
-      "name": "YJM1447",
+      "name": "r64",
       "sequence": {
         "type": "ReferenceSequenceTrack",
-        "trackId": "YJM1447-ReferenceSequenceTrack",
+        "trackId": "r64-ReferenceSequenceTrack",
         "adapter": {
           "type": "IndexedFastaAdapter",
           "fastaLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/GCA_000977955.2_Sc_YJM1447_v1_genomic.fna"
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64.fa"
           },
           "faiLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/GCA_000977955.2_Sc_YJM1447_v1_genomic.fna.fai"
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64.fa.fai"
           }
         }
       }
     },
     {
-      "name": "R64",
+      "name": "yjm1447",
       "sequence": {
         "type": "ReferenceSequenceTrack",
-        "trackId": "R64-ReferenceSequenceTrack",
+        "trackId": "yjm1447-ReferenceSequenceTrack",
         "adapter": {
           "type": "IndexedFastaAdapter",
           "fastaLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/GCA_000146045.2_R64_genomic.fna"
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/yjm1447.fa"
           },
           "faiLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/GCA_000146045.2_R64_genomic.fna.fai"
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/yjm1447.fa.fai"
           }
         }
       }
@@ -38,55 +38,460 @@
   "tracks": [
     {
       "type": "SyntenyTrack",
-      "trackId": "dotplot_track",
-      "assemblyNames": ["YJM1447", "R64"],
-      "name": "dotplot",
+      "trackId": "r64_vs_yjm1447",
+      "name": "r64_vs_yjm1447",
+      "assemblyNames": ["yjm1447", "r64"],
       "adapter": {
         "type": "PAFAdapter",
         "pafLocation": {
-          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf"
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64_vs_yjm1447.paf"
         },
-        "assemblyNames": ["YJM1447", "R64"]
+        "assemblyNames": ["yjm1447", "r64"]
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "r64.sorted.gff",
+      "name": "r64.sorted.gff",
+      "assemblyNames": ["r64"],
+      "adapter": {
+        "type": "Gff3TabixAdapter",
+        "gffGzLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64.sorted.gff.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64.sorted.gff.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "yjm1447.sorted.gff",
+      "name": "yjm1447.sorted.gff",
+      "assemblyNames": ["yjm1447"],
+      "adapter": {
+        "type": "Gff3TabixAdapter",
+        "gffGzLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/yjm1447.sorted.gff.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/yjm1447.sorted.gff.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
       }
     }
   ],
   "defaultSession": {
-    "name": "R64 vs YJM1447",
-    "width": 1850,
+    "id": "t4Gkdnu62",
+    "name": "New session 4/9/2021, 6:51:09 PM 4/9/2021, 7:02:43 PM",
+    "margin": 0,
     "drawerWidth": 384,
     "views": [
       {
-        "id": "MiDMyyWpp",
+        "id": "Z28xPG8KJ",
         "type": "DotplotView",
-        "assemblyNames": ["R64", "YJM1447"],
+        "headerHeight": 0,
+        "height": 600,
+        "borderSize": 20,
+        "tickSize": 5,
+        "vtextRotation": 0,
+        "htextRotation": -90,
+        "fontSize": 15,
+        "trackSelectorType": "hierarchical",
+        "assemblyNames": ["r64", "yjm1447"],
         "hview": {
-          "displayedRegions": [],
-          "bpPerPx": 100000,
-          "offsetPx": 0
+          "displayedRegions": [
+            {
+              "refName": "NC_001133.9",
+              "start": 0,
+              "end": 230218,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001134.8",
+              "start": 0,
+              "end": 813184,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001135.5",
+              "start": 0,
+              "end": 316620,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001136.10",
+              "start": 0,
+              "end": 1531933,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001137.3",
+              "start": 0,
+              "end": 576874,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001138.5",
+              "start": 0,
+              "end": 270161,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001139.9",
+              "start": 0,
+              "end": 1090940,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001140.6",
+              "start": 0,
+              "end": 562643,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001141.2",
+              "start": 0,
+              "end": 439888,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001142.9",
+              "start": 0,
+              "end": 745751,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001143.9",
+              "start": 0,
+              "end": 666816,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001144.5",
+              "start": 0,
+              "end": 1078177,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001145.3",
+              "start": 0,
+              "end": 924431,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001146.8",
+              "start": 0,
+              "end": 784333,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001147.6",
+              "start": 0,
+              "end": 1091291,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001148.4",
+              "start": 0,
+              "end": 948066,
+              "reversed": false,
+              "assemblyName": "r64"
+            },
+            {
+              "refName": "NC_001224.1",
+              "start": 0,
+              "end": 85779,
+              "reversed": false,
+              "assemblyName": "r64"
+            }
+          ],
+          "bpPerPx": 9437.502675529358,
+          "offsetPx": -21,
+          "interRegionPaddingWidth": 0,
+          "minimumBlockWidth": 0
         },
         "vview": {
-          "displayedRegions": [],
-          "bpPerPx": 100000,
-          "offsetPx": 0
+          "displayedRegions": [
+            {
+              "refName": "I",
+              "start": 0,
+              "end": 198540,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "II",
+              "start": 0,
+              "end": 781048,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "III",
+              "start": 0,
+              "end": 306081,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "IV",
+              "start": 0,
+              "end": 1464523,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "IX",
+              "start": 0,
+              "end": 416633,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "MT",
+              "start": 0,
+              "end": 74237,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "V",
+              "start": 0,
+              "end": 556288,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "VI",
+              "start": 0,
+              "end": 279643,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "VII",
+              "start": 0,
+              "end": 1065782,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "VIII",
+              "start": 0,
+              "end": 522291,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "X",
+              "start": 0,
+              "end": 692549,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XI",
+              "start": 0,
+              "end": 659272,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XII",
+              "start": 0,
+              "end": 1556556,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XIII",
+              "start": 0,
+              "end": 895110,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XIV",
+              "start": 0,
+              "end": 756080,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XV",
+              "start": 0,
+              "end": 1081906,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            },
+            {
+              "refName": "XVI",
+              "start": 0,
+              "end": 909714,
+              "reversed": false,
+              "assemblyName": "yjm1447"
+            }
+          ],
+          "bpPerPx": 27966.248303283493,
+          "offsetPx": -35,
+          "interRegionPaddingWidth": 0,
+          "minimumBlockWidth": 0
         },
         "tracks": [
           {
+            "id": "nf1leQSKA",
             "type": "SyntenyTrack",
-            "configuration": "dotplot_track",
+            "configuration": "r64_vs_yjm1447",
             "displays": [
               {
+                "id": "GCoP6_21AH",
                 "type": "DotplotDisplay",
-                "configuration": "dotplot_track-DotplotDisplay"
+                "configuration": "r64_vs_yjm1447-DotplotDisplay"
               }
             ]
           }
         ],
-        "headerHeight": 44,
-        "width": 1850,
-        "height": 600,
-        "displayName": "R64 vs YJM1447 dotplot",
-        "trackSelectorType": "hierarchical"
+        "viewTrackConfigs": [],
+        "viewAssemblyConfigs": []
       }
-    ]
+    ],
+    "widgets": {
+      "hierarchicalTrackSelector": {
+        "id": "hierarchicalTrackSelector",
+        "type": "HierarchicalTrackSelectorWidget",
+        "collapsed": {},
+        "filterText": "",
+        "view": "Z28xPG8KJ"
+      },
+      "baseFeature": {
+        "id": "baseFeature",
+        "type": "BaseFeatureWidget",
+        "featureData": {
+          "source": "RefSeq",
+          "type": "gene",
+          "start": 65777,
+          "end": 67520,
+          "strand": -1,
+          "phase": 0,
+          "refName": "NC_001133.9",
+          "id": "gene-YAL040C",
+          "dbxref": "GeneID:851191",
+          "name": "CLN3",
+          "end_range": ["67520", "."],
+          "gbkey": "Gene",
+          "gene": "CLN3",
+          "gene_biotype": "protein_coding",
+          "gene_synonym": ["DAF1", "FUN10", "WHI1"],
+          "locus_tag": "YAL040C",
+          "partial": "true",
+          "start_range": [".", "65778"],
+          "subfeatures": [
+            {
+              "source": "RefSeq",
+              "type": "mRNA",
+              "start": 65777,
+              "end": 67520,
+              "strand": -1,
+              "phase": 0,
+              "refName": "NC_001133.9",
+              "id": "rna-NM_001178185.1",
+              "parent": "gene-YAL040C",
+              "dbxref": ["GeneID:851191", "Genbank:NM_001178185.1"],
+              "name": "NM_001178185.1",
+              "end_range": ["67520", "."],
+              "gbkey": "mRNA",
+              "gene": "CLN3",
+              "locus_tag": "YAL040C",
+              "partial": "true",
+              "product": "cyclin CLN3",
+              "start_range": [".", "65778"],
+              "transcript_id": "NM_001178185.1",
+              "subfeatures": [
+                {
+                  "source": "RefSeq",
+                  "type": "CDS",
+                  "start": 65777,
+                  "end": 67520,
+                  "strand": -1,
+                  "phase": 0,
+                  "refName": "NC_001133.9",
+                  "id": "cds-NP_009360.1",
+                  "parent": "rna-NM_001178185.1",
+                  "dbxref": [
+                    "SGD:S000000038",
+                    "GeneID:851191",
+                    "Genbank:NP_009360.1"
+                  ],
+                  "name": "NP_009360.1",
+                  "note": "G1 cyclin involved in cell cycle progression; activates Cdc28p kinase to promote G1 to S phase transition; plays a role in regulating transcription of other G1 cyclins, CLN1 and CLN2; regulated by phosphorylation and proteolysis; acetyl-CoA induces CLN3 transcription in response to nutrient repletion to promote cell-cycle entry; cell cycle arrest phenotype of the cln1 cln2 cln3 triple null mutant is complemented by any of human cyclins CCNA2, CCNB1, CCNC, CCND1, or CCNE1",
+                  "experiment": "EXISTENCE:direct assay:GO:0005634 nucleus [PMID:10611233|PMID:11509671|PMID:11792824]",
+                  "gbkey": "CDS",
+                  "gene": "CLN3",
+                  "locus_tag": "YAL040C",
+                  "product": "cyclin CLN3",
+                  "protein_id": "NP_009360.1",
+                  "uniqueId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731-0-0",
+                  "parentId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731-0"
+                },
+                {
+                  "source": "RefSeq",
+                  "type": "exon",
+                  "start": 65777,
+                  "end": 67520,
+                  "strand": -1,
+                  "phase": 0,
+                  "refName": "NC_001133.9",
+                  "id": "exon-NM_001178185.1-1",
+                  "parent": "rna-NM_001178185.1",
+                  "dbxref": ["GeneID:851191", "Genbank:NM_001178185.1"],
+                  "end_range": ["67520", "."],
+                  "gbkey": "mRNA",
+                  "gene": "CLN3",
+                  "locus_tag": "YAL040C",
+                  "partial": "true",
+                  "product": "cyclin CLN3",
+                  "start_range": [".", "65778"],
+                  "transcript_id": "NM_001178185.1",
+                  "uniqueId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731-0-1",
+                  "parentId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731-0"
+                }
+              ],
+              "uniqueId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731-0",
+              "parentId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731"
+            }
+          ],
+          "uniqueId": "type-Gff3TabixAdapter;type-Gff3TabixAdapter;uri-https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r-offset-3197731"
+        }
+      }
+    },
+    "activeWidgets": {
+      "hierarchicalTrackSelector": "hierarchicalTrackSelector"
+    },
+    "connectionInstances": {},
+    "sessionTracks": [],
+    "sessionConnections": [],
+    "sessionAssemblies": [],
+    "minimized": false
   }
 }

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -16,9 +16,9 @@ toplevel: true
 
 #### What is special about JBrowse 2
 
-One thing that makes JBrowse 2 special is that we can create new view
-types via our plugin system, e.g. circular, dotplot, etc. Anything you want can
-be added as a view, and can be shown alongside our other views
+One thing that makes JBrowse 2 special is that we can create new view types via
+our plugin system, e.g. circular, dotplot, etc. Anything you want can be added
+as a view, and can be shown alongside our other views
 
 This makes JBrowse 2 more than just a genome browser-- it is really a platform
 that can be built on.
@@ -32,12 +32,14 @@ that can be built on.
 - Can display multiple chromosomes or discontinuous regions on a single linear
   genome view
 - Can connect to UCSC trackhubs
-- Alignments track has both coverage and pileup display integrated in a single track
+- Alignments track has both coverage and pileup display integrated in a single
+  track
 - Read pileups can be sorted by various attributes
 - Has ability to show soft clipped bases on reads
 - Interactively edit the configuration using the GUI
 - Circular, dotplot, stacked synteny views
-- SV inspector, that gives tabular and circular overview of data in a single view
+- SV inspector, that gives tabular and circular overview of data in a single
+  view
 - Linear genome view can be reverse complemented
 
 #### Can the linear genome view be reverse complemented
@@ -58,14 +60,15 @@ If you use a different platform such as Django, you may want to put it in the
 static resources folder.
 
 Note that the server that you use should support byte-range requests (e.g. the
-Range HTTP header) so that JBrowse can get small slices of large binary data
-files.
+[Range HTTP
+header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) so
+that JBrowse can get small slices of large binary data files.
 
 #### BAM files do not work on my server
 
-If you are using Apache then you will probably want to disable mime*magic. If
+If you are using Apache then you will probably want to disable mime_magic. If
 mime_magic is enabled, you may see that your server responds with the HTTP
-header Content-Encoding: gzip which JBrowse does \_NOT* want, because this
+header Content-Encoding: gzip which JBrowse does NOT want, because this
 instructs the browser to unzip the data but JBrowse should be in charge of
 this.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -6,7 +6,7 @@ toplevel: true
 
 ### General
 
-#### What technologies does JBrowse 2 use?
+#### What technologies does JBrowse 2 use
 
 - React
 - mobx-state-tree
@@ -14,7 +14,7 @@ toplevel: true
 - Typescript
 - Electron (for desktop specifically)
 
-#### What is special about JBrowse 2?
+#### What is special about JBrowse 2
 
 One thing that makes JBrowse 2 special is that we can create new view
 types via our plugin system, e.g. circular, dotplot, etc. Anything you want can
@@ -23,7 +23,7 @@ be added as a view, and can be shown alongside our other views
 This makes JBrowse 2 more than just a genome browser-- it is really a platform
 that can be built on.
 
-#### What are new features in JBrowse 2?
+#### What are new features in JBrowse 2
 
 - Uses web workers for multi-core data parsing and rendering of tracks
 - Use ctrl+scroll to zoom in and out quickly
@@ -46,7 +46,7 @@ Yes! See [here](user_guide#navigating-the-ui)
 
 ### Setup
 
-#### What web server do I need to run JBrowse 2?
+#### What web server do I need to run JBrowse 2
 
 JBrowse 2 by itself is just a set of JS, CSS, and HTML files that can be
 statically hosted on a webserver without any backend services running.
@@ -61,7 +61,7 @@ Note that the server that you use should support byte-range requests (e.g. the
 Range HTTP header) so that JBrowse can get small slices of large binary data
 files.
 
-#### BAM files do not work on my server?
+#### BAM files do not work on my server
 
 If you are using Apache then you will probably want to disable mime*magic. If
 mime_magic is enabled, you may see that your server responds with the HTTP
@@ -69,7 +69,7 @@ header Content-Encoding: gzip which JBrowse does \_NOT* want, because this
 instructs the browser to unzip the data but JBrowse should be in charge of
 this.
 
-#### How can I start the JBrowse 2 app as a developer?
+#### How can I start the JBrowse 2 app as a developer
 
 We recommend that you have the following
 
@@ -88,13 +88,13 @@ You can use `PORT=8080 yarn start` to manually specify a different port
 Note that this is a development server that gets started up. To install jbrowse
 2 in production on your webserver, see below
 
-#### Do you have any tips for learning React and mobx-state-tree?
+#### Do you have any tips for learning React and mobx-state-tree
 
 Here is a short guide to React and mobx-state-tree that could help get you oriented
 
 https://gist.github.com/cmdcolin/94d1cbc285e6319cc3af4b9a8556f03f
 
-#### How can I setup JBrowse 2 in production?
+#### How can I setup JBrowse 2 in production
 
 We recommend following the steps in the [quickstart web](quickstart_web) guide.
 
@@ -104,7 +104,7 @@ will download the latest version of jbrowse to your web folder e.g. in
 
 You can also use `jbrowse upgrade /var/www/html/jb2` to get the latest version
 
-#### How can I setup JBrowse 2 without the CLI tools?
+#### How can I setup JBrowse 2 without the CLI tools
 
 The jbrowse CLI tools are basically a convenience, and are not strictly required
 
@@ -124,7 +124,7 @@ to understand errors, because our config system is strongly typed
 
 Feel free to message the team if you encounter these
 
-#### How do I load a track into JBrowse 2?
+#### How do I load a track into JBrowse 2
 
 If you have followed the above steps and installed jbrowse 2 on your webserver
 and loaded the assembly, and have the CLI tools installed
@@ -146,21 +146,21 @@ myfile.bam.bai
 
 ### Curiosities
 
-#### Why do all the tracks need an assembly specified?
+#### Why do all the tracks need an assembly specified
 
 We require that all tracks have a specific genome assembly specified in their
 config. This is because jbrowse 2 is a multi-genome-assembly browser (and can
 compare genomes given the data). This may be different to using say jbrowse 1
 where it knows which genome assembly you are working with at any given time
 
-#### How are the menus structured in the app?
+#### How are the menus structured in the app
 
 In JBrowse 1, the app level menu operated on the single linear genome view, but
 with JBrowse 2, the top level menu only performs global operations and the
 linear genome view has it's own hamburger menu. Note that each track also has
 it's own track level menu.
 
-#### Why do some of my reads not display soft clipping?
+#### Why do some of my reads not display soft clipping
 
 Some reads, such as secondary reads, do not have a SEQ field on their records,
 so they will not display softclipping.

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -46,6 +46,29 @@ Yes! See [here](user_guide#navigating-the-ui)
 
 ### Setup
 
+#### What web server do I need to run JBrowse 2?
+
+JBrowse 2 by itself is just a set of JS, CSS, and HTML files that can be
+statically hosted on a webserver without any backend services running.
+
+Therefore, running JBrowse 2 generally involves just copying the JBrowse 2
+folder to your web server html folder e.g. `/var/www/html/`.
+
+If you use a different platform such as Django, you may want to put it in the
+static resources folder.
+
+Note that the server that you use should support byte-range requests (e.g. the
+Range HTTP header) so that JBrowse can get small slices of large binary data
+files.
+
+#### BAM files do not work on my server
+
+If you are using Apache then you will probably want to disable mime*magic. If
+mime_magic is enabled, you may see that your server responds with the HTTP
+header Content-Encoding: gzip which JBrowse does \_NOT* want, because this
+instructs the browser to unzip the data but JBrowse should be in charge of
+this.
+
 #### How can I start the JBrowse 2 app as a developer
 
 We recommend that you have the following
@@ -142,4 +165,4 @@ it's own track level menu.
 Some reads, such as secondary reads, do not have a SEQ field on their records,
 so they will not display softclipping.
 
-These reads will display their soft-clipping indicator as black
+These reads will display their soft-clipping indicator as black3

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -6,7 +6,7 @@ toplevel: true
 
 ### General
 
-#### What technologies does JBrowse 2 use
+#### What technologies does JBrowse 2 use?
 
 - React
 - mobx-state-tree
@@ -14,7 +14,7 @@ toplevel: true
 - Typescript
 - Electron (for desktop specifically)
 
-#### What is special about JBrowse 2
+#### What is special about JBrowse 2?
 
 One thing that makes JBrowse 2 special is that we can create new view
 types via our plugin system, e.g. circular, dotplot, etc. Anything you want can
@@ -23,9 +23,9 @@ be added as a view, and can be shown alongside our other views
 This makes JBrowse 2 more than just a genome browser-- it is really a platform
 that can be built on.
 
-#### What are new features in jbrowse 2
+#### What are new features in JBrowse 2?
 
-- Uses webworkers for data parsing and rendering tracks
+- Uses web workers for multi-core data parsing and rendering of tracks
 - Use ctrl+scroll to zoom in and out quickly
 - Status updates while track is loading (e.g. Downloading BAM index...)
 - Hi-C visualization from .hic format files
@@ -61,7 +61,7 @@ Note that the server that you use should support byte-range requests (e.g. the
 Range HTTP header) so that JBrowse can get small slices of large binary data
 files.
 
-#### BAM files do not work on my server
+#### BAM files do not work on my server?
 
 If you are using Apache then you will probably want to disable mime*magic. If
 mime_magic is enabled, you may see that your server responds with the HTTP
@@ -69,7 +69,7 @@ header Content-Encoding: gzip which JBrowse does \_NOT* want, because this
 instructs the browser to unzip the data but JBrowse should be in charge of
 this.
 
-#### How can I start the JBrowse 2 app as a developer
+#### How can I start the JBrowse 2 app as a developer?
 
 We recommend that you have the following
 
@@ -88,13 +88,13 @@ You can use `PORT=8080 yarn start` to manually specify a different port
 Note that this is a development server that gets started up. To install jbrowse
 2 in production on your webserver, see below
 
-#### Do you have any tips for learning React and mobx-state-tree
+#### Do you have any tips for learning React and mobx-state-tree?
 
 Here is a short guide to React and mobx-state-tree that could help get you oriented
 
 https://gist.github.com/cmdcolin/94d1cbc285e6319cc3af4b9a8556f03f
 
-#### How can I setup JBrowse 2 in production
+#### How can I setup JBrowse 2 in production?
 
 We recommend following the steps in the [quickstart web](quickstart_web) guide.
 
@@ -104,7 +104,7 @@ will download the latest version of jbrowse to your web folder e.g. in
 
 You can also use `jbrowse upgrade /var/www/html/jb2` to get the latest version
 
-#### How can I setup JBrowse 2 without the CLI tools
+#### How can I setup JBrowse 2 without the CLI tools?
 
 The jbrowse CLI tools are basically a convenience, and are not strictly required
 
@@ -124,7 +124,7 @@ to understand errors, because our config system is strongly typed
 
 Feel free to message the team if you encounter these
 
-#### How do I load a track into JBrowse 2
+#### How do I load a track into JBrowse 2?
 
 If you have followed the above steps and installed jbrowse 2 on your webserver
 and loaded the assembly, and have the CLI tools installed
@@ -146,14 +146,14 @@ myfile.bam.bai
 
 ### Curiosities
 
-#### Why do all the tracks need an assembly specified
+#### Why do all the tracks need an assembly specified?
 
 We require that all tracks have a specific genome assembly specified in their
 config. This is because jbrowse 2 is a multi-genome-assembly browser (and can
 compare genomes given the data). This may be different to using say jbrowse 1
 where it knows which genome assembly you are working with at any given time
 
-#### How are the menus structured in the app
+#### How are the menus structured in the app?
 
 In JBrowse 1, the app level menu operated on the single linear genome view, but
 with JBrowse 2, the top level menu only performs global operations and the
@@ -165,4 +165,4 @@ it's own track level menu.
 Some reads, such as secondary reads, do not have a SEQ field on their records,
 so they will not display softclipping.
 
-These reads will display their soft-clipping indicator as black3
+These soft clipping indicators on these reads will appear black.

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -165,4 +165,4 @@ it's own track level menu.
 Some reads, such as secondary reads, do not have a SEQ field on their records,
 so they will not display softclipping.
 
-These soft clipping indicators on these reads will appear black.
+The soft clipping indicators on these reads will appear black.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -9,9 +9,9 @@ Welcome to the JBrowse 2 documentation.
 
 We provide
 
-- [Super-quick start guide](quickstart_web) - super brief setup instructions
-  e.g. 10 lines of CLI commands to help admins who are familiar with jbrowse
-  with getting setup
+- [Super-quick start guide](superquickstart_web) - super brief setup
+  instructions e.g. 10 lines of CLI commands to help admins who are familiar
+  with jbrowse with getting setup
 - [Quick start guide](quickstart_web) - a more thourough quick-start guide to
   help admins setting up JBrowse 2 on their website
 - [User guide](user_guide) - screenshots of the app and general usage
@@ -19,7 +19,8 @@ We provide
 - [Developer guide](developer_guide) - for developers of plugins and
   core codebase topics
 - [FAQ](faq) - Some Q&A for troubleshooting or other topics
-- [@jbrowse/linear-genome-view docs](https://jbrowse.org/storybook/lgv/main/) - Docs for the re-usable linear genome view react component
+- [@jbrowse/linear-genome-view docs](https://jbrowse.org/storybook/lgv/main/) -
+  Docs for the re-usable linear genome view react component
 
 We also keep a log of our previous training classes in the sidebar
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -11,7 +11,7 @@ We provide
 
 - [Super-quick start guide](superquickstart_web) - super brief setup
   instructions e.g. 10 lines of CLI commands to help admins who are familiar
-  with jbrowse with getting setup
+  with jbrowse with getting set up
 - [Quick start guide](quickstart_web) - a more thourough quick-start guide to
   help admins setting up JBrowse 2 on their website
 - [User guide](user_guide) - screenshots of the app and general usage

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -20,7 +20,7 @@ We provide
   core codebase topics
 - [FAQ](faq) - Some Q&A for troubleshooting or other topics
 - [@jbrowse/linear-genome-view docs](https://jbrowse.org/storybook/lgv/main/) -
-  Docs for the re-usable linear genome view react component
+  Docs for the reusable linear genome view React component
 
 We also keep a log of our previous training classes in the sidebar
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -9,8 +9,11 @@ Welcome to the JBrowse 2 documentation.
 
 We provide
 
-- [Quick start guide](quickstart_web) - for admins setting up JBrowse 2 on
-  their website
+- [Super-quick start guide](quickstart_web) - super brief setup instructions
+  e.g. 10 lines of CLI commands to help admins who are familiar with jbrowse
+  with getting setup
+- [Quick start guide](quickstart_web) - a more thourough quick-start guide to
+  help admins setting up JBrowse 2 on their website
 - [User guide](user_guide) - screenshots of the app and general usage
 - [Configuration guide](config_guide) - for detailed configuration settings
 - [Developer guide](developer_guide) - for developers of plugins and

--- a/website/docs/quickquickstart_web.md
+++ b/website/docs/quickquickstart_web.md
@@ -1,0 +1,55 @@
+---
+id: quickquickstart_web
+title: Super-quick start for jbrowse web
+toplevel: true
+---
+
+This guide assumes you have some familiarity with JBrowse and running static
+sites
+
+This is a quick overview to get started running JBrowse 2 from scratch
+
+This guide assumes you have a webserver that reads files from /var/www/html/
+e.g. apache or nginx and Node 10+ installed
+
+```bash
+## Install jbrowse 2 CLI tools
+npm install -g @jbrowse/cli
+
+## Downloads latest release and unpacks it to web server folder
+jbrowse create /var/www/html/jbrowse2
+
+## Create indexed FASTA file for your genome
+samtools faidx genome.fa
+
+## Add your genome assembly to the config at /var/www/html/jbrowse2/config.json
+## Also copies the files to this directory
+jbrowse add-assembly genome.fa --out /var/www/html/jbrowse2 --load copy
+
+
+## Copy file.bam and file.bam.bai to /var/www/html/jbrowse2 and adds track to
+## the config at /var/www/html/jbrowse2/config.json. Note that I can refer to a
+## folder name with --out, in which case it is foldername+'config.json' or a
+## specific filename for a config
+jbrowse add-track file.bam --out /var/www/html/jbrowse2/config.json --load copy
+
+## adds a url entry for a bam file to the  config.json, but no file operations
+performed
+jbrowse add-track http://website.com/myfile.bam --out /var/www/html/jbrowse2
+
+
+## add a BigWig track
+jbrowse add-track myfile.bw --out /var/www/html/jbrowse2
+
+
+gt gff3 -sortlines -tidy myfile.gff > myfile.sorted.gff
+bgzip myfile.sorted.gff
+tabix myfile.sorted.gff.gz
+jbrowse add-track myfile.sorted.gff.gz --out /var/www/html/jbrowse2 --load copy
+```
+
+You can now visit http://localhost/jbrowse2 and your genome should be loaded
+with a bigwig, a GFF, and a BAM file!
+
+Please see the extended quick-start guide [quickstart_cli](here) for a more
+thorough tutorial

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -73,11 +73,24 @@ jbrowse add-track myfile.bam --subDir my_bams --out /var/www/html/jbrowse2 --loa
 cd /var/www/html/jbrowse2
 jbrowse add-track /path/to/my/file.bam --load copy
 
-## Loading a synteny track using a PAF file
-minimap2 grape.fa peach.fa > grape_peach_alignments.paf
-jbrowse add-track grape.fa --load copy
-jbrowse add-track peach.fa --load copy
-jbrowse add-track grape_peach_alignments.paf --assemblyNames grape,peach --out load copy
+## Demo for loading synteny data, both assemblies are outputted to a single
+## config.json in /var/www/html/jbrowse2/config.json
+minimap2 grape.fa peach.fa > peach_vs_grape.paf
+jbrowse add-assembly grape.fa --load copy --out /var/www/html/jbrowse2/ -n grape
+jbrowse add-assembly peach.fa --load copy --out /var/www/html/jbrowse2/ -n peach
+
+## Use gt gff3 to make sorted tabixed gffs for each assembly, and then load to
+## their respective ## assembly
+jbrowse add-track grape.sorted.gff.gz -a grape --load copy --out /var/www/html/jbrowse2
+jbrowse add-track peach.sorted.gff.gz -a peach --load copy --out /var/www/html/jbrowse2
+
+## Load the synteny "track" from a PAF file. Note the order matters here for
+## the --assemblyNames parameter. If minimap2 is run like `minimap2 grape.fa
+## peach.fa` then you load --assemblyNames peach,grape
+jbrowse add-track peach_vs_grape.paf --assemblyNames peach,grape --out load copy
+
+
+
 
 ## After you've had jbrowse for awhile, you can upgrade to our latest release
 jbrowse upgrade /var/www/html/jbrowse2

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -1,5 +1,5 @@
 ---
-id: quickquickstart_web
+id: superquickstart_web
 title: Super-quick start for jbrowse web
 toplevel: true
 ---
@@ -9,8 +9,12 @@ sites
 
 This is a quick overview to get started running JBrowse 2 from scratch
 
-This guide assumes you have a webserver that reads files from /var/www/html/
-e.g. apache or nginx and Node 10+ installed
+This guide assumes you have
+
+- a webserver that reads files from /var/www/html/ e.g. apache or nginx
+- Node 10+ installed
+- GenomeTools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`
+- samtools installed e.g. `sudo apt install samtools` or `brew install samtools`
 
 ```bash
 ## Install jbrowse 2 CLI tools
@@ -34,7 +38,7 @@ jbrowse add-assembly genome.fa --out /var/www/html/jbrowse2 --load copy
 jbrowse add-track file.bam --out /var/www/html/jbrowse2/config.json --load copy
 
 ## adds a url entry for a bam file to the  config.json, but no file operations
-performed
+## performed
 jbrowse add-track http://website.com/myfile.bam --out /var/www/html/jbrowse2
 
 
@@ -42,6 +46,7 @@ jbrowse add-track http://website.com/myfile.bam --out /var/www/html/jbrowse2
 jbrowse add-track myfile.bw --out /var/www/html/jbrowse2
 
 
+## load gene annotations from a GFF
 gt gff3 -sortlines -tidy myfile.gff > myfile.sorted.gff
 bgzip myfile.sorted.gff
 tabix myfile.sorted.gff.gz
@@ -51,5 +56,7 @@ jbrowse add-track myfile.sorted.gff.gz --out /var/www/html/jbrowse2 --load copy
 You can now visit http://localhost/jbrowse2 and your genome should be loaded
 with a bigwig, a GFF, and a BAM file!
 
-Please see the extended quick-start guide [quickstart_cli](here) for a more
-thorough tutorial
+This guide is meant to be a super-quick conceptual overview for getting jbrowse
+2 setup, but if you are new to the command line or to jbrowse in general, you
+might want to start with the slightly-longer quick-start guide
+[quickstart_cli](here).

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -46,7 +46,9 @@ jbrowse add-track myfile.bam --index myfile.bai --out /var/www/html/jbrowse2
 
 ## Alternative loading syntax where I specify a config file, and then this can
 ## be loaded via http://localhost/jbrowse2/?config=alt_config.json
-jbrowse add-assembly mygenome.fa --out /var/www/html/jbrowse2/alt_config.json
+## Also demonstrates using --load symlink instead of --load copy to avoid
+## copying large files
+jbrowse add-assembly mygenome.fa --out /var/www/html/jbrowse2/alt_config.json --load symlink
 
 
 ## add a BigWig track
@@ -67,11 +69,11 @@ with a bigwig, a GFF, and a BAM file!
 This guide is meant to be a super-quick conceptual overview for getting jbrowse
 2 setup, but if you are new to the command line or to jbrowse in general, you
 might want to start with the slightly-longer quick-start guide
-[quickstart_cli](here).
+[here](quickstart_cli).
 
 Footnote: JBrowse doesn't strictly need Apache or nginx, it is "static site
 compatible" meaning it uses no server side code and can run on any static
 website hosting. For example, you can upload the jbrowse folder that we
 prepared here in /var/www/html/jbrowse2 to Amazon S3, and it will work there
-too. Other types of servers that people use such as Django also should be ok,
-you may want to put your JBrowse files in the static folder for Django
+too. See the FAQ for [what webserver do I
+need](faq#what-web-server-do-i-need-to-run-jbrowse-2) for more info.

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -4,7 +4,7 @@ title: Super-quick start guide for JBrowse web
 toplevel: true
 ---
 
-This is a quick overview to get started running JBrowse 2 from scratch. It is
+This is a quick overview to get started running JBrowse 2 from scratch using the command line. It is
 helpful if you have some familiarity with the command line in general to follow
 these steps. This guide also assumes you have:
 
@@ -15,7 +15,7 @@ these steps. This guide also assumes you have:
 - tabix installed e.g. `sudo apt install tabix` or `brew install htslib`, used for created tabix indexes for BED/VCF/GFF files
 
 ```bash
-## Install jbrowse 2 CLI tools
+## Install JBrowse 2 CLI tools
 npm install -g @jbrowse/cli
 
 ## Downloads latest release and unpacks it to web server folder

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -47,7 +47,7 @@ jbrowse add-track myfile.bw --out /var/www/html/jbrowse2
 
 
 ## load gene annotations from a GFF
-gt gff3 -sortlines -tidy myfile.gff > myfile.sorted.gff
+gt gff3 -sortlines -tidy -retainids myfile.gff > myfile.sorted.gff
 bgzip myfile.sorted.gff
 tabix myfile.sorted.gff.gz
 jbrowse add-track myfile.sorted.gff.gz --out /var/www/html/jbrowse2 --load copy

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -1,17 +1,14 @@
 ---
 id: superquickstart_web
-title: Super-quick start for jbrowse web
+title: Super-quick start guide for JBrowse web
 toplevel: true
 ---
 
-This guide assumes you have some familiarity with JBrowse and running static
-sites
+This is a quick overview to get started running JBrowse 2 from scratch. It is
+helpful if you have some familiarity with the command line in general to follow
+these steps. This guide also assumes you have:
 
-This is a quick overview to get started running JBrowse 2 from scratch
-
-This guide assumes you have:
-
-- a webserver that reads files from /var/www/html/ e.g. Apache or nginx
+- a webserver that reads files from /var/www/html/ e.g. Apache or nginx (not strictly necessary for jbrowse to run, see footnote)
 - node 10+ installed
 - genometools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`, used for sorting GFF3 for creating tabix GFF
 - samtools installed e.g. `sudo apt install samtools` or `brew install samtools`, used for creating FASTA index and BAM/CRAM processing
@@ -72,8 +69,9 @@ This guide is meant to be a super-quick conceptual overview for getting jbrowse
 might want to start with the slightly-longer quick-start guide
 [quickstart_cli](here).
 
-Note that you can also upload your JBrowse instance to Amazon S3 or any other
-static site hosting. GitHub pages also works, but Github probably isn't as well
-suited for hosting large data files common in genomics. If you use a different
-server platform such as Django, you can put the JBrowse files in your "static"
-directory.
+Footnote: JBrowse doesn't strictly need Apache or nginx, it is "static site
+compatible" meaning it uses no server side code and can run on any static
+website hosting. For example, you can upload the jbrowse folder that we
+prepared here in /var/www/html/jbrowse2 to Amazon S3, and it will work there
+too. Other types of servers that people use such as Django also should be ok,
+you may want to put your JBrowse files in the static folder for Django

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -9,12 +9,13 @@ sites
 
 This is a quick overview to get started running JBrowse 2 from scratch
 
-This guide assumes you have
+This guide assumes you have:
 
-- a webserver that reads files from /var/www/html/ e.g. apache or nginx
-- Node 10+ installed
-- GenomeTools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`
-- samtools installed e.g. `sudo apt install samtools` or `brew install samtools`
+- a webserver that reads files from /var/www/html/ e.g. Apache or nginx
+- node 10+ installed
+- genometools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`, used for sorting GFF3 for creating tabix GFF
+- samtools installed e.g. `sudo apt install samtools` or `brew install samtools`, used for creating FASTA index and BAM/CRAM processing
+- tabix installed e.g. `sudo apt install tabix` or `brew install htslib`, used for created tabix indexes for BED/VCF/GFF files
 
 ```bash
 ## Install jbrowse 2 CLI tools
@@ -32,21 +33,31 @@ jbrowse add-assembly genome.fa --out /var/www/html/jbrowse2 --load copy
 
 
 ## Copy file.bam and file.bam.bai to /var/www/html/jbrowse2 and adds track to
-## the config at /var/www/html/jbrowse2/config.json. Note that I can refer to a
-## folder name with --out, in which case it is foldername+'config.json' or a
-## specific filename for a config
+## the config at /var/www/html/jbrowse2/config.json. Assumes that file.bam and
+## file.bam.bai exist
 jbrowse add-track file.bam --out /var/www/html/jbrowse2/config.json --load copy
 
-## adds a url entry for a bam file to the  config.json, but no file operations
-## performed
+## Adds a url entry for a bam file to the  config.json, but no file operations
+## performed, assumes BAM file is at http://website.com/myfile.bam.bai
 jbrowse add-track http://website.com/myfile.bam --out /var/www/html/jbrowse2
 
 
+## If your BAM index (bai) is not filename+'.bai' then you can manually
+## specifies index location with --index flag
+jbrowse add-track myfile.bam --index myfile.bai --out /var/www/html/jbrowse2
+
+
+## Alternative loading syntax where I specify a config file, and then this can
+## be loaded via http://localhost/jbrowse2/?config=alt_config.json
+jbrowse add-assembly mygenome.fa --out /var/www/html/jbrowse2/alt_config.json
+
+
 ## add a BigWig track
-jbrowse add-track myfile.bw --out /var/www/html/jbrowse2
+jbrowse add-track myfile.bw --out /var/www/html/jbrowse2 --load copy
 
 
-## load gene annotations from a GFF
+## load gene annotations from a GFF, using "GenomeTools" (gt) to sort the gff
+## and tabix to index the GFF3
 gt gff3 -sortlines -tidy -retainids myfile.gff > myfile.sorted.gff
 bgzip myfile.sorted.gff
 tabix myfile.sorted.gff.gz
@@ -60,3 +71,9 @@ This guide is meant to be a super-quick conceptual overview for getting jbrowse
 2 setup, but if you are new to the command line or to jbrowse in general, you
 might want to start with the slightly-longer quick-start guide
 [quickstart_cli](here).
+
+Note that you can also upload your JBrowse instance to Amazon S3 or any other
+static site hosting. GitHub pages also works, but Github probably isn't as well
+suited for hosting large data files common in genomics. If you use a different
+server platform such as Django, you can put the JBrowse files in your "static"
+directory.

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -4,15 +4,18 @@ title: Super-quick start guide for JBrowse web
 toplevel: true
 ---
 
-This is a quick overview to get started running JBrowse 2 from scratch using the command line. It is
-helpful if you have some familiarity with the command line in general to follow
+This is a quick overview to get started running JBrowse 2 from scratch using
+the command line. It is helpful if you have some familiarity with the command
+line and with some bioinformatics tools like samtools in general to follow
 these steps. This guide also assumes you have:
 
-- a webserver that reads files from /var/www/html/ e.g. Apache or nginx (not strictly necessary for jbrowse to run, see footnote)
+- a webserver that reads files from /var/www/html/ e.g. Apache or nginx (not
+  strictly necessary for jbrowse to run, see footnote)
 - node 10+ installed
 - genometools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`, used for sorting GFF3 for creating tabix GFF
 - samtools installed e.g. `sudo apt install samtools` or `brew install samtools`, used for creating FASTA index and BAM/CRAM processing
-- tabix installed e.g. `sudo apt install tabix` or `brew install htslib`, used for created tabix indexes for BED/VCF/GFF files
+- tabix installed e.g. `sudo apt install tabix` or `brew install htslib`, used
+  for created tabix indexes for BED/VCF/GFF files
 
 ## Super-quick overview for CLI
 
@@ -34,14 +37,14 @@ jbrowse create /var/www/html/jbrowse2
 samtools faidx genome.fa
 jbrowse add-assembly genome.fa --out /var/www/html/jbrowse2 --load copy
 
-## Copy file.bam and file.bam.bai to /var/www/html/jbrowse2 and adds track to
+## Copies file.bam and file.bam.bai to /var/www/html/jbrowse2 and adds track to
 ## the config at /var/www/html/jbrowse2/config.json. Assumes that file.bam and
 ## file.bam.bai exist
 samtools index file.bam
 jbrowse add-track file.bam --out /var/www/html/jbrowse2/ --load copy
 
 ## Adds a url entry for a bam file to the config.json, the URL is stored in the
-## config instead of downloading files
+## config instead of downloading files, so no --load flag is needed
 jbrowse add-track http://website.com/myfile.bam --out /var/www/html/jbrowse2
 
 ## If your BAM index (bai) is not filename+'.bai' then you can manually specify
@@ -74,7 +77,7 @@ jbrowse add-track /path/to/my/file.bam --load copy
 minimap2 grape.fa peach.fa > grape_peach_alignments.paf
 jbrowse add-track grape.fa --load copy
 jbrowse add-track peach.fa --load copy
-jbrowse add-track grape_peach_alignments.paf --assemblyNames grape,peach
+jbrowse add-track grape_peach_alignments.paf --assemblyNames grape,peach --out load copy
 
 ## After you've had jbrowse for awhile, you can upgrade to our latest release
 jbrowse upgrade /var/www/html/jbrowse2

--- a/website/docusaurus.config.json
+++ b/website/docusaurus.config.json
@@ -7,7 +7,8 @@
   "organizationName": "GMOD",
   "projectName": "jbrowse-components",
   "customFields": {
-    "currentLink": "https://s3.amazonaws.com/jbrowse.org/code/jb2/v1.1.0/index.html"
+    "currentLink": "https://s3.amazonaws.com/jbrowse.org/code/jb2/v1.1.0/index.html",
+    "currentVersion": "v1.1.0"
   },
   "themeConfig": {
     "colorMode": {

--- a/website/docusaurus.config.json
+++ b/website/docusaurus.config.json
@@ -33,6 +33,11 @@
           "position": "left"
         },
         {
+          "to": "download",
+          "label": "Download",
+          "position": "left"
+        },
+        {
           "to": "features",
           "label": "Features",
           "position": "left"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,6 +7,7 @@
       "type": "category",
       "label": "Quickstart guides",
       "items": [
+        "quickquickstart_web",
         "quickstart_web",
         "quickstart_cli",
         "quickstart_gui",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,7 +7,7 @@
       "type": "category",
       "label": "Quickstart guides",
       "items": [
-        "quickquickstart_web",
+        "superquickstart_web",
         "quickstart_web",
         "quickstart_cli",
         "quickstart_gui",

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -26,7 +26,14 @@ mv jbrowse_folder /var/www/html/jbrowse2
 
 Then your instance will be available from http://localhost/jbrowse2
 
-See [the quickstart guide](../docs/quickstart_web) for more info on loading tracks and getting started
+If you use some other custom system, such as django, follow steps to host your
+content in your static folder
+
+Note: this folder is a "static website compatible" content, containing just JS,
+CSS, and no server side scripts, so Amazon s3 any static site hosting can be
+used as an alternative
+
+See [the quickstart guide](/docs/quickstart_web) for more info on loading tracks and getting started
 
 You can also manually download this release as a zip file from GitHub here
 

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -1,0 +1,33 @@
+import { customFields } from '../../docusaurus.config.json'
+
+export const Link = () => {
+  const curr = `https://github.com/GMOD/jbrowse-components/releases/tag/${customFields.currentVersion}`
+  return <a href={curr}>{curr}</a>
+}
+
+# JBrowse 2 download
+
+To get started with JBrowse 2, we recommend using the "jbrowse CLI"
+
+Run
+
+```
+npm install -g @jbrowse/cli
+jbrowse create jbrowse_folder
+```
+
+This will download the latest jbrowse to a folder called jbrowse_folder
+
+If you have a server with apache or nginx, you can then
+
+```
+mv jbrowse_folder /var/www/html/jbrowse2
+```
+
+Then your instance will be available from http://localhost/jbrowse2
+
+See [the quickstart guide](../docs/quickstart_web) for more info on loading tracks and getting started
+
+You can also manually download this release as a zip file from GitHub here
+
+<Link />

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -12,7 +12,7 @@ export const Link = () => {
 ## JBrowse 2 web
 
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
-You'll want to use the jbrowse CLI for things like adding tracks too
+You'll want to use the jbrowse CLI for things like adding tracks too.
 
 ```
 npm install -g @jbrowse/cli
@@ -21,19 +21,19 @@ npm install -g @jbrowse/cli
 jbrowse create jbrowse_folder
 ```
 
-Alternatively manually download this release as a zip file from GitHub here
+Alternatively manually download this release as a zip file from GitHub here:
 
 <Link />
 
 To get it setup, check out our [super-quick start
-guide](/docs/superquickstart-web) or slightly-longer [quick-start
+guide](/docs/superquickstart_web) or slightly-longer [quick-start
 guide](/docs/quickstart_web) for setting up JBrowse Web.
 
 ## JBrowse 2 embedded components
 
 We also have our embedded components, such as
 @jbrowse/react-linear-genome-view, which is just the component for the linear
-genome browser view (no circular, dotplot, etc)
+genome browser view (no circular, dotplot, etc).
 
 See https://www.npmjs.com/package/@jbrowse/react-linear-genome-view for
-instructions on downloading this with npm or yarn
+instructions on downloading this with npm or yarn.

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -16,25 +16,6 @@ npm install -g @jbrowse/cli
 jbrowse create jbrowse_folder
 ```
 
-This will download the latest jbrowse to a folder called jbrowse_folder
-
-If you have a server with apache or nginx, you can then
-
-```
-mv jbrowse_folder /var/www/html/jbrowse2
-```
-
-Then your instance will be available from http://localhost/jbrowse2
-
-If you use some other custom system, such as django, follow steps to host your
-content in your static folder
-
-Note: this folder is a "static website compatible" content, containing just JS,
-CSS, and no server side scripts, so Amazon s3 any static site hosting can be
-used as an alternative
-
-See [the quickstart guide](/docs/quickstart_web) for more info on loading tracks and getting started
-
-You can also manually download this release as a zip file from GitHub here
+You can alternatively manually download this release as a zip file from GitHub here
 
 <Link />

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -25,7 +25,7 @@ Alternatively manually download this release as a zip file from GitHub here:
 
 <Link />
 
-To get it setup, check out our [super-quick start
+To get it set up, check out our [super-quick start
 guide](/docs/superquickstart_web) or slightly-longer [quick-start
 guide](/docs/quickstart_web) for setting up JBrowse Web.
 

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -32,7 +32,7 @@ guide](/docs/quickstart_web) for setting up JBrowse Web.
 ## JBrowse 2 embedded components
 
 We also have our embedded components, such as
-@jbrowse/react-linear-genome-view, which is just the component for the linear
+@jbrowse/react-linear-genome-view, which is the React component for the linear
 genome browser view (no circular, dotplot, etc).
 
 See https://www.npmjs.com/package/@jbrowse/react-linear-genome-view for

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -12,7 +12,7 @@ export const Link = () => {
 ## JBrowse 2 web
 
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
-You'll want to use the jbrowse CLI for things like adding tracks too.
+You can also use the jbrowse CLI for things like adding tracks too.
 
 ```
 npm install -g @jbrowse/cli

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -21,7 +21,7 @@ npm install -g @jbrowse/cli
 jbrowse create jbrowse_folder
 ```
 
-Alternatively manually download this release as a zip file from GitHub here:
+Alternatively, manually download this release as a zip file from GitHub here:
 
 <Link />
 

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -2,20 +2,38 @@ import { customFields } from '../../docusaurus.config.json'
 
 export const Link = () => {
   const curr = `https://github.com/GMOD/jbrowse-components/releases/tag/${customFields.currentVersion}`
-  return <a href={curr}>{curr}</a>
+  return (
+    <div style={{ margin: 50 }}>
+      <a href={curr}>{curr}</a>
+    </div>
+  )
 }
 
-# JBrowse 2 download
+## JBrowse 2 web
 
-To get started with JBrowse 2, we recommend using the "jbrowse CLI"
-
-Run
+To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
+You'll want to use the jbrowse CLI for things like adding tracks too
 
 ```
 npm install -g @jbrowse/cli
+
+## Downloads the latest release of jbrowse from github releases
 jbrowse create jbrowse_folder
 ```
 
-You can alternatively manually download this release as a zip file from GitHub here
+Alternatively manually download this release as a zip file from GitHub here
 
 <Link />
+
+To get it setup, check out our [super-quick start
+guide](/docs/superquickstart-web) or slightly-longer [quick-start
+guide](/docs/quickstart_web) for setting up JBrowse Web.
+
+## JBrowse 2 embedded components
+
+We also have our embedded components, such as
+@jbrowse/react-linear-genome-view, which is just the component for the linear
+genome browser view (no circular, dotplot, etc)
+
+See https://www.npmjs.com/package/@jbrowse/react-linear-genome-view for
+instructions on downloading this with npm or yarn


### PR DESCRIPTION
Proposes having a download page in the header bar for easy access to the latest release, for people that are too lazy to go through the blog post


Example screenshot
![localhost_3000_jb2_download (1)](https://user-images.githubusercontent.com/6511937/112881317-82930000-9099-11eb-9b90-e6636a9297a0.png)
