### PR TITLE
Fix test error and warning by waiting for multiple canvases to be rendered

### DIFF
--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -496,6 +496,10 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     return this.pTotalHeight * this.pitchY
   }
 
+  get totalHeight() {
+    return this.getTotalHeight()
+  }
+
   getRectangles(): Map<string, RectTuple> {
     return new Map(
       Array.from(this.rectangles.entries()).map(([id, rect]) => {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -36,61 +36,63 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
   },
 })
-const RenderedBlocks = observer((props: { model: BaseLinearDisplayModel }) => {
-  const { model } = props
-  const classes = useStyles()
-  const { blockDefinitions, blockState } = model
-  return (
-    <>
-      {blockDefinitions.map(block => {
-        if (block instanceof ContentBlock) {
-          const state = blockState.get(block.key)
-          return (
-            <ContentBlockComponent
-              block={block}
-              key={`${model.id}-${block.key}`}
-            >
-              {state && state.ReactComponent ? (
-                <state.ReactComponent model={state} />
-              ) : null}
-              {state && state.maxHeightReached ? (
-                <div
-                  className={classes.heightOverflowed}
-                  style={{
-                    top: state.layout.totalHeight - 16,
-                    pointerEvents: 'none',
-                    height: 16,
-                  }}
-                >
-                  Max height reached
-                </div>
-              ) : null}
-            </ContentBlockComponent>
-          )
-        }
-        if (block instanceof ElidedBlock) {
-          return (
-            <ElidedBlockComponent
-              key={`${model.id}-${block.key}`}
-              width={block.widthPx}
-            />
-          )
-        }
-        if (block instanceof InterRegionPaddingBlock) {
-          return (
-            <InterRegionPaddingBlockComponent
-              key={block.key}
-              width={block.widthPx}
-              style={{ background: 'none' }}
-              boundary={block.variant === 'boundary'}
-            />
-          )
-        }
-        throw new Error(`invalid block type ${typeof block}`)
-      })}
-    </>
-  )
-})
+const RenderedBlocks = observer(
+  ({ model }: { model: BaseLinearDisplayModel }) => {
+    const classes = useStyles()
+    const { blockDefinitions, blockState } = model
+    return (
+      <>
+        {blockDefinitions.map(block => {
+          if (block instanceof ContentBlock) {
+            const state = blockState.get(block.key)
+
+            return (
+              <ContentBlockComponent
+                block={block}
+                key={`${model.id}-${block.key}`}
+              >
+                {state && state.ReactComponent ? (
+                  <state.ReactComponent model={state} />
+                ) : null}
+                {state && state.maxHeightReached ? (
+                  <div
+                    className={classes.heightOverflowed}
+                    style={{
+                      top: state.layout.getTotalHeight() - 16,
+                      pointerEvents: 'none',
+                      height: 16,
+                    }}
+                  >
+                    Max height reached
+                  </div>
+                ) : null}
+              </ContentBlockComponent>
+            )
+          }
+          if (block instanceof ElidedBlock) {
+            return (
+              <ElidedBlockComponent
+                key={`${model.id}-${block.key}`}
+                width={block.widthPx}
+              />
+            )
+          }
+          if (block instanceof InterRegionPaddingBlock) {
+            return (
+              <InterRegionPaddingBlockComponent
+                key={block.key}
+                width={block.widthPx}
+                style={{ background: 'none' }}
+                boundary={block.variant === 'boundary'}
+              />
+            )
+          }
+          throw new Error(`invalid block type ${typeof block}`)
+        })}
+      </>
+    )
+  },
+)
 function LinearBlocks({ model }: { model: BaseLinearDisplayModel }) {
   const classes = useStyles()
   const { blockDefinitions } = model

--- a/products/jbrowse-web/src/tests/Alignments.test.js
+++ b/products/jbrowse-web/src/tests/Alignments.test.js
@@ -1,5 +1,11 @@
 // library
-import { cleanup, fireEvent, render, within } from '@testing-library/react'
+import {
+  cleanup,
+  waitFor,
+  fireEvent,
+  render,
+  within,
+} from '@testing-library/react'
 import React from 'react'
 import { LocalFile } from 'generic-filehandle'
 
@@ -277,11 +283,15 @@ describe('alignments track', () => {
     const { findAllByTestId } = within(
       await findByTestId('Blockset-snpcoverage'),
     )
-    const snpCoverageCanvas = await findAllByTestId(
-      'prerendered_canvas',
-      {},
+
+    await waitFor(
+      async () => {
+        const canvases = await findAllByTestId('prerendered_canvas')
+        expect(canvases.length).toBe(2)
+      },
       { timeout: 10000 },
     )
+    const snpCoverageCanvas = await findAllByTestId('prerendered_canvas')
 
     // this block tests that softclip avoids decrementing the total block
     // e.g. this line is not called for softclip/hardclip


### PR DESCRIPTION
The code makes the assumption that findAllByTestId would return multiple canvases (2) automatically, but this adds a waitFor to ensure that this is true

Fixes #1876 

Also uses getTotalHeight, a method on the BaseLayout, instead of accessing a property called totalHeight which only exists on PrecomputedLayout, to fix an error 

```
    [
      'Warning: `NaN` is an invalid value for the `%s` css style property.%s',
      'top',
      '\n' +
        '    in div (at LinearBlocks.tsx:57)\n' +
        '    in div (at Block.tsx:49)\n' +
        '    in wrappedComponent (at LinearBlocks.tsx:49)\n' +
        '    in wrappedComponent (at LinearBlocks.tsx:107)\n' +
        '    in div (at LinearBlocks.tsx:100)\n' +
        '    in LinearBlocks (at BaseLinearDisplay.tsx:85)\n' +
        '    in div (at BaseLinearDisplay.tsx:61)\n' +
        '    in wrappedComponent (at AlignmentsDisplay.tsx:43)\n' +
        '    in div (at AlignmentsDisplay.tsx:34)\n' +
        '    in div (at AlignmentsDisplay.tsx:10)\n' +
        '    in wrappedComponent (at TrackContainer.tsx:128)\n' +
        '    in div (at TrackContainer.tsx:123)\n' +
        '    in div (created by ForwardRef(Paper))\n' +
        '    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))\n' +
        '    in WithStyles(ForwardRef(Paper)) (at TrackContainer.tsx:111)\n' +
        '    in div (at TrackContainer.tsx:98)\n' +
        '    in TrackContainer (at LinearGenomeView.tsx:106)\n' +
        '    in div (at TracksContainer.tsx:169)\n' +
        '    in TracksContainer (at LinearGenomeView.tsx:90)\n' +
        '    in div (at LinearGenomeView.tsx:46)\n' +
        '    in wrappedComponent (at App.js:158)\n' +
        '    in div (created by ForwardRef(Paper))\n' +
        '    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))\n' +
        '    in WithStyles(ForwardRef(Paper)) (at ViewContainer.tsx:227)\n' +
        '    in div (created by ForwardRef(Paper))\n' +
        '    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))\n' +
        '    in WithStyles(ForwardRef(Paper)) (at ViewContainer.tsx:173)\n' +
        '    in wrappedComponent (created by WithContentRect)\n' +
        '    in WithContentRect (at App.js:153)\n' +
        '    in div (at App.js:145)\n' +
        '    in div (at App.js:112)\n' +
        '    in div (at App.js:104)\n' +
        '    in App (at JBrowse.js:74)\n' +
        '    in ThemeProvider (at JBrowse.js:72)\n' +
        '    in wrappedComponent (at Alignments.test.js:254)\n' +
        '    in StylesProvider (at react.js:9)'
    ]

```