### PR TITLE
Create extension point for session model

### DIFF
--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -15,6 +15,8 @@ export default abstract class Plugin {
 
   configure(_pluginManager: PluginManager): void {}
 
+  extendSession?: Function
+
   configurationSchema: AnyConfigurationSchemaType | undefined = undefined
 }
 

--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -15,8 +15,6 @@ export default abstract class Plugin {
 
   configure(_pluginManager: PluginManager): void {}
 
-  extendSession?: Function
-
   configurationSchema: AnyConfigurationSchemaType | undefined = undefined
 }
 

--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -1,5 +1,6 @@
 import PluginManager from './PluginManager'
 import { AnyConfigurationSchemaType } from './configuration/configurationSchema'
+import { IAnyModelType } from 'mobx-state-tree'
 
 /**
  * base class for a JBrowse plugin
@@ -14,6 +15,10 @@ export default abstract class Plugin {
   install(_pluginManager: PluginManager): void {}
 
   configure(_pluginManager: PluginManager): void {}
+
+  extendSession(sessionModel: IAnyModelType) {
+    return sessionModel
+  }
 
   configurationSchema: AnyConfigurationSchemaType | undefined = undefined
 }

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -31,15 +31,16 @@ It is likely preferable in most cases to install the tools first however
 ## Commands
 
 <!-- commands -->
-* [`jbrowse add-assembly SEQUENCE`](#jbrowse-add-assembly-sequence)
-* [`jbrowse add-connection CONNECTIONURLORPATH`](#jbrowse-add-connection-connectionurlorpath)
-* [`jbrowse add-track TRACK`](#jbrowse-add-track-track)
-* [`jbrowse add-track-json TRACK`](#jbrowse-add-track-json-track)
-* [`jbrowse admin-server`](#jbrowse-admin-server)
-* [`jbrowse create LOCALPATH`](#jbrowse-create-localpath)
-* [`jbrowse help [COMMAND]`](#jbrowse-help-command)
-* [`jbrowse set-default-session`](#jbrowse-set-default-session)
-* [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
+
+- [`jbrowse add-assembly SEQUENCE`](#jbrowse-add-assembly-sequence)
+- [`jbrowse add-connection CONNECTIONURLORPATH`](#jbrowse-add-connection-connectionurlorpath)
+- [`jbrowse add-track TRACK`](#jbrowse-add-track-track)
+- [`jbrowse add-track-json TRACK`](#jbrowse-add-track-json-track)
+- [`jbrowse admin-server`](#jbrowse-admin-server)
+- [`jbrowse create LOCALPATH`](#jbrowse-create-localpath)
+- [`jbrowse help [COMMAND]`](#jbrowse-help-command)
+- [`jbrowse set-default-session`](#jbrowse-set-default-session)
+- [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
 
 ## `jbrowse add-assembly SEQUENCE`
 
@@ -70,7 +71,7 @@ OPTIONS
       show CLI help
 
   -l, --load=copy|symlink|move|inPlace
-      Required flag when using a local file. Choose how to manage the data directory. Copy, symlink, or move the data 
+      Required flag when using a local file. Choose how to manage the data directory. Copy, symlink, or move the data
       directory to the JBrowse directory. Or use inPlace to modify the config without doing any file operations
 
   -n, --name=name
@@ -179,11 +180,11 @@ EXAMPLES
   $ jbrowse add-connection http://mysite.com/jbrowse/data/
   $ jbrowse add-connection http://mysite.com/jbrowse/custom_data_folder/ --type JBrowse1Connection
   $ jbrowse add-connection http://mysite.com/path/to/hub.txt --assemblyName hg19
-  $ jbrowse add-connection http://mysite.com/path/to/custom_hub_name.txt --type UCSCTrackHubConnection --assemblyName 
+  $ jbrowse add-connection http://mysite.com/path/to/custom_hub_name.txt --type UCSCTrackHubConnection --assemblyName
   hg19
-  $ jbrowse add-connection http://mysite.com/path/to/custom --type custom --config 
+  $ jbrowse add-connection http://mysite.com/path/to/custom --type custom --config
   '{"uri":{"url":"https://mysite.com/path/to/custom"}}' --assemblyName hg19
-  $ jbrowse add-connection https://mysite.com/path/to/hub.txt --connectionId newId --name newName --target 
+  $ jbrowse add-connection https://mysite.com/path/to/hub.txt --connectionId newId --name newName --target
   /path/to/jb2/installation/config.json
 ```
 
@@ -254,7 +255,7 @@ EXAMPLES
   # no --load flag to add literal URL for this track to config.json
   $ jbrowse add-track https://mywebsite.com/my.bam
 
-  # --load move to move the file 
+  # --load move to move the file
   $ jbrowse add-track /path/to/my.bam --name 'New Track' --load move
 
   # --load inPlace puts /url/relative/path.bam in the config without performing any file operations
@@ -397,7 +398,7 @@ OPTIONS
 
 EXAMPLES
   $ jbrowse set-default-session --session /path/to/default/session.json
-  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1, 
+  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1,
   track2, track3
   $ jbrowse set-default-session --view LinearGenomeView, --name newName --viewId view-no-tracks
   $ jbrowse set-default-session --currentSession # Prints out current default session
@@ -438,6 +439,7 @@ EXAMPLES
 ```
 
 _See code: [src/commands/upgrade.ts](https://github.com/GMOD/jbrowse-components/blob/v1.3.2/products/jbrowse-cli/src/commands/upgrade.ts)_
+
 <!-- commandsstop -->
 
 ## Debugging

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -696,11 +696,7 @@ export default function sessionModelFactory(
     }))
 
   pluginManager.plugins.forEach(plugin => {
-    // @ts-ignore
-    if (plugin.extendSession) {
-      // @ts-ignore
-      sessionModel = plugin.extendSession(sessionModel)
-    }
+    sessionModel = plugin.extendSession(sessionModel)
   })
 
   return types.snapshotProcessor(sessionModel, {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -696,7 +696,9 @@ export default function sessionModelFactory(
     }))
 
   pluginManager.plugins.forEach(plugin => {
+    // @ts-ignore
     if (plugin.extendSession) {
+      // @ts-ignore
       sessionModel = plugin.extendSession(sessionModel)
     }
   })

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -51,7 +51,7 @@ export default function sessionModelFactory(
   assemblyConfigSchemasType = types.frozen(), // if not using sessionAssemblies
 ) {
   const minDrawerWidth = 128
-  const sessionModel = types
+  let sessionModel = types
     .model('JBrowseWebSessionModel', {
       id: types.optional(types.identifier, shortid()),
       name: types.string,
@@ -694,6 +694,12 @@ export default function sessionModelFactory(
         ]
       },
     }))
+
+  pluginManager.plugins.forEach(plugin => {
+    if (plugin.extendSession) {
+      sessionModel = plugin.extendSession(sessionModel)
+    }
+  })
 
   return types.snapshotProcessor(sessionModel, {
     // @ts-ignore


### PR DESCRIPTION
This is a tiny PR from an idea that @cmdcolin and I worked on. It is related to #2032, but is for the session model, instead of the state model on a display type. This was motivated by work on #2080 .

Here, before the session model is returned from the model factory, it checks if any plugins have an `extendSession` method defined. If it does, it updates the session model with the result of that function.

For example:

```
extendSession(sessionModel: IAnyModelType) {
  return types.compose(
    sessionModel,
    types.model('HelloWorld', { foopy: types.optional(types.string, 'lol') }),
  )
}
```

Would extend the session with the new attribute `foopy`. 

We also investigated doing something similar for the LGV menu, but ran into some issues so stopped here for now. Would be curious about your thoughts @rbuels and @garrettjstevens .