### PR TITLE
Use a less greedy file watcher for lower dev CPU usage

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -10,9 +10,8 @@
   "dir": "src",
   "scripts": {
     "start": "concurrently \"yarn serve\" \"wait-on http://localhost:3000 && yarn develop\"",
-    "serve": "cross-env BROWSER=none yarn cra-start",
+    "serve": "cross-env BROWSER=none TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling rescripts start",
     "develop": "electron .",
-    "cra-start": "rescripts start",
     "test": "rescripts test",
     "electron-ts": "yarn tsc --strict --esModuleInterop --skipLibCheck public/electron.ts",
     "prebuild": "npm run electron-ts",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -6,7 +6,7 @@
   "main": "build",
   "dir": "src",
   "scripts": {
-    "start": "rescripts --max-http-header-size=100000 start",
+    "start": "cross-env TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling rescripts start",
     "build": "cross-env NODE_OPTIONS='--max-old-space-size=7000' rescripts build",
     "test": "rescripts test",
     "eject": "rescripts eject",


### PR DESCRIPTION
This proposes using a less greedy file watcher for our default yarn start setup

It also removes the max header size because we now use session sharing rather than huge url sizes

The less greedy file watcher helps reduce CPU usage considerably from ~6% CPU (what i see pretty much constantly while `yarn start` is idling, similar to the ~7% reported in the issue) to nothing (in issue it is reported as ~0.2%) 

https://github.com/microsoft/TypeScript/issues/31048


e.g. this is pretty much what my computer looks like 100% of the time developing jbrowse
![Screenshot from 2021-09-05 14-06-37](https://user-images.githubusercontent.com/6511937/132137410-821f6435-16a4-4216-9f26-a860bfbfb3be.png)

The reason why this PR is in question is that Typescript decided not to make it their default at the time being due to some rare caveats but IMO it is rare enough that we could make it default

Laptop temp cooler===happy