### PR TITLE
Fix deserializeArguments in CoreGetMetadata

### DIFF
--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -77,12 +77,18 @@ export class CoreGetFileInfo extends RpcMethodType {
 export class CoreGetMetadata extends RpcMethodType {
   name = 'CoreGetMetadata'
 
-  async execute(args: {
-    sessionId: string
-    signal: RemoteAbortSignal
-    adapterConfig: {}
-  }) {
-    const deserializedArgs = await this.deserializeArguments(args)
+  async execute(
+    args: {
+      sessionId: string
+      signal: RemoteAbortSignal
+      adapterConfig: {}
+    },
+    rpcDriverClassName: string,
+  ) {
+    const deserializedArgs = await this.deserializeArguments(
+      args,
+      rpcDriverClassName,
+    )
     const { sessionId, adapterConfig } = deserializedArgs
     const { dataAdapter } = getAdapter(
       this.pluginManager,


### PR DESCRIPTION
This fixes a TypeScript error present in main currently. Looks like it was introduced because #1790 added a param to the Base RPC Method's `deserializeArguments`, but that didn't exist yet when #1853 was created.