### PR TITLE
Hide reads with unmapped flag by default in alignments tracks

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -88,7 +88,7 @@ const stateModelFactory = (
         filterBy: types.optional(
           types.model({
             flagInclude: types.optional(types.number, 0),
-            flagExclude: types.optional(types.number, 1536),
+            flagExclude: types.optional(types.number, 1540),
             readName: types.maybe(types.string),
             tagFilter: types.maybe(
               types.model({ tag: types.string, value: types.string }),

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -34,7 +34,7 @@ const stateModelFactory = (
         filterBy: types.optional(
           types.model({
             flagInclude: types.optional(types.number, 0),
-            flagExclude: types.optional(types.number, 1536),
+            flagExclude: types.optional(types.number, 1540),
             readName: types.maybe(types.string),
             tagFilter: types.maybe(
               types.model({ tag: types.string, value: types.string }),


### PR DESCRIPTION
This is a small change to have "unmapped reads" included in the default set of flags hidden on alignments tracks

Unmapped reads can be weird in that they can exist at a given coordinate but be shown still

1540 can be seen here https://broadinstitute.github.io/picard/explain-flags.html

   read unmapped
   read fails platform/vendor quality checks
   read is PCR or optical duplicate


This is true in jbrowse 1 and igv by default. Had run into this with a hand crafted sam file that had unmapped reads that displayed in jbrowse but not in igv by default.