### PR TITLE
Fix import of BED and navToLocString from spreadsheet views

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "tslib": "^2.0.1",
     "typescript": "^3.7.2",
     "wait-on": "^5.0.0",
+    "web-encoding": "^1.1.5",
     "webpack-cli": "^3.3.11",
     "whatwg-fetch": "^3.0.0",
     "worker-loader": "^2.0.0"

--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -75,7 +75,7 @@ const FileLocationEditor = observer(
                 </ToggleButton>
               ) : null}
               <ToggleButton value="url" aria-label="url">
-                Url
+                URL
               </ToggleButton>
             </ToggleButtonGroup>
           </Grid>

--- a/packages/core/util/jexl.ts
+++ b/packages/core/util/jexl.ts
@@ -42,6 +42,7 @@ export default function (/* config?: any*/): JexlNonBuildable {
   j.addFunction('floor', Math.floor)
   j.addFunction('round', Math.round)
   j.addFunction('abs', Math.abs)
+  j.addFunction('parseInt', Number.parseInt)
 
   // string
   j.addFunction('split', (str: string, char: string) => str.split(char))

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -76,7 +76,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
               <span
                 class="MuiToggleButton-label"
               >
-                Url
+                URL
               </span>
               <span
                 class="MuiTouchRipple-root"

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
@@ -96,7 +96,7 @@ exports[`<AddTrackWidget /> renders 1`] = `
                           <span
                             class="MuiToggleButton-label"
                           >
-                            Url
+                            URL
                           </span>
                           <span
                             class="MuiTouchRipple-root"
@@ -156,7 +156,7 @@ exports[`<AddTrackWidget /> renders 1`] = `
                           <span
                             class="MuiToggleButton-label"
                           >
-                            Url
+                            URL
                           </span>
                           <span
                             class="MuiTouchRipple-root"

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
@@ -178,6 +178,7 @@ const ImportForm = observer(({ model }) => {
           <Button
             disabled={!model.isReadyToOpen}
             variant="contained"
+            data-testid="open_spreadsheet"
             color="primary"
             onClick={model.import}
           >

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -62,8 +62,8 @@ export async function parseBedBuffer(buffer: Buffer, options: ParseOptions) {
     name: 'Location',
     dataType: { type: 'LocString' },
     isDerived: true,
-    derivationFunctionText: `jexl:{text:row.cells.ref.text+':'+row.cells.start.text+'..'+row.cells.end.text,\n
-    extendedData: {refName: row.cells.ref.text, start: +row.cells.start.text, end: +row.cells.end.text}}`,
+    derivationFunctionText: `jexl:{text:row.cells[0].text+':'+row.cells[1].text+'..'+row.cells[2].text,\n
+    extendedData: {refName: row.cells.ref.text, start: parseInt(row.cells.start.text,10), end: parseInt(row.cells.end.text,10)}}`,
   })
   return data
 }

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/LocString.js
@@ -263,13 +263,13 @@ export default pluginManager => {
           displayName: assemblyName,
           id: newViewId,
         })
+        await when(() => view.initialized)
 
         // note that we have to clone this because otherwise it adds "same object
         // twice to the mst tree"
         view.setDisplayedRegions([
           JSON.parse(JSON.stringify(newDisplayedRegion)),
         ])
-        await when(() => view.initialized)
       }
       view.navToLocString(cell.text)
     } catch (e) {

--- a/products/jbrowse-web/src/tests/1.Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/1.Spreadsheet.test.js
@@ -53,7 +53,7 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
     ).not.toBeDisabled(),
   )
   fireEvent.click(await findByTestId('open_spreadsheet'))
-  fireEvent.click(await findByText('ctgA:276..277'))
+  // fireEvent.click(await findByText('ctgA:276..277'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)
 }, 15000)
 
@@ -77,6 +77,6 @@ test('opens a bed.gz file in the spreadsheet view', async () => {
     ).not.toBeDisabled(),
   )
   fireEvent.click(await findByTestId('open_spreadsheet'))
-  fireEvent.click(await findByText('ctgA:1299..9000'))
+  // fireEvent.click(await findByText('ctgA:1299..9000'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)
 }, 15000)

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.js
@@ -1,0 +1,53 @@
+// library
+import '@testing-library/jest-dom/extend-expect'
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { toMatchImageSnapshot } from 'jest-image-snapshot'
+import React from 'react'
+import { LocalFile } from 'generic-filehandle'
+
+// locals
+import { clearCache } from '@jbrowse/core/util/io/rangeFetcher'
+import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import { TextEncoder, TextDecoder } from 'web-encoding'
+import JBrowse from '../JBrowse'
+import { setup, getPluginManager, generateReadBuffer } from './util'
+
+window.TextEncoder = TextEncoder
+window.TextDecoder = TextDecoder
+
+expect.extend({ toMatchImageSnapshot })
+
+setup()
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  clearCache()
+  clearAdapterCache()
+  fetch.resetMocks()
+  fetch.mockResponse(
+    generateReadBuffer(url => {
+      return new LocalFile(require.resolve(`../../test_data/volvox/${url}`))
+    }),
+  )
+})
+
+test('looks at about this track dialog', async () => {
+  const pluginManager = getPluginManager()
+  const { findByTestId, getByTestId, findByText } = render(
+    <JBrowse pluginManager={pluginManager} />,
+  )
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Add'))
+  fireEvent.click(await findByText('Spreadsheet view'))
+
+  await findByTestId('spreadsheet_view_open')
+  fireEvent.click(await findByText('URL'))
+  fireEvent.change(await findByTestId('urlInput'), {
+    target: { value: 'volvox.filtered.vcf.gz' },
+  })
+
+  fireEvent.click(getByTestId('open_spreadsheet'))
+  await findByText('ctgA:9602..9603')
+}, 15000)

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.js
@@ -1,7 +1,7 @@
 // library
 import '@testing-library/jest-dom/extend-expect'
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
 import React from 'react'
 import { LocalFile } from 'generic-filehandle'
@@ -50,5 +50,25 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
 
   fireEvent.click(await findByTestId('open_spreadsheet'))
   fireEvent.click(await findByText('ctgA:9602..9603'))
+  expect(pluginManager.rootModel.session.views.length).toBe(2)
+}, 15000)
+
+test('opens a bed.gz file in the spreadsheet view', async () => {
+  const pluginManager = getPluginManager()
+  const { findByTestId, findByText } = render(
+    <JBrowse pluginManager={pluginManager} />,
+  )
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Add'))
+  fireEvent.click(await findByText('Spreadsheet view'))
+
+  await findByTestId('spreadsheet_view_open')
+  fireEvent.click(await findByText('URL'))
+  fireEvent.change(await findByTestId('urlInput'), {
+    target: { value: 'volvox-bed12.bed.gz' },
+  })
+
+  fireEvent.click(await findByTestId('open_spreadsheet'))
+  fireEvent.click(await findByText('ctgA:1299..9000'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)
 }, 15000)

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.js
@@ -33,9 +33,9 @@ beforeEach(() => {
   )
 })
 
-test('looks at about this track dialog', async () => {
+test('opens a vcf.gz file in the spreadsheet view', async () => {
   const pluginManager = getPluginManager()
-  const { findByTestId, getByTestId, findByText } = render(
+  const { findByTestId, findByText } = render(
     <JBrowse pluginManager={pluginManager} />,
   )
   fireEvent.click(await findByText('File'))
@@ -48,6 +48,7 @@ test('looks at about this track dialog', async () => {
     target: { value: 'volvox.filtered.vcf.gz' },
   })
 
-  fireEvent.click(getByTestId('open_spreadsheet'))
-  await findByText('ctgA:9602..9603')
+  fireEvent.click(await findByTestId('open_spreadsheet'))
+  fireEvent.click(await findByText('ctgA:9602..9603'))
+  expect(pluginManager.rootModel.session.views.length).toBe(2)
 }, 15000)

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.js
@@ -1,7 +1,7 @@
 // library
 import '@testing-library/jest-dom/extend-expect'
 
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
 import React from 'react'
 import { LocalFile } from 'generic-filehandle'
@@ -35,7 +35,7 @@ beforeEach(() => {
 
 test('opens a vcf.gz file in the spreadsheet view', async () => {
   const pluginManager = getPluginManager()
-  const { findByTestId, findByText } = render(
+  const { findByTestId, getByTestId, findByText } = render(
     <JBrowse pluginManager={pluginManager} />,
   )
   fireEvent.click(await findByText('File'))
@@ -47,8 +47,11 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
   fireEvent.change(await findByTestId('urlInput'), {
     target: { value: 'volvox.filtered.vcf.gz' },
   })
-
-  expect(await findByTestId('open_spreadsheet')).not.toBeDisabled()
+  await waitFor(() =>
+    expect(
+      getByTestId('open_spreadsheet').closest('button'),
+    ).not.toBeDisabled(),
+  )
   fireEvent.click(await findByTestId('open_spreadsheet'))
   fireEvent.click(await findByText('ctgA:276..277'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)
@@ -56,7 +59,7 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
 
 test('opens a bed.gz file in the spreadsheet view', async () => {
   const pluginManager = getPluginManager()
-  const { findByTestId, findByText } = render(
+  const { findByTestId, getByTestId, findByText } = render(
     <JBrowse pluginManager={pluginManager} />,
   )
   fireEvent.click(await findByText('File'))
@@ -68,8 +71,11 @@ test('opens a bed.gz file in the spreadsheet view', async () => {
   fireEvent.change(await findByTestId('urlInput'), {
     target: { value: 'volvox-bed12.bed.gz' },
   })
-
-  expect(await findByTestId('open_spreadsheet')).not.toBeDisabled()
+  await waitFor(() =>
+    expect(
+      getByTestId('open_spreadsheet').closest('button'),
+    ).not.toBeDisabled(),
+  )
   fireEvent.click(await findByTestId('open_spreadsheet'))
   fireEvent.click(await findByText('ctgA:1299..9000'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.js
@@ -48,8 +48,9 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
     target: { value: 'volvox.filtered.vcf.gz' },
   })
 
+  expect(await findByTestId('open_spreadsheet')).not.toBeDisabled()
   fireEvent.click(await findByTestId('open_spreadsheet'))
-  fireEvent.click(await findByText('ctgA:9602..9603'))
+  fireEvent.click(await findByText('ctgA:276..277'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)
 }, 15000)
 
@@ -68,6 +69,7 @@ test('opens a bed.gz file in the spreadsheet view', async () => {
     target: { value: 'volvox-bed12.bed.gz' },
   })
 
+  expect(await findByTestId('open_spreadsheet')).not.toBeDisabled()
   fireEvent.click(await findByTestId('open_spreadsheet'))
   fireEvent.click(await findByText('ctgA:1299..9000'))
   expect(pluginManager.rootModel.session.views.length).toBe(2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,6 +7493,11 @@
     mkdirp-promise "^5.0.1"
     mz "^2.5.0"
 
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -15313,6 +15318,11 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.8.tgz#dfb5c2b120e02b0a8d9d2c6806cd5621aa922f7b"
+  integrity sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -24770,6 +24780,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.3.tgz#971bb0292d2cc0c892dab7c6a5d37c2bec707888"
+  integrity sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@^0.4.0, utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -24960,6 +24982,15 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
The syntax +item is not available in jexl so I converted to parseInt (with the radix param :))

Also, for example, the variable row.cells.ref.text was not actually existing, the previous code was

var [ref, start, end] = row.cells
ref.text

In jexl form, without destructuring, we use row.cells[0].text

Finally the navToLocString click on cell gave an error for "model width undefined" so I moved the view.initialized await above the view.setDisplayedRegions. There was some rearrangement of this code at some point so it works better to check for initialized before setting displayed regions
