### PR TITLE
Fix issue with some falsy values being hidden in feature details

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -169,7 +169,7 @@ const SimpleValue = ({
   prefix?: string[]
 }) => {
   const classes = useStyles()
-  return value ? (
+  return value !== null && value !== undefined ? (
     <div className={classes.field}>
       <FieldName prefix={prefix} description={description} name={name} />
       <BasicValue value={value} />


### PR DESCRIPTION
Noted by @nathanhaigh in gitter chat that for example a VCF with QUAL 0 was not displayed

