### PR TITLE
Better error message if a file location has an empty string

### DIFF
--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -48,13 +48,22 @@ export function openLocation(location: FileLocation): GenericFilehandle {
   }
   if (isElectron) {
     if (isUriLocation(location)) {
+      if (!location.uri) {
+        throw new Error('No URI provided')
+      }
       return new ElectronRemoteFile(location.uri)
     }
     if (isLocalPathLocation(location)) {
+      if (!location.localPath) {
+        throw new Error('No local path provided')
+      }
       return new ElectronLocalFile(location.localPath)
     }
   } else {
     if (isUriLocation(location)) {
+      if (!location.uri) {
+        throw new Error('No URI provided')
+      }
       return openUrl(
         location.baseUri
           ? new URL(location.uri, location.baseUri).href
@@ -62,6 +71,9 @@ export function openLocation(location: FileLocation): GenericFilehandle {
       )
     }
     if (isLocalPathLocation(location)) {
+      if (!location.localPath) {
+        throw new Error('No local path provided')
+      }
       return new LocalFile(location.localPath)
     }
   }


### PR DESCRIPTION
As noted in [this gitter thread](https://gitter.im/GMOD/jbrowse2?at=60d26b3bbef0c66d9d1b9e71), leaving an empty string in the "uri" of a "faiLocation" of an assembly adapter wouldn't trigger a 404 like it would if you put in the URI incorrectly, and you'd get some error about an invalid refName. This is because `fetch('')` is a valid fetch that gets the current page. This adds some error throwing to `openLocation` if the uri (or localPath) is an empty string, so the error message would be at least a bit more sensible.