### PR TITLE
Add missing BoxRendererType exports

### DIFF
--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -62,7 +62,7 @@ import WidgetType from '../pluggableElementTypes/WidgetType'
 import * as pluggableElementTypeModels from '../pluggableElementTypes/models'
 import ServerSideRendererType from '../pluggableElementTypes/renderers/ServerSideRendererType'
 import CircularChordRendererType from '../pluggableElementTypes/renderers/CircularChordRendererType'
-import BoxRendererType from '../pluggableElementTypes/renderers/BoxRendererType'
+import * as BoxRendererType from '../pluggableElementTypes/renderers/BoxRendererType'
 
 import * as Configuration from '../configuration'
 import Plugin from '../Plugin'

--- a/packages/core/pluggableElementTypes/renderers/BoxRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/BoxRendererType.ts
@@ -118,7 +118,7 @@ export interface ResultsDeserialized extends FeatureResultsDeserialized {
   layout: PrecomputedLayout<string>
 }
 
-export default class BoxRendererType extends FeatureRendererType {
+export class BoxRendererType extends FeatureRendererType {
   sessions: { [sessionId: string]: LayoutSession } = {}
 
   getWorkerSession(props: LayoutSessionProps & { sessionId: string }) {

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/configSchema.test.js
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/configSchema.test.js
@@ -1,7 +1,7 @@
 import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
-import BoxRendererType from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
+import { BoxRendererType } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import {
   svgFeatureRendererConfigSchema,
   SvgFeatureRendererReactComponent,

--- a/plugins/alignments/src/LinearPileupDisplay/configSchema.test.js
+++ b/plugins/alignments/src/LinearPileupDisplay/configSchema.test.js
@@ -1,6 +1,6 @@
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
-import BoxRendererType from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
+import { BoxRendererType } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import {
   svgFeatureRendererConfigSchema,
   SvgFeatureRendererReactComponent,

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -1,6 +1,7 @@
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import { toArray } from 'rxjs/operators'
-import BoxRendererType, {
+import {
+  BoxRendererType,
   RenderArgs,
   RenderArgsSerialized,
   RenderArgsDeserialized as BoxRenderArgsDeserialized,

--- a/plugins/lollipop/src/LollipopRenderer/LollipopRenderer.js
+++ b/plugins/lollipop/src/LollipopRenderer/LollipopRenderer.js
@@ -1,4 +1,5 @@
-import BoxRendererType, {
+import {
+  BoxRendererType,
   LayoutSession,
 } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import MultiLayout from '@jbrowse/core/util/layouts/MultiLayout'

--- a/plugins/svg/src/index.ts
+++ b/plugins/svg/src/index.ts
@@ -1,4 +1,4 @@
-import BoxRendererType from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
+import { BoxRendererType } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import {

--- a/plugins/variants/src/LinearVariantDisplay/configSchema.test.js
+++ b/plugins/variants/src/LinearVariantDisplay/configSchema.test.js
@@ -1,4 +1,4 @@
-import BoxRendererType from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
+import { BoxRendererType } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import PileupRenderer, {


### PR DESCRIPTION
Discussion https://github.com/GMOD/jbrowse-components/discussions/2042 helped me realize that we have some things missing in our re-exports in core. In this case, BoxRendererType was the default export in `packages/core/pluggableElementTypes/renderers/BoxRendererType.ts`, and in `packages/core/ReExports/modules.ts` it did:

```ts
// other imports...
import BoxRendererType from '../pluggableElementTypes/renderers/BoxRendererType'
// other imports...

const libs = {
  // other libs...
 '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType': BoxRendererType,
  // other libs
}

// other stuff
```

That meant that the named exports in BoxRendererType.ts didn't get added to `libs`. I don't think there's a way to add both named and default exports to a single entry in `libs`, so this PR changes BoxRendererType to a named export and then re-exports everything from that file.

There could be other things missing in the same way, though. I'm wondering if there's a way to be more methodical about our re-exports to make sure we don't miss things. Or, we could ban default exports in core (like with a [lint rule](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-default-export.md)) to be sure this doesn't happen.