### PR TITLE
Fix warning on hic test

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -90,11 +90,15 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
   const { status: blockStatus } = model
   const { message: displayStatus } = getParent(model, 2)
   const status = displayStatus || blockStatus
-  return shown ? (
-    <div className={classes.loading}>
-      <div className={classes.dots}>{status ? `${status}` : 'Loading'}</div>
-    </div>
-  ) : null
+  return (
+    <>
+      {shown ? (
+        <div className={classes.loading}>
+          <div className={classes.dots}>{status ? `${status}` : 'Loading'}</div>
+        </div>
+      ) : null}
+    </>
+  )
 })
 
 function BlockMessage({

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -75,8 +75,16 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
   const [shown, setShown] = useState(false)
   const classes = useStyles()
   useEffect(() => {
-    const timeout = setTimeout(() => setShown(true), 300)
-    return () => clearTimeout(timeout)
+    let killed = false
+    const timeout = setTimeout(() => {
+      if (!killed) {
+        setShown(true)
+      }
+    }, 300)
+    return () => {
+      clearTimeout(timeout)
+      killed = true
+    }
   }, [])
 
   const { status: blockStatus } = model

--- a/products/jbrowse-web/src/tests/Hic.test.js
+++ b/products/jbrowse-web/src/tests/Hic.test.js
@@ -20,10 +20,6 @@ hicConfig.configuration = {
   },
 }
 
-function timeout(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
 test('hic', async () => {
   fetch.resetMocks()
   fetch.mockResponse(
@@ -40,7 +36,6 @@ test('hic', async () => {
   )
   state.session.views[0].setNewView(5000, 0)
   fireEvent.click(await findByTestId('htsTrackEntry-hic_test'))
-  await timeout(1000)
   const canvas = await findAllByTestId(
     'prerendered_canvas',
     {},


### PR DESCRIPTION
The hic tests were good and passing but have a little warning that is printed from, presumably, a setState after component teardown

```
  ● Console

    console.error
      Warning: An update to wrappedComponent inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at Repeater (/home/cdiesh/src/jbrowse-components2/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx:63:21)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at LinearBlocks (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at TrackContainer (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at TracksContainer (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at Suspense
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at WithContentRect (/home/cdiesh/src/jbrowse-components2/node_modules/react-measure/dist/index.cjs.js:96:33)
          at div
          at div
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at ThemeProvider (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at StylesProvider (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/StylesProvider/StylesProvider.js:57:24)

      76 |   const classes = useStyles()
      77 |   useEffect(() => {
    > 78 |     const timeout = setTimeout(() => setShown(true), 300)
         |                                      ^
      79 |     return () => clearTimeout(timeout)
      80 |   }, [])
      81 |

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:24064:9)
      at setShown (node_modules/react-dom/cjs/react-dom.development.js:16135:9)
      at plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx:78:38
      at Timeout.task [as _onTimeout] (node_modules/jsdom/lib/jsdom/browser/Window.js:516:19)

    console.error
      Warning: An update to wrappedComponent inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at Repeater (/home/cdiesh/src/jbrowse-components2/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx:63:21)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at LinearBlocks (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at div
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at TrackContainer (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at TracksContainer (/home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30)
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at Suspense
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles(ForwardRef(Paper)) (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at WithContentRect (/home/cdiesh/src/jbrowse-components2/node_modules/react-measure/dist/index.cjs.js:96:33)
          at div
          at div
          at div
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at ThemeProvider (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
          at /home/cdiesh/src/jbrowse-components2/node_modules/mobx-react-lite/lib/observer.js:26:30
          at StylesProvider (/home/cdiesh/src/jbrowse-components2/node_modules/@material-ui/styles/StylesProvider/StylesProvider.js:57:24)

      76 |   const classes = useStyles()
      77 |   useEffect(() => {
    > 78 |     const timeout = setTimeout(() => setShown(true), 300)
         |                                      ^
      79 |     return () => clearTimeout(timeout)
      80 |   }, [])
      81 |

```

This checks for a useEffect cleanup flag before doing the setState