### PR TITLE
Add --delete to set-default-session, fix --session

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -388,6 +388,8 @@ OPTIONS
                          DotplotView.
                          Must be provided if no default session file provided
 
+  --delete               Delete any existing default session.
+
   --out=out              synonym for target
 
   --target=target        path to config file in JB2 installation directory to write out to

--- a/products/jbrowse-cli/src/commands/set-default-session.test.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.test.ts
@@ -193,6 +193,30 @@ describe('set-default-session', () => {
         path.join(ctx.dir, 'config.json'),
       )
     })
+    .command(['set-default-session', '--delete'])
+    .it('deletes a default session', async ctx => {
+      const contents = await fsPromises.readFile(
+        path.join(ctx.dir, 'config.json'),
+        { encoding: 'utf8' },
+      )
+      expect(JSON.parse(contents)).toEqual({
+        ...defaultConfig,
+        tracks: [],
+        defaultSession: undefined,
+      })
+    })
+  setup
+    .do(async ctx => {
+      await fsPromises.copyFile(
+        testConfig,
+        path.join(ctx.dir, path.basename(testConfig)),
+      )
+
+      await fsPromises.rename(
+        path.join(ctx.dir, path.basename(testConfig)),
+        path.join(ctx.dir, 'config.json'),
+      )
+    })
     .command(['set-default-session', '--session', simpleDefaultSession])
     .it('adds a default session from a file', async ctx => {
       const contents = await fsPromises.readFile(

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -174,8 +174,10 @@ export default class SetDefaultSession extends JBrowseCommand {
     }
 
     try {
-      const { defaultSession } = parseJSON(defaultSessionJson)
-      return defaultSession
+      const session = parseJSON(defaultSessionJson)
+      // return top-level "session" if it exists, such as in files created by
+      // "File -> Export session"
+      return session.session || session
     } catch (error) {
       return this.error('Could not parse the given default session file', {
         exit: 160,

--- a/products/jbrowse-cli/test/data/sampleDefaultSession.json
+++ b/products/jbrowse-cli/test/data/sampleDefaultSession.json
@@ -1,17 +1,15 @@
 {
-  "defaultSession": {
-    "name": "test new session",
-    "views": [
-      {
-        "id": "823WX",
-        "type": "LinearGenomeView",
-        "tracks": [
-          {
-            "type": "AlignmentsTrack",
-            "configuration": "simple"
-          }
-        ]
-      }
-    ]
-  }
+  "name": "test new session",
+  "views": [
+    {
+      "id": "823WX",
+      "type": "LinearGenomeView",
+      "tracks": [
+        {
+          "type": "AlignmentsTrack",
+          "configuration": "simple"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This PR is a couple of small changes from when I was trying to figure out https://github.com/GMOD/jbrowse-components/discussions/1873.

* Fixes `jbrowse set-default-session --session session.json` so that it expects a session JSON file. It was previously expecting a config JSON file. Also added support for the session being in a top-level "session" attribute on the session JSON so that files created with `File -> Export session` can be used with `set-default-session`
* Adds a `--delete` option to `set-default-session` that removes the "defaultSession" from the config. Setting the default session to `null` or `{}` using `set-default-session --session file.json` caused errors, so this adds an easy way to clear the default session.