### PR TITLE
Add simple plugin with no build step

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -38,9 +38,9 @@ export default class PluginLoader {
     this.definitions = JSON.parse(JSON.stringify(pluginDefinitions))
   }
 
-  loadScript(scriptUrl: string): Promise<void> {
+  loadScript(scriptUrl: string, args: any): Promise<void> {
     if (document && document.getElementsByTagName) {
-      return domLoadScript(scriptUrl)
+      return domLoadScript(scriptUrl, args)
     }
     // @ts-ignore
     if (self && self.importScripts) {
@@ -67,7 +67,7 @@ export default class PluginLoader {
       parsedUrl.protocol === 'http:' ||
       parsedUrl.protocol === 'https:'
     ) {
-      await this.loadScript(definition.url)
+      await this.loadScript(definition.url, { type: 'module' })
       const moduleName = definition.name
       const umdName = `JBrowsePlugin${moduleName}`
       // Based on window-or-global
@@ -84,7 +84,7 @@ export default class PluginLoader {
         )
       }
 
-      return plugin.default
+      return plugin.default || plugin
     }
     throw new Error(
       `cannot load plugins using protocol "${parsedUrl.protocol}"`,

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -210,8 +210,10 @@ export default class PluginManager {
     if (this.configured) {
       throw new Error('JBrowse already configured, cannot add plugins')
     }
-    const [plugin, metadata = {}] =
-      load instanceof Plugin ? [load, {}] : [load.plugin, load.metadata]
+
+    const [plugin, metadata = {}] = load.plugin
+      ? [load.plugin, load.metadata]
+      : [load, {}]
 
     if (this.plugins.includes(plugin)) {
       throw new Error('plugin already installed')

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -220,7 +220,7 @@ const SessionLoader = types
         const pluginLoader = new PluginLoader(config.plugins)
         pluginLoader.installGlobalReExports(window)
         const runtimePlugins = await pluginLoader.load()
-        self.setRuntimePlugins([...runtimePlugins])
+        self.setRuntimePlugins(runtimePlugins)
       } catch (e) {
         console.error(e)
         self.setConfigError(e)

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -12,6 +12,10 @@
     {
       "name": "UCSC",
       "url": "https://unpkg.com/jbrowse-plugin-ucsc@^1/dist/jbrowse-plugin-ucsc.umd.production.min.js"
+    },
+    {
+      "name": "Sample",
+      "url": "test_data/sample_plugin.js"
     }
   ],
   "assemblies": [

--- a/test_data/sample_plugin.js
+++ b/test_data/sample_plugin.js
@@ -1,0 +1,8 @@
+class MyTinyPlugin {
+  install() {}
+  configure(pluginManager) {}
+}
+
+window.JBrowsePluginSample = MyTinyPlugin
+
+export default MyTinyPlugin


### PR DESCRIPTION
This is a possible example of a sample plugin that has zero compilation, uses loadScript with type="module"

This doesn't test that it works on the webworker, but it could be used for adding jexl functions for use in config callbacks

Xref #2033