### PR TITLE
Post-v1.3.0 release updates

### DIFF
--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Install deps

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,6 +20,8 @@ NPMUSER=$(npm whoami)
 [[ -n "$NPMUSER" ]] || { echo "No NPM user detected, please run 'npm adduser'" && exit 1; }
 MAINUPDATED=$(git rev-list --left-only --count origin/main...main)
 [[ "$MAINUPDATED" != 0 ]] && { echo "main is not up to date with origin/main. Please fetch and try again" && exit 1; }
+LOCAL_CHANGES=$(git status --short)
+[[ "$LOCAL_CHANGES" != "" ]] && { echo "Please discard or stash changes and try again." && exit 1; }
 
 # make sure packages are all up to date
 yarn


### PR DESCRIPTION
A couple updates to help make future releases smoother.

- Use node 12 on the CI job that builds JBrowse Web, since our dependencies don't support node 10 anymore
- Make sure the user doesn't have any local file changes when running the release script