### PR TITLE
Add example dataset for COLO829

### DIFF
--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -3195,7 +3195,6 @@
         }
       }
     },
-
     {
       "type": "AlignmentsTrack",
       "trackId": "modbam_test.read",
@@ -3296,6 +3295,34 @@
           "gziLocation": {
             "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
           }
+        }
+      }
+    },
+    {
+      "type": "QuantitativeTrack",
+      "trackId": "colo_normal",
+      "name": "COLO829 MinION normal (coverage)",
+      "description": "https://www.ebi.ac.uk/ena/browser/view/PRJEB27698",
+      "category": ["COLO829"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/COLO829/colo_normal.bw"
+        }
+      }
+    },
+    {
+      "type": "QuantitativeTrack",
+      "trackId": "colo_tumor",
+      "name": "COLO829 MinION tumor (coverage)",
+      "description": "https://www.ebi.ac.uk/ena/browser/view/PRJEB27698",
+      "category": ["COLO829"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/COLO829/colo_tumor.bw"
         }
       }
     }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -3226,6 +3226,78 @@
           }
         }
       }
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "truthset_somaticSVs_COLO829",
+      "name": "truthset_somaticSVs_COLO829",
+      "description": "Source https://github.com/UMCUGenetics/COLO829_somaticSV",
+      "category": ["COLO829"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "VcfAdapter",
+        "vcfLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/COLO829/truthset_somaticSVs_COLO829.vcf"
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "colo829.normal.ngmlr.sorted",
+      "name": "COLO829 MinION normal",
+      "category": ["COLO829"],
+      "assemblyNames": ["hg19"],
+      "description": "https://www.ebi.ac.uk/ena/browser/view/PRJEB27698",
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/COLO829/colo829.normal.ngmlr.sorted.merged.cram"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/COLO829/colo829.normal.ngmlr.sorted.merged.cram.crai"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "colo829.tumor.ngmlr.sorted.merged",
+      "name": "COLO829 MinION tumor",
+      "category": ["COLO829"],
+      "assemblyNames": ["hg19"],
+      "description": "https://www.ebi.ac.uk/ena/browser/view/PRJEB27698",
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/COLO829/colo829.tumor.ngmlr.sorted.merged.cram"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/COLO829/colo829.tumor.ngmlr.sorted.merged.cram.crai"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+          }
+        }
+      }
     }
   ],
   "connections": [],


### PR DESCRIPTION
This is an interesting tumor+normal paired dataset that I stumbled on here https://www.biorxiv.org/content/10.1101/2020.07.09.196527v1

The ENA has some BAM files for the data https://www.ebi.ac.uk/ena/browser/view/PRJEB27698


There is also a plain text "truth set" of breakends in a VCF source data file here https://github.com/UMCUGenetics/COLO829_somaticSV



