### PR TITLE
Fix missing mouseovers in some cases in pileup/svg tracks

### DIFF
--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.test.js
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.test.js
@@ -11,6 +11,7 @@ test('one', () => {
       height={500}
       regions={[{ refName: 'zonk', start: 1, end: 3 }]}
       layout={new PrecomputedLayout({ rectangles: {}, totalHeight: 20 })}
+      displayModel={{}}
       bpPerPx={3}
       config={{ type: 'DummyRenderer' }}
     />,

--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -31,8 +31,8 @@ function PileupRendering(props: {
     selectedFeatureId,
     featureIdUnderMouse,
     contextMenuFeature,
-    blockLayoutFeatures,
-  } = displayModel || {}
+  } = displayModel
+
   const [region] = regions
   const highlightOverlayCanvas = useRef<HTMLCanvasElement>(null)
   const [mouseIsDown, setMouseIsDown] = useState(false)
@@ -49,15 +49,11 @@ function PileupRendering(props: {
       return
     }
     ctx.clearRect(0, 0, canvas.width, canvas.height)
-    let rect
-    let blockLayout
-
-    if (
-      selectedFeatureId &&
-      (blockLayout = blockLayoutFeatures.get(blockKey)) &&
-      (rect = blockLayout.get(selectedFeatureId))
-    ) {
-      const [leftBp, topPx, rightBp, bottomPx] = rect
+    const selectedRect = selectedFeatureId
+      ? displayModel.getFeatureByID?.(selectedFeatureId)
+      : undefined
+    if (selectedRect) {
+      const [leftBp, topPx, rightBp, bottomPx] = selectedRect
       const [leftPx, rightPx] = bpSpanPx(leftBp, rightBp, region, bpPerPx)
       const rectTop = Math.round(topPx)
       const rectHeight = Math.round(bottomPx - topPx)
@@ -75,12 +71,11 @@ function PileupRendering(props: {
       ctx.clearRect(leftPx, rectTop, rightPx - leftPx, rectHeight)
     }
     const highlightedFeature = featureIdUnderMouse || contextMenuFeature?.id()
-    if (
-      highlightedFeature &&
-      (blockLayout = blockLayoutFeatures.get(blockKey)) &&
-      (rect = blockLayout.get(highlightedFeature))
-    ) {
-      const [leftBp, topPx, rightBp, bottomPx] = rect
+    const highlightedRect = highlightedFeature
+      ? displayModel.getFeatureByID?.(highlightedFeature)
+      : undefined
+    if (highlightedRect) {
+      const [leftBp, topPx, rightBp, bottomPx] = highlightedRect
       const [leftPx, rightPx] = bpSpanPx(leftBp, rightBp, region, bpPerPx)
       const rectTop = Math.round(topPx)
       const rectHeight = Math.round(bottomPx - topPx)
@@ -91,10 +86,9 @@ function PileupRendering(props: {
     bpPerPx,
     region,
     selectedFeatureId,
+    displayModel,
     featureIdUnderMouse,
     contextMenuFeature,
-    blockKey,
-    blockLayoutFeatures,
   ])
 
   function onMouseDown(event: MouseEvent) {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -137,23 +137,6 @@ export const BaseLinearDisplay = types
           : undefined
       },
 
-      /**
-       * returns per-base block layouts as the data structure
-       * `Map<blockKey, Map<featureId, LayoutRecord>>`
-       *
-       * this per-block is needed to avoid cross-contamination of
-       * layouts across blocks especially when building the rtree
-       */
-      get blockLayoutFeatures() {
-        const layoutMaps = new Map<string, Map<string, LayoutRecord>>()
-        for (const block of self.blockState.values()) {
-          if (block && block.layout && block.layout.rectangles) {
-            layoutMaps.set(block.key, block.layout.getRectangles())
-          }
-        }
-        return layoutMaps
-      },
-
       getFeatureOverlapping(blockKey: string, x: number, y: number) {
         return self.blockState.get(blockKey)?.layout?.getByCoord(x, y)
       },

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -158,7 +158,7 @@ export const BaseLinearDisplay = types
         return self.blockState.get(blockKey)?.layout?.getByCoord(x, y)
       },
 
-      getFeatureByID(id: string) {
+      getFeatureByID(id: string): [number, number, number, number] | undefined {
         let ret
         self.blockState.forEach(block => {
           const val = block?.layout?.getByID(id)

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.test.js
@@ -1015,12 +1015,8 @@ test('processed transcript (exons + impliedUTR)', () => {
   expect(container.firstChild).toMatchSnapshot()
 })
 
+// hacks existence of getFeatureByID
 test('svg selected', () => {
-  const blockLayoutFeatures = new Map()
-  const layout = new Map()
-  layout.set('one', [0, 0, 10, 10])
-  blockLayoutFeatures.set('block1', layout)
-
   const { container } = render(
     <svg>
       <SvgOverlay
@@ -1029,7 +1025,9 @@ test('svg selected', () => {
         blockKey="block1"
         region={{ refName: 'zonk', start: 0, end: 1000 }}
         displayModel={{
-          blockLayoutFeatures,
+          getFeatureByID: () => {
+            return [0, 0, 10, 10]
+          },
           featureIdUnderMouse: 'one',
           selectedFeatureId: 'one',
         }}

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
@@ -8,7 +8,7 @@ type LayoutRecord = [number, number, number, number]
 interface SvgOverlayProps {
   region: Region
   displayModel: {
-    blockLayoutFeatures: Map<string, Map<string, LayoutRecord>>
+    getFeatureByID: (arg0: string) => LayoutRecord
     selectedFeatureId?: string
     featureIdUnderMouse?: string
     contextMenuFeature?: SimpleFeature
@@ -112,10 +112,7 @@ function SvgOverlay({
     featureIdUnderMouse,
     contextMenuFeature,
   } = displayModel
-  // const blockLayout = blockLayoutFeatures?.get(blockKey)
-  // if (!blockLayout) {
-  //   return null
-  // }
+
   const mouseoverFeatureId = featureIdUnderMouse || contextMenuFeature?.id()
 
   function onFeatureMouseDown(
@@ -239,7 +236,7 @@ function SvgOverlay({
       ) : null}
       {selectedFeatureId ? (
         <OverlayRect
-          rect={blockLayout.get(selectedFeatureId)}
+          rect={displayModel.getFeatureByID?.(selectedFeatureId)}
           region={region}
           bpPerPx={bpPerPx}
           stroke="#00b8ff"

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
@@ -100,22 +100,22 @@ function OverlayRect({
 }
 
 function SvgOverlay({
-  displayModel: {
-    blockLayoutFeatures,
-    selectedFeatureId,
-    featureIdUnderMouse,
-    contextMenuFeature,
-  },
+  displayModel,
   blockKey,
   region,
   bpPerPx,
   movedDuringLastMouseDown,
   ...handlers
 }: SvgOverlayProps) {
-  const blockLayout = blockLayoutFeatures?.get(blockKey)
-  if (!blockLayout) {
-    return null
-  }
+  const {
+    selectedFeatureId,
+    featureIdUnderMouse,
+    contextMenuFeature,
+  } = displayModel
+  // const blockLayout = blockLayoutFeatures?.get(blockKey)
+  // if (!blockLayout) {
+  //   return null
+  // }
   const mouseoverFeatureId = featureIdUnderMouse || contextMenuFeature?.id()
 
   function onFeatureMouseDown(
@@ -218,7 +218,7 @@ function SvgOverlay({
     <>
       {mouseoverFeatureId ? (
         <OverlayRect
-          rect={blockLayout.get(mouseoverFeatureId)}
+          rect={displayModel.getFeatureByID?.(mouseoverFeatureId)}
           region={region}
           bpPerPx={bpPerPx}
           fill="#000"


### PR DESCRIPTION
This is probably a fix for #2130 

SVG and pileup tracks have been updated

The blockLayoutFeatures concept is completely removed now