### PR TITLE
Fix connection behavior

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ToggleConnectionsDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ToggleConnectionsDialog.tsx
@@ -43,9 +43,13 @@ function ToggleConnectionDialog({
 }) {
   const classes = useStyles()
   const { connections, connectionInstances } = session
-  const assemblySpecificConnections = connections.filter(c =>
-    readConfObject(c, 'assemblyNames').includes(assemblyName),
-  )
+  const assemblySpecificConnections = connections.filter(c => {
+    const configAssemblyNames = readConfObject(c, 'assemblyNames')
+    if (configAssemblyNames.length === 0) {
+      return true
+    }
+    return configAssemblyNames.includes(assemblyName)
+  })
   return (
     <Dialog open onClose={handleClose} maxWidth="lg">
       <DialogTitle>
@@ -63,7 +67,7 @@ function ToggleConnectionDialog({
           {assemblySpecificConnections.map(conf => {
             const name = readConfObject(conf, 'name')
             return (
-              <div>
+              <div key={conf.connectionId}>
                 <FormControlLabel
                   control={
                     <Checkbox

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -197,11 +197,16 @@ export default pluginManager =>
 
         const session = getSession(self)
         const conns = session.connectionInstances
-          .filter(conn =>
-            readConfObject(conn.configuration, 'assemblyNames').includes(
-              assemblyName,
-            ),
-          )
+          .filter(conn => {
+            const configAssemblyNames = readConfObject(
+              conn.configuration,
+              'assemblyNames',
+            )
+            if (configAssemblyNames.length === 0) {
+              return true
+            }
+            return configAssemblyNames.includes(assemblyName)
+          })
           .map((conn, index) => {
             const c = session.connections[index]
             return {

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -71,7 +71,6 @@
     "electron-debug": "^3.0.1",
     "electron-is-dev": "^1.1.0",
     "fontsource-roboto": "3.0.3",
-    "is-object": "^1.0.2",
     "json-stable-stringify": "^1.0.1",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import isObject from 'is-object'
 import {
   readConfObject,
   isConfigurationModel,
@@ -582,7 +581,7 @@ export default function sessionModelFactory(
         // connectionInstances schema changed from object to an array, so any
         // old connectionInstances as object is in snapshot, filter it out
         // https://github.com/GMOD/jbrowse-components/issues/1903
-        if (isObject(connectionInstances)) {
+        if (!Array.isArray(connectionInstances)) {
           return rest
         }
       }

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -50,7 +50,6 @@
     "crypto-js": "^3.0.0",
     "fastestsmallesttextencoderdecoder": "^1.0.14",
     "fontsource-roboto": "3.0.3",
-    "is-object": "^1.0.2",
     "json-stable-stringify": "^1.0.1",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import isObject from 'is-object'
 import {
   readConfObject,
   getConf,
@@ -672,7 +671,7 @@ export default function sessionModelFactory(
         // connectionInstances schema changed from object to an array, so any
         // old connectionInstances as object is in snapshot, filter it out
         // https://github.com/GMOD/jbrowse-components/issues/1903
-        if (isObject(connectionInstances)) {
+        if (!Array.isArray(connectionInstances)) {
           return rest
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15352,11 +15352,6 @@ is-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
-is-object@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
-  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
-
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"


### PR DESCRIPTION
Three connections-related fixes:

* Add key to ToggleConnectionsDialog to fix React warning
* Show connections in ToggleConnectionsDialog and HierarchicalTrackSelector if the connection's "assemblyNames" config slot is an empty array. This preserves prior behavior described here: https://github.com/GMOD/jbrowse-components/pull/1660#issuecomment-816281981
* Open connections were not getting preserved on refresh. This PR fixes that by using `Array.isArray` instead of `isObject` to check if the `connectionInstances` should be discarded when loading a session.