### PR TITLE
Fix "Can't resolve '@jbrowse/plugin-legacy-jbrowse'" in `@jbrowse/react-linear-genome-view`

### DIFF
--- a/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
@@ -8,7 +8,6 @@ import Sequence from '@jbrowse/plugin-sequence'
 import SVG from '@jbrowse/plugin-svg'
 import Variants from '@jbrowse/plugin-variants'
 import Wiggle from '@jbrowse/plugin-wiggle'
-import LegacyJBrowse from '@jbrowse/plugin-legacy-jbrowse'
 
 const corePlugins = [
   SVG,
@@ -21,7 +20,6 @@ const corePlugins = [
   Sequence,
   Variants,
   Wiggle,
-  LegacyJBrowse,
 ]
 
 export default corePlugins


### PR DESCRIPTION
Removes one reference to the legacy JBrowse plugin from `@jbrowse/react-linear-genome-view`, which is causing the following error:

```
ERROR in ./node_modules/@jbrowse/react-linear-genome-view/dist/react-linear-genome-view.cjs.production.min.js
Module not found: Error: Can't resolve '@jbrowse/plugin-legacy-jbrowse' in './node_modules/@jbrowse/react-linear-genome-view/dist'
```