### PR TITLE
Change "Fade mismatches by quality" setting to separate config param and make less strict

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -63,6 +63,7 @@ const stateModelFactory = (
         featureHeight: types.maybe(types.number),
         noSpacing: types.maybe(types.boolean),
         trackMaxHeight: types.maybe(types.number),
+        mismatchAlpha: types.maybe(types.boolean),
         sortedBy: types.maybe(
           types.model({
             type: types.string,
@@ -252,6 +253,9 @@ const stateModelFactory = (
       toggleSoftClipping() {
         self.showSoftClipping = !self.showSoftClipping
       },
+      toggleMismatchAlpha() {
+        self.mismatchAlpha = !self.mismatchAlpha
+      },
 
       setConfig(configuration: AnyConfigurationModel) {
         self.configuration = configuration
@@ -315,12 +319,18 @@ const stateModelFactory = (
           height: self.featureHeight,
           noSpacing: self.noSpacing,
           maxHeight: this.maxHeight,
+          mismatchAlpha: self.mismatchAlpha,
         })
       },
       get featureHeightSetting() {
         return (
           self.featureHeight || readConfObject(this.rendererConfig, 'height')
         )
+      },
+      get mismatchAlphaSetting() {
+        return self.mismatchAlpha !== undefined
+          ? self.mismatchAlpha
+          : readConfObject(this.rendererConfig, 'mismatchAlpha')
       },
     }))
     .views(self => {
@@ -490,12 +500,6 @@ const stateModelFactory = (
                   },
                 },
                 {
-                  label: 'Adjust mismatch visibility by quality',
-                  onClick: () => {
-                    self.setColorScheme({ type: 'mismatchQuality' })
-                  },
-                },
-                {
                   label: 'Insert size',
                   onClick: () => {
                     self.setColorScheme({ type: 'insertSize' })
@@ -544,6 +548,14 @@ const stateModelFactory = (
                   SetMaxHeightDlg,
                   self,
                 )
+              },
+            },
+            {
+              label: 'Fade mismatches by quality',
+              type: 'checkbox',
+              checked: self.mismatchAlphaSetting,
+              onClick: () => {
+                self.toggleMismatchAlpha()
               },
             },
           ]

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -444,7 +444,7 @@ export default class PileupRenderer extends BoxRendererType {
         let color = baseColor
         if (mismatchQuality && mismatch.qual !== undefined) {
           color = Color(baseColor)
-            .alpha(mismatch.qual / 90)
+            .alpha(Math.min(1, mismatch.qual / 50))
             .hsl()
             .string()
         }

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.ts
@@ -613,7 +613,6 @@ export default class PileupRenderer extends BoxRendererType {
       sortedBy,
       highResolutionScaling = 1,
       showSoftClip,
-      colorBy = {} as { type?: string },
       theme: configTheme,
     } = props
     const theme = createJBrowseTheme(configTheme)
@@ -653,6 +652,7 @@ export default class PileupRenderer extends BoxRendererType {
 
     const width = (region.end - region.start) / bpPerPx
     const height = Math.max(layout.getTotalHeight(), 1)
+    const mismatchAlpha = readConfObject(config, 'mismatchAlpha')
 
     const canvas = createCanvas(
       Math.ceil(width * highResolutionScaling),
@@ -670,14 +670,7 @@ export default class PileupRenderer extends BoxRendererType {
 
       ctx.fillStyle = readConfObject(config, 'color', { feature })
       this.drawAlignmentRect(ctx, { feature, topPx, heightPx }, props)
-      this.drawMismatches(
-        ctx,
-        feat,
-        props,
-        colorBy.type === 'mismatchQuality',
-        colorForBase,
-        theme,
-      )
+      this.drawMismatches(ctx, feat, props, mismatchAlpha, colorForBase, theme)
       if (showSoftClip) {
         this.drawSoftClipping(ctx, feat, props, config, theme)
       }

--- a/plugins/alignments/src/PileupRenderer/configSchema.ts
+++ b/plugins/alignments/src/PileupRenderer/configSchema.ts
@@ -55,6 +55,11 @@ export default ConfigurationSchema(
       description: 'remove spacing between features',
       defaultValue: false,
     },
+    mismatchAlpha: {
+      type: 'boolean',
+      defaultValue: true,
+      description: 'Color mismatches by their quality using alpha fade',
+    },
   },
   { explicitlyTyped: true },
 )

--- a/plugins/alignments/src/PileupRenderer/configSchema.ts
+++ b/plugins/alignments/src/PileupRenderer/configSchema.ts
@@ -57,8 +57,8 @@ export default ConfigurationSchema(
     },
     mismatchAlpha: {
       type: 'boolean',
-      defaultValue: true,
-      description: 'Color mismatches by their quality using alpha fade',
+      defaultValue: false,
+      description: 'Fade low quality mismatches',
     },
   },
   { explicitlyTyped: true },

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -1335,6 +1335,63 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
           class="makeStyles-slotModeSwitch"
         />
       </div>
+      <div
+        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          class="makeStyles-paperContent"
+        >
+          <div
+            class="MuiFormControl-root"
+          >
+            <label
+              class="MuiFormControlLabel-root"
+            >
+              <span
+                aria-disabled="false"
+                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+              >
+                <span
+                  class="MuiIconButton-label"
+                >
+                  <input
+                    class="PrivateSwitchBase-input"
+                    data-indeterminate="false"
+                    type="checkbox"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+              >
+                mismatchAlpha
+              </span>
+            </label>
+            <p
+              class="MuiFormHelperText-root"
+            >
+              Fade low quality mismatches
+            </p>
+          </div>
+        </div>
+        <div
+          class="makeStyles-slotModeSwitch"
+        />
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The "Color by" scheme for alignments currently has 'Fade mismatches by quality'

Instead of making this specifically a property of "Color by", I change this to a separate setting

Then I also make the fading less "strict" e.g. right now it is a scale on a 0-90 but I make it on 0-50 because at quality 40, you are 99.99% sure the base call is right (see https://learn.gencore.bio.nyu.edu/wp-content/uploads/2018/01/Screen-Shot-2018-01-07-at-1.36.09-PM-768x535.png) and so you really only need to worry at like 20 or less. Even though phred can go up to 90 it does not need to really be faded after 50 or so I think