### PR TITLE
Add v1.3.4 release announcement draft

### DIFF
--- a/website/release_announcement_drafts/v1.3.4.md
+++ b/website/release_announcement_drafts/v1.3.4.md
@@ -1,0 +1,12 @@
+This release adds a new UMD build of our
+[`@jbrowse/react-linear-genome-view`](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view)
+React component. This build will allow users to use our React Linear Genome View
+in a website that doesn't otherwise use React. See a tutorial for how to get
+started using this build:
+
+- https://jbrowse.org/jb2/docs/tutorials/embed_linear_genome_view/01_introduction
+
+A preliminary beta version of this build was used in a tutorial at BOSC2020,
+and that tutorial was also on our website. If you've used that version, the
+interface has changed somewhat, so come check out the new tutorial for the
+official released version!

--- a/website/release_announcement_drafts/v1.3.4.md
+++ b/website/release_announcement_drafts/v1.3.4.md
@@ -1,3 +1,8 @@
+We're excited to announce the v1.3.4 release of JBrowse! Some highlights of this
+release include:
+
+## New embedding build of `@jbrowse/react-linear-genome-view`
+
 This release adds a new UMD build of our
 [`@jbrowse/react-linear-genome-view`](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view)
 React component. This build will allow users to use our React Linear Genome View
@@ -6,7 +11,26 @@ started using this build:
 
 - https://jbrowse.org/jb2/docs/tutorials/embed_linear_genome_view/01_introduction
 
-A preliminary beta version of this build was used in a tutorial at BOSC2020,
-and that tutorial was also on our website. If you've used that version, the
+A preliminary beta version of this build was used in a tutorial at BOSC2020, and
+that tutorial was also on our website. If you've used that version, the
 interface has changed somewhat, so come check out the new tutorial for the
 official released version!
+
+## Bookmark widget
+
+A new widget has been added that is accessible from the Linear Genome View view
+menu or when you click and drag over a region in the header (a.k.a rubber band
+selection). This view keeps a list of bookmarked regions, which you can add
+custom labels to, and also which you can use to navigate back to that region.
+The bookmarks can also be exported.
+
+![Bookmark widget in use](https://user-images.githubusercontent.com/19295181/130518189-d8fa8904-d52f-45b0-8403-34f08c23740e.gif)
+
+## Note to plugin developers
+
+If your plugin adds menu items or context menu items to a track, there may be
+some changes that affect how those menu items work, particularly in
+[#2226](https://github.com/GMOD/jbrowse-components/pull/2226) and
+[#2229](https://github.com/GMOD/jbrowse-components/pull/2229). Also see an
+updated example of context menu items
+[here](https://jbrowse.org/jb2/docs/developer_guide#adding-track-context-menu-items).

--- a/website/release_announcement_drafts/v1.3.4.md
+++ b/website/release_announcement_drafts/v1.3.4.md
@@ -28,9 +28,9 @@ The bookmarks can also be exported.
 
 ## Note to plugin developers
 
-If your plugin adds menu items or context menu items to a track, there may be
-some changes that affect how those menu items work, particularly in
-[#2226](https://github.com/GMOD/jbrowse-components/pull/2226) and
-[#2229](https://github.com/GMOD/jbrowse-components/pull/2229). Also see an
+If your plugin adds menu items or context menu items to a track, or customizes
+`renderProps`, there may be some changes that affect how those menu items work,
+particularly in [#2226](https://github.com/GMOD/jbrowse-components/pull/2226)
+and [#2229](https://github.com/GMOD/jbrowse-components/pull/2229). Also see an
 updated example of context menu items
 [here](https://jbrowse.org/jb2/docs/developer_guide#adding-track-context-menu-items).


### PR DESCRIPTION
Here's the current changelog. Note that the beta pre-release of desktop has split up the changelog, and you have to do a bit of extra work to get it to generate for two releases. I'll probably fix the changelog manually in this release, but we might want to consider that before we do the next desktop beta release.

```markdown
#### :rocket: Enhancement
* Other
  * [#2163](https://github.com/GMOD/jbrowse-components/pull/2163) Add new embeddable React Circular Genome View ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2229](https://github.com/GMOD/jbrowse-components/pull/2229) Use extendPluggableElement for context menu items ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2233](https://github.com/GMOD/jbrowse-components/pull/2233) Add optional chromSizes config slot to TwoBitAdapter to speed up loading of TwoBit files with many refseqs ([@cmdcolin](https://github.com/cmdcolin))
  * [#2199](https://github.com/GMOD/jbrowse-components/pull/2199) Make the BED parser not interpret general tab delimited data as BED12 ([@cmdcolin](https://github.com/cmdcolin))
  * [#2241](https://github.com/GMOD/jbrowse-components/pull/2241) Restore previous window location when re-opening on desktop ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2203](https://github.com/GMOD/jbrowse-components/pull/2203) Add a helpful message if there is a 404 on config.json error ([@cmdcolin](https://github.com/cmdcolin))
  * [#2204](https://github.com/GMOD/jbrowse-components/pull/2204) Hide reads with unmapped flag by default in alignments tracks ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#2236](https://github.com/GMOD/jbrowse-components/pull/2236) Detect assembly loading error and encapsulate error instead of failing at app level ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#2245](https://github.com/GMOD/jbrowse-components/pull/2245) Fix missing regenerator runtime dependency in core ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2202](https://github.com/GMOD/jbrowse-components/pull/2202) Fixed a crash when an incompatible adapter is selected for provided data in 'open track' ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
* Other
  * [#2208](https://github.com/GMOD/jbrowse-components/pull/2208) Fix issue where collapsed categories were not remembered after toggling a track ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#2192](https://github.com/GMOD/jbrowse-components/pull/2192) Update Linear Genome View embedding docs ([@garrettjstevens](https://github.com/garrettjstevens))

#### :house: Internal
* `core`
  * [#2057](https://github.com/GMOD/jbrowse-components/pull/2057) Use idMaker for dataAdapterCache key for faster FromConfigAdapter performance ([@cmdcolin](https://github.com/cmdcolin))
  * [#2231](https://github.com/GMOD/jbrowse-components/pull/2231) Export offscreenCanvasUtils ([@cmdcolin](https://github.com/cmdcolin))
  * [#2226](https://github.com/GMOD/jbrowse-components/pull/2226) Use superRenderProps and superTrackMenuItems for better simulated inheritance model ([@cmdcolin](https://github.com/cmdcolin))
  * [#1874](https://github.com/GMOD/jbrowse-components/pull/1874) Add aborting to CoreGetFeatures rpcManager call ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2232](https://github.com/GMOD/jbrowse-components/pull/2232) Remove filtering display type from core ([@cmdcolin](https://github.com/cmdcolin))
  * [#2234](https://github.com/GMOD/jbrowse-components/pull/2234) Add rootModel setError on jbrowse-desktop ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))


## v1.3.3-beta.0 (2021-08-10)

#### :rocket: Enhancement
* Other
  * [#2198](https://github.com/GMOD/jbrowse-components/pull/2198) Add better inversion visualization to read vs reference visualizations ([@cmdcolin](https://github.com/cmdcolin))
  * [#2154](https://github.com/GMOD/jbrowse-components/pull/2154) Add UMD build of react-linear-genome-view for plain-js use ([@garrettjstevens](https://github.com/garrettjstevens))
* `core`
  * [#2029](https://github.com/GMOD/jbrowse-components/pull/2029) Polish desktop builds ([@elliothershberg](https://github.com/elliothershberg))
  * [#2140](https://github.com/GMOD/jbrowse-components/pull/2140) New core plugin that adds a "bookmarked regions" list widget, new extension points system ([@elliothershberg](https://github.com/elliothershberg))

#### :bug: Bug Fix
* `core`
  * [#2197](https://github.com/GMOD/jbrowse-components/pull/2197) Fix handle leak for killed worker checker ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Elliot Hershberg ([@elliothershberg](https://github.com/elliothershberg))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
```