### PR TITLE
Add extra re-exports for default modules

### DIFF
--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -25,6 +25,7 @@ export default [
   '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType',
   '@jbrowse/core/pluggableElementTypes/renderers/FeatureRendererType',
   '@jbrowse/core/pluggableElementTypes/renderers/RendererType',
+  '@jbrowse/core/pluggableElementTypes/renderers',
   '@jbrowse/core/configuration',
   '@jbrowse/core/util/types/mst',
   '@jbrowse/core/ui',
@@ -34,6 +35,7 @@ export default [
   '@jbrowse/core/util/Base1DViewModel',
   '@jbrowse/core/util/io',
   '@jbrowse/core/util/mst-reflection',
+  '@jbrowse/core/util/range',
   '@jbrowse/core/util/rxjs',
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail',
 

--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -65,15 +65,17 @@ import CircularChordRendererType from '../pluggableElementTypes/renderers/Circul
 import * as BoxRendererType from '../pluggableElementTypes/renderers/BoxRendererType'
 import * as FeatureRendererType from '../pluggableElementTypes/renderers/FeatureRendererType'
 import * as RendererType from '../pluggableElementTypes/renderers/RendererType'
+import * as renderers from '../pluggableElementTypes/renderers'
 
 import * as Configuration from '../configuration'
-import * as Plugin from '../Plugin'
+import Plugin from '../Plugin'
 import * as coreUi from '../ui'
 import * as coreUtil from '../util'
 import * as coreColor from '../util/color'
 import * as trackUtils from '../util/tracks'
 import * as coreIo from '../util/io'
 import * as coreMstReflection from '../util/mst-reflection'
+import * as range from '../util/range'
 import * as rxjs from '../util/rxjs'
 import * as MUIColors from './material-ui-colors'
 import * as mstTypes from '../util/types/mst'
@@ -147,6 +149,7 @@ const libs = {
   '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType': BoxRendererType,
   '@jbrowse/core/pluggableElementTypes/renderers/FeatureRendererType': FeatureRendererType,
   '@jbrowse/core/pluggableElementTypes/renderers/RendererType': RendererType,
+  '@jbrowse/core/pluggableElementTypes/renderers': renderers,
   '@jbrowse/core/configuration': Configuration,
   '@jbrowse/core/util/types/mst': mstTypes,
   '@jbrowse/core/ui': coreUi,
@@ -156,6 +159,7 @@ const libs = {
   '@jbrowse/core/util/Base1DViewModel': Base1DView,
   '@jbrowse/core/util/io': coreIo,
   '@jbrowse/core/util/mst-reflection': coreMstReflection,
+  '@jbrowse/core/util/range': range,
   '@jbrowse/core/util/rxjs': rxjs,
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail': BaseFeatureDetail,
 

--- a/packages/core/pluggableElementTypes/renderers/index.ts
+++ b/packages/core/pluggableElementTypes/renderers/index.ts
@@ -1,0 +1,17 @@
+import BoxRendererType from './BoxRendererType'
+import CircularChordRendererType from './CircularChordRendererType'
+import ComparativeServerSideRendererType from './ComparativeServerSideRendererType'
+import FeatureRendererType from './FeatureRendererType'
+import RendererType from './RendererType'
+import ServerSideRenderedContent from './ServerSideRenderedContent'
+import ServerSideRendererType from './ServerSideRendererType'
+
+export {
+  BoxRendererType,
+  CircularChordRendererType,
+  ComparativeServerSideRendererType,
+  FeatureRendererType,
+  RendererType,
+  ServerSideRenderedContent,
+  ServerSideRendererType,
+}


### PR DESCRIPTION
There are some inconsistencies in the way things are re-exported from core. For example, most of the pluggable element types look something like this:

```js
import TrackType from '../pluggableElementTypes/TrackType'
const libs = { '@jbrowse/core/pluggableElementTypes/TrackType': TrackType, /* ...all the other libs */ }
```

But the render type looks like this:

```js
import * as RendererType from '../pluggableElementTypes/renderers/RendererType'
const libs = { '@jbrowse/core/pluggableElementTypes/renderers/RendererType': RendererType, /* ...all the other libs */ }
```

Most of the renderers are like that, but the chord renderer is different:

https://github.com/GMOD/jbrowse-components/blob/67a19b3d04f72f576ddbbf4f48ca67cb29965b3d/packages/core/ReExports/modules.ts#L63-L67

This has some implications for how these are used at runtime. To properly get the TrackType at runtime, you have to do:

```js
const TrackType = JBrowseExports['@jbrowse/core/pluggableElementTypes/TrackType']
```

But for RendererType you have to add a `.default`

```js
const RendererType = JBrowseExports['@jbrowse/core/pluggableElementTypes/renderers/RendererType'].default
```

The real problem gets to be when a build system is trying to compile a plugin. These two imports looks similar:

```
import TrackType from '@jbrowse/core/pluggableElementTypes/TrackType'
import RendererType from '@jbrowse/core/pluggableElementTypes/renderers/RendererType'
```

but have to get compiled differently to use the global JBrowseExports properly. Our current UMD plugin build does some things to try to smooth this out, which work most of the time, but building to other targets doesn't work as well. Also, if core were ever used directly as a module running in Node, you'd have to worry about putting `.default`s in the right places as well.

The change in this PR doesn't change any of this behavior, since I didn't want to break anything, but it does add some exports for the renderers so there is a consistent and named (not default) way of importing them that build systems can understand more easily.