### PR TITLE
Fix ability to use add-track force on symlink tracks

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -292,21 +292,28 @@ export default class AddTrack extends JBrowseCommand {
     }
 
     // copy/symlinks/moves the track into the jbrowse installation directory
-    const filePaths = Object.values(this.guessFileNames(location, index))
+    const filePaths = Object.values(
+      this.guessFileNames(location, index),
+    ).filter(f => !!f) as string[]
+
+    const destinationFn = (dir: string, file: string) =>
+      path.join(dir, subDir, path.basename(file))
 
     switch (load) {
       case 'copy': {
         await Promise.all(
           filePaths.map(async filePath => {
-            if (!filePath) {
-              return undefined
+            const dest = destinationFn(configDirectory, filePath)
+            try {
+              if (force) await fsPromises.unlink(dest)
+            } catch (e) {
+              this.error(e)
             }
-            const dataLocation = path.join(
-              configDirectory,
-              subDir,
-              path.basename(filePath),
+            return fsPromises.copyFile(
+              filePath,
+              dest,
+              fs.constants.COPYFILE_EXCL,
             )
-            return fsPromises.copyFile(filePath, dataLocation)
           }),
         )
         break
@@ -314,15 +321,13 @@ export default class AddTrack extends JBrowseCommand {
       case 'symlink': {
         await Promise.all(
           filePaths.map(async filePath => {
-            if (!filePath) {
-              return undefined
+            const dest = destinationFn(configDirectory, filePath)
+            try {
+              if (force) await fsPromises.unlink(dest)
+            } catch (e) {
+              this.error(e)
             }
-            const dataLocation = path.join(
-              configDirectory,
-              subDir,
-              path.basename(filePath),
-            )
-            return fsPromises.symlink(filePath, dataLocation)
+            return fsPromises.symlink(filePath, dest)
           }),
         )
         break
@@ -330,15 +335,13 @@ export default class AddTrack extends JBrowseCommand {
       case 'move': {
         await Promise.all(
           filePaths.map(async filePath => {
-            if (!filePath) {
-              return undefined
+            const dest = destinationFn(configDirectory, filePath)
+            try {
+              if (force) await fsPromises.unlink(dest)
+            } catch (e) {
+              this.error(e)
             }
-            const dataLocation = path.join(
-              configDirectory,
-              subDir,
-              path.basename(filePath),
-            )
-            return fsPromises.rename(filePath, dataLocation)
+            return fsPromises.rename(filePath, dest)
           }),
         )
         break

--- a/products/jbrowse-web/src/tests/Alignments.test.js
+++ b/products/jbrowse-web/src/tests/Alignments.test.js
@@ -177,7 +177,11 @@ describe('alignments track', () => {
 
     // load track
     fireEvent.click(await findByTestId('htsTrackEntry-volvox-long-reads-cram'))
-    await findByTestId('display-volvox-long-reads-cram-LinearAlignmentsDisplay')
+    await findByTestId(
+      'display-volvox-long-reads-cram-LinearAlignmentsDisplay',
+      {},
+      delay,
+    )
     expect(state.session.views[0].tracks[0]).toBeTruthy()
 
     // opens the track menu and turns on soft clipping
@@ -213,7 +217,7 @@ describe('alignments track', () => {
 
     // load track
     fireEvent.click(await findByTestId('htsTrackEntry-volvox_cram'))
-    await findByTestId('display-volvox_cram-LinearAlignmentsDisplay')
+    await findByTestId('display-volvox_cram-LinearAlignmentsDisplay', {}, delay)
     expect(state.session.views[0].tracks[0]).toBeTruthy()
 
     // opens the track menu

--- a/website/src/pages/plugin_store.js
+++ b/website/src/pages/plugin_store.js
@@ -31,9 +31,10 @@ import { DialogContent } from '@material-ui/core'
 
 // eslint-disable-next-line import/no-unresolved
 import pluginJSON from '../../plugins.json'
-const { plugins } = pluginJSON
 
 import pluginStyles from '../css/pluginStyles.module.css'
+
+const { plugins } = pluginJSON
 
 function TopDocumentation() {
   const [aboutSectionOpen, setAboutSectionOpen] = useState(false)


### PR DESCRIPTION
Possible fix for #1958 

The main thing is that it needs to unlink the destination before trying to symlink it

It is somewhat of a coincidence that copy behavior is to overwrite by default. I changed it to actually use  COPYFILE_EXCL to avoid accidentally overwriting a destination file, and the user can go back and use --force to overwrite it, which matches the behavior of overwriting the symlink added in this PR

It uses a try catch because if the destination symlink doesn't exist it would otherwise throw

Adds some misc refactoring (could be split out) to  try to simplify or deduplicate some repetitive logic in the code and tests with the hope that simpler code==easier to see code paths

https://github.com/GMOD/jbrowse-components/compare/fix_symlink_add_track?expand=1#diff-7c20288c5391381db2117575ccf46defd61fd768480ee3af4cc60d2fe1bbde21R315-R318