### PR TITLE
Add better inversion visualization to read vs reference visualizations

### DIFF
--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -128,7 +128,9 @@ function SupplementaryAlignments(props: { tag: string; model: any }) {
             const locString = `${saRef}:${Math.max(1, start - extra)}-${
               end + extra
             }`
-            const displayString = `${saRef}:${start}-${end} (${saStrand})`
+            const displayStart = start.toLocaleString('en-US')
+            const displayEnd = end.toLocaleString('en-US')
+            const displayString = `${saRef}:${displayStart}-${displayEnd} (${saStrand})`
             return (
               <li key={`${locString}-${index}`}>
                 <Link

--- a/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
@@ -44,7 +44,7 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
     ;(hview.features || []).forEach(feature => {
       let start = feature.get('start')
       let end = feature.get('end')
-      const strand = feature.get('strand')
+      const strand = feature.get('strand') || 1
       const refName = feature.get('refName')
       const mate = feature.get('mate')
       const mateRef = mate.refName
@@ -92,10 +92,10 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
               const prevY = currY
 
               if (op === 'M' || op === '=' || op === 'X') {
-                currX += val / hview.bpPerPx
+                currX += (val / hview.bpPerPx) * strand
                 currY += val / vview.bpPerPx
               } else if (op === 'D' || op === 'N') {
-                currX += val / hview.bpPerPx
+                currX += (val / hview.bpPerPx) * strand
               } else if (op === 'I') {
                 currY += val / vview.bpPerPx
               }

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -306,9 +306,7 @@ export default class DotplotPlugin extends Plugin {
                     return mergeIntervals(group)
                   })
 
-                  const r = merged.flat().sort((a, b) => a.index - b.index)
-                  console.log({ r })
-                  return r
+                  return merged.flat().sort((a, b) => a.index - b.index)
                 }
 
                 session.addView('DotplotView', {

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -103,6 +103,11 @@ function getClip(cigar: string, strand: number) {
     : +(cigar.match(/^(\d+)([SH])/) || [])[1] || 0
 }
 
+function getTag(f: Feature, tag: string) {
+  const tags = f.get('tags')
+  return tags ? tags[tag] : f.get(tag)
+}
+
 interface ReducedFeature {
   refName: string
   start: number
@@ -186,10 +191,8 @@ export default class DotplotPlugin extends Plugin {
                 const clipPos = feature.get('clipPos')
                 const cigar = feature.get('CIGAR')
                 const flags = feature.get('flags')
-                const SA: string =
-                  (feature.get('tags')
-                    ? feature.get('tags').SA
-                    : feature.get('SA')) || ''
+                const origStrand = feature.get('strand')
+                const SA: string = getTag(feature, 'SA') || ''
                 const readName = feature.get('name')
                 const readAssembly = `${readName}_assembly`
                 const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
@@ -214,7 +217,7 @@ export default class DotplotPlugin extends Plugin {
                       clipPos: saClipPos,
                       CIGAR: saCigar,
                       assemblyName: trackAssembly,
-                      strand: 1, // saStrandNormalized,
+                      strand: origStrand * saStrandNormalized,
                       uniqueId: `${feature.id()}_SA${index}`,
                       mate: {
                         start: saClipPos,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -304,7 +304,7 @@ function WindowSizeDlg(props: {
           const saLength = getLength(saCigar)
           const saLengthSansClipping = getLengthSansClipping(saCigar)
           const saStrandNormalized = saStrand === '-' ? -1 : 1
-          const saClipPos = getClip(saCigar, saStrandNormalized)
+          const saClipPos = getClip(saCigar, saStrandNormalized * origStrand)
           const saRealStart = +saStart - 1
           return {
             refName: saRef,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -218,6 +218,7 @@ function WindowSizeDlg(props: {
       const clipPos = getClip(cigar, 1)
       const flags = feature.get('flags')
       const qual = feature.get('qual') as string
+      const origStrand = feature.get('strand')
       const SA: string = getTag(feature, 'SA') || ''
       const readName = feature.get('name')
 
@@ -239,11 +240,11 @@ function WindowSizeDlg(props: {
       const supplementaryAlignments = SA.split(';')
         .filter(aln => !!aln)
         .map((aln, index) => {
-          const [saRef, saStart, , saCigar] = aln.split(',')
+          const [saRef, saStart, saStrand, saCigar] = aln.split(',')
           const saLengthOnRef = getLengthOnRef(saCigar)
           const saLength = getLength(saCigar)
           const saLengthSansClipping = getLengthSansClipping(saCigar)
-          // const saStrandNormalized = saStrand === '-' ? -1 : 1
+          const saStrandNormalized = saStrand === '-' ? -1 : 1
           const saClipPos = getClip(saCigar, 1)
           const saRealStart = +saStart - 1
           return {
@@ -254,7 +255,7 @@ function WindowSizeDlg(props: {
             clipPos: saClipPos,
             CIGAR: saCigar,
             assemblyName: trackAssembly,
-            strand: 1, // saStrandNormalized,
+            strand: origStrand * saStrandNormalized,
             uniqueId: `${feature.id()}_SA${index}`,
             mate: {
               start: saClipPos,
@@ -361,7 +362,7 @@ function WindowSizeDlg(props: {
                   {
                     id: `${Math.random()}`,
                     type: 'LinearReferenceSequenceDisplay',
-                    showReverse: false,
+                    showReverse: true,
                     showTranslation: false,
                     height: 35,
                     configuration: `${seqTrackId}-LinearReferenceSequenceDisplay`,
@@ -392,7 +393,7 @@ function WindowSizeDlg(props: {
                   {
                     id: `${Math.random()}`,
                     type: 'LinearReferenceSequenceDisplay',
-                    showReverse: false,
+                    showReverse: true,
                     showTranslation: false,
                     height: 35,
                     configuration: `${seqTrackId}-LinearReferenceSequenceDisplay`,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -245,7 +245,7 @@ function WindowSizeDlg(props: {
           const saLength = getLength(saCigar)
           const saLengthSansClipping = getLengthSansClipping(saCigar)
           const saStrandNormalized = saStrand === '-' ? -1 : 1
-          const saClipPos = getClip(saCigar, 1)
+          const saClipPos = getClip(saCigar, saStrandNormalized)
           const saRealStart = +saStart - 1
           return {
             refName: saRef,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -211,7 +211,10 @@ function WindowSizeDlg(props: {
 
   function onSubmit() {
     try {
-      const feature = primaryFeature || preFeature
+      if (!primaryFeature) {
+        return
+      }
+      const feature = primaryFeature
       const session = getSession(track)
       const view = getContainingView(track)
       const cigar = feature.get('CIGAR')

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -193,6 +193,13 @@ export default function sessionModelFactory(
       },
 
       addAssembly(assemblyConfig: AnyConfigurationModel) {
+        const asm = self.sessionAssemblies.find(
+          f => f.name === assemblyConfig.name,
+        )
+        if (asm) {
+          console.warn(`Assembly ${assemblyConfig.name} was already existing`)
+          return asm
+        }
         self.sessionAssemblies.push(assemblyConfig)
       },
       addSessionPlugin(plugin: JBrowsePlugin) {

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -3325,6 +3325,66 @@
           "uri": "https://jbrowse.org/genomes/hg19/COLO829/colo_tumor.bw"
         }
       }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "lra.inv.bed",
+      "name": "lra.inv.bed",
+      "category": ["HG002 inversions"],
+      "description": "From <a href=\"https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717\">https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717</a>",
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/lra.inv.bed.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/lra.inv.bed.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "mm2.inv.bed",
+      "name": "mm2.inv.bed",
+      "description": "From <a href=\"https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717\">https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717</a>",
+      "category": ["HG002 inversions"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/mm2.inv.bed.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/mm2.inv.bed.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "ngmlr.inv.bed",
+      "name": "ngmlr.inv.bed",
+      "category": ["HG002 inversions"],
+      "description": "From <a href=\"https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717\">https://figshare.com/articles/dataset/lra-supplemental-HG002-SV_vcf_tar_gz/13238717</a>",
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/ngmlr.inv.bed.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg19/hg002/inv/ngmlr.inv.bed.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      }
     }
   ],
   "connections": [],


### PR DESCRIPTION
In the past PR #2024 the strand got ignored in read vs ref because after drawing negative strand alignments was added to the renderer, it was realized that strand was not specified correctly at that time of loading the data for read vs ref visualizations

This change makes the read vs reference strand become relative to the "original strand" the feature was on.

Intuitively if a read is on the forward strand, switches to the reverse, and back to forward

```
----->   <------ ----->
```

And the left most is the "primary" alignment (the rest are supplementary/split read alignments) then the strands are 1 for primary, -1 and then 1 for supp

But also the data can come in like


```
<------ -------> <------
```

This is fundamentally equivalent but the data is just from a reverse strand template. Therefore we flip the read orientation relative to the original strand when we plot it

Example showing inversion
![localhost_3000__config=test_data%2Fconfig_demo json session=local-6er93LMsa](https://user-images.githubusercontent.com/6511937/128688622-fa973fe6-38b9-4918-8a87-ee4badd0aff9.png)


In this case the supplementary alignments do not store their cigar strings in the SA tag, so they are not plotted, but the data should otherwise be accurate. The overhand of the inverted polygon with the left side is also I believe expected. We can look at the SA tag and see that it says 5002 bases soft clipped for the inverted part, and this directly corresponds to it starting at position 5002 on the bottom panel (since the bottom panel is the literal sequence, it is just starting at position 5002 because thats how many bases are clipped off)
