### PR TITLE
Add coarser/finer resolution toggles to Hi-C tracks and bump version

### DIFF
--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "abortable-promise-cache": "^1.0.1",
     "color": "^3.1.3",
-    "hic-straw": "^2.0.2"
+    "hic-straw": "^2.0.3"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/hic/src/HicAdapter/HicAdapter.ts
+++ b/plugins/hic/src/HicAdapter/HicAdapter.ts
@@ -111,8 +111,8 @@ export default class HicAdapter extends BaseFeatureDataAdapter {
   getFeatures(region: Region, opts: BaseOptions = {}) {
     return ObservableCreate<ContactRecord>(async observer => {
       const { refName: chr, start, end } = region
-      const { bpPerPx, statusCallback = () => {} } = opts
-      const res = await this.getResolution(bpPerPx || 1000, opts)
+      const { resolution, bpPerPx, statusCallback = () => {} } = opts
+      const res = await this.getResolution(bpPerPx / resolution || 1000, opts)
       statusCallback('Downloading .hic data')
 
       const records = await this.hic.getContactRecords(

--- a/plugins/hic/src/HicAdapter/HicAdapter.ts
+++ b/plugins/hic/src/HicAdapter/HicAdapter.ts
@@ -75,6 +75,13 @@ export default class HicAdapter extends BaseFeatureDataAdapter {
     })
   }
 
+
+  public async getHeader() {
+    const ret = await this.hic.getMetaData()
+    const {chromosomes,...rest}=ret
+    return rest
+  }
+
   async getRefNames() {
     const metadata = await this.hic.getMetaData()
     return metadata.chromosomes.map(chr => chr.name)
@@ -87,7 +94,7 @@ export default class HicAdapter extends BaseFeatureDataAdapter {
 
     for (let i = resolutions.length - 1; i >= 0; i -= 1) {
       const r = resolutions[i]
-      if (r <= 2 * bpPerPx) {
+      if (r <= 5 * bpPerPx) {
         chosenResolution = r
       }
     }

--- a/plugins/hic/src/HicAdapter/HicAdapter.ts
+++ b/plugins/hic/src/HicAdapter/HicAdapter.ts
@@ -31,6 +31,11 @@ interface Ref {
   end: number
 }
 
+interface HicOptions extends BaseOptions {
+  resolution?: number
+  bpPerPx?: number
+}
+
 // wraps generic-filehandle so the read function only takes a position and length
 // in some ways, generic-filehandle wishes it was just this but it has
 // to adapt to the node.js fs promises API
@@ -101,18 +106,18 @@ export default class HicAdapter extends BaseFeatureDataAdapter {
 
     for (let i = resolutions.length - 1; i >= 0; i -= 1) {
       const r = resolutions[i]
-      if (r <= 5 * bpPerPx) {
+      if (r <= 2 * bpPerPx) {
         chosenResolution = r
       }
     }
     return chosenResolution
   }
 
-  getFeatures(region: Region, opts: BaseOptions = {}) {
+  getFeatures(region: Region, opts: HicOptions = {}) {
     return ObservableCreate<ContactRecord>(async observer => {
       const { refName: chr, start, end } = region
-      const { resolution, bpPerPx, statusCallback = () => {} } = opts
-      const res = await this.getResolution(bpPerPx / resolution || 1000, opts)
+      const { resolution, bpPerPx = 1, statusCallback = () => {} } = opts
+      const res = await this.getResolution(bpPerPx / (resolution || 1000), opts)
       statusCallback('Downloading .hic data')
 
       const records = await this.hic.getContactRecords(

--- a/plugins/hic/src/HicRenderer/HicRenderer.ts
+++ b/plugins/hic/src/HicRenderer/HicRenderer.ts
@@ -144,14 +144,11 @@ export default class HicRenderer extends ServerSideRendererType {
     }
   }
 
-  async getFeatures({
-    dataAdapter,
-    signal,
-    bpPerPx,
-    regions,
-  }: RenderArgsDeserialized) {
+  async getFeatures(args: RenderArgsDeserialized) {
+    const { dataAdapter, regions } = args
     const features = await dataAdapter
-      .getFeatures(regions[0], { signal, bpPerPx })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .getFeatures(regions[0], args as any)
       .pipe(toArray())
       .toPromise()
     // cast to any to avoid return-type conflict, because the

--- a/plugins/hic/src/HicRenderer/HicRenderer.ts
+++ b/plugins/hic/src/HicRenderer/HicRenderer.ts
@@ -24,7 +24,7 @@ interface HicFeature {
 }
 
 interface HicDataAdapter extends BaseFeatureDataAdapter {
-  getResolution: (bp: number) => number
+  getResolution: (bp: number) => Promise<number>
 }
 
 export interface RenderArgs extends ServerSideRenderArgs {
@@ -37,6 +37,7 @@ export interface RenderArgsDeserialized
   dataAdapter: HicDataAdapter
   bpPerPx: number
   highResolutionScaling: number
+  resolution: number
 }
 
 export interface RenderArgsDeserializedWithFeatures
@@ -60,7 +61,7 @@ export default class HicRenderer extends ServerSideRendererType {
       highResolutionScaling = 1,
       dataAdapter,
       signal,
-      resolution
+      resolution,
     } = props
 
     const [region] = regions

--- a/plugins/hic/src/HicRenderer/HicRenderer.ts
+++ b/plugins/hic/src/HicRenderer/HicRenderer.ts
@@ -60,12 +60,14 @@ export default class HicRenderer extends ServerSideRendererType {
       highResolutionScaling = 1,
       dataAdapter,
       signal,
+      resolution
     } = props
 
     const [region] = regions
     const width = (region.end - region.start) / bpPerPx
     const height = readConfObject(config, 'maxHeight')
-    const res = await dataAdapter.getResolution(bpPerPx)
+    const res = await dataAdapter.getResolution(bpPerPx / resolution)
+
     if (!(width > 0) || !(height > 0)) {
       return { height: 0, width: 0, maxHeightReached: false }
     }

--- a/plugins/hic/src/LinearHicDisplay/model.ts
+++ b/plugins/hic/src/LinearHicDisplay/model.ts
@@ -12,6 +12,7 @@ export default (configSchema: AnyConfigurationSchemaType) =>
       types.model({
         type: types.literal('LinearHicDisplay'),
         configuration: ConfigurationReference(configSchema),
+        resolution: types.optional(types.number, 1),
       }),
     )
     .views(self => ({
@@ -37,6 +38,42 @@ export default (configSchema: AnyConfigurationSchemaType) =>
           config,
           rpcDriverName: self.rpcDriverName,
           displayModel: self,
+          resolution: self.resolution,
         }
       },
     }))
+    .actions(self => ({
+      setResolution(n: number) {
+        self.resolution = n
+      },
+    }))
+    .views(self => {
+      const { trackMenuItems } = self
+      return {
+        get composedTrackMenuItems() {
+          return [
+            {
+              label: 'Resolution',
+              subMenu: [
+                {
+                  label: 'Finer resolution',
+                  onClick: () => {
+                    self.setResolution(self.resolution * 2)
+                  },
+                },
+                {
+                  label: 'Coarser resolution',
+                  onClick: () => {
+                    self.setResolution(self.resolution / 2)
+                  },
+                },
+              ],
+            },
+          ]
+        },
+
+        get trackMenuItems() {
+          return [...trackMenuItems, ...this.composedTrackMenuItems]
+        },
+      }
+    })

--- a/products/jbrowse-web/src/tests/Alignments.test.js
+++ b/products/jbrowse-web/src/tests/Alignments.test.js
@@ -190,9 +190,7 @@ describe('alignments track', () => {
     expect(state.session.views[0].tracks[0]).toBeTruthy()
 
     // opens the track menu and turns on soft clipping
-    const trackMenu = await findByTestId('track_menu_icon')
-
-    fireEvent.click(trackMenu)
+    fireEvent.click(await findByTestId('track_menu_icon'))
     fireEvent.click(await findByText('Color scheme'))
     fireEvent.click(await findByText('Strand'))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14374,10 +14374,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-hic-straw@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hic-straw/-/hic-straw-2.0.2.tgz#4c989ca14f35755d14923c576a7a4c76405ca63d"
-  integrity sha512-buA/yLxHNbV6POP79gzOwSk1QhOBBlqt728sP7smJwbOe9K3k9fyBbPMI8sdWmbVtdV6wyC6dxn3/EnunpddcA==
+hic-straw@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hic-straw/-/hic-straw-2.0.3.tgz#4abacaa3edcdc227932c26ac55c2556b74bc5c8a"
+  integrity sha512-vudFB4e726w3s2UGO5mXueCsVF3rssdIka34WCQh2ZzQKRmo5d1S2jQiXOkwMMfSNK6XDSUtmfMrs2VJkzdAtw==
 
 highlight.js@^10.1.1, highlight.js@~10.2.0:
   version "10.2.1"


### PR DESCRIPTION
I had done this awhile ago but just wanted to rebase and put on master

Note that technically, and if interested we could do this, we could replace "coarser/finer" resolutions with a select box that chooses the true window size so it would instead be a dropdown with 5000,10000,25000,etc. that would probably be a custom RPC method that fetches that list of resolutions

Just an idea, though the coarser/finer seems to work pretty OK