### PR TITLE
Use idMaker for dataAdapterCache key for faster FromConfigAdapter performance

### DIFF
--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -2,7 +2,7 @@ import { Observable, merge } from 'rxjs'
 import { takeUntil } from 'rxjs/operators'
 import { isStateTreeNode, getSnapshot } from 'mobx-state-tree'
 import { ObservableCreate } from '../util/rxjs'
-import { checkAbortSignal, hashCode, observeAbortSignal } from '../util'
+import { checkAbortSignal, observeAbortSignal } from '../util'
 import { Feature } from '../util/simpleFeature'
 import {
   AnyConfigurationModel,
@@ -12,6 +12,7 @@ import { getSubAdapterType } from './dataAdapterCache'
 import { Region, NoAssemblyRegion } from '../util/types'
 import { blankStats, rectifyStats, scoresToStats } from '../util/stats'
 import BaseResult from '../TextSearch/BaseResults'
+import idMaker from '../util/idMaker'
 
 export interface BaseOptions {
   signal?: AbortSignal
@@ -48,26 +49,6 @@ export type AnyDataAdapter =
   | BaseTextSearchAdapter
   | RegionsAdapter
   | SequenceAdapter
-
-// generates a short "id fingerprint" from the config passed to the base
-// feature adapter by recursively enumerating props, but if config is too big
-// does not process entire config (FromConfigAdapter for example can be large)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function idMaker(args: any, id = '') {
-  const keys = Object.keys(args)
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i]
-    if (id.length > 5000) {
-      break
-    }
-    if (typeof args[key] === 'object' && args[key]) {
-      id += idMaker(args[key], id)
-    } else {
-      id += `${key}-${args[key]};`
-    }
-  }
-  return hashCode(id)
-}
 
 export abstract class BaseAdapter {
   public id: string

--- a/packages/core/data_adapters/dataAdapterCache.ts
+++ b/packages/core/data_adapters/dataAdapterCache.ts
@@ -1,14 +1,14 @@
-import jsonStableStringify from 'json-stable-stringify'
 import { SnapshotIn } from 'mobx-state-tree'
 import PluginManager from '../PluginManager'
 import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
 import { AnyDataAdapter } from './BaseAdapter'
 import { Region } from '../util/types'
+import idMaker from '../util/idMaker'
 
 function adapterConfigCacheKey(
   adapterConfig: SnapshotIn<AnyConfigurationSchemaType>,
 ) {
-  return `${jsonStableStringify(adapterConfig)}`
+  return `${idMaker(adapterConfig)}`
 }
 
 interface AdapterCacheEntry {

--- a/packages/core/util/idMaker.ts
+++ b/packages/core/util/idMaker.ts
@@ -1,0 +1,21 @@
+import { hashCode } from './'
+
+// generates a short "id fingerprint" from the config passed to the base
+// feature adapter by recursively enumerating props, but if config is too big
+// does not process entire config (FromConfigAdapter for example can be large)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function idMaker(args: any, id = '') {
+  const keys = Object.keys(args)
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    if (id.length > 5000) {
+      break
+    }
+    if (typeof args[key] === 'object' && args[key]) {
+      id += idMaker(args[key], id)
+    } else {
+      id += `${key}-${args[key]};`
+    }
+  }
+  return hashCode(id)
+}


### PR DESCRIPTION
This is a small proposal to use the "idMaker" concept from BaseAdapter for the dataAdapterCache key

The reason is that, potentially, the jsonStableStringify on a large FromConfigAdapter input would be large, and so automatically would take...just trying to estimate but I imagine the stringified version of a JSON object could be at least 2x but probably much more the size of the data (imagine 4byte ints vs 10char sequences...but also think of all the key values being stringified probably being stored more efficiently in memory)