### PR TITLE
Avoid warning dialog if plugin is in our plugins.json and popup confirmation dialog for unknown session plugins

### DIFF
--- a/products/jbrowse-web/src/ConfigWarningDialog.tsx
+++ b/products/jbrowse-web/src/ConfigWarningDialog.tsx
@@ -34,12 +34,10 @@ export default function ConfigWarningModal({
     <Dialog
       open
       maxWidth="xl"
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
       data-testid="session-warning-modal"
       className={classes.main}
     >
-      <DialogTitle id="alert-dialog-title">Warning</DialogTitle>
+      <DialogTitle>Warning</DialogTitle>
       <Divider />
       <div>
         <WarningIcon fontSize="large" />

--- a/products/jbrowse-web/src/ConfigWarningDialog.tsx
+++ b/products/jbrowse-web/src/ConfigWarningDialog.tsx
@@ -25,9 +25,11 @@ const useStyles = makeStyles(theme => ({
 export default function ConfigWarningModal({
   onConfirm,
   onCancel,
+  reason,
 }: {
   onConfirm: () => void
   onCancel: () => void
+  reason: { url: string }[]
 }) {
   const classes = useStyles()
   return (
@@ -44,10 +46,13 @@ export default function ConfigWarningModal({
         <WarningIcon fontSize="large" />
         <DialogContent>
           <DialogContentText>
-            This link contains a cross origin config that loads a configuration
-            from an external site.
-          </DialogContentText>
-          <DialogContentText>
+            This link contains a cross origin config that has the following
+            unknown plugins:
+            <ul>
+              {reason.map(r => (
+                <li>URL: {r.url}</li>
+              ))}
+            </ul>
             Please ensure you trust the source of this link.
           </DialogContentText>
         </DialogContent>

--- a/products/jbrowse-web/src/ConfigWarningDialog.tsx
+++ b/products/jbrowse-web/src/ConfigWarningDialog.tsx
@@ -35,9 +35,10 @@ export default function ConfigWarningModal({
       open
       maxWidth="xl"
       data-testid="session-warning-modal"
+      aria-labelledby="alert-dialog-title"
       className={classes.main}
     >
-      <DialogTitle>Warning</DialogTitle>
+      <DialogTitle id="alert-dialog-title">Warning</DialogTitle>
       <Divider />
       <div>
         <WarningIcon fontSize="large" />

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -224,9 +224,9 @@ const SessionLoader = types
         self.setConfigError(e)
       }
     },
-    async fetchSessionPlugins(snap: { sessionPlugins: PluginDefinition[] }) {
+    async fetchSessionPlugins(snap: { sessionPlugins?: PluginDefinition[] }) {
       try {
-        const pluginLoader = new PluginLoader(snap.sessionPlugins)
+        const pluginLoader = new PluginLoader(snap.sessionPlugins || [])
         pluginLoader.installGlobalReExports(window)
         const plugins = await pluginLoader.load()
         self.setSessionPlugins([...plugins])
@@ -238,7 +238,7 @@ const SessionLoader = types
 
     // passed
     async setSessionSnapshot(
-      snap: { sessionPlugins: PluginDefinition[] },
+      snap: { sessionPlugins?: PluginDefinition[] },
       userAcceptedConfirmation?: boolean,
     ) {
       try {

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -113,13 +113,7 @@ async function checkPlugins(pluginsToCheck: { url: string }[]) {
     plugins: { url: string }[]
   }
   const allowedPluginUrls = array.plugins.map(p => p.url)
-  const configPluginUrls: string[] = pluginsToCheck.map(
-    (p: { url: string }) => p.url,
-  )
-  const allPluginsAllowed = configPluginUrls.every(r =>
-    allowedPluginUrls.includes(r),
-  )
-  return allPluginsAllowed
+  return pluginsToCheck.every(p => allowedPluginUrls.includes(p.url))
 }
 
 type Config = SnapshotOut<AnyConfigurationModel>

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -679,6 +679,7 @@ const Renderer = observer(
               loader.setBlankSession(true)
               handleClose()
             }}
+            reason={loader.sessionTriaged.reason}
           />
         </Suspense>
       ) : (
@@ -696,6 +697,7 @@ const Renderer = observer(
               factoryReset()
               handleClose()
             }}
+            reason={loader.sessionTriaged.reason}
           />
         </Suspense>
       )

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -361,7 +361,7 @@ const SessionLoader = types
     async decodeJsonUrlSession() {
       // @ts-ignore
       const session = JSON.parse(self.sessionQuery.replace('json-', ''))
-      await this.setSessionSnapshot({ ...session, id: shortid() })
+      await this.setSessionSnapshot({ ...session.session, id: shortid() })
     },
 
     async afterCreate() {
@@ -430,7 +430,11 @@ const SessionLoader = types
     },
   }))
 
-export function Loader({ initialTimestamp }: { initialTimestamp: number }) {
+export function Loader({
+  initialTimestamp = Date.now(),
+}: {
+  initialTimestamp?: number
+}) {
   // return value if defined, else convert null to undefined for use with
   // types.maybe
   const load = (param: string | null | undefined) =>

--- a/products/jbrowse-web/src/SessionWarningDialog.tsx
+++ b/products/jbrowse-web/src/SessionWarningDialog.tsx
@@ -25,9 +25,11 @@ const useStyles = makeStyles(theme => ({
 export default function SessionWarningModal({
   onConfirm,
   onCancel,
+  reason,
 }: {
   onConfirm: () => void
   onCancel: () => void
+  reason: { url: string }[]
 }) {
   const classes = useStyles()
   return (
@@ -43,10 +45,12 @@ export default function SessionWarningModal({
         <WarningIcon fontSize="large" />
         <DialogContent>
           <DialogContentText>
-            This link contains an external session, which may contain dangerous
-            code.
-          </DialogContentText>
-          <DialogContentText>
+            This link contains a session that has the following unknown plugins:
+            <ul>
+              {reason.map(r => (
+                <li>URL: {r.url}</li>
+              ))}
+            </ul>
             Please ensure you trust the source of this session.
           </DialogContentText>
         </DialogContent>

--- a/products/jbrowse-web/src/SessionWarningDialog.tsx
+++ b/products/jbrowse-web/src/SessionWarningDialog.tsx
@@ -34,12 +34,10 @@ export default function SessionWarningModal({
     <Dialog
       open
       maxWidth="xl"
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
       data-testid="session-warning-modal"
       className={classes.main}
     >
-      <DialogTitle id="alert-dialog-title">Warning</DialogTitle>
+      <DialogTitle>Warning</DialogTitle>
       <Divider />
       <div>
         <WarningIcon fontSize="large" />

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -22,6 +22,21 @@ const getFile = (url: string) => {
 }
 
 const readBuffer = async (url: string, args: RequestInit) => {
+  if (url.match('plugin-store')) {
+    return {
+      ok: true,
+      async json() {
+        return {
+          plugins: [
+            {
+              url:
+                'https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js',
+            },
+          ],
+        }
+      },
+    }
+  }
   if (url.match(/testid/)) {
     return {
       ok: true,
@@ -86,8 +101,6 @@ function FallbackComponent({ error }: FallbackProps) {
   return <div>there was an error: {String(error)}</div>
 }
 
-const initialTimestamp = 0
-
 describe('<Loader />', () => {
   afterEach(() => {
     localStorage.clear()
@@ -99,7 +112,7 @@ describe('<Loader />', () => {
       <ErrorBoundary FallbackComponent={FallbackComponent}>
         {/* @ts-ignore */}
         <QueryParamProvider location={{ search: '?config=doesNotExist.json' }}>
-          <Loader initialTimestamp={initialTimestamp} />
+          <Loader />
         </QueryParamProvider>
       </ErrorBoundary>,
     )
@@ -123,7 +136,7 @@ describe('<Loader />', () => {
             '?config=test_data/volvox/config_main_thread.json&session=abcdefg',
         }}
       >
-        <Loader initialTimestamp={initialTimestamp} />
+        <Loader />
       </QueryParamProvider>,
     )
 
@@ -139,7 +152,7 @@ describe('<Loader />', () => {
             '?config=test_data/volvox/config_main_thread.json&session=share-testid&password=Z42aq',
         }}
       >
-        <Loader initialTimestamp={initialTimestamp} />
+        <Loader />
       </QueryParamProvider>,
     )
 
@@ -149,19 +162,40 @@ describe('<Loader />', () => {
     })
   })
 
-  xit('can warn of custom callbacks in shared session', async () => {
+  // minimal session with plugin in our plugins.json
+  // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
+  it('can warn of  callbacks in json session', async () => {
+    render(
+      <QueryParamProvider
+        // @ts-ignore
+        location={{
+          search:
+            '?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}',
+        }}
+      >
+        <Loader />
+      </QueryParamProvider>,
+    )
+    await waitFor(() => {
+      expect(sessionStorage.length).toBeGreaterThan(0)
+    })
+  }, 10000)
+
+  // minimal session,
+  // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
+  it('pops up a warning for evil plugin', async () => {
     const { findByTestId } = render(
       <QueryParamProvider
         // @ts-ignore
         location={{
           search:
-            '?config=test_data/volvox/config_main_thread.json&session=share-testcustomcallback&password=ZXCV1',
+            '?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://evil.com/evil.js"}]}}',
         }}
       >
-        <Loader initialTimestamp={initialTimestamp} />
+        <Loader />
       </QueryParamProvider>,
     )
-    expect(await findByTestId('session-warning-modal')).toBeTruthy()
+    await findByTestId('session-warning-modal')
   }, 10000)
 
   it('can use config from a url with nonexistent share param ', async () => {
@@ -174,7 +208,7 @@ describe('<Loader />', () => {
               '?config=test_data/volvox/config_main_thread.json&session=share-nonexist',
           }}
         >
-          <Loader initialTimestamp={initialTimestamp} />
+          <Loader />
         </QueryParamProvider>
       </ErrorBoundary>,
     )
@@ -191,7 +225,7 @@ describe('<Loader />', () => {
               '?config=test_data/bad_config_for_testing_error_catcher.json',
           }}
         >
-          <Loader initialTimestamp={initialTimestamp} />
+          <Loader />
         </QueryParamProvider>
       </ErrorBoundary>,
     )


### PR DESCRIPTION
We currently have this behavior in jbrowse-web loader

a) trust plugins in a users config file if loading same-origin config
b) prompt against loading cross-origin configs
c) load plugins from sessions (without any checking)


I propose changing it so

a) same behavior, trust plugins in users config file if loading same-origin config
b) trust cross-origin configs if they have plugins that match our plugins.json file (e.g. matches urls from there), only prompt if not
c) trust session plugins if they have plugins that match our plugins.json file (e.g. matches urls from there), only prompt if not

The motivation here is that (c) is sort of a currently existing security hole, and that (b) is not really a security hole after checking whitelisted plugins and change to jexl, so does not need a prompt