### PR TITLE
Auto adjust box RefNameAutocomplete width based on refName length

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -19,9 +19,6 @@ const useStyles = makeStyles(theme => ({
   importFormContainer: {
     padding: theme.spacing(2),
   },
-  importFormEntry: {
-    minWidth: 180,
-  },
   button: {
     margin: theme.spacing(2),
   },
@@ -140,7 +137,6 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                     margin: 'normal',
                     variant: 'outlined',
                     helperText: 'Enter a sequence or location',
-                    className: classes.importFormEntry,
                     onBlur: event => {
                       if (event.target.value !== '') {
                         setSelectedRegion(event.target.value)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -265,7 +265,6 @@ const ScaleBar = observer(
               <Typography
                 style={{
                   color: refNameColor,
-                  backgroundColor: 'rgba(255,255,255)',
                   zIndex: 100,
                 }}
                 className={classes.scaleBarRefName}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -263,7 +263,11 @@ const ScaleBar = observer(
             >
               {/* name of sequence */}
               <Typography
-                style={{ color: refNameColor }}
+                style={{
+                  color: refNameColor,
+                  backgroundColor: 'rgba(255,255,255)',
+                  zIndex: 100,
+                }}
                 className={classes.scaleBarRefName}
               >
                 {seq.refName}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -10,7 +10,7 @@ import { getEnv } from 'mobx-state-tree'
 
 // jbrowse core
 import { Region } from '@jbrowse/core/util/types'
-import { getSession, useDebounce } from '@jbrowse/core/util'
+import { getSession, useDebounce, measureText } from '@jbrowse/core/util'
 import TextSearchManager from '@jbrowse/core/TextSearch/TextSearchManager'
 import { SearchType } from '@jbrowse/core/data_adapters/BaseAdapter'
 import BaseResult, {
@@ -165,7 +165,8 @@ function RefNameAutocomplete({
       }
     }
   }
-
+  const inputBoxVal = coarseVisibleLocStrings || value || ''
+  const width = Math.max(measureText(inputBoxVal, 16) + 25, 200)
   return (
     <>
       <Autocomplete
@@ -178,8 +179,8 @@ function RefNameAutocomplete({
         freeSolo
         includeInputInList
         selectOnFocus
-        style={style}
-        value={coarseVisibleLocStrings || value || ''}
+        style={{ ...style, width }}
+        value={inputBoxVal}
         loading={loaded !== undefined ? !loaded : false}
         loadingText="loading results"
         open={open}
@@ -237,7 +238,6 @@ function RefNameAutocomplete({
               {...params}
               {...TextFieldProps}
               helperText={helperText}
-              value={coarseVisibleLocStrings || value || ''}
               InputProps={TextFieldInputProps}
               placeholder="Search for location"
               onChange={e => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -167,7 +167,7 @@ function RefNameAutocomplete({
   }
   const inputBoxVal = coarseVisibleLocStrings || value || ''
   // heuristic, text width + icon width, minimum 200
-  const width = Math.max(measureText(inputBoxVal, 16) + 25, 200)
+  const width = Math.min(Math.max(measureText(inputBoxVal, 16) + 25, 200), 550)
   return (
     <>
       <Autocomplete

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -166,6 +166,7 @@ function RefNameAutocomplete({
     }
   }
   const inputBoxVal = coarseVisibleLocStrings || value || ''
+  // heuristic, text width + icon width, minimum 200
   const width = Math.max(measureText(inputBoxVal, 16) + 25, 200)
   return (
     <>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -29,7 +29,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-              style="color: rgb(153, 102, 0);"
+              style="color: rgb(153, 102, 0); z-index: 100;"
             >
               ctgA
             </p>
@@ -170,6 +170,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             class="MuiAutocomplete-root"
             data-testid="autocomplete"
             role="combobox"
+            style="width: 200px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
@@ -639,9 +640,10 @@ exports[`<LinearGenomeView /> renders setup wizard 1`] = `
           class="MuiAutocomplete-root"
           data-testid="autocomplete"
           role="combobox"
+          style="width: 200px;"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root makeStyles-importFormEntry MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
           >
             <div
               class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
@@ -768,7 +770,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-              style="color: rgb(153, 102, 0);"
+              style="color: rgb(153, 102, 0); z-index: 100;"
             >
               ctgA
             </p>
@@ -783,6 +785,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
+              style="z-index: 100;"
             >
               ctgB
             </p>
@@ -923,6 +926,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             class="MuiAutocomplete-root"
             data-testid="autocomplete"
             role="combobox"
+            style="width: 235.22500000000002px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <p
                       class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-                      style="color: rgb(153, 102, 0);"
+                      style="color: rgb(153, 102, 0); z-index: 100;"
                     >
                       ctgA
                     </p>
@@ -254,6 +254,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="MuiAutocomplete-root"
                     data-testid="autocomplete"
                     role="combobox"
+                    style="width: 200px;"
                   >
                     <div
                       class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-marginDense MuiFormControl-fullWidth"

--- a/test_data/large.chrom.sizes
+++ b/test_data/large.chrom.sizes
@@ -199998,3 +199998,4 @@ chrxPA83thw	50000
 chrzzBm4qd6	50000
 chrBPhPrUOC	50000
 chrsOS3sFH9	50000
+reallyreallyreallyreallyreallylong	50000


### PR DESCRIPTION
Fixes #1899 


Before

![Screenshot from 2021-08-30 11-58-18](https://user-images.githubusercontent.com/6511937/131368449-bc08ffe5-cdcc-472e-80ac-6bd4261060c9.png)
After
![Screenshot from 2021-08-30 11-57-58](https://user-images.githubusercontent.com/6511937/131368462-5d65abbb-6dc0-41c2-b5c6-d391cb237265.png)

One notable case is that when viewing all chromosomes e.g. "Show all regions in assembly" it makes a long ref string concatenating all strings. we could consider making a compact representation. Anyways, there is a maxWidth:500, minWidth:200 (uses custom width calculation instead of directly using minWidth/maxWidth  in css, didn't seem like it works in css to sensibly autoadjust by specifying those see https://codesandbox.io/s/material-demo-forked-j2c1b?file=/demo.js seems to expand to maxWidth by default)

![Screenshot from 2021-08-30 12-03-28](https://user-images.githubusercontent.com/6511937/131370096-7c520c33-69c0-4add-9b59-a37b9a2dd11b.png)

