### PR TITLE
Add react-window to the data-management plugin, remove from linear-genome-view

### DIFF
--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -40,7 +40,8 @@
     "object-hash": "^1.3.1",
     "pluralize": "^8.0.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-vtree": "^3.0.0-beta.1"
+    "react-vtree": "^3.0.0-beta.1",
+    "react-window": "^1.8.6"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -44,8 +44,7 @@
     "json-stable-stringify": "^1.0.1",
     "normalize-wheel": "^1.0.1",
     "rbush": "^3.0.1",
-    "react-sizeme": "^2.6.7",
-    "react-window": "^1.8.5"
+    "react-sizeme": "^2.6.7"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21389,10 +21389,10 @@ react-vtree@^3.0.0-beta.1:
     "@babel/runtime" "^7.11.0"
     react-merge-refs "^1.1.0"
 
-react-window@^1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
-  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
+react-window@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
+  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"


### PR DESCRIPTION
The react-vtree has a peerDependency on react-window

Currently there is a react-window dependency listed in linear-genome-view but that appears unused, so I just moved it over to the data-management plugin