### PR TITLE
Fix infinite loop in adding some plugins on desktop

### DIFF
--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -52,8 +52,10 @@ export default function RootModel(pluginManager: PluginManager) {
       savedSessionNames: types.maybe(types.array(types.string)),
       version: types.maybe(types.string),
       isAssemblyEditing: false,
-      pluginsUpdated: true,
     })
+    .volatile(() => ({
+      pluginsUpdated: false,
+    }))
     .actions(self => ({
       setSavedSessionNames(sessionNames: string[]) {
         self.savedSessionNames = cast(sessionNames)

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -120,9 +120,9 @@ export default function RootModel(
       version: types.maybe(types.string),
       isAssemblyEditing: false,
       isDefaultSessionEditing: false,
-      pluginsUpdated: false,
     })
     .volatile(self => ({
+      pluginsUpdated: false,
       rpcManager: new RpcManager(
         pluginManager,
         self.jbrowse.configuration.rpc,


### PR DESCRIPTION
Currently adding some plugins using the plugin store on desktop can run into an error of infinite looping. The CIVIC plugin is an example of this

I don't actually know what the reason was but I tried a couple small rearrangements to try to fix it, which appeared to work

a) making the pluginsUpdated a volatile
b) separate the code that does the window reload out into it's own little useeffect instead of getting debounced

