### PR TITLE
Export XYPlotRenderer and configSchema

### DIFF
--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -123,6 +123,8 @@ export default class extends Plugin {
   exports = {
     LinearWiggleDisplayReactComponent,
     XYPlotRendererReactComponent,
+    XYPlotRenderer,
+    xyPlotRendererConfigSchema,
     utils,
     WiggleBaseRenderer,
     linearWiggleDisplayModelFactory,


### PR DESCRIPTION
This adds the XYPlotRenderer and xyPlotRendererConfigSchema to the exports for the wiggle plugin. This was necessary in order to be able to import them when working on the quantseq external plugin.