### PR TITLE
Add help icon and more extensive tooltip text to RefNameAutocomplete

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -19,9 +19,9 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import TextField, { TextFieldProps as TFP } from '@material-ui/core/TextField'
 import Tooltip from '@material-ui/core/Tooltip'
 import Typography from '@material-ui/core/Typography'
+import HelpIcon from '@material-ui/icons/Help'
 import SearchIcon from '@material-ui/icons/Search'
 import { InputAdornment } from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
 import Autocomplete, {
   createFilterOptions,
 } from '@material-ui/lab/Autocomplete'
@@ -30,7 +30,7 @@ import { LinearGenomeViewModel } from '..'
 
 /**
  *  Option interface used to format results to display in dropdown
- *  of the materila ui interface
+ *  of the material ui interface
  */
 export interface Option {
   group: string
@@ -44,12 +44,6 @@ const filter = createFilterOptions<Option>({
   ignoreCase: true,
   limit: 101,
 })
-const helperSearchText = `Search for features or navigate to a location using syntax "chr1:1-100" or "chr1:1..100"`
-const useStyles = makeStyles(() => ({
-  customWidth: {
-    maxWidth: 150,
-  },
-}))
 
 async function fetchResults(
   self: LinearGenomeViewModel,
@@ -70,6 +64,40 @@ async function fetchResults(
     []
   return searchResults
 }
+
+function HelperText() {
+  return (
+    <>
+      <Typography variant="body2" paragraph>
+        You can search for sequence names or any indexed identifiers. Only the
+        first 100 matching results are displayed, so you can enter more search
+        text to narrow you results
+      </Typography>
+      <Typography variant="body2" paragraph>
+        You can also enter a specific location to navigate to, such as
+        <ul>
+          <li>
+            <code>chr1:500..1500</code>
+            <br />
+            Navigates to sequence <code>chr1</code>, bases 500 to 1500
+          </li>
+          <li>
+            <code>chr1:500</code>
+            <br />
+            Navigates to sequence <code>chr1</code>, with base 500 centered at
+            maximum zoom level
+          </li>
+          <li>
+            <code>chr1</code>
+            <br />
+            Navigates so that all of <code>chr1</code> is visible
+          </li>
+        </ul>
+      </Typography>
+    </>
+  )
+}
+
 function RefNameAutocomplete({
   model,
   onSelect,
@@ -85,9 +113,7 @@ function RefNameAutocomplete({
   style?: React.CSSProperties
   TextFieldProps?: TFP
 }) {
-  const classes = useStyles()
   const session = getSession(model)
-  const { pluginManager } = getEnv(session)
   const [open, setOpen] = useState(false)
   const [, setError] = useState<Error>()
   const [currentSearch, setCurrentSearch] = useState('')
@@ -219,19 +245,24 @@ function RefNameAutocomplete({
         const TextFieldInputProps = {
           ...params.InputProps,
           ...InputProps,
+          startAdornment: (
+            <InputAdornment position="start" style={{ marginLeft: 7 }}>
+              <SearchIcon />
+            </InputAdornment>
+          ),
           endAdornment: (
             <>
               {regions.length === 0 && searchOptions.length === 0 ? (
                 <CircularProgress color="inherit" size={20} />
               ) : (
                 <Tooltip
-                  title={helperSearchText}
+                  title={<HelperText />}
                   leaveDelay={300}
-                  placement="top"
-                  classes={{ tooltip: classes.customWidth }}
+                  placement="right-start"
+                  arrow
                 >
                   <InputAdornment position="end" style={{ marginRight: 7 }}>
-                    <SearchIcon />
+                    <HelpIcon color="action" />
                   </InputAdornment>
                 </Tooltip>
               )}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -176,25 +176,12 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               style="margin: 7px; min-width: 175px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
               >
-                <input
-                  aria-autocomplete="list"
-                  aria-invalid="false"
-                  autocapitalize="none"
-                  autocomplete="off"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                  id="refNameAutocomplete-lgv"
-                  placeholder="Search for location"
-                  spellcheck="false"
-                  type="text"
-                  value="ctgA:1..100"
-                />
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                  style="margin-right: 7px;"
-                  title="Search for features or navigate to a location using syntax \\"chr1:1-100\\" or \\"chr1:1..100\\""
+                  class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+                  style="margin-left: 7px;"
                 >
                   <svg
                     aria-hidden="true"
@@ -204,6 +191,33 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                   >
                     <path
                       d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-autocomplete="list"
+                  aria-invalid="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                  id="refNameAutocomplete-lgv"
+                  placeholder="Search for location"
+                  spellcheck="false"
+                  type="text"
+                  value="ctgA:1..100"
+                />
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  style="margin-right: 7px;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorAction"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
                     />
                   </svg>
                 </div>
@@ -643,25 +657,11 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
             class="MuiFormControl-root MuiTextField-root makeStyles-importFormEntry MuiFormControl-marginNormal MuiFormControl-fullWidth"
           >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
             >
-              <input
-                aria-autocomplete="list"
-                aria-describedby="refNameAutocomplete-lgv-helper-text"
-                aria-invalid="false"
-                autocapitalize="none"
-                autocomplete="off"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                id="refNameAutocomplete-lgv"
-                placeholder="Search for location"
-                spellcheck="false"
-                type="text"
-                value="ctgA"
-              />
               <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                style="margin-right: 7px;"
-                title="Search for features or navigate to a location using syntax \\"chr1:1-100\\" or \\"chr1:1..100\\""
+                class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+                style="margin-left: 7px;"
               >
                 <svg
                   aria-hidden="true"
@@ -671,6 +671,34 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
                 >
                   <path
                     d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-autocomplete="list"
+                aria-describedby="refNameAutocomplete-lgv-helper-text"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                id="refNameAutocomplete-lgv"
+                placeholder="Search for location"
+                spellcheck="false"
+                type="text"
+                value="ctgA"
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                style="margin-right: 7px;"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-colorAction"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
                   />
                 </svg>
               </div>
@@ -928,25 +956,12 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               style="margin: 7px; min-width: 175px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
                 style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
               >
-                <input
-                  aria-autocomplete="list"
-                  aria-invalid="false"
-                  autocapitalize="none"
-                  autocomplete="off"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                  id="refNameAutocomplete-lgv"
-                  placeholder="Search for location"
-                  spellcheck="false"
-                  type="text"
-                  value="ctgA:1..100;ctgB:1,001..1,698"
-                />
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                  style="margin-right: 7px;"
-                  title="Search for features or navigate to a location using syntax \\"chr1:1-100\\" or \\"chr1:1..100\\""
+                  class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+                  style="margin-left: 7px;"
                 >
                   <svg
                     aria-hidden="true"
@@ -956,6 +971,33 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                   >
                     <path
                       d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-autocomplete="list"
+                  aria-invalid="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                  id="refNameAutocomplete-lgv"
+                  placeholder="Search for location"
+                  spellcheck="false"
+                  type="text"
+                  value="ctgA:1..100;ctgB:1,001..1,698"
+                />
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  style="margin-right: 7px;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorAction"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
                     />
                   </svg>
                 </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -257,25 +257,12 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     style="margin: 7px; min-width: 175px;"
                   >
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd MuiInputBase-marginDense MuiOutlinedInput-marginDense"
                       style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
                     >
-                      <input
-                        aria-autocomplete="list"
-                        aria-invalid="false"
-                        autocapitalize="none"
-                        autocomplete="off"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
-                        id="refNameAutocomplete-test_view"
-                        placeholder="Search for location"
-                        spellcheck="false"
-                        type="text"
-                        value="ctgA:1..40"
-                      />
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-marginDense"
-                        style="margin-right: 7px;"
-                        title="Search for features or navigate to a location using syntax \\"chr1:1-100\\" or \\"chr1:1..100\\""
+                        class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-marginDense"
+                        style="margin-left: 7px;"
                       >
                         <svg
                           aria-hidden="true"
@@ -285,6 +272,33 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         >
                           <path
                             d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                          />
+                        </svg>
+                      </div>
+                      <input
+                        aria-autocomplete="list"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+                        id="refNameAutocomplete-test_view"
+                        placeholder="Search for location"
+                        spellcheck="false"
+                        type="text"
+                        value="ctgA:1..40"
+                      />
+                      <div
+                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-marginDense"
+                        style="margin-right: 7px;"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
                           />
                         </svg>
                       </div>


### PR DESCRIPTION
After originally showing the idea in https://github.com/GMOD/jbrowse-components/issues/2086 and then our discussion in the weekly meeting, here's a draft for a more extensive tooltip text for the RefNameAutocomplete.

This moves the "search" icon to the beginning of the box and adds a "help" icon to the end of the box that has the tooltip. This way, since it's a large tooltip, it'll only show up if you hover over the help button, and otherwise it won't get in your way. The disadvantage to this approach is it takes up a bit more space it what is already sometimes a cramped text box. We could also consider making that box wider as part of this PR.

![image](https://user-images.githubusercontent.com/25592344/124038422-551e6100-d9be-11eb-9d34-c1385229d816.png)
