### PR TITLE
Make SNPCoverage independently generate the modifications tag-color mapping

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -376,7 +376,11 @@ export function getModificationTypes(mm: string) {
       if (!matches) {
         throw new Error('bad format for MM tag')
       }
-      const [, , , type] = matches
-      return type
+      const [, , , typestr] = matches
+
+      // can be a multi e.g. C+mh for both meth (m) and hydroxymeth (h) so
+      // split, and they can also be chemical codes (ChEBI) e.g. C+16061
+      return typestr.split(/(\d+|.)/).filter(f => !!f)
     })
+    .flat()
 }

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -205,20 +205,6 @@ const stateModelFactory = (
                 getSnapshot(self.PileupDisplay.colorBy),
               )
             }
-            if (
-              !deepEqual(
-                self.SNPCoverageDisplay.modificationTagMap,
-                JSON.parse(
-                  JSON.stringify(self.PileupDisplay.modificationTagMap),
-                ),
-              )
-            ) {
-              self.SNPCoverageDisplay.setModificationTagMap(
-                JSON.parse(
-                  JSON.stringify(self.PileupDisplay.modificationTagMap),
-                ),
-              )
-            }
           }),
         )
         addDisposer(

--- a/plugins/alignments/src/LinearPileupDisplay/components/ColorByModifications.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/ColorByModifications.tsx
@@ -14,9 +14,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close'
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    width: 300,
-  },
+  root: {},
   closeButton: {
     position: 'absolute',
     right: theme.spacing(1),
@@ -32,6 +30,32 @@ const useStyles = makeStyles(theme => ({
     },
   },
 }))
+
+function ModificationTable({
+  modifications,
+}: {
+  modifications: [string, string][]
+}) {
+  const classes = useStyles()
+  return (
+    <table className={classes.table}>
+      <tbody>
+        {modifications.map(([key, value]) => (
+          <tr key={key}>
+            <td>{key}</td>
+            <td>{value}</td>
+            <td
+              style={{
+                width: '1em',
+                background: value,
+              }}
+            />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
 
 function ColorByTagDlg(props: {
   model: {
@@ -59,11 +83,18 @@ function ColorByTagDlg(props: {
           <CloseIcon />
         </IconButton>
       </DialogTitle>
-      <DialogContent style={{ overflowX: 'hidden' }}>
+      <DialogContent>
         <div className={classes.root}>
           <Typography>
-            This dialog presents current settings for the color by modifications
-            setting
+            You can choose to color the modifications in the BAM/CRAM MM/ML
+            specification using this dialog. Choosing modifications colors the
+            modified positions and can color multiple modification types.
+            Choosing the methylation setting colors methylated and unmethylated
+            CpG.
+          </Typography>
+          <Typography>
+            Note: you can revisit this dialog to see the current mapping of
+            colors to modification type for the modification coloring mode
           </Typography>
           <div style={{ margin: 20 }}>
             {colorBy?.type === 'modifications' ? (
@@ -71,23 +102,9 @@ function ColorByTagDlg(props: {
                 {modifications.length ? (
                   <>
                     Current modification-type-to-color mapping
-                    <table className={classes.table}>
-                      <tbody>
-                        {modifications.map(([key, value]) => (
-                          <tr key={key}>
-                            <td>{key}</td>
-                            <td>{value}</td>
-                            <td
-                              style={{
-                                width: 14,
-                                height: 14,
-                                background: value,
-                              }}
-                            />
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                    <ModificationTable
+                      modifications={[...modificationTagMap.entries()]}
+                    />
                   </>
                 ) : (
                   <div>
@@ -100,27 +117,51 @@ function ColorByTagDlg(props: {
                 )}
               </div>
             ) : null}
+            {colorBy?.type === 'methylation' ? (
+              <ModificationTable
+                modifications={[
+                  ['methylated', 'red'],
+                  ['unmethylated', 'blue'],
+                ]}
+              />
+            ) : null}
           </div>
-          <Button
-            variant="contained"
-            color="primary"
-            style={{ marginLeft: 20 }}
-            onClick={() => {
-              model.setColorScheme({
-                type: 'modifications',
-              })
-              handleClose()
-            }}
-          >
-            Color by modifications
-          </Button>
-          <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => handleClose()}
-          >
-            Cancel
-          </Button>
+          <div style={{ display: 'flex' }}>
+            <Button
+              variant="contained"
+              color="primary"
+              style={{ margin: 5 }}
+              onClick={() => {
+                model.setColorScheme({
+                  type: 'modifications',
+                })
+                handleClose()
+              }}
+            >
+              Modifications
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              style={{ margin: 5 }}
+              onClick={() => {
+                model.setColorScheme({
+                  type: 'methylation',
+                })
+                handleClose()
+              }}
+            >
+              Methylation
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              style={{ margin: 5 }}
+              onClick={() => handleClose()}
+            >
+              Cancel
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -187,6 +187,7 @@ const stateModelFactory = (
                 if (colorBy?.type === 'modifications') {
                   const uniqueModificationsSet = await getUniqueModificationValues(
                     self,
+                    getConf(self.parentTrack, ['adapter']),
                     colorBy,
                     view.staticBlocks,
                   )

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -14,7 +14,6 @@ import {
   getContainingView,
 } from '@jbrowse/core/util'
 
-import { BlockSet } from '@jbrowse/core/util/blockTypes'
 import VisibilityIcon from '@material-ui/icons/Visibility'
 import { ContentCopy as ContentCopyIcon } from '@jbrowse/core/ui/Icons'
 import {
@@ -35,6 +34,8 @@ import { AnyConfigurationModel } from '@jbrowse/core/configuration/configuration
 import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
 import { LinearPileupDisplayConfigModel } from './configSchema'
 import LinearPileupDisplayBlurb from './components/LinearPileupDisplayBlurb'
+
+import { getUniqueTagValues, getUniqueModificationValues } from '../shared'
 
 const ColorByTagDlg = lazy(() => import('./components/ColorByTag'))
 const FilterByTagDlg = lazy(() => import('./components/FilterByTag'))
@@ -125,61 +126,9 @@ const stateModelFactory = (
         self.colorBy = cast(colorScheme)
         self.ready = false
       },
-      async getUniqueTagValues(
-        colorScheme: { type: string; tag?: string },
-        blocks: BlockSet,
-        opts?: {
-          headers?: Record<string, string>
-          signal?: AbortSignal
-          filters?: string[]
-        },
-      ) {
-        const { rpcManager } = getSession(self)
-        const { adapterConfig } = self
-        const sessionId = getRpcSessionId(self)
-        const values = await rpcManager.call(
-          getRpcSessionId(self),
-          'PileupGetGlobalValueForTag',
-          {
-            adapterConfig,
-            tag: colorScheme.tag,
-            sessionId,
-            regions: blocks.contentBlocks,
-            ...opts,
-          },
-        )
-        return values as string[]
-      },
-      async getUniqueModificationValues(
-        colorScheme: { type: string; tag?: string },
-        blocks: BlockSet,
-        opts?: {
-          headers?: Record<string, string>
-          signal?: AbortSignal
-          filters?: string[]
-        },
-      ) {
-        const { rpcManager } = getSession(self)
-        const { adapterConfig } = self
-        const sessionId = getRpcSessionId(self)
-        const values = await rpcManager.call(
-          getRpcSessionId(self),
-          'PileupGetVisibleModifications',
-          {
-            adapterConfig,
-            tag: colorScheme.tag,
-            sessionId,
-            regions: blocks.contentBlocks,
-            ...opts,
-          },
-        )
-        return values as string[]
-      },
 
       updateModificationColorMap(uniqueModifications: string[]) {
-        // pale color scheme https://cran.r-project.org/web/packages/khroma/vignettes/tol.html e.g. "tol_light"
         const colorPalette = ['red', 'blue', 'green', 'orange', 'purple']
-
         uniqueModifications.forEach(value => {
           if (!self.modificationTagMap.has(value)) {
             const totalKeys = [...self.modificationTagMap.keys()].length
@@ -227,7 +176,8 @@ const stateModelFactory = (
                 // continually generate the vc pairing, set and rerender if any
                 // new values seen
                 if (colorBy?.tag) {
-                  const uniqueTagSet = await self.getUniqueTagValues(
+                  const uniqueTagSet = await getUniqueTagValues(
+                    self,
                     colorBy,
                     view.staticBlocks,
                   )
@@ -235,7 +185,8 @@ const stateModelFactory = (
                 }
 
                 if (colorBy?.type === 'modifications') {
-                  const uniqueModificationsSet = await self.getUniqueModificationValues(
+                  const uniqueModificationsSet = await getUniqueModificationValues(
+                    self,
                     colorBy,
                     view.staticBlocks,
                   )

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -511,17 +511,11 @@ const stateModelFactory = (
                   },
                 },
                 {
-                  label: 'Base modifications (MM+MP/ML)',
+                  label: 'Modifications or methylation',
                   onClick: () => {
                     getSession(self).setDialogComponent(ModificationsDlg, {
                       model: self,
                     })
-                  },
-                },
-                {
-                  label: 'Methylation (specialized MM+MP/ML)',
-                  onClick: () => {
-                    self.setColorScheme({ type: 'methylation' })
                   },
                 },
                 {

--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -1,0 +1,58 @@
+import { BlockSet } from '@jbrowse/core/util/blockTypes'
+
+import { getSession } from '@jbrowse/core/util'
+import { getRpcSessionId } from '@jbrowse/core/util/tracks'
+
+export async function getUniqueTagValues(
+  self: any,
+  colorScheme: { type: string; tag?: string },
+  blocks: BlockSet,
+  opts?: {
+    headers?: Record<string, string>
+    signal?: AbortSignal
+    filters?: string[]
+  },
+) {
+  const { rpcManager } = getSession(self)
+  const { adapterConfig } = self
+  const sessionId = getRpcSessionId(self)
+  const values = await rpcManager.call(
+    getRpcSessionId(self),
+    'PileupGetGlobalValueForTag',
+    {
+      adapterConfig,
+      tag: colorScheme.tag,
+      sessionId,
+      regions: blocks.contentBlocks,
+      ...opts,
+    },
+  )
+  return values as string[]
+}
+
+export async function getUniqueModificationValues(
+  self: any,
+  colorScheme: { type: string; tag?: string },
+  blocks: BlockSet,
+  opts?: {
+    headers?: Record<string, string>
+    signal?: AbortSignal
+    filters?: string[]
+  },
+) {
+  const { rpcManager } = getSession(self)
+  const { adapterConfig } = self
+  const sessionId = getRpcSessionId(self)
+  const values = await rpcManager.call(
+    sessionId,
+    'PileupGetVisibleModifications',
+    {
+      adapterConfig,
+      tag: colorScheme.tag,
+      sessionId,
+      regions: blocks.contentBlocks,
+      ...opts,
+    },
+  )
+  return values as string[]
+}

--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -2,9 +2,11 @@ import { BlockSet } from '@jbrowse/core/util/blockTypes'
 
 import { getSession } from '@jbrowse/core/util'
 import { getRpcSessionId } from '@jbrowse/core/util/tracks'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
 export async function getUniqueTagValues(
-  self: any,
+  self: IAnyStateTreeNode & { adapterConfig: AnyConfigurationModel },
   colorScheme: { type: string; tag?: string },
   blocks: BlockSet,
   opts?: {
@@ -31,8 +33,8 @@ export async function getUniqueTagValues(
 }
 
 export async function getUniqueModificationValues(
-  self: any,
-  adapterConfig: any,
+  self: IAnyStateTreeNode,
+  adapterConfig: AnyConfigurationModel,
   colorScheme: { type: string; tag?: string },
   blocks: BlockSet,
   opts?: {

--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -32,6 +32,7 @@ export async function getUniqueTagValues(
 
 export async function getUniqueModificationValues(
   self: any,
+  adapterConfig: any,
   colorScheme: { type: string; tag?: string },
   blocks: BlockSet,
   opts?: {
@@ -41,7 +42,6 @@ export async function getUniqueModificationValues(
   },
 ) {
   const { rpcManager } = getSession(self)
-  const { adapterConfig } = self
   const sessionId = getRpcSessionId(self)
   const values = await rpcManager.call(
     sessionId,


### PR DESCRIPTION
This is a sort of tricky one where the SNPCoverage track, when colorBy modifications is turned on, draws with an uninitialized tag->color mapping

This could be a correctness issue as it could affect first-time rendering

Currently the Alignments track synchronizes the tag -> color mapping from the pileup to the snpcoverage display

One alternative would be to treat the snpcoverage track and pileup track is functionally independent, so they both do their own work to get the color mapping independently

This actually is extra work done, and could result in slowdown, as the getUniqueModifications RPC call is an extra pass through the data. We can count the number of passes through the data like this

So to draw a track, we get something like this

SNPCov - stats estimation
SNPCov - modification tag color mapping
SNPCov - draw pileup, 2-3 blocks, 2-3 passes
Pileup - modification tag color mapping
Pileup - 2-3 blocks=2-3 passes 
~7-9 passes through the data to draw the alignments track.

It could be nice if there was less passes through the data, and this PR technically only adds 1 extra pass to those that are already there.