### PR TITLE
Export offscreenCanvasPonyfil from core/util

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "color": "^3.1.3",
     "copy-to-clipboard": "^3.3.1",
     "deepmerge": "^4.2.2",
+    "detect-node": "^2.1.0",
     "dompurify": "^2.0.11",
     "escape-html": "^1.0.3",
     "fast-deep-equal": "^3.1.3",

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -29,6 +29,8 @@ export * from './types'
 export * from './aborting'
 export * from './when'
 
+export * from './offscreenCanvasPonyfill'
+
 if (!Object.fromEntries) {
   // @ts-ignore
   fromEntries.shim()

--- a/packages/core/util/offscreenCanvasPonyfill.js
+++ b/packages/core/util/offscreenCanvasPonyfill.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Path from 'svg-path-generator'
 import Color from 'color'
+import isNode from 'detect-node'
 
 // This is a ponyfill for the HTML5 OffscreenCanvas API.
 export let createCanvas
@@ -12,11 +13,8 @@ export let ImageBitmapType
 const isElectron = typeof window !== 'undefined' && Boolean(window.electron)
 
 const weHave = {
-  realOffscreenCanvas:
-    typeof __webpack_require__ === 'function' &&
-    typeof OffscreenCanvas === 'function',
-  node:
-    typeof __webpack_require__ === 'undefined' && typeof process === 'object',
+  realOffscreenCanvas: typeof OffscreenCanvas === 'function',
+  node: isNode,
 }
 
 export class PonyfillOffscreenContext {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8856,6 +8856,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"


### PR DESCRIPTION
Two small changes here to help plugins. First, the `__webpack_require__` check was removed from offscreenCanvasPonyfill. Instead, it just checks for `OffscreenCanvas` without checking `__webpack_require__` first. To detect node, it uses [`detect-node`](https://www.npmjs.com/package/detect-node), a popular NPM library.

The second change was to export the offscreenCanvasPonyfill functions from `@jbrowse/core/util`. That way plugins can use them without them being built into the plugin (since offscreenCanvasPonyfill itself isn't in our re-exports). This change fixes https://github.com/GMOD/jbrowse-plugin-template/issues/15.