### PR TITLE
Fix rendering of negative strand alignment modifications/methylation

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
@@ -492,6 +492,7 @@ test('getModificationPositions', () => {
   const positions = getModificationPositions(
     'C+m,2,2,1,4,1',
     'AGCTCTCCAGAGTCGNACGCCATYCGCGCGCCACCA',
+    1,
   )
   expect(positions[0]).toEqual({ type: 'm', positions: [6, 17, 20, 31, 34] })
 })

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -349,14 +349,12 @@ export function getModificationPositions(mm: string, seq: string) {
           positions: rest
             .map(score => +score)
             .map(delta => {
-              i++
               do {
                 if (base === 'N' || base === seq[i]) {
                   delta--
                 }
                 i++
               } while (delta >= 0 && i < seq.length)
-              i--
               return i
             }),
         }

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -1,3 +1,4 @@
+import { revcom } from '@jbrowse/core/util'
 export interface Mismatch {
   qual?: number
   start: number
@@ -314,9 +315,14 @@ export function* getNextRefPos(cigarOps: string[], positions: number[]) {
   }
 }
 
-export function getModificationPositions(mm: string, seq: string) {
-  const mods = mm.split(';')
-  return mods
+export function getModificationPositions(
+  mm: string,
+  featureSeq: string,
+  strand: number,
+) {
+  const seq = strand === -1 ? revcom(featureSeq) : featureSeq
+  return mm
+    .split(';')
     .filter(mod => !!mod)
     .map(mod => {
       const [basemod, ...rest] = mod.split(',')

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -348,26 +348,25 @@ export function getModificationPositions(
       // sequence of the read, if we have a modification type e.g. C+m;2 and a
       // sequence ACGTACGTAC we skip the two instances of C and go to the last
       // C
-      const mods = []
-      for (let i = 0; i < types.length; i++) {
-        const type = types[i]
-        let pos = 0
-        const positions = []
-        for (let j = 0; j < skips.length; j++) {
-          let skip = +skips[j]
-          do {
-            if (base === 'N' || base === seq[pos]) {
-              skip--
-            }
-            pos++
-          } while (skip >= 0 && i < seq.length)
-          pos--
-          positions.push(fstrand === -1 ? seq.length - 1 - pos : pos)
-          pos++
+      return types.map(type => {
+        let i = 0
+        return {
+          type,
+          positions: skips
+            .map(score => +score)
+            .map(delta => {
+              do {
+                if (base === 'N' || base === seq[i]) {
+                  delta--
+                }
+                i++
+              } while (delta >= 0 && i < seq.length)
+              const temp = i - 1
+              return fstrand === -1 ? seq.length - 1 - temp : temp
+            })
+            .sort((a, b) => a - b),
         }
-        mods.push({ type, positions: positions.sort((a, b) => a - b) })
-      }
-      return mods
+      })
     })
     .flat()
 }

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -390,11 +390,12 @@ export default class PileupRenderer extends BoxRendererType {
     const fstart = feature.get('start')
     const fend = feature.get('end')
     const seq = feature.get('seq')
+    const strand = feature.get('strand')
     const cigarOps = parseCigar(cigar)
     const { start: rstart, end: rend } = region
 
     const methBins = new Array(rend - rstart).fill(0)
-    getModificationPositions(mm, seq).forEach(({ type, positions }) => {
+    getModificationPositions(mm, seq, strand).forEach(({ type, positions }) => {
       if (type === 'm' && positions) {
         for (const pos of getNextRefPos(cigarOps, positions)) {
           const epos = pos + fstart - rstart

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -334,9 +334,10 @@ export default class PileupRenderer extends BoxRendererType {
     const start = feature.get('start')
     const end = feature.get('end')
     const seq = feature.get('seq')
+    const strand = feature.get('strand')
     const cigarOps = parseCigar(cigar)
 
-    const modifications = getModificationPositions(mm, seq)
+    const modifications = getModificationPositions(mm, seq, strand)
 
     // probIndex applies across multiple modifications e.g.
     let probIndex = 0

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -189,21 +189,23 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
                   .map(elt => Math.min(1, elt / 50))
 
             let probIndex = 0
-            getModificationPositions(mm, seq).forEach(({ type, positions }) => {
-              const mod = `mod_${type}`
-              for (const pos of getNextRefPos(cigarOps, positions)) {
-                const epos = pos + fstart - region.start
-                if (epos >= 0 && epos < bins.length && pos + fstart < fend) {
-                  const bin = bins[epos]
-                  if (probabilities[probIndex] > 0.5) {
-                    inc(bin, fstrand, 'cov', mod)
-                  } else {
-                    inc(bin, fstrand, 'lowqual', mod)
+            getModificationPositions(mm, seq, fstrand).forEach(
+              ({ type, positions }) => {
+                const mod = `mod_${type}`
+                for (const pos of getNextRefPos(cigarOps, positions)) {
+                  const epos = pos + fstart - region.start
+                  if (epos >= 0 && epos < bins.length && pos + fstart < fend) {
+                    const bin = bins[epos]
+                    if (probabilities[probIndex] > 0.5) {
+                      inc(bin, fstrand, 'cov', mod)
+                    } else {
+                      inc(bin, fstrand, 'lowqual', mod)
+                    }
                   }
+                  probIndex++
                 }
-                probIndex++
-              }
-            })
+              },
+            )
           }
 
           // methylation based coloring takes into account both reference

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -220,17 +220,19 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
             const mm = getTagAlt(feature, 'MM', 'Mm') || ''
             const methBins = new Array(region.end - region.start).fill(0)
 
-            getModificationPositions(mm, seq).forEach(({ type, positions }) => {
-              // we are processing methylation
-              if (type === 'm') {
-                for (const pos of getNextRefPos(cigarOps, positions)) {
-                  const epos = pos + fstart - region.start
-                  if (epos >= 0 && epos < methBins.length) {
-                    methBins[epos] = 1
+            getModificationPositions(mm, seq, fstrand).forEach(
+              ({ type, positions }) => {
+                // we are processing methylation
+                if (type === 'm') {
+                  for (const pos of getNextRefPos(cigarOps, positions)) {
+                    const epos = pos + fstart - region.start
+                    if (epos >= 0 && epos < methBins.length) {
+                      methBins[epos] = 1
+                    }
                   }
                 }
-              }
-            })
+              },
+            )
 
             for (let j = fstart; j < fend; j++) {
               const i = j - region.start


### PR DESCRIPTION
There is a subtle part of the MM tag specification which says

"If SAM FLAG 0x10 is set, indicating that SEQ has been reverse complemented from the sequence observed by the sequencing machine, note that these base modification field values will be in the opposite orientation to SEQ and other derived SAM fields."

This means all the calculations have to be done backwards on the reverse complemented read sequence, and then flipped back forward