### PR TITLE
Update peerDependencies for react-linear-genome-view to help npm install peer deps warnings

### DIFF
--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -58,7 +58,7 @@
     "rxjs": "^6.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Small contribution to try to fix warnings about peer dependencies from npm installing our @jbrowse/react-linear-genome-view

Uses greater than react 16.8.0  instead of just the 16 version range

