### PR TITLE
Prevent the ToggleButton for the FileSelector toggling to local file when only URL should be available

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -56,7 +56,7 @@ const FileLocationEditor = observer(
               onChange={(_, newValue) => {
                 if (newValue === 'url') {
                   setFileOrUrlState('url')
-                } else {
+                } else if (newValue === 'file') {
                   setFileOrUrlState('file')
                 }
               }}


### PR DESCRIPTION
Fixes #2246

The key is that, onChange will produce a "null" change when its in exclusive mode, and you click a button that is already depressed expecting it to become undepressed. Our code switched it from url->file mode however.
