### PR TITLE
Pass initialDisplay snapshot via separate param to showTrack

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -530,7 +530,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
         this.scrollTo(self.totalBp / self.bpPerPx - self.offsetPx - self.width)
       },
 
-      showTrack(trackId: string, initialSnapshot = {}, initialSnapshot2 = {}) {
+      showTrack(
+        trackId: string,
+        initialSnapshot = {},
+        displayInitialSnapshot = {},
+      ) {
         const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
           'track',
         )
@@ -563,7 +567,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             {
               type: displayConf.type,
               configuration: displayConf,
-              ...initialSnapshot2,
+              ...displayInitialSnapshot,
             },
           ],
         })

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -530,7 +530,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         this.scrollTo(self.totalBp / self.bpPerPx - self.offsetPx - self.width)
       },
 
-      showTrack(trackId: string, initialSnapshot = {}) {
+      showTrack(trackId: string, initialSnapshot = {}, initialSnapshot2 = {}) {
         const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
           'track',
         )
@@ -559,7 +559,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
           ...initialSnapshot,
           type: configuration.type,
           configuration,
-          displays: [{ type: displayConf.type, configuration: displayConf }],
+          displays: [
+            {
+              type: displayConf.type,
+              configuration: displayConf,
+              ...initialSnapshot2,
+            },
+          ],
         })
         self.tracks.push(track)
         return track


### PR DESCRIPTION
The showTrack has a "initial snapshot" method that it can use to instantiate track specific state, but it is also useful to be able to initialize display specific state too (in the GDC plugin, we can use this to provide initial min and max scores for wiggle display for dynamically added tracks for example)