### PR TITLE
Make renameRegionsIfNeeded use assemblyName defined on regions themselves

### DIFF
--- a/plugins/alignments/src/shared.ts
+++ b/plugins/alignments/src/shared.ts
@@ -1,10 +1,7 @@
 import { BlockSet } from '@jbrowse/core/util/blockTypes'
 
 import { getSession } from '@jbrowse/core/util'
-import {
-  getRpcSessionId,
-  getTrackAssemblyNames,
-} from '@jbrowse/core/util/tracks'
+import { getRpcSessionId } from '@jbrowse/core/util/tracks'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
@@ -58,7 +55,6 @@ export async function getUniqueModificationValues(
       tag: colorScheme.tag,
       sessionId,
       regions: blocks.contentBlocks,
-      assemblyName: getTrackAssemblyNames(self.parentTrack)[0],
       ...opts,
     },
   )

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -13,7 +13,6 @@ import {
 import {
   getParentRenderProps,
   getRpcSessionId,
-  getTrackAssemblyNames,
 } from '@jbrowse/core/util/tracks'
 import {
   BaseLinearDisplay,
@@ -512,19 +511,14 @@ const stateModelFactory = (
             'WiggleGetMultiRegionStats',
             {
               ...params,
-              assemblyName: getTrackAssemblyNames(self.parentTrack)[0],
-              regions: JSON.parse(
-                JSON.stringify(
-                  dynamicBlocks.contentBlocks.map(region => {
-                    const { start, end } = region
-                    return {
-                      ...region,
-                      start: Math.floor(start),
-                      end: Math.ceil(end),
-                    }
-                  }),
-                ),
-              ),
+              regions: dynamicBlocks.contentBlocks.map(region => {
+                const { start, end } = region
+                return {
+                  ...region,
+                  start: Math.floor(start),
+                  end: Math.ceil(end),
+                }
+              }),
               bpPerPx,
             },
           )) as FeatureStats


### PR DESCRIPTION
This uses the assemblyName defined on a region object to do the renameRegionsIfNeeded operation. It first prepares a map of assemblyName->refNameMap and uses those for the individual renameRegionIfNeeded calls as usual