### PR TITLE
Fix using Color by modifications on BAM/CRAM that need ref renaming

### DIFF
--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -36,7 +36,9 @@ export async function getUniqueTagValues(
 }
 
 export async function getUniqueModificationValues(
-  self: IAnyStateTreeNode & { parentTrack: any },
+  self: IAnyStateTreeNode & {
+    parentTrack: IAnyStateTreeNode & { configuration: AnyConfigurationModel }
+  },
   adapterConfig: AnyConfigurationModel,
   colorScheme: { type: string; tag?: string },
   blocks: BlockSet,

--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -1,7 +1,10 @@
 import { BlockSet } from '@jbrowse/core/util/blockTypes'
 
 import { getSession } from '@jbrowse/core/util'
-import { getRpcSessionId } from '@jbrowse/core/util/tracks'
+import {
+  getRpcSessionId,
+  getTrackAssemblyNames,
+} from '@jbrowse/core/util/tracks'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
@@ -33,7 +36,7 @@ export async function getUniqueTagValues(
 }
 
 export async function getUniqueModificationValues(
-  self: IAnyStateTreeNode,
+  self: IAnyStateTreeNode & { parentTrack: any },
   adapterConfig: AnyConfigurationModel,
   colorScheme: { type: string; tag?: string },
   blocks: BlockSet,
@@ -53,6 +56,7 @@ export async function getUniqueModificationValues(
       tag: colorScheme.tag,
       sessionId,
       regions: blocks.contentBlocks,
+      assemblyName: getTrackAssemblyNames(self.parentTrack)[0],
       ...opts,
     },
   )

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -3167,8 +3167,9 @@
     {
       "type": "AlignmentsTrack",
       "trackId": "modbam_test.reference",
-      "name": "modbam_test.reference",
-      "assemblyNames": ["hg19"],
+      "name": "Nanopolish modbam_test.reference 20:10000000",
+      "assemblyNames": ["hg38"],
+      "category": ["Methylation"],
       "adapter": {
         "type": "BamAdapter",
         "bamLocation": {
@@ -3183,22 +3184,24 @@
         "sequenceAdapter": {
           "type": "BgzipFastaAdapter",
           "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
           },
           "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
           },
           "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
           }
         }
       }
     },
+
     {
       "type": "AlignmentsTrack",
       "trackId": "modbam_test.read",
-      "name": "modbam_test.read",
-      "assemblyNames": ["hg19"],
+      "name": "Nanopolish modbam_test.read 20:10000000",
+      "category": ["Methylation"],
+      "assemblyNames": ["hg38"],
       "adapter": {
         "type": "BamAdapter",
         "bamLocation": {
@@ -3213,13 +3216,13 @@
         "sequenceAdapter": {
           "type": "BgzipFastaAdapter",
           "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
           },
           "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
           },
           "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
           }
         }
       }

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -3163,6 +3163,66 @@
           "uri": "https://jbrowse.org/genomes/GRCh38/methylation/modified_bases.5mC.bb"
         }
       }
+    },
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "modbam_test.reference",
+      "name": "modbam_test.reference",
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BamAdapter",
+        "bamLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/nanopolish_methylation_test/modbam_test.reference.bam"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg19/nanopolish_methylation_test/modbam_test.reference.bam.bai"
+          },
+          "indexType": "BAI"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "modbam_test.read",
+      "name": "modbam_test.read",
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BamAdapter",
+        "bamLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/nanopolish_methylation_test/modbam_test.read.bam"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg19/nanopolish_methylation_test/modbam_test.read.bam.bai"
+          },
+          "indexType": "BAI"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi"
+          }
+        }
+      }
     }
   ],
   "connections": [],


### PR DESCRIPTION
Fixes #2125 

There is a subtle chain of behaviors where because the ref renaming didn't work, it created the invalid state seen in #2125 

It started with the assemblyName not being defined, so renameRegionsIfNeeded returned the regions back, so then the bamadapter just returned 0 features for requests to the wrong chromosome for getting the 'modification color map' preprocessing step, so then the colors were black

complicated chain of events...it could be interesting if it used the assemblyName on the region object perhaps but this fixes the issue in the current way that things work

