### PR TITLE
Better feature details when there are short arrays of json supplied as feature data

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -190,18 +190,38 @@ const ArrayValue = ({
 }) => {
   const classes = useStyles()
   return (
-    <div className={classes.field}>
-      <FieldName prefix={prefix} description={description} name={name} />
+    <>
       {value.length === 1 ? (
-        <BasicValue value={value[0]} />
+        isObject(value[0]) ? (
+          <Attributes attributes={value[0]} prefix={[...prefix, name]} />
+        ) : (
+          <div className={classes.field}>
+            <FieldName prefix={prefix} description={description} name={name} />
+            <BasicValue value={value[0]} />
+          </div>
+        )
       ) : (
         value.map((val, i) => (
           <div key={`${name}-${i}`} className={classes.fieldSubvalue}>
-            <BasicValue value={val} />
+            {isObject(val) ? (
+              <Attributes
+                attributes={val}
+                prefix={[...prefix, name + '-' + i]}
+              />
+            ) : (
+              <div className={classes.field}>
+                <FieldName
+                  prefix={prefix}
+                  description={description}
+                  name={name}
+                />
+                <BasicValue value={val} />
+              </div>
+            )}
           </div>
         ))
       )}
-    </div>
+    </>
   )
 }
 
@@ -394,6 +414,7 @@ export const Attributes: React.FunctionComponent<AttributeProps> = props => {
               />
             )
           }
+
           if (isObject(value)) {
             return (
               <Attributes


### PR DESCRIPTION
The base feature details has heuristics and such to make sure sort of arbitrary "json type data" can get a reasonable display

If there is an array of json, it can display a datagrid or a list of elements but currently the list of elements dumps some raw json to the screen

This makes it so array values switch back to using the "attributes" if an object is encountered instead of dumping the stringified json to the screen

![localhost_3000__config=http%3A%2F%2Flocalhost%3A9000%2Fconfig json session=local-ope7pKn8r](https://user-images.githubusercontent.com/6511937/118513524-c9988b80-b701-11eb-9ecf-6848ac4afd51.png)


Note: screenshot is of the CIVIC cancer variants API