### PR TITLE
Restore previous desktop window location when re-opening

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -71,6 +71,7 @@
     "deepmerge": "^4.2.2",
     "electron-debug": "^3.0.1",
     "electron-is-dev": "^1.1.0",
+    "electron-window-state": "^5.0.3",
     "fontsource-roboto": "3.0.3",
     "json-stable-stringify": "^1.0.1",
     "mobx": "^5.10.1",

--- a/products/jbrowse-desktop/public/electron.js
+++ b/products/jbrowse-desktop/public/electron.js
@@ -1,6 +1,7 @@
 const electron = require('electron')
 const debug = require('electron-debug')
 const isDev = require('electron-is-dev')
+const windowStateKeeper = require('electron-window-state')
 const fs = require('fs')
 const path = require('path')
 const url = require('url')
@@ -29,10 +30,17 @@ try {
 
 let mainWindow
 
-function createWindow() {
+async function createWindow() {
+  const mainWindowState = windowStateKeeper({
+    defaultWidth: 1400,
+    defaultHeight: 800,
+  })
+  const { x, y, width, height } = mainWindowState
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 800,
+    x,
+    y,
+    width,
+    height,
     webPreferences: {
       webSecurity: false,
       nodeIntegration: true,
@@ -40,6 +48,7 @@ function createWindow() {
       contextIsolation: false,
     },
   })
+  mainWindowState.manage(mainWindow)
   mainWindow.loadURL(
     isDev
       ? url.format(devServerUrl)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9335,6 +9335,14 @@ electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.564, electron-to-chromi
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.775.tgz#046517d1f2cea753e06fff549995b9dc45e20082"
   integrity sha512-EGuiJW4yBPOTj2NtWGZcX93ZE8IGj33HJAx4d3ouE2zOfW2trbWU+t1e0yzLr1qQIw81++txbM3BH52QwSRE6Q==
 
+electron-window-state@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/electron-window-state/-/electron-window-state-5.0.3.tgz#4f36d09e3f953d87aff103bf010f460056050aa8"
+  integrity sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==
+  dependencies:
+    jsonfile "^4.0.0"
+    mkdirp "^0.5.1"
+
 electron@13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.2.tgz#8c9abf9015766c9cbc16f10c99282d00d6ae1b90"


### PR DESCRIPTION
I've been using this change to make working on desktop easier, so I thought I'd put it in as a separate PR.

This adds `electron-window-state`, which keeps track of the size and location of the window is in when it closes in JBrowse Desktop. When you re-open JBrowse Desktop, it restores the window to the same size and position.