### PR TITLE
Make session plugins get transferred to the worker properly

### DIFF
--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -7,6 +7,10 @@ import { AnyConfigurationSchemaType } from './configuration/configurationSchema'
 export default abstract class Plugin {
   abstract name: string
 
+  url?: string
+
+  version?: string
+
   install(_pluginManager: PluginManager): void {}
 
   configure(_pluginManager: PluginManager): void {}

--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -26,6 +26,11 @@ export interface PluginDefinition {
   url: string
 }
 
+export interface PluginRecord {
+  plugin: PluginConstructor
+  definition: PluginDefinition
+}
+
 export default class PluginLoader {
   definitions: PluginDefinition[] = []
 
@@ -95,9 +100,12 @@ export default class PluginLoader {
     })
   }
 
-  async load(): Promise<PluginConstructor[]> {
+  async load(): Promise<PluginRecord[]> {
     return Promise.all(
-      this.definitions.map(definition => this.loadPlugin(definition)),
+      this.definitions.map(async definition => ({
+        plugin: await this.loadPlugin(definition),
+        definition,
+      })),
     )
   }
 }

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -307,7 +307,7 @@ export default class PluginManager {
 
   get pluginDefinitions(): PluginDefinition[] {
     return Object.values(this.pluginMetaData)
-      .map(p => p.definition)
+      .map(p => p.definition as PluginDefinition)
       .filter(f => !!f)
   }
 

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -32,6 +32,7 @@ import { AnyConfigurationSchemaType } from './configuration/configurationSchema'
 import { AbstractRootModel } from './util'
 import CorePlugin from './CorePlugin'
 import createJexlInstance from './util/jexl'
+import { PluginDefinition } from './PluginLoader'
 
 /** little helper class that keeps groups of callbacks that are
 then run in a specified order by group */
@@ -302,6 +303,12 @@ export default class PluginManager {
     })
 
     return this
+  }
+
+  get pluginDefinitions(): PluginDefinition[] {
+    return Object.values(this.pluginMetaData)
+      .map(p => p.definition)
+      .filter(f => !!f)
   }
 
   getElementType(groupName: PluggableElementTypeGroup, typeName: string) {

--- a/packages/core/rpc/RpcManager.ts
+++ b/packages/core/rpc/RpcManager.ts
@@ -40,11 +40,8 @@ export default class RpcManager {
 
   backendConfigurations: BackendConfigurations
 
-  runtimePluginDefinitions: PluginDefinition[]
-
   constructor(
     pluginManager: PluginManager,
-    runtimePluginDefinitions: PluginDefinition[] = [],
     mainConfiguration: AnyConfigurationModel,
     backendConfigurations: BackendConfigurations,
   ) {
@@ -52,7 +49,6 @@ export default class RpcManager {
       throw new Error('RpcManager requires at least a main configuration')
     }
     this.pluginManager = pluginManager
-    this.runtimePluginDefinitions = runtimePluginDefinitions
     this.mainConfiguration = mainConfiguration
     this.backendConfigurations = backendConfigurations
     this.driverObjects = new Map()
@@ -74,7 +70,7 @@ export default class RpcManager {
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const newDriver = new DriverClassImpl(backendConfiguration as any, {
-      plugins: this.runtimePluginDefinitions,
+      plugins: this.pluginManager.runtimePluginDefinitions,
     })
     this.driverObjects.set(backendName, newDriver)
     return newDriver

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -89,6 +89,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   showWidget?: Function
   addWidget?: Function
 
+  addTrackConf?: Function
   DialogComponent?: DialogComponentType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DialogProps: any

--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPluginsList.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPluginsList.tsx
@@ -17,30 +17,26 @@ function InstalledPluginsList({
   pluginManager: PluginManager
   model: PluginStoreModel
 }) {
-  const { plugins } = pluginManager
+  const { plugins } = pluginManager as PluginManager
 
   const corePlugins = plugins
-    .filter((p: BasePlugin) =>
-      Boolean(pluginManager.pluginMetaData[p.name]?.isCore),
-    )
-    .map((p: BasePlugin) => p.name)
+    .filter(p => pluginManager.pluginMetadata[p.name]?.isCore)
+    .map(p => p.name)
 
-  const externalPlugins = plugins.filter((plugin: BasePlugin) => {
-    return !corePlugins.includes(plugin.name)
-  })
-
-  const externalPluginsRender = externalPlugins
-    .filter((plugin: BasePlugin) => {
-      return plugin.name.toLowerCase().includes(model.filterText.toLowerCase())
-    })
-    .map((plugin: BasePlugin) => {
-      return <InstalledPlugin key={plugin.name} plugin={plugin} model={model} />
-    })
+  const externalPlugins = plugins.filter(
+    plugin => !corePlugins.includes(plugin.name),
+  )
 
   return (
     <List>
       {externalPlugins.length ? (
-        externalPluginsRender
+        externalPlugins
+          .filter(plugin =>
+            plugin.name.toLowerCase().includes(model.filterText.toLowerCase()),
+          )
+          .map(plugin => (
+            <InstalledPlugin key={plugin.name} plugin={plugin} model={model} />
+          ))
       ) : (
         <Typography>No plugins currently installed</Typography>
       )}

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.test.js
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.test.js
@@ -1,10 +1,32 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import AboutWidget from './AboutWidget'
+import { types } from 'mobx-state-tree'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
 
 describe('<AboutWidget />', () => {
   it('renders', () => {
-    const { container } = render(<AboutWidget />)
+    const session = types
+      .model({
+        configuration: ConfigurationSchema('Null', {}),
+        rpcManager: types.frozen({}),
+      })
+      .create(
+        {},
+        {
+          pluginManager: {
+            pluginMetadata: {},
+            plugins: [
+              {
+                name: 'HelloPlugin',
+                version: '1.0.0',
+                url: 'http://google.com',
+              },
+            ],
+          },
+        },
+      )
+    const { container } = render(<AboutWidget model={session} />)
     expect(container.firstChild).toMatchSnapshot()
   })
 })

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 import { IAnyStateTreeNode, getEnv } from 'mobx-state-tree'
 import { getSession } from '@jbrowse/core/util'
 import { makeStyles, Typography, Link } from '@material-ui/core'
-import { PluginMetaData } from '@jbrowse/core/PluginManager'
+import PluginManager from '@jbrowse/core/PluginManager'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -19,46 +19,28 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-interface BasePlugin {
-  version?: string
-  name: string
-  url?: string
-}
-
 function About({ model }: { model: IAnyStateTreeNode }) {
   const classes = useStyles()
-  const slotDefinition = {
-    version: '',
-    pluginManager: {
-      plugins: [],
-      pluginMetaData: {} as Record<string, PluginMetaData>,
-    },
-  }
-  const { pluginManager } = model ? getEnv(model) : slotDefinition
-  const { plugins } = pluginManager
+  const { version } = getSession(model)
+  const { pluginManager } = getEnv(model)
+  const { plugins } = pluginManager as PluginManager
   const corePlugins = plugins
-    .filter((p: BasePlugin) =>
-      Boolean(pluginManager.pluginMetaData[p.name]?.isCore),
-    )
-    .map((p: BasePlugin) => p.name)
+    .filter(p => pluginManager.pluginMetadata[p.name]?.isCore)
+    .map(p => p.name)
 
   const corePluginsRender = plugins
-    .filter((plugin: BasePlugin) => {
+    .filter(plugin => {
       return corePlugins.includes(plugin.name)
     })
-    .map((plugin: BasePlugin) => {
-      return (
-        <li key={plugin.name}>
-          {plugin.name} {plugin.version || ''}
-        </li>
-      )
-    })
+    .map(plugin => (
+      <li key={plugin.name}>
+        {plugin.name} {plugin.version || ''}
+      </li>
+    ))
 
   const externalPluginsRender = plugins
-    .filter((plugin: BasePlugin) => {
-      return !corePlugins.includes(plugin.name)
-    })
-    .map((plugin: BasePlugin) => {
+    .filter(plugin => !corePlugins.includes(plugin.name))
+    .map(plugin => {
       const text = `${plugin.name} ${plugin.version || ''}`
       return (
         <li key={plugin.name}>
@@ -79,7 +61,7 @@ function About({ model }: { model: IAnyStateTreeNode }) {
         JBrowse 2
       </Typography>
       <Typography variant="h6" align="center" className={classes.subtitle}>
-        {model ? getSession(model).version : slotDefinition.version}
+        {version}
       </Typography>
       <Typography align="center" variant="body2">
         JBrowse is a{' '}

--- a/plugins/menus/src/AboutWidget/components/__snapshots__/AboutWidget.test.js.snap
+++ b/plugins/menus/src/AboutWidget/components/__snapshots__/AboutWidget.test.js.snap
@@ -36,6 +36,24 @@ exports[`<AboutWidget /> renders 1`] = `
   </p>
   <div
     class="makeStyles-pluginList"
-  />
+  >
+    <h6
+      class="MuiTypography-root MuiTypography-h6"
+    >
+      External plugins loaded
+    </h6>
+    <ul>
+      <li>
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+          href="http://google.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          HelloPlugin 1.0.0
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>
 `;

--- a/products/jbrowse-desktop/src/Loader.tsx
+++ b/products/jbrowse-desktop/src/Loader.tsx
@@ -82,7 +82,7 @@ export default function Loader({
             })),
             ...runtimePlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
-              metadata: { definition },
+              definition,
             })),
           ])
         } catch (e) {

--- a/products/jbrowse-desktop/src/Loader.tsx
+++ b/products/jbrowse-desktop/src/Loader.tsx
@@ -80,7 +80,10 @@ export default function Loader({
               plugin: new P(),
               metadata: { isCore: true },
             })),
-            ...runtimePlugins.map(P => new P()),
+            ...runtimePlugins.map(({ plugin: P, definition }) => ({
+              plugin: new P(),
+              metadata: { definition },
+            })),
           ])
         } catch (e) {
           // used to launch an error dialog for whatever caused plugin loading

--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -140,7 +140,6 @@ export default function RootModel(pluginManager: PluginManager) {
       ] as Menu[],
       rpcManager: new RpcManager(
         pluginManager,
-        getSnapshot(self.jbrowse.plugins),
         self.jbrowse.configuration.rpc,
         {
           ElectronRpcDriver: { workerCreationChannel: 'createWindowWorker' },

--- a/products/jbrowse-desktop/src/worker.ts
+++ b/products/jbrowse-desktop/src/worker.ts
@@ -87,8 +87,10 @@ async function getPluginManager() {
   const pluginLoader = new PluginLoader(config.plugins)
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()
-  const plugins = [...corePlugins, ...runtimePlugins]
-  const pluginManager = new PluginManager(plugins.map(P => new P()))
+  const plugins = [...corePlugins.map(p => ({ plugin: p })), ...runtimePlugins]
+  const pluginManager = new PluginManager(
+    plugins.map(({ plugin: P }) => new P()),
+  )
 
   pluginManager.createPluggableElements()
   pluginManager.configure()

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createModel.ts
@@ -54,14 +54,9 @@ export default function createModel(runtimePlugins: PluginConstructor[]) {
       },
     }))
     .volatile(self => ({
-      rpcManager: new RpcManager(
-        pluginManager,
-        // don't need runtimePluginDefinitions since MainThreadRpcDriver doesn't
-        // use them
-        [],
-        self.config.configuration.rpc,
-        { MainThreadRpcDriver: {} },
-      ),
+      rpcManager: new RpcManager(pluginManager, self.config.configuration.rpc, {
+        MainThreadRpcDriver: {},
+      }),
     }))
   return { model: rootModel, pluginManager }
 }

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,4 +1,4 @@
-import { PluginConstructor } from '@jbrowse/core/Plugin'
+import { PluginRecord } from '@jbrowse/core/PluginLoader'
 import React, { useEffect, useState } from 'react'
 import {
   createViewState,
@@ -164,7 +164,7 @@ export const WithPlugins = () => {
   // const plugins = [UCSCPlugin]
 
   // alternative usage with runtime plugins
-  const [plugins, setPlugins] = useState<PluginConstructor[]>()
+  const [plugins, setPlugins] = useState<PluginRecord[]>()
   useEffect(() => {
     async function getPlugins() {
       const loadedPlugins = await loadPlugins([
@@ -213,7 +213,7 @@ export const WithPlugins = () => {
         },
       },
     },
-    plugins,
+    plugins: plugins.map(p => p.plugin),
     tracks: [
       {
         type: 'FeatureTrack',

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -499,11 +499,11 @@ const Renderer = observer(
             }),
             ...runtimePlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
-              metadata: { definition },
+              definition,
             })),
             ...sessionPlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
-              metadata: { definition },
+              definition,
             })),
           ])
           pluginManager.createPluggableElements()

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -119,6 +119,11 @@ async function checkPlugins(pluginsToCheck: { url: string }[]) {
 
 type Config = SnapshotOut<AnyConfigurationModel>
 
+interface PluginRecord {
+  plugin: PluginConstructor
+  definition: PluginDefinition
+}
+
 const SessionLoader = types
   .model({
     configPath: types.maybe(types.string),
@@ -132,8 +137,8 @@ const SessionLoader = types
     shareWarningOpen: false as any,
     configSnapshot: undefined as any,
     sessionSnapshot: undefined as any,
-    runtimePlugins: [] as PluginConstructor[],
-    sessionPlugins: [] as PluginConstructor[],
+    runtimePlugins: [] as PluginRecord[],
+    sessionPlugins: [] as PluginRecord[],
     sessionError: undefined as Error | undefined,
     configError: undefined as Error | undefined,
     bc1:
@@ -187,10 +192,10 @@ const SessionLoader = types
     setSessionError(error: Error) {
       self.sessionError = error
     },
-    setRuntimePlugins(plugins: PluginConstructor[]) {
+    setRuntimePlugins(plugins: PluginRecord[]) {
       self.runtimePlugins = plugins
     },
-    setSessionPlugins(plugins: PluginConstructor[]) {
+    setSessionPlugins(plugins: PluginRecord[]) {
       self.sessionPlugins = plugins
     },
     setConfigSnapshot(snap: unknown) {
@@ -494,8 +499,14 @@ const Renderer = observer(
                 metadata: { isCore: true },
               } as PluginLoadRecord
             }),
-            ...runtimePlugins.map(P => new P()),
-            ...sessionPlugins.map(P => new P()),
+            ...runtimePlugins.map(({ plugin: P, definition }) => ({
+              plugin: new P(),
+              metadata: { definition },
+            })),
+            ...sessionPlugins.map(({ plugin: P, definition }) => ({
+              plugin: new P(),
+              metadata: { definition },
+            })),
           ])
           pluginManager.createPluggableElements()
 

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { lazy, useEffect, useState, Suspense } from 'react'
 import PluginManager, { PluginLoadRecord } from '@jbrowse/core/PluginManager'
-import PluginLoader, { PluginDefinition } from '@jbrowse/core/PluginLoader'
+import PluginLoader, {
+  PluginDefinition,
+  PluginRecord,
+} from '@jbrowse/core/PluginLoader'
 import { observer } from 'mobx-react'
 import { inDevelopment, fromUrlSafeB64 } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
@@ -118,11 +121,6 @@ async function checkPlugins(pluginsToCheck: { url: string }[]) {
 }
 
 type Config = SnapshotOut<AnyConfigurationModel>
-
-interface PluginRecord {
-  plugin: PluginConstructor
-  definition: PluginDefinition
-}
 
 const SessionLoader = types
   .model({

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -125,7 +125,6 @@ export default function RootModel(
     .volatile(self => ({
       rpcManager: new RpcManager(
         pluginManager,
-        pluginManager.pluginDefinitions,
         self.jbrowse.configuration.rpc,
         {
           WebWorkerRpcDriver: { WorkerClass: RenderWorker },

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -122,7 +122,16 @@ export default function RootModel(
       isDefaultSessionEditing: false,
       pluginsUpdated: false,
     })
-    .volatile(() => ({
+    .volatile(self => ({
+      rpcManager: new RpcManager(
+        pluginManager,
+        pluginManager.pluginDefinitions,
+        self.jbrowse.configuration.rpc,
+        {
+          WebWorkerRpcDriver: { WorkerClass: RenderWorker },
+          MainThreadRpcDriver: {},
+        },
+      ),
       savedSessionsVolatile: observable.map({}),
       pluginManager,
       error: undefined as undefined | Error,
@@ -370,15 +379,6 @@ export default function RootModel(
             ]
           : []),
       ] as Menu[],
-      rpcManager: new RpcManager(
-        pluginManager,
-        getSnapshot(self.jbrowse.plugins),
-        self.jbrowse.configuration.rpc,
-        {
-          WebWorkerRpcDriver: { WorkerClass: RenderWorker },
-          MainThreadRpcDriver: {},
-        },
-      ),
       adminMode,
     }))
     .actions(self => ({

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -44,8 +44,10 @@ async function getPluginManager() {
   const pluginLoader = new PluginLoader(config.plugins)
   pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()
-  const plugins = [...corePlugins, ...runtimePlugins]
-  const pluginManager = new PluginManager(plugins.map(P => new P()))
+  const plugins = [...corePlugins.map(p => ({ plugin: p })), ...runtimePlugins]
+  const pluginManager = new PluginManager(
+    plugins.map(({ plugin: P }) => new P()),
+  )
   pluginManager.createPluggableElements()
   pluginManager.configure()
   jbPluginManager = pluginManager


### PR DESCRIPTION
Currently there is a bug where the session plugins are not properly installed in the webworker

This is a little tricky to fix because we need to have a handle on the plugin definitions themselves, and the place where RpcManager is initialized in rootModel doesn't have session.sessionPlugins yet (the model is still initializing so session is undefined)

This takes the approach to store all plugin definitions as plugin metadata, and then adds a getter called PluginManager.pluginDefinitions and this can be used for the workerBootConfiguration

