### PR TITLE
Fix rIC ponyfill for use on Safari

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -863,7 +863,7 @@ export const complement = (() => {
 export const rIC =
   // eslint-disable-next-line no-nested-ternary
   typeof jest === 'undefined'
-    ? typeof window !== 'undefined'
+    ? typeof window !== 'undefined' && window.requestIdleCallback
       ? window.requestIdleCallback
       : (cb: Function) => setTimeout(() => cb(), 1)
     : (cb: Function) => cb()


### PR DESCRIPTION
Currently opening a track on https://s3.amazonaws.com/jbrowse.org/code/jb2/v1.1.0/index.html in midori browser and presumably, safari produces an error

```
TypeError: Object is not a function. (In 'Object(_.rIC)', 'Object' is an instance of Object)
```

This fixes the rIC ponyfill by making it actually check for the existence of window.requestIdleCallback before using it in the ponyfill