### PR TITLE
Fix autocomplete height on small displays

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -214,7 +214,6 @@ function RefNameAutocomplete({
               ])
             : filtered
         }}
-        ListboxProps={{ style: { maxHeight: 250 } }}
         renderInput={params => {
           const { helperText, InputProps = {} } = TextFieldProps
           const TextFieldInputProps = {


### PR DESCRIPTION
When viewing on a small display, this particular autocomplete attribute would make the dropdown display differently

before
![Screenshot from 2021-08-29 23-34-12](https://user-images.githubusercontent.com/6511937/131281413-9976bdfb-3194-4fd1-99b7-cf640828b8a8.png)

after
![Screenshot from 2021-08-29 23-34-46](https://user-images.githubusercontent.com/6511937/131281436-fbe22378-734e-428f-8e92-72d90665a9ff.png)

Kind of an unexpected effect but I think this helps