### PR TITLE
Fix reloading of local sessions when using React.StrictMode

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -178,7 +178,6 @@ const SessionLoader = types
     },
     setSessionSnapshot(snap: unknown) {
       self.sessionSnapshot = snap
-      sessionStorage.setItem('current', JSON.stringify(snap))
     },
     setBlankSession(flag: boolean) {
       self.blankSession = flag


### PR DESCRIPTION
This was found while testing React.StrictMode, which revealed that page refreshes did not keep the local session working.

StrictMode does a little "chaos testing" like double rendering components which can reveal weird things

In this case, I found sessionStorage from rootModel autorun outputs sessionStorage.setItem('current', JSON.stringify({session}))

The code here in loader was outputting sessionStorage.setItem('current', JSON.stringify(session)) instead

This fixes it so they both output {session}

It may be possible to not even update sessionStorage here and only rely on rootModel's autorun but I didn't look into this yet