### PR TITLE
Reorient strands on read vs ref plots

### DIFF
--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -214,7 +214,7 @@ export default class DotplotPlugin extends Plugin {
                       clipPos: saClipPos,
                       CIGAR: saCigar,
                       assemblyName: trackAssembly,
-                      strand: saStrandNormalized,
+                      strand: 1, // saStrandNormalized,
                       uniqueId: `${feature.id()}_SA${index}`,
                       mate: {
                         start: saClipPos,
@@ -225,6 +225,7 @@ export default class DotplotPlugin extends Plugin {
                   })
 
                 const feat = feature.toJSON()
+                feat.strand = 1
                 feat.mate = {
                   refName: readName,
                   start: clipPos,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -254,7 +254,7 @@ function WindowSizeDlg(props: {
             clipPos: saClipPos,
             CIGAR: saCigar,
             assemblyName: trackAssembly,
-            strand: saStrandNormalized,
+            strand: 1, // saStrandNormalized,
             uniqueId: `${feature.id()}_SA${index}`,
             mate: {
               start: saClipPos,
@@ -266,6 +266,7 @@ function WindowSizeDlg(props: {
 
       const feat = feature.toJSON()
       feat.clipPos = clipPos
+      feat.strand = 1
 
       feat.mate = {
         refName: readName,


### PR DESCRIPTION
The fix from #2024 caused a knock-on effect of the read-vs-ref displays to display inversions where none existed. Reason being was that the read vs ref code assumed it should provide the strand of the read, but even though the strand of a given BAM read might be given as -1, all the data is actually oriented in the forward direction (e.g. the SEQ field will be read left to right aka 5' to 3' even for negative strand features)

Example: Current main displays inversions on a "volvox SV" example which should not be inversions (it is just a deletion)

![jbrowse org_code_jb2_main__config=test_data%2Fvolvox%2Fconfig json session=local-SfLi55OZW](https://user-images.githubusercontent.com/6511937/123317787-68cc5200-d4fc-11eb-8ee1-01726f8f986b.png)


