### PR TITLE
Use URL instead of name to remove plugins

### DIFF
--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
@@ -18,6 +18,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close'
 import LockIcon from '@material-ui/icons/Lock'
 
+import PluginManager from '@jbrowse/core/PluginManager'
 import { getSession } from '@jbrowse/core/util'
 import { BasePlugin } from '@jbrowse/core/util/types'
 import { isSessionWithSessionPlugins } from '@jbrowse/core/util/types'
@@ -99,9 +100,11 @@ function PluginDialog({
 function InstalledPlugin({
   plugin,
   model,
+  pluginManager,
 }: {
   plugin: BasePlugin
   model: PluginStoreModel
+  pluginManager: PluginManager
 }) {
   const [dialogPlugin, setDialogPlugin] = useState<string>()
 
@@ -110,7 +113,7 @@ function InstalledPlugin({
   // @ts-ignore
   const { sessionPlugins } = session
   const isSessionPlugin = sessionPlugins?.some(
-    (p: BasePlugin) => `${p.name}Plugin` === plugin.name,
+    (p: BasePlugin) => pluginManager.pluginMetadata[plugin.name].url === p.url,
   )
 
   const rootModel = getParent(model, 3)
@@ -123,10 +126,12 @@ function InstalledPlugin({
           plugin={dialogPlugin}
           onClose={name => {
             if (name) {
+              const pluginMetadata = pluginManager.pluginMetadata[plugin.name]
+              const pluginUrl = pluginMetadata.url
               if (adminMode) {
-                jbrowse.removePlugin(plugin.name)
+                jbrowse.removePlugin(pluginUrl)
               } else if (isSessionWithSessionPlugins(session)) {
-                session.removeSessionPlugin(plugin.name)
+                session.removeSessionPlugin(pluginUrl)
               }
             }
             setDialogPlugin(undefined)

--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPluginsList.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPluginsList.tsx
@@ -30,7 +30,12 @@ function InstalledPluginsList({
             plugin.name.toLowerCase().includes(model.filterText.toLowerCase()),
           )
           .map(plugin => (
-            <InstalledPlugin key={plugin.name} plugin={plugin} model={model} />
+            <InstalledPlugin
+              key={plugin.name}
+              plugin={plugin}
+              model={model}
+              pluginManager={pluginManager}
+            />
           ))
       ) : (
         <Typography>No plugins currently installed</Typography>

--- a/plugins/data-management/src/PluginStoreWidget/components/PluginCard.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/PluginCard.tsx
@@ -16,6 +16,7 @@ import PersonIcon from '@material-ui/icons/Person'
 import AddIcon from '@material-ui/icons/Add'
 import CheckIcon from '@material-ui/icons/Check'
 
+import PluginManager from '@jbrowse/core/PluginManager'
 import { getSession } from '@jbrowse/core/util'
 import type { JBrowsePlugin } from '@jbrowse/core/util/types'
 import { isSessionWithSessionPlugins } from '@jbrowse/core/util/types'
@@ -51,8 +52,12 @@ function PluginCard({
 }) {
   const classes = useStyles()
   const session = getSession(model)
-  const { pluginManager } = getEnv(model)
-  const isInstalled = pluginManager.hasPlugin(`${plugin.name}Plugin`)
+  const { pluginManager } = getEnv(model) as { pluginManager: PluginManager }
+  const isInstalled = Boolean(
+    pluginManager.runtimePluginDefinitions.find(
+      pluginDefinition => pluginDefinition.url === plugin.url,
+    ),
+  )
   const [tempDisabled, setTempDisabled] = useState(false)
   const disableButton = isInstalled || tempDisabled
 

--- a/products/jbrowse-desktop/src/Loader.tsx
+++ b/products/jbrowse-desktop/src/Loader.tsx
@@ -83,6 +83,7 @@ export default function Loader({
             ...runtimePlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
               definition,
+              metadata: { url: definition.url },
             })),
           ])
         } catch (e) {

--- a/products/jbrowse-desktop/src/jbrowseModel.js
+++ b/products/jbrowse-desktop/src/jbrowseModel.js
@@ -158,10 +158,8 @@ export default function JBrowseDesktop(
         const rootModel = getParent(self)
         rootModel.setPluginsUpdated(true)
       },
-      removePlugin(pluginName) {
-        self.plugins = self.plugins.filter(
-          plugin => `${plugin.name}Plugin` !== pluginName,
-        )
+      removePlugin(pluginUrl) {
+        self.plugins = self.plugins.filter(plugin => plugin.url !== pluginUrl)
         const rootModel = getParent(self)
         rootModel.setPluginsUpdated(true)
       },

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -503,10 +503,12 @@ const Renderer = observer(
             ...runtimePlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
               definition,
+              metadata: { url: definition.url },
             })),
             ...sessionPlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
               definition,
+              metadata: { url: definition.url },
             })),
           ])
           pluginManager.createPluggableElements()

--- a/products/jbrowse-web/src/jbrowseModel.js
+++ b/products/jbrowse-web/src/jbrowseModel.js
@@ -178,10 +178,8 @@ export default function JBrowseWeb(
         const rootModel = getRoot(self)
         rootModel.setPluginsUpdated(true)
       },
-      removePlugin(pluginName) {
-        self.plugins = self.plugins.filter(
-          plugin => `${plugin.name}Plugin` !== pluginName,
-        )
+      removePlugin(pluginUrl) {
+        self.plugins = self.plugins.filter(plugin => plugin.url !== pluginUrl)
         const rootModel = getRoot(self)
         rootModel.setPluginsUpdated(true)
       },

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -211,9 +211,9 @@ export default function sessionModelFactory(
           self.sessionAssemblies.splice(index, 1)
         }
       },
-      removeSessionPlugin(pluginName: string) {
+      removeSessionPlugin(pluginUrl: string) {
         const index = self.sessionPlugins.findIndex(
-          plugin => `${plugin.name}Plugin` === pluginName,
+          plugin => plugin.url === pluginUrl,
         )
         if (index !== -1) {
           self.sessionPlugins.splice(index, 1)


### PR DESCRIPTION
This fixes https://github.com/GMOD/jbrowse-components/issues/2052 by not using the name at all when removing plugins and instead relying on the plugin URL to identify which plugin to remove.