### PR TITLE
Avoid error calculating UTR on features that have no exon subfeatures

### DIFF
--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails.tsx
@@ -205,7 +205,7 @@ export const SequencePanel = React.forwardRef<
   let utr = dedupe(children.filter(sub => sub.type.match(/utr/i)))
   let exons = dedupe(children.filter(sub => sub.type === 'exon'))
 
-  if (!utr.length && cds.length) {
+  if (!utr.length && cds.length && exons.length) {
     utr = calculateUTRs(cds, exons)
   }
 


### PR DESCRIPTION
As title says, UTR prediction is not done if no exon subfeatures are available. Fixes #1983