### PR TITLE
Fix some synteny workflow crashes

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -85,7 +85,7 @@ export default () => {
         assemblyNames[selected[1]],
       ])
 
-      if ('uri' in trackData) {
+      if ('uri' in trackData && trackData.uri) {
         const fileName = trackData.uri
           ? trackData.uri.slice(trackData.uri.lastIndexOf('/') + 1)
           : null

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -112,7 +112,7 @@ const ImportForm = observer(({ model }: { model: LinearSyntenyViewModel }) => {
 
     model.views.forEach(view => view.setWidth(model.width))
 
-    if ('uri' in trackData) {
+    if ('uri' in trackData && trackData.uri) {
       const fileName = trackData.uri
         ? trackData.uri.slice(trackData.uri.lastIndexOf('/') + 1)
         : null

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -22,7 +22,7 @@ Current version demos
 - <Link extra="?config=test_data/breakpoint/config.json">
     Breakpoint split view demo (showing chromosomal translocation)
   </Link>
-- <Link extra="?config=test_data%2Fconfig_dotplot.json&session=share-yPV_esOMis&password=CD32t">
+- <Link extra="?config=test_data%2Fconfig_dotplot.json&session=share-zw51jIwuXb&password=i8WqY">
     Grape vs Peach dotplot
   </Link>
 - <Link extra="?config=test_data/yeast_synteny/config.json">Yeast dotplot</Link>


### PR DESCRIPTION
Currently, there are a couple of crashes in synteny workflows

1. Closing a linear synteny track produces an error on getContainingView of displayModel
2. Opening a dotplot or linear synteny view in the import form without a PAF file specified produces a crash



