### PR TITLE
Fix alignments read filter jexl syntax

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -383,7 +383,7 @@ const stateModelFactory = (
             if (self.filterBy.tagFilter) {
               const { tag, value } = self.filterBy.tagFilter
               filters.push(
-                `jexl:"${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}")`,
+                `jexl:"${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}"`,
               )
             }
             if (self.filterBy.readName) {

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -142,7 +142,7 @@ const stateModelFactory = (
         },
         // The SNPCoverage filters are called twice because the BAM/CRAM features
         // pass filters and then the SNPCoverage score features pass through
-        // here, and those have no name/flags/tags so those are passed thru
+        // here, and are already have 'snpinfo' are passed through
         get filters() {
           let filters: string[] = []
           if (self.filterBy) {
@@ -156,13 +156,16 @@ const stateModelFactory = (
             if (self.filterBy.tagFilter) {
               const { tag, value } = self.filterBy.tagFilter
               filters.push(
-                `jexl:get(feature,'snpinfo') != undefined ? true : "${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}"`,
+                `jexl:get(feature,'snpinfo') != undefined ? true : ` +
+                  `"${value}" =='*' ? getTag(feature,"${tag}") != undefined : ` +
+                  `getTag(feature,"${tag}") == "${value}"`,
               )
             }
             if (self.filterBy.readName) {
               const { readName } = self.filterBy
               filters.push(
-                `jexl:get(feature,'snpinfo') != undefined ? true : get(feature,'name') == "${readName}"`,
+                `jexl:get(feature,'snpinfo') != undefined ? true : ` +
+                  `get(feature,'name') == "${readName}"`,
               )
             }
           }

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -148,19 +148,19 @@ const stateModelFactory = (
           if (self.filterBy) {
             const { flagInclude, flagExclude } = self.filterBy
             filters = [
-              `jexl:get(feature,'snpinfo') != undefined ? true : ((get(feature,'flags')&${flagInclude})==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
+              `jexl:get(feature,'snpinfo') != undefined ? true : (get(feature,'flags')&${flagInclude}==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
             ]
 
             if (self.filterBy.tagFilter) {
               const { tag, value } = self.filterBy.tagFilter
               filters.push(
-                `jexl:get(feature,'snpinfo') ? true : "${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}")`,
+                `jexl:get(feature,'snpinfo') != undefined ? true : "${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}"`,
               )
             }
             if (self.filterBy.readName) {
               const { readName } = self.filterBy
               filters.push(
-                `jexl:get(feature,'snpinfo') ? true : get(feature,'name') == "${readName}"`,
+                `jexl:get(feature,'snpinfo') != undefined ? true : get(feature,'name') == "${readName}"`,
               )
             }
           }

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -148,7 +148,9 @@ const stateModelFactory = (
           if (self.filterBy) {
             const { flagInclude, flagExclude } = self.filterBy
             filters = [
-              `jexl:get(feature,'snpinfo') != undefined ? true : (get(feature,'flags')&${flagInclude}==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
+              `jexl:get(feature,'snpinfo') != undefined ? true : ` +
+                `((get(feature,'flags')&${flagInclude})==${flagInclude}) && ` +
+                `!((get(feature,'flags')&${flagExclude}))`,
             ]
 
             if (self.filterBy.tagFilter) {


### PR DESCRIPTION
This fixes the filters on alignments track e.g. read name, which currently had jexl syntax errors which are displayed in 1.1.0 if filters attempt to be used
