### PR TITLE
reorganize the demo page to emphasize the cancer sv demo more

### DIFF
--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -17,13 +17,15 @@ to live sessions in order for you to be able to experience the app yourself.
 The link above will always direct to the most recent demo that has been released.
 Enjoy!
 
-Current version demos
+Guided demos
+
+- [Cancer demo](http://jbrowse.org/demos/cancer-demo-2020/) - guided demo of structural
+  variant functionality and embedding the linear genome view in another application
+
+Demo instances
 
 - <Link extra="?config=test_data/config_demo.json&session=share-oTyYRpz9fN&password=fYAbt">
     Human instance with HG002 insertion shown (many other tracks available too)
-  </Link>
-- <Link extra="?config=test_data/volvox/config.json&session=share-hTdIfgecWK&password=U9SDX">
-    Volvox sample data (small imaginary test datasets)
   </Link>
 - <a href="https://jbrowse.org/code/jb2/main/?config=test_data/breakpoint/config.json">
     Breakpoint split view demo (showing chromosomal translocation)
@@ -35,8 +37,11 @@ Current version demos
 - <Link extra="?config=%2Fgenomes%2FGRCh38%2F1000genomes%2Fconfig_1000genomes.json&session=share-SUK-mntGyB&password=eQF0F">
     1000 genomes extended trio demo
   </Link>
+- <Link extra="?config=test_data/volvox/config.json&session=share-hTdIfgecWK&password=U9SDX">
+    Volvox sample data (small imaginary test datasets)
+  </Link>
 
-Conference demos:
+Conference demos
 
 - [BOG2021](http://jbrowse.org/demos/bog2021/)
 - [ASHG2020](http://jbrowse.org/demos/ashg2020/)
@@ -45,4 +50,4 @@ Conference demos:
 
 Embedded demos
 
-- [Embedded mode + cancer genomics demo](http://jbrowse.org/demos/cancer-demo-2020/)
+- [Cancer demo](http://jbrowse.org/demos/cancer-demo-2020/) - includes section on embedded components


### PR DESCRIPTION
The cancer demo that takes people through the SV features gives grant reviewers a good overview of things without them having to do the work to click around, which I think is important right now.