### PR TITLE
Make @jbrowse/react-linear-genome-view storybook docs more visible

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -16,8 +16,9 @@ We provide
 - [Developer guide](developer_guide) - for developers of plugins and
   core codebase topics
 - [FAQ](faq) - Some Q&A for troubleshooting or other topics
+- [@jbrowse/linear-genome-view docs](https://jbrowse.org/storybook/lgv/main/) - Docs for the re-usable linear genome view react component
 
-We also keep a log of our previous training classes
+We also keep a log of our previous training classes in the sidebar
 
 ### Contact information
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -73,7 +73,7 @@ function Home() {
                 <Link href="https://www.npmjs.com/package/@jbrowse/react-linear-genome-view">
                   Linear genome view React component on <tt>npm</tt>
                 </Link>{' '}
-                <Link href={storybookLink}>(docs)</Link>
+                also see <Link href={storybookLink}>storybook docs</Link>
               </li>
               <li>
                 <Link href="https://gmod.github.io/JBrowseR/">


### PR DESCRIPTION
It is not really clear from the (docs) that this (docs) is a separate link, so I made it into a separate part of a sentence

Also linked to the storybook docs from the /jb2/docs/ landing page

screenshots
![localhost_3000_jb2_](https://user-images.githubusercontent.com/6511937/113042390-23042580-9169-11eb-834e-1d8e06fbed56.png)


![localhost_3000_jb2_ (1)](https://user-images.githubusercontent.com/6511937/113042384-21d2f880-9169-11eb-8b21-5db7787467e0.png)

