### PR TITLE
Make using --out for add-assembly create output directory if it does not exist

### DIFF
--- a/products/jbrowse-cli/src/commands/add-assembly.test.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.test.ts
@@ -26,6 +26,15 @@ const baseSequence = {
   adapter: {},
 }
 
+const twobitPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'test',
+  'data',
+  'simple.2bit',
+)
+
 describe('add-assembly', () => {
   setup
     .command(['add-assembly', '{}'])
@@ -867,5 +876,28 @@ describe('add-assembly', () => {
           },
         ],
       })
+    })
+
+  setup
+    .do(ctx =>
+      fs.copyFileSync(
+        twobitPath,
+        path.join(ctx.dir, path.basename(twobitPath)),
+      ),
+    )
+    .command([
+      'add-assembly',
+      'simple.2bit',
+      '--load',
+      'copy',
+      '--out',
+      'testing',
+    ])
+    .it('can use --out to make a new directory', async ctx => {
+      const contents = await fsPromises.readFile(
+        path.join(ctx.dir, 'testing', 'config.json'),
+        { encoding: 'utf8' },
+      )
+      expect(JSON.parse(contents).assemblies.length).toBe(1)
     })
 })

--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -344,10 +344,19 @@ custom         Either a JSON file location or inline JSON that defines a custom
   }
 
   async run() {
+    // https://stackoverflow.com/a/35008327/2129219
+    const exists = (s: string) =>
+      new Promise(r => fs.access(s, fs.constants.F_OK, e => r(!e)))
+
     const { args: runArgs, flags: runFlags } = this.parse(AddAssembly)
 
     const output = runFlags.target || runFlags.out || '.'
-    const isDir = (await fsPromises.lstat(output)).isDirectory()
+
+    if (!(await exists(output))) {
+      await fsPromises.mkdir(output, { recursive: true })
+    }
+
+    const isDir = fs.statSync(output).isDirectory()
     this.target = isDir ? `${output}/config.json` : output
 
     const { sequence: argsSequence } = runArgs as { sequence: string }


### PR DESCRIPTION
Fixes #1898

Also fixes issue trying to use --out on a symbolic link, use fstat instead of lstat

Currently on main using a symlink, if i am testing correctly, produces

```
mkdir ~/testing
ln -s testing
bin/run add-assembly --out testing volvox.fa --load copy
    Error: ELOOP: too many symbolic links encountered, open 'testing'
    Code: ELOOP

```