### PR TITLE
Fix loading indicator on refnameautocomplete being stuck

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -94,10 +94,10 @@ function RefNameAutocomplete({
   const [searchOptions, setSearchOptions] = useState<Option[]>([])
   const { assemblyManager } = session
   const { coarseVisibleLocStrings } = model
-  const assembly = assemblyName && assemblyManager.get(assemblyName)
-  const regions: Region[] = useMemo(() => {
-    return (assembly && assembly.regions) || []
-  }, [assembly])
+  const assembly = assemblyName ? assemblyManager.get(assemblyName) : undefined
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const regions: Region[] = assembly?.regions || []
   // default options for dropdown
   const limitOption: Array<Option> = [
     {


### PR DESCRIPTION
Fixes #2118 

Gets rid of useMemo statement. It could use assembly.regions as the parameter for useMemo but it is more straightforward i think to not useMemo here