### PR TITLE
More usage of typography

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -135,13 +135,11 @@ export const FieldName = ({
   return description ? (
     <Tooltip title={description} placement="left">
       <div className={clsx(classes.fieldDescription, classes.fieldName)}>
-        <Typography variant="body2">{val}</Typography>
+        {val}
       </div>
     </Tooltip>
   ) : (
-    <div className={classes.fieldName}>
-      <Typography variant="body2">{val}</Typography>
-    </div>
+    <div className={classes.fieldName}>{val}</div>
   )
 }
 

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -121,7 +121,7 @@ export function BaseCard({
   )
 }
 
-const FieldName = ({
+export const FieldName = ({
   description,
   name,
   prefix = [],
@@ -145,23 +145,31 @@ const FieldName = ({
   )
 }
 
-const BasicValue = ({ value }: { value: string | React.ReactNode }) => {
+export const BasicValue = ({ value }: { value: string | React.ReactNode }) => {
   const classes = useStyles()
   return (
     <div className={classes.fieldValue}>
-      {React.isValidElement(value) ? (
-        value
-      ) : (
-        <Typography variant="body2">
+      <Typography
+        component={({ children, ...rest }) => {
+          // use a div instead of <p> to avoid nesting SanitizedHTML <div>
+          // contents in a <p>
+          return <div {...rest}>{children}</div>
+        }}
+        variant="body2"
+      >
+        {React.isValidElement(value) ? (
+          value
+        ) : (
           <SanitizedHTML
             html={isObject(value) ? JSON.stringify(value) : String(value)}
           />
-        </Typography>
-      )}
+        )}
+      </Typography>
     </div>
   )
 }
-const SimpleValue = ({
+
+export const SimpleValue = ({
   name,
   value,
   description,

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -135,11 +135,13 @@ const FieldName = ({
   return description ? (
     <Tooltip title={description} placement="left">
       <div className={clsx(classes.fieldDescription, classes.fieldName)}>
-        {val}
+        <Typography>{val}</Typography>
       </div>
     </Tooltip>
   ) : (
-    <div className={classes.fieldName}>{val}</div>
+    <div className={classes.fieldName}>
+      <Typography>{val}</Typography>
+    </div>
   )
 }
 
@@ -150,9 +152,11 @@ const BasicValue = ({ value }: { value: string | React.ReactNode }) => {
       {React.isValidElement(value) ? (
         value
       ) : (
-        <SanitizedHTML
-          html={isObject(value) ? JSON.stringify(value) : String(value)}
-        />
+        <Typography>
+          <SanitizedHTML
+            html={isObject(value) ? JSON.stringify(value) : String(value)}
+          />
+        </Typography>
       )}
     </div>
   )
@@ -250,12 +254,12 @@ function CoreDetails(props: BaseProps) {
   ]
   return (
     <>
-      {coreRenderedDetails.map(key => {
-        const value = displayedDetails[key.toLowerCase()]
-        return value !== null && value !== undefined ? (
+      {coreRenderedDetails
+        .map(key => [key, displayedDetails[key.toLowerCase()]])
+        .filter(([, value]) => value !== null && value !== undefined)
+        .map(([key, value]) => (
           <SimpleValue key={key} name={key} value={value} />
-        ) : null
-      })}
+        ))}
     </>
   )
 }
@@ -473,10 +477,10 @@ export const FeatureDetails = (props: {
 
   return (
     <BaseCard title={title}>
-      <div>Core details</div>
+      <Typography>Core details</Typography>
       <CoreDetails {...props} />
       <Divider />
-      <div>Attributes</div>
+      <Typography>Attributes</Typography>
       <Attributes
         attributes={feature}
         {...props}

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -135,12 +135,12 @@ const FieldName = ({
   return description ? (
     <Tooltip title={description} placement="left">
       <div className={clsx(classes.fieldDescription, classes.fieldName)}>
-        <Typography>{val}</Typography>
+        <Typography variant="body2">{val}</Typography>
       </div>
     </Tooltip>
   ) : (
     <div className={classes.fieldName}>
-      <Typography>{val}</Typography>
+      <Typography variant="body2">{val}</Typography>
     </div>
   )
 }
@@ -152,7 +152,7 @@ const BasicValue = ({ value }: { value: string | React.ReactNode }) => {
       {React.isValidElement(value) ? (
         value
       ) : (
-        <Typography>
+        <Typography variant="body2">
           <SanitizedHTML
             html={isObject(value) ? JSON.stringify(value) : String(value)}
           />
@@ -486,6 +486,7 @@ export const FeatureDetails = (props: {
         {...props}
         omit={[...omit, ...coreDetails]}
       />
+
       {sequenceTypes.includes(feature.type) ? (
         <ErrorBoundary
           FallbackComponent={({ error }) => (
@@ -497,7 +498,8 @@ export const FeatureDetails = (props: {
           <SequenceFeatureDetails {...props} />
         </ErrorBoundary>
       ) : null}
-      {subfeatures && subfeatures.length ? (
+
+      {subfeatures?.length ? (
         <BaseCard
           title="Subfeatures"
           defaultExpanded={!sequenceTypes.includes(feature.type)}

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -149,22 +149,13 @@ export const BasicValue = ({ value }: { value: string | React.ReactNode }) => {
   const classes = useStyles()
   return (
     <div className={classes.fieldValue}>
-      <Typography
-        component={({ children, ...rest }) => {
-          // use a div instead of <p> to avoid nesting SanitizedHTML <div>
-          // contents in a <p>
-          return <div {...rest}>{children}</div>
-        }}
-        variant="body2"
-      >
-        {React.isValidElement(value) ? (
-          value
-        ) : (
-          <SanitizedHTML
-            html={isObject(value) ? JSON.stringify(value) : String(value)}
-          />
-        )}
-      </Typography>
+      {React.isValidElement(value) ? (
+        value
+      ) : (
+        <SanitizedHTML
+          html={isObject(value) ? JSON.stringify(value) : String(value)}
+        />
+      )}
     </div>
   )
 }

--- a/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
+++ b/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
@@ -69,11 +69,7 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldName"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  Position
-                </p>
+                Position
               </div>
               <div
                 class="makeStyles-fieldValue"
@@ -89,11 +85,7 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldName"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  Length
-                </p>
+                Length
               </div>
               <div
                 class="makeStyles-fieldValue"
@@ -117,11 +109,7 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldName"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  score
-                </p>
+                score
               </div>
               <div
                 class="makeStyles-fieldValue"

--- a/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
+++ b/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
@@ -58,22 +58,32 @@ exports[`open up a widget 1`] = `
           <div
             class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
           >
-            <div>
+            <p
+              class="MuiTypography-root MuiTypography-body1"
+            >
               Core details
-            </div>
+            </p>
             <div
               class="makeStyles-field"
             >
               <div
                 class="makeStyles-fieldName"
               >
-                Position
+                <p
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  Position
+                </p>
               </div>
               <div
                 class="makeStyles-fieldValue"
               >
-                <div>
-                  ctgA:3..102 (+)
+                <div
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  <div>
+                    ctgA:3..102 (+)
+                  </div>
                 </div>
               </div>
             </div>
@@ -83,35 +93,53 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldName"
               >
-                Length
+                <p
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  Length
+                </p>
               </div>
               <div
                 class="makeStyles-fieldValue"
               >
-                <div>
-                  100
+                <div
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  <div>
+                    100
+                  </div>
                 </div>
               </div>
             </div>
             <hr
               class="MuiDivider-root"
             />
-            <div>
+            <p
+              class="MuiTypography-root MuiTypography-body1"
+            >
               Attributes
-            </div>
+            </p>
             <div
               class="makeStyles-field"
             >
               <div
                 class="makeStyles-fieldName"
               >
-                score
+                <p
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  score
+                </p>
               </div>
               <div
                 class="makeStyles-fieldValue"
               >
-                <div>
-                  37
+                <div
+                  class="MuiTypography-root MuiTypography-body2"
+                >
+                  <div>
+                    37
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
+++ b/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
@@ -78,12 +78,8 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldValue"
               >
-                <div
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  <div>
-                    ctgA:3..102 (+)
-                  </div>
+                <div>
+                  ctgA:3..102 (+)
                 </div>
               </div>
             </div>
@@ -102,12 +98,8 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldValue"
               >
-                <div
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  <div>
-                    100
-                  </div>
+                <div>
+                  100
                 </div>
               </div>
             </div>
@@ -134,12 +126,8 @@ exports[`open up a widget 1`] = `
               <div
                 class="makeStyles-fieldValue"
               >
-                <div
-                  class="MuiTypography-root MuiTypography-body2"
-                >
-                  <div>
-                    37
-                  </div>
+                <div>
+                  37
                 </div>
               </div>
             </div>

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -1,14 +1,30 @@
-import { Typography, Link, Paper } from '@material-ui/core'
+import React, { useState } from 'react'
+import {
+  Typography,
+  Link,
+  Paper,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  makeStyles,
+} from '@material-ui/core'
 import { observer } from 'mobx-react'
 import { getSession } from '@jbrowse/core/util'
-import React, { useState } from 'react'
 import copy from 'copy-to-clipboard'
 import {
   FeatureDetails,
   BaseCard,
-  useStyles,
+  SimpleValue,
 } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
 import { parseCigar } from '../BamAdapter/MismatchParser'
+
+const useStyles = makeStyles(() => ({
+  compact: {
+    paddingRight: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+}))
 
 const omit = ['clipPos', 'flags']
 
@@ -33,20 +49,28 @@ function AlignmentFlags(props: { feature: any }) {
   ]
   return (
     <BaseCard {...props} title="Flags">
-      <div style={{ display: 'flex' }}>
-        <div className={classes.fieldName}>Flag</div>
-        <div className={classes.fieldValue}>{flags}</div>
-      </div>
-      {flagNames.map((name, index) => {
-        const val = flags & (1 << index)
-        const key = `${name}_${val}`
-        return (
-          <div key={key}>
-            <input type="checkbox" checked={Boolean(val)} id={key} readOnly />
-            <label htmlFor={key}>{name}</label>
-          </div>
-        )
-      })}
+      <SimpleValue name={'Flag'} value={flags} />
+
+      <FormGroup>
+        {flagNames.map((name, index) => {
+          const val = flags & (1 << index)
+          const key = `${name}_${val}`
+          return (
+            <FormControlLabel
+              key={key}
+              control={
+                <Checkbox
+                  className={classes.compact}
+                  checked={Boolean(val)}
+                  name={name}
+                  readOnly
+                />
+              }
+              label={name}
+            />
+          )
+        })}
+      </FormGroup>
     </BaseCard>
   )
 }

--- a/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -76,11 +76,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Position
-                  </p>
+                  Position
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -96,11 +92,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Name
-                  </p>
+                  Name
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -116,11 +108,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Length
-                  </p>
+                  Length
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -136,11 +124,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Type
-                  </p>
+                  Type
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -164,11 +148,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    seq
-                  </p>
+                  seq
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -184,11 +164,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    score
-                  </p>
+                  score
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -204,11 +180,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    qual
-                  </p>
+                  qual
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -234,11 +206,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    MQ
-                  </p>
+                  MQ
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -254,11 +222,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    CIGAR
-                  </p>
+                  CIGAR
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -274,11 +238,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    length_on_ref
-                  </p>
+                  length_on_ref
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -294,11 +254,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    template_length
-                  </p>
+                  template_length
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -314,11 +270,7 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    seq_length
-                  </p>
+                  seq_length
                 </div>
                 <div
                   class="makeStyles-fieldValue"

--- a/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -85,12 +85,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      ctgA:3..102 (+)
-                    </div>
+                  <div>
+                    ctgA:3..102 (+)
                   </div>
                 </div>
               </div>
@@ -109,12 +105,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      ctgA_3_555_0:0:0_2:0:0_102d
-                    </div>
+                  <div>
+                    ctgA_3_555_0:0:0_2:0:0_102d
                   </div>
                 </div>
               </div>
@@ -133,12 +125,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      100
-                    </div>
+                  <div>
+                    100
                   </div>
                 </div>
               </div>
@@ -157,12 +145,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      match
-                    </div>
+                  <div>
+                    match
                   </div>
                 </div>
               </div>
@@ -189,12 +173,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG
-                    </div>
+                  <div>
+                    TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG
                   </div>
                 </div>
               </div>
@@ -213,12 +193,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      37
-                    </div>
+                  <div>
+                    37
                   </div>
                 </div>
               </div>
@@ -237,22 +213,18 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
+                  <button
+                    type="button"
                   >
-                    <button
-                      type="button"
-                    >
-                      Copy
-                    </button>
-                    <button
-                      type="button"
-                    >
-                      Show more
-                    </button>
-                    <div>
-                      17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 1...
-                    </div>
+                    Copy
+                  </button>
+                  <button
+                    type="button"
+                  >
+                    Show more
+                  </button>
+                  <div>
+                    17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 1...
                   </div>
                 </div>
               </div>
@@ -271,12 +243,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      37
-                    </div>
+                  <div>
+                    37
                   </div>
                 </div>
               </div>
@@ -295,12 +263,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      100M
-                    </div>
+                  <div>
+                    100M
                   </div>
                 </div>
               </div>
@@ -319,12 +283,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      100
-                    </div>
+                  <div>
+                    100
                   </div>
                 </div>
               </div>
@@ -343,12 +303,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      0
-                    </div>
+                  <div>
+                    0
                   </div>
                 </div>
               </div>
@@ -367,12 +323,8 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      100
-                    </div>
+                  <div>
+                    100
                   </div>
                 </div>
               </div>

--- a/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -65,22 +65,32 @@ exports[`open up a widget 1`] = `
             <div
               class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
             >
-              <div>
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
                 Core details
-              </div>
+              </p>
               <div
                 class="makeStyles-field"
               >
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Position
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Position
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    ctgA:3..102 (+)
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      ctgA:3..102 (+)
+                    </div>
                   </div>
                 </div>
               </div>
@@ -90,13 +100,21 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Name
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Name
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    ctgA_3_555_0:0:0_2:0:0_102d
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      ctgA_3_555_0:0:0_2:0:0_102d
+                    </div>
                   </div>
                 </div>
               </div>
@@ -106,13 +124,21 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Length
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Length
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    100
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      100
+                    </div>
                   </div>
                 </div>
               </div>
@@ -122,77 +148,53 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Type
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Type
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    match
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      match
+                    </div>
                   </div>
                 </div>
               </div>
               <hr
                 class="MuiDivider-root"
               />
-              <div>
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
                 Attributes
-              </div>
+              </p>
               <div
                 class="makeStyles-field"
               >
                 <div
                   class="makeStyles-fieldName"
                 >
-                  seq
-                </div>
-                <div
-                  class="makeStyles-fieldValue"
-                >
-                  <div>
-                    TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG
-                  </div>
-                </div>
-              </div>
-              <div
-                class="makeStyles-field"
-              >
-                <div
-                  class="makeStyles-fieldName"
-                >
-                  score
-                </div>
-                <div
-                  class="makeStyles-fieldValue"
-                >
-                  <div>
-                    37
-                  </div>
-                </div>
-              </div>
-              <div
-                class="makeStyles-field"
-              >
-                <div
-                  class="makeStyles-fieldName"
-                >
-                  qual
-                </div>
-                <div
-                  class="makeStyles-fieldValue"
-                >
-                  <button
-                    type="button"
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
                   >
-                    Copy
-                  </button>
-                  <button
-                    type="button"
+                    seq
+                  </p>
+                </div>
+                <div
+                  class="makeStyles-fieldValue"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
                   >
-                    Show more
-                  </button>
-                  <div>
-                    17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 1...
+                    <div>
+                      TTGTTGCGGAGTTGAACAACGGCATTAGGAACACTTCCGTCTCTCACTTTTATACGATTATGATTGGTTCTTTAGCCTTGGTTTAGATTGGTAGTAGTAG
+                    </div>
                   </div>
                 </div>
               </div>
@@ -202,13 +204,21 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  MQ
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    score
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    37
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      37
+                    </div>
                   </div>
                 </div>
               </div>
@@ -218,13 +228,31 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  CIGAR
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    qual
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    100M
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <button
+                      type="button"
+                    >
+                      Copy
+                    </button>
+                    <button
+                      type="button"
+                    >
+                      Show more
+                    </button>
+                    <div>
+                      17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 1...
+                    </div>
                   </div>
                 </div>
               </div>
@@ -234,13 +262,21 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  length_on_ref
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    MQ
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    100
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      37
+                    </div>
                   </div>
                 </div>
               </div>
@@ -250,13 +286,21 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  template_length
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    CIGAR
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    0
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      100M
+                    </div>
                   </div>
                 </div>
               </div>
@@ -266,13 +310,69 @@ exports[`open up a widget 1`] = `
                 <div
                   class="makeStyles-fieldName"
                 >
-                  seq_length
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    length_on_ref
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    100
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      100
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="makeStyles-field"
+              >
+                <div
+                  class="makeStyles-fieldName"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    template_length
+                  </p>
+                </div>
+                <div
+                  class="makeStyles-fieldValue"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      0
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="makeStyles-field"
+              >
+                <div
+                  class="makeStyles-fieldName"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    seq_length
+                  </p>
+                </div>
+                <div
+                  class="makeStyles-fieldValue"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      100
+                    </div>
                   </div>
                 </div>
               </div>
@@ -343,159 +443,475 @@ exports[`open up a widget 1`] = `
               class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
             >
               <div
-                style="display: flex;"
+                class="MuiFormGroup-root"
               >
-                <div
-                  class="makeStyles-fieldName"
-                >
-                  Flag
-                </div>
-                <div
-                  class="makeStyles-fieldValue"
-                />
-              </div>
-              <div>
-                <input
-                  id="read paired_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read paired_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read paired
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read paired"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read paired
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="read mapped in proper pair_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read mapped in proper pair_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read mapped in proper pair
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read mapped in proper pair"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read mapped in proper pair
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="read unmapped_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read unmapped_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read unmapped
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read unmapped"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read unmapped
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="mate unmapped_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="mate unmapped_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  mate unmapped
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="mate unmapped"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    mate unmapped
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="read reverse strand_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read reverse strand_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read reverse strand
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read reverse strand"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read reverse strand
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="mate reverse strand_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="mate reverse strand_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  mate reverse strand
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="mate reverse strand"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    mate reverse strand
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="first in pair_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="first in pair_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  first in pair
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="first in pair"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    first in pair
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="second in pair_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="second in pair_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  second in pair
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="second in pair"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    second in pair
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="not primary alignment_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="not primary alignment_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  not primary alignment
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="not primary alignment"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    not primary alignment
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="read fails platform/vendor quality checks_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read fails platform/vendor quality checks_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read fails platform/vendor quality checks
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read fails platform/vendor quality checks"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read fails platform/vendor quality checks
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="read is PCR or optical duplicate_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="read is PCR or optical duplicate_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  read is PCR or optical duplicate
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="read is PCR or optical duplicate"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    read is PCR or optical duplicate
+                  </span>
                 </label>
-              </div>
-              <div>
-                <input
-                  id="supplementary alignment_0"
-                  readonly=""
-                  type="checkbox"
-                />
                 <label
-                  for="supplementary alignment_0"
+                  class="MuiFormControlLabel-root"
                 >
-                  supplementary alignment
+                  <span
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary makeStyles-compact MuiIconButton-colorSecondary"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input"
+                        data-indeterminate="false"
+                        name="supplementary alignment"
+                        readonly=""
+                        type="checkbox"
+                        value=""
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  >
+                    supplementary alignment
+                  </span>
                 </label>
               </div>
             </div>

--- a/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
@@ -1,8 +1,8 @@
+import React, { useEffect, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import LinearProgress from '@material-ui/core/LinearProgress'
+import { Typography, LinearProgress } from '@material-ui/core'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
 
 const useStyles = makeStyles({
   loading: {
@@ -43,7 +43,7 @@ function LoadingMessage() {
 
   return shown ? (
     <div data-testid="loading-synteny" className={classes.loading}>
-      Loading &hellip;
+      <Typography>Loading &hellip;</Typography>
       <LinearProgress />
     </div>
   ) : null
@@ -51,7 +51,11 @@ function LoadingMessage() {
 
 function BlockMessage({ messageText }: { messageText: string }) {
   const classes = useStyles()
-  return <div className={classes.blockMessage}>{messageText}</div>
+  return (
+    <div className={classes.blockMessage}>
+      <Typography>{messageText}</Typography>
+    </div>
+  )
 }
 BlockMessage.propTypes = {
   messageText: PropTypes.string.isRequired,
@@ -59,7 +63,11 @@ BlockMessage.propTypes = {
 
 function BlockError({ error }: { error: Error }) {
   const classes = useStyles()
-  return <div className={classes.blockError}>{error.message}</div>
+  return (
+    <div className={classes.blockError}>
+      <Typography>{error.message}</Typography>
+    </div>
+  )
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -94,7 +94,11 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
     <>
       {shown ? (
         <div className={classes.loading}>
-          <div className={classes.dots}>{status ? `${status}` : 'Loading'}</div>
+          <Typography>
+            <div className={classes.dots}>
+              {status ? `${status}` : 'Loading'}
+            </div>
+          </Typography>
         </div>
       ) : null}
     </>
@@ -130,21 +134,17 @@ function BlockError({
   return (
     <div className={classes.blockError} style={{ height: displayHeight }}>
       {reload ? (
-        <>
-          <Button
-            data-testid="reload_button"
-            onClick={reload}
-            startIcon={<RefreshIcon />}
-          >
-            Reload
-          </Button>
-          {`${error}`}
-        </>
-      ) : (
-        <Typography color="error" variant="body2">
-          {`${error}`}
-        </Typography>
-      )}
+        <Button
+          data-testid="reload_button"
+          onClick={reload}
+          startIcon={<RefreshIcon />}
+        >
+          Reload
+        </Button>
+      ) : null}
+      <Typography color="error" variant="body2" display="inline">
+        {`${error}`}
+      </Typography>
     </div>
   )
 }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -94,10 +94,8 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
     <>
       {shown ? (
         <div className={classes.loading}>
-          <Typography>
-            <div className={classes.dots}>
-              {status ? `${status}` : 'Loading'}
-            </div>
+          <Typography className={classes.dots} variant="body2">
+            {status ? `${status}` : 'Loading'}
           </Typography>
         </div>
       ) : null}
@@ -112,12 +110,12 @@ function BlockMessage({
 }) {
   const classes = useStyles()
 
-  return typeof messageContent === 'string' ? (
+  return React.isValidElement(messageContent) ? (
+    <div className={classes.blockReactNodeMessage}>{messageContent}</div>
+  ) : (
     <Typography variant="body2" className={classes.blockMessage}>
       {messageContent}
     </Typography>
-  ) : (
-    <div className={classes.blockReactNodeMessage}>{messageContent}</div>
   )
 }
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -273,9 +273,10 @@ const ScaleBar = observer(
 
               {/* the number labels drawn in overview scale bar*/}
               {tickLabels.map((tickLabel, labelIdx) => (
-                <div
+                <Typography
                   key={`${JSON.stringify(seq)}-${tickLabel}-${labelIdx}`}
                   className={classes.scaleBarLabel}
+                  variant="body2"
                   style={{
                     left: ((labelIdx + 1) * gridPitch.majorPitch) / scale,
                     pointerEvents: 'none',
@@ -283,7 +284,7 @@ const ScaleBar = observer(
                   }}
                 >
                   {tickLabel.toLocaleString('en-US')}
-                </div>
+                </Typography>
               ))}
             </div>
           )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -315,21 +315,17 @@ function OverviewScaleBar({
   const scale =
     model.totalBp / (width - (displayedRegions.length - 1) * wholeSeqSpacer)
 
-  if (!displayedRegions.length) {
-    return (
-      <>
-        <div className={classes.scaleBar}>
-          <LinearProgress
-            variant="indeterminate"
-            style={{ marginTop: 4, width: '100%' }}
-          />
-        </div>
-        <div>{children}</div>
-      </>
-    )
-  }
-
-  return (
+  return !displayedRegions.length ? (
+    <>
+      <div className={classes.scaleBar}>
+        <LinearProgress
+          variant="indeterminate"
+          style={{ marginTop: 4, width: '100%' }}
+        />
+      </div>
+      <div>{children}</div>
+    </>
+  ) : (
     <div>
       <OverviewRubberBand
         model={model}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ReturnToImportFormDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   Divider,
   IconButton,
+  Typography,
 } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
 
@@ -47,8 +48,10 @@ function ReturnToImportFormDialog({
       <Divider />
 
       <DialogContent>
-        Are you sure you want to return to the import form? This will lose your
-        current view
+        <Typography>
+          Are you sure you want to return to the import form? This will lose
+          your current view
+        </Typography>
       </DialogContent>
       <DialogActions>
         <Button

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -33,36 +33,36 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             >
               ctgA
             </p>
-            <div
-              class="makeStyles-scaleBarLabel"
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
             >
               20
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
             >
               40
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
             >
               60
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
             >
               80
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
             >
               100
-            </div>
+            </p>
           </div>
           <div
             class="makeStyles-scaleBarContig"
@@ -785,36 +785,36 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             >
               ctgB
             </p>
-            <div
-              class="makeStyles-scaleBarLabel"
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 145.0909090909091px; pointer-events: none;"
             >
               1,200
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 290.1818181818182px; pointer-events: none;"
             >
               1,400
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 435.27272727272725px; pointer-events: none;"
             >
               1,600
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 580.3636363636364px; pointer-events: none;"
             >
               1,800
-            </div>
-            <div
-              class="makeStyles-scaleBarLabel"
+            </p>
+            <p
+              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
               style="left: 725.4545454545454px; pointer-events: none;"
             >
               2,000
-            </div>
+            </p>
           </div>
           <div
             class="makeStyles-scaleBarContig"

--- a/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -76,11 +76,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Position
-                  </p>
+                  Position
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -96,11 +92,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Name
-                  </p>
+                  Name
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -116,11 +108,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    Length
-                  </p>
+                  Length
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -145,11 +133,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title="reference base(s): Each base must be one of A,C,G,T,N (case insensitive)."
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    REF
-                  </p>
+                  REF
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -166,11 +150,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title=" alternate base(s): Comma-separated list of alternate non-reference alleles"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    ALT
-                  </p>
+                  ALT
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -187,11 +167,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title="quality: Phred-scaled quality score for the assertion made in ALT"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    QUAL
-                  </p>
+                  QUAL
                 </div>
                 <div
                   class="makeStyles-fieldValue"
@@ -207,11 +183,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    INFO.MQ
-                  </p>
+                  INFO.MQ
                 </div>
                 <div
                   class="makeStyles-fieldValue"

--- a/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -85,12 +85,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      ctgA:177..177 
-                    </div>
+                  <div>
+                    ctgA:177..177 
                   </div>
                 </div>
               </div>
@@ -109,12 +105,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      rs123
-                    </div>
+                  <div>
+                    rs123
                   </div>
                 </div>
               </div>
@@ -133,12 +125,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      1
-                    </div>
+                  <div>
+                    1
                   </div>
                 </div>
               </div>
@@ -166,12 +154,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      A
-                    </div>
+                  <div>
+                    A
                   </div>
                 </div>
               </div>
@@ -191,12 +175,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      &lt;TRA&gt;
-                    </div>
+                  <div>
+                    &lt;TRA&gt;
                   </div>
                 </div>
               </div>
@@ -216,12 +196,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      10.4
-                    </div>
+                  <div>
+                    10.4
                   </div>
                 </div>
               </div>
@@ -240,12 +216,8 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-body2"
-                  >
-                    <div>
-                      5
-                    </div>
+                  <div>
+                    5
                   </div>
                 </div>
               </div>

--- a/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -65,22 +65,32 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
             <div
               class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
             >
-              <div>
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
                 Core details
-              </div>
+              </p>
               <div
                 class="makeStyles-field"
               >
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Position
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Position
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    ctgA:177..177 
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      ctgA:177..177 
+                    </div>
                   </div>
                 </div>
               </div>
@@ -90,13 +100,21 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Name
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Name
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    rs123
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      rs123
+                    </div>
                   </div>
                 </div>
               </div>
@@ -106,22 +124,32 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  Length
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    Length
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    1
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      1
+                    </div>
                   </div>
                 </div>
               </div>
               <hr
                 class="MuiDivider-root"
               />
-              <div>
+              <p
+                class="MuiTypography-root MuiTypography-body1"
+              >
                 Attributes
-              </div>
+              </p>
               <div
                 class="makeStyles-field"
               >
@@ -129,13 +157,21 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title="reference base(s): Each base must be one of A,C,G,T,N (case insensitive)."
                 >
-                  REF
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    REF
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    A
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      A
+                    </div>
                   </div>
                 </div>
               </div>
@@ -146,13 +182,21 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title=" alternate base(s): Comma-separated list of alternate non-reference alleles"
                 >
-                  ALT
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    ALT
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    &lt;TRA&gt;
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      &lt;TRA&gt;
+                    </div>
                   </div>
                 </div>
               </div>
@@ -163,13 +207,21 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                   class="makeStyles-fieldDescription makeStyles-fieldName"
                   title="quality: Phred-scaled quality score for the assertion made in ALT"
                 >
-                  QUAL
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    QUAL
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    10.4
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      10.4
+                    </div>
                   </div>
                 </div>
               </div>
@@ -179,13 +231,21 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
                 <div
                   class="makeStyles-fieldName"
                 >
-                  INFO.MQ
+                  <p
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    INFO.MQ
+                  </p>
                 </div>
                 <div
                   class="makeStyles-fieldValue"
                 >
-                  <div>
-                    5
+                  <div
+                    class="MuiTypography-root MuiTypography-body2"
+                  >
+                    <div>
+                      5
+                    </div>
                   </div>
                 </div>
               </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -93,7 +93,6 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 <div
                   class="makeStyles-scaleBar"
                 >
-<<<<<<< HEAD
                   <div
                     class="makeStyles-scaleBarVisibleRegion"
                     style="width: 267px; left: 0px;"
@@ -112,91 +111,47 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     >
                       ctgA
                     </p>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       20
-                    </div>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    </p>
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       40
-                    </div>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    </p>
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       60
-                    </div>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    </p>
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       80
-                    </div>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    </p>
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       100
-                    </div>
-                    <div
-                      class="makeStyles-scaleBarLabel"
+                    </p>
+                    <p
+                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                       style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
                     >
                       120
-                    </div>
+                    </p>
                   </div>
                   <div
                     class="makeStyles-scaleBarContig"
                     style="width: 0px; left: 800px; background-color: rgb(153, 153, 153);"
                   />
-=======
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-                    style="color: rgb(153, 102, 0);"
-                  >
-                    ctgA
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    20
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    40
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    60
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    80
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    100
-                  </p>
-                  <p
-                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                    style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
-                  >
-                    120
-                  </p>
->>>>>>> 27747efc7... Update snaps, fix issue with making SanitizedHTML wrapped in a
                 </div>
               </div>
             </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 <div
                   class="makeStyles-scaleBar"
                 >
+<<<<<<< HEAD
                   <div
                     class="makeStyles-scaleBarVisibleRegion"
                     style="width: 267px; left: 0px;"
@@ -152,6 +153,50 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="makeStyles-scaleBarContig"
                     style="width: 0px; left: 800px; background-color: rgb(153, 153, 153);"
                   />
+=======
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
+                    style="color: rgb(153, 102, 0);"
+                  >
+                    ctgA
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    20
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    40
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    60
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    80
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    100
+                  </p>
+                  <p
+                    class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                    style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
+                  >
+                    120
+                  </p>
+>>>>>>> 27747efc7... Update snaps, fix issue with making SanitizedHTML wrapped in a
                 </div>
               </div>
             </div>


### PR DESCRIPTION
In jbrowse/react-linear-genome-view, if there are bare "divs with text", then the font used might be something like "Times new roman" instead of a nice font

This tries to use typographies more thoroughly to make the font's a bit better