### PR TITLE
Add plain VCF adapter recognition to guessAdapter

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -165,7 +165,8 @@ export function guessAdapter(
 
   if (/\.vcf$/i.test(fileName)) {
     return {
-      type: 'UNSUPPORTED',
+      type: 'VcfAdapter',
+      vcfLocation: file,
     }
   }
 

--- a/plugins/variants/src/VcfAdapter/VcfAdapter.ts
+++ b/plugins/variants/src/VcfAdapter/VcfAdapter.ts
@@ -62,6 +62,11 @@ export default class VcfAdapter extends BaseFeatureDataAdapter {
     return readVcf(fileContents)
   }
 
+  public async getHeader() {
+    const { header } = await this.decodeFileContents()
+    return header
+  }
+
   public async getLines() {
     const { header, lines } = await this.decodeFileContents()
 

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -547,7 +547,8 @@ export default class AddTrack extends JBrowseCommand {
 
     if (/\.vcf$/i.test(fileName)) {
       return {
-        type: 'UNSUPPORTED',
+        type: 'VcfAdapter',
+        vcfLocation: makeLocation(fileName),
       }
     }
 


### PR DESCRIPTION
This adds the VcfAdapter for a plain VCF to both CLI and add-track. It doesn't really try to warn against large VCFs but it should be fine for small VCF that are encountered in the wild. The VcfAdapter was created by @carolinebridge-oicr originally

We could think about also unifying the cli and core codebase, and making it more pluggable perhaps too...but maybe as follow ons :)