### PR TITLE
Fix issue with using --force error when no track was previously loaded

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -305,7 +305,7 @@ export default class AddTrack extends JBrowseCommand {
           filePaths.map(async filePath => {
             const dest = destinationFn(configDirectory, filePath)
             try {
-              if (force) {
+              if (force && fs.existsSync(dest)) {
                 await fsPromises.unlink(dest)
               }
             } catch (e) {
@@ -325,7 +325,7 @@ export default class AddTrack extends JBrowseCommand {
           filePaths.map(async filePath => {
             const dest = destinationFn(configDirectory, filePath)
             try {
-              if (force) {
+              if (force && fs.existsSync(dest)) {
                 await fsPromises.unlink(dest)
               }
             } catch (e) {
@@ -341,7 +341,7 @@ export default class AddTrack extends JBrowseCommand {
           filePaths.map(async filePath => {
             const dest = destinationFn(configDirectory, filePath)
             try {
-              if (force) {
+              if (force && fs.existsSync(dest)) {
                 await fsPromises.unlink(dest)
               }
             } catch (e) {


### PR DESCRIPTION
If --force was used but no track/file existed there to overwrite, then the script failed

This checks for the file existing

This code is a little tedious and it would be sorta nice if we could "operate at a slightly higher level of abstraction" than the raw fs module, but this does fix the issue :)