### PR TITLE
Force publish all packages on release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,4 +66,4 @@ git add .
 git commit --message "Prepare for $RELEASE_TAG release"
 
 # Run lerna version first, publish after changelog and blog post have been created
-yarn lerna publish "$SEMVER_LEVEL" --message "[update docs] %s"
+yarn lerna publish --force-publish "*" "$SEMVER_LEVEL" --message "[update docs] %s"


### PR DESCRIPTION
This attempts to force publish all packages on each release, despite if they have not changed

This could be considered overkill and a reaction to the v1.3.4 to v1.3.5 release thing but it seemed to have resulted in a fair bit of confusion. It may be best to publish all every time. The only downside may be taking up a bit more npmjs.com server space

https://lerna.js.org/#command-publish
