### PR TITLE
Make clicking away from autocomplete popup on track container work

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -95,7 +95,6 @@ function TracksContainer({
 
     // otherwise do click and drag scroll
     if (event.button === 0) {
-      event.preventDefault()
       prevX.current = event.clientX
       setMouseDragging(true)
     }


### PR DESCRIPTION
Possible fix for #1897

The behavior of event.preventDefault made it so that when an autocomplete popup was open, it couldn't be closed by clicking in the track container

I couldn't necessarily find a reason why this line was needed...if there is one we might need a more advanced fix but this may help