### PR TITLE
Disable rasterize layer option for browsers without offscreen canvas

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
@@ -31,7 +31,9 @@ export default function ExportSvgDlg({
   model: LGV
   handleClose: () => void
 }) {
-  const [rasterizeLayers, setRasterizeLayers] = useState(true)
+  const [rasterizeLayers, setRasterizeLayers] = useState(
+    typeof OffscreenCanvas !== 'undefined',
+  )
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error>()
   const classes = useStyles()
@@ -52,15 +54,23 @@ export default function ExportSvgDlg({
             <Typography display="inline">Creating SVG</Typography>
           </div>
         ) : null}
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={rasterizeLayers}
-              onChange={() => setRasterizeLayers(val => !val)}
-            />
-          }
-          label="Rasterize canvas based tracks? File may be much larger if this is turned off"
-        />
+
+        {typeof OffscreenCanvas !== 'undefined' ? (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={rasterizeLayers}
+                onChange={() => setRasterizeLayers(val => !val)}
+              />
+            }
+            label="Rasterize canvas based tracks? File may be much larger if this is turned off"
+          />
+        ) : (
+          <Typography>
+            Note: rasterizing layers not yet supported in this browser, so SVG
+            size may be large
+          </Typography>
+        )}
 
         <Button
           variant="contained"


### PR DESCRIPTION
The Export SVG feature has to option to "rasterize layers" so that e.g. a very information dense wiggle or pileup visualization can just be an embedded PNG inside the SVG

This  doesn't work on Firefox and Safari where OffscreenCanvas based rasterizing doesn't exist, so we can try to avoid allowing that option to be used on these browsers