### PR TITLE
Position sticky for drawer widget appbar

### DIFF
--- a/packages/core/ui/DrawerWidget.js
+++ b/packages/core/ui/DrawerWidget.js
@@ -64,7 +64,7 @@ const DrawerWidget = observer(props => {
   return (
     <Drawer session={session} open={Boolean(activeWidgets.size)}>
       <div className={classes.defaultDrawer}>
-        <AppBar position="static" color="secondary">
+        <AppBar position="sticky" color="secondary">
           <Toolbar disableGutters className={classes.drawerToolbar}>
             <Select
               value={visibleWidget || ''}


### PR DESCRIPTION
This adds position="sticky" on the DrawerWidget AppBar to make it so you can scroll far down and the header is always visible

There may be other ways to achieve this but I think this is easy

This does not have support on ie11 but I believe this has already been omitted from our support


Currently it is position="static"

There is also position="fixed" but this makes it take up 100% of the screen widthy @li

Requested by @li153348734 if I understood correctly