### PR TITLE
Update website to link to demos on cloudfront for better compression

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,8 +38,7 @@ BLOGPOST_DRAFT=website/release_announcement_drafts/$RELEASE_TAG.md
 [[ -f $BLOGPOST_DRAFT ]] || { echo "No blogpost draft found at $BLOGPOST_DRAFT, please write one." && exit 1; }
 
 # Updates the "Browse demo instance" link on the homepage
-INSTANCE=https://s3.amazonaws.com/jbrowse.org/code/jb2/$RELEASE_TAG/index.html
-RELEASE_TAG=$RELEASE_TAG INSTANCE=$INSTANCE node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentLink = process.env.INSTANCE; config.customFields.currentVersion = process.env.RELEASE_TAG; JSON.stringify(config,0,2)" >tmp.json
+RELEASE_TAG=$RELEASE_TAG node --print "const config = require('./website/docusaurus.config.json'); config.customFields.currentVersion = process.env.RELEASE_TAG; JSON.stringify(config,0,2)" >tmp.json
 mv tmp.json website/docusaurus.config.json
 
 # Packages that have changed and will have their version bumped

--- a/website/docusaurus.config.json
+++ b/website/docusaurus.config.json
@@ -7,7 +7,6 @@
   "organizationName": "GMOD",
   "projectName": "jbrowse-components",
   "customFields": {
-    "currentLink": "https://s3.amazonaws.com/jbrowse.org/code/jb2/v1.1.0/index.html",
     "currentVersion": "v1.1.0"
   },
   "themeConfig": {

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -1,7 +1,13 @@
 import { customFields } from '../../docusaurus.config.json'
 
 export const Link = ({ extra, children }) => {
-  return <a href={`${customFields.currentLink}${extra}`}>{children}</a>
+  return (
+    <a
+      href={`https://jbrowse.org/code/jb2/${customFields.currentVersion}/${extra}`}
+    >
+      {children}
+    </a>
+  )
 }
 
 # JBrowse 2 demos

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -37,10 +37,7 @@ const useStyles = makeStyles(theme => ({
 function Home() {
   const context = useDocusaurusContext()
   const { siteConfig = {} } = context
-  const { currentLink } = siteConfig.customFields
-  const pathArray = currentLink.split('/')
-  const currentVersion = pathArray[pathArray.length - 2]
-  const storybookLink = `https://jbrowse.org/storybook/lgv/${currentVersion}/`
+  const { currentVersion } = siteConfig.customFields
   const classes = useStyles()
 
   return (
@@ -64,7 +61,9 @@ function Home() {
                 <Link href="/jb2/blog">Download latest web release</Link>
               </li>
               <li>
-                <Link href={currentLink}>Browse web demo instance</Link>
+                <Link href={`https://jbrowse.org/code/jb2/${currentVersion}/`}>
+                  Browse web demo instance
+                </Link>
               </li>
             </ul>
             <h3>Embedded</h3>
@@ -73,7 +72,12 @@ function Home() {
                 <Link href="https://www.npmjs.com/package/@jbrowse/react-linear-genome-view">
                   Linear genome view React component on <tt>npm</tt>
                 </Link>{' '}
-                also see <Link href={storybookLink}>storybook docs</Link>
+                also see{' '}
+                <Link
+                  href={`https://jbrowse.org/storybook/lgv/${currentVersion}/`}
+                >
+                  storybook docs
+                </Link>
               </li>
               <li>
                 <Link href="https://gmod.github.io/JBrowseR/">


### PR DESCRIPTION
Xref previous lab talk where I noted that our S3 bucket doesn't have compression enabled...I went ahead and tried turning on a setting to turn on compression on cloudfront with these instructions

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-cloudfront-configuring

I tried a couple tests loading volvox cram files, etc and it seemed to work fine

This makes overall downloaded content 

Initial load of v1.1.0 is ~1MB total amount downloaded vs before which has 3.9MB downloaded, so the new bundle size is 25% of the size of the old bundle (or a 75% decrease)

Can see comparing

https://s3.amazonaws.com/jbrowse.org/code/jb2/v1.1.0/index.html
https://jbrowse.org/code/jb2/v1.1.0/index.html

So this PR updates demo links to use cloudfront, and removes the "currentLink" field in the docusaurus json and instead manually uses currentVersion in template strings

I still believe that things like optimizing bundle size is important, especially since users of jbrowse may not configure their compression properly + just perceived improvements in load time do matter, but if you do have it configured properly it can make a big difference

