### PR TITLE
Add demo for 1000 genomes extended trio dataset to website

### DIFF
--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -32,6 +32,9 @@ Current version demos
     Grape vs Peach dotplot
   </Link>
 - <Link extra="?config=test_data/yeast_synteny/config.json">Yeast dotplot</Link>
+- <Link extra="?config=%2Fgenomes%2FGRCh38%2F1000genomes%2Fconfig_1000genomes.json&session=share-SUK-mntGyB&password=eQF0F">
+    1000 genomes extended trio demo
+  </Link>
 
 Conference demos:
 


### PR DESCRIPTION
This adds a demo for the 1000 genomes extended trio dataset reference paper (https://www.biorxiv.org/content/10.1101/2021.02.06.430068v1)

I had to do manual data munging to produce a tracklist from this data, and sometimes the NCBI servers where we fetch the data from are a little finicky and return status 200 for range requests, but it is mostly a good demo I think