### PR TITLE
Fix ability for the variant detail panel to create breakpoint split view for <TRA> elements

### DIFF
--- a/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
@@ -226,12 +226,17 @@ export default class VCFFeature implements Feature {
       // least 1% in population, and can't be sure we meet that
       return ['SNV', this._makeDescriptionString('SNV', ref, alt)]
     }
-
-    if (alt.includes('<')) {
+    if (alt === '<INS>') {
+      return ['insertion', alt]
+    } else if (alt === '<DEL>') {
+      return ['deletion', alt]
+    } else if (alt === '<INV>') {
+      return ['deletion', alt]
+    } else if (alt === '<TRA>') {
+      return ['translocation', alt]
+    } else if (alt.includes('<')) {
       return ['sv', alt]
-    }
-
-    if (ref.length === alt.length) {
+    } else if (ref.length === alt.length) {
       if (ref.split('').reverse().join('') === alt) {
         return ['inversion', this._makeDescriptionString('inversion', ref, alt)]
       }


### PR DESCRIPTION
This adds the feature.get('type') for some variant symbolic allele types

The VariantDetailWidget  actually needs (in some form, or it has to change itself) because it checks for feature.type==='breakend' and feature.type==='translocation' but the translocation one wasn't working