### PR TITLE
[auth-for-plugin-adjustments] slight adjustments to openLocation changes for plugins

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -324,6 +324,7 @@ const UrlChooser = (props: {
           console.log(metadata)
           setLocation({
             uri: metadata.downloadUrl,
+            authHeader: 'Authorization',
             authToken: `Bearer ${oauthAccessTokenGoogle}`,
           })
           if (setName) {

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -57,12 +57,15 @@ export function openLocation(location: FileLocation): GenericFilehandle {
     }
   } else {
     if (isUriLocation(location)) {
+      //@ts-ignore
+      const optionalHeaders = location.authHeader && location.authToken ? { [location.authHeader]: `${location.authToken}` } : undefined
+
       return openUrl(
+        //@ts-ignore
         location.baseUri
           ? new URL(location.uri, location.baseUri).href
           : location.uri,
-
-        { Authorization: `${location.authToken}` },
+          optionalHeaders
       )
     }
     if (isLocalPathLocation(location)) {

--- a/packages/core/util/types/mst.ts
+++ b/packages/core/util/types/mst.ts
@@ -51,6 +51,7 @@ export const BlobLocation = types.model('BlobLocation', {
 
 export const UriLocationRaw = types.model('UriLocation', {
   uri: types.string, // TODO: refine
+  authHeader: types.maybe(types.string),
   authToken: types.maybe(types.string),
   baseUri: types.maybe(types.string),
 })


### PR DESCRIPTION
this PR addresses two issues:

1. A CORS rejection when attempting to load the app while also running a plugin
2. The requirement for custom headers to be sent as part of openURL (not just Authorization)

A ternary check for optional headers is performed before attempting to openUrl(), if authHeader and authToken are not defined, then this field will be undefined and avoid the CORS error being thrown when running the app with plugins.

A new field is added to the `UriLocation` model, `authHeader` which needs to be the header required to execute the authorization, this is a string.

For example, if you are creating the 'location' of a request to be made, your object might now look like
```js
{
  uri: metadata.downloadUrl,
  authHeader: 'Authorization',
  authToken: `Bearer ${oauthAccessTokenGoogle}`,
}
```

such that `authHeader` can be anything the user requires when the request is performed (my specific use case is `X-Auth-Header`, GDC's custom authorization header).