### PR TITLE
Fix issue with page reload after editing session title

### DIFF
--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -220,7 +220,6 @@ export default function RootModel(
                   }),
                 )
                 if (self.pluginsUpdated) {
-                  this.setPluginsUpdated(false)
                   // reload app to get a fresh plugin manager
                   window.location.reload()
                 }
@@ -242,9 +241,6 @@ export default function RootModel(
             self.session = oldSession
             throw error
           }
-        }
-        if (oldSession) {
-          this.setPluginsUpdated(true)
         }
       },
       setAssemblyEditing(flag: boolean) {


### PR DESCRIPTION
This may have been vestigial or unneeded logic to do "setPluginsUpdated" anytime setSession was called.

Removing it, I can still see plugin install and remove work in the in-app plugin store