### PR TITLE
Fix mouseover after force load

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -238,7 +238,7 @@ export const BaseLinearDisplay = types
     reload() {
       const temp = JSON.parse(JSON.stringify(self.blockState))
       Object.keys(temp).forEach(blockState => {
-        temp[blockState].key += '-reload'
+        temp[blockState].reload = true
       })
       self.blockState = temp
     },

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -236,11 +236,7 @@ export const BaseLinearDisplay = types
       self.featureIdUnderMouse = feature
     },
     reload() {
-      const temp = JSON.parse(JSON.stringify(self.blockState))
-      Object.keys(temp).forEach(blockState => {
-        temp[blockState].reload = true
-      })
-      self.blockState = temp
+      ;[...self.blockState.values()].map(val => val.doReload())
     },
     addAdditionalContextMenuItemCallback(callback: Function) {
       self.additionalContextMenuItemCallbacks.push(callback)

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -24,7 +24,7 @@ const blockState = types
   .model('BlockState', {
     key: types.string,
     region: Region,
-    reload: false,
+    reloadFlag: 0,
     isLeftEndOfDisplayedRegion: false,
     isRightEndOfDisplayedRegion: false,
   })
@@ -45,6 +45,9 @@ const blockState = types
   .actions(self => {
     let renderInProgress: undefined | AbortController
     return {
+      doReload() {
+        self.reloadFlag = self.reloadFlag + 1
+      },
       afterAttach() {
         const display = getContainingDisplay(self)
         makeAbortableReaction(
@@ -235,7 +238,7 @@ export function renderBlockData(
         rendererType: rendererType.name,
         sessionId,
         blockKey: self.key,
-        reload: self.reload,
+        reloadFlag: self.reloadFlag,
         timeout: 1000000, // 10000,
       },
     }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -24,6 +24,7 @@ const blockState = types
   .model('BlockState', {
     key: types.string,
     region: Region,
+    reload: false,
     isLeftEndOfDisplayedRegion: false,
     isRightEndOfDisplayedRegion: false,
   })

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -235,6 +235,7 @@ export function renderBlockData(
         rendererType: rendererType.name,
         sessionId,
         blockKey: self.key,
+        reload: self.reload,
         timeout: 1000000, // 10000,
       },
     }


### PR DESCRIPTION
Fixes #2130 

This is a surprise where I thought the layout data structure was causing issues and resulted in some layout code restructuring (converting to rbush)

I still think converting to rbush was a good change, but the proximal issue for #2130 is that the code for getting the feature calls

```
       getFeatureOverlapping(blockKey: string, x: number, y: number) {
+        console.log(self.blockState.get(blockKey), blockKey, [
+          ...self.blockState.keys(),
+        ])
         return self.blockState.get(blockKey)?.layout?.getByCoord(x, y)
       },
```

We could even consider this to be a little too low level for BaseLinearDisplay but when you console.log this the blockKey that is received has -reload appended, an earlier way we used to force a rerender, while the blockKeys in self.blockState.keys() do not have the -reload appended. I did not fully map why that is the case, but this PR provides an alternative way to force a re-render where it has a reload tag on the block state, and fixes the issue 
