### PR TITLE
Move ThemeProvider inside React JBrowseLinearGenomeView

### DIFF
--- a/products/jbrowse-react-linear-genome-view/README.md
+++ b/products/jbrowse-react-linear-genome-view/README.md
@@ -13,12 +13,8 @@ import React from 'react'
 import 'fontsource-roboto'
 import {
   createViewState,
-  createJBrowseTheme,
   JBrowseLinearGenomeView,
-  ThemeProvider,
 } from '@jbrowse/react-linear-genome-view'
-
-const theme = createJBrowseTheme()
 
 function View() {
   const state = createViewState({
@@ -29,11 +25,7 @@ function View() {
       /* tracks */
     ],
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 ```
 

--- a/products/jbrowse-react-linear-genome-view/docs/example.md
+++ b/products/jbrowse-react-linear-genome-view/docs/example.md
@@ -7,12 +7,8 @@ import React from 'react'
 import 'fontsource-roboto'
 import {
   createViewState,
-  createJBrowseTheme,
   JBrowseLinearGenomeView,
-  ThemeProvider,
 } from '@jbrowse/react-linear-genome-view'
-
-const theme = createJBrowseTheme()
 
 const assembly = {
   name: 'GRCh38',
@@ -108,11 +104,7 @@ function View() {
     location: '10:29,838,737..29,838,819',
     defaultSession,
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export default View

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
@@ -1,10 +1,12 @@
 import React, { Suspense } from 'react'
 import { observer } from 'mobx-react'
 import { getEnv } from 'mobx-state-tree'
-import { makeStyles } from '@material-ui/core'
-import { SessionModel } from '../createModel/createSessionModel'
+import { readConfObject } from '@jbrowse/core/configuration'
+import { createJBrowseTheme } from '@jbrowse/core/ui'
+import { makeStyles, ThemeProvider } from '@material-ui/core'
 import ModalWidget from './ModalWidget'
 import ViewContainer from './ViewContainer'
+import { ViewModel } from '../createModel/createModel'
 
 const useStyles = makeStyles(() => ({
   // avoid parent styles getting into this div
@@ -15,7 +17,7 @@ const useStyles = makeStyles(() => ({
 }))
 
 const JBrowseLinearGenomeView = observer(
-  ({ viewState }: { viewState: { session: SessionModel } }) => {
+  ({ viewState }: { viewState: ViewModel }) => {
     const classes = useStyles()
     const { session } = viewState
     const { view } = session
@@ -24,16 +26,21 @@ const JBrowseLinearGenomeView = observer(
       throw new Error(`unknown view type ${view.type}`)
     }
     const { ReactComponent } = viewType
+    const theme = createJBrowseTheme(
+      readConfObject(viewState.config.configuration, 'theme'),
+    )
 
     return (
-      <div className={classes.avoidParentStyle}>
-        <ViewContainer key={`view-${view.id}`} view={view}>
-          <Suspense fallback={<div>Loading...</div>}>
-            <ReactComponent model={view} session={session} />
-          </Suspense>
-        </ViewContainer>
-        <ModalWidget session={session} />
-      </div>
+      <ThemeProvider theme={theme}>
+        <div className={classes.avoidParentStyle}>
+          <ViewContainer key={`view-${view.id}`} view={view}>
+            <Suspense fallback={<div>Loading...</div>}>
+              <ReactComponent model={view} session={session} />
+            </Suspense>
+          </ViewContainer>
+          <ModalWidget session={session} />
+        </div>
+      </ThemeProvider>
     )
   },
 )

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
 >
   <div
     class="MuiPaper-root makeStyles-viewContainer MuiPaper-elevation12 MuiPaper-rounded"
-    style="padding: 0px 8px 8px;"
+    style="padding: 0px 4px 4px;"
   >
     <div
       style="display: flex;"
@@ -15,7 +15,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
         aria-controls="view-menu"
         aria-haspopup="true"
         aria-label="more"
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconRoot MuiIconButton-edgeStart"
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-iconRoot MuiIconButton-sizeSmall MuiIconButton-edgeStart"
         data-testid="view_menu_icon"
         tabindex="0"
         type="button"
@@ -25,7 +25,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root makeStyles-icon"
+            class="MuiSvgIcon-root makeStyles-icon MuiSvgIcon-fontSizeSmall"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -161,16 +161,16 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               width="100%"
             >
               <polygon
-                fill="rgba(121, 134, 203, 0.3)"
+                fill="rgba(66, 119, 127, 0.3)"
                 points="0,48,801,48,267,0,0,0"
-                stroke="rgba(121, 134, 203, 0.8)"
+                stroke="rgba(66, 119, 127, 0.8)"
               />
             </svg>
             <div
               class="makeStyles-headerBar"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-toggleButton MuiButton-textSecondary"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text makeStyles-toggleButton MuiButton-textSecondary MuiButton-textSizeSmall MuiButton-sizeSmall"
                 tabindex="0"
                 title="Open track selector"
                 type="button"
@@ -181,7 +181,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root makeStyles-buttonSpacer"
+                    class="MuiSvgIcon-root makeStyles-buttonSpacer MuiSvgIcon-fontSizeSmall"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -201,7 +201,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="MuiFormGroup-root makeStyles-headerForm MuiFormGroup-row"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
                   tabindex="0"
                   type="button"
                 >
@@ -210,7 +210,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
@@ -224,7 +224,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   />
                 </button>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-panButton MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
                   tabindex="0"
                   type="button"
                 >
@@ -233,7 +233,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
@@ -253,11 +253,11 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   role="combobox"
                 >
                   <div
-                    class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
+                    class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-marginDense MuiFormControl-fullWidth"
                     style="margin: 7px; min-width: 175px;"
                   >
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
                       style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
                     >
                       <input
@@ -265,7 +265,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         aria-invalid="false"
                         autocapitalize="none"
                         autocomplete="off"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                        class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
                         id="refNameAutocomplete-test_view"
                         placeholder="Search for location"
                         spellcheck="false"
@@ -273,12 +273,12 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         value="ctgA:1..40"
                       />
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-marginDense"
                         style="margin-right: 7px;"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                           focusable="false"
                           viewBox="0 0 24 24"
                         >
@@ -317,7 +317,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="makeStyles-container"
               >
                 <button
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
                   data-testid="zoom_out"
                   tabindex="0"
                   type="button"
@@ -327,7 +327,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
@@ -367,7 +367,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   />
                 </span>
                 <button
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
                   data-testid="zoom_in"
                   tabindex="0"
                   type="button"
@@ -377,7 +377,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
@@ -751,7 +751,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-dragHandleIcon"
+                  class="MuiSvgIcon-root makeStyles-dragHandleIcon MuiSvgIcon-fontSizeSmall"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -761,7 +761,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 </svg>
               </span>
               <button
-                class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary"
+                class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
                 tabindex="0"
                 title="close this track"
                 type="button"
@@ -771,7 +771,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
@@ -792,7 +792,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               <button
                 aria-controls="simple-menu"
                 aria-haspopup="true"
-                class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary"
+                class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
                 data-testid="track_menu_icon"
                 tabindex="0"
                 type="button"
@@ -802,7 +802,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createConfigModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createConfigModel.ts
@@ -18,6 +18,7 @@ export default function createConfigModel(
           type: 'number',
           defaultValue: 2,
         },
+        theme: { type: 'frozen', defaultValue: {} },
       }),
       assembly: assemblyConfigSchemasType,
       tracks: types.array(pluginManager.pluggableConfigSchemaType('track')),

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createModel.ts
@@ -4,7 +4,7 @@ import assemblyManagerFactory, {
 import { PluginConstructor } from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'
-import { cast, getSnapshot, SnapshotIn, types } from 'mobx-state-tree'
+import { cast, getSnapshot, Instance, SnapshotIn, types } from 'mobx-state-tree'
 import corePlugins from '../corePlugins'
 import createConfigModel from './createConfigModel'
 import createSessionModel from './createSessionModel'
@@ -60,3 +60,6 @@ export default function createModel(runtimePlugins: PluginConstructor[]) {
     }))
   return { model: rootModel, pluginManager }
 }
+
+export type ViewStateModel = ReturnType<typeof createModel>['model']
+export type ViewModel = Instance<ViewStateModel>

--- a/products/jbrowse-react-linear-genome-view/src/deprecations.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/deprecations.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from 'react'
+import { createJBrowseTheme as coreCreateJBrowseTheme } from '@jbrowse/core/ui'
+import { Theme, ThemeOptions } from '@material-ui/core/styles'
+
+export function createJBrowseTheme(theme?: ThemeOptions) {
+  console.warn(
+    'Deprecation warning: `createJBrowseTheme` will be removed in a future ' +
+      'release. It can be imported from @jbrowse/core/ui if needed.',
+  )
+  return coreCreateJBrowseTheme(theme)
+}
+
+export function ThemeProvider({
+  theme,
+  children,
+}: {
+  theme: Theme
+  children: ReactNode
+}) {
+  console.warn(
+    'Deprecation warning: `ThemeProvider` is no longer supported as a way to ' +
+      'theme @jbrowse/react-linear-genome-view. If using a custom theme, ' +
+      'please pass the theme in to the "configuration" of `createViewState` ' +
+      'instead.',
+  )
+  return <>{children}</>
+}

--- a/products/jbrowse-react-linear-genome-view/src/index.ts
+++ b/products/jbrowse-react-linear-genome-view/src/index.ts
@@ -1,5 +1,3 @@
-export { createJBrowseTheme } from '@jbrowse/core/ui'
-export { ThemeProvider } from '@material-ui/core/styles'
 export { default as JBrowseLinearGenomeView } from './JBrowseLinearGenomeView'
 export { default as createModel } from './createModel'
 export { default as createViewState } from './createViewState'

--- a/products/jbrowse-react-linear-genome-view/src/index.ts
+++ b/products/jbrowse-react-linear-genome-view/src/index.ts
@@ -1,3 +1,4 @@
+export { createJBrowseTheme, ThemeProvider } from './deprecations'
 export { default as JBrowseLinearGenomeView } from './JBrowseLinearGenomeView'
 export { default as createModel } from './createModel'
 export { default as createViewState } from './createViewState'

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,16 +1,8 @@
 import { PluginRecord } from '@jbrowse/core/PluginLoader'
 import React, { useEffect, useState } from 'react'
-import {
-  createViewState,
-  createJBrowseTheme,
-  JBrowseLinearGenomeView,
-  loadPlugins,
-  ThemeProvider,
-} from '../src'
+import { createViewState, JBrowseLinearGenomeView, loadPlugins } from '../src'
 import volvoxConfig from '../public/test_data/volvox/config.json'
 import volvoxSession from '../public/volvox-session.json'
-
-const theme = createJBrowseTheme()
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addRelativeUris(config: any, baseUri: string) {
@@ -66,11 +58,7 @@ export const OneLinearGenomeView = () => {
       console.log('patch', patch)
     },
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export const OneLinearGenomeViewUsingLocObject = () => {
@@ -86,11 +74,7 @@ export const OneLinearGenomeViewUsingLocObject = () => {
       console.log('patch', patch)
     },
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export const LinearViewWithLongReads = () => {
@@ -105,11 +89,7 @@ export const LinearViewWithLongReads = () => {
     },
   })
 
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export const OneLinearGenomeViewWithOutsideStyling = () => {
@@ -127,9 +107,7 @@ export const OneLinearGenomeViewWithOutsideStyling = () => {
   return (
     <div style={{ textAlign: 'center', fontFamily: 'monospace' }}>
       <h2>Hello world, this is centered but not affecting the internal LGV</h2>
-      <ThemeProvider theme={theme}>
-        <JBrowseLinearGenomeView viewState={state} />
-      </ThemeProvider>
+      <JBrowseLinearGenomeView viewState={state} />
     </div>
   )
 }
@@ -151,10 +129,10 @@ export const TwoLinearGenomeViews = () => {
     location: 'ctgA:5560..30589',
   })
   return (
-    <ThemeProvider theme={theme}>
+    <>
       <JBrowseLinearGenomeView viewState={state1} />
       <JBrowseLinearGenomeView viewState={state2} />
-    </ThemeProvider>
+    </>
   )
 }
 
@@ -267,11 +245,62 @@ export const WithPlugins = () => {
       },
     },
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
+}
+
+export const CustomTheme = () => {
+  const state = createViewState({
+    assembly,
+    tracks,
+    defaultSession: {
+      ...defaultSession,
+      view: {
+        ...defaultSession.view,
+        bpPerPx: 0.1,
+        offsetPx: 10000,
+        tracks: [
+          {
+            id: 'q3UA86xQA',
+            type: 'ReferenceSequenceTrack',
+            configuration: 'volvox_refseq',
+            displays: [
+              {
+                id: '6JCCxQScPJ',
+                type: 'LinearReferenceSequenceDisplay',
+                configuration: 'volvox_refseq-LinearReferenceSequenceDisplay',
+                height: 210,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    configuration: {
+      theme: {
+        palette: {
+          primary: {
+            main: '#311b92',
+          },
+          secondary: {
+            main: '#0097a7',
+          },
+          tertiary: {
+            main: '#f57c00',
+          },
+          quaternary: {
+            main: '#d50000',
+          },
+          bases: {
+            A: { main: '#98FB98' },
+            C: { main: '#87CEEB' },
+            G: { main: '#DAA520' },
+            T: { main: '#DC143C' },
+          },
+        },
+      },
+    },
+  })
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 const JBrowseLinearGenomeViewStories = {

--- a/products/jbrowse-react-linear-genome-view/stories/NextJsUsage.stories.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/NextJsUsage.stories.mdx
@@ -50,11 +50,7 @@ Here is an example of how to dynamically load a component using the JB2 componen
 import {
   createViewState,
   createJBrowseTheme,
-  JBrowseLinearGenomeView,
-  ThemeProvider,
 } from '@jbrowse/react-linear-genome-view'
-
-const theme = createJBrowseTheme()
 
 const assembly = {
   // configuration
@@ -75,11 +71,7 @@ function View() {
     location: '10:29,838,737..29,838,819',
     defaultSession,
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export default View

--- a/products/jbrowse-react-linear-genome-view/stories/NextstrainGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/NextstrainGenomeView.stories.tsx
@@ -1,22 +1,6 @@
 import React from 'react'
-import {
-  createViewState,
-  createJBrowseTheme,
-  JBrowseLinearGenomeView,
-  ThemeProvider,
-} from '../src'
+import { createViewState, JBrowseLinearGenomeView } from '../src'
 import nextstrainConfig from '../public/nextstrain_covid.json'
-
-const theme = createJBrowseTheme({
-  palette: {
-    primary: {
-      main: '#5da8a3',
-    },
-    secondary: {
-      main: '#333',
-    },
-  },
-})
 
 const { assembly } = nextstrainConfig
 const { tracks } = nextstrainConfig
@@ -32,12 +16,20 @@ export const NextstrainGenomeView = () => {
       // eslint-disable-next-line no-console
       console.log('patch', patch)
     },
+    configuration: {
+      theme: {
+        palette: {
+          primary: {
+            main: '#5da8a3',
+          },
+          secondary: {
+            main: '#333',
+          },
+        },
+      },
+    },
   })
-  return (
-    <ThemeProvider theme={theme}>
-      <JBrowseLinearGenomeView viewState={state} />
-    </ThemeProvider>
-  )
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 const NextstrainStory = {


### PR DESCRIPTION
I realized that #2014 would probably be a problem when thinking about #1996. This is because the theme has to be in the configuration so that it can be passed through in the RPC render, but the React LGV didn't have a slot for the theme in the configuration. The first commit in this PR adds that slot.

The problem then, though, is that users would have to put the theme both in the ThemeProvider and in the configuration for it to work. This PR proposes moving the ThemeProvider inside the ReactLGV, so that users no longer have to worry about it in their code. Theming will still be available, but via the configuration instead.

As an example:

Before
```js
const theme = {
  palette: {
    primary: { main: '#311b92' },
    bases: { A: { main: '#98FB98' } },
  },
}
function View() {
  const state = createViewState({
    assembly: { /* assembly */ },
    tracks: [ /* tracks */ ],
    configuration: { theme }
  })
  return (
    <ThemeProvider theme={createJBrowseTheme(theme)}>
      <JBrowseLinearGenomeView viewState={state} />
    </ThemeProvider>
  )
}
```

After
```js
const theme = {
  palette: {
    primary: { main: '#311b92' },
    bases: { A: { main: '#98FB98' } },
  },
}
function View() {
  const state = createViewState({
    assembly: { /* assembly */ },
    tracks: [ /* tracks */ ],
    configuration: { theme }
  })
  return <JBrowseLinearGenomeView viewState={state} />
}
```

Fixes #2014