### PR TITLE
Fix issue with synteny polygons displaying slightly offset

### DIFF
--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -82,16 +82,36 @@ const Base1DView = types
       let offsetBp = 0
 
       const interRegionPaddingBp = self.interRegionPaddingWidth * self.bpPerPx
-      const index = self.displayedRegions.findIndex((r, idx) => {
-        if (refName === r.refName && coord >= r.start && coord <= r.end) {
+      const minimumBlockBp = self.minimumBlockWidth * self.bpPerPx
+      const index = self.displayedRegions.findIndex((region, idx) => {
+        const len = region.end - region.start
+        if (
+          refName === region.refName &&
+          coord >= region.start &&
+          coord <= region.end
+        ) {
           if (regionNumber ? regionNumber === idx : true) {
-            offsetBp += r.reversed ? r.end - coord : coord - r.start
+            offsetBp += region.reversed
+              ? region.end - coord
+              : coord - region.start
             return true
           }
         }
-        offsetBp += r.end - r.start + interRegionPaddingBp
+
+        // add the interRegionPaddingWidth if the boundary is in the screen
+        // e.g. offset>0 && offset<width
+        if (
+          region.end - region.start > minimumBlockBp &&
+          offsetBp / self.bpPerPx > 0 &&
+          offsetBp / self.bpPerPx < this.width
+        ) {
+          offsetBp += len + interRegionPaddingBp
+        } else {
+          offsetBp += len
+        }
         return false
       })
+
       const foundRegion = self.displayedRegions[index]
       if (foundRegion) {
         return Math.round(offsetBp / self.bpPerPx)

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -295,14 +295,33 @@ export function stateModelFactory(pluginManager: PluginManager) {
         let offsetBp = 0
 
         const interRegionPaddingBp = this.interRegionPaddingWidth * self.bpPerPx
-        const index = self.displayedRegions.findIndex((r, idx) => {
-          if (refName === r.refName && coord >= r.start && coord <= r.end) {
+        const minimumBlockBp = self.minimumBlockWidth * self.bpPerPx
+        const index = self.displayedRegions.findIndex((region, idx) => {
+          const len = region.end - region.start
+          if (
+            refName === region.refName &&
+            coord >= region.start &&
+            coord <= region.end
+          ) {
             if (regionNumber ? regionNumber === idx : true) {
-              offsetBp += r.reversed ? r.end - coord : coord - r.start
+              offsetBp += region.reversed
+                ? region.end - coord
+                : coord - region.start
               return true
             }
           }
-          offsetBp += r.end - r.start + interRegionPaddingBp
+
+          // add the interRegionPaddingWidth if the boundary is in the screen
+          // e.g. offset>=0 && offset<width
+          if (
+            len > minimumBlockBp &&
+            offsetBp / self.bpPerPx >= 0 &&
+            offsetBp / self.bpPerPx < self.width
+          ) {
+            offsetBp += len + interRegionPaddingBp
+          } else {
+            offsetBp += len
+          }
           return false
         })
         const foundRegion = self.displayedRegions[index]

--- a/products/jbrowse-web/src/tests/Alignments.test.js
+++ b/products/jbrowse-web/src/tests/Alignments.test.js
@@ -125,6 +125,8 @@ describe('alignments track', () => {
 
     const pileupCanvas = await findAllByTestId1(
       'prerendered_canvas_softclipped',
+      {},
+      { timeout: 10000 },
     )
     const pileupImg = pileupCanvas[0].toDataURL()
     const pileupData = pileupImg.replace(/^data:image\/\w+;base64,/, '')

--- a/test_data/yeast_synteny/config.json
+++ b/test_data/yeast_synteny/config.json
@@ -488,7 +488,6 @@
     "activeWidgets": {
       "hierarchicalTrackSelector": "hierarchicalTrackSelector"
     },
-    "connectionInstances": {},
     "sessionTracks": [],
     "sessionConnections": [],
     "sessionAssemblies": [],


### PR DESCRIPTION
Fixes #1895

Currently bpToPx overestimates the amount of times it needs to incorporate interRegionPaddingBlock to all the displayedRegions that are offscreen to the left of any particular view

It actually only needs to incorporate the interRegionPaddingBlock for any displayedRegion that is on the blocks, not ones that are off screen to the left.

A similar concept was incorporated in pxToBp (which was much needed when using show all regions in assembly) but needed to be applied to bpToPx here too.
