### PR TITLE
Fix support for opening local files in spreadsheet/SV inspector

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
@@ -96,7 +96,6 @@ const ImportForm = observer(({ model }) => {
               <FileSelector
                 location={model.fileSource}
                 setLocation={model.setFileSource}
-                localFileAllowed
               />
             </FormGroup>
           </FormControl>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -52,7 +52,7 @@ export default (pluginManager: PluginManager) => {
         return (
           !self.error &&
           self.fileSource &&
-          (self.fileSource.blob ||
+          (self.fileSource.blobId ||
             self.fileSource.localPath ||
             self.fileSource.uri)
         )
@@ -75,7 +75,7 @@ export default (pluginManager: PluginManager) => {
         return (
           self.fileSource.uri ||
           self.fileSource.localPath ||
-          (self.fileSource.blob && self.fileSource.blob.name)
+          (self.fileSource.blobId && self.fileSource.name)
         )
       },
 


### PR DESCRIPTION
This fixes the ability to open local files in spreadsheet/sv inspector. This was a regression following the change of our FileSelector to return the objects with blobId instead of blob from #1975