### PR TITLE
Update admin-server to accept a configPath

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -311,8 +311,6 @@ OPTIONS
 
   --out=out        synonym for target
 
-  --skipCheck      Don't check whether or not you are in a JBrowse directory
-
   --target=target  path to config file in JB2 installation directory to write out to.
                    Creates ./config.json if nonexistent
 

--- a/products/jbrowse-cli/src/commands/admin-server.test.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.test.ts
@@ -201,6 +201,6 @@ describe('admin-server', () => {
         body: JSON.stringify(payload),
       })
       expect(response.status).toBe(500)
-      expect(await response.text()).toBe('Could not write config file')
+      expect(await response.text()).toMatch(/Could not write config file/)
     })
 })

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -1,4 +1,5 @@
 import { flags } from '@oclif/command'
+import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
 import boxen from 'boxen'
@@ -6,9 +7,7 @@ import chalk from 'chalk'
 import os from 'os'
 import express from 'express'
 import cors from 'cors'
-import JBrowseCommand, { Config } from '../base'
-
-const fsPromises = fs.promises
+import JBrowseCommand from '../base'
 
 function isValidPort(port: number) {
   return port > 0 && port < 65535
@@ -20,9 +19,6 @@ function generateKey() {
 }
 
 export default class AdminServer extends JBrowseCommand {
-  // @ts-ignore
-  private target: string
-
   static description = 'Start up a small admin server for JBrowse configuration'
 
   static examples = ['$ jbrowse admin-server', '$ jbrowse admin-server -p 8888']
@@ -39,35 +35,32 @@ export default class AdminServer extends JBrowseCommand {
     out: flags.string({
       description: 'synonym for target',
     }),
-    skipCheck: flags.boolean({
-      description: "Don't check whether or not you are in a JBrowse directory",
-    }),
+
     help: flags.help({ char: 'h' }),
   }
 
   async run() {
     const { flags: runFlags } = this.parse(AdminServer)
+    const { target, out } = runFlags
 
-    const output = runFlags.target || runFlags.out || '.'
-    const isDir = (await fsPromises.lstat(output)).isDirectory()
-    this.target = isDir ? `${output}/config.json` : output
+    const output = target || out || '.'
+    const isDir = fs.lstatSync(output).isDirectory()
+    const outFile = isDir ? `${output}/config.json` : output
+    const baseDir = path.dirname(outFile)
 
-    // check if the config file exists, if none exists write default
-    const defaultConfig: Config = {
-      assemblies: [],
-      configuration: {},
-      connections: [],
-      defaultSession: {
-        name: 'New Session',
-      },
-      tracks: [],
-    }
-
-    if (fs.existsSync(this.target)) {
-      this.debug(`Found existing config file ${this.target}`)
+    if (fs.existsSync(outFile)) {
+      this.debug(`Found existing config file ${outFile}`)
     } else {
-      this.debug(`Creating config file ${this.target}`)
-      await this.writeJsonFile('./config.json', defaultConfig)
+      this.debug(`Creating config file ${outFile}`)
+      await this.writeJsonFile('./config.json', {
+        assemblies: [],
+        configuration: {},
+        connections: [],
+        defaultSession: {
+          name: 'New Session',
+        },
+        tracks: [],
+      })
     }
 
     // start server with admin key in URL query string
@@ -85,24 +78,24 @@ export default class AdminServer extends JBrowseCommand {
 
     // POST route to save config
     app.use(express.json())
-    app.post(
-      '/updateConfig',
-      async (req: express.Request, res: express.Response) => {
-        this.debug('Req body: ', req.body)
-
-        if (req.body.adminKey === adminKey) {
-          this.debug('Admin key matches')
-          try {
-            await this.writeJsonFile(this.target, req.body.config)
-            res.send('Config written to disk')
-          } catch {
-            res.status(500).send('Could not write config file')
-          }
-        } else {
-          res.status(403).send('Admin key does not match')
+    app.post('/updateConfig', async (req, res) => {
+      if (adminKey === req.body.adminKey) {
+        this.debug('Admin key matches')
+        try {
+          await this.writeJsonFile(
+            req.body.configPath
+              ? path.join(baseDir, req.body.configPath)
+              : outFile,
+            req.body.config,
+          )
+          res.send('Config written to disk')
+        } catch (e) {
+          res.status(500).send(`Could not write config file ${e}`)
         }
-      },
-    )
+      } else {
+        res.status(403).send('Admin key does not match')
+      }
+    })
 
     app.post(
       '/shutdown',

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -40,18 +40,16 @@ const JBrowse = observer(({ pluginManager }) => {
   useEffect(() => {
     onSnapshot(jbrowse, async snapshot => {
       if (adminKey) {
-        const payload = {
-          adminKey,
-          configPath,
-          config: deleteBaseUris(JSON.parse(JSON.stringify(snapshot))),
-        }
-
         const response = await fetch(adminServer || `/updateConfig`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify({
+            adminKey,
+            configPath,
+            config: deleteBaseUris(JSON.parse(JSON.stringify(snapshot))),
+          }),
         })
         if (!response.ok) {
           const message = await response.text()

--- a/products/jbrowse-web/src/JBrowse.js
+++ b/products/jbrowse-web/src/JBrowse.js
@@ -25,6 +25,7 @@ function deleteBaseUris(config) {
 const JBrowse = observer(({ pluginManager }) => {
   const [adminKey] = useQueryParam('adminKey', StringParam)
   const [adminServer] = useQueryParam('adminServer', StringParam)
+  const [configPath] = useQueryParam('config', StringParam)
   const [, setSessionId] = useQueryParam('session', StringParam)
   const { rootModel } = pluginManager
   const { error, jbrowse, session } = rootModel || {}
@@ -41,6 +42,7 @@ const JBrowse = observer(({ pluginManager }) => {
       if (adminKey) {
         const payload = {
           adminKey,
+          configPath,
           config: deleteBaseUris(JSON.parse(JSON.stringify(snapshot))),
         }
 
@@ -61,7 +63,7 @@ const JBrowse = observer(({ pluginManager }) => {
         }
       }
     })
-  }, [jbrowse, session, adminKey, adminServer])
+  }, [jbrowse, session, adminKey, adminServer, configPath])
 
   if (error) {
     throw error


### PR DESCRIPTION
Possible fix for #2139 

This would let the admin-server receive a config path from a client and write to it

Note that with the current admin-server, something like this is possible: you setup --out to a specific config.json, and then you navigate to that specific config using &config=

However, if you wanted e.g. to edit multiple configs in the same admin-server session, this PR would help

