### PR TITLE
Make the BED parser not interpret general tab delimited data as BED12

### DIFF
--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@gmod/bbi": "^1.0.30",
-    "@gmod/bed": "^2.0.5",
+    "@gmod/bed": "^2.0.6",
     "@gmod/tabix": "^1.5.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,10 +1818,10 @@
     quick-lru "^4.0.0"
     rxjs "^6.5.2"
 
-"@gmod/bed@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@gmod/bed/-/bed-2.0.5.tgz#c2598cacd05a01ae185a6ac8fdebd38b8a4c0e93"
-  integrity sha512-n8RRoG049vmSCMjVQq/CMw6eCsaV3JzipcB/nQThojGkKhNeBQm6BN21NvVEH7KZRflZWmHy4PGznQOAmZQ6aw==
+"@gmod/bed@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@gmod/bed/-/bed-2.0.6.tgz#9ef995da968fadb4788c353a8d11ebf1b366c4da"
+  integrity sha512-gPT9VFALXEyGu9liRDti5ifKW4cacaeEvo1cjXASSLViXecD8BGsozQr/fKyAKb5wxDsCyYX5OPXGGwZj8QE2w==
 
 "@gmod/bgzf-filehandle@^1.2.4", "@gmod/bgzf-filehandle@^1.3.3", "@gmod/bgzf-filehandle@^1.3.4":
   version "1.3.4"


### PR DESCRIPTION
The current @gmod/bed parser makes I think too  assumptions about what a BED file is if no info is specified e.g. as with BED tabix files. 

For example, currently the inversion BED tabix files in #2198 are displayed incorrectly (it thinks it is an intron because it thinks it's like a BED12 file)

This proposes using an "unassuming" BED parser that will use the strand/score fields if it makes sense to, otherwise it just stores the fieldnames, and only tries to use @gmod/bed if the code is actually a BED12 file or has autoSql attached

With this change added, the BED tabix files in #2198 display properly e.g. just as boxes indicating the region of the inversion, and some fields that don't have any description are called field5,field6,field7... in the feature details panel
