### PR TITLE
Rename "Manage connections" to "Delete connections..."

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -382,7 +382,7 @@ const HierarchicalTrackSelectorHeader = observer(
         onClick: () => setConnectionToggleOpen(true),
       },
       {
-        label: 'Manage connections',
+        label: 'Delete connections...',
         onClick: () => setConnectionManagerOpen(true),
       },
     ]

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ManageConnectionsDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ManageConnectionsDialog.tsx
@@ -44,7 +44,7 @@ export default observer(
     return (
       <Dialog open onClose={handleClose} maxWidth="lg">
         <DialogTitle>
-          Manage connections
+          Delete connections
           <IconButton
             className={classes.closeButton}
             onClick={() => handleClose()}


### PR DESCRIPTION
Internally, it is still called ManageConnectionsDialog but usefully it only is used to delete connections. If needed I can change the internal name too.