### PR TITLE
Increase number of results returned by @gmod/trix by default

### DIFF
--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -35,6 +35,7 @@ export default class TrixTextSearchAdapter
       openLocation(ixxFilePath) as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       openLocation(ixFilePath) as any,
+      200,
     )
   }
 


### PR DESCRIPTION
This PR makes the trix search adapter return more results by default. This has some implications with duplicated results, because sometimes a query can return many duplicates and then you don't get that many autocompletes. For example in the volvox example, there are many features named seg02, but there are features named from seg01-seg15. It would be nice to list many of them, but if you search "seg", the autocomplete only has seg01 and seg02 in the dropdown. With this change, we get more seg results


Before:
![Screenshot from 2021-07-30 12-23-47](https://user-images.githubusercontent.com/6511937/127682769-8227cef7-69f4-4612-afca-62bbaf310d30.png)

After:
![Screenshot from 2021-07-30 12-21-33](https://user-images.githubusercontent.com/6511937/127682586-901c0083-dcd3-4c52-bb7d-15099f5b4bd7.png)


