### PR TITLE
Remove flushLog in rpc.worker for easier debugging

### DIFF
--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-globals, no-console, react-hooks/rules-of-hooks */
+/* eslint-disable no-restricted-globals, react-hooks/rules-of-hooks */
 import './workerPolyfill'
 
 import RpcServer from '@librpc/web'
@@ -54,22 +54,6 @@ async function getPluginManager() {
   return pluginManager
 }
 
-const logBuffer: [string, ...unknown[]][] = []
-function flushLog() {
-  if (logBuffer.length) {
-    for (const l of logBuffer) {
-      const [head, ...rest] = l
-      if (head === 'rpc-error') {
-        console.error(head, ...rest)
-      } else {
-        console.log(head, ...rest)
-      }
-    }
-    logBuffer.length = 0
-  }
-}
-setInterval(flushLog, 1000)
-
 interface WrappedFuncArgs {
   rpcDriverClassName: string
   channel: string
@@ -103,8 +87,7 @@ function wrapForRpc(
         if (isAbortException(error)) {
           // logBuffer.push(['rpc-abort', myId, funcName, args])
         } else {
-          logBuffer.push(['rpc-error', myId, funcName, error])
-          flushLog()
+          console.error('rpc-error', myId, funcName, error)
         }
         throw error
       })


### PR DESCRIPTION
This is a minor thing but it sometimes confuses debugging when you pause the debugger and it is in the flushLog instead of another part of the code that you are interested in.

I am not sure if there was context behind the logging like this but it seems like reverting to a direct console log is fine