### PR TITLE
Fix issue where collapsed categories were not remembered after toggling a track

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -546,7 +546,7 @@ const HierarchicalTrackSelector = observer(({ model, toolbarHeight = 0 }) => {
   const [assemblyIdx, setAssemblyIdx] = useState(0)
   const [headerHeight, setHeaderHeight] = useState(0)
 
-  const { assemblyNames, collapsed } = model
+  const { assemblyNames } = model
   const assemblyName = assemblyNames[assemblyIdx]
   return assemblyName ? (
     <>
@@ -557,7 +557,7 @@ const HierarchicalTrackSelector = observer(({ model, toolbarHeight = 0 }) => {
         assemblyIdx={assemblyIdx}
       />
       <AutoSizedHierarchicalTree
-        tree={model.hierarchy(assemblyName, collapsed)}
+        tree={model.hierarchy(assemblyName)}
         model={model}
         offset={toolbarHeight + headerHeight}
       />

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -54,7 +54,7 @@ export function generateHierarchy(model, trackConfigurations, collapsed) {
             children: [],
             name: category,
             id,
-            state: { expanded: !collapsed.get(id) },
+            isOpenByDefault: !collapsed.get(id),
           }
           currLevel.children.push(n)
           currLevel = n
@@ -90,7 +90,6 @@ export default pluginManager =>
       view: types.safeReference(
         pluginManager.pluggableMstType('view', 'stateModel'),
       ),
-      collapsedCategories: types.map(types.string, types.boolean),
     })
     .actions(self => ({
       setView(view) {
@@ -188,11 +187,11 @@ export default pluginManager =>
           })
       },
 
-      hierarchy(assemblyName) {
+      hierarchy(assemblyName, collapsed) {
         const hier = generateHierarchy(
           self,
           self.trackConfigurations(assemblyName),
-          self.collapsed,
+          collapsed,
         )
 
         const session = getSession(self)

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -187,11 +187,11 @@ export default pluginManager =>
           })
       },
 
-      hierarchy(assemblyName, collapsed) {
+      hierarchy(assemblyName) {
         const hier = generateHierarchy(
           self,
           self.trackConfigurations(assemblyName),
-          collapsed,
+          self.collapsed,
         )
 
         const session = getSession(self)


### PR DESCRIPTION
The title of this PR somewhat underestimates the issue scope but it is what the end user experiences

The collapsed category state was not stored in the widget model properly, and it was causing the code to forget the collapsed categories after a track is toggled (which causes the tree to get rerendered)

Note: Technically it might be somewhat expensive/not the best way to do things for for the tree to get recalculated after things like a track toggle or category collapse, but it seems to work fine afaik

This change is also good because it is nice for the collapsed categories to also be remembered in state e.g. across page refreshes

Fixes #2207 