### PR TITLE
Faster tooltip method for feature tracks and wiggle tracks

### DIFF
--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -1,28 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
-import MUITooltip from '@material-ui/core/Tooltip'
 import { observer } from 'mobx-react'
-import { makeStyles } from '@material-ui/core/styles'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
-
-const useStyles = makeStyles(theme => ({
-  popper: {
-    fontSize: '0.8em',
-    zIndex: theme.zIndex.tooltip, // important to have a zIndex directly on the popper itself, material-ui Tooltip uses popper and has similar thing
-    pointerEvents: 'none', // needed to avoid rapid mouseLeave/mouseEnter on popper
-  },
-
-  hoverVertical: {
-    background: '#333',
-    border: 'none',
-    width: 1,
-    height: '100%',
-    top: 0,
-    cursor: 'default',
-    position: 'absolute',
-    pointerEvents: 'none',
-  },
-}))
+import { Tooltip } from '@jbrowse/plugin-wiggle'
 
 type Count = {
   [key: string]: {
@@ -31,13 +11,15 @@ type Count = {
   }
 }
 
+const en = (n: number) => n.toLocaleString('en-US')
+
 function TooltipContents({ feature }: { feature: Feature }) {
-  const refName = feature.get('refName')
-  const start = (feature.get('start') + 1).toLocaleString('en-US')
-  const end = feature.get('end').toLocaleString('en-US')
-  const loc = `${refName ? `${refName}:` : ''}${
-    start === end ? start : `${start}..${end}`
-  }`
+  const start = feature.get('start')
+  const end = feature.get('end')
+  const ref = feature.get('refName')
+  const loc = [ref, start === end ? en(start) : `${en(start)}..${en(end)}`]
+    .filter(f => !!f)
+    .join(':')
 
   const info = feature.get('snpinfo') as {
     ref: Count
@@ -48,7 +30,8 @@ function TooltipContents({ feature }: { feature: Feature }) {
     total: number
   }
 
-  const { total, ref, cov, noncov, lowqual, delskips } = info
+  const total = info.total
+
   return (
     <div>
       <table>
@@ -69,78 +52,37 @@ function TooltipContents({ feature }: { feature: Feature }) {
             <td />
           </tr>
 
-          {Object.entries({ ref, cov, noncov, delskips, lowqual }).map(
-            ([key, entry]) => {
+          {Object.entries(info).map(([key, entry]) => {
+            return Object.entries(entry).map(([base, score]) => {
+              const { strands } = score
               return (
-                <React.Fragment key={key}>
-                  {Object.entries(entry).map(([base, score]) => {
-                    const { strands } = score
-                    return (
-                      <tr key={base}>
-                        <td>{base.toUpperCase()}</td>
-                        <td>{score.total}</td>
-                        <td>
-                          {base === 'total'
-                            ? '---'
-                            : `${Math.floor((score.total / total) * 100)}%`}
-                        </td>
-                        <td>
-                          {strands['-1'] ? `${strands['-1']}(-)` : ''}
-                          {strands['1'] ? `${strands['1']}(+)` : ''}
-                        </td>
-                        <td>{key}</td>
-                      </tr>
-                    )
-                  })}
-                </React.Fragment>
+                <tr key={base}>
+                  <td>{base.toUpperCase()}</td>
+                  <td>{score.total}</td>
+                  <td>
+                    {base === 'total'
+                      ? '---'
+                      : `${Math.floor((score.total / total) * 100)}%`}
+                  </td>
+                  <td>
+                    {strands['-1'] ? `${strands['-1']}(-)` : ''}
+                    {strands['1'] ? `${strands['1']}(+)` : ''}
+                  </td>
+                  <td>{key}</td>
+                </tr>
               )
-            },
-          )}
+            })
+          })}
         </tbody>
       </table>
     </div>
   )
 }
 
-type Coord = [number, number]
-const Tooltip = observer(
-  ({
-    model,
-    height,
-    mouseCoord,
-  }: {
-    model: any
-    height: number
-    mouseCoord: Coord
-  }) => {
-    const { featureUnderMouse } = model
-    const classes = useStyles()
-
-    return featureUnderMouse ? (
-      <>
-        <MUITooltip
-          placement="right-start"
-          className={classes.popper}
-          open
-          title={<TooltipContents feature={featureUnderMouse} />}
-        >
-          <div
-            style={{
-              position: 'absolute',
-              left: mouseCoord[0],
-              top: 0,
-            }}
-          >
-            {' '}
-          </div>
-        </MUITooltip>
-        <div
-          className={classes.hoverVertical}
-          style={{ left: mouseCoord[0], height }}
-        />
-      </>
-    ) : null
+const SNPCoverageTooltip = observer(
+  (props: { model: any; height: number; mouseCoord: [number, number] }) => {
+    return <Tooltip TooltipContents={TooltipContents} {...props} />
   },
 )
 
-export default Tooltip
+export default SNPCoverageTooltip

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -1,13 +1,15 @@
 import { getConf } from '@jbrowse/core/configuration'
 import { Menu } from '@jbrowse/core/ui'
-import { useTheme, makeStyles } from '@material-ui/core/styles'
+import { alpha, useTheme, makeStyles } from '@material-ui/core'
 import { observer } from 'mobx-react'
 import React, { useState, useRef } from 'react'
-import MUITooltip from '@material-ui/core/Tooltip'
 import LinearBlocks from './LinearBlocks'
 import { BaseLinearDisplayModel } from '../models/BaseLinearDisplayModel'
 
-const useStyles = makeStyles({
+function round(value: number) {
+  return Math.round(value * 1e5) / 1e5
+}
+const useStyles = makeStyles(theme => ({
   display: {
     position: 'relative',
     whiteSpace: 'nowrap',
@@ -15,26 +17,45 @@ const useStyles = makeStyles({
     width: '100%',
     minHeight: '100%',
   },
-})
+
+  // these styles come from
+  // https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js
+  tooltip: {
+    position: 'absolute',
+    pointerEvents: 'none',
+    backgroundColor: alpha(theme.palette.grey[700], 0.9),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.common.white,
+    fontFamily: theme.typography.fontFamily,
+    padding: '4px 8px',
+    fontSize: theme.typography.pxToRem(10),
+    lineHeight: `${round(14 / 10)}em`,
+    maxWidth: 300,
+    wordWrap: 'break-word',
+    fontWeight: theme.typography.fontWeightMedium,
+  },
+}))
 const Tooltip = observer(
-  (props: { model: BaseLinearDisplayModel; mouseCoord: [number, number] }) => {
-    const { model, mouseCoord } = props
+  ({
+    model,
+    mouseCoord,
+  }: {
+    model: BaseLinearDisplayModel
+    mouseCoord: [number, number]
+  }) => {
+    const classes = useStyles()
     const { featureUnderMouse } = model
-    const mouseover = featureUnderMouse
-      ? getConf(model, 'mouseover', { feature: featureUnderMouse })
-      : undefined
-    return mouseover ? (
-      <MUITooltip title={mouseover} open placement="right">
-        <div
-          style={{
-            position: 'absolute',
-            left: mouseCoord[0],
-            top: mouseCoord[1],
-          }}
-        >
-          {' '}
-        </div>
-      </MUITooltip>
+
+    return featureUnderMouse ? (
+      <div
+        className={classes.tooltip}
+        style={{
+          left: mouseCoord[0] + 25,
+          top: mouseCoord[1],
+        }}
+      >
+        {getConf(model, 'mouseover', { feature: featureUnderMouse })}
+      </div>
     ) : null
   },
 )

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -7,21 +7,13 @@ import { YSCALEBAR_LABEL_OFFSET } from '../models/model'
 
 const toP = (s = 0) => parseFloat(s.toPrecision(6))
 
+const en = (n: number) => n.toLocaleString('en-US')
+
 function round(value: number) {
   return Math.round(value * 1e5) / 1e5
 }
+
 const useStyles = makeStyles(theme => ({
-  popper: {
-    fontSize: '0.8em',
-
-    // important to have a zIndex directly on the popper itself
-    // @material-ui/Tooltip uses popper and has similar thing
-    zIndex: theme.zIndex.tooltip,
-
-    // needed to avoid rapid mouseLeave/mouseEnter on popper
-    pointerEvents: 'none',
-  },
-
   hoverVertical: {
     background: '#333',
     border: 'none',
@@ -37,6 +29,7 @@ const useStyles = makeStyles(theme => ({
   // https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js
   tooltip: {
     position: 'absolute',
+    zIndex: 10000,
     pointerEvents: 'none',
     backgroundColor: alpha(theme.palette.grey[700], 0.9),
     borderRadius: theme.shape.borderRadius,
@@ -51,14 +44,13 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-function TooltipContents(props: { feature: Feature }) {
-  const { feature } = props
+function TooltipContents({ feature }: { feature: Feature }) {
+  const start = feature.get('start')
+  const end = feature.get('end')
   const ref = feature.get('refName')
-  const displayRef = `${ref ? `${ref}:` : ''}`
-  const start = (feature.get('start') + 1).toLocaleString('en-US')
-  const end = feature.get('end').toLocaleString('en-US')
-  const coord = start === end ? start : `${start}..${end}`
-  const loc = `${displayRef}${coord}`
+  const loc = [ref, start === end ? en(start) : `${en(start)}..${en(end)}`]
+    .filter(f => !!f)
+    .join(':')
 
   return feature.get('summary') !== undefined ? (
     <div>
@@ -79,16 +71,17 @@ function TooltipContents(props: { feature: Feature }) {
   )
 }
 
-type Coord = [number, number]
 const Tooltip = observer(
   ({
     model,
     height,
     mouseCoord,
+    TooltipContents,
   }: {
     model: any
     height: number
-    mouseCoord: Coord
+    mouseCoord: [number, number]
+    TooltipContents: React.FC<any>
   }) => {
     const { featureUnderMouse } = model
     const classes = useStyles()
@@ -116,4 +109,10 @@ const Tooltip = observer(
   },
 )
 
-export default Tooltip
+const WiggleTooltip = observer(
+  (props: { model: any; height: number; mouseCoord: [number, number] }) => {
+    return <Tooltip TooltipContents={TooltipContents} {...props} />
+  },
+)
+export default WiggleTooltip
+export { Tooltip }

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
-import MUITooltip from '@material-ui/core/Tooltip'
 import { observer } from 'mobx-react'
-import { makeStyles } from '@material-ui/core/styles'
+import { alpha, makeStyles } from '@material-ui/core'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { YSCALEBAR_LABEL_OFFSET } from '../models/model'
 
 const toP = (s = 0) => parseFloat(s.toPrecision(6))
 
+function round(value: number) {
+  return Math.round(value * 1e5) / 1e5
+}
 const useStyles = makeStyles(theme => ({
   popper: {
     fontSize: '0.8em',
@@ -29,6 +31,23 @@ const useStyles = makeStyles(theme => ({
     cursor: 'default',
     position: 'absolute',
     pointerEvents: 'none',
+  },
+
+  // these styles come from
+  // https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js
+  tooltip: {
+    position: 'absolute',
+    pointerEvents: 'none',
+    backgroundColor: alpha(theme.palette.grey[700], 0.9),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.common.white,
+    fontFamily: theme.typography.fontFamily,
+    padding: '4px 8px',
+    fontSize: theme.typography.pxToRem(10),
+    lineHeight: `${round(14 / 10)}em`,
+    maxWidth: 300,
+    wordWrap: 'break-word',
+    fontWeight: theme.typography.fontWeightMedium,
   },
 }))
 
@@ -76,22 +95,15 @@ const Tooltip = observer(
 
     return featureUnderMouse ? (
       <>
-        <MUITooltip
-          placement="right-start"
-          className={classes.popper}
-          open
-          title={<TooltipContents feature={featureUnderMouse} />}
+        <div
+          className={classes.tooltip}
+          style={{
+            left: mouseCoord[0] + 25,
+            top: 0,
+          }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              left: mouseCoord[0],
-              top: 5,
-            }}
-          >
-            {' '}
-          </div>
-        </MUITooltip>
+          <TooltipContents feature={featureUnderMouse} />
+        </div>
         <div
           className={classes.hoverVertical}
           style={{

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -139,3 +139,4 @@ export { WiggleRendering }
 export { WiggleBaseRenderer }
 export { LinearWiggleDisplayReactComponent, linearWiggleDisplayModelFactory }
 export { YSCALEBAR_LABEL_OFFSET }
+export { Tooltip } from './LinearWiggleDisplay/components/Tooltip'


### PR DESCRIPTION
Currently our code for doing tooltips makes a fake div at a particular position and then wraps that div with a MUITooltip

This ends up getting pretty slow when the page gets busy, and can strongly affect perceived performance of the page getting bogged down, when really it's mostly the tooltip getting bogged down and the various popper.js calculations to try to keep it on the page.

If we don't have strong need for all the popper.js calculations that are done, we can adopt a PR like this

A fairly "busy" page is like this http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-bh9n1V64we&password=IRpTf

Both the feature tooltips and wiggle tooltips are a bit improved on this complex page

mousing over the bigwig and feature tracks is quite painful on v1.3.5/main branch here

https://jbrowse.org/code/jb2/v1.3.5/index.html?config=test_data%2Fconfig_demo.json&session=share-bh9n1V64we&password=IRpTf

much faster here (once build gets uploaded)
https://jbrowse.org/code/jb2/faster_tooltips/index.html?config=test_data%2Fconfig_demo.json&session=share-bh9n1V64we&password=IRpTf


there are "nice things that popper does" e.g. trying to keep the tooltip on the page if it overflows but I think the benefits of speed strongly outweigh these extra calculations right now