### PR TITLE
Add example for using a build-time included plugin to storybook

### DIFF
--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -63,7 +63,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "jbrowse-plugin-ucsc": "^1.0.3"
-  }
+  "devDependencies": {}
 }

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -62,5 +62,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "jbrowse-plugin-ucsc": "^1.0.3"
   }
 }

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,5 +1,6 @@
 import { PluginConstructor } from '@jbrowse/core/Plugin'
 import React, { useEffect, useState } from 'react'
+import UCSC from 'jbrowse-plugin-ucsc'
 import {
   createViewState,
   createJBrowseTheme,
@@ -230,6 +231,98 @@ export const WithRuntimePlugins = () => {
     location: '1:2,467,681..2,667,681',
     defaultSession: {
       name: 'Runtime plugins',
+      view: {
+        id: 'aU9Nqje1U',
+        type: 'LinearGenomeView',
+        offsetPx: 22654,
+        bpPerPx: 108.93300653594771,
+        displayedRegions: [
+          {
+            refName: '1',
+            start: 0,
+            end: 249250621,
+            reversed: false,
+            assemblyName: 'hg19',
+          },
+        ],
+        tracks: [
+          {
+            id: 'MbiRphmDa',
+            type: 'FeatureTrack',
+            configuration: 'segdups_ucsc_hg19',
+            displays: [
+              {
+                id: '8ovhuA5cFM',
+                type: 'LinearBasicDisplay',
+                height: 100,
+                configuration: 'segdups_ucsc_hg19-LinearBasicDisplay',
+              },
+            ],
+          },
+        ],
+        hideHeader: false,
+        hideHeaderOverview: false,
+        trackSelectorType: 'hierarchical',
+        trackLabels: 'overlapping',
+        showCenterLine: false,
+      },
+    },
+  })
+  return (
+    <ThemeProvider theme={theme}>
+      <JBrowseLinearGenomeView viewState={state} />
+    </ThemeProvider>
+  )
+}
+
+export const WithBuildTimePlugins = () => {
+  const state = createViewState({
+    assembly: {
+      name: 'hg19',
+      aliases: ['GRCh37'],
+      sequence: {
+        type: 'ReferenceSequenceTrack',
+        trackId: 'Pd8Wh30ei9R',
+        adapter: {
+          type: 'BgzipFastaAdapter',
+          fastaLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
+          },
+          faiLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
+          },
+          gziLocation: {
+            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
+          },
+        },
+      },
+      refNameAliases: {
+        adapter: {
+          type: 'RefNameAliasAdapter',
+          location: {
+            uri:
+              'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
+          },
+        },
+      },
+    },
+    plugins: [UCSC],
+    tracks: [
+      {
+        type: 'FeatureTrack',
+        trackId: 'segdups_ucsc_hg19',
+        name: 'UCSC SegDups',
+        category: ['Annotation'],
+        assemblyNames: ['hg19'],
+        adapter: {
+          type: 'UCSCAdapter',
+          track: 'genomicSuperDups',
+        },
+      },
+    ],
+    location: '1:2,467,681..2,667,681',
+    defaultSession: {
+      name: 'Build-time plugins',
       view: {
         id: 'aU9Nqje1U',
         type: 'LinearGenomeView',

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,6 +1,5 @@
 import { PluginConstructor } from '@jbrowse/core/Plugin'
 import React, { useEffect, useState } from 'react'
-import UCSC from 'jbrowse-plugin-ucsc'
 import {
   createViewState,
   createJBrowseTheme,
@@ -163,9 +162,13 @@ export const TwoLinearGenomeViews = () => {
   )
 }
 
-export const WithRuntimePlugins = () => {
-  const [plugins, setPlugins] = useState<PluginConstructor[]>()
+export const WithPlugins = () => {
+  // usage with buildtime plugins
+  // import UCSCPlugin from 'jbrowse-plugin-ucsc'
+  // const plugins = [UCSCPlugin]
 
+  // alternative usage with runtime plugins
+  const [plugins, setPlugins] = useState<PluginConstructor[]>()
   useEffect(() => {
     async function getPlugins() {
       const loadedPlugins = await loadPlugins([
@@ -231,98 +234,6 @@ export const WithRuntimePlugins = () => {
     location: '1:2,467,681..2,667,681',
     defaultSession: {
       name: 'Runtime plugins',
-      view: {
-        id: 'aU9Nqje1U',
-        type: 'LinearGenomeView',
-        offsetPx: 22654,
-        bpPerPx: 108.93300653594771,
-        displayedRegions: [
-          {
-            refName: '1',
-            start: 0,
-            end: 249250621,
-            reversed: false,
-            assemblyName: 'hg19',
-          },
-        ],
-        tracks: [
-          {
-            id: 'MbiRphmDa',
-            type: 'FeatureTrack',
-            configuration: 'segdups_ucsc_hg19',
-            displays: [
-              {
-                id: '8ovhuA5cFM',
-                type: 'LinearBasicDisplay',
-                height: 100,
-                configuration: 'segdups_ucsc_hg19-LinearBasicDisplay',
-              },
-            ],
-          },
-        ],
-        hideHeader: false,
-        hideHeaderOverview: false,
-        trackSelectorType: 'hierarchical',
-        trackLabels: 'overlapping',
-        showCenterLine: false,
-      },
-    },
-  })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
-}
-
-export const WithBuildTimePlugins = () => {
-  const state = createViewState({
-    assembly: {
-      name: 'hg19',
-      aliases: ['GRCh37'],
-      sequence: {
-        type: 'ReferenceSequenceTrack',
-        trackId: 'Pd8Wh30ei9R',
-        adapter: {
-          type: 'BgzipFastaAdapter',
-          fastaLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
-          },
-          faiLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
-          },
-          gziLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
-          },
-        },
-      },
-      refNameAliases: {
-        adapter: {
-          type: 'RefNameAliasAdapter',
-          location: {
-            uri:
-              'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
-          },
-        },
-      },
-    },
-    plugins: [UCSC],
-    tracks: [
-      {
-        type: 'FeatureTrack',
-        trackId: 'segdups_ucsc_hg19',
-        name: 'UCSC SegDups',
-        category: ['Annotation'],
-        assemblyNames: ['hg19'],
-        adapter: {
-          type: 'UCSCAdapter',
-          track: 'genomicSuperDups',
-        },
-      },
-    ],
-    location: '1:2,467,681..2,667,681',
-    defaultSession: {
-      name: 'Build-time plugins',
       view: {
         id: 'aU9Nqje1U',
         type: 'LinearGenomeView',

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -62,7 +62,29 @@ export const OneLinearGenomeView = () => {
     assembly,
     tracks,
     defaultSession,
+
+    // use 1-based coordinates for locstring
     location: 'ctgA:1105..1221',
+    onChange: patch => {
+      // eslint-disable-next-line no-console
+      console.log('patch', patch)
+    },
+  })
+  return (
+    <ThemeProvider theme={theme}>
+      <JBrowseLinearGenomeView viewState={state} />
+    </ThemeProvider>
+  )
+}
+
+export const OneLinearGenomeViewUsingLocObject = () => {
+  const state = createViewState({
+    assembly,
+    tracks,
+    defaultSession,
+
+    // use 0-based coordinates for "location object" here
+    location: { refName: 'ctgA', start: 10000, end: 20000 },
     onChange: patch => {
       // eslint-disable-next-line no-console
       console.log('patch', patch)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15721,6 +15721,11 @@ jake@^10.6.1:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
+jbrowse-plugin-ucsc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/jbrowse-plugin-ucsc/-/jbrowse-plugin-ucsc-1.0.3.tgz#1a71857657b8202ee29e8153001171242aed28ed"
+  integrity sha512-nhoyPjuGLwO7Iwfbe0xT40hEdZZodRfYykdNGpPqC9TfvisagbvVxmWRrKj67oo8NYQjZmeQsGpv32Xl9tXTdg==
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15721,11 +15721,6 @@ jake@^10.6.1:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
-jbrowse-plugin-ucsc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/jbrowse-plugin-ucsc/-/jbrowse-plugin-ucsc-1.0.3.tgz#1a71857657b8202ee29e8153001171242aed28ed"
-  integrity sha512-nhoyPjuGLwO7Iwfbe0xT40hEdZZodRfYykdNGpPqC9TfvisagbvVxmWRrKj67oo8NYQjZmeQsGpv32Xl9tXTdg==
-
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"


### PR DESCRIPTION
The storybook has an example of runtime-including a plugin but it is actually probably more common to use build-time plugins, so I added an example of that here

This adds a devDependency on jbrowse-plugin-ucsc to use as an example