### PR TITLE
Proposal: Make FileSelector default to URL instead of File

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -44,7 +44,7 @@ const FileLocationEditor = observer(
     description?: string
   }) => {
     const { location, name, description } = props
-    const fileOrUrl = location && isUriLocation(location) ? 'url' : 'file'
+    const fileOrUrl = !location || isUriLocation(location) ? 'url' : 'file'
     const [fileOrUrlState, setFileOrUrlState] = useState(fileOrUrl)
 
     return (

--- a/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
+++ b/plugins/data-management/src/AddTrackWidget/components/__snapshots__/AddTrackWidget.test.js.snap
@@ -87,8 +87,8 @@ exports[`<AddTrackWidget /> renders 1`] = `
                       >
                         <button
                           aria-label="local file"
-                          aria-pressed="true"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
+                          aria-pressed="false"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
                           tabindex="0"
                           type="button"
                           value="file"
@@ -104,8 +104,8 @@ exports[`<AddTrackWidget /> renders 1`] = `
                         </button>
                         <button
                           aria-label="url"
-                          aria-pressed="false"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
+                          aria-pressed="true"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
                           tabindex="0"
                           type="button"
                           value="url"
@@ -125,27 +125,19 @@ exports[`<AddTrackWidget /> renders 1`] = `
                       class="MuiGrid-root MuiGrid-item"
                     >
                       <div
-                        style="position: relative;"
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                       >
-                        <label
-                          aria-disabled="false"
-                          class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
-                          role="button"
-                          tabindex="0"
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                         >
-                          <span
-                            class="MuiButton-label"
-                          >
-                            Choose File
-                            <input
-                              style="position: absolute; top: 0px; left: 0px; width: 100%; opacity: 0;"
-                              type="file"
-                            />
-                          </span>
-                          <span
-                            class="MuiTouchRipple-root"
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input"
+                            data-testid="urlInput"
+                            type="text"
+                            value=""
                           />
-                        </label>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -172,8 +164,8 @@ exports[`<AddTrackWidget /> renders 1`] = `
                       >
                         <button
                           aria-label="local file"
-                          aria-pressed="true"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
+                          aria-pressed="false"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
                           tabindex="0"
                           type="button"
                           value="file"
@@ -189,8 +181,8 @@ exports[`<AddTrackWidget /> renders 1`] = `
                         </button>
                         <button
                           aria-label="url"
-                          aria-pressed="false"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
+                          aria-pressed="true"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
                           tabindex="0"
                           type="button"
                           value="url"
@@ -210,27 +202,19 @@ exports[`<AddTrackWidget /> renders 1`] = `
                       class="MuiGrid-root MuiGrid-item"
                     >
                       <div
-                        style="position: relative;"
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                       >
-                        <label
-                          aria-disabled="false"
-                          class="MuiButtonBase-root MuiButton-root MuiButton-outlined"
-                          role="button"
-                          tabindex="0"
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                         >
-                          <span
-                            class="MuiButton-label"
-                          >
-                            Choose File
-                            <input
-                              style="position: absolute; top: 0px; left: 0px; width: 100%; opacity: 0;"
-                              type="file"
-                            />
-                          </span>
-                          <span
-                            class="MuiTouchRipple-root"
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input"
+                            data-testid="urlInput"
+                            type="text"
+                            value=""
                           />
-                        </label>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/products/jbrowse-web/src/tests/1.Spreadsheet.test.js
+++ b/products/jbrowse-web/src/tests/1.Spreadsheet.test.js
@@ -43,7 +43,6 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
   fireEvent.click(await findByText('Spreadsheet view'))
 
   await findByTestId('spreadsheet_view_open')
-  fireEvent.click(await findByText('URL'))
   fireEvent.change(await findByTestId('urlInput'), {
     target: { value: 'volvox.filtered.vcf.gz' },
   })
@@ -67,7 +66,6 @@ test('opens a bed.gz file in the spreadsheet view', async () => {
   fireEvent.click(await findByText('Spreadsheet view'))
 
   await findByTestId('spreadsheet_view_open')
-  fireEvent.click(await findByText('URL'))
   fireEvent.change(await findByTestId('urlInput'), {
     target: { value: 'volvox-bed12.bed.gz' },
   })

--- a/products/jbrowse-web/src/tests/2.SVInspector.test.js
+++ b/products/jbrowse-web/src/tests/2.SVInspector.test.js
@@ -46,7 +46,6 @@ test('opens a vcf.gz file in the sv inspector view', async () => {
   fireEvent.click(await findByText('Add'))
   fireEvent.click(await findByText('SV inspector'))
 
-  fireEvent.click(await findByText('URL'))
   fireEvent.change(await findByTestId('urlInput'), {
     target: { value: 'volvox.dup.renamed.vcf.gz' },
   })


### PR DESCRIPTION
This changes the default of the FileSelector component so that if it's not provided a location, it defaults to prompting for a URL instead of a local file. I think this is the more common use case, especially for JBrowse Web, and so would hopefully save users clicks (and possibly avoid some confusion).