### PR TITLE
Use extendPluggableElement for context menu items

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -353,7 +353,7 @@ const stateModelFactory = (
           return rendererType
         },
 
-        get contextMenuItems() {
+        contextMenuItems() {
           const feat = self.contextMenuFeature
           const contextMenuItems = feat
             ? [
@@ -378,12 +378,6 @@ const stateModelFactory = (
                 },
               ]
             : []
-          self.additionalContextMenuItemCallbacks.forEach(
-            (callback: Function) => {
-              const menuItems = callback(feat, self, pluginManager)
-              contextMenuItems.push(...menuItems)
-            },
-          )
           return contextMenuItems
         },
 

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -194,7 +194,7 @@ const stateModelFactory = (
           return true
         },
 
-        get contextMenuItems() {
+        contextMenuItems() {
           return []
         },
 

--- a/plugins/alignments/src/index.ts
+++ b/plugins/alignments/src/index.ts
@@ -29,6 +29,7 @@ import {
   configSchemaFactory as linearPileupDisplayConfigSchemaFactory,
   modelFactory as linearPileupDisplayModelFactory,
 } from './LinearPileupDisplay'
+import { LinearPileupDisplayModel } from './LinearPileupDisplay/model'
 import {
   configSchemaFactory as linearSNPCoverageDisplayConfigSchemaFactory,
   modelFactory as linearSNPCoverageDisplayModelFactory,
@@ -48,6 +49,7 @@ import {
 } from './PileupRPC/rpcMethods'
 
 export { MismatchParser }
+export type { LinearPileupDisplayModel }
 
 export default class AlignmentsPlugin extends Plugin {
   name = 'AlignmentsPlugin'

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -173,6 +173,149 @@ interface ReducedFeature {
   seqLength: number
 }
 
+function onClick(feature: Feature, self: LinearPileupDisplayModel) {
+  const session = getSession(self)
+  try {
+    const cigar = feature.get('CIGAR')
+    const clipPos = getClip(cigar, 1)
+    const flags = feature.get('flags')
+    const origStrand = feature.get('strand')
+    const SA: string = getTag(feature, 'SA') || ''
+    const readName = feature.get('name')
+    const readAssembly = `${readName}_assembly`
+    const { parentTrack } = self
+    const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
+    const assemblyNames = [trackAssembly, readAssembly]
+    const trackId = `track-${Date.now()}`
+    const trackName = `${readName}_vs_${trackAssembly}`
+    const supplementaryAlignments = SA.split(';')
+      .filter(aln => !!aln)
+      .map((aln, index) => {
+        const [saRef, saStart, saStrand, saCigar] = aln.split(',')
+        const saLengthOnRef = getLengthOnRef(saCigar)
+        const saLength = getLength(saCigar)
+        const saLengthSansClipping = getLengthSansClipping(saCigar)
+        const saStrandNormalized = saStrand === '-' ? -1 : 1
+        const saClipPos = getClip(saCigar, saStrandNormalized * origStrand)
+        const saRealStart = +saStart - 1
+        return {
+          refName: saRef,
+          start: saRealStart,
+          end: saRealStart + saLengthOnRef,
+          seqLength: saLength,
+          clipPos: saClipPos,
+          CIGAR: saCigar,
+          assemblyName: trackAssembly,
+          strand: origStrand * saStrandNormalized,
+          uniqueId: `${feature.id()}_SA${index}`,
+          mate: {
+            start: saClipPos,
+            end: saClipPos + saLengthSansClipping,
+            refName: readName,
+          },
+        }
+      })
+
+    const feat = feature.toJSON()
+    feat.strand = 1
+    feat.mate = {
+      refName: readName,
+      start: clipPos,
+      end: clipPos + getLengthSansClipping(cigar),
+    }
+
+    // if secondary alignment or supplementary, calculate length
+    // from SA[0]'s CIGAR which is the primary alignments.
+    // otherwise it is the primary alignment just use seq.length if
+    // primary alignment
+    const totalLength = getLength(
+      flags & 2048 ? supplementaryAlignments[0].CIGAR : cigar,
+    )
+
+    const features = [feat, ...supplementaryAlignments] as ReducedFeature[]
+
+    features.sort((a, b) => a.clipPos - b.clipPos)
+
+    const refLength = features.reduce((a, f) => a + f.end - f.start, 0)
+
+    session.addView('DotplotView', {
+      type: 'DotplotView',
+      hview: {
+        offsetPx: 0,
+        bpPerPx: refLength / 800,
+        displayedRegions: gatherOverlaps(
+          features.map((f, index) => {
+            const { start, end, refName } = f
+            return {
+              start,
+              end,
+              refName,
+              index,
+              assemblyName: trackAssembly,
+            }
+          }),
+        ),
+      },
+      vview: {
+        offsetPx: 0,
+        bpPerPx: totalLength / 400,
+        minimumBlockWidth: 0,
+        interRegionPaddingWidth: 0,
+        displayedRegions: [
+          {
+            assemblyName: readAssembly,
+            start: 0,
+            end: totalLength,
+            refName: readName,
+          },
+        ],
+      },
+      viewTrackConfigs: [
+        {
+          type: 'SyntenyTrack',
+          assemblyNames,
+          adapter: {
+            type: 'FromConfigAdapter',
+            features,
+          },
+          trackId,
+          name: trackName,
+        },
+      ],
+      viewAssemblyConfigs: [
+        {
+          name: readAssembly,
+          sequence: {
+            type: 'ReferenceSequenceTrack',
+            trackId: `${readName}_${Date.now()}`,
+            adapter: {
+              type: 'FromConfigSequenceAdapter',
+              features: [feature.toJSON()],
+            },
+          },
+        },
+      ],
+      assemblyNames,
+      tracks: [
+        {
+          configuration: trackId,
+          type: 'SyntenyTrack',
+          displays: [
+            {
+              type: 'DotplotDisplay',
+              configuration: `${trackId}-DotplotDisplay`,
+            },
+          ],
+        },
+      ],
+      displayName: `${readName} vs ${trackAssembly}`,
+    })
+  } catch (e) {
+    console.error(e)
+    session.notify(`${e}`, 'error')
+  }
+}
+
 export default class DotplotPlugin extends Plugin {
   name = 'DotplotPlugin'
 
@@ -241,165 +384,7 @@ export default class DotplotPlugin extends Plugin {
                       {
                         label: 'Dotplot of read vs ref',
                         icon: AddIcon,
-                        onClick: () => {
-                          const session = getSession(self)
-                          const cigar = feature.get('CIGAR')
-                          const clipPos = getClip(cigar, 1)
-                          const flags = feature.get('flags')
-                          const origStrand = feature.get('strand')
-                          const SA: string = getTag(feature, 'SA') || ''
-                          const readName = feature.get('name')
-                          const readAssembly = `${readName}_assembly`
-                          const { parentTrack } = self
-                          const [trackAssembly] = getConf(
-                            parentTrack,
-                            'assemblyNames',
-                          )
-                          const assemblyNames = [trackAssembly, readAssembly]
-                          const trackId = `track-${Date.now()}`
-                          const trackName = `${readName}_vs_${trackAssembly}`
-                          const supplementaryAlignments = SA.split(';')
-                            .filter(aln => !!aln)
-                            .map((aln, index) => {
-                              const [
-                                saRef,
-                                saStart,
-                                saStrand,
-                                saCigar,
-                              ] = aln.split(',')
-                              const saLengthOnRef = getLengthOnRef(saCigar)
-                              const saLength = getLength(saCigar)
-                              const saLengthSansClipping = getLengthSansClipping(
-                                saCigar,
-                              )
-                              const saStrandNormalized =
-                                saStrand === '-' ? -1 : 1
-                              const saClipPos = getClip(
-                                saCigar,
-                                saStrandNormalized * origStrand,
-                              )
-                              const saRealStart = +saStart - 1
-                              return {
-                                refName: saRef,
-                                start: saRealStart,
-                                end: saRealStart + saLengthOnRef,
-                                seqLength: saLength,
-                                clipPos: saClipPos,
-                                CIGAR: saCigar,
-                                assemblyName: trackAssembly,
-                                strand: origStrand * saStrandNormalized,
-                                uniqueId: `${feature.id()}_SA${index}`,
-                                mate: {
-                                  start: saClipPos,
-                                  end: saClipPos + saLengthSansClipping,
-                                  refName: readName,
-                                },
-                              }
-                            })
-
-                          const feat = feature.toJSON()
-                          feat.strand = 1
-                          feat.mate = {
-                            refName: readName,
-                            start: clipPos,
-                            end: clipPos + getLengthSansClipping(cigar),
-                          }
-
-                          // if secondary alignment or supplementary, calculate length
-                          // from SA[0]'s CIGAR which is the primary alignments.
-                          // otherwise it is the primary alignment just use seq.length if
-                          // primary alignment
-                          const totalLength = getLength(
-                            flags & 2048
-                              ? supplementaryAlignments[0].CIGAR
-                              : cigar,
-                          )
-
-                          const features = [
-                            feat,
-                            ...supplementaryAlignments,
-                          ] as ReducedFeature[]
-
-                          features.sort((a, b) => a.clipPos - b.clipPos)
-
-                          const refLength = features.reduce(
-                            (a, f) => a + f.end - f.start,
-                            0,
-                          )
-
-                          session.addView('DotplotView', {
-                            type: 'DotplotView',
-                            hview: {
-                              offsetPx: 0,
-                              bpPerPx: refLength / 800,
-                              displayedRegions: gatherOverlaps(
-                                features.map((f, index) => {
-                                  const { start, end, refName } = f
-                                  return {
-                                    start,
-                                    end,
-                                    refName,
-                                    index,
-                                    assemblyName: trackAssembly,
-                                  }
-                                }),
-                              ),
-                            },
-                            vview: {
-                              offsetPx: 0,
-                              bpPerPx: totalLength / 400,
-                              minimumBlockWidth: 0,
-                              interRegionPaddingWidth: 0,
-                              displayedRegions: [
-                                {
-                                  assemblyName: readAssembly,
-                                  start: 0,
-                                  end: totalLength,
-                                  refName: readName,
-                                },
-                              ],
-                            },
-                            viewTrackConfigs: [
-                              {
-                                type: 'SyntenyTrack',
-                                assemblyNames,
-                                adapter: {
-                                  type: 'FromConfigAdapter',
-                                  features,
-                                },
-                                trackId,
-                                name: trackName,
-                              },
-                            ],
-                            viewAssemblyConfigs: [
-                              {
-                                name: readAssembly,
-                                sequence: {
-                                  type: 'ReferenceSequenceTrack',
-                                  trackId: `${readName}_${Date.now()}`,
-                                  adapter: {
-                                    type: 'FromConfigSequenceAdapter',
-                                    features: [feature.toJSON()],
-                                  },
-                                },
-                              },
-                            ],
-                            assemblyNames,
-                            tracks: [
-                              {
-                                configuration: trackId,
-                                type: 'SyntenyTrack',
-                                displays: [
-                                  {
-                                    type: 'DotplotDisplay',
-                                    configuration: `${trackId}-DotplotDisplay`,
-                                  },
-                                ],
-                              },
-                            ],
-                            displayName: `${readName} vs ${trackAssembly}`,
-                          })
-                        },
+                        onClick: () => onClick(feature, self),
                       },
                     ]
 

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -5,7 +5,6 @@ import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
 
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
 import AddIcon from '@material-ui/icons/Add'
-import { autorun } from 'mobx'
 import PluginManager from '@jbrowse/core/PluginManager'
 import {
   AbstractSessionModel,
@@ -15,10 +14,8 @@ import {
 
 import { getConf } from '@jbrowse/core/configuration'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
-import { AbstractDisplayModel } from '@jbrowse/core/util/types'
 import TimelineIcon from '@material-ui/icons/Timeline'
 import { MismatchParser } from '@jbrowse/plugin-alignments'
-import { IAnyStateTreeNode } from 'mobx-state-tree'
 import {
   configSchemaFactory as dotplotDisplayConfigSchemaFactory,
   stateModelFactory as dotplotDisplayStateModelFactory,
@@ -35,6 +32,8 @@ import {
   AdapterClass as PAFAdapter,
 } from './PAFAdapter'
 import ComparativeRender from './DotplotRenderer/ComparativeRenderRpc'
+import { PluggableElementType } from '@jbrowse/core/pluggableElementTypes'
+import { LinearPileupDisplayModel } from '@jbrowse/plugin-alignments'
 
 const { parseCigar } = MismatchParser
 
@@ -42,8 +41,6 @@ interface Track {
   id: string
   type: string
   displays: {
-    addAdditionalContextMenuItemCallback: Function
-    additionalContextMenuItemCallbacks: Function[]
     id: string
     type: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -223,6 +220,201 @@ export default class DotplotPlugin extends Plugin {
 
     // install our comparative rendering rpc callback
     pluginManager.addRpcMethod(() => new ComparativeRender(pluginManager))
+
+    pluginManager.addToExtensionPoint(
+      'Core-extendPluggableElement',
+      (pluggableElement: PluggableElementType) => {
+        if (pluggableElement.name === 'LinearPileupDisplay') {
+          const { stateModel } = pluggableElement as ViewType
+          const newStateModel = stateModel.extend(
+            (self: LinearPileupDisplayModel) => {
+              const superContextMenuItems = self.contextMenuItems
+              return {
+                views: {
+                  contextMenuItems() {
+                    const feature = self.contextMenuFeature
+                    if (!feature) {
+                      return superContextMenuItems()
+                    }
+                    const newMenuItems = [
+                      ...superContextMenuItems(),
+                      {
+                        label: 'Dotplot of read vs ref',
+                        icon: AddIcon,
+                        onClick: () => {
+                          const session = getSession(self)
+                          const cigar = feature.get('CIGAR')
+                          const clipPos = getClip(cigar, 1)
+                          const flags = feature.get('flags')
+                          const origStrand = feature.get('strand')
+                          const SA: string = getTag(feature, 'SA') || ''
+                          const readName = feature.get('name')
+                          const readAssembly = `${readName}_assembly`
+                          const { parentTrack } = self
+                          const [trackAssembly] = getConf(
+                            parentTrack,
+                            'assemblyNames',
+                          )
+                          const assemblyNames = [trackAssembly, readAssembly]
+                          const trackId = `track-${Date.now()}`
+                          const trackName = `${readName}_vs_${trackAssembly}`
+                          const supplementaryAlignments = SA.split(';')
+                            .filter(aln => !!aln)
+                            .map((aln, index) => {
+                              const [
+                                saRef,
+                                saStart,
+                                saStrand,
+                                saCigar,
+                              ] = aln.split(',')
+                              const saLengthOnRef = getLengthOnRef(saCigar)
+                              const saLength = getLength(saCigar)
+                              const saLengthSansClipping = getLengthSansClipping(
+                                saCigar,
+                              )
+                              const saStrandNormalized =
+                                saStrand === '-' ? -1 : 1
+                              const saClipPos = getClip(
+                                saCigar,
+                                saStrandNormalized * origStrand,
+                              )
+                              const saRealStart = +saStart - 1
+                              return {
+                                refName: saRef,
+                                start: saRealStart,
+                                end: saRealStart + saLengthOnRef,
+                                seqLength: saLength,
+                                clipPos: saClipPos,
+                                CIGAR: saCigar,
+                                assemblyName: trackAssembly,
+                                strand: origStrand * saStrandNormalized,
+                                uniqueId: `${feature.id()}_SA${index}`,
+                                mate: {
+                                  start: saClipPos,
+                                  end: saClipPos + saLengthSansClipping,
+                                  refName: readName,
+                                },
+                              }
+                            })
+
+                          const feat = feature.toJSON()
+                          feat.strand = 1
+                          feat.mate = {
+                            refName: readName,
+                            start: clipPos,
+                            end: clipPos + getLengthSansClipping(cigar),
+                          }
+
+                          // if secondary alignment or supplementary, calculate length
+                          // from SA[0]'s CIGAR which is the primary alignments.
+                          // otherwise it is the primary alignment just use seq.length if
+                          // primary alignment
+                          const totalLength = getLength(
+                            flags & 2048
+                              ? supplementaryAlignments[0].CIGAR
+                              : cigar,
+                          )
+
+                          const features = [
+                            feat,
+                            ...supplementaryAlignments,
+                          ] as ReducedFeature[]
+
+                          features.sort((a, b) => a.clipPos - b.clipPos)
+
+                          const refLength = features.reduce(
+                            (a, f) => a + f.end - f.start,
+                            0,
+                          )
+
+                          session.addView('DotplotView', {
+                            type: 'DotplotView',
+                            hview: {
+                              offsetPx: 0,
+                              bpPerPx: refLength / 800,
+                              displayedRegions: gatherOverlaps(
+                                features.map((f, index) => {
+                                  const { start, end, refName } = f
+                                  return {
+                                    start,
+                                    end,
+                                    refName,
+                                    index,
+                                    assemblyName: trackAssembly,
+                                  }
+                                }),
+                              ),
+                            },
+                            vview: {
+                              offsetPx: 0,
+                              bpPerPx: totalLength / 400,
+                              minimumBlockWidth: 0,
+                              interRegionPaddingWidth: 0,
+                              displayedRegions: [
+                                {
+                                  assemblyName: readAssembly,
+                                  start: 0,
+                                  end: totalLength,
+                                  refName: readName,
+                                },
+                              ],
+                            },
+                            viewTrackConfigs: [
+                              {
+                                type: 'SyntenyTrack',
+                                assemblyNames,
+                                adapter: {
+                                  type: 'FromConfigAdapter',
+                                  features,
+                                },
+                                trackId,
+                                name: trackName,
+                              },
+                            ],
+                            viewAssemblyConfigs: [
+                              {
+                                name: readAssembly,
+                                sequence: {
+                                  type: 'ReferenceSequenceTrack',
+                                  trackId: `${readName}_${Date.now()}`,
+                                  adapter: {
+                                    type: 'FromConfigSequenceAdapter',
+                                    features: [feature.toJSON()],
+                                  },
+                                },
+                              },
+                            ],
+                            assemblyNames,
+                            tracks: [
+                              {
+                                configuration: trackId,
+                                type: 'SyntenyTrack',
+                                displays: [
+                                  {
+                                    type: 'DotplotDisplay',
+                                    configuration: `${trackId}-DotplotDisplay`,
+                                  },
+                                ],
+                              },
+                            ],
+                            displayName: `${readName} vs ${trackAssembly}`,
+                          })
+                        },
+                      },
+                    ]
+
+                    return newMenuItems
+                  },
+                },
+              }
+            },
+          )
+
+          ;(pluggableElement as DisplayType).stateModel = newStateModel
+        }
+        return pluggableElement
+      },
+    )
   }
 
   configure(pluginManager: PluginManager) {
@@ -235,201 +427,5 @@ export default class DotplotPlugin extends Plugin {
         },
       })
     }
-
-    const cb = (
-      feature: Feature,
-      display: AbstractDisplayModel & IAnyStateTreeNode,
-    ) => {
-      const { parentTrack } = display
-      return feature
-        ? [
-            {
-              label: 'Dotplot of read vs ref',
-              icon: AddIcon,
-              onClick: () => {
-                const session = getSession(display)
-                const cigar = feature.get('CIGAR')
-                const clipPos = getClip(cigar, 1)
-                const flags = feature.get('flags')
-                const origStrand = feature.get('strand')
-                const SA: string = getTag(feature, 'SA') || ''
-                const readName = feature.get('name')
-                const readAssembly = `${readName}_assembly`
-                const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
-                const assemblyNames = [trackAssembly, readAssembly]
-                const trackId = `track-${Date.now()}`
-                const trackName = `${readName}_vs_${trackAssembly}`
-                const supplementaryAlignments = SA.split(';')
-                  .filter(aln => !!aln)
-                  .map((aln, index) => {
-                    const [saRef, saStart, saStrand, saCigar] = aln.split(',')
-                    const saLengthOnRef = getLengthOnRef(saCigar)
-                    const saLength = getLength(saCigar)
-                    const saLengthSansClipping = getLengthSansClipping(saCigar)
-                    const saStrandNormalized = saStrand === '-' ? -1 : 1
-                    const saClipPos = getClip(
-                      saCigar,
-                      saStrandNormalized * origStrand,
-                    )
-                    const saRealStart = +saStart - 1
-                    return {
-                      refName: saRef,
-                      start: saRealStart,
-                      end: saRealStart + saLengthOnRef,
-                      seqLength: saLength,
-                      clipPos: saClipPos,
-                      CIGAR: saCigar,
-                      assemblyName: trackAssembly,
-                      strand: origStrand * saStrandNormalized,
-                      uniqueId: `${feature.id()}_SA${index}`,
-                      mate: {
-                        start: saClipPos,
-                        end: saClipPos + saLengthSansClipping,
-                        refName: readName,
-                      },
-                    }
-                  })
-
-                const feat = feature.toJSON()
-                feat.strand = 1
-                feat.mate = {
-                  refName: readName,
-                  start: clipPos,
-                  end: clipPos + getLengthSansClipping(cigar),
-                }
-
-                // if secondary alignment or supplementary, calculate length
-                // from SA[0]'s CIGAR which is the primary alignments.
-                // otherwise it is the primary alignment just use seq.length if
-                // primary alignment
-                const totalLength = getLength(
-                  flags & 2048 ? supplementaryAlignments[0].CIGAR : cigar,
-                )
-
-                const features = [
-                  feat,
-                  ...supplementaryAlignments,
-                ] as ReducedFeature[]
-
-                features.sort((a, b) => a.clipPos - b.clipPos)
-
-                const refLength = features.reduce(
-                  (a, f) => a + f.end - f.start,
-                  0,
-                )
-
-                session.addView('DotplotView', {
-                  type: 'DotplotView',
-                  hview: {
-                    offsetPx: 0,
-                    bpPerPx: refLength / 800,
-                    displayedRegions: gatherOverlaps(
-                      features.map((f, index) => {
-                        const { start, end, refName } = f
-                        return {
-                          start,
-                          end,
-                          refName,
-                          index,
-                          assemblyName: trackAssembly,
-                        }
-                      }),
-                    ),
-                  },
-                  vview: {
-                    offsetPx: 0,
-                    bpPerPx: totalLength / 400,
-                    minimumBlockWidth: 0,
-                    interRegionPaddingWidth: 0,
-                    displayedRegions: [
-                      {
-                        assemblyName: readAssembly,
-                        start: 0,
-                        end: totalLength,
-                        refName: readName,
-                      },
-                    ],
-                  },
-                  viewTrackConfigs: [
-                    {
-                      type: 'SyntenyTrack',
-                      assemblyNames,
-                      adapter: {
-                        type: 'FromConfigAdapter',
-                        features,
-                      },
-                      trackId,
-                      name: trackName,
-                    },
-                  ],
-                  viewAssemblyConfigs: [
-                    {
-                      name: readAssembly,
-                      sequence: {
-                        type: 'ReferenceSequenceTrack',
-                        trackId: `${readName}_${Date.now()}`,
-                        adapter: {
-                          type: 'FromConfigSequenceAdapter',
-                          features: [feature.toJSON()],
-                        },
-                      },
-                    },
-                  ],
-                  assemblyNames,
-                  tracks: [
-                    {
-                      configuration: trackId,
-                      type: 'SyntenyTrack',
-                      displays: [
-                        {
-                          type: 'DotplotDisplay',
-                          configuration: `${trackId}-DotplotDisplay`,
-                        },
-                      ],
-                    },
-                  ],
-                  displayName: `${readName} vs ${trackAssembly}`,
-                })
-              },
-            },
-          ]
-        : []
-    }
-    function addContextMenu(view: View) {
-      if (view.type === 'LinearGenomeView') {
-        view.tracks.forEach(track => {
-          if (track.type === 'AlignmentsTrack') {
-            track.displays.forEach(display => {
-              if (
-                display.type === 'LinearPileupDisplay' &&
-                !display.additionalContextMenuItemCallbacks.includes(cb)
-              ) {
-                display.addAdditionalContextMenuItemCallback(cb)
-              } else if (
-                display.type === 'LinearAlignmentsDisplay' &&
-                display.PileupDisplay &&
-                !display.PileupDisplay.additionalContextMenuItemCallbacks.includes(
-                  cb,
-                )
-              ) {
-                display.PileupDisplay.addAdditionalContextMenuItemCallback(cb)
-              }
-            })
-          }
-        })
-      }
-    }
-    autorun(() => {
-      const session = pluginManager.rootModel?.session as Session | undefined
-      if (session) {
-        session.views.forEach(view => {
-          if (view.views) {
-            view.views.forEach(v => addContextMenu(v))
-          } else {
-            addContextMenu(view)
-          }
-        })
-      }
-    })
   }
 }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -92,7 +92,7 @@ const BaseLinearDisplay = observer(
         />
 
         <Menu
-          open={Boolean(contextCoord) && Boolean(contextMenuItems.length)}
+          open={Boolean(contextCoord) && Boolean(contextMenuItems().length)}
           onMenuItemClick={(_, callback) => {
             callback()
             setContextCoord(undefined)
@@ -114,7 +114,7 @@ const BaseLinearDisplay = observer(
               : undefined
           }
           style={{ zIndex: theme.zIndex.tooltip }}
-          menuItems={contextMenuItems}
+          menuItems={contextMenuItems()}
           data-testid="base_linear_display_context_menu"
         />
       </div>

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -288,8 +288,8 @@ export const BaseLinearDisplay = types
       return []
     },
 
-    get contextMenuItems() {
-      const contextMenuItems = self.contextMenuFeature
+    contextMenuItems() {
+      return self.contextMenuFeature
         ? [
             {
               label: 'Open feature details',
@@ -302,8 +302,6 @@ export const BaseLinearDisplay = types
             },
           ]
         : []
-
-      return contextMenuItems
     },
     renderProps() {
       return {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -17,7 +17,7 @@ import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
 import MenuOpenIcon from '@material-ui/icons/MenuOpen'
 import { autorun } from 'mobx'
-import { addDisposer, Instance, isAlive, types, getEnv } from 'mobx-state-tree'
+import { addDisposer, Instance, isAlive, types } from 'mobx-state-tree'
 import React from 'react'
 import { Tooltip } from '../components/BaseLinearDisplay'
 import BlockState, { renderBlockData } from './serverSideRenderedBlock'
@@ -56,7 +56,6 @@ export const BaseLinearDisplay = types
     message: '',
     featureIdUnderMouse: undefined as undefined | string,
     contextMenuFeature: undefined as undefined | Feature,
-    additionalContextMenuItemCallbacks: [] as Function[],
     scrollTop: 0,
   }))
   .views(self => ({
@@ -238,9 +237,6 @@ export const BaseLinearDisplay = types
     reload() {
       ;[...self.blockState.values()].map(val => val.doReload())
     },
-    addAdditionalContextMenuItemCallback(callback: Function) {
-      self.additionalContextMenuItemCallbacks.push(callback)
-    },
     setContextMenuFeature(feature?: Feature) {
       self.contextMenuFeature = feature
     },
@@ -293,7 +289,6 @@ export const BaseLinearDisplay = types
     },
 
     get contextMenuItems() {
-      const { pluginManager } = getEnv(self)
       const contextMenuItems = self.contextMenuFeature
         ? [
             {
@@ -308,10 +303,6 @@ export const BaseLinearDisplay = types
           ]
         : []
 
-      self.additionalContextMenuItemCallbacks.forEach(callback => {
-        const menuItems = callback(self.contextMenuFeature, self, pluginManager)
-        contextMenuItems.push(...menuItems)
-      })
       return contextMenuItems
     },
     renderProps() {


### PR DESCRIPTION
Inspired by #2226, this makes it so that plugins that want to add context menu items to displays now do so using the `Core-extendPluggableElement` extension point. This removes the need for there to be an autorun that watches for new displays and adds "additionalContextMenuItems" to them. Instead, it extends the display state model itself so all instances of the display already have the additional context menu items.