### PR TITLE
Add aborting to CoreGetFeatures rpcManager call

### DIFF
--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -116,6 +116,7 @@ export class CoreGetFeatures extends RpcMethodType {
       signal: RemoteAbortSignal
       region: Region
       adapterConfig: {}
+      opts?: { signal?: AbortSignal }
     },
     rpcDriverClassName: string,
   ) {
@@ -123,18 +124,18 @@ export class CoreGetFeatures extends RpcMethodType {
       args,
       rpcDriverClassName,
     )
-    const { sessionId, adapterConfig, region } = deserializedArgs
+    const { sessionId, adapterConfig, region,opts } = deserializedArgs
     const { dataAdapter } = await getAdapter(
       this.pluginManager,
       sessionId,
       adapterConfig,
     )
-    if (isFeatureAdapter(dataAdapter)) {
-      const ret = dataAdapter.getFeatures(region)
-      const r = await ret.pipe(toArray()).toPromise()
-      return r.map(f => f.toJSON())
+    if (!isFeatureAdapter(dataAdapter)) {
+      return []
     }
-    return []
+    const ret = dataAdapter.getFeatures(region, opts)
+    const r = await ret.pipe(toArray()).toPromise()
+    return r.map(f => f.toJSON())
   }
 }
 

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -114,6 +114,7 @@ export class CoreGetFeatures extends RpcMethodType {
       region: Region
       adapterConfig: {}
       signal?: RemoteAbortSignal
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       opts?: any
     },
     rpcDriverClassName: string,

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -113,10 +113,10 @@ export class CoreGetFeatures extends RpcMethodType {
   async execute(
     args: {
       sessionId: string
-      signal: RemoteAbortSignal
       region: Region
       adapterConfig: {}
-      opts?: { signal?: AbortSignal }
+      signal?: RemoteAbortSignal
+      opts?: any
     },
     rpcDriverClassName: string,
   ) {
@@ -124,7 +124,7 @@ export class CoreGetFeatures extends RpcMethodType {
       args,
       rpcDriverClassName,
     )
-    const { sessionId, adapterConfig, region,opts } = deserializedArgs
+    const { sessionId, adapterConfig, region, opts } = deserializedArgs
     const { dataAdapter } = await getAdapter(
       this.pluginManager,
       sessionId,

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -105,9 +105,7 @@ export class CoreGetFeatures extends RpcMethodType {
   name = 'CoreGetFeatures'
 
   async deserializeReturn(feats: SimpleFeatureSerialized[]) {
-    return feats.map(feat => {
-      return new SimpleFeature(feat)
-    })
+    return feats.map(feat => new SimpleFeature(feat))
   }
 
   async execute(
@@ -124,7 +122,7 @@ export class CoreGetFeatures extends RpcMethodType {
       args,
       rpcDriverClassName,
     )
-    const { sessionId, adapterConfig, region, opts } = deserializedArgs
+    const { signal, sessionId, adapterConfig, region, opts } = deserializedArgs
     const { dataAdapter } = await getAdapter(
       this.pluginManager,
       sessionId,
@@ -133,7 +131,7 @@ export class CoreGetFeatures extends RpcMethodType {
     if (!isFeatureAdapter(dataAdapter)) {
       return []
     }
-    const ret = dataAdapter.getFeatures(region, opts)
+    const ret = dataAdapter.getFeatures(region, { ...opts, signal })
     const r = await ret.pipe(toArray()).toPromise()
     return r.map(f => f.toJSON())
   }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
@@ -23,7 +23,7 @@ import CloseIcon from '@material-ui/icons/Close'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import { getSession } from '@jbrowse/core/util'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
-import { formatSeqFasta, SeqChunk } from '@jbrowse/core/util/formatFastaStrings'
+import { formatSeqFasta } from '@jbrowse/core/util/formatFastaStrings'
 import { LinearGenomeViewModel } from '..'
 
 const useStyles = makeStyles(theme => ({
@@ -62,9 +62,7 @@ async function fetchSequence(
   }
 
   if (leftOffset.assemblyName !== rightOffset.assemblyName) {
-    throw new Error(
-      'not able to fetch from multiple assemblies at once currently',
-    )
+    throw new Error('not able to fetch sequences from multiple assemblies')
   }
   const { rpcManager, assemblyManager } = session
   const assemblyName = leftOffset.assemblyName || rightOffset.assemblyName || ''

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
@@ -46,21 +46,36 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Fetches and returns a list features for a given list of regions
- * @param selectedRegions - Region[]
- * @returns Features[]
  */
 async function fetchSequence(
-  self: LinearGenomeViewModel,
+  model: LinearGenomeViewModel,
   selectedRegions: Region[],
+  opts: {
+    signal?: AbortSignal
+  },
 ) {
-  const session = getSession(self)
-  const assemblyName =
-    self.leftOffset?.assemblyName || self.rightOffset?.assemblyName || ''
-  const { rpcManager, assemblyManager } = session
-  const assemblyConfig = assemblyManager.get(assemblyName)?.configuration
+  const session = getSession(model)
+  const { leftOffset, rightOffset } = model
 
-  // assembly configuration
-  const adapterConfig = readConfObject(assemblyConfig, ['sequence', 'adapter'])
+  if (!leftOffset || !rightOffset) {
+    throw new Error('no offsets on model to use for range')
+  }
+
+  if (leftOffset.assemblyName !== rightOffset.assemblyName) {
+    throw new Error(
+      'not able to fetch from multiple assemblies at once currently',
+    )
+  }
+  const { rpcManager, assemblyManager } = session
+  const assemblyName = leftOffset.assemblyName || rightOffset.assemblyName || ''
+  const assembly = assemblyManager.get(assemblyName)
+  if (!assembly) {
+    throw new Error(`assembly ${assemblyName} not found`)
+  }
+  const adapterConfig = readConfObject(assembly.configuration, [
+    'sequence',
+    'adapter',
+  ])
 
   const sessionId = 'getSequence'
   const chunks = (await Promise.all(
@@ -69,6 +84,7 @@ async function fetchSequence(
         adapterConfig,
         region,
         sessionId,
+        opts,
       }),
     ),
   )) as Feature[][]
@@ -101,41 +117,38 @@ function SequenceDialog({
 
   useEffect(() => {
     let active = true
+    const controller = new AbortController()
 
     function formatSequence(seqChunks: Feature[]) {
-      const sequenceChunks: SeqChunk[] = []
-      const incompleteSeqErrs: string[] = []
-      seqChunks.forEach((chunk: Feature) => {
-        const chunkSeq = chunk.get('seq')
-        const chunkRefName = chunk.get('refName')
-        const chunkStart = chunk.get('start') + 1
-        const chunkEnd = chunk.get('end')
-        const chunkLocstring = `${chunkRefName}:${chunkStart}-${chunkEnd}`
-        if (chunkSeq) {
-          sequenceChunks.push({ header: chunkLocstring, seq: chunkSeq })
-          if (chunkSeq.length !== chunkEnd - chunkStart + 1) {
-            incompleteSeqErrs.push(
+      return formatSeqFasta(
+        seqChunks.map(chunk => {
+          const chunkSeq = chunk.get('seq')
+          const chunkRefName = chunk.get('refName')
+          const chunkStart = chunk.get('start') + 1
+          const chunkEnd = chunk.get('end')
+          const chunkLocstring = `${chunkRefName}:${chunkStart}-${chunkEnd}`
+          if (chunkSeq?.length !== chunkEnd - chunkStart + 1) {
+            throw new Error(
               `${chunkLocstring} returned ${chunkSeq.length.toLocaleString()} bases, but should have returned ${(
                 chunkEnd - chunkStart
               ).toLocaleString()}`,
             )
           }
-        }
-      })
-      if (incompleteSeqErrs.length > 0) {
-        session.notify(
-          `Unable to retrieve complete reference sequence from regions:${incompleteSeqErrs.join()}`,
-        )
-      }
-      setSequence(formatSeqFasta(sequenceChunks))
+          return { header: chunkLocstring, seq: chunkSeq }
+        }),
+      )
     }
 
     ;(async () => {
       try {
         if (regionsSelected.length > 0) {
-          const chunks = await fetchSequence(model, regionsSelected)
+          const chunks = await fetchSequence(
+            model,
+            regionsSelected,
+            controller.signal,
+          )
           if (active) {
-            formatSequence(chunks)
+            setSequence(formatSequence(chunks))
           }
         } else {
           throw new Error('Selected region is out of bounds')
@@ -149,6 +162,7 @@ function SequenceDialog({
     })()
 
     return () => {
+      controller.abort()
       active = false
     }
   }, [model, session, regionsSelected, setSequence])
@@ -161,10 +175,8 @@ function SequenceDialog({
       maxWidth="xl"
       open
       onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
     >
-      <DialogTitle id="alert-dialog-title">
+      <DialogTitle>
         Reference sequence
         {handleClose ? (
           <IconButton

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
@@ -50,9 +50,7 @@ const useStyles = makeStyles(theme => ({
 async function fetchSequence(
   model: LinearGenomeViewModel,
   selectedRegions: Region[],
-  opts: {
-    signal?: AbortSignal
-  },
+  signal?: AbortSignal,
 ) {
   const session = getSession(model)
   const { leftOffset, rightOffset } = model
@@ -82,7 +80,7 @@ async function fetchSequence(
         adapterConfig,
         region,
         sessionId,
-        opts,
+        signal,
       }),
     ),
   )) as Feature[][]
@@ -173,8 +171,10 @@ function SequenceDialog({
       maxWidth="xl"
       open
       onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
     >
-      <DialogTitle>
+      <DialogTitle id="alert-dialog-title">
         Reference sequence
         {handleClose ? (
           <IconButton

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -35,7 +35,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@gmod/indexedfasta": "^2.0.0",
+    "@gmod/indexedfasta": "^2.0.1",
     "@gmod/twobit": "^1.1.10",
     "abortable-promise-cache": "^1.3.0",
     "clsx": "^1.1.0",

--- a/plugins/sequence/src/BgzipFastaAdapter/BgzipFastaAdapter.ts
+++ b/plugins/sequence/src/BgzipFastaAdapter/BgzipFastaAdapter.ts
@@ -1,13 +1,12 @@
 import { BgzipIndexedFasta } from '@gmod/indexedfasta'
 import { FileLocation } from '@jbrowse/core/util/types'
 import { openLocation } from '@jbrowse/core/util/io'
-import { Instance } from 'mobx-state-tree'
 import { readConfObject } from '@jbrowse/core/configuration'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import IndexedFasta from '../IndexedFastaAdapter/IndexedFastaAdapter'
-import MyConfigSchema from './configSchema'
 
 export default class extends IndexedFasta {
-  public constructor(config: Instance<typeof MyConfigSchema>) {
+  public constructor(config: AnyConfigurationModel) {
     super(config)
     const fastaLocation = readConfObject(config, 'fastaLocation')
     const faiLocation = readConfObject(config, 'faiLocation')

--- a/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
@@ -45,11 +45,11 @@ export default class extends BaseFeatureDataAdapter implements SequenceAdapter {
     this.fasta = new IndexedFasta(fastaOpts)
   }
 
-  public getRefNames(opts: BaseOptions) {
+  public getRefNames(opts?: BaseOptions) {
     return this.fasta.getSequenceNames(opts)
   }
 
-  public async getRegions(opts: BaseOptions): Promise<NoAssemblyRegion[]> {
+  public async getRegions(opts?: BaseOptions): Promise<NoAssemblyRegion[]> {
     const seqSizes = await this.fasta.getSequenceSizes(opts)
     return Object.keys(seqSizes).map(
       (refName): NoAssemblyRegion => ({
@@ -65,7 +65,7 @@ export default class extends BaseFeatureDataAdapter implements SequenceAdapter {
    * @param param -
    * @returns Observable of Feature objects in the region
    */
-  public getFeatures(region: NoAssemblyRegion, opts: BaseOptions) {
+  public getFeatures(region: NoAssemblyRegion, opts?: BaseOptions) {
     const { refName, start, end } = region
     return ObservableCreate<Feature>(async observer => {
       const size = await this.fasta.getSequenceSize(refName, opts)

--- a/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
@@ -81,7 +81,7 @@ export default class extends BaseFeatureDataAdapter implements SequenceAdapter {
           start: chunkStart,
           end: chunkStart + chunkSize,
         }
-        chunks.push(this.seqCache.get(JSON.stringify(r), r, opts.signal))
+        chunks.push(this.seqCache.get(JSON.stringify(r), r, opts?.signal))
       }
       const seq = (await Promise.all(chunks))
         .join('')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,6 +3047,21 @@
   dependencies:
     "@librpc/ee" "1.0.4"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@material-ui/core@^4.12.2":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.2.tgz#59a8b19f16b8c218d912f37f5ae70473c3c82c73"
@@ -9171,11 +9186,6 @@ dotenv@8.2.0, dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
-
-dotenv@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@^6.2.0:
   version "6.2.0"
@@ -15795,7 +15805,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -20469,7 +20479,7 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -20486,6 +20496,18 @@ tar@^6.0.0, tar@^6.0.2:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
   integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.1.0:
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.7.tgz#c566d1107d38b09e92983a68db5534fc7f6cab42"
+  integrity sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,15 +1866,16 @@
     tmp-promise "^1.0.4"
     typical "^2.6.1"
 
-"@gmod/indexedfasta@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@gmod/indexedfasta/-/indexedfasta-2.0.0.tgz#05798ce8e825fcb9bcc03c63163a423267d4cdaa"
-  integrity sha512-72dlTolCr3zmCI8bjYRJNyXn7n7hJbXaT5yoM02UqgqYH3ilUS+tWsRITzvRfLEidrKmDqOf1u3fq3iyyQB/Ag==
+"@gmod/indexedfasta@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@gmod/indexedfasta/-/indexedfasta-2.0.1.tgz#dd64e5246028c9eea109205eb7184d51d601ac31"
+  integrity sha512-Y0Dn4TqrJzY/hP5CXdR7rqUGbdtfO3O3vHuhXd/whjQezVePrzGUFMrDs0FsZBboeCJ/MDpJ3XUeKBSzDOD1HA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gmod/bgzf-filehandle" "^1.2.4"
     browser-or-node "^1.3.0"
     es6-promisify "^6.0.1"
+    object.fromentries "^2.0.4"
 
 "@gmod/nclist@^0.1.1":
   version "0.1.1"


### PR DESCRIPTION
This PR that adds an AbortSignal options parameter to "CoreGetFeatures" rpcManager

This was just based on the observation that "SequenceDialog" if a large region is selected and then the dialog is closed, does not cancel the fetch of sequence

This does not yet actually add full aborting for that sequence fetch, because the sequence adapters such as indexedfasta-js et al would have to add abort support to make this really work, but it may be worth it to have the infrastructure added here anyways



