### PR TITLE
Ensure CLI's README is formatted whenever it's updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "nock": "^12.0.3",
+    "npm-run-all": "^4.1.5",
     "open-cli": "^6.0.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -31,15 +31,16 @@ It is likely preferable in most cases to install the tools first however
 ## Commands
 
 <!-- commands -->
-* [`jbrowse add-assembly SEQUENCE`](#jbrowse-add-assembly-sequence)
-* [`jbrowse add-connection CONNECTIONURLORPATH`](#jbrowse-add-connection-connectionurlorpath)
-* [`jbrowse add-track TRACK`](#jbrowse-add-track-track)
-* [`jbrowse add-track-json TRACK`](#jbrowse-add-track-json-track)
-* [`jbrowse admin-server`](#jbrowse-admin-server)
-* [`jbrowse create LOCALPATH`](#jbrowse-create-localpath)
-* [`jbrowse help [COMMAND]`](#jbrowse-help-command)
-* [`jbrowse set-default-session`](#jbrowse-set-default-session)
-* [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
+
+- [`jbrowse add-assembly SEQUENCE`](#jbrowse-add-assembly-sequence)
+- [`jbrowse add-connection CONNECTIONURLORPATH`](#jbrowse-add-connection-connectionurlorpath)
+- [`jbrowse add-track TRACK`](#jbrowse-add-track-track)
+- [`jbrowse add-track-json TRACK`](#jbrowse-add-track-json-track)
+- [`jbrowse admin-server`](#jbrowse-admin-server)
+- [`jbrowse create LOCALPATH`](#jbrowse-create-localpath)
+- [`jbrowse help [COMMAND]`](#jbrowse-help-command)
+- [`jbrowse set-default-session`](#jbrowse-set-default-session)
+- [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
 
 ## `jbrowse add-assembly SEQUENCE`
 
@@ -70,7 +71,7 @@ OPTIONS
       show CLI help
 
   -l, --load=copy|symlink|move|inPlace
-      Required flag when using a local file. Choose how to manage the data directory. Copy, symlink, or move the data 
+      Required flag when using a local file. Choose how to manage the data directory. Copy, symlink, or move the data
       directory to the JBrowse directory. Or use inPlace to modify the config without doing any file operations
 
   -n, --name=name
@@ -179,11 +180,11 @@ EXAMPLES
   $ jbrowse add-connection http://mysite.com/jbrowse/data/
   $ jbrowse add-connection http://mysite.com/jbrowse/custom_data_folder/ --type JBrowse1Connection
   $ jbrowse add-connection http://mysite.com/path/to/hub.txt --assemblyName hg19
-  $ jbrowse add-connection http://mysite.com/path/to/custom_hub_name.txt --type UCSCTrackHubConnection --assemblyName 
+  $ jbrowse add-connection http://mysite.com/path/to/custom_hub_name.txt --type UCSCTrackHubConnection --assemblyName
   hg19
-  $ jbrowse add-connection http://mysite.com/path/to/custom --type custom --config 
+  $ jbrowse add-connection http://mysite.com/path/to/custom --type custom --config
   '{"uri":{"url":"https://mysite.com/path/to/custom"}}' --assemblyName hg19
-  $ jbrowse add-connection https://mysite.com/path/to/hub.txt --connectionId newId --name newName --target 
+  $ jbrowse add-connection https://mysite.com/path/to/hub.txt --connectionId newId --name newName --target
   /path/to/jb2/installation/config.json
 ```
 
@@ -254,7 +255,7 @@ EXAMPLES
   # no --load flag to add literal URL for this track to config.json
   $ jbrowse add-track https://mywebsite.com/my.bam
 
-  # --load move to move the file 
+  # --load move to move the file
   $ jbrowse add-track /path/to/my.bam --name 'New Track' --load move
 
   # --load inPlace puts /url/relative/path.bam in the config without performing any file operations
@@ -397,7 +398,7 @@ OPTIONS
 
 EXAMPLES
   $ jbrowse set-default-session --session /path/to/default/session.json
-  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1, 
+  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1,
   track2, track3
   $ jbrowse set-default-session --view LinearGenomeView, --name newName --viewId view-no-tracks
   $ jbrowse set-default-session --currentSession # Prints out current default session
@@ -438,6 +439,7 @@ EXAMPLES
 ```
 
 _See code: [src/commands/upgrade.ts](https://github.com/GMOD/jbrowse-components/blob/v1.3.2/products/jbrowse-cli/src/commands/upgrade.ts)_
+
 <!-- commandsstop -->
 
 ## Debugging

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -32,10 +32,16 @@
   },
   "scripts": {
     "build": "oclif-dev pack",
-    "postpack": "rm -f oclif.manifest.json",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "version": "oclif-dev readme && git add README.md",
-    "docs": "oclif-dev readme && prettier --write README.md"
+    "build:typescript": "tsc --build",
+    "postpack": "rimraf oclif.manifest.json",
+    "clean": "rimraf lib",
+    "prepack": "npm-run-all clean build:typescript manifest docs",
+    "manifest": "oclif-dev manifest",
+    "version": "npm-run-all docs:**",
+    "docs": "npm-run-all docs:*",
+    "docs:create": "oclif-dev readme",
+    "docs:format": "prettier --write README.md",
+    "docs:version:add": "git add README.md"
   },
   "dependencies": {
     "@oclif/command": "^1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14794,6 +14794,11 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -15638,6 +15643,21 @@ npm-pick-manifest@^3.0.0:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -16456,6 +16476,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -19360,7 +19385,7 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==


### PR DESCRIPTION
It looks like sometimes during the release process, the README for the CLI gets auto-generated, but the pre-commit hook doesn't make sure it gets properly formatted. This adds formatting to the step where the CLI gets auto-generated, so it'll get formatted even if the pre-commit hook doesn't work. It also makes the CLI's package.json more cross-platform by using [`npm-run-all`](https://www.npmjs.com/package/npm-run-all) instead of chained `&&`s and replacing `rm -rf` with [`rimraf`](https://www.npmjs.com/package/rimraf).