### PR TITLE
Make sure to wait for assembly to load before downloading canonical refnames in SV inspector

### DIFF
--- a/plugins/circular-view/src/CircularView/models/CircularView.ts
+++ b/plugins/circular-view/src/CircularView/models/CircularView.ts
@@ -299,6 +299,7 @@ export default function CircularView(pluginManager: PluginManager) {
         },
 
         setError(error: Error) {
+          console.error(error)
           self.error = error
         },
 

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -219,7 +219,7 @@ const SvInspectorViewF = pluginManager => {
         addDisposer(
           self,
           autorun(
-            () => {
+            async () => {
               const {
                 assemblyName,
                 onlyDisplayRelevantRegionsInCircularView,
@@ -229,15 +229,16 @@ const SvInspectorViewF = pluginManager => {
               const { tracks } = circularView
               const session = getSession(self)
               if (assemblyName) {
-                const assembly = session.assemblyManager.get(assemblyName)
+                const assembly = await session.assemblyManager.waitForAssembly(
+                  assemblyName,
+                )
                 if (assembly) {
-                  const { regions: assemblyRegions = [] } = assembly
+                  const {
+                    getCanonicalRefName,
+                    regions: assemblyRegions = [],
+                  } = assembly
                   if (onlyDisplayRelevantRegionsInCircularView) {
                     if (tracks.length === 1) {
-                      const {
-                        getCanonicalRefName,
-                      } = session.assemblyManager.get(assemblyName)
-
                       featuresRefNamesP
                         .then(featureRefNames => {
                           // canonicalize the store's ref names if necessary

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -44,11 +44,9 @@ Demo instances
     Volvox sample data (small imaginary test datasets)
   </Link>
 
-
 Conference demos
 
 - [BOG2021](http://jbrowse.org/demos/bog2021/)
 - [ASHG2020](http://jbrowse.org/demos/ashg2020/)
 - [ITCR2020](http://jbrowse.org/demos/itcr2020/)
 - [BOG2020](http://jbrowse.org/demos/bog2020/)
-


### PR DESCRIPTION
Fixes #2108 

Historical note:
There has been a tension in the history of the development regarding whether assemblies should be "waited on using promises" or "respond to observability" and this is a move towards "waited on using promises". This can interact with the mobx observability in weird ways e.g. anything after an await likely would not be picked up by the mobx autorun-observer-stuff but that should be ok here