### PR TITLE
Remove duplicate options from LGV search dropdown and dialog

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -123,7 +123,7 @@ const LinearGenomeViewHeader = observer(({ model }: { model: LGV }) => {
   const searchScope = model.searchScope(assemblyName)
   async function setDisplayedRegion(result: BaseResult) {
     if (result) {
-      const newRegionValue = result.getLocation()
+      const newRegionValue = result.getLabel()
       // need to fix finding region
       const newRegion = regions.find(
         region => newRegionValue === region.refName,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -123,7 +123,7 @@ const LinearGenomeViewHeader = observer(({ model }: { model: LGV }) => {
   const searchScope = model.searchScope(assemblyName)
 
   async function fetchResults(queryString: string) {
-    const results =
+    const results: BaseResult[] =
       (await textSearchManager?.search(
         {
           queryString: queryString.toLocaleLowerCase(),
@@ -134,14 +134,19 @@ const LinearGenomeViewHeader = observer(({ model }: { model: LGV }) => {
       )) || []
     //  TODO: test trackID filter
     const filteredResults = results.filter(function (elem, index, self) {
-      const value1 = `${elem.label}-${elem.locString}-${elem.trackID}`
+      const value1 = `${elem.getLabel()}-${elem.getLocation()}-${
+        elem.getTrackId() || ''
+      }`
       return (
         index ===
-        self.findIndex(t => `${t.label}-${t.locString}-${t.trackID}` === value1)
+        self.findIndex(
+          t =>
+            `${t.getLabel()}-${t.getLocation()}-${t.getTrackId() || ''}` ===
+            value1,
+        )
       )
     })
     return filteredResults
-    // return results
   }
   async function setDisplayedRegion(result: BaseResult) {
     if (result) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -73,7 +73,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   }
 
   async function fetchResults(queryString: string) {
-    const results =
+    const results: BaseResult[] =
       (await textSearchManager?.search(
         {
           queryString: queryString.toLocaleLowerCase(),
@@ -84,10 +84,16 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
       )) || []
     //  TODO: test trackID filter
     const filteredResults = results.filter(function (elem, index, self) {
-      const value1 = `${elem.label}-${elem.locString}-${elem.trackID}`
+      const value1 = `${elem.getLabel()}-${elem.getLocation()}-${
+        elem.getTrackId() || ''
+      }`
       return (
         index ===
-        self.findIndex(t => `${t.label}-${t.locString}-${t.trackID}` === value1)
+        self.findIndex(
+          t =>
+            `${t.getLabel()}-${t.getLocation()}-${t.getTrackId() || ''}` ===
+            value1,
+        )
       )
     })
     return filteredResults

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -69,7 +69,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   }, [assemblyManager, assemblyName])
 
   function setSelectedValue(selectedOption: BaseResult) {
-    setSelectedRegion(selectedOption.getLocation())
+    setSelectedRegion(selectedOption.getLabel())
   }
 
   async function handleSelectedRegion(input: string) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -72,6 +72,26 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     setSelectedRegion(selectedOption.getLabel())
   }
 
+  async function fetchResults(queryString: string) {
+    const results =
+      (await textSearchManager?.search(
+        {
+          queryString: queryString.toLocaleLowerCase(),
+          searchType: 'exact',
+        },
+        searchScope,
+        rankSearchResults,
+      )) || []
+    //  TODO: test trackID filter
+    const filteredResults = results.filter(function (elem, index, self) {
+      const value1 = `${elem.label}-${elem.locString}-${elem.trackID}`
+      return (
+        index ===
+        self.findIndex(t => `${t.label}-${t.locString}-${t.trackID}` === value1)
+      )
+    })
+    return filteredResults
+  }
   async function handleSelectedRegion(input: string) {
     const newRegion = assemblyRegions.find(r => selectedRegion === r.refName)
     if (newRegion) {
@@ -80,15 +100,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
       // region visible, xref #1703
       model.showAllRegions()
     } else {
-      const results =
-        (await textSearchManager?.search(
-          {
-            queryString: input.toLocaleLowerCase(),
-            searchType: 'exact',
-          },
-          searchScope,
-          rankSearchResults,
-        )) || []
+      const results = await fetchResults(input.toLocaleLowerCase())
       if (results.length > 0) {
         model.setSearchResults(results, input.toLocaleLowerCase())
       } else {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -56,10 +56,13 @@ async function fetchResults(
     queryString: query,
     searchType: 'prefix',
   }
-  const searchResults =
+  const searchResults: BaseResult[] =
     (await textSearchManager?.search(args, searchScope, rankSearchResults)) ||
     []
-  return searchResults
+  const filteredResults = searchResults.filter(function (elem, index, self) {
+    return index === self.findIndex(t => t.label === elem.label)
+  })
+  return filteredResults
 }
 function RefNameAutocomplete({
   model,

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -71,16 +71,17 @@ export default class TrixTextSearchAdapter
     }
     // Example: {"locstring":"ctgB;1659..1984","Name":["f07"],"Note":["This is an example"],"type":"remark"}
     const formattedResults = results.map(result => {
-      const { Name, Note, ID, locstring } = JSON.parse(result)
+      const { Name, Note, ID, locstring, trackID } = JSON.parse(result)
       const locString = locstring.replace(/;/g, ':')
       return new LocStringResult({
         locString,
         label: Name?.[0] || Note?.[0] || ID?.[0],
         matchedAttribute: 'name',
         matchedObject: result,
+        trackId: trackID,
       })
     })
     return formattedResults
   }
-  freeResources() {}
+  freeResources() { }
 }

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -83,5 +83,5 @@ export default class TrixTextSearchAdapter
     })
     return formattedResults
   }
-  freeResources() { }
+  freeResources() {}
 }

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -51,6 +51,20 @@
   ],
   "aggregateTextSearchAdapters": [
     {
+      "type": "JBrowse1TextSearchAdapter",
+      "textSearchAdapterId": "JBrowse1GenerateNamesAdapter",
+      "namesIndexLocation": {
+        "uri": "names/"
+      },
+      "tracks": [
+        "bedtabix_genes",
+        "volvox_test_vcf",
+        "gff3tabix_genes",
+        "volvox_filtered_vcf"
+      ],
+      "assemblies": ["volvox", "volvox2"]
+    },
+    {
       "type": "TrixTextSearchAdapter",
       "textSearchAdapterId": "TrixAdapter",
       "ixFilePath": {

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -51,20 +51,6 @@
   ],
   "aggregateTextSearchAdapters": [
     {
-      "type": "JBrowse1TextSearchAdapter",
-      "textSearchAdapterId": "JBrowse1GenerateNamesAdapter",
-      "namesIndexLocation": {
-        "uri": "names/"
-      },
-      "tracks": [
-        "bedtabix_genes",
-        "volvox_test_vcf",
-        "gff3tabix_genes",
-        "volvox_filtered_vcf"
-      ],
-      "assemblies": ["volvox", "volvox2"]
-    },
-    {
       "type": "TrixTextSearchAdapter",
       "textSearchAdapterId": "TrixAdapter",
       "ixFilePath": {


### PR DESCRIPTION
Reduces duplicates of options displayed in the dropdown. Should simplify flow of selecting option and opening more searchResults dialog. Instead of adding an indicator for the different types of options which could be misleading or confusing to the user, this simplifies displaying more options in the search results dialog.

Before:
<img width="390" alt="Screen Shot 2021-07-26 at 12 33 20 AM" src="https://user-images.githubusercontent.com/45598764/127033440-94b6f7b2-f14d-46d5-a10c-a017ac28c4ad.png">

After:

<img width="390" alt="Screen Shot 2021-07-26 at 12 38 56 AM" src="https://user-images.githubusercontent.com/45598764/127033758-d4547eac-02ac-4ed7-b696-3232d0522a6e.png">

before:

<img width="390" alt="Screen Shot 2021-07-26 at 10 36 43 AM" src="https://user-images.githubusercontent.com/45598764/127033865-491ffc09-94f7-49b9-8fa8-d7786b5429c5.png">
after:

<img width="390" alt="Screen Shot 2021-07-26 at 10 36 55 AM" src="https://user-images.githubusercontent.com/45598764/127033685-c04062eb-fb13-4cc3-8220-0d85fc4d6533.png">


TODO: need to adjust to not open dialog when there is only one result, check for trackID in index in order to open track