### PR TITLE
Import bookmarks functionality for grid bookmark widget

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
@@ -31,10 +31,6 @@ function AssemblySelector({ model }: { model: GridBookmarkModel }) {
   const { assemblies, selectedAssembly, setSelectedAssembly } = model
   const noAssemblies = assemblies.length === 0 ? true : false
 
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setSelectedAssembly(event.target.value as string)
-  }
-
   const determineCurrentValue = (selectedAssembly: string) => {
     if (selectedAssembly === 'all') {
       return 'all'
@@ -53,7 +49,7 @@ function AssemblySelector({ model }: { model: GridBookmarkModel }) {
       <FormControl className={classes.flexItem} disabled={noAssemblies}>
         <Select
           value={determineCurrentValue(selectedAssembly)}
-          onChange={handleChange}
+          onChange={event => setSelectedAssembly(event.target.value as string)}
         >
           <MenuItem value="none" key="no-assembly">
             none
@@ -61,13 +57,11 @@ function AssemblySelector({ model }: { model: GridBookmarkModel }) {
           <MenuItem value="all" key="all-assemblies">
             all
           </MenuItem>
-          {assemblies.map((assembly: string) => {
-            return (
-              <MenuItem value={assembly} key={assembly}>
-                {assembly}
-              </MenuItem>
-            )
-          })}
+          {assemblies.map(assembly => (
+            <MenuItem value={assembly} key={assembly}>
+              {assembly}
+            </MenuItem>
+          ))}
         </Select>
       </FormControl>
     </div>

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
@@ -6,6 +6,8 @@ import {
   IconButton,
   Dialog,
   DialogTitle,
+  DialogContent,
+  DialogActions,
   Typography,
   makeStyles,
 } from '@material-ui/core'
@@ -42,6 +44,7 @@ function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
       </Button>
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
         <DialogTitle>
+          Clear bookmarks
           <IconButton
             className={classes.closeDialog}
             aria-label="close-dialog"
@@ -50,27 +53,33 @@ function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <div className={classes.dialogContainer}>
-          <>
-            <Typography>
-              Clear all bookmarks? Note this will clear bookmarks for all
-              assemblies
-            </Typography>
-            <br />
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => {
-                  clearAllBookmarks()
-                  setDialogOpen(false)
-                }}
-              >
-                Confirm
-              </Button>
-            </div>
-          </>
-        </div>
+        <DialogContent>
+          <Typography>
+            Clear all bookmarks? Note this will clear bookmarks for all
+            assemblies
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => {
+              setDialogOpen(false)
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => {
+              clearAllBookmarks()
+              setDialogOpen(false)
+            }}
+          >
+            Confirm
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   )

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ClearBookmarks.tsx
@@ -38,7 +38,7 @@ function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
         aria-label="clear bookmarks"
         onClick={() => setDialogOpen(true)}
       >
-        Clear bookmarks
+        Clear
       </Button>
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
         <DialogTitle>
@@ -52,7 +52,10 @@ function ClearBookmarks({ model }: { model: GridBookmarkModel }) {
         </DialogTitle>
         <div className={classes.dialogContainer}>
           <>
-            <Typography>Clear all bookmarks?</Typography>
+            <Typography>
+              Clear all bookmarks? Note this will clear bookmarks for all
+              assemblies
+            </Typography>
             <br />
             <div style={{ display: 'flex', justifyContent: 'center' }}>
               <Button

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 
+import { assembleLocString } from '@jbrowse/core/util'
+
 import {
   IconButton,
   Button,
@@ -25,11 +27,11 @@ const useStyles = makeStyles(() => ({
 }))
 
 function DeleteBookmarkDialog({
-  locString,
+  rowNumber,
   model,
   onClose,
 }: {
-  locString: string | undefined
+  rowNumber: number | undefined
   model: GridBookmarkModel
   onClose: () => void
 }) {
@@ -38,7 +40,7 @@ function DeleteBookmarkDialog({
   const { removeBookmark } = model
 
   return (
-    <Dialog open={!!locString} onClose={onClose}>
+    <Dialog open={rowNumber !== undefined} onClose={onClose}>
       <DialogTitle>
         <IconButton
           className={classes.closeDialog}
@@ -50,7 +52,12 @@ function DeleteBookmarkDialog({
       </DialogTitle>
       <div className={classes.dialogContainer}>
         <Typography>
-          Remove <code>{locString}</code>?
+          Remove row number{' '}
+          <code>
+            {rowNumber !== undefined
+              ? assembleLocString(model.bookmarkedRegions[rowNumber])
+              : ''}
+          </code>
         </Typography>
         <br />
         <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -58,8 +65,8 @@ function DeleteBookmarkDialog({
             variant="contained"
             color="primary"
             onClick={() => {
-              if (locString) {
-                removeBookmark(locString)
+              if (rowNumber !== undefined) {
+                removeBookmark(rowNumber)
                 onClose()
               }
             }}

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DeleteBookmark.tsx
@@ -8,6 +8,8 @@ import {
   Button,
   Dialog,
   DialogTitle,
+  DialogContent,
+  DialogActions,
   Typography,
   makeStyles,
 } from '@material-ui/core'
@@ -42,6 +44,7 @@ function DeleteBookmarkDialog({
   return (
     <Dialog open={rowNumber !== undefined} onClose={onClose}>
       <DialogTitle>
+        Delete bookmark
         <IconButton
           className={classes.closeDialog}
           aria-label="close-dialog"
@@ -50,31 +53,41 @@ function DeleteBookmarkDialog({
           <CloseIcon />
         </IconButton>
       </DialogTitle>
-      <div className={classes.dialogContainer}>
+      <DialogContent>
         <Typography>
-          Remove row number{' '}
+          Remove{' '}
           <code>
             {rowNumber !== undefined
               ? assembleLocString(model.bookmarkedRegions[rowNumber])
               : ''}
-          </code>
+          </code>{' '}
+          ?
         </Typography>
-        <br />
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => {
-              if (rowNumber !== undefined) {
-                removeBookmark(rowNumber)
-                onClose()
-              }
-            }}
-          >
-            Confirm
-          </Button>
-        </div>
-      </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            onClose()
+          }}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            if (rowNumber !== undefined) {
+              removeBookmark(rowNumber)
+              onClose()
+            }
+          }}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/DownloadBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/DownloadBookmarks.tsx
@@ -6,8 +6,11 @@ import {
   Button,
   Dialog,
   DialogTitle,
-  Select,
+  DialogContent,
+  DialogActions,
   MenuItem,
+  Select,
+  Typography,
   makeStyles,
 } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
@@ -39,11 +42,6 @@ function DownloadBookmarks({ model }: { model: GridBookmarkModel }) {
   const classes = useStyles()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [fileType, setFileType] = useState('BED')
-
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setFileType(event.target.value as string)
-  }
-
   const { bookmarkedRegions } = model
 
   return (
@@ -61,34 +59,40 @@ function DownloadBookmarks({ model }: { model: GridBookmarkModel }) {
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <div className={classes.dialogContainer}>
-          <>
-            <div className={classes.flexContainer}>
-              <Select
-                className={classes.flexItem}
-                data-testid="selectFileType"
-                value={fileType}
-                onChange={handleChange}
-              >
-                <MenuItem value="BED">BED</MenuItem>
-                <MenuItem value="TSV">TSV</MenuItem>
-              </Select>
-              <Button
-                className={classes.flexItem}
-                data-testid="dialogDownload"
-                variant="contained"
-                color="primary"
-                startIcon={<GetAppIcon />}
-                onClick={() => {
-                  downloadBookmarkFile(bookmarkedRegions, fileType, model)
-                  setDialogOpen(false)
-                }}
-              >
-                Download
-              </Button>
-            </div>
-          </>
-        </div>
+        <DialogContent>
+          <Typography>Format to download</Typography>
+          <Select
+            className={classes.flexItem}
+            data-testid="selectFileType"
+            value={fileType}
+            onChange={event => setFileType(event.target.value as string)}
+          >
+            <MenuItem value="BED">BED</MenuItem>
+            <MenuItem value="TSV">TSV</MenuItem>
+          </Select>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => setDialogOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            className={classes.flexItem}
+            data-testid="dialogDownload"
+            variant="contained"
+            color="primary"
+            startIcon={<GetAppIcon />}
+            onClick={() => {
+              downloadBookmarkFile(bookmarkedRegions, fileType, model)
+              setDialogOpen(false)
+            }}
+          >
+            Download
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   )

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.test.js
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.test.js
@@ -53,7 +53,7 @@ describe('<GridBookmarkWidget />', () => {
 
     const { findByText } = render(<GridBookmarkWidget model={model} />)
 
-    expect(findByText('chr1:1-12')).toBeTruthy()
+    expect(await findByText('chr1:2..12')).toBeTruthy()
   })
 
   it('deletes individual bookmarks correctly', async () => {
@@ -84,7 +84,7 @@ describe('<GridBookmarkWidget />', () => {
 
     const { findByText } = render(<GridBookmarkWidget model={model} />)
 
-    fireEvent.click(await findByText('Clear bookmarks'))
+    fireEvent.click(await findByText('Clear'))
     fireEvent.click(await findByText('Confirm'))
 
     expect(await findByText('No rows')).toBeTruthy()

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/GridBookmarkWidget.tsx
@@ -14,6 +14,7 @@ import ViewCompactIcon from '@material-ui/icons/ViewCompact'
 import AssemblySelector from './AssemblySelector'
 import DeleteBookmarkDialog from './DeleteBookmark'
 import DownloadBookmarks from './DownloadBookmarks'
+import ImportBookmarks from './ImportBookmarks'
 import ClearBookmarks from './ClearBookmarks'
 
 // creates a coarse measurement of column width, similar to code in BaseFeatureDetails
@@ -130,6 +131,7 @@ function GridBookmarkWidget({ model }: { model: GridBookmarkModel }) {
     <>
       <AssemblySelector model={model} />
       <DownloadBookmarks model={model} />
+      <ImportBookmarks model={model} />
       <ClearBookmarks model={model} />
       <Button
         startIcon={<ViewCompactIcon />}

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
@@ -44,13 +44,13 @@ function ImportBookmarks({
   assemblyName: string
 }) {
   const classes = useStyles()
+  const session = getSession(model)
+  const { assemblyNames } = session
   const [dialogOpen, setDialogOpen] = useState(false)
   const [location, setLocation] = useState<FileLocation>()
   const [error, setError] = useState<Error>()
-  const [fileType, setFileType] = useState('BED')
-  const session = getSession(model)
-  const [selectedAsm, setSelectedAsm] = useState<string>(
-    assemblyName || session.assemblyNames[0],
+  const [selectedAsm, setSelectedAsm] = useState(
+    assemblyName || assemblyNames[0],
   )
 
   return (
@@ -64,6 +64,7 @@ function ImportBookmarks({
         maxWidth="xl"
       >
         <DialogTitle>
+          Import bookmarks
           <IconButton
             className={classes.closeDialog}
             aria-label="close-dialog"
@@ -73,43 +74,33 @@ function ImportBookmarks({
           </IconButton>
         </DialogTitle>
         <DialogContent>
-          <Grid container direction="column" spacing={10}>
-            <Grid item>
-              <Typography>
-                Currently, only simple BED file imports are supported
-              </Typography>
-              <Select
-                className={classes.flexItem}
-                data-testid="selectFileType"
-                value={fileType}
-                disabled
-                onChange={event => setFileType(event.target.value as string)}
-              >
-                <MenuItem value="BED">BED</MenuItem>
-                <MenuItem value="TSV">TSV</MenuItem>
-              </Select>
-            </Grid>
-            <Grid item>
-              <Typography>Select assembly that your data belongs to</Typography>
-              <AssemblySelector
-                onChange={val => setSelectedAsm(val)}
-                session={session}
-                selected={selectedAsm}
-              />
-            </Grid>
-            <Grid item>
-              <FileSelector
-                location={location}
-                setLocation={setLocation}
-                name="File"
-              />
-            </Grid>
-          </Grid>
+          <Typography>
+            Choose a BED format file to import. The first 4 columns will be used
+          </Typography>
+
+          <FileSelector
+            location={location}
+            setLocation={setLocation}
+            name="File"
+          />
+          <Typography>Select assembly that your data belongs to</Typography>
+          <AssemblySelector
+            onChange={val => setSelectedAsm(val)}
+            session={session}
+            selected={selectedAsm}
+          />
           {error ? (
             <Typography color="error" variant="h6">{`${error}`}</Typography>
           ) : null}
         </DialogContent>
         <DialogActions>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => setDialogOpen(false)}
+          >
+            Cancel
+          </Button>
           <Button
             className={classes.flexItem}
             data-testid="dialogImport"

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react'
+import { observer } from 'mobx-react'
+
+import {
+  IconButton,
+  Button,
+  Dialog,
+  DialogTitle,
+  Select,
+  MenuItem,
+  makeStyles,
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+import ImportIcon from '@material-ui/icons/Publish'
+
+import { GridBookmarkModel } from '../model'
+import { downloadBookmarkFile } from '../utils'
+
+const useStyles = makeStyles(() => ({
+  closeDialog: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  dialogContainer: {
+    margin: 15,
+  },
+  flexItem: {
+    margin: 5,
+  },
+  flexContainer: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    width: 200,
+  },
+}))
+
+function ImportBookmarks({ model }: { model: GridBookmarkModel }) {
+  const classes = useStyles()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [fileType, setFileType] = useState('BED')
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setFileType(event.target.value as string)
+  }
+
+  const { bookmarkedRegions } = model
+
+  return (
+    <>
+      <Button startIcon={<ImportIcon />} onClick={() => setDialogOpen(true)}>
+        Import
+      </Button>
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+        <DialogTitle>
+          <IconButton
+            className={classes.closeDialog}
+            aria-label="close-dialog"
+            onClick={() => setDialogOpen(false)}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <div className={classes.dialogContainer}>
+          <>
+            <div className={classes.flexContainer}>
+              <Select
+                className={classes.flexItem}
+                data-testid="selectFileType"
+                value={fileType}
+                onChange={handleChange}
+              >
+                <MenuItem value="BED">BED</MenuItem>
+                <MenuItem value="TSV">TSV</MenuItem>
+              </Select>
+              <Button
+                className={classes.flexItem}
+                data-testid="dialogImport"
+                variant="contained"
+                color="primary"
+                startIcon={<ImportIcon />}
+                onClick={() => {
+                  downloadBookmarkFile(bookmarkedRegions, fileType, model)
+                  setDialogOpen(false)
+                }}
+              >
+                Download
+              </Button>
+            </div>
+          </>
+        </div>
+      </Dialog>
+    </>
+  )
+}
+
+export default observer(ImportBookmarks)

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
@@ -12,9 +12,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Grid,
-  Select,
-  MenuItem,
   makeStyles,
   Typography,
 } from '@material-ui/core'

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/utils.ts
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/utils.ts
@@ -77,7 +77,7 @@ export function downloadBookmarkFile(
   const fileContents = bookmarkedRegions
     .map(b => {
       const { label } = b
-      const labelVal = label === '' ? 'NA' : label
+      const labelVal = label === '' ? '.' : label
       const locString = assembleLocString(b)
 
       if (fileFormat === 'BED') {


### PR DESCRIPTION
I had a quick interest in getting a import bookmarks function implemented

This let's a user quickly import a BED formatted file. The name column 4 is stored in the "label" field

It also has a couple more add-ons

* replaces the NA default export with a . which is the standard not available data description for BED
* makes it so duplicates in bookmarks are allowed, as this may come from data files, and rather than filtering on import, it retains them (note that if this was not done, then strange errors would occur on editing fields)
* makes the hover style on links in the grid bookmark widget cursor:pointer

Some motivation to this includes my feeling that you can easily loose track of your session 

During development especially, I cycle through tons of sessions and I imagine a user may also, and if we're not careful, we would loose our bookmarks (since bookmarks are currently tied to session...). So if we can at least re-import them, it seems useful

Just an idea I picked up and ran with :)