### PR TITLE
 Remove the lzutf8 package from cli to fix process hang

### DIFF
--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -8,7 +8,6 @@ import { LocStringResult } from '@jbrowse/core/TextSearch/BaseResults'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { Instance } from 'mobx-state-tree'
 import { RemoteFile } from 'generic-filehandle'
-import { decompress } from 'lzutf8'
 
 import MyConfigSchema from './configSchema'
 
@@ -59,9 +58,7 @@ export default class TrixTextSearchAdapter
     const results = await this.trixJs.search(queryString)
 
     results.forEach(data => {
-      buff = decompress(Buffer.from(data, 'base64'), {
-        outputEncoding: 'Buffer',
-      })
+      buff = Buffer.from(data, 'base64')
       const stringBuffer = buff.toString()
       searchResults.push(stringBuffer)
     })

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -48,7 +48,6 @@
     "express": "^4.17.1",
     "follow-redirects": "^1.14.1",
     "json-parse-better-errors": "^1.0.2",
-    "lzutf8": "^0.6.0",
     "node-fetch": "^2.6.0",
     "pako": "^1.0.11",
     "tslib": "^1",

--- a/products/jbrowse-cli/src/commands/text-index.ts
+++ b/products/jbrowse-cli/src/commands/text-index.ts
@@ -9,7 +9,6 @@ import {
   http as httpFR,
   https as httpsFR,
 } from 'follow-redirects'
-import { compress } from 'lzutf8'
 import { createGunzip, Gunzip } from 'zlib'
 import { IncomingMessage } from 'http'
 import path from 'path'
@@ -397,9 +396,7 @@ export default class TextIndex extends JBrowseCommand {
         // encodes the record object so that it can be used by ixIxx
         // appends the attributes that we are indexing by to the end
         // of the string before pushing to ixIxx
-        const buff = compress(Buffer.from(JSON.stringify(recordObj)), {
-          outputEncoding: 'Base64',
-        })
+        const buff = Buffer.from(JSON.stringify(recordObj))
 
         let str: string = buff.toString()
         str += attrString + '\n'

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -50,7 +50,6 @@
     "crypto-js": "^3.0.0",
     "fontsource-roboto": "3.0.3",
     "json-stable-stringify": "^1.0.1",
-    "lzutf8": "^0.6.0",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14548,13 +14548,6 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-lzutf8@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/lzutf8/-/lzutf8-0.6.0.tgz#ddfced3aa9959be68cc46d12c609e64d41e710f8"
-  integrity sha512-Ji0WsBU3OIA/c/RHd/vvHbda+WnbnXREpE1xHgdoyy601dQn3ZFlkDtGKDh/AtFpbO1+3YFL01KqJrD7NYuWHg==
-  dependencies:
-    readable-stream "^3.6.0"
-
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"


### PR DESCRIPTION
I found that removing the lzutf8 package stopped the hanging that was seen in #2116 

I propose removing the lzutf8 package as a result

I think it is probably ok to remove it and I don't believe we need a replacement for it

The current usage of having per-line or per-entry compression is probably not very efficient, it is better to compress larger blocks of text so you can exploit redundancy across lines/entries

It may be worth considering alternative encodings or compression if we see issues but I think removing is ok for now

It is unclear to me why removing lzutf8 fixed the hanging but it was very reproducible to me

This is a PR targetting the text_searching branch