### PR TITLE
Add logoPath on jbrowse-desktop to fix crash

### DIFF
--- a/packages/core/ui/App.js
+++ b/packages/core/ui/App.js
@@ -78,6 +78,16 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+const Logo = observer(({ session }) => {
+  const { configuration } = session
+  const logoPath = readConfObject(configuration, 'logoPath')
+  if (!logoPath?.uri) {
+    return <LogoFull variant="white" />
+  } else {
+    return <img src={logoPath.uri} alt="Custom logo" />
+  }
+})
+
 const App = observer(({ session, HeaderButtons }) => {
   const classes = useStyles()
   const { pluginManager } = getEnv(session)
@@ -90,17 +100,7 @@ const App = observer(({ session, HeaderButtons }) => {
     name,
     menus,
     views,
-    configuration,
   } = session
-
-  function renderLogo() {
-    const logoPath = readConfObject(configuration, 'logoPath')
-    if (logoPath.uri === '') {
-      return <LogoFull variant="white" />
-    } else {
-      return <img src={logoPath.uri} alt="Custom logo" />
-    }
-  }
 
   function handleNameChange(newName) {
     if (savedSessionNames && savedSessionNames.includes(newName)) {
@@ -157,7 +157,9 @@ const App = observer(({ session, HeaderButtons }) => {
               </Tooltip>
               {HeaderButtons}
               <div className={classes.grow} />
-              <div style={{ width: 150, maxHeight: 48 }}>{renderLogo()}</div>
+              <div style={{ width: 150, maxHeight: 48 }}>
+                <Logo session={session} />
+              </div>
             </Toolbar>
           </AppBar>
         </div>

--- a/packages/core/ui/NewSessionCards.tsx
+++ b/packages/core/ui/NewSessionCards.tsx
@@ -54,7 +54,12 @@ function NewSessionCard({
       >
         <CardMedia className={classes.media} image={image} />
       </Card>
-      <Typography variant="subtitle2" className={classes.name}>
+      <Typography
+        variant="subtitle2"
+        className={classes.name}
+        style={{ cursor: 'pointer' }}
+        onClick={onClick}
+      >
         {name}
       </Typography>
     </Container>

--- a/products/jbrowse-desktop/src/JBrowse.test.tsx
+++ b/products/jbrowse-desktop/src/JBrowse.test.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react'
 import PluginManager from '@jbrowse/core/PluginManager'
 import fs from 'fs'
 import { ipcMain, ipcRenderer } from 'electron'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { SnapshotIn } from 'mobx-state-tree'
-import React from 'react'
 import corePlugins from './corePlugins'
 import JBrowse from './JBrowse'
 import JBrowseRootModelFactory from './rootModel'
@@ -79,6 +79,7 @@ describe('main jbrowse app render', () => {
     const { findByText } = render(
       <JBrowse pluginManager={getPluginManager()} />,
     )
-    await findByText('Start a new session')
+    fireEvent.click(await findByText('Empty'))
+    await findByText('Help')
   })
 })

--- a/products/jbrowse-desktop/src/StartScreen.tsx
+++ b/products/jbrowse-desktop/src/StartScreen.tsx
@@ -82,9 +82,7 @@ const DeleteSessionDialog = ({
           Cancel
         </Button>
         <Button
-          onClick={() => {
-            setDeleteSession(true)
-          }}
+          onClick={() => setDeleteSession(true)}
           color="primary"
           variant="contained"
           autoFocus
@@ -153,9 +151,7 @@ const RenameSessionDialog = ({
           Cancel
         </Button>
         <Button
-          onClick={() => {
-            setRenameSession(true)
-          }}
+          onClick={() => setRenameSession(true)}
           color="primary"
           variant="contained"
           disabled={!newSessionName || sessionNames.includes(newSessionName)}
@@ -307,28 +303,24 @@ export default function StartScreen({
           Recent sessions
         </Typography>
         <Grid container spacing={4}>
-          {sortedSessions
-            ? sortedSessions.map(
-                ([sessionName, sessionData]: [string, any]) => (
-                  <Grid item key={sessionName}>
-                    <RecentSessionCard
-                      sessionName={sessionName}
-                      sessionStats={sessionData.stats}
-                      sessionScreenshot={sessionData.screenshot}
-                      onClick={() => {
-                        setSessionToLoad(sessionName)
-                      }}
-                      onDelete={() => {
-                        setSessionToDelete(sessionName)
-                      }}
-                      onRename={() => {
-                        setSessionToRename(sessionName)
-                      }}
-                    />
-                  </Grid>
-                ),
-              )
-            : null}
+          {sortedSessions?.map(([sessionName, sessionData]: [string, any]) => (
+            <Grid item key={sessionName}>
+              <RecentSessionCard
+                sessionName={sessionName}
+                sessionStats={sessionData.stats}
+                sessionScreenshot={sessionData.screenshot}
+                onClick={() => {
+                  setSessionToLoad(sessionName)
+                }}
+                onDelete={() => {
+                  setSessionToDelete(sessionName)
+                }}
+                onRename={() => {
+                  setSessionToRename(sessionName)
+                }}
+              />
+            </Grid>
+          ))}
         </Grid>
       </Container>
 
@@ -337,9 +329,7 @@ export default function StartScreen({
         anchorEl={menuAnchorEl}
         keepMounted
         open={Boolean(menuAnchorEl)}
-        onClose={() => {
-          setMenuAnchorEl(null)
-        }}
+        onClose={() => setMenuAnchorEl(null)}
       >
         <ListSubheader>Advanced Settings</ListSubheader>
         <MenuItem

--- a/products/jbrowse-desktop/src/jbrowseModel.js
+++ b/products/jbrowse-desktop/src/jbrowseModel.js
@@ -36,10 +36,22 @@ export default function JBrowseDesktop(
           type: 'boolean',
           defaultValue: false,
         },
+        featureDetails: ConfigurationSchema('FeatureDetails', {
+          sequenceTypes: {
+            type: 'stringArray',
+            defaultValue: ['mRNA', 'transcript'],
+          },
+        }),
         disableAnalytics: {
           type: 'boolean',
           defaultValue: false,
         },
+        theme: { type: 'frozen', defaultValue: {} },
+        logoPath: {
+          type: 'fileLocation',
+          defaultValue: { uri: '' },
+        },
+        ...pluginManager.pluginConfigurationSchemas(),
       }),
       plugins: types.array(types.frozen()),
       assemblies: types.array(assemblyConfigSchemasType),

--- a/products/jbrowse-web/src/StartScreen.tsx
+++ b/products/jbrowse-web/src/StartScreen.tsx
@@ -1,24 +1,27 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Button from '@material-ui/core/Button'
-import CircularProgress from '@material-ui/core/CircularProgress'
-import Container from '@material-ui/core/Container'
-import Dialog from '@material-ui/core/Dialog'
-import DialogActions from '@material-ui/core/DialogActions'
-import DialogContent from '@material-ui/core/DialogContent'
-import DialogContentText from '@material-ui/core/DialogContentText'
-import DialogTitle from '@material-ui/core/DialogTitle'
-import Grid from '@material-ui/core/Grid'
-import List from '@material-ui/core/List'
+import React, { useEffect, useState } from 'react'
+import {
+  Button,
+  CircularProgress,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  IconButton,
+  List,
+  ListItemIcon,
+  ListSubheader,
+  Menu,
+  MenuItem,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
 import WarningIcon from '@material-ui/icons/Warning'
 import SettingsIcon from '@material-ui/icons/Settings'
-import IconButton from '@material-ui/core/IconButton'
-import ListItemIcon from '@material-ui/core/ListItemIcon'
-import ListSubheader from '@material-ui/core/ListSubheader'
-import Menu from '@material-ui/core/Menu'
-import MenuItem from '@material-ui/core/MenuItem'
-import { makeStyles } from '@material-ui/core/styles'
-import Typography from '@material-ui/core/Typography'
-import React, { useEffect, useState } from 'react'
+
 import { LogoFull, FactoryResetDialog } from '@jbrowse/core/ui'
 import {
   NewEmptySession,
@@ -82,9 +85,7 @@ const DeleteSessionDialog = ({
           Cancel
         </Button>
         <Button
-          onClick={() => {
-            setDeleteSession(true)
-          }}
+          onClick={() => setDeleteSession(true)}
           color="primary"
           variant="contained"
           autoFocus
@@ -195,13 +196,13 @@ export default function StartScreen({
             Start a new session
           </Typography>
           <Grid container spacing={4}>
-            <Grid item data-testid="emptySession">
+            <Grid item>
               <NewEmptySession root={root} />
             </Grid>
-            <Grid item data-testid="emptyLGVSession">
+            <Grid item>
               <NewLinearGenomeViewSession root={root} />
             </Grid>
-            <Grid item data-testid="emptySVSession">
+            <Grid item>
               <NewSVInspectorSession root={root} />
             </Grid>
           </Grid>
@@ -216,20 +217,14 @@ export default function StartScreen({
               maxHeight: 200,
             }}
           >
-            {sessionNames
-              ? sessionNames.map((sessionName: string) => (
-                  <RecentSessionCard
-                    key={sessionName}
-                    sessionName={sessionName}
-                    onClick={() => {
-                      setSessionToLoad(sessionName)
-                    }}
-                    onDelete={() => {
-                      setSessionToDelete(sessionName)
-                    }}
-                  />
-                ))
-              : null}
+            {sessionNames?.map((sessionName: string) => (
+              <RecentSessionCard
+                key={sessionName}
+                sessionName={sessionName}
+                onClick={() => setSessionToLoad(sessionName)}
+                onDelete={() => setSessionToDelete(sessionName)}
+              />
+            ))}
           </List>
         </div>
       </Container>

--- a/products/jbrowse-web/src/tests/StartScreen.test.js
+++ b/products/jbrowse-web/src/tests/StartScreen.test.js
@@ -28,22 +28,22 @@ describe('<StartScreen />', () => {
 test('Add New Session', async () => {
   const pluginManager = getPluginManager()
   const root = pluginManager.rootModel
-  const { findByTestId, findByText } = render(
+  const { findByText } = render(
     <StartScreen root={root} onFactoryReset={factoryReset} />,
   )
   await findByText('Start a new session')
-  fireEvent.click(await findByTestId('emptySession'))
+  fireEvent.click(await findByText('Empty'))
   expect(root.session).toBeTruthy()
 })
 
 test('Add New LGV Session', async () => {
   const pluginManager = getPluginManager()
   const root = pluginManager.rootModel
-  const { findByTestId, findByText } = render(
+  const { findByText } = render(
     <StartScreen root={root} onFactoryReset={factoryReset} />,
   )
   await findByText('Start a new session')
-  fireEvent.click(await findByTestId('emptyLGVSession'))
+  fireEvent.click(await findByText('Linear Genome View'))
   expect(root.session).toBeTruthy()
   expect(root.session.views.length).toBeGreaterThan(0)
 })
@@ -51,11 +51,11 @@ test('Add New LGV Session', async () => {
 test('Add New SV Inspector Session', async () => {
   const pluginManager = getPluginManager()
   const root = pluginManager.rootModel
-  const { findByTestId, findByText } = render(
+  const { findByText } = render(
     <StartScreen root={root} onFactoryReset={factoryReset} />,
   )
   await findByText('Start a new session')
-  fireEvent.click(await findByTestId('emptySVSession'))
+  fireEvent.click(await findByText('Structural Variant Inspector'))
   expect(root.session).toBeTruthy()
   expect(root.session.views.length).toBeGreaterThan(0)
 })


### PR DESCRIPTION
Currently starting up jbrowse desktop crashes because it tries to access a nonexistant logoPath configslot on the desktop's jbrowseModel

This fixes that by adding the logoPath configslot to desktop, plus a couple of items that jbrowse-web has that desktop didn't have  (theme, featureDetails,and ...pluginConfigurationSchemas()) just for good measure

Also makes the Logo a component