### PR TITLE
Omit configurationSchema snapshot when it matches the default

### DIFF
--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -7,6 +7,7 @@ import {
   isLateType,
   SnapshotOut,
   ModelPropertiesDeclaration,
+  getSnapshot,
 } from 'mobx-state-tree'
 
 import { ElementId } from '../util/types/mst'
@@ -190,10 +191,27 @@ function makeConfigurationSchemaModel<
   if (options.extend) {
     completeModel = completeModel.extend(options.extend)
   }
+
+  const identifierDefault = identifier ? { [identifier]: 'placeholderId' } : {}
+  const modelDefault = options.explicitlyTyped
+    ? { type: modelName, ...identifierDefault }
+    : identifierDefault
+
+  const defaultSnap = getSnapshot(completeModel.create(modelDefault))
   completeModel = completeModel.postProcessSnapshot(snap => {
     const newSnap: SnapshotOut<typeof completeModel> = {}
+    let matchesDefault = true
     // let keyCount = 0
-    Object.entries(snap).forEach(([key, value]) => {
+    for (const [key, value] of Object.entries(snap)) {
+      if (matchesDefault) {
+        if (typeof defaultSnap[key] === 'object' && typeof value === 'object') {
+          if (JSON.stringify(defaultSnap[key]) !== JSON.stringify(value)) {
+            matchesDefault = false
+          }
+        } else if (defaultSnap[key] !== value) {
+          matchesDefault = false
+        }
+      }
       if (
         value !== undefined &&
         volatileConstants[key] === undefined &&
@@ -203,7 +221,10 @@ function makeConfigurationSchemaModel<
         // keyCount += 1
         newSnap[key] = value
       }
-    })
+    }
+    if (matchesDefault) {
+      return {}
+    }
     return newSnap
   })
 
@@ -211,13 +232,7 @@ function makeConfigurationSchemaModel<
     completeModel = completeModel.preProcessSnapshot(options.preProcessSnapshot)
   }
 
-  const identifierDefault = identifier ? { [identifier]: 'placeholderId' } : {}
-  const schemaType = types.optional(
-    completeModel,
-    options.explicitlyTyped
-      ? { type: modelName, ...identifierDefault }
-      : identifierDefault,
-  )
+  const schemaType = types.optional(completeModel, modelDefault)
   return schemaType
 }
 

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -39,7 +39,7 @@ export interface ConfigurationSchemaDefinition {
 interface ConfigurationSchemaOptions {
   explicitlyTyped?: boolean
   explicitIdentifier?: string
-  implicitIdentifier?: string
+  implicitIdentifier?: string | boolean
   baseConfiguration?: AnyConfigurationSchemaType
 
   actions?: (self: unknown) => any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/plugins/alignments/src/__snapshots__/index.test.ts.snap
+++ b/plugins/alignments/src/__snapshots__/index.test.ts.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "BamAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;

--- a/plugins/bed/src/__snapshots__/index.test.js.snap
+++ b/plugins/bed/src/__snapshots__/index.test.js.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "BigBedAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;

--- a/plugins/config/src/FromConfigAdapter/configSchema.ts
+++ b/plugins/config/src/FromConfigAdapter/configSchema.ts
@@ -12,7 +12,7 @@ export const configSchema = ConfigurationSchema(
       defaultValue: 'SimpleFeature',
     },
   },
-  { explicitlyTyped: true },
+  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
 )
 
 export const regionsConfigSchema = ConfigurationSchema(
@@ -27,7 +27,7 @@ export const regionsConfigSchema = ConfigurationSchema(
       defaultValue: 'SimpleFeature',
     },
   },
-  { explicitlyTyped: true },
+  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
 )
 
 export const sequenceConfigSchema = ConfigurationSchema(
@@ -42,5 +42,5 @@ export const sequenceConfigSchema = ConfigurationSchema(
       defaultValue: 'SimpleFeature',
     },
   },
-  { explicitlyTyped: true },
+  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
 )

--- a/plugins/config/src/__snapshots__/index.test.js.snap
+++ b/plugins/config/src/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`Config editing adds config editor widget 1`] = `Object {}`;
 
 exports[`Config editing creates proper FromConfigAdapter 1`] = `
 Object {
+  "adapterId": "testFromConfigAdapterId",
   "type": "FromConfigAdapter",
 }
 `;

--- a/plugins/config/src/index.test.js
+++ b/plugins/config/src/index.test.js
@@ -34,6 +34,7 @@ describe('Config editing', () => {
     const adapter = pluginManager.getAdapterType('FromConfigAdapter')
     const config = adapter.configSchema.create({
       type: 'FromConfigAdapter',
+      adapterId: 'testFromConfigAdapterId',
     })
     expect(getSnapshot(config)).toMatchSnapshot()
   })

--- a/plugins/dotplot-view/src/DotplotDisplay/index.ts
+++ b/plugins/dotplot-view/src/DotplotDisplay/index.ts
@@ -58,7 +58,7 @@ export function stateModelFactory(configSchema: any) {
     )
     .views(self => ({
       get rendererTypeName() {
-        return getConf(self, 'renderer').type
+        return getConf(self, ['renderer', 'type'])
       },
       get renderProps() {
         return {

--- a/plugins/filtering/src/__snapshots__/index.test.js.snap
+++ b/plugins/filtering/src/__snapshots__/index.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "TwoBitAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;
 
-exports[`plugin in a stock JBrowse 2`] = `
-Object {
-  "type": "IndexedFastaAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 2`] = `Object {}`;

--- a/plugins/legacy-jbrowse/src/__snapshots__/index.test.js.snap
+++ b/plugins/legacy-jbrowse/src/__snapshots__/index.test.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "NCListAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;
 
 exports[`test creating a text search adapter 1`] = `
 Object {

--- a/plugins/linear-comparative-view/src/LinearComparativeDisplay/index.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeDisplay/index.ts
@@ -50,7 +50,7 @@ export function stateModelFactory(configSchema: any) {
     }))
     .views(self => ({
       get rendererTypeName() {
-        return getConf(self, 'renderer').type
+        return getConf(self, ['renderer', 'type'])
       },
       get renderProps() {
         return {

--- a/plugins/rdf/src/__snapshots__/index.test.js.snap
+++ b/plugins/rdf/src/__snapshots__/index.test.js.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "SPARQLAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;

--- a/plugins/sequence/src/__snapshots__/index.test.js.snap
+++ b/plugins/sequence/src/__snapshots__/index.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "TwoBitAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;
 
-exports[`plugin in a stock JBrowse 2`] = `
-Object {
-  "type": "IndexedFastaAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 2`] = `Object {}`;

--- a/plugins/variants/src/__snapshots__/index.test.js.snap
+++ b/plugins/variants/src/__snapshots__/index.test.js.snap
@@ -1,29 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "VcfTabixAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;
 
 exports[`plugin in a stock JBrowse 2`] = `
 Object {
-  "adapter": Object {
-    "type": "VcfTabixAdapter",
-  },
   "displays": Array [
     Object {
       "displayId": "trackId0-ChordVariantDisplay",
-      "renderer": Object {
-        "type": "StructuralVariantChordRenderer",
-      },
       "type": "ChordVariantDisplay",
     },
     Object {
       "displayId": "trackId0-LinearVariantDisplay",
-      "renderer": Object {
-        "type": "StructuralVariantChordRenderer",
-      },
       "type": "LinearVariantDisplay",
     },
   ],

--- a/plugins/wiggle/src/__snapshots__/index.test.js.snap
+++ b/plugins/wiggle/src/__snapshots__/index.test.js.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin in a stock JBrowse 1`] = `
-Object {
-  "type": "BigWigAdapter",
-}
-`;
+exports[`plugin in a stock JBrowse 1`] = `Object {}`;

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -69,6 +69,7 @@ Object {
       "name": "volvox",
       "refNameAliases": Object {
         "adapter": Object {
+          "adapterId": "W6DyPGJ0UU",
           "features": Array [
             Object {
               "aliases": Array [
@@ -1606,6 +1607,7 @@ Object {
     },
     Object {
       "adapter": Object {
+        "adapterId": "Xvg1McRUAP",
         "features": Array [
           Object {
             "end": 191,
@@ -1682,6 +1684,7 @@ Object {
     },
     Object {
       "adapter": Object {
+        "adapterId": "DvufUT5OYV",
         "features": Array [
           Object {
             "end": 191,

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -4,15 +4,7 @@ exports[`JBrowse model creates with empty snapshot 1`] = `
 Object {
   "aggregateTextSearchAdapters": Array [],
   "assemblies": Array [],
-  "configuration": Object {
-    "rpc": Object {
-      "drivers": Object {
-        "MainThreadRpcDriver": Object {
-          "type": "MainThreadRpcDriver",
-        },
-      },
-    },
-  },
+  "configuration": Object {},
   "connections": Array [],
   "defaultSession": Object {
     "name": "New session",
@@ -101,9 +93,6 @@ Object {
         "displays": Array [
           Object {
             "displayId": "volvox_refseq-LinearReferenceSequenceDisplay",
-            "renderer": Object {
-              "type": "DivSequenceRenderer",
-            },
             "type": "LinearReferenceSequenceDisplay",
           },
         ],
@@ -126,9 +115,6 @@ Object {
         "displays": Array [
           Object {
             "displayId": "volvox_refseq2-LinearReferenceSequenceDisplay",
-            "renderer": Object {
-              "type": "DivSequenceRenderer",
-            },
             "type": "LinearReferenceSequenceDisplay",
           },
         ],
@@ -137,15 +123,7 @@ Object {
       },
     },
   ],
-  "configuration": Object {
-    "rpc": Object {
-      "drivers": Object {
-        "MainThreadRpcDriver": Object {
-          "type": "MainThreadRpcDriver",
-        },
-      },
-    },
-  },
+  "configuration": Object {},
   "connections": Array [],
   "defaultSession": Object {
     "activeWidgets": Object {
@@ -200,16 +178,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_sv_test-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_sv_test-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
@@ -248,24 +220,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_sv_test_renamed-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_sv_test_renamed-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
       "name": "volvox structural variant test w/renamed refs",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_sv_test_renamed",
       "type": "VariantTrack",
     },
@@ -294,56 +256,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_alignments-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_alignments-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_cram_alignments-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.cram (contigA, default display)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_alignments",
       "type": "AlignmentsTrack",
     },
@@ -372,48 +296,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_pileup_pileup",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_cram_pileup-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_pileup-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
@@ -421,10 +311,6 @@ Object {
         "source": "We generated 150bp paired end reads from a <i>Volvox mythicus</i>, an imaginary species, for this jbrowse demo",
       },
       "name": "volvox-sorted.cram (contigA, LinearPileupDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_pileup",
       "type": "AlignmentsTrack",
     },
@@ -453,56 +339,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_snpcoverage_snpcoverage",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
         Object {
           "displayId": "volvox_cram_snpcoverage-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_snpcoverage-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
       ],
       "name": "volvox-sorted.cram (contigA, LinearSNPCoverageDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_snpcoverage",
       "type": "AlignmentsTrack",
     },
@@ -531,56 +379,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_alignments_ctga-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_alignments_ctga-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_cram_alignments_ctga-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.cram (ctgA, default display)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_alignments_ctga",
       "type": "AlignmentsTrack",
     },
@@ -609,56 +419,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_pileup_ctga_pileup",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_cram_pileup_ctga-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_pileup_ctga-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.cram (ctgA, LinearPileupDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_pileup_ctga",
       "type": "AlignmentsTrack",
     },
@@ -687,56 +459,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram_pileup_ctga_snpcoverage",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
         Object {
           "displayId": "volvox_cram_snpcoverage_ctga-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram_snpcoverage_ctga-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
       ],
       "name": "volvox-sorted.cram (ctgA, LinearSNPCoverageDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram_snpcoverage_ctga",
       "type": "AlignmentsTrack",
     },
@@ -765,54 +499,20 @@ Object {
           "pileupDisplay": Object {
             "defaultRendering": "svg",
             "displayId": "volvox_bam_altname_alignments_pileup",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
             "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
           },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_alignments-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_alignments-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (ctgA, svg)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_alignments",
       "type": "AlignmentsTrack",
     },
@@ -837,56 +537,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_bam_snpcoverage_snpcoverage",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
         Object {
           "displayId": "volvox_bam_snpcoverage-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_bam_snpcoverage-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
       ],
       "name": "volvox-sorted.bam (contigA LinearSNPCoverageDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bam_snpcoverage",
       "type": "AlignmentsTrack",
     },
@@ -911,56 +573,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_bam_pileup_pileup",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_bam_pileup-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_bam_pileup-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (contigA LinearPileupDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bam_pileup",
       "type": "AlignmentsTrack",
     },
@@ -985,56 +609,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_alignments_pileup_coverage-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_alignments_pileup_coverage-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_alignments_pileup_coverage-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (ctgA, canvas)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_alignments_pileup_coverage",
       "type": "AlignmentsTrack",
     },
@@ -1062,54 +648,20 @@ Object {
           "pileupDisplay": Object {
             "defaultRendering": "svg",
             "displayId": "volvox_bam_altname_alignments_pileup",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
             "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
           },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_bam_altname-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_bam_altname-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (contigA, svg)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bam_altname",
       "type": "AlignmentsTrack",
     },
@@ -1141,50 +693,21 @@ Object {
                 "maxHeight": 10,
                 "type": "PileupRenderer",
               },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
             },
             "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
           },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_bam_small_max_height-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_bam_small_max_height-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (small max height)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bam_small_max_height",
       "type": "AlignmentsTrack",
     },
@@ -1209,24 +732,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_test_vcf-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_test_vcf-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
       "name": "volvox 1000genomes vcf",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_test_vcf",
       "type": "VariantTrack",
     },
@@ -1246,17 +759,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "nclist_long_names-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "nclist with long names/descriptions",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "nclist_long_names",
       "type": "FeatureTrack",
     },
@@ -1281,56 +787,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_alignments_bam_nonexist-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_alignments_bam_nonexist-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_alignments_bam_nonexist-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (bam nonexist 404)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_alignments_bam_nonexist",
       "type": "AlignmentsTrack",
     },
@@ -1355,56 +823,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_alignments_bai_nonexist-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_alignments_bai_nonexist-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_alignments_bai_nonexist-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam (bai nonexist 404)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_alignments_bai_nonexist",
       "type": "AlignmentsTrack",
     },
@@ -1425,25 +855,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_bigwig_nonexist-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track 404",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bigwig_nonexist",
       "type": "QuantitativeTrack",
     },
@@ -1464,25 +879,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_microarray-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track xyplot",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_microarray",
       "type": "QuantitativeTrack",
     },
@@ -1504,25 +904,10 @@ Object {
         Object {
           "defaultRendering": "line",
           "displayId": "volvox_microarray_line_line",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track lineplot",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_microarray_line",
       "type": "QuantitativeTrack",
     },
@@ -1544,25 +929,10 @@ Object {
         Object {
           "defaultRendering": "density",
           "displayId": "volvox_microarray_density_density",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track density",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_microarray_density",
       "type": "QuantitativeTrack",
     },
@@ -1583,25 +953,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_microarray_density_altname-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track density (altname)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_microarray_density_altname",
       "type": "QuantitativeTrack",
     },
@@ -1661,24 +1016,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "lollipop_track_linear",
-          "renderer": Object {
-            "type": "LollipopRenderer",
-          },
           "type": "LinearLollipopDisplay",
         },
         Object {
           "displayId": "lollipop_track-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "FromConfig Track (defaults to LinearLollipopDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "lollipop_track",
       "type": "FeatureTrack",
     },
@@ -1738,24 +1083,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "filtering_track_linear",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearFilteringDisplay",
         },
         Object {
           "displayId": "filtering_track-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "FromConfig Track (defaults to LinearFilteringDisplay)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "filtering_track",
       "type": "FeatureTrack",
     },
@@ -1780,56 +1115,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-long-reads-sv-bam-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-sv-bam-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-sv-bam-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-long reads with SV",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-long-reads-sv-bam",
       "type": "AlignmentsTrack",
     },
@@ -1858,56 +1155,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-long-reads-sv-cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-sv-cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-sv-cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-long reads with SV (cram)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-long-reads-sv-cram",
       "type": "AlignmentsTrack",
     },
@@ -1936,56 +1195,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-long-reads-cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-long reads (cram)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-long-reads-cram",
       "type": "AlignmentsTrack",
     },
@@ -2010,56 +1231,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-long-reads-bam-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-bam-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-long-reads-bam-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-long reads",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-long-reads-bam",
       "type": "AlignmentsTrack",
     },
@@ -2088,56 +1271,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_samspec_cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_samspec_cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_samspec_cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-samspec (cram)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_samspec_cram",
       "type": "AlignmentsTrack",
     },
@@ -2162,56 +1307,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_samspec-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_samspec-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_samspec-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-samspec",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_samspec",
       "type": "AlignmentsTrack",
     },
@@ -2240,56 +1347,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_sv_cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_sv_cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_sv_cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sv (cram)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_sv_cram",
       "type": "AlignmentsTrack",
     },
@@ -2314,56 +1383,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_sv-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_sv-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_sv-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sv",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_sv",
       "type": "AlignmentsTrack",
     },
@@ -2388,17 +1419,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "gff3tabix_genes-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "GFF3Tabix genes",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "gff3tabix_genes",
       "type": "FeatureTrack",
     },
@@ -2427,56 +1451,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.cram",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_cram",
       "type": "AlignmentsTrack",
     },
@@ -2501,56 +1487,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_bam-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox_bam-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox_bam-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-sorted.bam",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_bam",
       "type": "AlignmentsTrack",
     },
@@ -2575,24 +1523,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_filtered_vcf-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_filtered_vcf-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
       "name": "volvox filtered vcf",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_filtered_vcf",
       "type": "VariantTrack",
     },
@@ -2612,24 +1550,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_filtered_vcf_plaintext-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_filtered_vcf_plaintext-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
       "name": "volvox filtered vcf (plaintext)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_filtered_vcf_plaintext",
       "type": "VariantTrack",
     },
@@ -2654,24 +1582,14 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_filtered_vcf_assembly_alias-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
           "displayId": "volvox_filtered_vcf_assembly_alias-LinearVariantDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearVariantDisplay",
         },
       ],
       "name": "volvox filtered vcf (with assembly alias)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_filtered_vcf_assembly_alias",
       "type": "VariantTrack",
     },
@@ -2691,17 +1609,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "bigbed_genes-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "BigBed genes",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "bigbed_genes",
       "type": "FeatureTrack",
     },
@@ -2726,17 +1637,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "bedtabix_genes-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "BedTabix genes",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "bedtabix_genes",
       "type": "FeatureTrack",
     },
@@ -2758,25 +1662,10 @@ Object {
         Object {
           "defaultRendering": "line",
           "displayId": "LrM3WWJR0tj_line",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "LrM3WWJR0tj",
       "type": "QuantitativeTrack",
     },
@@ -2796,17 +1685,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "Genes-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "NCList genes",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "Genes",
       "type": "FeatureTrack",
     },
@@ -2828,25 +1710,10 @@ Object {
         Object {
           "defaultRendering": "density",
           "displayId": "VUyE25kYsQo_density",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "VUyE25kYsQo",
       "type": "QuantitativeTrack",
     },
@@ -2867,25 +1734,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "24eGIUSM86l-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "24eGIUSM86l",
       "type": "QuantitativeTrack",
     },
@@ -2907,25 +1759,10 @@ Object {
         Object {
           "defaultRendering": "density",
           "displayId": "oMVFQozR9NO_density",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray - negative",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "oMVFQozR9NO",
       "type": "QuantitativeTrack",
     },
@@ -2946,25 +1783,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "1at1sLO1Gsl-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray - negative",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "1at1sLO1Gsl",
       "type": "QuantitativeTrack",
     },
@@ -2986,25 +1808,10 @@ Object {
         Object {
           "defaultRendering": "line",
           "displayId": "wiggle_track_posneg_line",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray with +/- values",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "wiggle_track_posneg",
       "type": "QuantitativeTrack",
     },
@@ -3026,25 +1833,10 @@ Object {
         Object {
           "defaultRendering": "line",
           "displayId": "wiggle_track_fractional_posneg_line",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray with +/- fractional values",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "wiggle_track_fractional_posneg",
       "type": "QuantitativeTrack",
     },
@@ -3065,25 +1857,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "jdYHuGnpAc_-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox microarray with +/- values",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "jdYHuGnpAc_",
       "type": "QuantitativeTrack",
     },
@@ -3105,25 +1882,10 @@ Object {
         Object {
           "defaultRendering": "line",
           "displayId": "p7FU-K6WqS__line",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox - BAM coverage",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "p7FU-K6WqS_",
       "type": "QuantitativeTrack",
     },
@@ -3143,25 +1905,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "pOOtg9wxcUC-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "Volvox - BAM coverage",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "pOOtg9wxcUC",
       "type": "QuantitativeTrack",
     },
@@ -3183,31 +1930,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_fake_synteny-DotplotDisplay",
-          "renderer": Object {
-            "type": "DotplotRenderer",
-          },
           "type": "DotplotDisplay",
         },
         Object {
           "displayId": "volvox_fake_synteny-LinearComparativeDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearComparativeDisplay",
         },
         Object {
           "displayId": "volvox_fake_synteny-LinearSyntenyDisplay",
-          "renderer": Object {
-            "type": "LinearSyntenyRenderer",
-          },
           "type": "LinearSyntenyDisplay",
         },
       ],
       "name": "volvox_fake_synteny",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_fake_synteny",
       "type": "SyntenyTrack",
     },
@@ -3238,56 +1972,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-rg-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-rg-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-rg-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-rg (read groups, bam)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-rg",
       "type": "AlignmentsTrack",
     },
@@ -3316,56 +2012,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox-rg-cram-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "volvox-rg-cram-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "volvox-rg-cram-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "volvox-rg (read groups, cram)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox-rg-cram",
       "type": "AlignmentsTrack",
     },
@@ -3385,25 +2043,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_wrong_assembly-LinearWiggleDisplay",
-          "renderers": Object {
-            "DensityRenderer": Object {
-              "type": "DensityRenderer",
-            },
-            "LinePlotRenderer": Object {
-              "type": "LinePlotRenderer",
-            },
-            "XYPlotRenderer": Object {
-              "type": "XYPlotRenderer",
-            },
-          },
           "type": "LinearWiggleDisplay",
         },
       ],
       "name": "wiggle_track (wrong assembly error)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "volvox_wrong_assembly",
       "type": "QuantitativeTrack",
     },
@@ -3428,9 +2071,6 @@ Object {
       "displays": Array [
         Object {
           "displayId": "volvox_filtered_vcf_color-ChordVariantDisplay",
-          "renderer": Object {
-            "type": "StructuralVariantChordRenderer",
-          },
           "type": "ChordVariantDisplay",
         },
         Object {
@@ -3443,10 +2083,6 @@ Object {
         },
       ],
       "name": "volvox filtered vcf (green snp, purple indel)",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "variant_colors",
       "type": "VariantTrack",
     },
@@ -3477,56 +2113,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "MM-chebi-volvox-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "MM-chebi-volvox-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "MM-chebi-volvox-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "MM-chebi-volvox",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "MM-chebi-volvox",
       "type": "AlignmentsTrack",
     },
@@ -3557,56 +2155,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "MM-double-volvox-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "MM-double-volvox-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "MM-double-volvox-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "MM-double-volvox",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "MM-double-volvox",
       "type": "AlignmentsTrack",
     },
@@ -3637,56 +2197,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "MM-multi-volvox-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "MM-multi-volvox-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "MM-multi-volvox-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "MM-multi-volvox",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "MM-multi-volvox",
       "type": "AlignmentsTrack",
     },
@@ -3717,56 +2239,18 @@ Object {
       "displays": Array [
         Object {
           "displayId": "MM-orient-volvox-LinearAlignmentsDisplay",
-          "pileupDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "PileupRenderer": Object {
-                "type": "PileupRenderer",
-              },
-              "SvgFeatureRenderer": Object {
-                "type": "SvgFeatureRenderer",
-              },
-            },
-            "type": "LinearPileupDisplay",
-          },
-          "snpCoverageDisplay": Object {
-            "displayId": "placeholderId",
-            "renderers": Object {
-              "SNPCoverageRenderer": Object {
-                "type": "SNPCoverageRenderer",
-              },
-            },
-            "type": "LinearSNPCoverageDisplay",
-          },
           "type": "LinearAlignmentsDisplay",
         },
         Object {
           "displayId": "MM-orient-volvox-LinearPileupDisplay",
-          "renderers": Object {
-            "PileupRenderer": Object {
-              "type": "PileupRenderer",
-            },
-            "SvgFeatureRenderer": Object {
-              "type": "SvgFeatureRenderer",
-            },
-          },
           "type": "LinearPileupDisplay",
         },
         Object {
           "displayId": "MM-orient-volvox-LinearSNPCoverageDisplay",
-          "renderers": Object {
-            "SNPCoverageRenderer": Object {
-              "type": "SNPCoverageRenderer",
-            },
-          },
           "type": "LinearSNPCoverageDisplay",
         },
       ],
       "name": "MM-orient-volvox",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "MM-orient-volvox",
       "type": "AlignmentsTrack",
     },
@@ -3791,17 +2275,10 @@ Object {
       "displays": Array [
         Object {
           "displayId": "single_exon_gene-LinearBasicDisplay",
-          "renderer": Object {
-            "type": "SvgFeatureRenderer",
-          },
           "type": "LinearBasicDisplay",
         },
       ],
       "name": "Single exon gene",
-      "textSearchAdapter": Object {
-        "textSearchAdapterId": "placeholderId",
-        "type": "JBrowse1TextSearchAdapter",
-      },
       "trackId": "single_exon_gene",
       "type": "FeatureTrack",
     },

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -106,6 +106,7 @@ Object {
   "name": "assembly1",
   "sequence": Object {
     "adapter": Object {
+      "adapterId": "sequenceConfigAdapterId",
       "features": Array [
         Object {
           "end": 10,

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -121,9 +121,6 @@ Object {
     "displays": Array [
       Object {
         "displayId": "sequenceConfigId-LinearReferenceSequenceDisplay",
-        "renderer": Object {
-          "type": "DivSequenceRenderer",
-        },
         "type": "LinearReferenceSequenceDisplay",
       },
     ],
@@ -135,22 +132,12 @@ Object {
 
 exports[`Root MST model adds track and connection configs to an assembly 2`] = `
 Object {
-  "adapter": Object {
-    "type": "BamAdapter",
-  },
   "displays": Array [
     Object {
       "displayId": "trackId0-LinearBasicDisplay",
-      "renderer": Object {
-        "type": "SvgFeatureRenderer",
-      },
       "type": "LinearBasicDisplay",
     },
   ],
-  "textSearchAdapter": Object {
-    "textSearchAdapterId": "placeholderId",
-    "type": "JBrowse1TextSearchAdapter",
-  },
   "trackId": "trackId0",
   "type": "FeatureTrack",
 }
@@ -163,14 +150,4 @@ Object {
 }
 `;
 
-exports[`Root MST model creates with defaults 1`] = `
-Object {
-  "rpc": Object {
-    "drivers": Object {
-      "MainThreadRpcDriver": Object {
-        "type": "MainThreadRpcDriver",
-      },
-    },
-  },
-}
-`;
+exports[`Root MST model creates with defaults 1`] = `Object {}`;

--- a/products/jbrowse-web/src/rootModel.test.js
+++ b/products/jbrowse-web/src/rootModel.test.js
@@ -73,6 +73,7 @@ describe('Root MST model', () => {
               type: 'ReferenceSequenceTrack',
               adapter: {
                 type: 'FromConfigSequenceAdapter',
+                adapterId: 'sequenceConfigAdapterId',
                 features: [
                   {
                     refName: 'ctgA',

--- a/test_data/config_synteny_grape_peach.json
+++ b/test_data/config_synteny_grape_peach.json
@@ -15,8 +15,7 @@
         "displays": [
           {
             "type": "LinearReferenceSequenceDisplay",
-            "displayId": "grape_seq-LinearReferenceSequenceDisplay",
-            "renderer": { "type": "DivSequenceRenderer" }
+            "displayId": "grape_seq-LinearReferenceSequenceDisplay"
           }
         ]
       }
@@ -35,8 +34,7 @@
         "displays": [
           {
             "type": "LinearReferenceSequenceDisplay",
-            "displayId": "peach_seq-LinearReferenceSequenceDisplay",
-            "renderer": { "type": "DivSequenceRenderer" }
+            "displayId": "peach_seq-LinearReferenceSequenceDisplay"
           }
         ]
       }
@@ -73,18 +71,15 @@
       "displays": [
         {
           "type": "DotplotDisplay",
-          "displayId": "grape_peach_synteny_mcscan-DotplotDisplay",
-          "renderer": { "type": "DotplotRenderer" }
+          "displayId": "grape_peach_synteny_mcscan-DotplotDisplay"
         },
         {
           "type": "LinearComparativeDisplay",
-          "displayId": "grape_peach_synteny_mcscan-LinearComparativeDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_peach_synteny_mcscan-LinearComparativeDisplay"
         },
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "grape_peach_synteny_mcscan-LinearSyntenyDisplay",
-          "renderer": { "type": "LinearSyntenyRenderer" }
+          "displayId": "grape_peach_synteny_mcscan-LinearSyntenyDisplay"
         }
       ]
     },
@@ -103,18 +98,15 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "peach_genes_linear",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes_linear"
         },
         {
           "type": "LinearFilteringDisplay",
-          "displayId": "peach_genes-LinearFilteringDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes-LinearFilteringDisplay"
         },
         {
           "type": "LinearLollipopDisplay",
-          "displayId": "peach_genes-LinearLollipopDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes-LinearLollipopDisplay"
         }
       ]
     },
@@ -133,18 +125,15 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "peach_genes2-LinearBasicDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes2-LinearBasicDisplay"
         },
         {
           "type": "LinearFilteringDisplay",
-          "displayId": "peach_genes2-LinearFilteringDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes2-LinearFilteringDisplay"
         },
         {
           "type": "LinearLollipopDisplay",
-          "displayId": "peach_genes2-LinearLollipopDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "peach_genes2-LinearLollipopDisplay"
         }
       ]
     },
@@ -163,18 +152,15 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "grape_genes_linear",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes_linear"
         },
         {
           "type": "LinearFilteringDisplay",
-          "displayId": "grape_genes-LinearFilteringDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes-LinearFilteringDisplay"
         },
         {
           "type": "LinearLollipopDisplay",
-          "displayId": "grape_genes-LinearLollipopDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes-LinearLollipopDisplay"
         }
       ]
     },
@@ -193,18 +179,15 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "grape_genes2-LinearBasicDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes2-LinearBasicDisplay"
         },
         {
           "type": "LinearFilteringDisplay",
-          "displayId": "grape_genes2-LinearFilteringDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes2-LinearFilteringDisplay"
         },
         {
           "type": "LinearLollipopDisplay",
-          "displayId": "grape_genes2-LinearLollipopDisplay",
-          "renderer": { "type": "SvgFeatureRenderer" }
+          "displayId": "grape_genes2-LinearLollipopDisplay"
         }
       ]
     }

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -19,6 +19,7 @@
       "refNameAliases": {
         "adapter": {
           "type": "FromConfigAdapter",
+          "adapterId": "W6DyPGJ0UU",
           "features": [
             {
               "refName": "ctgA",
@@ -600,6 +601,7 @@
       "category": ["Miscellaneous"],
       "adapter": {
         "type": "FromConfigAdapter",
+        "adapterId": "Xvg1McRUAP",
         "features": [
           {
             "uniqueId": "one",
@@ -661,6 +663,7 @@
       "category": ["Miscellaneous"],
       "adapter": {
         "type": "FromConfigAdapter",
+        "adapterId": "DvufUT5OYV",
         "features": [
           {
             "uniqueId": "one",

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -69,9 +69,7 @@
       "textSearchAdapterId": "AdapterWithoutAssemblies",
       "namesIndexLocation": {
         "uri": "names/"
-      },
-      "tracks": [],
-      "assemblies": []
+      }
     },
     {
       "type": "JBrowse1TextSearchAdapter",
@@ -79,7 +77,6 @@
       "namesIndexLocation": {
         "uri": "names/"
       },
-      "tracks": [],
       "assemblies": ["volvox3", "volvox4"]
     }
   ],
@@ -90,7 +87,6 @@
       "name": "volvox structural variant test",
       "category": ["VCF"],
       "assemblyNames": ["volvox"],
-      "textSearchIndexingAttributes": ["Name", "ID", "Description"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -108,7 +104,6 @@
         "namesIndexLocation": {
           "uri": "names/"
         },
-        "tracks": [],
         "assemblies": ["NonExistantAssembly"]
       }
     },
@@ -1009,7 +1004,6 @@
           "uri": "volvox-bed12.bed.gz"
         },
         "index": {
-          "type": "TBI",
           "location": {
             "uri": "volvox-bed12.bed.gz.tbi"
           }
@@ -1423,8 +1417,7 @@
         "index": {
           "location": {
             "uri": "single_exon_gene.sorted.gff.gz.tbi"
-          },
-          "indexType": "TBI"
+          }
         }
       }
     }


### PR DESCRIPTION
During pairing @teresam856 and I were thinking about the "textSearchAdapter" in her branch. It's an "optional" config sub-schema, but the default value of the sub-schema was still showing up in config snapshots, which we thought might be confusing. This is an option we came up with that will omit the snapshot of a configuration schema if the snapshot matches the snapshot for the default value of that schema. We though this might be good as a separate PR.

This can be a bit odd if the whole config matches the default, since it makes the whole config snapshot be `undefined` instead of `{}`. We also had to change a couple places that used `getConf(self, 'renderer').type` to `getConf(self, ['renderer', 'type'])`.

It does have the advantage of removing unused things from our config snapshot, e.g. renderers with no customization:
```diff
diff --git a/test_data/volvox/config.json b/test_data/volvox/config.json
--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -663,10 +663,7 @@
       "displays": [
         {
           "type": "LinearFilteringDisplay",
-          "displayId": "filtering_track_linear",
-          "renderer": {
-            "type": "SvgFeatureRenderer"
-          }
+          "displayId": "filtering_track_linear"
         }
       ]
     },
```

There's an unexpected change in one of the snapshots, so keeping as a draft for now.