### PR TITLE
Create v1.3.0.md, draft of release announcements

### DIFF
--- a/website/release_announcement_drafts/v1.3.0.md
+++ b/website/release_announcement_drafts/v1.3.0.md
@@ -7,7 +7,6 @@ Building on the plugin store on our website in the last release, we're now
 excited to announce that plugins can be installed from within JBrowse Web!
 Plugins from our plugin store can now be installed with the click of a button.
 
-![Screenshot of plugin store](https://user-images.githubusercontent.com/19295181/117894133-8dcc7480-b270-11eb-89fc-779be2e517a3.png)
 ![Screenshot of plugin store with MsaView plugin installed and open](https://user-images.githubusercontent.com/19295181/117894797-f9631180-b271-11eb-9c81-69c5aa6ae497.png)
 
 ## Open local files
@@ -21,8 +20,8 @@ will be available when we release JBrowse Desktop.
 ## Color by MM and MP/ML tags in BAM/CRAM
 
 The MM and MP/ML tags can be used to color alignments tracks by either base
-modifications or by methylation.
+modifications or by methylation. The modifications mode is exciting because it
+can show arbitrary DNA/RNA modifications, and the methylation mode uses
+specific CpG context to show both modified and unmodified CpGs.
 
-![Screenshot of alignments track colored by methylation](https://user-images.githubusercontent.com/25592344/119381778-83ea3e80-bc7e-11eb-861d-ca39645a9eb1.png)
-
-![Screenshot of alignments track colored by ase modifications](https://user-images.githubusercontent.com/25592344/119381366-6c12ba80-bc7e-11eb-960f-471bdec309d7.png)
+![Screenshot of alignments track colored by methylation](https://raw.githubusercontent.com/GMOD/jbrowse-components/7f0c725a929bb15a6adfcf3a155bf9dc5f717af7/website/static/img/alignments/modifications1.png)

--- a/website/release_announcement_drafts/v1.3.0.md
+++ b/website/release_announcement_drafts/v1.3.0.md
@@ -1,0 +1,1 @@
+We're excited to announce the v1.3.0 release of JBrowse Web!

--- a/website/release_announcement_drafts/v1.3.0.md
+++ b/website/release_announcement_drafts/v1.3.0.md
@@ -1,1 +1,28 @@
-We're excited to announce the v1.3.0 release of JBrowse Web!
+We're excited to announce the v1.3.0 release of JBrowse Web! Some highlights of
+this release include:
+
+## In-app plugin store
+
+Building on the plugin store on our website in the last release, we're now
+excited to announce that plugins can be installed from within JBrowse Web!
+Plugins from our plugin store can now be installed with the click of a button.
+
+![Screenshot of plugin store](https://user-images.githubusercontent.com/19295181/117894133-8dcc7480-b270-11eb-89fc-779be2e517a3.png)
+![Screenshot of plugin store with MsaView plugin installed and open](https://user-images.githubusercontent.com/19295181/117894797-f9631180-b271-11eb-9c81-69c5aa6ae497.png)
+
+## Open local files
+
+JBrowse Web now has the ability for tracks to use files on your local hard
+drive. This is a great option if you want to visualize files you have locally
+without uploading them to a server. These files will need to be re-opened each
+time the app is opened or refreshed, but more robust handling of local files
+will be available when we release JBrowse Desktop.
+
+## Color by MM and MP/ML tags in BAM/CRAM
+
+The MM and MP/ML tags can be used to color alignments tracks by either base
+modifications or by methylation.
+
+![Screenshot of alignments track colored by methylation](https://user-images.githubusercontent.com/25592344/119381778-83ea3e80-bc7e-11eb-861d-ca39645a9eb1.png)
+
+![Screenshot of alignments track colored by ase modifications](https://user-images.githubusercontent.com/25592344/119381366-6c12ba80-bc7e-11eb-960f-471bdec309d7.png)

--- a/website/release_announcement_drafts/v1.3.0.md
+++ b/website/release_announcement_drafts/v1.3.0.md
@@ -17,6 +17,8 @@ without uploading them to a server. These files will need to be re-opened each
 time the app is opened or refreshed, but more robust handling of local files
 will be available when we release JBrowse Desktop.
 
+![Screenshot of selector in URL and File states](https://user-images.githubusercontent.com/25592344/119403133-1d274e00-bc9b-11eb-832d-519f557b1d7d.png)
+
 ## Color by MM and MP/ML tags in BAM/CRAM
 
 The MM and MP/ML tags can be used to color alignments tracks by either base
@@ -24,4 +26,7 @@ modifications or by methylation. The modifications mode is exciting because it
 can show arbitrary DNA/RNA modifications, and the methylation mode uses
 specific CpG context to show both modified and unmodified CpGs.
 
-![Screenshot of alignments track colored by methylation](https://raw.githubusercontent.com/GMOD/jbrowse-components/7f0c725a929bb15a6adfcf3a155bf9dc5f717af7/website/static/img/alignments/modifications1.png)
+![Screenshot of alignments tracks colored by methylation and base modification](https://raw.githubusercontent.com/GMOD/jbrowse-components/7f0c725a929bb15a6adfcf3a155bf9dc5f717af7/website/static/img/alignments/modifications1.png)
+
+In this screenshot, the top alignments track is colored by methylation and the
+bottom alignments track is colored by base modification.

--- a/website/release_announcement_drafts/v1.3.0.md
+++ b/website/release_announcement_drafts/v1.3.0.md
@@ -17,7 +17,7 @@ without uploading them to a server. These files will need to be re-opened each
 time the app is opened or refreshed, but more robust handling of local files
 will be available when we release JBrowse Desktop.
 
-![Screenshot of selector in URL and File states](https://user-images.githubusercontent.com/25592344/119403133-1d274e00-bc9b-11eb-832d-519f557b1d7d.png)
+![Screenshot of selector in URL and File states](https://user-images.githubusercontent.com/25592344/119404009-6f1ca380-bc9c-11eb-8d77-d8706dfa1d90.png)
 
 ## Color by MM and MP/ML tags in BAM/CRAM
 


### PR DESCRIPTION
Here is the changelog so far:

#### :rocket: Enhancement

- Other
  - [#2001](https://github.com/GMOD/jbrowse-components/pull/2001) Make tracks added using the add track widget a session track if not in adminMode ([@cmdcolin](https://github.com/cmdcolin))
  - [#1980](https://github.com/GMOD/jbrowse-components/pull/1980) Add popup confirmation dialog for unknown session plugins, and use plugins.json as a whitelist ([@cmdcolin](https://github.com/cmdcolin))
  - [#1977](https://github.com/GMOD/jbrowse-components/pull/1977) Upgrade @material-ui/data-grid ([@cmdcolin](https://github.com/cmdcolin))
- `core`
  - [#1982](https://github.com/GMOD/jbrowse-components/pull/1982) Allow manually specifying adapter type if filename does not match expected pattern ([@cmdcolin](https://github.com/cmdcolin))
  - [#1975](https://github.com/GMOD/jbrowse-components/pull/1975) Allow local files on the users computer to be opened as tracks in jbrowse-web ([@cmdcolin](https://github.com/cmdcolin))
  - [#1865](https://github.com/GMOD/jbrowse-components/pull/1865) Show modified bases using MM and MP/ML tags in BAM/CRAM ([@cmdcolin](https://github.com/cmdcolin))
  - [#1984](https://github.com/GMOD/jbrowse-components/pull/1984) Better feature details when there are short arrays of json supplied as feature data ([@cmdcolin](https://github.com/cmdcolin))
  - [#1931](https://github.com/GMOD/jbrowse-components/pull/1931) Create in app graphical plugin store ([@elliothershberg](https://github.com/elliothershberg))

#### :bug: Bug Fix

- `core`
  - [#1954](https://github.com/GMOD/jbrowse-components/pull/1954) Add more environments to configSchema create calls to fix ability to use custom jexl commands with main thread rendering ([@cmdcolin](https://github.com/cmdcolin))
  - [#1963](https://github.com/GMOD/jbrowse-components/pull/1963) Fix ability to use DialogComponent (used for svg export, pileup sort, etc) on embedded components ([@cmdcolin](https://github.com/cmdcolin))
  - [#1945](https://github.com/GMOD/jbrowse-components/pull/1945) Fix hic not being able to render due to incorrect lazy loading ([@cmdcolin](https://github.com/cmdcolin))
- Other
  - [#1956](https://github.com/GMOD/jbrowse-components/pull/1956) Fix connection behavior ([@garrettjstevens](https://github.com/garrettjstevens))
  - [#1966](https://github.com/GMOD/jbrowse-components/pull/1966) Fix ability to use add-track force on symlink tracks ([@cmdcolin](https://github.com/cmdcolin))
  - [#1951](https://github.com/GMOD/jbrowse-components/pull/1951) Fix breakpoint split view demo configuration on website ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation

- [#1976](https://github.com/GMOD/jbrowse-components/pull/1976) reorganize the demo page to emphasize the cancer sv demo more ([@rbuels](https://github.com/rbuels))
- [#1952](https://github.com/GMOD/jbrowse-components/pull/1952) Add demo for 1000 genomes extended trio dataset to website ([@cmdcolin](https://github.com/cmdcolin))
- [#1862](https://github.com/GMOD/jbrowse-components/pull/1862) Add example for using a build-time included plugin to storybook ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal

- `core`, `development-tools`
  - [#1930](https://github.com/GMOD/jbrowse-components/pull/1930) Upgrade react scripts+react to latest versions ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 4

- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Elliot Hershberg ([@elliothershberg](https://github.com/elliothershberg))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
- Robert Buels ([@rbuels](https://github.com/rbuels))
