### PR TITLE
Fix ability to use DialogComponent (used for svg export, pileup sort, etc) on embedded components

### DIFF
--- a/packages/core/ui/AboutDialog.tsx
+++ b/packages/core/ui/AboutDialog.tsx
@@ -26,18 +26,18 @@ const useStyles = makeStyles(theme => ({
 }))
 
 export default function AboutDialog({
-  model,
+  config,
   handleClose,
 }: {
-  model: AnyConfigurationModel
+  config: AnyConfigurationModel
   handleClose: () => void
 }) {
   const classes = useStyles()
   const [info, setInfo] = useState<FileInfo>()
   const [error, setError] = useState<Error>()
-  const session = getSession(model)
+  const session = getSession(config)
   const { rpcManager } = session
-  const conf = readConfObject(model)
+  const conf = readConfObject(config)
 
   useEffect(() => {
     const aborter = new AbortController()
@@ -45,8 +45,8 @@ export default function AboutDialog({
     let cancelled = false
     ;(async () => {
       try {
-        const adapterConfig = readConfObject(model, 'adapter')
-        const result = await rpcManager.call(model.trackId, 'CoreGetInfo', {
+        const adapterConfig = readConfObject(config, 'adapter')
+        const result = await rpcManager.call(config.trackId, 'CoreGetInfo', {
           adapterConfig,
           signal,
         })
@@ -55,6 +55,7 @@ export default function AboutDialog({
         }
       } catch (e) {
         if (!cancelled) {
+          console.error(e)
           setError(e)
         }
       }
@@ -64,13 +65,13 @@ export default function AboutDialog({
       aborter.abort()
       cancelled = true
     }
-  }, [model, rpcManager])
+  }, [config, rpcManager])
 
-  let trackName = readConfObject(model, 'name')
-  if (readConfObject(model, 'type') === 'ReferenceSequenceTrack') {
+  let trackName = readConfObject(config, 'name')
+  if (readConfObject(config, 'type') === 'ReferenceSequenceTrack') {
     trackName = 'Reference Sequence'
     session.assemblies.forEach(assembly => {
-      if (assembly.sequence === model.configuration) {
+      if (assembly.sequence === config.configuration) {
         trackName = `Reference Sequence (${readConfObject(assembly, 'name')})`
       }
     })

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -15,8 +15,6 @@ import { isAlive } from 'mobx-state-tree'
 import React, { useEffect, useRef, useState } from 'react'
 import { ContentRect, withContentRect } from 'react-measure'
 
-import AboutDialog from './AboutDialog'
-import { getSession } from '../util'
 import { IBaseViewModel } from '../pluggableElementTypes/models'
 import EditableTypography from './EditableTypography'
 import Menu from './Menu'
@@ -144,7 +142,6 @@ export default withContentRect('bounds')(
       const classes = useStyles()
       const theme = useTheme()
       const padWidth = theme.spacing(1)
-      const session = getSession(view)
 
       let width = 0
       if (contentRect.bounds) {
@@ -163,16 +160,10 @@ export default withContentRect('bounds')(
       // note that this effect will run only once, because of
       // the empty array second param
       useEffect(() => {
-        if (
-          scrollRef &&
-          scrollRef.current &&
-          scrollRef.current.scrollIntoView
-        ) {
+        if (scrollRef?.current?.scrollIntoView) {
           scrollRef.current.scrollIntoView({ block: 'center' })
         }
       }, [])
-
-      const aboutTrack = session.showAboutConfig
 
       return (
         <Paper
@@ -181,12 +172,6 @@ export default withContentRect('bounds')(
           className={classes.viewContainer}
           style={{ ...style, padding: `0px ${padWidth}px ${padWidth}px` }}
         >
-          {aboutTrack ? (
-            <AboutDialog
-              model={aboutTrack}
-              handleClose={() => session.setShowAboutConfig?.(undefined)}
-            />
-          ) : null}
           <div ref={scrollRef} style={{ display: 'flex' }}>
             <ViewMenu
               model={view}

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -57,6 +57,10 @@ export interface JBrowsePlugin {
   image?: string
 }
 
+export type DialogComponentType =
+  | React.LazyExoticComponent<React.FC<any>>
+  | React.FC<any>
+
 /** minimum interface that all session state models must implement */
 export interface AbstractSessionModel extends AbstractViewContainer {
   setSelection(feature: Feature): void
@@ -73,8 +77,6 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   getTrackActionMenuItems?: Function
   addAssembly?: Function
   removeAssembly?: Function
-  showAboutConfig?: AnyConfigurationModel
-  setShowAboutConfig?: Function
   connections: AnyConfigurationModel[]
   deleteConnection?: Function
   sessionConnections?: AnyConfigurationModel[]
@@ -83,8 +85,12 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   adminMode?: boolean
   showWidget?: Function
   addWidget?: Function
+
+  DialogComponent?: DialogComponentType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setDialogComponent: (dlg: React.FC<any>, props?: any) => void
+  DialogProps: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setDialogComponent: (dlg?: DialogComponentType, props?: any) => void
 }
 export function isSessionModel(thing: unknown): thing is AbstractSessionModel {
   return (
@@ -166,9 +172,7 @@ export function isViewModel(thing: unknown): thing is AbstractViewModel {
   )
 }
 
-export interface AbstractTrackModel {
-  setDialogComponent(dlg: unknown, display?: unknown): void
-}
+export interface AbstractTrackModel {}
 export function isTrackModel(thing: unknown): thing is AbstractTrackModel {
   return (
     typeof thing === 'object' &&

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -58,7 +58,9 @@ export interface JBrowsePlugin {
 }
 
 export type DialogComponentType =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | React.LazyExoticComponent<React.FC<any>>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | React.FC<any>
 
 /** minimum interface that all session state models must implement */
@@ -172,7 +174,7 @@ export function isViewModel(thing: unknown): thing is AbstractViewModel {
   )
 }
 
-export interface AbstractTrackModel {}
+type AbstractTrackModel = {}
 export function isTrackModel(thing: unknown): thing is AbstractTrackModel {
   return (
     typeof thing === 'object' &&

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { lazy } from 'react'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import isObject from 'is-object'
 import {
@@ -9,6 +10,7 @@ import {
   Region,
   NotificationLevel,
   TrackViewModel,
+  DialogComponentType,
 } from '@jbrowse/core/util/types'
 import { getContainingView } from '@jbrowse/core/util'
 import { observable } from 'mobx'
@@ -31,6 +33,8 @@ import SettingsIcon from '@material-ui/icons/Settings'
 import CopyIcon from '@material-ui/icons/FileCopy'
 import DeleteIcon from '@material-ui/icons/Delete'
 import InfoIcon from '@material-ui/icons/Info'
+
+const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 declare interface ReferringNode {
   node: IAnyStateTreeNode
@@ -78,10 +82,7 @@ export default function sessionModelFactory(
        */
       task: undefined,
 
-      // which config is being shown in the "About track" menu
-      showAboutConfig: undefined as undefined | AnyConfigurationModel,
-
-      DialogComponent: undefined as React.FC<any> | undefined,
+      DialogComponent: undefined as DialogComponentType | undefined,
       DialogProps: undefined as any,
     }))
     .views(self => ({
@@ -162,13 +163,11 @@ export default function sessionModelFactory(
       },
     }))
     .actions(self => ({
-      setDialogComponent(comp?: React.FC<unknown>, props?: unknown) {
+      setDialogComponent(comp?: DialogComponentType, props?: unknown) {
         self.DialogComponent = comp
         self.DialogProps = props
       },
-      setShowAboutConfig(showConfig: AnyConfigurationModel) {
-        self.showAboutConfig = showConfig
-      },
+
       makeConnection(
         configuration: AnyConfigurationModel,
         initialSnapshot = {},
@@ -532,7 +531,7 @@ export default function sessionModelFactory(
           {
             label: 'About track',
             onClick: () => {
-              session.setShowAboutConfig(config)
+              session.setDialogComponent(AboutDialog, { config })
             },
             icon: InfoIcon,
           },

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, Suspense } from 'react'
 import {
   IconButton,
   IconButtonProps as IconButtonPropsType,
@@ -13,7 +13,6 @@ import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
 import useDimensions from 'react-use-dimensions'
-import AboutDialog from '@jbrowse/core/ui/AboutDialog'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
@@ -58,21 +57,13 @@ const ViewMenu = observer(
     IconProps: SvgIconProps
   }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement>()
-    const session = getSession(model)
 
     if (!model.menuItems?.length) {
       return null
     }
 
-    const aboutTrack = session.showAboutConfig
     return (
       <>
-        {aboutTrack ? (
-          <AboutDialog
-            model={aboutTrack}
-            handleClose={() => session.setShowAboutConfig?.(undefined)}
-          />
-        ) : null}
         <IconButton
           {...IconButtonProps}
           aria-label="more"
@@ -106,6 +97,7 @@ const ViewContainer = observer(
   ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
     const classes = useStyles()
     const theme = useTheme()
+    const session = getSession(view)
     const [measureRef, { width }] = useDimensions()
 
     const padWidth = theme.spacing(1)
@@ -125,6 +117,16 @@ const ViewContainer = observer(
         className={classes.viewContainer}
         style={{ padding: `0px ${padWidth}px ${padWidth}px` }}
       >
+        {session.DialogComponent ? (
+          <Suspense fallback={<div />}>
+            <session.DialogComponent
+              handleClose={() =>
+                session.setDialogComponent(undefined, undefined)
+              }
+              {...session.DialogProps}
+            />
+          </Suspense>
+        ) : null}
         <div style={{ display: 'flex' }}>
           <ViewMenu
             model={view}

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { lazy } from 'react'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import {
   NotificationLevel,
   AbstractSessionModel,
   TrackViewModel,
+  DialogComponentType,
 } from '@jbrowse/core/util/types'
 import { getContainingView } from '@jbrowse/core/util'
 import { observable } from 'mobx'
@@ -24,6 +26,8 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { readConfObject } from '@jbrowse/core/configuration'
 import InfoIcon from '@material-ui/icons/Info'
 import { ReferringNode } from '../types'
+
+const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
   return types
@@ -57,10 +61,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
        */
       task: undefined,
 
-      // which config is being shown in the "About track" menu
-      showAboutConfig: undefined as undefined | AnyConfigurationModel,
-
-      DialogComponent: undefined as React.FC<any> | undefined,
+      DialogComponent: undefined as DialogComponentType | undefined,
       DialogProps: undefined as any,
     }))
     .views(self => ({
@@ -130,12 +131,9 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions(self => ({
-      setDialogComponent(comp?: React.FC<any>, props?: any) {
+      setDialogComponent(comp?: DialogComponentType, props?: any) {
         self.DialogComponent = comp
         self.DialogProps = props
-      },
-      setShowAboutConfig(showConfig: AnyConfigurationModel) {
-        self.showAboutConfig = showConfig
       },
       makeConnection(
         configuration: AnyConfigurationModel,
@@ -303,7 +301,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
           {
             label: 'About track',
             onClick: () => {
-              self.setShowAboutConfig(config)
+              self.setDialogComponent(AboutDialog, { config })
             },
             icon: InfoIcon,
           },

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { lazy } from 'react'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import isObject from 'is-object'
 import {
@@ -12,6 +13,7 @@ import {
   AbstractSessionModel,
   TrackViewModel,
   JBrowsePlugin,
+  DialogComponentType,
 } from '@jbrowse/core/util/types'
 import { getContainingView } from '@jbrowse/core/util'
 import { observable } from 'mobx'
@@ -38,6 +40,8 @@ import CopyIcon from '@material-ui/icons/FileCopy'
 import DeleteIcon from '@material-ui/icons/Delete'
 import InfoIcon from '@material-ui/icons/Info'
 import shortid from 'shortid'
+
+const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 declare interface ReferringNode {
   node: IAnyStateTreeNode
@@ -94,9 +98,7 @@ export default function sessionModelFactory(
        */
       task: undefined,
 
-      showAboutConfig: undefined as undefined | AnyConfigurationModel,
-
-      DialogComponent: undefined as React.FC<any> | undefined,
+      DialogComponent: undefined as DialogComponentType | undefined,
       DialogProps: undefined as any,
     }))
     .views(self => ({
@@ -184,16 +186,14 @@ export default function sessionModelFactory(
       },
     }))
     .actions(self => ({
-      setDialogComponent(comp?: React.FC<any>, props?: any) {
+      setDialogComponent(comp?: DialogComponentType, props?: any) {
         self.DialogComponent = comp
         self.DialogProps = props
       },
       setName(str: string) {
         self.name = str
       },
-      setShowAboutConfig(showConfig: AnyConfigurationModel) {
-        self.showAboutConfig = showConfig
-      },
+
       addAssembly(assemblyConfig: AnyConfigurationModel) {
         self.sessionAssemblies.push(assemblyConfig)
       },
@@ -633,7 +633,7 @@ export default function sessionModelFactory(
           {
             label: 'About track',
             onClick: () => {
-              session.setShowAboutConfig(config)
+              session.setDialogComponent(AboutDialog, { config })
             },
             icon: InfoIcon,
           },

--- a/website/src/pages/plugin_store.js
+++ b/website/src/pages/plugin_store.js
@@ -31,9 +31,10 @@ import { DialogContent } from '@material-ui/core'
 
 // eslint-disable-next-line import/no-unresolved
 import pluginJSON from '../../plugins.json'
-const { plugins } = pluginJSON
 
 import pluginStyles from '../css/pluginStyles.module.css'
+
+const { plugins } = pluginJSON
 
 function TopDocumentation() {
   const [aboutSectionOpen, setAboutSectionOpen] = useState(false)


### PR DESCRIPTION
The embedded component was not using the DialogComponent volatile option properly to do things like export svg and other features that use the results of session.setDialogComponent

This also makes the About track dialog use this setDialogComponent method instead of being a special case on the session model

For reference, this feature is pretty similar to widgets on the session, but is more explicitly a dialog box