### PR TITLE
Add Material UI's DataGrid to re-exports

### DIFF
--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -10,6 +10,7 @@ export default [
   '@material-ui/core/SvgIcon',
   '@material-ui/core/utils',
   '@material-ui/lab',
+  '@material-ui/data-grid',
 
   '@jbrowse/core/Plugin',
   '@jbrowse/core/pluggableElementTypes/ViewType',

--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -13,6 +13,7 @@ import * as MUICore from '@material-ui/core'
 import * as MUIUtils from '@material-ui/core/utils'
 import MUISvgIcon from '@material-ui/core/SvgIcon'
 import * as MUILab from '@material-ui/lab'
+import * as MUIDataGrid from '@material-ui/data-grid'
 import MUIBox from '@material-ui/core/Box'
 import MUIButton from '@material-ui/core/Button'
 import MUIButtonGroup from '@material-ui/core/ButtonGroup'
@@ -92,6 +93,7 @@ const libs = {
   '@material-ui/core/utils': MUIUtils,
   // end special case
   '@material-ui/lab': MUILab,
+  '@material-ui/data-grid': MUIDataGrid,
 
   // material-ui subcomponents, should get rid of these
   '@material-ui/core/colors': MUIColors,


### PR DESCRIPTION
@peterkxie is using the data-grid in the Apollo plugin, but it was proving hard to install in the plugin due to some conflicts with how we re-export Material UI for plugins. There are probably some improvements that could be made to make that easier, but as a first step, since the DataGrid is already in the peerDeps of core and is a useful component, I think we may as well re-export it so it's easy to use.