### PR TITLE
Configurable app logo for web

### DIFF
--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -9,6 +9,7 @@ import EditableTypography from './EditableTypography'
 import { LogoFull } from './Logo'
 import Snackbar from './Snackbar'
 import ViewContainer from './ViewContainer'
+import { readConfObject } from '../configuration'
 
 const useStyles = makeStyles(theme => ({
   '@global': {
@@ -89,7 +90,17 @@ const App = observer(({ session, HeaderButtons }) => {
     name,
     menus,
     views,
+    configuration,
   } = session
+
+  function renderLogo() {
+    const logoPath = readConfObject(configuration, 'logoPath')
+    if (logoPath.uri === '') {
+      return <LogoFull variant="white" />
+    } else {
+      return <img src={logoPath.uri} alt="Custom logo" />
+    }
+  }
 
   function handleNameChange(newName) {
     if (savedSessionNames && savedSessionNames.includes(newName)) {
@@ -101,6 +112,7 @@ const App = observer(({ session, HeaderButtons }) => {
       session.renameCurrentSession(newName)
     }
   }
+
   return (
     <div
       className={classes.root}
@@ -145,9 +157,7 @@ const App = observer(({ session, HeaderButtons }) => {
               </Tooltip>
               {HeaderButtons}
               <div className={classes.grow} />
-              <div style={{ width: 150, maxHeight: 48 }}>
-                <LogoFull variant="white" />
-              </div>
+              <div style={{ width: 150, maxHeight: 48 }}>{renderLogo()}</div>
             </Toolbar>
           </AppBar>
         </div>

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -45,6 +45,10 @@ export default function JBrowseWeb(
           defaultValue: false,
         },
         theme: { type: 'frozen', defaultValue: {} },
+        logoPath: {
+          type: 'fileLocation',
+          defaultValue: { uri: '' },
+        },
         ...pluginManager.pluginConfigurationSchemas(),
       }),
       plugins: types.array(types.frozen()),

--- a/test_data/test_custom_logo.svg
+++ b/test_data/test_custom_logo.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="150px" height="48px" viewBox="0 0 150 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>jb-logo</title>
+    <g id="jb-logo" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect fill="#FFFFFF" x="0" y="0" width="150" height="48"></rect>
+        <text id="LOLTEST" font-family="Roboto-Regular, Roboto" font-size="34" font-weight="normal" fill="#000000">
+            <tspan x="8" y="36">LOLTEST</tspan>
+        </text>
+    </g>
+</svg>

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -1087,6 +1087,24 @@ The customized theme screenshot uses the below configuration
   }
 ```
 
+### Logo
+
+It is also possible to supply a custom logo to be displayed in the top right
+corner of the app instead of the JBrowse 2 logo. To do this, store a SVG file
+containing your logo on your server, and specify the path in your configuration:
+
+```json
+{
+  "configuration": {
+    "logoPath": {
+      "uri": "path/to/my/custom-logo.svg"
+    }
+  }
+}
+```
+
+The dimensions of the logo should be `150x48px`.
+
 ### Sizing
 
 You can also change some sizing options by specifying the "typography" (to


### PR DESCRIPTION
This is a small PR that adds a config slot to jbrowse-web for providing a custom logo. This should help with model organism communities who want to customize their app.

A quick way to test is to toss this config in `config.json`

```json
"configuration": {
  "logoPath": {
    "uri": "/test_data/jb-logo.svg"
  }
}
```