### PR TITLE
Avoid CPU freeze in dev from react-error-overlay with MST validation errors

### DIFF
--- a/products/jbrowse-web/src/index.tsx
+++ b/products/jbrowse-web/src/index.tsx
@@ -1,9 +1,22 @@
 import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom'
+
+// @ts-ignore
 import Loading from './Loading'
 import * as serviceWorker from './serviceWorker'
+
 // this is the main process, so start and register our service worker and web workers
 serviceWorker.register()
+
+// avoid using react-error-overlay, which can cause 100% cpu from doing regex
+// on large error messages, but this currently breaks hot module reloading
+// https://github.com/facebook/create-react-app/issues/10611
+if (process.env.NODE_ENV === 'development') {
+  // @ts-ignore uses dynamic import to avoid bundling package into production
+  import('react-error-overlay').then(m => {
+    m.stopReportingRuntimeErrors()
+  })
+}
 
 const Main = lazy(() => import('./Loader'))
 const initialTimeStamp = Date.now()


### PR DESCRIPTION
When we are in development mode, the react-error-overlay can cause freezing of the app because it runs a regex over the error message, and our error messages can be quite long, so it produces 100% CPU and it's a bad dev experience. This doesn't happen in production, but it causes some freezing of the computer in dev.



This can be mitigated in some cases if you catch the error but we often just let errors go to our top level errorboundary and those messages get shown by both react-error-overlay and the ErrorBoundary

This PR just disables the react-error-overlay effectively (https://stackoverflow.com/questions/46589819/disable-error-overlay-in-development-mode) 

Note that this causes hot module reloading to fail https://github.com/facebook/create-react-app/issues/10611

If we like hot module reloading, we could wait for a fix for that but it is useful to avoid 100% CPUs in dev to have some solution at some point

