### PR TITLE
Fix timestamp on session cards on desktop

### DIFF
--- a/products/jbrowse-desktop/public/electron.js
+++ b/products/jbrowse-desktop/public/electron.js
@@ -249,26 +249,20 @@ ipcMain.handle('listSessions', async () => {
     const data = await Promise.all(sessionFilesData)
     const sessions = {}
     sessionFiles.forEach((sessionFile, idx) => {
-      if (path.extname(sessionFile) === '.thumbnail') {
-        const sessionName = decodeURIComponent(
-          path.basename(sessionFile, '.thumbnail'),
-        )
+      const ext = path.extname(sessionFile)
+      const basename = path.basename(sessionFile, ext)
+      if (ext === '.thumbnail') {
+        const sessionName = decodeURIComponent(basename)
         if (!sessions[sessionName]) {
           sessions[sessionName] = {}
         }
         sessions[sessionName].screenshot = data[idx]
-      } else if (path.extname(sessionFile) === '.json') {
-        const sessionName = decodeURIComponent(
-          path.basename(sessionFile, '.json'),
-        )
+      } else if (ext === '.json') {
+        const sessionName = decodeURIComponent(basename)
         if (!sessions[sessionName]) {
           sessions[sessionName] = {}
-        } else if (path.extname(sessionFile) === '.json') {
-          if (!sessions[sessionName]) {
-            sessions[sessionName] = {}
-          }
-          sessions[sessionName].stats = data[idx]
         }
+        sessions[sessionName].stats = data[idx]
       }
     })
     return sessions


### PR DESCRIPTION
The PR for #336 resulted required a bugfix to fix loading of sessions, but currently now displays "Invalid Date" for session card timestamps

This fixes the loading of stats onto the sessions loaded in the electron IPC (and simplifies the logic a little bit)