### PR TITLE
Add note about legacy-peer-deps to readme

### DIFF
--- a/products/jbrowse-react-circular-genome-view/README.md
+++ b/products/jbrowse-react-circular-genome-view/README.md
@@ -44,12 +44,11 @@ $ yarn add @jbrowse/react-circular-genome-view
 Or with [npm](https://npmjs.org/):
 
 ```
-$ npm install @jbrowse/react-circular-genome-view
+$ npm install @jbrowse/react-circular-genome-view --legacy-peer-deps
 ```
 
-## Documentation
-
-The latest Storybook documentation for the component is hosted [here](https://jbrowse.org/storybook/lgv/main).
+The --legacy-peer-deps helps with installing via NPM to avoid warnings about
+the peer dependencies not being met while installing.
 
 ### Note on fonts
 

--- a/products/jbrowse-react-linear-genome-view/README.md
+++ b/products/jbrowse-react-linear-genome-view/README.md
@@ -3,8 +3,8 @@
 > JBrowse 2 linear genome view React component
 
 [JBrowse 2](https://jbrowse.org/jb2/) is a pluggable open-source platform for
-visualizing, integrating, and sharing biological data. This component consists of a single
-JBrowse 2 linear view.
+visualizing, integrating, and sharing biological data. This component consists
+of a single JBrowse 2 linear view.
 
 ## Usage
 
@@ -42,8 +42,11 @@ $ yarn add @jbrowse/react-linear-genome-view
 Or with [npm](https://npmjs.org/):
 
 ```
-$ npm install @jbrowse/react-linear-genome-view
+$ npm install @jbrowse/react-linear-genome-view --legacy-peer-deps
 ```
+
+The --legacy-peer-deps helps with installing via NPM to avoid warnings about
+the peer dependencies not being met while installing.
 
 ## Documentation
 


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/pull/1943

If we don't want to suggest legacy-peer-deps we might need https://github.com/GMOD/jbrowse-components/pull/1727 and maybe even other evaluations of our many dependencies and their peerDependencies...it's just quite a picky system sometimes

Also removes storybook note from circular view

@garrettjstevens is the circular view storybook published?

