### PR TITLE
Improve assembly manager styling and typography

### DIFF
--- a/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
@@ -9,6 +9,7 @@ import TableContainer from '@material-ui/core/TableContainer'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
 import CreateIcon from '@material-ui/icons/Create'
 import DeleteIcon from '@material-ui/icons/Delete'
 
@@ -17,7 +18,8 @@ import { readConfObject } from '@jbrowse/core/configuration'
 
 const useStyles = makeStyles(() => ({
   table: {
-    minWidth: 650,
+    minWidth: 500,
+    minHeight: 150,
   },
   buttonCell: {
     padding: 3,
@@ -83,12 +85,18 @@ const AssemblyTable = observer(
 
     return (
       <TableContainer component={Paper}>
-        <Table>
+        <Table className={classes.table}>
           <TableHead>
             <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Aliases</TableCell>
-              <TableCell>Actions</TableCell>
+              <TableCell>
+                <Typography variant="h5">Name</Typography>
+              </TableCell>
+              <TableCell>
+                <Typography variant="h5">Aliases</Typography>
+              </TableCell>
+              <TableCell>
+                <Typography variant="h5">Actions</Typography>
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>{rows}</TableBody>


### PR DESCRIPTION
This is a tiny PR that revisits the styling and typography of the assembly manager screen. As I got started on the plugin store stuff, I felt like it looked a bit small and sad. Just adjusted spacing and typography a bit.

Before:

<img width="278" alt="Screen Shot 2021-04-09 at 3 57 02 PM" src="https://user-images.githubusercontent.com/19295181/114248475-a33a4000-994c-11eb-83ff-d36aff88376a.png">

After:

<img width="549" alt="Screen Shot 2021-04-09 at 3 58 04 PM" src="https://user-images.githubusercontent.com/19295181/114248484-aa614e00-994c-11eb-856a-3110210f7358.png">
