### PR TITLE
Make copy button on sequence feature details have a plaintext copy option

### DIFF
--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails.tsx
@@ -31,6 +31,7 @@ interface ParentFeat extends Feat {
  * will fallback to execCommand if needed.
  * Still use copy-to-clipboard for HTML copy
  * @param value- the value to save in clipboard
+ * @param html- should it be saved as html
  * @returns nothing, just used to break early
  */
 const copyToClipboard = (value: string | null, html = false) => {


### PR DESCRIPTION
PR to fix #2257 

Instead of using copy-to-clipboard package, this use the native clipboard API to make the copy to clipboard.
If not available, it will fall back to the deprecated execCommand API.

While this fix the issue, it loses the ability to copy a sequence with color.
So at the request of @cmdcolin  I have also added a `Copy HTML` button. It still uses copy-to-clipboard for this, as the clipboard API is too recent to be used with HTML (usage with HTML is experimental with Firefox and was added to Chrome less than a year ago) and I wasn't able to make it work with execCommand.

Note before merge, test on Safari is needed, as I have seen people having problem with it concerning clipboard, and I don't own a mac to test.

Before:

![image](https://user-images.githubusercontent.com/24433720/130996305-71c6dfb2-2899-41dc-a67e-474787568df1.png)

After:

![image](https://user-images.githubusercontent.com/24433720/131007231-d1395040-0e0d-4de0-892d-2a8d1786a9fd.png)
