### PR TITLE
Updates to bookmark widget

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
@@ -23,9 +23,6 @@ const useStyles = makeStyles(() => ({
   dialogContainer: {
     margin: 15,
   },
-  clearButton: {
-    marginBottom: 5,
-  },
 }))
 
 function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
@@ -37,7 +34,6 @@ function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
   return (
     <>
       <Button
-        className={classes.clearButton}
         startIcon={<ClearAllIcon />}
         aria-label="clear bookmarks"
         onClick={() => setDialogOpen(true)}

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { observer } from 'mobx-react'
 
 import {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
@@ -9,7 +9,6 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core'
-import DeleteIcon from '@material-ui/icons/Delete'
 import CloseIcon from '@material-ui/icons/Close'
 
 import { GridBookmarkModel } from '../model'
@@ -25,60 +24,52 @@ const useStyles = makeStyles(() => ({
   },
 }))
 
-function DeleteBookmark({
+function DeleteBookmarkDialog({
   locString,
   model,
+  onClose,
 }: {
-  locString: string
+  locString: string | undefined
   model: GridBookmarkModel
+  onClose: () => void
 }) {
   const classes = useStyles()
-  const [dialogOpen, setDialogOpen] = useState(false)
 
   const { removeBookmark } = model
 
   return (
-    <>
-      <IconButton
-        data-testid="deleteBookmark"
-        aria-label="delete"
-        onClick={() => setDialogOpen(true)}
-      >
-        <DeleteIcon />
-      </IconButton>
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
-        <DialogTitle>
-          <IconButton
-            className={classes.closeDialog}
-            aria-label="close-dialog"
-            onClick={() => setDialogOpen(false)}
+    <Dialog open={!!locString} onClose={onClose}>
+      <DialogTitle>
+        <IconButton
+          className={classes.closeDialog}
+          aria-label="close-dialog"
+          onClick={onClose}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <div className={classes.dialogContainer}>
+        <Typography>
+          Remove <code>{locString}</code>?
+        </Typography>
+        <br />
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => {
+              if (locString) {
+                removeBookmark(locString)
+                onClose()
+              }
+            }}
           >
-            <CloseIcon />
-          </IconButton>
-        </DialogTitle>
-        <div className={classes.dialogContainer}>
-          <>
-            <Typography>
-              Remove <code>{locString}</code>?
-            </Typography>
-            <br />
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => {
-                  removeBookmark(locString)
-                  setDialogOpen(false)
-                }}
-              >
-                Confirm
-              </Button>
-            </div>
-          </>
+            Confirm
+          </Button>
         </div>
-      </Dialog>
-    </>
+      </div>
+    </Dialog>
   )
 }
 
-export default observer(DeleteBookmark)
+export default observer(DeleteBookmarkDialog)

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DownloadBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DownloadBookmarks.tsx
@@ -25,9 +25,6 @@ const useStyles = makeStyles(() => ({
   dialogContainer: {
     margin: 15,
   },
-  downloadButton: {
-    marginBottom: 5,
-  },
   flexItem: {
     margin: 5,
   },
@@ -51,11 +48,7 @@ function DownloadBookmarks({ model }: { model: GridBookmarkModel }) {
 
   return (
     <>
-      <Button
-        className={classes.downloadButton}
-        startIcon={<GetAppIcon />}
-        onClick={() => setDialogOpen(true)}
-      >
+      <Button startIcon={<GetAppIcon />} onClick={() => setDialogOpen(true)}>
         Download
       </Button>
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
@@ -1,33 +1,36 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { observer } from 'mobx-react'
+import AutoSizer from 'react-virtualized-auto-sizer'
 
-import { makeStyles, Link } from '@material-ui/core'
+import {
+  Link,
+  IconButton,
+  FormControlLabel,
+  Checkbox,
+  Typography,
+} from '@material-ui/core'
 import {
   DataGrid,
   GridCellParams,
   GridEditCellPropsParams,
 } from '@material-ui/data-grid'
 
-import { getSession, assembleLocString } from '@jbrowse/core/util'
+import { getSession, assembleLocString, measureText } from '@jbrowse/core/util'
 import { Region } from '@jbrowse/core/util/types'
 
 import { GridBookmarkModel } from '../model'
 import { navToBookmark } from '../utils'
 
+import DeleteIcon from '@material-ui/icons/Delete'
 import AssemblySelector from './AssemblySelector'
-import DeleteBookmark from './DeleteBookmark'
+import DeleteBookmarkDialog from './DeleteBookmark'
 import DownloadBookmarks from './DownloadBookmarks'
 import ClearBookmarks from './ClearBookmarks'
 
-const useStyles = makeStyles(() => ({
-  container: {
-    margin: 12,
-  },
-}))
-
 function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
-  const classes = useStyles()
+  const [dialogOpen, setDialogOpen] = useState<string>()
   const { views } = getSession(model)
+  const [compact, setCompact] = useState(false)
   const { bookmarkedRegions, updateBookmarkLabel, selectedAssembly } = model
 
   const bookmarkRows = bookmarkedRegions
@@ -58,11 +61,14 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
     [bookmarkRows, updateBookmarkLabel],
   )
 
+  const measure = (row: any, col: string) =>
+    Math.min(Math.max(measureText(String(row[col]), 14) + 50, 80), 1000)
+
   const columns = [
     {
       field: 'id',
       headerName: 'bookmark link',
-      width: 200,
+      width: Math.max(...bookmarkRows.map(row => measure(row, 'id'))),
       renderCell: (params: GridCellParams) => {
         const { value } = params
         return (
@@ -78,7 +84,10 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
     },
     {
       field: 'label',
-      width: 105,
+      width: Math.max(
+        100,
+        Math.max(...bookmarkRows.map(row => measure(row, 'label'))),
+      ),
       editable: true,
     },
     {
@@ -86,25 +95,64 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
       width: 30,
       renderCell: (params: GridCellParams) => {
         const { value } = params
-        return <DeleteBookmark locString={value as string} model={model} />
+        return (
+          <IconButton
+            data-testid="deleteBookmark"
+            aria-label="delete"
+            onClick={() => setDialogOpen(value as string)}
+            style={{ padding: 0 }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        )
       },
     },
   ]
 
   return (
-    <div className={classes.container}>
+    <>
       <AssemblySelector model={model} />
       <DownloadBookmarks model={model} />
       <ClearBookmarks model={model} />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={compact}
+            onChange={() => {
+              setCompact(!compact)
+            }}
+            color="primary"
+          />
+        }
+        label="Compact"
+        style={{ marginLeft: 4 }}
+      />
+
+      <div style={{ margin: 12 }}>
+        <Typography>
+          Note: you can double click the "label" field to add your own custom
+          notes
+        </Typography>
+      </div>
       <div style={{ height: 800, width: '100%' }}>
         <DataGrid
           rows={bookmarkRows}
+          rowHeight={compact ? 25 : undefined}
+          headerHeight={compact ? 25 : undefined}
           columns={columns}
           onEditCellChangeCommitted={handleEditCellChangeCommitted}
           disableSelectionOnClick
         />
       </div>
-    </div>
+
+      <DeleteBookmarkDialog
+        locString={dialogOpen}
+        model={model}
+        onClose={() => {
+          setDialogOpen(undefined)
+        }}
+      />
+    </>
   )
 }
 

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react'
 import { observer } from 'mobx-react'
 
-import {
-  Link,
-  IconButton,
-  FormControlLabel,
-  Checkbox,
-  Typography,
-} from '@material-ui/core'
+import { Link, IconButton, Typography, Button } from '@material-ui/core'
 import {
   DataGrid,
   GridCellParams,
@@ -21,6 +15,7 @@ import { GridBookmarkModel } from '../model'
 import { navToBookmark } from '../utils'
 
 import DeleteIcon from '@material-ui/icons/Delete'
+import ViewCompactIcon from '@material-ui/icons/ViewCompact'
 import AssemblySelector from './AssemblySelector'
 import DeleteBookmarkDialog from './DeleteBookmark'
 import DownloadBookmarks from './DownloadBookmarks'
@@ -62,7 +57,7 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const measure = (row: any, col: string) =>
-    Math.min(Math.max(measureText(String(row[col]), 14) + 50, 80), 1000)
+    Math.min(Math.max(measureText(String(row[col]), 14) + 20, 80), 1000)
 
   const columns = [
     {
@@ -114,27 +109,21 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
       <AssemblySelector model={model} />
       <DownloadBookmarks model={model} />
       <ClearBookmarks model={model} />
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={compact}
-            onChange={() => {
-              setCompact(!compact)
-            }}
-            color="primary"
-          />
-        }
-        label="Compact"
-        style={{ marginLeft: 4 }}
-      />
-
+      <Button
+        startIcon={<ViewCompactIcon />}
+        onClick={() => {
+          setCompact(!compact)
+        }}
+      >
+        Compact
+      </Button>
       <div style={{ margin: 12 }}>
         <Typography>
-          Note: you can double click the "label" field to add your own custom
-          notes
+          Note: you can double click the <code>label</code> field to add your
+          own custom notes
         </Typography>
       </div>
-      <div style={{ height: 800, width: '100%' }}>
+      <div style={{ height: 750, width: '100%' }}>
         <DataGrid
           rows={bookmarkRows}
           rowHeight={compact ? 25 : undefined}

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { observer } from 'mobx-react'
-import AutoSizer from 'react-virtualized-auto-sizer'
 
 import {
   Link,
@@ -61,6 +60,7 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
     [bookmarkRows, updateBookmarkLabel],
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const measure = (row: any, col: string) =>
     Math.min(Math.max(measureText(String(row[col]), 14) + 50, 80), 1000)
 


### PR DESCRIPTION
These are a couple proposals for the bookmark widget


1) Uses a method for "auto-calculating" the width of a particular column that is used in the base feature details
2) Makes it so DeleteBookmark is just a dialog and not also a button. If it is a Button with a Dialog state inside it, it will render that dialog many times, even if in a hidden state. I propose extracting the Dialog as such
3) Makes a compact mode. I personally prefer the look of compact data displays, but could understand if this is not what all users want. I add it as an option here
4) Adds a note that lets users know that they can edit the label field by double clicking


Main thing I wanted to do this PR is (1)

The reason is we presupply a pixel width for each column. DataGrid does not have a method to change column widths. It would probably be ideal to have that, but even still, auto-calculating the width of a column is somewhat nice

Example screenshots
![localhost_3001__config=test_data%2Fconfig_demo json session=local-DCWuY7uMV](https://user-images.githubusercontent.com/6511937/127578794-a37ff6ff-8b3b-4978-bbe2-8259afc83997.png)
Thin right panel with a long label, can side scroll the widget to see more
![localhost_3001__config=test_data%2Fconfig_demo json session=local-DCWuY7uMV (1)](https://user-images.githubusercontent.com/6511937/127578798-2efed02d-b38d-4b62-96a9-0636d28d230e.png)
Expanded right panel with long label, showing the whole label is visible
![localhost_3001__config=test_data%2Fconfig_demo json session=local-DCWuY7uMV (2)](https://user-images.githubusercontent.com/6511937/127578802-b06f61aa-6269-4ae0-9d3c-b98f6b673efe.png)
On current bookmark branch, whole label not visible