### PR TITLE
Fix infinite recursion in FromConfigAdaptor by avoiding mutating the passed in data when using SimpleFeature

### DIFF
--- a/packages/core/util/simpleFeature.ts
+++ b/packages/core/util/simpleFeature.ts
@@ -1,3 +1,4 @@
+import clone from 'clone'
 /**
  * Abstract feature object
  */
@@ -96,10 +97,11 @@ export default class SimpleFeature implements Feature {
    * which will be inflated to more instances of this class.
    */
   public constructor(args: SimpleFeatureArgs | SimpleFeatureSerialized) {
+    args = clone(args)
     if (isSimpleFeatureSerialized(args)) {
-      this.data = args
+      this.data = clone(args)
     } else {
-      this.data = args.data || {}
+      this.data = clone(args.data || {})
       // load handle from args.parent (not args.data.parent)
       // this reason is because if args is an object, it likely isn't properly loaded with
       // parent as a Feature reference (probably a raw parent ID or something instead)

--- a/packages/core/util/simpleFeature.ts
+++ b/packages/core/util/simpleFeature.ts
@@ -128,13 +128,17 @@ export default class SimpleFeature implements Feature {
       this.subfeatures = this.data.subfeatures?.map(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (f: any, i: number) =>
-          new SimpleFeature({
-            id: f.uniqueId || `${id}-${i}`,
-            strand: f.strand || this.data.strand,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            data: f as Record<string, any>,
-            parent: this,
-          }),
+          typeof f.get !== 'function'
+            ? new SimpleFeature({
+                id: f.uniqueId || `${id}-${i}`,
+                data: {
+                  strand: this.data.strand,
+                  ...f,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as Record<string, any>,
+                parent: this,
+              })
+            : f,
       )
     }
   }

--- a/packages/core/util/simpleFeature.ts
+++ b/packages/core/util/simpleFeature.ts
@@ -130,6 +130,7 @@ export default class SimpleFeature implements Feature {
         (f: any, i: number) =>
           new SimpleFeature({
             id: f.uniqueId || `${id}-${i}`,
+            strand: f.strand || this.data.strand,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             data: f as Record<string, any>,
             parent: this,

--- a/plugins/config/src/FromConfigAdapter/FromConfigAdapter.test.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigAdapter.test.ts
@@ -18,3 +18,38 @@ test('adapter can fetch features', async () => {
   expect(featuresArray.length).toBe(1)
   expect(featuresArray[0].toJSON()).toEqual(features[0])
 })
+
+test('adapter can fetch features with subfeatures', async () => {
+  const features = [
+    {
+      refName: 'ctgA',
+      uniqueId: 'feat1',
+      start: 200,
+      end: 750,
+      name: 'Feature1',
+      subfeatures: [
+        {
+          uniqueId: 'feat2',
+          start: 225,
+          end: 300,
+          name: 'Feature2',
+        },
+        {
+          uniqueId: 'feat3',
+          start: 400,
+          end: 600,
+          name: 'Feature3',
+        },
+      ],
+    },
+  ]
+  const adapter = new Adapter(configSchema.create({ features }))
+  const result = adapter.getFeatures({
+    refName: 'ctgA',
+    start: 0,
+    end: 20000,
+  })
+
+  const featuresArray = await result.pipe(toArray()).toPromise()
+  expect(featuresArray.length).toBe(1)
+})

--- a/test_data/volvox/fromconfig_integration_test.json
+++ b/test_data/volvox/fromconfig_integration_test.json
@@ -1,0 +1,85 @@
+{
+  "configuration": {
+    "rpc": {
+      "defaultDriver": "MainThreadRpcDriver"
+    }
+  },
+  "assemblies": [
+    {
+      "name": "volvox",
+      "aliases": ["vvx"],
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "volvox_refseq",
+        "adapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "volvox.2bit"
+          }
+        }
+      },
+      "refNameAliases": {
+        "adapter": {
+          "type": "FromConfigAdapter",
+          "features": [
+            {
+              "refName": "ctgA",
+              "uniqueId": "alias1",
+              "aliases": ["A", "contigA"]
+            },
+            {
+              "refName": "ctgB",
+              "uniqueId": "alias2",
+              "aliases": ["B", "contigB"]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "tracks": [
+    {
+      "type": "FeatureTrack",
+      "trackId": "track1",
+      "name": "Track1",
+      "assemblyNames": ["volvox"],
+      "category": ["Annotation"],
+      "adapter": {
+        "type": "FromConfigAdapter",
+        "features": [
+          {
+            "refName": "ctgA",
+            "uniqueId": "feat1",
+            "start": 200,
+            "end": 750,
+            "name": "Feature1",
+            "subfeatures": [
+              {
+                "uniqueId": "feat2",
+                "start": 225,
+                "end": 300,
+                "name": "Feature2"
+              },
+              {
+                "uniqueId": "feat3",
+                "start": 400,
+                "end": 600,
+                "name": "Feature3"
+              }
+            ]
+          }
+        ]
+      },
+      "displays": [
+        {
+          "type": "LinearBasicDisplay",
+          "displayId": "track1-display1",
+          "configuration": "track1-display1",
+          "renderer": {
+            "type": "SvgFeatureRenderer"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR started with trying out copying the data by default here https://github.com/GMOD/jbrowse-components/commit/b5810295e6633fae357509ee6184113e23ca67df

I realized this data copying could be reduced if we store the subfeatures array outside of this.data, thereby not mutating it

We could also consider methods to avoid the idMaker crash, or other possible approaches, but this solution seemed nice because it did not necessarily require a full object clone of the inputted simplefeature args (which i tried first here  https://github.com/GMOD/jbrowse-components/commit/b5810295e6633fae357509ee6184113e23ca67df before using this alternative solution https://github.com/GMOD/jbrowse-components/commit/3ac1218c353c0134ab5d0c604789b9b9619dcfd2)