### PR TITLE
Improve performance with large numbers of reference sequences by using MST volatiles

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -391,5 +391,3 @@ async function loadAssemblyReaction(
   return { adapterRegionsWithAssembly, refNameAliases }
 }
 export type Assembly = Instance<ReturnType<typeof assemblyFactory>>
-
-export type AssemblyRegions = Assembly['regions']

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -145,7 +145,7 @@ export default function assemblyFactory(
   return types
     .model({
       configuration: types.safeReference(assemblyConfigType),
-      regions: types.maybe(types.array(MSTRegion)),
+      regions: types.frozen(),
       refNameAliases: types.maybe(types.map(types.string)),
     })
     .views(self => ({
@@ -233,7 +233,7 @@ export default function assemblyFactory(
         }
       },
       setRegions(regions: Region[]) {
-        self.regions = cast(regions)
+        self.regions = regions
       },
       setRefNameAliases(refNameAliases: RefNameAliases) {
         self.refNameAliases = cast(refNameAliases)

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -145,7 +145,15 @@ export default function assemblyFactory(
   return types
     .model({
       configuration: types.safeReference(assemblyConfigType),
-      regions: types.frozen(),
+      regions: types.frozen<
+        | {
+            start: number
+            end: number
+            refName: string
+            assemblyName: string
+          }[]
+        | undefined
+      >(),
       refNameAliases: types.maybe(types.map(types.string)),
     })
     .views(self => ({

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -154,7 +154,7 @@ export default function assemblyFactory(
           }[]
         | undefined
       >(),
-      refNameAliases: types.maybe(types.map(types.string)),
+      refNameAliases: types.frozen<{ [key: string]: string } | undefined>(),
     })
     .views(self => ({
       get initialized() {
@@ -182,7 +182,7 @@ export default function assemblyFactory(
         if (!self.refNameAliases) {
           return undefined
         }
-        return Array.from(self.refNameAliases.keys())
+        return Object.keys(self.refNameAliases.keys)
       },
       get rpcManager() {
         return getParent(self, 2).rpcManager
@@ -205,7 +205,7 @@ export default function assemblyFactory(
             'aliases not loaded, we expect them to be loaded before getCanonicalRefName can be called',
           )
         }
-        return self.refNameAliases.get(refName)
+        return self.refNameAliases[refName]
       },
       getRefNameColor(refName: string) {
         const idx = self.refNames?.findIndex(r => r === refName)
@@ -244,7 +244,7 @@ export default function assemblyFactory(
         self.regions = regions
       },
       setRefNameAliases(refNameAliases: RefNameAliases) {
-        self.refNameAliases = cast(refNameAliases)
+        self.refNameAliases = refNameAliases
       },
       afterAttach() {
         makeAbortableReaction(

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -145,17 +145,18 @@ export default function assemblyFactory(
   return types
     .model({
       configuration: types.safeReference(assemblyConfigType),
-      regions: types.frozen<
+    })
+    .volatile(() => ({
+      regions: undefined as
         | {
             start: number
             end: number
             refName: string
             assemblyName: string
           }[]
-        | undefined
-      >(),
-      refNameAliases: types.frozen<{ [key: string]: string } | undefined>(),
-    })
+        | undefined,
+      refNameAliases: undefined as { [key: string]: string } | undefined,
+    }))
     .views(self => ({
       get initialized() {
         return Boolean(self.refNameAliases)
@@ -390,3 +391,5 @@ async function loadAssemblyReaction(
   return { adapterRegionsWithAssembly, refNameAliases }
 }
 export type Assembly = Instance<ReturnType<typeof assemblyFactory>>
+
+export type AssemblyRegions = Assembly['regions']

--- a/plugins/circular-view/src/CircularView/components/CircularView.js
+++ b/plugins/circular-view/src/CircularView/components/CircularView.js
@@ -1,3 +1,6 @@
+import React, { useState } from 'react'
+import { observer } from 'mobx-react'
+
 import ZoomOut from '@material-ui/icons/ZoomOut'
 import ZoomIn from '@material-ui/icons/ZoomIn'
 import RotateLeft from '@material-ui/icons/RotateLeft'
@@ -5,10 +8,6 @@ import RotateRight from '@material-ui/icons/RotateRight'
 import LockOutline from '@material-ui/icons/LockOutlined'
 import LockOpen from '@material-ui/icons/LockOpen'
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
-
-import { observer } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
-import React, { useState } from 'react'
 
 // material-ui stuff
 import {

--- a/plugins/circular-view/src/CircularView/components/CircularView.js
+++ b/plugins/circular-view/src/CircularView/components/CircularView.js
@@ -179,8 +179,7 @@ const ImportForm = observer(({ model }) => {
   const { assemblyNames, assemblyManager } = getSession(model)
   const assemblyError = assemblyNames.length ? '' : 'No configured assemblies'
   const assembly = assemblyManager.get(assemblyNames[selectedAssemblyIdx])
-  const regions =
-    assembly && assembly.regions ? getSnapshot(assembly.regions) : []
+  const regions = assembly?.regions || []
 
   function onAssemblyChange(event) {
     setSelectedAssemblyIdx(Number(event.target.value))

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -169,7 +169,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
                       if (assembly) {
                         const { regions } = assembly
                         if (regions && regions.length) {
-                          const regionsSnapshot = getSnapshot(regions)
+                          const regionsSnapshot = regions
                           if (regionsSnapshot) {
                             transaction(() => {
                               views[index].setDisplayedRegions(regionsSnapshot)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -6,7 +6,7 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import FormGroup from '@material-ui/core/FormGroup'
 import Typography from '@material-ui/core/Typography'
 import { observer } from 'mobx-react'
-import { Instance, getEnv, getSnapshot } from 'mobx-state-tree'
+import { Instance, getEnv } from 'mobx-state-tree'
 import React from 'react'
 
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
@@ -129,7 +129,7 @@ const LinearGenomeViewHeader = observer(({ model }: { model: LGV }) => {
         region => newRegionValue === region.refName,
       )
       if (newRegion) {
-        model.setDisplayedRegions([getSnapshot(newRegion)])
+        model.setDisplayedRegions([newRegion])
         // we use showAllRegions after setDisplayedRegions to make the entire
         // region visible, xref #1703
         model.showAllRegions()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -55,7 +55,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
       if (assemblyName) {
         const assembly = await assemblyManager.waitForAssembly(assemblyName)
         if (assembly && assembly.regions) {
-          const regions = getSnapshot(assembly.regions)
+          const regions = assembly.regions
           if (!done && regions) {
             setSelectedRegion(regions[0].refName)
             setAssemblyRegions(regions)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchResultsDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchResultsDialog.tsx
@@ -76,7 +76,7 @@ export default function SearchResultsDialog({
         region => location === region.refName,
       )
       if (newRegion) {
-        model.setDisplayedRegions([getSnapshot(newRegion)])
+        model.setDisplayedRegions([newRegion])
         // we use showAllRegions after setDisplayedRegions to make the entire
         // region visible, xref #1703
         model.showAllRegions()

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -53,9 +53,25 @@ function initialize() {
   stubManager.configure()
 
   const Assembly = types
-    .model({
-      regions: types.array(Region),
-    })
+    .model({})
+    .volatile(() => ({
+      regions: [
+        {
+          assemblyName: 'volvox',
+          start: 0,
+          end: 50001,
+          refName: 'ctgA',
+          reversed: false,
+        },
+        {
+          assemblyName: 'volvox',
+          start: 0,
+          end: 6079,
+          refName: 'ctgB',
+          reversed: false,
+        },
+      ],
+    }))
     .views(() => ({
       getCanonicalRefName(refName: string) {
         if (refName === 'contigA') {
@@ -79,29 +95,7 @@ function initialize() {
       },
     }))
     .volatile((/* self */) => ({
-      assemblyManager: new Map([
-        [
-          'volvox',
-          Assembly.create({
-            regions: [
-              {
-                assemblyName: 'volvox',
-                start: 0,
-                end: 50001,
-                refName: 'ctgA',
-                reversed: false,
-              },
-              {
-                assemblyName: 'volvox',
-                start: 0,
-                end: 6079,
-                refName: 'ctgB',
-                reversed: false,
-              },
-            ],
-          }),
-        ],
-      ]),
+      assemblyManager: new Map([['volvox', Assembly.create({})]]),
     }))
 
   return { Session, LinearGenomeModel, Assembly }
@@ -941,16 +935,10 @@ describe('Get Sequence for selected displayed regions', () => {
 test('navToLocString with human assembly', () => {
   const { LinearGenomeModel } = initialize()
   const HumanAssembly = types
-    .model({
-      regions: types.frozen<
-        {
-          start: number
-          end: number
-          refName: string
-          assemblyName: string
-        }[]
-      >(),
-    })
+    .model({})
+    .volatile(() => ({
+      regions: hg38DisplayedRegions,
+    }))
     .views(() => ({
       getCanonicalRefName(refName: string) {
         return refName.replace('chr', '')

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -942,7 +942,14 @@ test('navToLocString with human assembly', () => {
   const { LinearGenomeModel } = initialize()
   const HumanAssembly = types
     .model({
-      regions: types.array(Region),
+      regions: types.frozen<
+        {
+          start: number
+          end: number
+          refName: string
+          assemblyName: string
+        }[]
+      >(),
     })
     .views(() => ({
       getCanonicalRefName(refName: string) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -736,8 +736,6 @@ describe('Get Sequence for selected displayed regions', () => {
     model.setDisplayedRegions([
       { assemblyName: 'volvox', refName: 'ctgA', start: 0, end: 800 },
     ])
-    expect(model.displayedParentRegions.length).toEqual(1)
-    expect(model.displayedParentRegionsLength).toEqual(50001)
     model.setOffsets(
       {
         refName: 'ctgA',

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -766,7 +766,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             region => region.refName === canonicalRefName,
           )
           if (newDisplayedRegion) {
-            this.setDisplayedRegions([getSnapshot(newDisplayedRegion)])
+            this.setDisplayedRegions([newDisplayedRegion])
           } else {
             throw new Error(
               `Could not find refName ${parsedLocString.refName} in ${assembly.name}`,

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -232,7 +232,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const { assemblyManager } = getSession(self)
         self.displayedRegions.forEach(({ refName, assemblyName }) => {
           const assembly = assemblyManager.get(assemblyName)
-          const r = assembly && (assembly.regions as Region[])
+          const r = assembly?.regions
           if (r) {
             const wholeSequence = r.find(
               sequence => sequence.refName === refName,

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -227,32 +227,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const leftPadding = 10
         return this.displayedRegionsTotalPx - leftPadding
       },
-      get displayedParentRegions() {
-        const wholeRefSeqs = [] as Region[]
-        const { assemblyManager } = getSession(self)
-        self.displayedRegions.forEach(({ refName, assemblyName }) => {
-          const assembly = assemblyManager.get(assemblyName)
-          const r = assembly?.regions
-          if (r) {
-            const wholeSequence = r.find(
-              sequence => sequence.refName === refName,
-            )
-            const alreadyExists = wholeRefSeqs.find(
-              sequence => sequence.refName === refName,
-            )
-            if (wholeSequence && !alreadyExists) {
-              wholeRefSeqs.push(wholeSequence)
-            }
-          }
-        })
-        return wholeRefSeqs
-      },
 
-      get displayedParentRegionsLength() {
-        return this.displayedParentRegions
-          .map(a => a.end - a.start)
-          .reduce((a, b) => a + b, 0)
-      },
       get minOffset() {
         // objectively determined to keep the linear genome on the main screen
         const rightPadding = 30
@@ -285,13 +260,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           tracks: self.tracks,
         }
       },
-      parentRegion(assemblyName: string, refName: string) {
-        return this.displayedParentRegions.find(
-          parentRegion =>
-            parentRegion.assemblyName === assemblyName &&
-            parentRegion.refName === refName,
-        )
-      },
+
       /**
        * @param refName - refName of the displayedRegion
        * @param coord - coordinate at the displayed Region
@@ -677,7 +646,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.showCenterLine = !self.showCenterLine
       },
 
-      setDisplayedRegions(regions: Region[]) {
+      setDisplayedRegions(
+        regions: {
+          start: number
+          end: number
+          refName: string
+          assemblyName: string
+          reversed?: boolean
+        }[],
+      ) {
         self.displayedRegions = cast(regions)
         self.zoomTo(self.bpPerPx)
       },

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -363,7 +363,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           const region = self.displayedRegions[0]
           const offset = bp
           return {
-            ...getSnapshot(region),
+            ...region,
             oob: true,
             coord: region.reversed
               ? Math.floor(region.end - offset) + 1
@@ -382,7 +382,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           const offset = bp - bpSoFar
           if (len + bpSoFar > bp && bpSoFar <= bp) {
             return {
-              ...getSnapshot(region),
+              ...region,
               oob: false,
               offset,
               coord: region.reversed
@@ -410,7 +410,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
           const len = region.end - region.start
           const offset = bp - bpSoFar + len
           return {
-            ...getSnapshot(region),
+            ...region,
             oob: true,
             offset,
             coord: region.reversed
@@ -1162,7 +1162,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         }
         const assembly = assemblyManager.get(assemblyName)
         if (assembly) {
-          const { regions } = getSnapshot(assembly)
+          const { regions } = assembly
           if (regions) {
             this.setDisplayedRegions(regions)
             self.zoomTo(self.maxBpPerPx)

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -233,12 +233,7 @@ const SvInspectorViewF = pluginManager => {
               if (assemblyName) {
                 const assembly = session.assemblyManager.get(assemblyName)
                 if (assembly) {
-                  let { regions: assemblyRegions } = assembly
-                  if (!assemblyRegions) {
-                    assemblyRegions = []
-                  } else {
-                    assemblyRegions = getSnapshot(assemblyRegions)
-                  }
+                  const { regions: assemblyRegions = [] } = assembly
                   if (onlyDisplayRelevantRegionsInCircularView) {
                     if (tracks.length === 1) {
                       const {

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -45,9 +45,7 @@ function defaultOnChordClick(feature, chordTrack, pluginManager) {
 const SvInspectorViewF = pluginManager => {
   const { jbrequire } = pluginManager
   const { autorun, reaction } = pluginManager.lib.mobx
-  const { types, getParent, addDisposer, getSnapshot } = pluginManager.lib[
-    'mobx-state-tree'
-  ]
+  const { types, getParent, addDisposer } = pluginManager.lib['mobx-state-tree']
   const { BaseViewModel } = jbrequire(
     '@jbrowse/core/pluggableElementTypes/models',
   )


### PR DESCRIPTION
This is a possible proposal to help speed up large assemblies

This demo has 200,000 contigs

https://s3.amazonaws.com/jbrowse.org/code/jb2/main/index.html?config=test_data%2Fconfig_many_contigs.json

This can hang the page for as much as 10 seconds on a fast machine, production build

After this change the load time is about 3 seconds, with the code that does this coming from refNameAliases instead of assembly.regions now, so probably can be reduced more

This is an early proof of concept PR but note that types.frozens can also be typescripted 

Possible help for #1847 

