### PR TITLE
Faster tooltip method for feature tracks and wiggle tracks with react-popper

### DIFF
--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -13,71 +13,73 @@ type Count = {
 
 const en = (n: number) => n.toLocaleString('en-US')
 
-function TooltipContents({ feature }: { feature: Feature }) {
-  const start = feature.get('start')
-  const end = feature.get('end')
-  const ref = feature.get('refName')
-  const loc = [ref, start === end ? en(start) : `${en(start)}..${en(end)}`]
-    .filter(f => !!f)
-    .join(':')
+const TooltipContents = React.forwardRef(
+  ({ feature }: { feature: Feature }, ref: any) => {
+    const start = feature.get('start')
+    const end = feature.get('end')
+    const name = feature.get('refName')
+    const loc = [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
+      .filter(f => !!f)
+      .join(':')
 
-  const info = feature.get('snpinfo') as {
-    ref: Count
-    cov: Count
-    lowqual: Count
-    noncov: Count
-    delskips: Count
-    total: number
-  }
+    const info = feature.get('snpinfo') as {
+      ref: Count
+      cov: Count
+      lowqual: Count
+      noncov: Count
+      delskips: Count
+      total: number
+    }
 
-  const total = info.total
+    const total = info.total
 
-  return (
-    <div>
-      <table>
-        <caption>{loc}</caption>
-        <thead>
-          <tr>
-            <th>Base</th>
-            <th>Count</th>
-            <th>% of Total</th>
-            <th>Strands</th>
-            <th>Source</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Total</td>
-            <td>{total}</td>
-            <td />
-          </tr>
+    return (
+      <div ref={ref}>
+        <table>
+          <caption>{loc}</caption>
+          <thead>
+            <tr>
+              <th>Base</th>
+              <th>Count</th>
+              <th>% of Total</th>
+              <th>Strands</th>
+              <th>Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Total</td>
+              <td>{total}</td>
+              <td />
+            </tr>
 
-          {Object.entries(info).map(([key, entry]) => {
-            return Object.entries(entry).map(([base, score]) => {
-              const { strands } = score
-              return (
-                <tr key={base}>
-                  <td>{base.toUpperCase()}</td>
-                  <td>{score.total}</td>
-                  <td>
-                    {base === 'total'
-                      ? '---'
-                      : `${Math.floor((score.total / total) * 100)}%`}
-                  </td>
-                  <td>
-                    {strands['-1'] ? `${strands['-1']}(-)` : ''}
-                    {strands['1'] ? `${strands['1']}(+)` : ''}
-                  </td>
-                  <td>{key}</td>
-                </tr>
-              )
-            })
-          })}
-        </tbody>
-      </table>
-    </div>
-  )
-}
+            {Object.entries(info).map(([key, entry]) => {
+              return Object.entries(entry).map(([base, score]) => {
+                const { strands } = score
+                return (
+                  <tr key={base}>
+                    <td>{base.toUpperCase()}</td>
+                    <td>{score.total}</td>
+                    <td>
+                      {base === 'total'
+                        ? '---'
+                        : `${Math.floor((score.total / total) * 100)}%`}
+                    </td>
+                    <td>
+                      {strands['-1'] ? `${strands['-1']}(-)` : ''}
+                      {strands['1'] ? `${strands['1']}(+)` : ''}
+                    </td>
+                    <td>{key}</td>
+                  </tr>
+                )
+              })
+            })}
+          </tbody>
+        </table>
+      </div>
+    )
+  },
+)
 
 type Coord = [number, number]
 

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",
+    "@popperjs/core": "^2.9.3",
     "clone": "^2.1.2",
     "clsx": "^1.0.4",
     "copy-to-clipboard": "^3.3.1",
@@ -43,6 +44,7 @@
     "is-object": "^1.0.1",
     "json-stable-stringify": "^1.0.1",
     "normalize-wheel": "^1.0.1",
+    "react-popper": "^2.0.0",
     "react-sizeme": "^2.6.7"
   },
   "peerDependencies": {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -44,12 +44,11 @@ const BaseLinearDisplay = observer(
   (props: { model: BaseLinearDisplayModel; children?: React.ReactNode }) => {
     const classes = useStyles()
     const theme = useTheme()
-
+    const ref = useRef<HTMLDivElement>(null)
     const [clientRect, setClientRect] = useState<ClientRect>()
     const [offsetMouseCoord, setOffsetMouseCoord] = useState<Coord>([0, 0])
     const [clientMouseCoord, setClientMouseCoord] = useState<Coord>([0, 0])
     const [contextCoord, setContextCoord] = useState<Coord>()
-    const ref = useRef<HTMLDivElement>(null)
     const { model, children } = props
     const {
       TooltipComponent,

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -48,7 +48,7 @@ const TooltipContents = ({
   feature: Feature
   model: BaseLinearDisplayModel
 }) => {
-  return getConf(model, 'mouseover', { feature })
+  return <div>{getConf(model, 'mouseover', { feature })}</div>
 }
 
 const Tooltip = observer(
@@ -60,13 +60,16 @@ const Tooltip = observer(
     clientMouseCoord: Coord
     offsetMouseCoord: Coord
     clientRect?: ClientRect
-    TooltipContents: React.FC<any>
+    TooltipContents: React.FC<{ feature: Feature }>
   }) => {
     const classes = useStyles()
     const { featureUnderMouse } = model
 
-    const [popperElement, setPopperElement] = useState<any>(null)
+    const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
+      null,
+    )
 
+    // must be memoized a la https://github.com/popperjs/react-popper/issues/391
     const virtElement = useMemo(
       () => ({
         getBoundingClientRect: () => {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -45,7 +45,9 @@ const BaseLinearDisplay = observer(
     const classes = useStyles()
     const theme = useTheme()
 
-    const [mouseCoord, setMouseCoord] = useState<Coord>([0, 0])
+    const [clientRect, setClientRect] = useState<ClientRect>()
+    const [offsetMouseCoord, setOffsetMouseCoord] = useState<Coord>([0, 0])
+    const [clientMouseCoord, setClientMouseCoord] = useState<Coord>([0, 0])
     const [contextCoord, setContextCoord] = useState<Coord>()
     const ref = useRef<HTMLDivElement>(null)
     const { model, children } = props
@@ -74,7 +76,12 @@ const BaseLinearDisplay = observer(
         onMouseMove={event => {
           if (ref.current) {
             const rect = ref.current.getBoundingClientRect()
-            setMouseCoord([event.clientX - rect.left, event.clientY - rect.top])
+            setOffsetMouseCoord([
+              event.clientX - rect.left,
+              event.clientY - rect.top,
+            ])
+            setClientMouseCoord([event.clientX, event.clientY])
+            setClientRect(rect)
           }
         }}
         role="presentation"
@@ -85,10 +92,14 @@ const BaseLinearDisplay = observer(
           <LinearBlocks {...props} />
         )}
         {children}
+
         <TooltipComponent
           model={model}
           height={height}
-          mouseCoord={mouseCoord}
+          offsetMouseCoord={offsetMouseCoord}
+          clientMouseCoord={clientMouseCoord}
+          clientRect={clientRect}
+          mouseCoord={offsetMouseCoord}
         />
 
         <Menu

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -97,8 +97,7 @@ export const BaseLinearDisplay = types
      */
     get selectedFeatureId() {
       if (isAlive(self)) {
-        const session = getSession(self)
-        const { selection } = session
+        const { selection } = getSession(self)
         // does it quack like a feature?
         if (isFeature(selection)) {
           return selection.id()

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -37,11 +37,13 @@
   "dependencies": {
     "@gmod/bbi": "^1.0.30",
     "@material-ui/icons": "^4.11.2",
+    "@popperjs/core": "^2.9.3",
     "abortable-promise-cache": "^1.1.3",
     "color": "^3.1.1",
     "d3-scale": "^3.2.3",
     "json-stable-stringify": "^1.0.1",
     "react-color": "^2.19.3",
+    "react-popper": "^2.0.0",
     "react-d3-axis": "^0.1.2"
   },
   "peerDependencies": {

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
 import { observer } from 'mobx-react'
-import { makeStyles } from '@material-ui/core'
+import { makeStyles, Portal } from '@material-ui/core'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { YSCALEBAR_LABEL_OFFSET } from '../models/model'
 import { usePopper, Popper } from 'react-popper'
@@ -60,28 +60,13 @@ function TooltipContents(props: { feature: Feature }) {
   )
 }
 
-// This is going to create a virtual reference element
-// positioned 10px from top and left of the document
-// 90px wide and 10px high
-const virtualReference = {
-  getBoundingClientRect() {
-    return {
-      top: 10 + 300,
-      left: 10 + 300,
-      bottom: 20 + 300,
-      right: 100 + 300,
-      width: 90,
-      height: 10,
-    }
-  },
-}
-
 type Coord = [number, number]
 const Tooltip = observer(
   ({
     model,
     height,
     mouseCoord,
+    clientRect,
   }: {
     model: any
     height: number
@@ -92,25 +77,44 @@ const Tooltip = observer(
     const classes = useStyles()
 
     const [popperElement, setPopperElement] = React.useState<any>(null)
-    const { styles, attributes } = usePopper(virtualReference, popperElement, {
-      strategy: 'fixed',
-    })
+    const { styles, attributes } = usePopper(
+      {
+        getBoundingClientRect() {
+          const top = 100
+          console.log(mouseCoord[0])
+          return {
+            top,
+            left: mouseCoord[0],
+            bottom: top + 1,
+            right: mouseCoord[0] + 1,
+            width: 90,
+            height: 10,
+          }
+        },
+      },
+      popperElement,
+      {
+        strategy: 'fixed',
+      },
+    )
 
     return featureUnderMouse ? (
       <>
-        <div
-          ref={setPopperElement}
-          style={{
-            ...styles.popper,
-            background: 'white',
-            zIndex: 10000,
-          }}
-          {...attributes.popper}
-        >
-          Popper element Popper element Popper element
-          <br /> Popper element Popper element Popper element <br />
-          Popper element
-        </div>
+        <Portal>
+          <div
+            ref={setPopperElement}
+            style={{
+              ...styles.popper,
+              background: 'white',
+              zIndex: 10000,
+            }}
+            {...attributes.popper}
+          >
+            Popper element Popper element Popper element
+            <br /> Popper element Popper element Popper element <br />
+            Popper element
+          </div>
+        </Portal>
 
         <div
           className={classes.hoverVertical}

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -98,11 +98,13 @@ const Tooltip = observer(
     const virtElement = useMemo(
       () => ({
         getBoundingClientRect: () => {
+          const y = clientRect?.top || 0
+          const x = clientMouseCoord[0] + 20
           return {
-            top: clientRect?.top || 0,
-            left: clientMouseCoord[0] + 20,
-            bottom: clientRect?.top || 0,
-            right: clientMouseCoord[0],
+            top: y,
+            left: x,
+            bottom: y,
+            right: x,
             width: 0,
             height: 0,
           }

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -99,6 +99,7 @@ const Tooltip = observer(
 
     const [popperElement, setPopperElement] = useState<any>(null)
 
+    // must be memoized a la https://github.com/popperjs/react-popper/issues/391
     const virtElement = useMemo(
       () => ({
         getBoundingClientRect: () => {
@@ -129,7 +130,9 @@ const Tooltip = observer(
             {...attributes.popper}
           >
             <TooltipContents
-              ref={elt => setWidth(elt?.getBoundingClientRect().width || 0)}
+              ref={(elt: HTMLDivElement) => {
+                setWidth(elt?.getBoundingClientRect().width || 0)
+              }}
               feature={featureUnderMouse}
             />
           </div>

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
-import MUITooltip from '@material-ui/core/Tooltip'
 import { observer } from 'mobx-react'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { YSCALEBAR_LABEL_OFFSET } from '../models/model'
+import { usePopper, Popper } from 'react-popper'
 
 const toP = (s = 0) => parseFloat(s.toPrecision(6))
 
@@ -60,6 +60,22 @@ function TooltipContents(props: { feature: Feature }) {
   )
 }
 
+// This is going to create a virtual reference element
+// positioned 10px from top and left of the document
+// 90px wide and 10px high
+const virtualReference = {
+  getBoundingClientRect() {
+    return {
+      top: 10 + 300,
+      left: 10 + 300,
+      bottom: 20 + 300,
+      right: 100 + 300,
+      width: 90,
+      height: 10,
+    }
+  },
+}
+
 type Coord = [number, number]
 const Tooltip = observer(
   ({
@@ -70,28 +86,32 @@ const Tooltip = observer(
     model: any
     height: number
     mouseCoord: Coord
+    clientRect: ClientRect
   }) => {
     const { featureUnderMouse } = model
     const classes = useStyles()
 
+    const [popperElement, setPopperElement] = React.useState<any>(null)
+    const { styles, attributes } = usePopper(virtualReference, popperElement, {
+      strategy: 'fixed',
+    })
+
     return featureUnderMouse ? (
       <>
-        <MUITooltip
-          placement="right-start"
-          className={classes.popper}
-          open
-          title={<TooltipContents feature={featureUnderMouse} />}
+        <div
+          ref={setPopperElement}
+          style={{
+            ...styles.popper,
+            background: 'white',
+            zIndex: 10000,
+          }}
+          {...attributes.popper}
         >
-          <div
-            style={{
-              position: 'absolute',
-              left: mouseCoord[0],
-              top: 5,
-            }}
-          >
-            {' '}
-          </div>
-        </MUITooltip>
+          Popper element Popper element Popper element
+          <br /> Popper element Popper element Popper element <br />
+          Popper element
+        </div>
+
         <div
           className={classes.hoverVertical}
           style={{

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -46,8 +46,8 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const TooltipContents = React.forwardRef(
-  ({ feature }: { feature: Feature }, ref: any) => {
+const TooltipContents = React.forwardRef<HTMLDivElement, { feature: Feature }>(
+  ({ feature }: { feature: Feature }, ref) => {
     const start = feature.get('start')
     const end = feature.get('end')
     const name = feature.get('refName')
@@ -103,8 +103,8 @@ const Tooltip = observer(
     const virtElement = useMemo(
       () => ({
         getBoundingClientRect: () => {
+          const x = clientMouseCoord[0] + width / 2 + 20
           const y = clientRect?.top || 0
-          const x = clientMouseCoord[0] + (width * 2) / 3
           return {
             top: y,
             left: x,

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -138,4 +138,5 @@ export * from './util'
 export { WiggleRendering }
 export { WiggleBaseRenderer }
 export { LinearWiggleDisplayReactComponent, linearWiggleDisplayModelFactory }
+export { Tooltip } from './LinearWiggleDisplay/components/Tooltip'
 export { YSCALEBAR_LABEL_OFFSET }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,6 +3487,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@popperjs/core@^2.9.3":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.0.tgz#6f2f845cbb8f8f897236d9bf221379f14429c608"
+  integrity sha512-QWvCHtYwNIR3C/mxW9jGzOu1gbaZkq/6is2OedayPH7HsxI4CVuVzAZ1PmxRElXLwwwCN7aMjRhxtTAGLEZ8IQ==
+
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -18235,6 +18240,14 @@ react-popper-tooltip@^3.1.1:
     "@babel/runtime" "^7.12.5"
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
+
+react-popper@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-popper@^2.2.4:
   version "2.2.4"


### PR DESCRIPTION
This uses react-popper library manually to create a tooltip

It is a second approach to  https://github.com/GMOD/jbrowse-components/pull/2284

This can now display it's tooltip outside the bounds of the track

See snpcoverage for example here, displaying over the track panel


![localhost_3000__config=test_data%2Fvolvox%2Fconfig json session=local-1W7VU8L7u](https://user-images.githubusercontent.com/6511937/132031022-41e21640-2b3d-4e1c-ad1c-2391e43503c2.png)


The calculation of the width of the tooltip is done manually with getBoundingClientRect. It doesn't appear to perfectly track the coordinates of where you want to display it

I think that overcoming the limitations in #2284 will be good, and while it takes a fair amount more code to do it this way, it helps greatly with the users perceived speed on the page.

I think it is either this or we get rid of some tooltips by default
