### PR TITLE
Resolves prefix matches found in search results dialog

### DIFF
--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -43,13 +43,20 @@ export default class TrixTextSearchAdapter
    */
   async searchIndex(args: BaseArgs) {
     const results = await this.trixJs.search(args.queryString)
-
-    return this.formatResults(
+    const formatted = this.formatResults(
       results.map(
         data =>
           JSON.parse(Buffer.from(data, 'base64').toString('utf8')) as string[],
       ),
     )
+    if (args.searchType === 'exact') {
+      return formatted.filter(
+        result =>
+          result.getLabel().toLocaleLowerCase() ===
+          args.queryString.toLocaleLowerCase(),
+      )
+    }
+    return formatted
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
@@ -244,7 +244,7 @@ describe('valid file tests', () => {
     autocomplete.focus()
     fireEvent.mouseDown(inputBox)
     fireEvent.change(inputBox, {
-      target: { value: 'apple' },
+      target: { value: 'seg02' },
     })
     // fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
     // fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })


### PR DESCRIPTION
Mentioned in comment [here](https://github.com/GMOD/jbrowse-components/pull/1881#issuecomment-901524338)
* filters formatted results in trix text search adapter to return only those that exactly match the label when searchType is set to exact
* this resolves options reappearing on the dialog when a user has already chosen an option from the dropdown

Before:

https://user-images.githubusercontent.com/45598764/130001901-f782b32f-0a7e-43c7-9a63-5fbc29fd1e09.mov

After:

https://user-images.githubusercontent.com/45598764/130001618-8a58c0d2-fb4f-475c-969c-bce95f609dfa.mov

