### PR TITLE
Add ability to customize feature detail fields with configuration expressions

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -15,7 +15,7 @@ import { DataGrid } from '@material-ui/data-grid'
 import { observer } from 'mobx-react'
 import clsx from 'clsx'
 import isObject from 'is-object'
-import { IAnyStateTreeNode } from 'mobx-state-tree'
+import { getEnv, IAnyStateTreeNode } from 'mobx-state-tree'
 import { getConf } from '../configuration'
 import { measureText, getSession } from '../util'
 import SanitizedHTML from '../ui/SanitizedHTML'
@@ -515,16 +515,23 @@ export const FeatureDetails = (props: {
 const BaseFeatureDetails = observer((props: BaseInputProps) => {
   const { model } = props
   const { featureData } = model
+  const session = getSession(model)
 
   if (!featureData) {
     return null
   }
   const feature = JSON.parse(JSON.stringify(featureData))
+  const extraFields = getConf(session, ['featureDetails', 'extraFields'], {
+    feature,
+  })
 
   if (isEmpty(feature)) {
     return null
   }
-  return <FeatureDetails model={model} feature={feature} />
+
+  return (
+    <FeatureDetails model={model} feature={{ ...feature, ...extraFields }} />
+  )
 })
 
 export default BaseFeatureDetails

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -15,7 +15,7 @@ import { DataGrid } from '@material-ui/data-grid'
 import { observer } from 'mobx-react'
 import clsx from 'clsx'
 import isObject from 'is-object'
-import { getEnv, IAnyStateTreeNode } from 'mobx-state-tree'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
 import { getConf } from '../configuration'
 import { measureText, getSession } from '../util'
 import SanitizedHTML from '../ui/SanitizedHTML'
@@ -514,23 +514,29 @@ export const FeatureDetails = (props: {
 
 const BaseFeatureDetails = observer((props: BaseInputProps) => {
   const { model } = props
-  const { featureData } = model
+  const { featureData, view, display, track } = model
   const session = getSession(model)
 
   if (!featureData) {
     return null
   }
   const feature = JSON.parse(JSON.stringify(featureData))
-  const extraFields = getConf(session, ['featureDetails', 'extraFields'], {
-    feature,
-  })
-
   if (isEmpty(feature)) {
     return null
   }
 
+  const sessionExtra = getConf(session, ['featureDetails', 'extraFields'], {
+    feature,
+  })
+  const trackExtra = getConf(track, ['extraFields'], {
+    feature,
+  })
+
   return (
-    <FeatureDetails model={model} feature={{ ...feature, ...extraFields }} />
+    <FeatureDetails
+      model={model}
+      feature={{ ...feature, ...sessionExtra, ...trackExtra }}
+    />
   )
 })
 

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -514,7 +514,7 @@ export const FeatureDetails = (props: {
 
 const BaseFeatureDetails = observer((props: BaseInputProps) => {
   const { model } = props
-  const { featureData, view, display, track } = model
+  const { featureData, track } = model
   const session = getSession(model)
 
   if (!featureData) {
@@ -525,12 +525,16 @@ const BaseFeatureDetails = observer((props: BaseInputProps) => {
     return null
   }
 
-  const sessionExtra = getConf(session, ['featureDetails', 'extraFields'], {
-    feature,
-  })
-  const trackExtra = getConf(track, ['extraFields'], {
-    feature,
-  })
+  const sessionExtra = session
+    ? getConf(session, ['featureDetails', 'extraFields'], {
+        feature,
+      })
+    : {}
+  const trackExtra = track
+    ? getConf(track, ['extraFields'], {
+        feature,
+      })
+    : {}
 
   return (
     <FeatureDetails

--- a/packages/core/BaseFeatureWidget/index.ts
+++ b/packages/core/BaseFeatureWidget/index.ts
@@ -14,6 +14,12 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       view: types.safeReference(
         pluginManager.pluggableMstType('view', 'stateModel'),
       ),
+      track: types.safeReference(
+        pluginManager.pluggableMstType('track', 'stateModel'),
+      ),
+      display: types.safeReference(
+        pluginManager.pluggableMstType('display', 'stateModel'),
+      ),
     })
     .actions(self => ({
       setFeatureData(data: Record<string, unknown>) {

--- a/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
+++ b/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
@@ -46,6 +46,12 @@ export function createBaseTrackConfig(pluginManager: PluginManager) {
       //   ),
       //   defaultValue: [],
       // },
+      extraFields: {
+        type: 'string',
+        description: 'modifies on the base feature details',
+        defaultValue: `jexl:{}`,
+        contextVariable: ['feature'],
+      },
     },
     {
       preProcessSnapshot: s => {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -4,6 +4,7 @@ import { getConf } from '@jbrowse/core/configuration'
 import { MenuItem } from '@jbrowse/core/ui'
 import {
   getContainingView,
+  getContainingTrack,
   getSession,
   isSelectionContainer,
   isSessionModelWithWidgets,
@@ -272,7 +273,12 @@ export const BaseLinearDisplay = types
         const featureWidget = session.addWidget(
           'BaseFeatureWidget',
           'baseFeature',
-          { featureData: feature.toJSON(), view: getContainingView(self) },
+          {
+            featureData: feature.toJSON(),
+            view: getContainingView(self),
+            display: self,
+            track: getContainingTrack(self),
+          },
         )
         session.showWidget(featureWidget)
       }

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -39,6 +39,12 @@ export default function JBrowseWeb(
             type: 'stringArray',
             defaultValue: ['mRNA', 'transcript'],
           },
+          extraFields: {
+            type: 'string',
+            description: 'modifies on the base feature details',
+            defaultValue: `jexl:{civicdb:"<a href=https://civicdb.org/events/genes/"+feature.gene_id+"/summary/variants/"+feature.id+"/summary>Link to CIVIC</a>"}`,
+            contextVariable: ['feature'],
+          },
         }),
         disableAnalytics: {
           type: 'boolean',

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -42,7 +42,7 @@ export default function JBrowseWeb(
           extraFields: {
             type: 'string',
             description: 'modifies on the base feature details',
-            defaultValue: `jexl:{civicdb:"<a href=https://civicdb.org/events/genes/"+feature.gene_id+"/summary/variants/"+feature.id+"/summary>Link to CIVIC</a>"}`,
+            defaultValue: 'jexl:{}',
             contextVariable: ['feature'],
           },
         }),

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -7,7 +7,11 @@
     },
     {
       "name": "GDC",
-      "url": "https://unpkg.com/jbrowse-plugin-gdc@^1/dist/jbrowse-plugin-gdc.umd.production.min.js"
+      "url": "http://localhost:9000/dist/jbrowse-plugin-gdc.umd.development.js"
+    },
+    {
+      "name": "CIVIC",
+      "url": "https://unpkg.com/jbrowse-plugin-civic/dist/jbrowse-plugin-civic.umd.production.min.js"
     },
     {
       "name": "UCSC",
@@ -73,6 +77,16 @@
     }
   ],
   "tracks": [
+    {
+      "type": "FeatureTrack",
+      "trackId": "civic_hg19",
+      "name": "CIVIC cancer variants hg19",
+      "category": ["Annotation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "CIVICAdapter"
+      }
+    },
     {
       "type": "FeatureTrack",
       "trackId": "ncbi_gff_hg19",

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -7,15 +7,15 @@
     },
     {
       "name": "GDC",
-      "url": "http://localhost:9000/dist/jbrowse-plugin-gdc.umd.development.js"
-    },
-    {
-      "name": "CIVIC",
-      "url": "https://unpkg.com/jbrowse-plugin-civic/dist/jbrowse-plugin-civic.umd.production.min.js"
+      "url": "https://unpkg.com/jbrowse-plugin-gdc@^1/dist/jbrowse-plugin-gdc.umd.production.min.js"
     },
     {
       "name": "UCSC",
       "url": "https://unpkg.com/jbrowse-plugin-ucsc@^1/dist/jbrowse-plugin-ucsc.umd.production.min.js"
+    },
+    {
+      "name": "CIVIC",
+      "url": "https://unpkg.com/jbrowse-plugin-civic/dist/jbrowse-plugin-civic.umd.production.min.js"
     }
   ],
   "assemblies": [
@@ -77,16 +77,6 @@
     }
   ],
   "tracks": [
-    {
-      "type": "FeatureTrack",
-      "trackId": "civic_hg19",
-      "name": "CIVIC cancer variants hg19",
-      "category": ["Annotation"],
-      "assemblyNames": ["hg19"],
-      "adapter": {
-        "type": "CIVICAdapter"
-      }
-    },
     {
       "type": "FeatureTrack",
       "trackId": "ncbi_gff_hg19",


### PR DESCRIPTION
This is a way to provide customization to the feature detail panels without making a plugin+ making a custom display type + making a custom widget panel

It allows a jexl expression instead in the config so that you can have something like this


    jexl:{hello:'world'}

This would add a field called hello with value world to the feature details

You can also stitch together multiple attributes, or rewrite existing fields. It uses object spread which will overwrite fields or create new ones. This can be used to make links

Example here

    jexl:{civicdb:'<a target=\"_blank\" href=https://civicdb.org/events/genes/'+feature.gene_id+'/summary/variants/'+feature.id+'/summary>Link to CIVIC</a>'}



This is possibly a bit verbose if you want to provide multiple customization, as it is all contained in one field and possibly on a single line in json. Users facing this issue could make a plugin that adds some custom jexl expressions and then possibly it could look just like this

     jexl:{civicdb: generateCivicLink(feature), otherfield: generateOtherField(feature)}