### PR TITLE
Fix breakpoint split view visualizations for files that need ref renaming (e.g. chr1 vs 1)

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -65,6 +65,8 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   connectionInstances?: { name: string }[]
   makeConnection?: Function
   adminMode?: boolean
+  showWidget?: Function
+  addWidget?: Function
 }
 export function isSessionModel(thing: unknown): thing is AbstractSessionModel {
   return (

--- a/plugins/breakpoint-split-view/src/components/AlignmentConnections.tsx
+++ b/plugins/breakpoint-split-view/src/components/AlignmentConnections.tsx
@@ -25,9 +25,15 @@ export default (pluginManager: any) => {
       parentRef: React.RefObject<SVGSVGElement>
     }) => {
       const { views, showIntraviewLinks } = model
+      const { assemblyManager } = getSession(model)
+
       const session = getSession(model)
       const snap = getSnapshot(model)
       useNextFrame(snap)
+      const assembly = assemblyManager.get(views[0].assemblyNames[0])
+      if (!assembly) {
+        return null
+      }
 
       const totalFeatures = model.getTrackFeatures(trackConfigId)
       const features = model.hasPairedReads(trackConfigId)
@@ -72,7 +78,11 @@ export default (pluginManager: any) => {
               if (!showIntraviewLinks && level1 === level2) {
                 return null
               }
-
+              const f1ref = assembly.getCanonicalRefName(f1.get('refName'))
+              const f2ref = assembly.getCanonicalRefName(f2.get('refName'))
+              if (!f1ref || !f2ref) {
+                throw new Error(`unable to find ref for ${f1ref || f2ref}`)
+              }
               const x1 = getPxFromCoordinate(
                 views[level1],
                 f1.get('refName'),

--- a/plugins/breakpoint-split-view/src/components/Breakends.tsx
+++ b/plugins/breakpoint-split-view/src/components/Breakends.tsx
@@ -1,5 +1,6 @@
 import Path from 'svg-path-generator'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
+import { getSession } from '@jbrowse/core/util'
 import { BreakpointViewModel, Breakend } from '../model'
 import { yPos, getPxFromCoordinate, useNextFrame } from '../util'
 
@@ -32,6 +33,10 @@ export default (pluginManager: any) => {
       parentRef: React.RefObject<SVGSVGElement>
     }) => {
       const { views } = model
+      const session = getSession(model)
+      const { assemblyManager } = session
+
+      const totalFeatures = model.getTrackFeatures(trackConfigId)
       const features = model.getMatchedBreakendFeatures(trackConfigId)
       const layoutMatches = model.getMatchedFeaturesInLayout(
         trackConfigId,
@@ -40,12 +45,17 @@ export default (pluginManager: any) => {
       const [mouseoverElt, setMouseoverElt] = useState()
       const snap = getSnapshot(model)
       useNextFrame(snap)
+      const assembly = assemblyManager.get(views[0].assemblyNames[0])
+      if (!assembly) {
+        return null
+      }
 
-      let yOffset = 0
+      let yoff = 0
       if (ref.current) {
         const rect = ref.current.getBoundingClientRect()
-        yOffset = rect.top
+        yoff = rect.top
       }
+
       return (
         <g
           stroke="green"
@@ -57,32 +67,30 @@ export default (pluginManager: any) => {
         >
           {layoutMatches.map(chunk => {
             const ret = []
-            // we follow a path in the list of chunks, not from top to bottom, just in series
-            // following x1,y1 -> x2,y2
+            // we follow a path in the list of chunks, not from top to bottom,
+            // just in series following x1,y1 -> x2,y2
             for (let i = 0; i < chunk.length - 1; i += 1) {
               const { layout: c1, feature: f1, level: level1 } = chunk[i]
               const { layout: c2, feature: f2, level: level2 } = chunk[i + 1]
-              const id = `${f1.id()}-${f2.id()}`
+              const id = f1.id()
+
               const relevantAlt = findMatchingAlt(f1, f2)
-              if (!c1 || !c2) return null
-              const x1 = getPxFromCoordinate(
-                views[level1],
-                f1.get('refName'),
-                c1[LEFT],
-              )
-              const x2 = getPxFromCoordinate(
-                views[level2],
-                f2.get('refName'),
-                c2[LEFT],
-              )
+              if (!c1 || !c2) {
+                return null
+              }
+              const f1ref = assembly.getCanonicalRefName(f1.get('refName'))
+              const f2ref = assembly.getCanonicalRefName(f2.get('refName'))
+              if (!f1ref || !f2ref) {
+                throw new Error(`unable to find ref for ${f1ref || f2ref}`)
+              }
+              const x1 = getPxFromCoordinate(views[level1], f1ref, c1[LEFT])
+              const x2 = getPxFromCoordinate(views[level2], f2ref, c2[LEFT])
               const reversed1 = views[level1].pxToBp(x1).reversed
               const reversed2 = views[level2].pxToBp(x2).reversed
 
               const tracks = views.map(v => v.getTrack(trackConfigId))
-              const y1 =
-                yPos(trackConfigId, level1, views, tracks, c1) - yOffset
-              const y2 =
-                yPos(trackConfigId, level2, views, tracks, c2) - yOffset
+              const y1 = yPos(trackConfigId, level1, views, tracks, c1) - yoff
+              const y2 = yPos(trackConfigId, level2, views, tracks, c2) - yoff
               if (!relevantAlt) {
                 console.warn(
                   'the relevant ALT allele was not found, cannot render',
@@ -111,6 +119,16 @@ export default (pluginManager: any) => {
                     d={path}
                     key={JSON.stringify(path)}
                     strokeWidth={id === mouseoverElt ? 10 : 5}
+                    onClick={() => {
+                      const featureWidget = session.addWidget?.(
+                        'VariantFeatureWidget',
+                        'variantFeature',
+                        {
+                          featureData: totalFeatures.get(id),
+                        },
+                      )
+                      session.showWidget?.(featureWidget)
+                    }}
                     onMouseOver={() => setMouseoverElt(id)}
                     onMouseOut={() => setMouseoverElt(undefined)}
                   />,

--- a/plugins/breakpoint-split-view/src/components/BreakpointSplitView.tsx
+++ b/plugins/breakpoint-split-view/src/components/BreakpointSplitView.tsx
@@ -1,11 +1,12 @@
 import { makeStyles } from '@material-ui/core/styles'
+import PluginManager from '@jbrowse/core/PluginManager'
 import { BreakpointViewModel, VIEW_DIVIDER_HEIGHT } from '../model'
 import AlignmentConnectionsFactory from './AlignmentConnections'
 import BreakendsFactory from './Breakends'
 import HeaderFactory from './Header'
 import TranslocationsFactory from './Translocations'
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default (pluginManager: any) => {
+
+export default (pluginManager: PluginManager) => {
   const { jbrequire } = pluginManager
   const { observer, PropTypes } = jbrequire('mobx-react')
   const React = jbrequire('react')

--- a/plugins/breakpoint-split-view/src/components/Translocations.tsx
+++ b/plugins/breakpoint-split-view/src/components/Translocations.tsx
@@ -1,11 +1,11 @@
 import Path from 'svg-path-generator'
+import { getSession } from '@jbrowse/core/util'
 import { BreakpointViewModel, LayoutRecord } from '../model'
 import { yPos, getPxFromCoordinate, useNextFrame } from '../util'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default (pluginManager: any) => {
   const { jbrequire } = pluginManager
-  const { getSession } = jbrequire('@jbrowse/core/util')
   const { observer } = jbrequire('mobx-react')
   const React = jbrequire('react')
   const { useState } = jbrequire('react')
@@ -35,6 +35,11 @@ export default (pluginManager: any) => {
       const [mouseoverElt, setMouseoverElt] = useState()
       const snap = getSnapshot(model)
       useNextFrame(snap)
+      const { assemblyManager } = session
+      const assembly = assemblyManager.get(views[0].assemblyNames[0])
+      if (!assembly) {
+        return null
+      }
 
       let yOffset = 0
       if (ref.current) {
@@ -42,11 +47,10 @@ export default (pluginManager: any) => {
         yOffset = rect.top
       }
 
-      // we hardcode the TRA to go to the "other view" and
-      // if there is none, we just return null here
-      // note: would need to do processing of the INFO CHR2/END
-      // and see which view could contain those coordinates
-      // to really do it properly
+      // we hardcode the TRA to go to the "other view" and if there is none, we
+      // just return null here note: would need to do processing of the INFO
+      // CHR2/END and see which view could contain those coordinates to really
+      // do it properly
       if (views.length < 2) {
         return null
       }
@@ -60,8 +64,8 @@ export default (pluginManager: any) => {
           }
         >
           {layoutMatches.map(chunk => {
-            // we follow a path in the list of chunks, not from top to bottom, just in series
-            // following x1,y1 -> x2,y2
+            // we follow a path in the list of chunks, not from top to bottom,
+            // just in series following x1,y1 -> x2,y2
             const ret = []
             for (let i = 0; i < chunk.length; i += 1) {
               const { layout: c1, feature: f1, level: level1 } = chunk[i]
@@ -117,7 +121,7 @@ export default (pluginManager: any) => {
                     key={JSON.stringify(path)}
                     strokeWidth={id === mouseoverElt ? 10 : 5}
                     onClick={() => {
-                      const featureWidget = session.addWidget(
+                      const featureWidget = session.addWidget?.(
                         'VariantFeatureWidget',
                         'variantFeature',
                         {
@@ -126,7 +130,7 @@ export default (pluginManager: any) => {
                           ).toJSON(),
                         },
                       )
-                      session.showWidget(featureWidget)
+                      session.showWidget?.(featureWidget)
                     }}
                     onMouseOver={() => setMouseoverElt(id)}
                     onMouseOut={() => setMouseoverElt(undefined)}


### PR DESCRIPTION
Fixes #1902 

This makes sure to use canonical refname when searching.

There are possible alternatives to this PR

We could try to make all our adapters return features with a field called feature.get('originalRefName') that can be used for purposes like this (note that adapters do receive a parameter called region.originalRefName which is the canonical ref name for the assembly being views to their getFeatures function)

This could either

a) be the adapters responsibility to fill out this field or
b) be some sort of auto-added thing by some other aspect of our system (renderer/serialization/adapter/something else?)

Or we stick with this this type of solution, and wait until we find a good abstraction