### PR TITLE
Update Analytics and Share Endpoints For Clarity

### DIFF
--- a/packages/core/util/analytics.ts
+++ b/packages/core/util/analytics.ts
@@ -14,7 +14,7 @@ export async function writeAWSAnalytics(
   initialTimeStamp: number,
   sessionQuery?: string | null,
 ) {
-  const url = 'https://analytics.jbrowse.org/jbrowse-analytics'
+  const url = 'https://analytics.jbrowse.org/api/v1'
 
   const multiAssemblyTracks = rootModel.jbrowse.tracks.filter(
     (track: any) => (readConfObject(track, 'assemblyNames') || []).length > 1,

--- a/packages/core/util/analytics.ts
+++ b/packages/core/util/analytics.ts
@@ -14,8 +14,7 @@ export async function writeAWSAnalytics(
   initialTimeStamp: number,
   sessionQuery?: string | null,
 ) {
-  const url =
-    'https://mdvkjocq3e.execute-api.us-east-1.amazonaws.com/default/jbrowse-analytics'
+  const url = 'https://analytics.jbrowse.org/jbrowse-analytics'
 
   const multiAssemblyTracks = rootModel.jbrowse.tracks.filter(
     (track: any) => (readConfObject(track, 'assemblyNames') || []).length > 1,

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -269,8 +269,7 @@ const SessionLoader = types
         return (conf.configuration || {})[attr] || def
       }
 
-      const defaultURL =
-        'https://g5um1mrb0i.execute-api.us-east-1.amazonaws.com/api/v1/'
+      const defaultURL = 'https://share.jbrowse.org/api/v1/'
       const decryptedSession = await readSessionFromDynamo(
         `${readConf(self.configSnapshot, 'shareURL', defaultURL)}load`,
         self.sessionQuery || '',

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -31,8 +31,7 @@ export default function JBrowseWeb(
         },
         shareURL: {
           type: 'string',
-          defaultValue:
-            'https://g5um1mrb0i.execute-api.us-east-1.amazonaws.com/api/v1/',
+          defaultValue: 'https://share.jbrowse.org/api/v1/',
         },
         featureDetails: ConfigurationSchema('FeatureDetails', {
           sequenceTypes: {


### PR DESCRIPTION
closes #1927 
endpoints for analytics and sharing are now analytics.jbrowse.org and share.jbrowse.org

Used Route 53 to create the analytics and share subdomains of jbrowse.org

Both use alias redirects to Custom domain names in API Gateway under the same name

The custom domain names in API Gateway have API mappings to the existing endpoints that analytics and sharing sessions uses