### PR TITLE
Add curly:error to global eslint config

### DIFF
--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -35,6 +35,7 @@
     "class-methods-use-this": "off",
     "global-require": "off",
     "import/no-cycle": "off",
+    "curly": "error",
     "import/prefer-default-export": "off",
     "jsx-a11y/mouse-events-have-key-events": "off",
     "max-classes-per-file": "off",

--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -73,10 +73,11 @@ export default class PluginLoader {
         this
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const plugin = (scope as any)[umdName] as { default: PluginConstructor }
-      if (!plugin)
+      if (!plugin) {
         throw new Error(
           `plugin ${moduleName} failed to load, ${scope.constructor.name}.${umdName} is undefined`,
         )
+      }
 
       return plugin.default
     }

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -111,10 +111,11 @@ class TypeRecord<ElementClass extends PluggableElementBase> {
   }
 
   get(name: string) {
-    if (!this.has(name))
+    if (!this.has(name)) {
       throw new Error(
         `${this.typeName} '${name}' not found, perhaps its plugin is not loaded or its plugin has not added it.`,
       )
+    }
     return this.registeredTypes[name]
   }
 
@@ -285,8 +286,9 @@ export default class PluginManager {
 
     this.elementCreationSchedule.add(groupName, () => {
       const newElement = creationCallback(this)
-      if (!newElement.name)
+      if (!newElement.name) {
         throw new Error(`cannot add a ${groupName} with no name`)
+      }
 
       if (typeRecord.has(newElement.name)) {
         throw new Error(
@@ -351,8 +353,9 @@ export default class PluginManager {
           pluggableTypes.push(thing)
         }
       })
-    if (pluggableTypes.length === 0)
+    if (pluggableTypes.length === 0) {
       pluggableTypes.push(ConfigurationSchema('Null', {}))
+    }
     return types.union(...pluggableTypes)
   }
 

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -207,10 +207,11 @@ export default function assemblyFactory(
         return self.refNameColors[idx % self.refNameColors.length]
       },
       isValidRefName(refName: string) {
-        if (!self.refNameAliases)
+        if (!self.refNameAliases) {
           throw new Error(
             'isValidRefName cannot be called yet, the assembly has not finished loading',
           )
+        }
         return !!this.getCanonicalRefName(refName)
       },
     }))

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -93,10 +93,11 @@ function makeConfigurationSchemaModel<
     modelDefinition.type = types.optional(types.literal(modelName), modelName)
   }
 
-  if (options.explicitIdentifier && options.implicitIdentifier)
+  if (options.explicitIdentifier && options.implicitIdentifier) {
     throw new Error(
       `Cannot have both explicit and implicit identifiers in ${modelName}`,
     )
+  }
   if (options.explicitIdentifier) {
     if (typeof options.explicitIdentifier === 'string') {
       modelDefinition[options.explicitIdentifier] = types.identifier

--- a/packages/core/configuration/configurationSlot.ts
+++ b/packages/core/configuration/configurationSlot.ts
@@ -237,10 +237,11 @@ export default function ConfigSlot(
       // }),
     )
     .postProcessSnapshot(snap => {
-      if (typeof snap.value === 'object')
+      if (typeof snap.value === 'object') {
         return JSON.stringify(snap.value) !== JSON.stringify(defaultValue)
           ? snap.value
           : undefined
+      }
       return snap.value !== defaultValue ? snap.value : undefined
     })
     .actions(self => ({

--- a/packages/core/data_adapters/dataAdapterCache.ts
+++ b/packages/core/data_adapters/dataAdapterCache.ts
@@ -36,10 +36,11 @@ export function getAdapter(
   const cacheKey = adapterConfigCacheKey(adapterConfigSnapshot)
   if (!adapterCache[cacheKey]) {
     const adapterType = (adapterConfigSnapshot || {}).type
-    if (!adapterType)
+    if (!adapterType) {
       throw new Error(
         'could not determine adapter type from adapter config snapshot',
       )
+    }
     const dataAdapterType = pluginManager.getAdapterType(adapterType)
     if (!dataAdapterType) {
       throw new Error(`unknown data adapter type ${adapterType}`)
@@ -113,8 +114,9 @@ export function freeAdapterResources(specification: Record<string, any>) {
           specification.regions ||
           (specification.region ? [specification.region] : [])
         regions.forEach((region: Region) => {
-          if (region.refName !== undefined)
+          if (region.refName !== undefined) {
             cacheEntry.dataAdapter.freeResources(region)
+          }
         })
       }
     })

--- a/packages/core/pluggableElementTypes/ConnectionType.ts
+++ b/packages/core/pluggableElementTypes/ConnectionType.ts
@@ -33,9 +33,11 @@ export default class ConnectionType extends PluggableElementBase {
     this.description = stuff.description
     this.url = stuff.url
     this.configEditorComponent = stuff.configEditorComponent
-    if (!this.stateModel)
+    if (!this.stateModel) {
       throw new Error(`no stateModel defined for connection ${this.name}`)
-    if (!this.configSchema)
+    }
+    if (!this.configSchema) {
       throw new Error(`no configSchema defined for connection ${this.name}`)
+    }
   }
 }

--- a/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
+++ b/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
@@ -69,12 +69,14 @@ export const BaseDisplay = types
     get rendererType() {
       const { pluginManager } = getEnv(self)
       const RendererType = pluginManager.getRendererType(self.rendererTypeName)
-      if (!RendererType)
+      if (!RendererType) {
         throw new Error(`renderer "${self.rendererTypeName}" not found`)
-      if (!RendererType.ReactComponent)
+      }
+      if (!RendererType.ReactComponent) {
         throw new Error(
           `renderer ${self.rendererTypeName} has no ReactComponent, it may not be completely implemented yet`,
         )
+      }
       return RendererType
     },
 

--- a/packages/core/pluggableElementTypes/renderers/BoxRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/BoxRendererType.ts
@@ -123,8 +123,9 @@ export default class BoxRendererType extends FeatureRendererType {
 
   getWorkerSession(props: LayoutSessionProps & { sessionId: string }) {
     const { sessionId } = props
-    if (!this.sessions[sessionId])
+    if (!this.sessions[sessionId]) {
       this.sessions[sessionId] = this.createSession(props)
+    }
     const session = this.sessions[sessionId]
     session.update(props)
     return session

--- a/packages/core/pluggableElementTypes/renderers/util/serializableFilterChain.ts
+++ b/packages/core/pluggableElementTypes/renderers/util/serializableFilterChain.ts
@@ -29,8 +29,9 @@ export default class SerializableFilterChain {
       if (
         // @ts-ignore
         !this.filterChain[i].expr.evalSync({ feature: args[0] })
-      )
+      ) {
         return false
+      }
     }
     return true
   }

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -224,10 +224,11 @@ export class CoreRender extends RpcMethodType {
       sessionId,
       adapterConfig,
     )
-    if (!(dataAdapter instanceof BaseFeatureDataAdapter))
+    if (!(dataAdapter instanceof BaseFeatureDataAdapter)) {
       throw new Error(
         `CoreRender cannot handle this type of data adapter ${dataAdapter}`,
       )
+    }
 
     const RendererType = validateRendererType(
       rendererType,

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -163,8 +163,13 @@ export default withContentRect('bounds')(
       // note that this effect will run only once, because of
       // the empty array second param
       useEffect(() => {
-        if (scrollRef && scrollRef.current && scrollRef.current.scrollIntoView)
+        if (
+          scrollRef &&
+          scrollRef.current &&
+          scrollRef.current.scrollIntoView
+        ) {
           scrollRef.current.scrollIntoView({ block: 'center' })
+        }
       }, [])
 
       const aboutTrack = session.showAboutConfig

--- a/packages/core/util/calculateStaticBlocks.ts
+++ b/packages/core/util/calculateStaticBlocks.ts
@@ -57,8 +57,9 @@ export default function calculateStaticBlocks(
 
     let windowRightBlockNum =
       Math.floor((windowRightBp - regionBpOffset) / blockSizeBp) + extra
-    if (windowRightBlockNum >= regionBlockCount)
+    if (windowRightBlockNum >= regionBlockCount) {
       windowRightBlockNum = regionBlockCount - 1
+    }
 
     let windowLeftBlockNum =
       Math.floor((windowLeftBp - regionBpOffset) / blockSizeBp) - extra

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -711,8 +711,9 @@ export function makeAbortableReaction<T, U, V>(
           successFunction(result)
         }
       } catch (error) {
-        if (thisInProgress && !thisInProgress.signal.aborted)
+        if (thisInProgress && !thisInProgress.signal.aborted) {
           thisInProgress.abort()
+        }
         handleError(error)
       }
     },

--- a/packages/core/util/io/ElectronLocalFile.ts
+++ b/packages/core/util/io/ElectronLocalFile.ts
@@ -22,20 +22,22 @@ export default class ElectronLocalFile implements GenericFilehandle {
   constructor(source: PathLike) {
     let ipcRenderer
     if (electron) ipcRenderer = electron.ipcRenderer
-    if (!ipcRenderer)
+    if (!ipcRenderer) {
       throw new Error(
         'Cannot use ElectronLocalFile without ipcRenderer from electron',
       )
+    }
     this.ipcRenderer = ipcRenderer
     this.filename = source
   }
 
   private async getFd(): Promise<number> {
     if (!this.filename) throw new Error('no file path specified')
-    if (!this.fd)
+    if (!this.fd) {
       this.fd = this.ipcRenderer.invoke('open', this.filename, 'r') as Promise<
         number
       >
+    }
     return this.fd
   }
 

--- a/packages/core/util/io/ElectronRemoteFile.ts
+++ b/packages/core/util/io/ElectronRemoteFile.ts
@@ -48,10 +48,11 @@ export default class ElectronRemoteFile implements GenericFilehandle {
   public constructor(source: string, opts: FilehandleOptions = {}) {
     let ipcRenderer
     if (electron) ipcRenderer = electron.ipcRenderer
-    if (!ipcRenderer)
+    if (!ipcRenderer) {
       throw new Error(
         'Cannot use ElectronLocalFile without ipcRenderer from electron',
       )
+    }
     this.ipcRenderer = ipcRenderer
 
     this.url = source
@@ -113,10 +114,11 @@ export default class ElectronRemoteFile implements GenericFilehandle {
   protected async getFetch(
     opts: FilehandleOptions,
   ): Promise<PolyfilledResponse> {
-    if (!this.fetch)
+    if (!this.fetch) {
       throw new Error(
         'a fetch function must be available unless using a file:// url',
       )
+    }
     if (!this.url) {
       throw new Error('no URL specified')
     }
@@ -152,8 +154,9 @@ export default class ElectronRemoteFile implements GenericFilehandle {
       if (requestOptions.headers && requestOptions.headers.range) {
         const contentRange = response.headers.get('content-range')
         const sizeMatch = /\/(\d+)$/.exec(contentRange || '')
-        if (sizeMatch && sizeMatch[1])
+        if (sizeMatch && sizeMatch[1]) {
           this._stat = { size: parseInt(sizeMatch[1], 10) }
+        }
       } else {
         const contentLength = response.headers.get('content-length')
         if (contentLength) this._stat = { size: parseInt(contentLength, 10) }
@@ -233,8 +236,9 @@ export default class ElectronRemoteFile implements GenericFilehandle {
   public async stat(): Promise<Stats> {
     if (!this._stat) await this.headFetch()
     if (!this._stat) await this.read(Buffer.allocUnsafe(10), 0, 10, 0)
-    if (!this._stat)
+    if (!this._stat) {
       throw new Error(`unable to determine size of file at ${this.url}`)
+    }
     return this._stat
   }
 }

--- a/packages/core/util/io/rangeFetcher.ts
+++ b/packages/core/util/io/rangeFetcher.ts
@@ -89,12 +89,12 @@ async function globalCacheFetch(
   let range
   if (requestHeaders) {
     if (requestHeaders instanceof Headers) range = requestHeaders.get('range')
-    else if (Array.isArray(requestHeaders))
-      [, range] = requestHeaders.find(([key]) => key === 'range') || [
+    else if (Array.isArray(requestHeaders)) {
+      ;[, range] = requestHeaders.find(([key]) => key === 'range') || [
         undefined,
         undefined,
       ]
-    else range = requestHeaders.range
+    } else range = requestHeaders.range
   }
   if (range) {
     const rangeParse = /bytes=(\d+)-(\d+)/.exec(range)

--- a/packages/core/util/layouts/SceneGraph.ts
+++ b/packages/core/util/layouts/SceneGraph.ts
@@ -77,9 +77,11 @@ export default class SceneGraph {
     data?: Record<string, any>,
   ): SceneGraph {
     let child: SceneGraph
-    if (nameOrSceneGraph instanceof SceneGraph) child = nameOrSceneGraph
-    else
+    if (nameOrSceneGraph instanceof SceneGraph) {
+      child = nameOrSceneGraph
+    } else {
       child = new SceneGraph(nameOrSceneGraph, left, top, width, height, data)
+    }
 
     if (!(child instanceof SceneGraph)) {
       throw new TypeError(
@@ -87,8 +89,9 @@ export default class SceneGraph {
       )
     }
 
-    if (this.children.has(child.name))
+    if (this.children.has(child.name)) {
       throw new Error(`child named "${child.name}" already exists`)
+    }
 
     // update the bounds to match the child
     child.parent = this
@@ -146,7 +149,9 @@ export default class SceneGraph {
     if (bottom !== undefined && newBottom > bottom) {
       this.height += newBottom - bottom
     }
-    if (this.parent) this.parent.expand(newLeft, newRight, newTop, newBottom)
+    if (this.parent) {
+      this.parent.expand(newLeft, newRight, newTop, newBottom)
+    }
     this.absoluteCache.dirty = true
   }
 

--- a/plugins/circular-view/src/BaseChordDisplay/models/BaseChordDisplayModel.ts
+++ b/plugins/circular-view/src/BaseChordDisplay/models/BaseChordDisplayModel.ts
@@ -97,12 +97,14 @@ export const BaseChordDisplayModel = types
       const ThisRendererType = pluginManager.getRendererType(
         self.rendererTypeName,
       )
-      if (!ThisRendererType)
+      if (!ThisRendererType) {
         throw new Error(`renderer "${display.rendererTypeName}" not found`)
-      if (!ThisRendererType.ReactComponent)
+      }
+      if (!ThisRendererType.ReactComponent) {
         throw new Error(
           `renderer ${display.rendererTypeName} has no ReactComponent, it may not be completely implemented yet`,
         )
+      }
       return ThisRendererType
     },
 

--- a/plugins/circular-view/src/BaseChordDisplay/models/renderReaction.js
+++ b/plugins/circular-view/src/BaseChordDisplay/models/renderReaction.js
@@ -54,10 +54,11 @@ export default ({ jbrequire }) => {
     }
 
     // check renderertype compatibility
-    if (!self.isCompatibleWithRenderer(rendererType))
+    if (!self.isCompatibleWithRenderer(rendererType)) {
       throw new Error(
         `renderer ${rendererType.name} is not compatible with this display type`,
       )
+    }
 
     const { html, ...data } = await rendererType.renderInClient(rpcManager, {
       ...renderArgs,

--- a/plugins/circular-view/src/CircularView/models/CircularView.ts
+++ b/plugins/circular-view/src/CircularView/models/CircularView.ts
@@ -190,8 +190,9 @@ export default function CircularView(pluginManager: PluginManager) {
         get assemblyNames() {
           const assemblyNames: string[] = []
           self.displayedRegions.forEach(displayedRegion => {
-            if (!assemblyNames.includes(displayedRegion.assemblyName))
+            if (!assemblyNames.includes(displayedRegion.assemblyName)) {
               assemblyNames.push(displayedRegion.assemblyName)
+            }
           })
           return assemblyNames
         },

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -55,8 +55,9 @@ const Member = observer(props => {
           slotName={slotName}
           slot={slot}
           onChange={evt => {
-            if (evt.target.value !== slot.type)
+            if (evt.target.value !== slot.type) {
               schema.setSubschema(slotName, { type: evt.target.value })
+            }
           }}
         />
       )

--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
@@ -393,8 +393,9 @@ const SlotEditor = observer(({ slot, slotSchema }) => {
     console.warn(`no slot editor defined for ${type}, editing as string`)
     ValueComponent = StringEditor
   }
-  if (!(type in valueComponents))
+  if (!(type in valueComponents)) {
     console.warn(`SlotEditor needs to implement ${type}`)
+  }
   return (
     <Paper className={classes.paper}>
       <div className={classes.paperContent}>

--- a/plugins/data-management/scripts/getUcscAssemblies.js
+++ b/plugins/data-management/scripts/getUcscAssemblies.js
@@ -15,10 +15,11 @@ const downloadsPageUrl = 'http://hgdownload.soe.ucsc.edu/downloads.html'
 http
   .get(downloadsPageUrl, res => {
     const { statusCode } = res
-    if (statusCode !== 200)
+    if (statusCode !== 200) {
       throw new Error(
         `Could not get downloads page, status code ${statusCode}: ${downloadsPageUrl}`,
       )
+    }
     res.setEncoding('utf8')
     let pageContent = ''
     res.on('data', chunk => {

--- a/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.js
+++ b/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.js
@@ -95,8 +95,9 @@ function AddConnectionWidget({ model }) {
     if (
       (activeStep === 0 && connectionType.name) ||
       (activeStep === 1 && configModel && configModelReady)
-    )
+    ) {
       return true
+    }
     return false
   }
 

--- a/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.test.js
+++ b/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.test.js
@@ -1,4 +1,3 @@
-/* eslint curly:error*/
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import React from 'react'
 import { createTestSession } from '@jbrowse/web/src/rootModel'

--- a/plugins/data-management/src/ucsc-trackhub/model.js
+++ b/plugins/data-management/src/ucsc-trackhub/model.js
@@ -33,13 +33,14 @@ export default function (pluginManager) {
           fetchHubFile(hubFileLocation)
             .then(hubFile => {
               let genomesFileLocation
-              if (hubFileLocation.uri)
+              if (hubFileLocation.uri) {
                 genomesFileLocation = {
                   uri: new URL(hubFile.get('genomesFile'), hubFileLocation.uri)
                     .href,
                 }
-              else
+              } else {
                 genomesFileLocation = { localPath: hubFile.get('genomesFile') }
+              }
               return Promise.all([
                 hubFile,
                 fetchGenomesFile(genomesFileLocation),

--- a/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
+++ b/plugins/data-management/src/ucsc-trackhub/ucscTrackHub.js
@@ -90,19 +90,20 @@ function makeTrackConfig(
   if (
     baseTrackType === 'bam' &&
     track.get('bigDataUrl').toLowerCase().endsWith('cram')
-  )
+  ) {
     baseTrackType = 'cram'
+  }
   let bigDataLocation
-  if (trackDbFileLocation.uri)
+  if (trackDbFileLocation.uri) {
     bigDataLocation = {
       uri: new URL(track.get('bigDataUrl'), trackDbFileLocation.uri).href,
     }
-  else bigDataLocation = { localPath: track.get('bigDataUrl') }
+  } else bigDataLocation = { localPath: track.get('bigDataUrl') }
   let bigDataIndexLocation
 
   switch (baseTrackType) {
     case 'bam':
-      if (trackDbFileLocation.uri)
+      if (trackDbFileLocation.uri) {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? {
               uri: new URL(track.get('bigDataIndex'), trackDbFileLocation.uri)
@@ -114,10 +115,11 @@ function makeTrackConfig(
                 trackDbFileLocation.uri,
               ).href,
             }
-      else
+      } else {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? { localPath: track.get('bigDataIndex') }
           : { localPath: `${track.get('bigDataUrl')}.bai` }
+      }
       return {
         type: 'AlignmentsTrack',
         name: track.get('shortLabel'),
@@ -271,7 +273,7 @@ function makeTrackConfig(
         categories,
       )
     case 'cram':
-      if (trackDbFileLocation.uri)
+      if (trackDbFileLocation.uri) {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? {
               uri: new URL(track.get('bigDataIndex'), trackDbFileLocation.uri)
@@ -283,10 +285,11 @@ function makeTrackConfig(
                 trackDbFileLocation.uri,
               ).href,
             }
-      else
+      } else {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? { localPath: track.get('bigDataIndex') }
           : { localPath: `${track.get('bigDataUrl')}.crai` }
+      }
       return {
         type: 'AlignmentsTrack',
         name: track.get('shortLabel'),
@@ -335,7 +338,7 @@ function makeTrackConfig(
         categories,
       )
     case 'vcfTabix':
-      if (trackDbFileLocation.uri)
+      if (trackDbFileLocation.uri) {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? {
               uri: new URL(track.get('bigDataIndex'), trackDbFileLocation.uri)
@@ -347,10 +350,11 @@ function makeTrackConfig(
                 trackDbFileLocation.uri,
               ).href,
             }
-      else
+      } else {
         bigDataIndexLocation = track.get('bigDataIndex')
           ? { localPath: track.get('bigDataIndex') }
           : { localPath: `${track.get('bigDataUrl')}.tbi` }
+      }
       return {
         type: 'VariantTrack',
         name: track.get('shortLabel'),

--- a/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
@@ -43,10 +43,11 @@ export default class ComparativeRender extends RpcMethodType {
 
     const RendererType = this.pluginManager.getRendererType(rendererType)
 
-    if (!(RendererType instanceof ComparativeServerSideRendererType))
+    if (!(RendererType instanceof ComparativeServerSideRendererType)) {
       throw new Error(
         'CoreRender requires a renderer that is a subclass of ServerSideRendererType',
       )
+    }
 
     return RendererType.serializeArgsInClient(renamedArgs)
   }
@@ -72,10 +73,11 @@ export default class ComparativeRender extends RpcMethodType {
       sessionId,
       adapterConfig,
     )
-    if (!(dataAdapter instanceof BaseFeatureDataAdapter))
+    if (!(dataAdapter instanceof BaseFeatureDataAdapter)) {
       throw new Error(
         `ComparativeRender cannot handle this type of data adapter ${dataAdapter}`,
       )
+    }
 
     const RendererType = this.pluginManager.getRendererType(rendererType)
 
@@ -88,10 +90,11 @@ export default class ComparativeRender extends RpcMethodType {
       )
     }
 
-    if (!(RendererType instanceof ComparativeServerSideRendererType))
+    if (!(RendererType instanceof ComparativeServerSideRendererType)) {
       throw new Error(
         'CoreRender requires a renderer that is a subclass of ServerSideRendererType',
       )
+    }
 
     const renderArgs = {
       ...deserializedArgs,
@@ -125,10 +128,11 @@ export default class ComparativeRender extends RpcMethodType {
         `renderer ${rendererType} has no ReactComponent, it may not be completely implemented yet`,
       )
     }
-    if (!(RendererType instanceof ComparativeServerSideRendererType))
+    if (!(RendererType instanceof ComparativeServerSideRendererType)) {
       throw new Error(
         'CoreRender requires a renderer that is a subclass of ServerSideRendererType',
       )
+    }
     return RendererType.deserializeResultsInClient(
       serializedReturn as ResultsSerialized,
       args,

--- a/plugins/filtering/src/LinearFilteringDisplay/model.js
+++ b/plugins/filtering/src/LinearFilteringDisplay/model.js
@@ -58,9 +58,9 @@ export default configSchema => {
       .actions(self => ({
         setFilterControlsHeight(newHeight) {
           if (newHeight > self.filterControlsMinHeight) {
-            if (newHeight < self.filterControlsMaxHeight)
+            if (newHeight < self.filterControlsMaxHeight) {
               self.filterControlsHeight = newHeight
-            else self.filterControlsHeight = self.filterControlsMaxHeight
+            } else self.filterControlsHeight = self.filterControlsMaxHeight
           } else self.filterControlsHeight = self.filterControlsMinHeight
           return self.filterControlsHeight
         },

--- a/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/Gff3TabixAdapter.ts
@@ -131,8 +131,9 @@ export default class extends BaseFeatureDataAdapter {
       const gff3 = lines
         .map((lineRecord: LineFeature) => {
           if (lineRecord.fields[8] && lineRecord.fields[8] !== '.') {
-            if (!lineRecord.fields[8].includes('_lineHash'))
+            if (!lineRecord.fields[8].includes('_lineHash')) {
               lineRecord.fields[8] += `;_lineHash=${lineRecord.lineHash}`
+            }
           } else {
             lineRecord.fields[8] = `_lineHash=${lineRecord.lineHash}`
           }

--- a/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigLoad.ts
+++ b/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigLoad.ts
@@ -32,11 +32,12 @@ export async function fetchJb1(
   let dataRootLocation = ''
   if (isUriLocation(dataRoot)) dataRootLocation = dataRoot.uri
   if (isLocalPathLocation(dataRoot)) dataRootLocation = dataRoot.localPath
-  if (dataRootLocation.endsWith('/'))
+  if (dataRootLocation.endsWith('/')) {
     dataRootReg[protocol] = dataRootLocation.slice(
       0,
       dataRootLocation.length - 1,
     )
+  }
   if (
     (isUriLocation(baseConfigRoot) && baseConfigRoot.uri) ||
     (isLocalPathLocation(baseConfigRoot) && baseConfigRoot.localPath)
@@ -44,13 +45,15 @@ export async function fetchJb1(
     const baseProtocol = 'uri' in baseConfigRoot ? 'uri' : 'localPath'
     let baseConfigLocation = ''
     if (isUriLocation(baseConfigRoot)) baseConfigLocation = baseConfigRoot.uri
-    if (isLocalPathLocation(baseConfigRoot))
+    if (isLocalPathLocation(baseConfigRoot)) {
       baseConfigLocation = baseConfigRoot.localPath
-    if (baseConfigLocation.endsWith('/'))
+    }
+    if (baseConfigLocation.endsWith('/')) {
       baseConfigLocation = baseConfigLocation.slice(
         0,
         baseConfigLocation.length - 1,
       )
+    }
     let newConfig: Config = {}
     for (const conf of ['jbrowse.conf', 'jbrowse_conf.json']) {
       let fetchedConfig = null
@@ -89,8 +92,9 @@ export async function createFinalConfig(
 
 export async function fetchConfigFile(location: JBLocation): Promise<Config> {
   const result = await openLocation(location).readFile('utf8')
-  if (typeof result !== 'string')
+  if (typeof result !== 'string') {
     throw new Error(`Error opening location: ${location}`)
+  }
   if (isUriLocation(location)) return parseJb1(result, location.uri)
   if (isLocalPathLocation(location)) return parseJb1(result, location.localPath)
   return parseJb1(result)
@@ -113,12 +117,13 @@ function mergeConfigs(a: Config | null, b: Config | null): Config | null {
     if (prop === 'tracks' && prop in a) {
       const aTracks = a[prop] || []
       const bTracks = b[prop] || []
-      if (Array.isArray(aTracks) && Array.isArray(bTracks))
+      if (Array.isArray(aTracks) && Array.isArray(bTracks)) {
         a[prop] = mergeTrackConfigs(aTracks || [], bTracks || [])
-      else
+      } else {
         throw new Error(
           `Track config has not been properly regularized: ${aTracks} ${bTracks}`,
         )
+      }
     } else if (
       !noRecursiveMerge(prop) &&
       prop in a &&
@@ -183,10 +188,11 @@ async function loadIncludes(inputConfig: Config): Promise<Config> {
     upstreamConf: Config,
   ): Promise<Config> {
     const sourceUrl = config.sourceUrl || config.baseUrl
-    if (!sourceUrl)
+    if (!sourceUrl) {
       throw new Error(
         `Could not determine source URL: ${JSON.stringify(config)}`,
       )
+    }
     const newUpstreamConf = mergeConfigs(clone(upstreamConf), config)
     if (!newUpstreamConf) throw new Error('Problem merging configs')
     const includes = fillTemplates(

--- a/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigParse.ts
+++ b/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigParse.ts
@@ -54,12 +54,13 @@ function parse(text: string, url: string): Config {
         const match = value.match(/^json:(.+)/i)
         if (match) parsedValue = JSON.parse(match[1])
         // parse numbers if it looks numeric
-        else if (/^[+-]?[\d.,]+([eE][-+]?\d+)?$/.test(value))
+        else if (/^[+-]?[\d.,]+([eE][-+]?\d+)?$/.test(value)) {
           parsedValue = parseFloat(value.replace(/,/g, ''))
-        else parsedValue = value
+        } else parsedValue = value
 
-        if (!keyPath)
+        if (!keyPath) {
           throw new Error(`Error parsing in section ${section.join(' - ')}`)
+        }
         const path = section.concat(keyPath).join('.')
         if (operation === '+=') {
           let existing = getValue(data, path)
@@ -95,8 +96,9 @@ function parse(text: string, url: string): Config {
       keyPath = undefined
       value = undefined
       section = match[1].trim().split(/\s*\.\s*/)
-      if (section.length === 1 && section[0].toLowerCase() === 'general')
+      if (section.length === 1 && section[0].toLowerCase() === 'general') {
         section = []
+      }
     }
     // new value
     else if (
@@ -194,8 +196,9 @@ export function regularizeConf(conf: Config, url: string): Config {
   }
 
   conf.sourceUrl = conf.sourceUrl || url
-  if (conf.sourceUrl.startsWith('/'))
+  if (conf.sourceUrl.startsWith('/')) {
     conf.sourceUrl = new URL(conf.sourceUrl, window.location.href).href
+  }
   conf.baseUrl = conf.baseUrl || new URL('.', conf.sourceUrl).href
   if (conf.baseUrl.length && !conf.baseUrl.endsWith('/')) conf.baseUrl += '/'
 
@@ -212,8 +215,9 @@ export function regularizeConf(conf: Config, url: string): Config {
     })
 
     // resolve the refSeqs and nameUrl if present
-    if (conf.refSeqs && typeof conf.refSeqs === 'string')
+    if (conf.refSeqs && typeof conf.refSeqs === 'string') {
       conf.refSeqs = new URL(conf.refSeqs, conf.sourceUrl).href
+    }
     if (conf.nameUrl) conf.nameUrl = new URL(conf.nameUrl, conf.sourceUrl).href
   }
 
@@ -231,24 +235,26 @@ export function regularizeConf(conf: Config, url: string): Config {
     if (trackConfig.store) return
 
     let trackClassName: string
-    if (trackConfig.type === 'FeatureTrack')
+    if (trackConfig.type === 'FeatureTrack') {
       trackClassName = 'JBrowse/View/Track/HTMLFeatures'
-    else if (trackConfig.type === 'ImageTrack')
+    } else if (trackConfig.type === 'ImageTrack') {
       trackClassName = 'JBrowse/View/Track/FixedImage'
-    else if (trackConfig.type === 'ImageTrack.Wiggle')
+    } else if (trackConfig.type === 'ImageTrack.Wiggle') {
       trackClassName = 'JBrowse/View/Track/FixedImage/Wiggle'
-    else if (trackConfig.type === 'SequenceTrack')
+    } else if (trackConfig.type === 'SequenceTrack') {
       trackClassName = 'JBrowse/View/Track/Sequence'
-    else
+    } else {
       trackClassName = regularizeClass('JBrowse/View/Track', trackConfig.type)
+    }
 
     trackConfig.type = trackClassName
 
     synthesizeTrackStoreConfig(conf, trackConfig)
 
     if (trackConfig.histograms) {
-      if (!trackConfig.histograms.baseUrl)
+      if (!trackConfig.histograms.baseUrl) {
         trackConfig.histograms.baseUrl = trackConfig.baseUrl
+      }
       synthesizeTrackStoreConfig(conf, trackConfig.histograms)
     }
   })
@@ -273,35 +279,45 @@ function guessStoreClass(
   urlTemplate: string,
 ): string {
   if (!trackConfig) return ''
-  if (trackConfig.type && trackConfig.type.includes('/FixedImage'))
+  if (trackConfig.type && trackConfig.type.includes('/FixedImage')) {
     return `JBrowse/Store/TiledImage/Fixed${
       trackConfig.backendVersion === 0 ? '_v0' : ''
     }`
-  if (/\.jsonz?$/i.test(urlTemplate))
+  }
+  if (/\.jsonz?$/i.test(urlTemplate)) {
     return `JBrowse/Store/SeqFeature/NCList${
       trackConfig.backendVersion === 0 ? '_v0' : ''
     }`
+  }
   if (/\.bam$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/BAM'
   if (/\.cram$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/CRAM'
   if (/\.gff3?$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/GFF3'
   if (/\.bed$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/BED'
-  if (/\.vcf.b?gz$/i.test(urlTemplate))
+  if (/\.vcf.b?gz$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/VCFTabix'
-  if (/\.gff3?.b?gz$/i.test(urlTemplate))
+  }
+  if (/\.gff3?.b?gz$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/GFF3Tabix'
-  if (/\.bed.b?gz$/i.test(urlTemplate))
+  }
+  if (/\.bed.b?gz$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/BEDTabix'
-  if (/\.(bw|bigwig)$/i.test(urlTemplate))
+  }
+  if (/\.(bw|bigwig)$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/BigWig'
-  if (/\.(bb|bigbed)$/i.test(urlTemplate))
+  }
+  if (/\.(bb|bigbed)$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/BigBed'
-  if (/\.(fa|fasta)$/i.test(urlTemplate))
+  }
+  if (/\.(fa|fasta)$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/IndexedFasta'
-  if (/\.(fa|fasta)\.b?gz$/i.test(urlTemplate))
+  }
+  if (/\.(fa|fasta)\.b?gz$/i.test(urlTemplate)) {
     return 'JBrowse/Store/SeqFeature/BgzipIndexedFasta'
+  }
   if (/\.2bit$/i.test(urlTemplate)) return 'JBrowse/Store/SeqFeature/TwoBit'
-  if (trackConfig.type && trackConfig.type.endsWith('/Sequence'))
+  if (trackConfig.type && trackConfig.type.endsWith('/Sequence')) {
     return 'JBrowse/Store/Sequence/StaticChunked'
+  }
   return ''
 }
 
@@ -314,9 +330,9 @@ function synthesizeTrackStoreConfig(
   const { urlTemplate = '' } = trackConfig
 
   let storeClass: string
-  if (trackConfig.storeClass)
+  if (trackConfig.storeClass) {
     storeClass = regularizeClass('JBrowse/Store', trackConfig.storeClass)
-  else storeClass = guessStoreClass(trackConfig, urlTemplate)
+  } else storeClass = guessStoreClass(trackConfig, urlTemplate)
 
   if (!storeClass) {
     console.warn(

--- a/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ToJb2.ts
+++ b/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ToJb2.ts
@@ -102,16 +102,16 @@ export function convertTrackConfig(
         type: 'BamAdapter',
         bamLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.baiUrlTemplate)
+      if (jb1TrackConfig.baiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.baiUrlTemplate) },
         }
-      else if (jb1TrackConfig.csiUrlTemplate)
+      } else if (jb1TrackConfig.csiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.csiUrlTemplate) },
           indexType: 'CSI',
         }
-      else adapter.index = { location: { uri: `${urlTemplate}.bai` } }
+      } else adapter.index = { location: { uri: `${urlTemplate}.bai` } }
       return {
         ...jb2TrackConfig,
         type: 'AlignmentsTrack',
@@ -124,11 +124,11 @@ export function convertTrackConfig(
         cramLocation: { uri: urlTemplate },
         sequenceAdapter,
       }
-      if (jb1TrackConfig.craiUrlTemplate)
+      if (jb1TrackConfig.craiUrlTemplate) {
         adapter.craiLocation = {
           uri: resolveUrlTemplate(jb1TrackConfig.craiUrlTemplate),
         }
-      else adapter.craiLocation = { uri: `${urlTemplate}.crai` }
+      } else adapter.craiLocation = { uri: `${urlTemplate}.crai` }
       return {
         ...jb2TrackConfig,
         type: 'AlignmentsTrack',
@@ -171,16 +171,16 @@ export function convertTrackConfig(
         type: 'VcfTabixAdapter',
         vcfGzLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.tbiUrlTemplate)
+      if (jb1TrackConfig.tbiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.tbiUrlTemplate) },
         }
-      else if (jb1TrackConfig.csiUrlTemplate)
+      } else if (jb1TrackConfig.csiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.csiUrlTemplate) },
           indexType: 'CSI',
         }
-      else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
+      } else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
       return {
         ...jb2TrackConfig,
         type: 'VariantTrack',
@@ -216,16 +216,16 @@ export function convertTrackConfig(
         type: 'Gff3TabixAdapter',
         gffGzLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.tbiUrlTemplate)
+      if (jb1TrackConfig.tbiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.tbiUrlTemplate) },
         }
-      else if (jb1TrackConfig.csiUrlTemplate)
+      } else if (jb1TrackConfig.csiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.csiUrlTemplate) },
           indexType: 'CSI',
         }
-      else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
+      } else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
       return {
         ...jb2TrackConfig,
         type: 'FeatureTrack',
@@ -244,16 +244,16 @@ export function convertTrackConfig(
         type: 'BedTabixAdapter',
         bedGzLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.tbiUrlTemplate)
+      if (jb1TrackConfig.tbiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.tbiUrlTemplate) },
         }
-      else if (jb1TrackConfig.csiUrlTemplate)
+      } else if (jb1TrackConfig.csiUrlTemplate) {
         adapter.index = {
           location: { uri: resolveUrlTemplate(jb1TrackConfig.csiUrlTemplate) },
           indexType: 'CSI',
         }
-      else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
+      } else adapter.index = { location: { uri: `${urlTemplate}.tbi` } }
       return {
         ...jb2TrackConfig,
         type: 'FeatureTrack',
@@ -289,11 +289,11 @@ export function convertTrackConfig(
         type: 'IndexedFastaAdapter',
         fastaLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.faiUrlTemplate)
+      if (jb1TrackConfig.faiUrlTemplate) {
         adapter.faiLocation = {
           uri: resolveUrlTemplate(jb1TrackConfig.faiUrlTemplate),
         }
-      else adapter.faiLocation = { uri: `${urlTemplate}.fai` }
+      } else adapter.faiLocation = { uri: `${urlTemplate}.fai` }
       return {
         ...jb2TrackConfig,
         type: 'SequenceTrack',
@@ -305,16 +305,16 @@ export function convertTrackConfig(
         type: 'BgzipFastaAdapter',
         fastaLocation: { uri: urlTemplate },
       }
-      if (jb1TrackConfig.faiUrlTemplate)
+      if (jb1TrackConfig.faiUrlTemplate) {
         adapter.faiLocation = {
           uri: resolveUrlTemplate(jb1TrackConfig.faiUrlTemplate),
         }
-      else adapter.faiLocation = { uri: `${urlTemplate}.fai` }
-      if (jb1TrackConfig.gziUrlTemplate)
+      } else adapter.faiLocation = { uri: `${urlTemplate}.fai` }
+      if (jb1TrackConfig.gziUrlTemplate) {
         adapter.gziLocation = {
           uri: resolveUrlTemplate(jb1TrackConfig.gziUrlTemplate),
         }
-      else adapter.gziLocation = { uri: `${urlTemplate}.gzi` }
+      } else adapter.gziLocation = { uri: `${urlTemplate}.gzi` }
       return {
         ...jb2TrackConfig,
         type: 'ReferenceSequenceTrack',

--- a/plugins/legacy-jbrowse/src/NCListAdapter/NCListFeature.ts
+++ b/plugins/legacy-jbrowse/src/NCListAdapter/NCListFeature.ts
@@ -45,9 +45,10 @@ export default class NCListFeature implements Feature {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(attrName: string): any {
     const attr = this.ncFeature.get(this.jb2TagToJb1Tag(attrName))
-    if (attr && attrName === 'subfeatures')
+    if (attr && attrName === 'subfeatures') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return attr.map((subfeature: any) => new NCListFeature(subfeature, this))
+    }
     return attr
   }
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -587,13 +587,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const oldIndex = self.tracks.findIndex(
           track => track.id === movingTrackId,
         )
-        if (oldIndex === -1)
+        if (oldIndex === -1) {
           throw new Error(`Track ID ${movingTrackId} not found`)
+        }
         const newIndex = self.tracks.findIndex(
           track => track.id === targetTrackId,
         )
-        if (newIndex === -1)
+        if (newIndex === -1) {
           throw new Error(`Track ID ${targetTrackId} not found`)
+        }
         const track = getSnapshot(self.tracks[oldIndex])
         self.tracks.splice(oldIndex, 1)
         self.tracks.splice(newIndex, 0, track)

--- a/plugins/lollipop/src/LollipopRenderer/Layout.ts
+++ b/plugins/lollipop/src/LollipopRenderer/Layout.ts
@@ -104,8 +104,9 @@ export class FloatingLayout {
   }
 
   getTotalHeight() {
-    if (this.layoutDirty)
+    if (this.layoutDirty) {
       throw new Error('getTotalHeight does not work when the layout is dirty.')
+    }
     return this.totalHeight
   }
 
@@ -114,8 +115,9 @@ export class FloatingLayout {
   }
 
   toJSON() {
-    if (this.layoutDirty)
+    if (this.layoutDirty) {
       throw new Error('toJSON does not work when the layout is dirty.')
+    }
     return { pairs: [...this.getLayout()], totalHeight: this.getTotalHeight() }
   }
 
@@ -141,8 +143,9 @@ export class PrecomputedFloatingLayout {
   }
 
   add(uniqueId: string) {
-    if (!this.layout.has(uniqueId))
+    if (!this.layout.has(uniqueId)) {
       throw new Error(`layout error, precomputed layout is missing ${uniqueId}`)
+    }
   }
 
   getLayout() {

--- a/plugins/lollipop/src/LollipopRenderer/components/LollipopRendering.js
+++ b/plugins/lollipop/src/LollipopRenderer/components/LollipopRendering.js
@@ -57,12 +57,13 @@ function LollipopRendering(props) {
     const centerPx = bpToPx(centerBp, region, bpPerPx)
     const radiusPx = readConfObject(args.config, 'radius', { feature })
 
-    if (!radiusPx)
+    if (!radiusPx) {
       console.error(
         new Error(
           `lollipop radius ${radiusPx} configured for feature ${feature.id()}`,
         ),
       )
+    }
     layout.add(feature.id(), centerPx, radiusPx * 2, radiusPx * 2, {
       featureId: feature.id(),
       anchorX: centerPx,

--- a/plugins/rdf/src/SPARQLAdapter/SPARQLAdapter.ts
+++ b/plugins/rdf/src/SPARQLAdapter/SPARQLAdapter.ts
@@ -101,8 +101,9 @@ export default class SPARQLAdapter extends BaseFeatureDataAdapter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async querySparql(query: string, opts?: BaseOptions): Promise<any> {
     let additionalQueryParams = ''
-    if (this.additionalQueryParams.length)
+    if (this.additionalQueryParams.length) {
       additionalQueryParams = `&${this.additionalQueryParams.join('&')}`
+    }
     const signal = opts && opts.signal
     const response = await fetch(
       `${this.endpoint}?query=${query}${additionalQueryParams}`,
@@ -118,8 +119,9 @@ export default class SPARQLAdapter extends BaseFeatureDataAdapter {
     const rows = ((response || {}).results || {}).bindings || []
     if (!rows.length) return []
     const fields = response.head.vars
-    if (!fields.includes('refName'))
+    if (!fields.includes('refName')) {
       throw new Error('"refName" not found in refNamesQueryTemplate response')
+    }
     return rows.map(row => row.refName.value)
   }
 
@@ -132,10 +134,11 @@ export default class SPARQLAdapter extends BaseFeatureDataAdapter {
     const fields = results.head.vars
     const requiredFields = ['start', 'end', 'uniqueId']
     requiredFields.forEach(requiredField => {
-      if (!fields.includes(requiredField))
+      if (!fields.includes(requiredField)) {
         console.error(
           `Required field ${requiredField} missing from feature data`,
         )
+      }
     })
     const seenFeatures: Record<string, SPARQLFeature> = {}
     rows.forEach(row => {

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.js
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.js
@@ -54,8 +54,9 @@ describe('<DivSequenceRendering />', () => {
         args[0].includes(
           'The above error occurred in the <SequenceDivs> component',
         )
-      )
+      ) {
         return
+      }
       originalError.call(console, ...args)
     }
   })

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ColumnFilterControls.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ColumnFilterControls.js
@@ -42,8 +42,9 @@ const ColumnFilterControls = observer(
     }
 
     const columnDefinition = viewModel.spreadsheet.columns[columnNumber]
-    if (!columnDefinition)
+    if (!columnDefinition) {
       throw new Error('no column definition! filters are probably out of date')
+    }
     return (
       <Grid
         container

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/BedImport.ts
@@ -128,8 +128,9 @@ export async function parseBedPEBuffer(buffer: Buffer, options: ParseOptions) {
       if (bedColumn) {
         // a predefined column
         if (bedColumn.featureField.length === 2) {
-          if (!featureData[bedColumn.featureField[0]])
+          if (!featureData[bedColumn.featureField[0]]) {
             featureData[bedColumn.featureField[0]] = {}
+          }
           featureData[bedColumn.featureField[0]][
             bedColumn.featureField[1]
           ] = val

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Number.js
@@ -129,10 +129,11 @@ export default ({ jbrequire }) => {
     .views(self => ({
       // returns a function that tests the given row
       get predicate() {
-        if (typeof self.firstNumber !== 'number')
+        if (typeof self.firstNumber !== 'number') {
           return function alwaysTrue() {
             return true
           }
+        }
 
         const { firstNumber, secondNumber, operation, columnNumber } = self // avoid closing over self
         return function stringPredicate(sheet, row) {
@@ -145,8 +146,9 @@ export default ({ jbrequire }) => {
           if (typeof parsedCellText !== 'number') return false
 
           const predicate = OPERATION_PREDICATES[operation]
-          if (!predicate)
+          if (!predicate) {
             throw new Error(`"${operation}" not implemented in location filter`)
+          }
 
           return predicate(parsedCellText, firstNumber, secondNumber)
         }
@@ -154,14 +156,14 @@ export default ({ jbrequire }) => {
     }))
     .actions(self => ({
       setFirstNumber(n) {
-        if (Number.isNaN(n) || typeof n !== 'number')
+        if (Number.isNaN(n) || typeof n !== 'number') {
           self.firstNumber = undefined
-        else self.firstNumber = n
+        } else self.firstNumber = n
       },
       setSecondNumber(n) {
-        if (Number.isNaN(n) || typeof n !== 'number')
+        if (Number.isNaN(n) || typeof n !== 'number') {
           self.secondNumber = undefined
-        else self.secondNumber = n
+        } else self.secondNumber = n
       },
       setOperation(op) {
         self.operation = op

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ColumnDataTypes/Text.js
@@ -140,8 +140,9 @@ export default pluginManager => {
           const cell = cellsWithDerived[columnNumber]
           if (!cell || !cell.text) return false
           const predicate = OPERATION_PREDICATES[operation]
-          if (!predicate)
+          if (!predicate) {
             throw new Error(`"${operation}" not implemented in location filter`)
+          }
           return predicate(cell.text, s)
         }
       },

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/FilterControls.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/FilterControls.ts
@@ -18,10 +18,11 @@ export default (pluginManager: PluginManager) => {
       // returns a function that tests the given row
       get predicate() {
         let s = self.stringToFind // avoid closing over self
-        if (!s)
+        if (!s) {
           return function alwaysTrue() {
             return true
           }
+        }
         s = s.toLowerCase()
         return function stringPredicate(
           _sheet: unknown,

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -151,8 +151,9 @@ export default (pluginManager: PluginManager) => {
         try {
           if (!self.fileSource) return
 
-          if (self.loading)
+          if (self.loading) {
             throw new Error('cannot import, load already in progress')
+          }
           self.loading = true
           const typeParser = await fileTypeParsers[
             self.fileType as keyof typeof fileTypeParsers
@@ -165,12 +166,13 @@ export default (pluginManager: PluginManager) => {
           filehandle
             .stat()
             .then(stat => {
-              if (stat.size > IMPORT_SIZE_LIMIT)
+              if (stat.size > IMPORT_SIZE_LIMIT) {
                 throw new Error(
                   `File is too big. Tabular files are limited to at most ${(
                     IMPORT_SIZE_LIMIT / 1000
                   ).toLocaleString()}kb.`,
                 )
+              }
             })
             .then(() => filehandle.readFile())
             .then(buffer => {

--- a/plugins/sv-inspector/src/SvInspectorView/models/adhocFeatureUtils.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/adhocFeatureUtils.js
@@ -111,8 +111,9 @@ export default ({ jbrequire }) => {
     const columnTypes = {}
     columnDisplayOrder.forEach(columnNumber => {
       const columnDefinition = columns[columnNumber]
-      if (!columnTypes[columnDefinition.dataType.type])
+      if (!columnTypes[columnDefinition.dataType.type]) {
         columnTypes[columnDefinition.dataType.type] = []
+      }
       columnTypes[columnDefinition.dataType.type].push(columnNumber)
     })
     const locationColumnNumbers = columnTypes.LocString || []

--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.js
@@ -19,9 +19,10 @@ function ProcessedTranscript(props) {
 function makeSubpartsFilter(confKey = 'subParts', config) {
   let filter = readConfObject(config, confKey)
 
-  if (typeof filter == 'string')
+  if (typeof filter == 'string') {
     // convert to array
     filter = filter.split(/\s*,\s*/)
+  }
 
   if (Array.isArray(filter)) {
     const typeNames = filter.map(typeName => typeName.toLowerCase())
@@ -75,8 +76,9 @@ function makeUTRs(parent, subs) {
   }
 
   // bail if we don't have exons and CDS
-  if (!(exons.length && codeStart < Infinity && codeEnd > -Infinity))
+  if (!(exons.length && codeStart < Infinity && codeEnd > -Infinity)) {
     return subparts
+  }
 
   // make sure the exons are sorted by coord
   exons.sort((a, b) => a.get('start') - b.get('start'))
@@ -86,7 +88,7 @@ function makeUTRs(parent, subs) {
   // make the left-hand UTRs
   let start
   let end
-  if (!haveLeftUTR)
+  if (!haveLeftUTR) {
     for (let i = 0; i < exons.length; i++) {
       start = exons[i].get('start')
       if (start >= codeStart) {
@@ -102,9 +104,10 @@ function makeUTRs(parent, subs) {
         }),
       )
     }
+  }
 
   // make the right-hand UTRs
-  if (!haveRightUTR)
+  if (!haveRightUTR) {
     for (let i = exons.length - 1; i >= 0; i--) {
       end = exons[i].get('end')
       if (end <= codeEnd) {
@@ -121,6 +124,7 @@ function makeUTRs(parent, subs) {
         }),
       )
     }
+  }
 
   return subparts
 }

--- a/plugins/svg/src/SvgFeatureRenderer/components/Segments.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Segments.js
@@ -32,12 +32,13 @@ function Segments(props) {
     [left + width, top + height / 2],
   ]
   const strand = feature.get('strand')
-  if (strand)
+  if (strand) {
     points.push(
       [left + width - height / 4, top + height / 4],
       [left + width - height / 4, top + 3 * (height / 4)],
       [left + width, top + height / 2],
     )
+  }
 
   return (
     <>

--- a/plugins/trackhub-registry/src/trackhub-registry/HubDetails.js
+++ b/plugins/trackhub-registry/src/trackhub-registry/HubDetails.js
@@ -52,7 +52,7 @@ function HubDetails(props) {
 
     getHubTxt()
   }, [hubUrl])
-  if (errorMessage)
+  if (errorMessage) {
     return (
       <Card>
         <CardContent>
@@ -60,7 +60,8 @@ function HubDetails(props) {
         </CardContent>
       </Card>
     )
-  if (hubFile)
+  }
+  if (hubFile) {
     return (
       <Card>
         <CardHeader title={shortLabel} />
@@ -90,6 +91,7 @@ function HubDetails(props) {
         </CardActions>
       </Card>
     )
+  }
   return <LinearProgress variant="query" />
 }
 

--- a/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
+++ b/plugins/trackhub-registry/src/trackhub-registry/TrackHubRegistrySelect.js
@@ -120,9 +120,9 @@ function TrackHubRegistrySelect({ model, setModelReady }) {
     )
     if (response) {
       for (const item of response.items) {
-        if (item.hub.url.startsWith('ftp://'))
+        if (item.hub.url.startsWith('ftp://')) {
           item.error = 'JBrowse cannot add connections from FTP sources'
-        else {
+        } else {
           const hub = openLocation({ uri: item.hub.url })
           try {
             // eslint-disable-next-line no-await-in-loop
@@ -329,14 +329,16 @@ function TrackHubRegistrySelect({ model, setModelReady }) {
         </FormControl>
       </div>,
     )
-    if (!allHubsRetrieved)
+    if (!allHubsRetrieved) {
       renderItems.push(<QueryStatus key="hubStatus" status="Retrieving hubs" />)
+    }
   }
 
-  if (selectedHub)
+  if (selectedHub) {
     renderItems.push(
       <HubDetails key="hubDetails" hub={hubs.get(selectedHub).hub} />,
     )
+  }
 
   return <>{renderItems}</>
 }

--- a/plugins/trackhub-registry/src/trackhub-registry/tracks.js
+++ b/plugins/trackhub-registry/src/trackhub-registry/tracks.js
@@ -18,7 +18,7 @@ export function generateTracks(trackDb, assemblyName, sequenceAdapter) {
   })
 
   function getSubtracks(track, trackPath = []) {
-    if (track.members)
+    if (track.members) {
       return Object.values(track.members)
         .map(subTrack =>
           getSubtracks(
@@ -27,6 +27,7 @@ export function generateTracks(trackDb, assemblyName, sequenceAdapter) {
           ),
         )
         .flat()
+    }
     track.categories = trackPath
     return [track]
   }
@@ -38,8 +39,9 @@ function makeTrackConfig(track, trackDbUrl, sequenceAdapter) {
   if (
     baseTrackType === 'bam' &&
     track.bigDataUrl.toLowerCase().endsWith('cram')
-  )
+  ) {
     baseTrackType = 'cram'
+  }
   const { bigDataUrl } = track
   const bigDataLocation = {
     uri: new URL(bigDataUrl, trackDbUrl).href,
@@ -48,7 +50,7 @@ function makeTrackConfig(track, trackDbUrl, sequenceAdapter) {
   let bigDataIndexLocation
   switch (baseTrackType) {
     case 'bam':
-      if (trackDbUrl)
+      if (trackDbUrl) {
         bigDataIndexLocation = track.bigDataIndex
           ? {
               uri: new URL(track.bigDataIndex, trackDbUrl).href,
@@ -56,10 +58,11 @@ function makeTrackConfig(track, trackDbUrl, sequenceAdapter) {
           : {
               uri: new URL(`${track.bigDataUrl}.bai`, trackDbUrl).href,
             }
-      else
+      } else {
         bigDataIndexLocation = track.bigDataIndex
           ? { localPath: track.bigDataIndex }
           : { localPath: `${track.bigDataUrl}.bai` }
+      }
       return {
         type: 'AlignmentsTrack',
         name: track.shortLabel,
@@ -162,7 +165,7 @@ function makeTrackConfig(track, trackDbUrl, sequenceAdapter) {
         categories,
       )
     case 'cram':
-      if (trackDbUrl)
+      if (trackDbUrl) {
         bigDataIndexLocation = track.bigDataIndex
           ? {
               uri: new URL(track.bigDataIndex, trackDbUrl).href,
@@ -170,10 +173,11 @@ function makeTrackConfig(track, trackDbUrl, sequenceAdapter) {
           : {
               uri: new URL(`${track.bigDataUrl}.bai`, trackDbUrl).href,
             }
-      else
+      } else {
         bigDataIndexLocation = track.bigDataIndex
           ? { localPath: track.bigDataIndex }
           : { localPath: `${track.bigDataUrl}.bai` }
+      }
       return {
         type: 'AlignmentsTrack',
         name: track.shortLabel,

--- a/products/jbrowse-aws-lambda-functions/saved-sessions/jbrowse_analytics.js
+++ b/products/jbrowse-aws-lambda-functions/saved-sessions/jbrowse_analytics.js
@@ -18,8 +18,9 @@ function recordStats(event, context, done) {
   stats.acceptLanguage = headers['Accept-Language'] || null
   stats.acceptCharset = headers['Accept-Charset'] || null
   stats.host = stats.referer ? url_parser.parse(stats.referer).host : null
-  if (stats.host && stats.host.startsWith('www.'))
+  if (stats.host && stats.host.startsWith('www.')) {
     stats.host = stats.host.slice(4)
+  }
   // stats.fullHeaders = event.headers
 
   // construct JSON for the track types

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -1,4 +1,3 @@
-/* eslint curly:error */
 import { flags } from '@oclif/command'
 import fs from 'fs'
 import path from 'path'

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -1,4 +1,3 @@
-/* eslint curly:error */
 import { flags } from '@oclif/command'
 import fs from 'fs'
 import fetch from 'node-fetch'

--- a/products/jbrowse-desktop/public/electron.js
+++ b/products/jbrowse-desktop/public/electron.js
@@ -1,4 +1,3 @@
-/* eslint curly:error */
 // eslint-disable-next-line import/no-extraneous-dependencies
 const electron = require('electron')
 const debug = require('electron-debug')

--- a/products/jbrowse-desktop/public/preload.js
+++ b/products/jbrowse-desktop/public/preload.js
@@ -2,6 +2,7 @@
 window.electron = require('electron')
 window.electronBetterIpc = require('electron-better-ipc-extra')
 
-if (process.env.NODE_ENV !== 'production')
+if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line no-underscore-dangle
   window.__devtron = { require, process }
+}

--- a/products/jbrowse-desktop/src/StartScreen.tsx
+++ b/products/jbrowse-desktop/src/StartScreen.tsx
@@ -230,7 +230,7 @@ export default function StartScreen({
     })()
   }, [ipcRenderer, updateSessionsList])
 
-  if (!sessions)
+  if (!sessions) {
     return (
       <CircularProgress
         style={{
@@ -243,6 +243,7 @@ export default function StartScreen({
         size={50}
       />
     )
+  }
 
   return (
     <>

--- a/products/jbrowse-desktop/src/jbrowseModel.js
+++ b/products/jbrowse-desktop/src/jbrowseModel.js
@@ -85,10 +85,11 @@ export default function JBrowseDesktop(
       addAssemblyConf(assemblyConf) {
         const { name } = assemblyConf
         if (!name) throw new Error('Can\'t add assembly with no "name"')
-        if (self.assemblyNames.includes(name))
+        if (self.assemblyNames.includes(name)) {
           throw new Error(
             `Can't add assembly with name "${name}", an assembly with that name already exists`,
           )
+        }
         const length = self.assemblies.push({
           ...assemblyConf,
           sequence: {

--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -141,9 +141,9 @@ export default function RootModel(pluginManager: PluginManager) {
     .actions(self => ({
       activateSession(sessionSnapshot: SnapshotIn<typeof Session>) {
         self.setSession(sessionSnapshot)
-        if (sessionSnapshot)
+        if (sessionSnapshot) {
           this.setHistory(UndoManager.create({}, { targetStore: self.session }))
-        else this.setHistory(undefined)
+        } else this.setHistory(undefined)
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       setHistory(history: any) {

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -126,11 +126,12 @@ export default function sessionModelFactory(
         return { theme: readConfObject(this.configuration, 'theme') }
       },
       get visibleWidget() {
-        if (isAlive(self))
+        if (isAlive(self)) {
           // returns most recently added item in active widgets
           return Array.from(self.activeWidgets.values())[
             self.activeWidgets.size - 1
           ]
+        }
         return undefined
       },
 
@@ -309,12 +310,13 @@ export default function sessionModelFactory(
             if (!dereferenceTypeCount[type]) dereferenceTypeCount[type] = 0
             dereferenceTypeCount[type] += 1
           }
-          if (!dereferenced)
+          if (!dereferenced) {
             throw new Error(
               `Error when closing this connection, the following node is still referring to a track configuration: ${JSON.stringify(
                 getSnapshot(node),
               )}`,
             )
+          }
         })
       },
 
@@ -375,10 +377,11 @@ export default function sessionModelFactory(
           (s: AnyConfigurationModel) =>
             readConfObject(s, 'name') === assemblyName,
         )
-        if (!assembly)
+        if (!assembly) {
           throw new Error(
             `Could not add view of assembly "${assemblyName}", assembly name not found`,
           )
+        }
         initialState.displayRegionsFromAssemblyName = readConfObject(
           assembly,
           'name',
@@ -415,8 +418,9 @@ export default function sessionModelFactory(
       },
 
       showWidget(widget: any) {
-        if (self.activeWidgets.has(widget.id))
+        if (self.activeWidgets.has(widget.id)) {
           self.activeWidgets.delete(widget.id)
+        }
         self.activeWidgets.set(widget.id, widget)
       },
 

--- a/products/jbrowse-desktop/src/worker.ts
+++ b/products/jbrowse-desktop/src/worker.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* eslint curly:error */
 import PluginManager from '@jbrowse/core/PluginManager'
 import { remoteAbortRpcHandler } from '@jbrowse/core/rpc/remoteAbortSignals'
 import { isAbortException } from '@jbrowse/core/util'

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -98,11 +98,12 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         return { theme: readConfObject(this.configuration, 'theme') }
       },
       get visibleWidget() {
-        if (isAlive(self))
+        if (isAlive(self)) {
           // returns most recently added item in active widgets
           return Array.from(self.activeWidgets.values())[
             self.activeWidgets.size - 1
           ]
+        }
         return undefined
       },
       /**
@@ -186,12 +187,13 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
             if (!dereferenceTypeCount[type]) dereferenceTypeCount[type] = 0
             dereferenceTypeCount[type] += 1
           }
-          if (!dereferenced)
+          if (!dereferenced) {
             throw new Error(
               `Error when closing this connection, the following node is still referring to a track configuration: ${JSON.stringify(
                 getSnapshot(node),
               )}`,
             )
+          }
         })
       },
 
@@ -253,8 +255,9 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
 
       showWidget(widget: any) {
-        if (self.activeWidgets.has(widget.id))
+        if (self.activeWidgets.has(widget.id)) {
           self.activeWidgets.delete(widget.id)
+        }
         self.activeWidgets.set(widget.id, widget)
       },
 

--- a/products/jbrowse-web/src/StartScreen.tsx
+++ b/products/jbrowse-web/src/StartScreen.tsx
@@ -147,7 +147,7 @@ export default function StartScreen({
     })()
   }, [root.savedSessions, updateSessionsList])
 
-  if (!sessions)
+  if (!sessions) {
     return (
       <CircularProgress
         style={{
@@ -160,6 +160,7 @@ export default function StartScreen({
         size={50}
       />
     )
+  }
 
   return (
     <>

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -1,4 +1,3 @@
-/* eslint curly:error*/
 import assemblyManagerFactory, {
   assemblyConfigSchemas as AssemblyConfigSchemasFactory,
 } from '@jbrowse/core/assemblyManager'

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -120,8 +120,9 @@ getPluginManager()
     const rpcConfig: { [methodName: string]: Function } = {}
     const rpcMethods = pluginManager.getElementTypesInGroup('rpc method')
     rpcMethods.forEach(rpcMethod => {
-      if (!(rpcMethod instanceof RpcMethodType))
+      if (!(rpcMethod instanceof RpcMethodType)) {
         throw new Error('invalid rpc method??')
+      }
 
       rpcConfig[rpcMethod.name] = wrapForRpc(
         rpcMethod.execute.bind(rpcMethod),

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -149,11 +149,12 @@ export default function sessionModelFactory(
         return { theme: readConfObject(this.configuration, 'theme') }
       },
       get visibleWidget() {
-        if (isAlive(self))
+        if (isAlive(self)) {
           // returns most recently added item in active widgets
           return Array.from(self.activeWidgets.values())[
             self.activeWidgets.size - 1
           ]
+        }
         return undefined
       },
       /**
@@ -254,12 +255,13 @@ export default function sessionModelFactory(
             if (!dereferenceTypeCount[type]) dereferenceTypeCount[type] = 0
             dereferenceTypeCount[type] += 1
           }
-          if (!dereferenced)
+          if (!dereferenced) {
             throw new Error(
               `Error when closing this connection, the following node is still referring to a track configuration: ${JSON.stringify(
                 getSnapshot(node),
               )}`,
             )
+          }
         })
       },
 
@@ -425,10 +427,11 @@ export default function sessionModelFactory(
           (s: AnyConfigurationModel) =>
             readConfObject(s, 'name') === assemblyName,
         )
-        if (!assembly)
+        if (!assembly) {
           throw new Error(
             `Could not add view of assembly "${assemblyName}", assembly name not found`,
           )
+        }
         initialState.displayRegionsFromAssemblyName = readConfObject(
           assembly,
           'name',
@@ -465,8 +468,9 @@ export default function sessionModelFactory(
       },
 
       showWidget(widget: any) {
-        if (self.activeWidgets.has(widget.id))
+        if (self.activeWidgets.has(widget.id)) {
           self.activeWidgets.delete(widget.id)
+        }
         self.activeWidgets.set(widget.id, widget)
         self.minimized = false
       },


### PR DESCRIPTION
In general, I find it much more intentional to have curlies around any code block that is indented

This makes a global eslint rule to produce an error if it is not, and it is also autofixable too

There are some instances of single-line-if-statements that are still allowed with this, but when it spans multiple lines it should have a curly