### PR TITLE
Add close button to assembly manager dialog box

### DIFF
--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
@@ -81,12 +81,12 @@ describe('AssemblyManager GUI', () => {
     )
   })
 
-  it('closes when the return button is clicked', () => {
+  it('closes when the Close button is clicked', () => {
     const onClose = jest.fn()
     const { getByText } = render(
       <AssemblyManager rootModel={mockRootModel} open onClose={onClose} />,
     )
-    fireEvent.click(getByText('Return'))
+    fireEvent.click(getByText('Close'))
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
@@ -8,6 +8,7 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import AddIcon from '@material-ui/icons/Add'
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos'
+import CloseIcon from '@material-ui/icons/Close'
 import { IconButton } from '@material-ui/core/'
 
 import AssemblyTable from './AssemblyTable'
@@ -29,6 +30,12 @@ const useStyles = makeStyles(theme => ({
     left: theme.spacing(4),
     top: theme.spacing(4),
   },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
 }))
 
 const AssemblyManager = observer(
@@ -40,7 +47,7 @@ const AssemblyManager = observer(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rootModel: any
     open: boolean
-    onClose: Function
+    onClose: (arg: boolean) => void
   }) => {
     const classes = useStyles()
     const [isFormOpen, setFormOpen] = useState(false)
@@ -50,7 +57,7 @@ const AssemblyManager = observer(
     const showAssemblyTable = !isFormOpen && !isAssemblyBeingEdited
 
     return (
-      <Dialog open={open}>
+      <Dialog open={open} onClose={onClose}>
         <DialogTitle className={classes.titleBox}>
           {showAssemblyTable ? 'Assembly manager' : null}
           {isFormOpen ? (
@@ -77,6 +84,13 @@ const AssemblyManager = observer(
               {returnAssemblyName(assemblyBeingEdited)}
             </>
           ) : null}
+          <IconButton
+            aria-label="close"
+            className={classes.closeButton}
+            onClick={onClose}
+          >
+            <CloseIcon />
+          </IconButton>
         </DialogTitle>
         <DialogContent>
           <div className={classes.dialogContent}>
@@ -108,7 +122,7 @@ const AssemblyManager = observer(
                   onClose(false)
                 }}
               >
-                Return
+                Close
               </Button>
               <Button
                 variant="contained"

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
@@ -193,7 +193,11 @@ describe('valid file tests', () => {
     )
 
     fireEvent.click(await findByTestId('htsTrackEntry-volvox_alignments'))
-    await findByTestId('display-volvox_alignments_alignments')
+    await findByTestId(
+      'display-volvox_alignments_alignments',
+      {},
+      { timeout: 10000 },
+    )
 
     // opens the view menu and selects show center line
     const viewMenu = await findByTestId('view_menu_icon')


### PR DESCRIPTION
This adds a X close icon to the top right of the assembly manager, and makes clicking outside the dialog close the dialog (as is the case with most of our dialogs, this behavior is made by having an onClose prop to the Dialog component)

Also renames the "Return" button to "Close"


