### PR TITLE
Hide local file option if the adminKey url param is in place

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -62,9 +62,13 @@ const FileLocationEditor = observer(
               }}
               aria-label="file or url picker"
             >
-              <ToggleButton value="file" aria-label="local file">
-                File
-              </ToggleButton>
+              {new URLSearchParams(window.location.search).get(
+                'adminKey',
+              ) ? null : (
+                <ToggleButton value="file" aria-label="local file">
+                  File
+                </ToggleButton>
+              )}
               <ToggleButton value="url" aria-label="url">
                 URL
               </ToggleButton>


### PR DESCRIPTION
Proposal for #2138 

This is a little hacky but it is fairly straightforward

Alternatively, we could try something like a react context, or passing an mst tree to the file selector so we get a handle on a flag that we can use to determine when to hide the option. Note that the adminMode flag on session is just true in desktop so might need to be alternative if that was considered