### PR TITLE
Dropdown warnings 2058

### DIFF
--- a/packages/core/TextSearch/TextSearchManager.ts
+++ b/packages/core/TextSearch/TextSearchManager.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /*  text-searching controller */
 import BaseResult from './BaseResults'
 import { AnyConfigurationModel } from '../configuration/configurationSchema'
@@ -72,7 +71,7 @@ export default (pluginManager: PluginManager) => {
       // only return track text search adapters that cover relevant tracks,
       // for now only returning text search adapters that cover configured assemblies)
       // root level adapters and track adapters
-      const { aggregateTextSearchAdapters, tracks } = pluginManager.rootModel
+      const { aggregateTextSearchAdapters, tracks } = pluginManager.rootModel // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ?.jbrowse as any
       let trackTextSearchAdapters: AnyConfigurationModel[] = []
       tracks.forEach((trackConfig: AnyConfigurationModel) => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -148,7 +148,7 @@ const LinearGenomeViewHeader = observer(({ model }: { model: LGV }) => {
           model.setSearchResults(results, newRegionValue.toLocaleLowerCase())
         } else {
           try {
-            model.navToLocString(newRegionValue)
+            newRegionValue !== '' && model.navToLocString(newRegionValue)
           } catch (e) {
             if (
               `${e}` === `Error: Unknown reference sequence "${newRegionValue}"`

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -42,7 +42,9 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   const { textSearchManager } = pluginManager.rootModel
   const { rankSearchResults } = model
   const [selectedAssemblyIdx, setSelectedAssemblyIdx] = useState(0)
-  const [selectedRegion, setSelectedRegion] = useState<string | undefined>('')
+  const [selectedRegion, setSelectedRegion] = useState<string | undefined>(
+    undefined,
+  )
   const [assemblyRegions, setAssemblyRegions] = useState<Region[]>([])
   const error = !assemblyNames.length ? 'No configured assemblies' : ''
   const hasError = Boolean(error)
@@ -143,7 +145,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
           </Grid>
           <Grid item>
             {assemblyName ? (
-              selectedRegion && model.volatileWidth ? (
+              selectedRegion !== undefined && model.volatileWidth ? (
                 <RefNameAutocomplete
                   model={model}
                   assemblyName={

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -42,6 +42,7 @@ const filter = createFilterOptions<Option>({
   trim: true,
   matchFrom: 'start',
   ignoreCase: true,
+  limit: 101,
 })
 const helperSearchText = `Search for features or navigate to a location using syntax "chr1:1-100" or "chr1:1..100"`
 const useStyles = makeStyles(() => ({
@@ -99,7 +100,23 @@ function RefNameAutocomplete({
     return (assembly && assembly.regions) || []
   }, [assembly])
   // default options for dropdown
-  const options: Array<Option> = useMemo(() => {
+  const limitOption: Array<Option> = [
+    {
+      group: 'reference sequence',
+      result: new BaseResult({
+        refName: '',
+        label: '',
+        renderingComponent: (
+          <Tooltip
+            title={'Displaying first 100 refNames. Search for more results'}
+          >
+            <Typography noWrap>{'more results...'}</Typography>
+          </Tooltip>
+        ),
+      }),
+    },
+  ]
+  let options: Array<Option> = useMemo(() => {
     const defaultOptions = regions.map(option => {
       const defaultOption: Option = {
         group: 'reference sequence',
@@ -113,8 +130,11 @@ function RefNameAutocomplete({
     })
     return defaultOptions
   }, [regions])
+
+  options =
+    regions.length > 100 ? options.slice(0, 100).concat(limitOption) : options
   // assembly and regions have loaded
-  const loaded = regions.length !== 0 && options.length !== 0
+  const loaded = regions.length !== 0 && assemblyName
   useEffect(() => {
     let active = true
 
@@ -177,7 +197,7 @@ function RefNameAutocomplete({
       includeInputInList
       clearOnBlur
       selectOnFocus
-      disabled={!assemblyName || !loaded}
+      disabled={!assemblyName}
       style={style}
       value={coarseVisibleLocStrings || value || ''}
       open={open}
@@ -187,7 +207,9 @@ function RefNameAutocomplete({
         setCurrentSearch('')
         setSearchOptions([])
       }}
-      options={searchOptions.length === 0 ? options : searchOptions}
+      options={
+        searchOptions.length === 0 ? options.concat(limitOption) : searchOptions
+      }
       groupBy={option => String(option.group)}
       filterOptions={(possibleOptions, params) => {
         return filter(possibleOptions, params)
@@ -201,7 +223,7 @@ function RefNameAutocomplete({
           ...InputProps,
           endAdornment: (
             <>
-              {!loaded ? (
+              {false ? (
                 <CircularProgress color="inherit" size={20} />
               ) : (
                 <Tooltip

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -221,7 +221,7 @@ function RefNameAutocomplete({
           ...InputProps,
           endAdornment: (
             <>
-              {false ? (
+              {regions.length === 0 && searchOptions.length === 0 ? (
                 <CircularProgress color="inherit" size={20} />
               ) : (
                 <Tooltip

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -132,7 +132,7 @@ function RefNameAutocomplete({
   }, [regions])
 
   options =
-    regions.length > 100 ? options.slice(0, 100).concat(limitOption) : options
+    options.length > 100 ? options.slice(0, 100).concat(limitOption) : options
   // assembly and regions have loaded
   const loaded = regions.length !== 0 && assemblyName
   useEffect(() => {
@@ -207,9 +207,7 @@ function RefNameAutocomplete({
         setCurrentSearch('')
         setSearchOptions([])
       }}
-      options={
-        searchOptions.length === 0 ? options.concat(limitOption) : searchOptions
-      }
+      options={searchOptions.length === 0 ? options : searchOptions}
       groupBy={option => String(option.group)}
       filterOptions={(possibleOptions, params) => {
         return filter(possibleOptions, params)

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -42,7 +42,6 @@
     "@jbrowse/plugin-config": "^1.3.0",
     "@jbrowse/plugin-data-management": "^1.3.0",
     "@jbrowse/plugin-gff3": "^1.3.0",
-    "@jbrowse/plugin-legacy-jbrowse": "^1.3.0",
     "@jbrowse/plugin-linear-genome-view": "^1.3.0",
     "@jbrowse/plugin-sequence": "^1.3.0",
     "@jbrowse/plugin-svg": "^1.3.0",

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -44,7 +44,6 @@ const longReadsSession = {
   ...defaultSession,
   view: volvoxSession.session.views[0],
 }
-const aggregateTextSearchAdapters = volvoxConfig.aggregateTextSearchAdapters
 export const OneLinearGenomeView = () => {
   const state = createViewState({
     assembly,
@@ -242,22 +241,6 @@ export const WithPlugins = () => {
         trackLabels: 'overlapping',
         showCenterLine: false,
       },
-    },
-  })
-  return <JBrowseLinearGenomeView viewState={state} />
-}
-
-export const WithTextSearching = () => {
-  const state = createViewState({
-    assembly,
-    tracks,
-    defaultSession,
-    aggregateTextSearchAdapters,
-    // use 1-based coordinates for locstring
-    location: 'ctgA:1105..1221',
-    onChange: patch => {
-      // eslint-disable-next-line no-console
-      console.log('patch', patch)
     },
   })
   return <JBrowseLinearGenomeView viewState={state} />


### PR DESCRIPTION
In this pr
[Issue 2058 : Missing supercontig in the chromosome selector](https://github.com/GMOD/jbrowse-components/issues/2058)
* Removes jbrowse-legacy plugin dependency
* Removes storybook text searching example for now
* Adds message at the end of the dropdown to guide user to search when there are more than 100 refName options
* sets dropdown limit to 100 options