### PR TITLE
Improve breakend parsing and don't rely on SVTYPE=BND for displaying breakend split view options

### DIFF
--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",
+    "@gmod/vcf": "^5.0.0",
     "clsx": "^1.0.4",
     "is-object": "^1.0.1",
     "react-sizeme": "^2.6.7",

--- a/plugins/breakpoint-split-view/src/components/AlignmentConnections.tsx
+++ b/plugins/breakpoint-split-view/src/components/AlignmentConnections.tsx
@@ -25,10 +25,6 @@ const AlignmentConnections = observer(
     const snap = getSnapshot(model)
     useNextFrame(snap)
     const assembly = assemblyManager.get(views[0].assemblyNames[0])
-    if (!assembly) {
-      return null
-    }
-
     const totalFeatures = model.getTrackFeatures(trackConfigId)
     const features = model.hasPairedReads(trackConfigId)
       ? model.getBadlyPairedAlignments(trackConfigId)
@@ -46,6 +42,10 @@ const AlignmentConnections = observer(
     if (parentRef.current) {
       const rect = parentRef.current.getBoundingClientRect()
       yOffset = rect.top
+    }
+
+    if (!assembly) {
+      return null
     }
     return (
       <g

--- a/plugins/breakpoint-split-view/src/components/Breakends.tsx
+++ b/plugins/breakpoint-split-view/src/components/Breakends.tsx
@@ -4,15 +4,26 @@ import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { getSession } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
+import { parseBreakend } from '@gmod/vcf'
+
+// locals
 import { yPos, getPxFromCoordinate, useNextFrame } from '../util'
-import { BreakpointViewModel, Breakend } from '../model'
+import { BreakpointViewModel } from '../model'
 
 const [LEFT] = [0, 1, 2, 3]
 
+interface Breakend {
+  MatePosition: string
+  MateDirection: string
+  Join: string
+}
+
 function findMatchingAlt(feat1: Feature, feat2: Feature) {
   const candidates: Record<string, Breakend> = {}
-  feat1.get('ALT').forEach((alt: Breakend) => {
-    candidates[alt.MatePosition] = alt
+  const alts = feat1.get('ALT') as string[] | undefined
+  alts?.forEach(alt => {
+    const bnd = parseBreakend(alt)
+    candidates[bnd.MatePosition] = bnd
   })
   return candidates[`${feat2.get('refName')}:${feat2.get('start') + 1}`]
 }
@@ -63,8 +74,8 @@ const Breakends = observer(
       >
         {layoutMatches.map(chunk => {
           const ret = []
-          // we follow a path in the list of chunks, not from top to bottom,
-          // just in series following x1,y1 -> x2,y2
+          // we follow a path in the list of chunks, not from top to bottom, just
+          // in series following x1,y1 -> x2,y2
           for (let i = 0; i < chunk.length - 1; i += 1) {
             const { layout: c1, feature: f1, level: level1 } = chunk[i]
             const { layout: c2, feature: f2, level: level2 } = chunk[i + 1]

--- a/plugins/breakpoint-split-view/src/components/Header.tsx
+++ b/plugins/breakpoint-split-view/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { withSize } from 'react-sizeme'
 import { observer } from 'mobx-react'
-import { IconButton, makeStyles } from '@material-ui/core'
+import IconButton from '@material-ui/core/IconButton'
+import { makeStyles } from '@material-ui/core/styles'
 
 // icons
 import LocationSearching from '@material-ui/icons/LocationSearching'
@@ -13,7 +14,8 @@ import LinkOffIcon from '@material-ui/icons/LinkOff'
 
 import { BreakpointViewModel } from '../model'
 
-const useStyles = makeStyles(theme => ({
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useStyles = makeStyles((theme: any) => ({
   headerBar: {
     gridArea: '1/1/auto/span 2',
     display: 'flex',

--- a/plugins/breakpoint-split-view/src/components/Header.tsx
+++ b/plugins/breakpoint-split-view/src/components/Header.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { withSize } from 'react-sizeme'
 import { observer } from 'mobx-react'
-import IconButton from '@material-ui/core/IconButton'
-import { makeStyles } from '@material-ui/core/styles'
+import { IconButton, makeStyles } from '@material-ui/core'
 
 // icons
 import LocationSearching from '@material-ui/icons/LocationSearching'
@@ -14,8 +13,7 @@ import LinkOffIcon from '@material-ui/icons/LinkOff'
 
 import { BreakpointViewModel } from '../model'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const useStyles = makeStyles((theme: any) => ({
+const useStyles = makeStyles(theme => ({
   headerBar: {
     gridArea: '1/1/auto/span 2',
     display: 'flex',

--- a/plugins/breakpoint-split-view/src/declare.d.ts
+++ b/plugins/breakpoint-split-view/src/declare.d.ts
@@ -1,2 +1,2 @@
-declare module 'array-intersection'
 declare module 'svg-path-generator'
+declare module '@gmod/vcf'

--- a/plugins/breakpoint-split-view/src/model.ts
+++ b/plugins/breakpoint-split-view/src/model.ts
@@ -286,6 +286,7 @@ export default function stateModelFactory(pluginManager: any) {
         self.views.forEach(view => {
           const ret = getPath(view)
           if (ret.lastIndexOf(path) !== ret.length - path.length) {
+            // @ts-ignore
             view[actionName](args?.[0])
           }
         })

--- a/plugins/breakpoint-split-view/src/model.ts
+++ b/plugins/breakpoint-split-view/src/model.ts
@@ -2,13 +2,22 @@
 import { MenuItem } from '@jbrowse/core/ui'
 import CompositeMap from '@jbrowse/core/util/compositeMap'
 import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
-import { types, Instance } from 'mobx-state-tree'
+import {
+  types,
+  getParent,
+  onAction,
+  addDisposer,
+  getPath,
+  Instance,
+} from 'mobx-state-tree'
+import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
-import isObject from 'is-object'
+import { parseBreakend } from '@gmod/vcf'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
-// https://stackoverflow.com/a/49186706/2129219
-// the array-intersection package on npm has a large kb size, and we are just
-// intersecting open track ids so simple is better
+// https://stackoverflow.com/a/49186706/2129219 the array-intersection package
+// on npm has a large kb size, and we are just intersecting open track ids so
+// simple is better
 function intersect<T>(a1: T[] = [], a2: T[] = [], ...rest: T[]): T[] {
   const a12 = a1.filter(value => a2.includes(value))
   if (rest.length === 0) {
@@ -30,21 +39,9 @@ export interface Breakend {
 export type LayoutRecord = [number, number, number, number]
 
 export default function stateModelFactory(pluginManager: any) {
-  const { jbrequire } = pluginManager
-  const {
-    types: jbrequiredTypes,
-    getParent,
-    onAction,
-    addDisposer,
-    getPath,
-  } = jbrequire('mobx-state-tree')
-  const { BaseViewModel } = jbrequire(
-    '@jbrowse/core/pluggableElementTypes/models',
-  )
-
   const minHeight = 40
   const defaultHeight = 400
-  const model = (jbrequiredTypes as Instance<typeof types>)
+  const model = types
     .model('BreakpointSplitView', {
       type: types.literal('BreakpointSplitView'),
       headerHeight: 0,
@@ -70,16 +67,18 @@ export default function stateModelFactory(pluginManager: any) {
     }))
     .views(self => ({
       // Find all track ids that match across multiple views
-      get matchedTracks(): string[] {
+      get matchedTracks() {
         return intersect(
-          // @ts-ignore expects at least two params but this is fine
           ...self.views.map(view =>
-            view.tracks.map(t => t.configuration.trackId),
+            view.tracks.map(
+              (t: { configuration: AnyConfigurationModel }) =>
+                t.configuration.trackId as string,
+            ),
           ),
         )
       },
 
-      menuItems(): MenuItem[] {
+      menuItems() {
         const menuItems: MenuItem[] = []
         self.views.forEach((view, idx) => {
           if (view.menuItems?.()) {
@@ -118,12 +117,13 @@ export default function stateModelFactory(pluginManager: any) {
         )
       },
 
-      // Get a composite map of featureId->feature map for a track
-      // across multiple views
+      // Get a composite map of featureId->feature map for a track across
+      // multiple views
       getTrackFeatures(trackConfigId: string) {
-        const tracks = this.getMatchedTracks(trackConfigId)
         return new CompositeMap<string, Feature>(
-          (tracks || []).map(t => t.displays[0].features),
+          this.getMatchedTracks(trackConfigId)?.map(
+            t => t.displays[0].features,
+          ) || [],
         )
       },
 
@@ -155,12 +155,13 @@ export default function stateModelFactory(pluginManager: any) {
         for (const f of features.values()) {
           if (!alreadySeen.has(f.id())) {
             if (f.get('type') === 'breakend') {
-              f.get('ALT').forEach((a: Breakend | string) => {
+              const alts = f.get('ALT') as string[] | undefined
+              alts?.forEach(a => {
                 const cur = `${f.get('refName')}:${f.get('start') + 1}`
-                if (isObject(a)) {
-                  const alt = a as Breakend
+                const bnd = parseBreakend(a)
+                if (bnd) {
                   if (!candidates[cur]) {
-                    candidates[alt.MatePosition] = [f]
+                    candidates[bnd.MatePosition] = [f]
                   } else {
                     candidates[cur].push(f)
                   }
@@ -258,8 +259,8 @@ export default function stateModelFactory(pluginManager: any) {
               args,
             }: {
               name: string
-              path: string
-              args: any[]
+              path?: string
+              args?: any[]
             }) => {
               if (self.linkViews) {
                 const actions = [
@@ -281,12 +282,11 @@ export default function stateModelFactory(pluginManager: any) {
         )
       },
 
-      onSubviewAction(actionName: string, path: string, args: any[]) {
+      onSubviewAction(actionName: string, path: string, args?: any[]) {
         self.views.forEach(view => {
           const ret = getPath(view)
           if (ret.lastIndexOf(path) !== ret.length - path.length) {
-            // @ts-ignore
-            view[actionName](args[0])
+            view[actionName](args?.[0])
           }
         })
       },
@@ -319,10 +319,7 @@ export default function stateModelFactory(pluginManager: any) {
       },
     }))
 
-  const stateModel = (jbrequiredTypes as typeof types).compose(
-    BaseViewModel,
-    model,
-  )
+  const stateModel = types.compose(BaseViewModel, model)
 
   return { stateModel }
 }

--- a/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
@@ -5,9 +5,8 @@ import SimpleFeature, {
 } from '@jbrowse/core/util/simpleFeature'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import { NoAssemblyRegion } from '@jbrowse/core/util/types'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import { readConfObject } from '@jbrowse/core/configuration'
-import { ConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import { configSchema as FromConfigAdapterConfigSchema } from './configSchema'
 
 /**
  * Adapter that just returns the features defined in its `features` configuration
@@ -18,15 +17,10 @@ import { configSchema as FromConfigAdapterConfigSchema } from './configSchema'
 export default class FromConfigAdapter extends BaseFeatureDataAdapter {
   protected features: Map<string, Feature[]>
 
-  constructor(
-    config: ConfigurationModel<typeof FromConfigAdapterConfigSchema>,
-  ) {
-    super(config)
-    const features = readConfObject(
-      config,
-      'features',
-    ) as SimpleFeatureSerialized[]
-    this.features = FromConfigAdapter.makeFeatures(features || [])
+  constructor(conf: AnyConfigurationModel) {
+    super(conf)
+    const feats = readConfObject(conf, 'features') as SimpleFeatureSerialized[]
+    this.features = FromConfigAdapter.makeFeatures(feats || [])
   }
 
   static makeFeatures(fdata: SimpleFeatureSerialized[]) {
@@ -58,7 +52,7 @@ export default class FromConfigAdapter extends BaseFeatureDataAdapter {
   }
 
   async getRefNames() {
-    return [...new Set(Object.keys(this.features))]
+    return [...this.features.keys()]
   }
 
   async getRefNameAliases() {
@@ -73,8 +67,9 @@ export default class FromConfigAdapter extends BaseFeatureDataAdapter {
 
     return ObservableCreate<Feature>(async observer => {
       const features = this.features.get(refName) || []
-      for (let i = 0; i < features.length; i += 1) {
+      for (let i = 0; i < features.length; i++) {
         const f = features[i]
+
         if (f.get('end') > start && f.get('start') < end) {
           observer.next(f)
         }

--- a/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
@@ -53,37 +53,12 @@ export default class FromConfigAdapter extends BaseFeatureDataAdapter {
     return features
   }
 
-  static makeFeature(data: SimpleFeatureSerialized): SimpleFeature {
+  static makeFeature(data: SimpleFeatureSerialized) {
     return new SimpleFeature(data)
   }
 
   async getRefNames() {
-    const refNames: Set<string> = new Set()
-    for (const [refName, features] of this.features) {
-      // add the feature's primary refname
-      refNames.add(refName)
-
-      // also look in the features for mate or breakend specifications, and add
-      // the refName targets of those
-      features.forEach(feature => {
-        // get refNames of generic "mate" records
-        const mate = feature.get('mate')
-        if (mate && mate.refName) {
-          refNames.add(mate.refName)
-        }
-        // get refNames of VCF BND and TRA records
-        const svType = ((feature.get('INFO') || {}).SVTYPE || [])[0]
-        if (svType === 'BND') {
-          const breakendSpecification = (feature.get('ALT') || [])[0]
-          const matePosition = breakendSpecification.MatePosition.split(':')
-          refNames.add(matePosition[0])
-        } else if (svType === 'TRA') {
-          const chr2 = ((feature.get('INFO') || {}).CHR2 || [])[0]
-          refNames.add(chr2)
-        }
-      })
-    }
-    return Array.from(refNames)
+    return [...new Set(Object.keys(this.features))]
   }
 
   async getRefNameAliases() {

--- a/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/ComparativeRenderRpc.ts
@@ -39,9 +39,7 @@ export default class ComparativeRender extends RpcMethodType {
       return renamedArgs
     }
 
-    const { rendererType } = args
-
-    const RendererType = this.pluginManager.getRendererType(rendererType)
+    const RendererType = this.pluginManager.getRendererType(args.rendererType)
 
     if (!(RendererType instanceof ComparativeServerSideRendererType)) {
       throw new Error(

--- a/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
@@ -41,15 +41,14 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
     const [hview, vview] = views
     const db1 = hview.dynamicBlocks.contentBlocks[0].offsetPx
     const db2 = vview.dynamicBlocks.contentBlocks[0].offsetPx
-    ;(hview.features || []).forEach(feature => {
+
+    hview.features?.forEach(feature => {
       let start = feature.get('start')
       let end = feature.get('end')
       const strand = feature.get('strand') || 1
       const refName = feature.get('refName')
       const mate = feature.get('mate')
       const mateRef = mate.refName
-      // const identity = feature.get('numMatches') / feature.get('blockLen')
-      // ctx.fillStyle = `hsl(${identity * 150},50%,50%)`
       const color = readConfObject(config, 'color', { feature })
       ctx.fillStyle = color
       ctx.strokeStyle = color
@@ -133,12 +132,11 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
     })
     await Promise.all(
       realizedViews.map(async view => {
-        view.setFeatures(
-          await this.getFeatures({
-            ...renderProps,
-            regions: view.dynamicBlocks.contentBlocks,
-          }),
-        )
+        const feats = await this.getFeatures({
+          ...renderProps,
+          regions: view.dynamicBlocks.contentBlocks,
+        })
+        view.setFeatures(feats)
       }),
     )
     const imageData = await this.makeImageData({

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -143,7 +143,8 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       get assembliesInitialized() {
         const { assemblyManager } = getSession(self)
         return self.assemblyNames.every(assemblyName => {
-          return assemblyManager.get(assemblyName)?.initialized
+          const assembly = assemblyManager.get(assemblyName)
+          return assembly !== undefined ? assembly.initialized : true
         })
       },
       get initialized() {

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -180,14 +180,14 @@ function onClick(feature: Feature, self: LinearPileupDisplayModel) {
     const clipPos = getClip(cigar, 1)
     const flags = feature.get('flags')
     const origStrand = feature.get('strand')
-    const SA: string = getTag(feature, 'SA') || ''
     const readName = feature.get('name')
-    const readAssembly = `${readName}_assembly`
+    const readAssembly = `${readName}_assembly_${Date.now()}`
     const { parentTrack } = self
     const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
     const assemblyNames = [trackAssembly, readAssembly]
     const trackId = `track-${Date.now()}`
     const trackName = `${readName}_vs_${trackAssembly}`
+    const SA: string = getTag(feature, 'SA') || ''
     const supplementaryAlignments = SA.split(';')
       .filter(aln => !!aln)
       .map((aln, index) => {

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -10,16 +10,16 @@ import { transaction } from 'mobx'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 import {
-  types,
-  getParent,
-  onAction,
   addDisposer,
-  Instance,
-  resolveIdentifier,
-  getPath,
-  SnapshotIn,
   cast,
+  getParent,
+  getPath,
   getRoot,
+  onAction,
+  resolveIdentifier,
+  types,
+  Instance,
+  SnapshotIn,
 } from 'mobx-state-tree'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 
@@ -65,7 +65,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       },
 
       get refNames() {
-        return (self.views || []).map(v => [
+        return self.views.map(v => [
           ...new Set(v.staticBlocks.map(m => m.refName)),
         ])
       },
@@ -203,34 +203,33 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             `could not find a compatible display for view type ${self.type}`,
           )
         }
-        const track = trackType.stateModel.create({
-          ...initialSnapshot,
-          type: configuration.type,
-          configuration,
-          displays: [{ type: displayConf.type, configuration: displayConf }],
-        })
-        self.tracks.push(track)
+        self.tracks.push(
+          trackType.stateModel.create({
+            ...initialSnapshot,
+            type: configuration.type,
+            configuration,
+            displays: [{ type: displayConf.type, configuration: displayConf }],
+          }),
+        )
       },
 
       hideTrack(trackId: string) {
         const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
           'track',
         )
-        const configuration = resolveIdentifier(
+        const config = resolveIdentifier(
           trackConfigSchema,
           getRoot(self),
           trackId,
         )
         // if we have any tracks with that configuration, turn them off
-        const shownTracks = self.tracks.filter(
-          t => t.configuration === configuration,
-        )
+        const shownTracks = self.tracks.filter(t => t.configuration === config)
         transaction(() => shownTracks.forEach(t => self.tracks.remove(t)))
         return shownTracks.length
       },
     }))
     .views(self => ({
-      menuItems(): MenuItem[] {
+      menuItems() {
         const menuItems: MenuItem[] = []
         self.views.forEach((view, idx) => {
           if (view.menuItems?.()) {

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.3.4",
-    "@gmod/vcf": "^4.0.0",
+    "@gmod/vcf": "^5.0.0",
     "@jbrowse/plugin-variants": "^1.3.4",
     "@material-ui/icons": "^4.9.1",
     "classnames": "^2.2.6",

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -2177,7 +2177,7 @@ Object {
             ],
             "description": "deletion ACTAT -> A",
             "end": 48032878,
-            "name": "rs2234731",
+            "name": "rs2234731,rs767177736",
             "refName": "2",
             "samples": Object {
               "1801160099-N32519_26611_S51_56704": Object {
@@ -9881,7 +9881,7 @@ Object {
             ],
             "description": "deletion TAA -> T",
             "end": 108098461,
-            "name": "rs2066734",
+            "name": "rs2066734,rs766396464",
             "refName": "11",
             "samples": Object {
               "1801160099-N32519_26611_S51_56704": Object {
@@ -13151,7 +13151,7 @@ Object {
             ],
             "description": "insertion T -> TG",
             "end": 29563085,
-            "name": "rs56874702",
+            "name": "rs56874702,rs72813695",
             "refName": "17",
             "samples": Object {
               "1801160099-N32519_26611_S51_56704": Object {
@@ -13310,7 +13310,7 @@ Object {
             ],
             "description": "insertion T -> TA",
             "end": 29663625,
-            "name": "rs553817239",
+            "name": "rs553817239,rs7406039",
             "refName": "17",
             "samples": Object {
               "1801160099-N32519_26611_S51_56704": Object {

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.3.4",
     "@gmod/tabix": "^1.5.0",
-    "@gmod/vcf": "^4.0.3",
+    "@gmod/vcf": "^5.0.0",
     "@material-ui/data-grid": "^4.0.0-alpha.37",
     "@material-ui/icons": "^4.11.2",
     "generic-filehandle": "^2.0.0"

--- a/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.js
+++ b/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.js
@@ -1,190 +1,182 @@
-const ChordRendererF = ({ jbrequire }) => {
-  const React = jbrequire('react')
-  const { useMemo } = jbrequire('react')
-  const { observer, PropTypes: MobxPropTypes } = jbrequire('mobx-react')
-  const { polarToCartesian } = jbrequire('@jbrowse/core/util')
-  const { readConfObject } = jbrequire('@jbrowse/core/configuration')
+import React, { useMemo } from 'react'
+import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
+import { polarToCartesian } from '@jbrowse/core/util'
+import { readConfObject } from '@jbrowse/core/configuration'
+import { PropTypes as CommonPropTypes } from '@jbrowse/core/util/types/mst'
+import PropTypes from 'prop-types'
 
-  const { PropTypes: CommonPropTypes } = jbrequire(
-    '@jbrowse/core/util/types/mst',
-  )
-  const PropTypes = jbrequire('prop-types')
+function bpToRadians(block, pos) {
+  const blockStart = block.region.elided ? 0 : block.region.start
+  const blockEnd = block.region.elided ? 0 : block.region.end
+  const bpOffset = block.flipped ? blockEnd - pos : pos - blockStart
+  const radians = bpOffset / block.bpPerRadian + block.startRadians
+  return radians
+}
 
-  function bpToRadians(block, pos) {
-    const blockStart = block.region.elided ? 0 : block.region.start
-    const blockEnd = block.region.elided ? 0 : block.region.end
-    const bpOffset = block.flipped ? blockEnd - pos : pos - blockStart
-    const radians = bpOffset / block.bpPerRadian + block.startRadians
-    return radians
+const Chord = observer(function Chord({
+  feature,
+  blocksForRefs,
+  radius,
+  config,
+  bezierRadius,
+  selected,
+  onClick,
+}) {
+  // find the blocks that our start and end points belong to
+  const startBlock = blocksForRefs[feature.get('refName')]
+  if (!startBlock) {
+    return null
+  }
+  let svType
+  if (feature.get('INFO')) {
+    ;[svType] = feature.get('INFO').SVTYPE || []
+  } else if (feature.get('mate')) {
+    svType = 'mate'
+  }
+  let endPosition
+  let endBlock
+  if (svType === 'BND') {
+    // VCF BND
+    const breakendSpecification = (feature.get('ALT') || [])[0]
+    const matePosition = breakendSpecification.MatePosition.split(':')
+    endPosition = parseInt(matePosition[1], 10)
+    endBlock = blocksForRefs[matePosition[0]]
+  } else if (svType === 'TRA') {
+    // VCF TRA
+    const chr2 = ((feature.get('INFO') || {}).CHR2 || [])[0]
+    const end = ((feature.get('INFO') || {}).END || [])[0]
+    endPosition = parseInt(end, 10)
+    endBlock = blocksForRefs[chr2]
+  } else if (svType === 'mate') {
+    // generic simplefeatures arcs
+    const mate = feature.get('mate')
+    const chr2 = mate.refName
+    endPosition = mate.start
+    endBlock = blocksForRefs[chr2]
+  }
+  if (endBlock) {
+    const startPos = feature.get('start')
+    const startRadians = bpToRadians(startBlock, startPos)
+    const endRadians = bpToRadians(endBlock, endPosition)
+    const startXY = polarToCartesian(radius, startRadians)
+    const endXY = polarToCartesian(radius, endRadians)
+    const controlXY = polarToCartesian(
+      bezierRadius,
+      (endRadians + startRadians) / 2,
+    )
+
+    let strokeColor
+    if (selected) {
+      strokeColor = readConfObject(config, 'strokeColorSelected', { feature })
+    } else {
+      strokeColor = readConfObject(config, 'strokeColor', { feature })
+    }
+    const hoverStrokeColor = readConfObject(config, 'strokeColorHover', {
+      feature,
+    })
+    return (
+      <path
+        data-testid={`chord-${feature.id()}`}
+        d={['M', ...startXY, 'Q', ...controlXY, ...endXY].join(' ')}
+        style={{ stroke: strokeColor }}
+        onClick={evt =>
+          onClick(feature, startBlock.region, endBlock.region, evt)
+        }
+        onMouseOver={evt => {
+          if (!selected) {
+            evt.target.style.stroke = hoverStrokeColor
+          }
+        }}
+        onMouseOut={evt => {
+          if (!selected) {
+            evt.target.style.stroke = strokeColor
+          }
+        }}
+      />
+    )
   }
 
-  const Chord = observer(function Chord({
-    feature,
-    blocksForRefs,
-    radius,
+  return null
+})
+
+function StructuralVariantChords(props) {
+  const {
+    features,
     config,
+    displayModel,
+    blockDefinitions,
+    radius,
     bezierRadius,
-    selected,
-    onClick,
-  }) {
-    // find the blocks that our start and end points belong to
-    const startBlock = blocksForRefs[feature.get('refName')]
-    if (!startBlock) {
-      return null
-    }
-    let svType
-    if (feature.get('INFO')) {
-      ;[svType] = feature.get('INFO').SVTYPE || []
-    } else if (feature.get('mate')) {
-      svType = 'mate'
-    }
-    let endPosition
-    let endBlock
-    if (svType === 'BND') {
-      // VCF BND
-      const breakendSpecification = (feature.get('ALT') || [])[0]
-      const matePosition = breakendSpecification.MatePosition.split(':')
-      endPosition = parseInt(matePosition[1], 10)
-      endBlock = blocksForRefs[matePosition[0]]
-    } else if (svType === 'TRA') {
-      // VCF TRA
-      const chr2 = ((feature.get('INFO') || {}).CHR2 || [])[0]
-      const end = ((feature.get('INFO') || {}).END || [])[0]
-      endPosition = parseInt(end, 10)
-      endBlock = blocksForRefs[chr2]
-    } else if (svType === 'mate') {
-      // generic simplefeatures arcs
-      const mate = feature.get('mate')
-      const chr2 = mate.refName
-      endPosition = mate.start
-      endBlock = blocksForRefs[chr2]
-    }
-    if (endBlock) {
-      const startPos = feature.get('start')
-      const startRadians = bpToRadians(startBlock, startPos)
-      const endRadians = bpToRadians(endBlock, endPosition)
-      const startXY = polarToCartesian(radius, startRadians)
-      const endXY = polarToCartesian(radius, endRadians)
-      const controlXY = polarToCartesian(
-        bezierRadius,
-        (endRadians + startRadians) / 2,
-      )
+    displayModel: { selectedFeatureId },
 
-      let strokeColor
-      if (selected) {
-        strokeColor = readConfObject(config, 'strokeColorSelected', { feature })
-      } else {
-        strokeColor = readConfObject(config, 'strokeColor', { feature })
-      }
-      const hoverStrokeColor = readConfObject(config, 'strokeColorHover', {
-        feature,
+    onChordClick,
+  } = props
+  // make a map of refName -> blockDefinition
+  const blocksForRefsMemo = useMemo(() => {
+    const blocksForRefs = {}
+    blockDefinitions.forEach(block => {
+      const regions = block.region.elided
+        ? block.region.regions
+        : [block.region]
+      regions.forEach(region => {
+        blocksForRefs[region.refName] = block
       })
-      return (
-        <path
-          data-testid={`chord-${feature.id()}`}
-          d={['M', ...startXY, 'Q', ...controlXY, ...endXY].join(' ')}
-          style={{ stroke: strokeColor }}
-          onClick={evt =>
-            onClick(feature, startBlock.region, endBlock.region, evt)
-          }
-          onMouseOver={evt => {
-            if (!selected) {
-              evt.target.style.stroke = hoverStrokeColor
-            }
-          }}
-          onMouseOut={evt => {
-            if (!selected) {
-              evt.target.style.stroke = strokeColor
-            }
-          }}
-        />
-      )
-    }
-
-    return null
-  })
-
-  function StructuralVariantChords(props) {
-    const {
-      features,
-      config,
-      displayModel,
-      blockDefinitions,
-      radius,
-      bezierRadius,
-      displayModel: { selectedFeatureId },
-
-      onChordClick,
-    } = props
-    // make a map of refName -> blockDefinition
-    const blocksForRefsMemo = useMemo(() => {
-      const blocksForRefs = {}
-      blockDefinitions.forEach(block => {
-        const regions = block.region.elided
-          ? block.region.regions
-          : [block.region]
-        regions.forEach(region => {
-          blocksForRefs[region.refName] = block
-        })
-      })
-      return blocksForRefs
-    }, [blockDefinitions])
-    // console.log(blocksForRefs)
-    const chords = []
-    for (const [id, feature] of features) {
-      const selected = String(selectedFeatureId) === String(feature.id())
-      chords.push(
-        <Chord
-          key={id}
-          feature={feature}
-          config={config}
-          displayModel={displayModel}
-          radius={radius}
-          bezierRadius={bezierRadius}
-          blocksForRefs={blocksForRefsMemo}
-          selected={selected}
-          onClick={onChordClick}
-        />,
-      )
-    }
-    const trackStyleId = `chords-${displayModel.id}`
-    return (
-      <g id={trackStyleId} data-testid="structuralVariantChordRenderer">
-        <style
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: `
+    })
+    return blocksForRefs
+  }, [blockDefinitions])
+  // console.log(blocksForRefs)
+  const chords = []
+  for (const [id, feature] of features) {
+    const selected = String(selectedFeatureId) === String(feature.id())
+    chords.push(
+      <Chord
+        key={id}
+        feature={feature}
+        config={config}
+        displayModel={displayModel}
+        radius={radius}
+        bezierRadius={bezierRadius}
+        blocksForRefs={blocksForRefsMemo}
+        selected={selected}
+        onClick={onChordClick}
+      />,
+    )
+  }
+  const trackStyleId = `chords-${displayModel.id}`
+  return (
+    <g id={trackStyleId} data-testid="structuralVariantChordRenderer">
+      <style
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: `
           #${trackStyleId} > path {
             cursor: crosshair;
             fill: none;
           }
 `,
-          }}
-        />
-        {chords}
-      </g>
-    )
-  }
-
-  StructuralVariantChords.propTypes = {
-    features: PropTypes.instanceOf(Map).isRequired,
-    config: CommonPropTypes.ConfigSchema.isRequired,
-    displayModel: MobxPropTypes.objectOrObservableObject,
-    blockDefinitions: PropTypes.arrayOf(MobxPropTypes.objectOrObservableObject)
-      .isRequired,
-    radius: PropTypes.number.isRequired,
-    bezierRadius: PropTypes.number.isRequired,
-    selectedFeatureId: PropTypes.string,
-    onChordClick: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  }
-
-  StructuralVariantChords.defaultProps = {
-    displayModel: undefined,
-    selectedFeatureId: '',
-    onChordClick: undefined,
-  }
-
-  return observer(StructuralVariantChords)
+        }}
+      />
+      {chords}
+    </g>
+  )
 }
 
-export default ChordRendererF
+StructuralVariantChords.propTypes = {
+  features: PropTypes.instanceOf(Map).isRequired,
+  config: CommonPropTypes.ConfigSchema.isRequired,
+  displayModel: MobxPropTypes.objectOrObservableObject,
+  blockDefinitions: PropTypes.arrayOf(MobxPropTypes.objectOrObservableObject)
+    .isRequired,
+  radius: PropTypes.number.isRequired,
+  bezierRadius: PropTypes.number.isRequired,
+  selectedFeatureId: PropTypes.string,
+  onChordClick: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+}
+
+StructuralVariantChords.defaultProps = {
+  displayModel: undefined,
+  selectedFeatureId: '',
+  onChordClick: undefined,
+}
+
+export default observer(StructuralVariantChords)

--- a/plugins/variants/src/StructuralVariantChordRenderer/index.js
+++ b/plugins/variants/src/StructuralVariantChordRenderer/index.js
@@ -1,13 +1,8 @@
-import ReactComponentFactory from './ReactComponent'
+import ChordRendererType from '@jbrowse/core/pluggableElementTypes/renderers/CircularChordRendererType'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import ReactComponent from './ReactComponent'
 
 const ChordRendererConfigF = pluginManager => {
-  const { jbrequire } = pluginManager
-  const ChordRendererType = jbrequire(
-    '@jbrowse/core/pluggableElementTypes/renderers/CircularChordRendererType',
-  )
-  const { ConfigurationSchema } = jbrequire('@jbrowse/core/configuration')
-
-  const ReactComponent = jbrequire(ReactComponentFactory)
   const configSchema = ConfigurationSchema(
     'StructuralVariantChordRenderer',
     {

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -126,7 +126,13 @@ function BreakendPanel(props: {
   const session = getSession(model)
   const { pluginManager } = getEnv(session)
   const [breakpointDialog, setBreakpointDialog] = useState(false)
-  const viewType = pluginManager.getViewType('BreakpointSplitView')
+  let viewType
+
+  try {
+    viewType = pluginManager.getViewType('BreakpointSplitView')
+  } catch (e) {
+    // ignore
+  }
 
   const simpleFeature = new SimpleFeature(feature)
   return (

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -21,19 +21,7 @@ import {
   BaseCard,
 } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
 import BreakendOptionDialog from './BreakendOptionDialog'
-import { Breakend } from '../VcfTabixAdapter/VcfFeature'
-
-// from vcf-js
-function toString(feat: string | Breakend) {
-  if (typeof feat === 'string') {
-    return feat
-  }
-  const char = feat.MateDirection === 'left' ? ']' : '['
-  if (feat.Join === 'left') {
-    return `${char}${feat.MatePosition}${char}${feat.Replacement}`
-  }
-  return `${feat.Replacement}${char}${feat.MatePosition}${char}`
-}
+import { parseBreakend } from '@gmod/vcf'
 
 function VariantSamples(props: any) {
   const [filter, setFilter] = useState<any>({})
@@ -138,61 +126,47 @@ function BreakendPanel(props: {
   const session = getSession(model)
   const { pluginManager } = getEnv(session)
   const [breakpointDialog, setBreakpointDialog] = useState(false)
-  let viewType: any
-  try {
-    viewType = pluginManager.getViewType('BreakpointSplitView')
-  } catch (e) {
-    // plugin not added
-  }
+  const viewType = pluginManager.getViewType('BreakpointSplitView')
 
   const simpleFeature = new SimpleFeature(feature)
   return (
     <BaseCard {...props} title="Breakends">
       <Typography>Link to linear view of breakend endpoints</Typography>
       <ul>
-        {locStrings.map((locString, index) => {
-          return (
-            <li key={`${JSON.stringify(locString)}-${index}`}>
-              <Link
-                href="#"
-                onClick={() => {
-                  const { view } = model
-                  if (view) {
-                    view.navToLocString?.(locString)
-                  } else {
-                    session.notify(
-                      'No view associated with this feature detail panel anymore',
-                      'warning',
-                    )
-                  }
-                }}
-              >
-                {`LGV - ${locString}`}
-              </Link>
-            </li>
-          )
-        })}
+        {locStrings.map(locString => (
+          <li key={`${JSON.stringify(locString)}`}>
+            <Link
+              href="#"
+              onClick={() => {
+                const { view } = model
+                if (view) {
+                  view.navToLocString?.(locString)
+                } else {
+                  session.notify(
+                    'No view associated with this feature detail panel anymore',
+                    'warning',
+                  )
+                }
+              }}
+            >
+              {`LGV - ${locString}`}
+            </Link>
+          </li>
+        ))}
       </ul>
       {viewType ? (
-        <>
+        <div>
           <Typography>
             Launch split views with breakend source and target
           </Typography>
           <ul>
-            {locStrings.map((locString, index) => {
-              return (
-                <li key={`${JSON.stringify(locString)}-${index}`}>
-                  <Link
-                    href="#"
-                    onClick={() => {
-                      setBreakpointDialog(true)
-                    }}
-                  >
-                    {`${feature.refName}:${feature.start} // ${locString} (split view)`}
-                  </Link>
-                </li>
-              )
-            })}
+            {locStrings.map(locString => (
+              <li key={`${JSON.stringify(locString)}`}>
+                <Link href="#" onClick={() => setBreakpointDialog(true)}>
+                  {`${feature.refName}:${feature.start} // ${locString} (split view)`}
+                </Link>
+              </li>
+            ))}
           </ul>
           {breakpointDialog ? (
             <BreakendOptionDialog
@@ -204,7 +178,7 @@ function BreakendPanel(props: {
               }}
             />
           ) : null}
-        </>
+        </div>
       ) : null}
     </BaseCard>
   )
@@ -224,7 +198,7 @@ function VariantFeatureDetails(props: any) {
     REF:
       'reference base(s): Each base must be one of A,C,G,T,N (case insensitive).',
     ALT:
-      ' alternate base(s): Comma-separated list of alternate non-reference alleles',
+      'alternate base(s): Comma-separated list of alternate non-reference alleles',
     QUAL: 'quality: Phred-scaled quality score for the assertion made in ALT',
     FILTER:
       'filter status: PASS if this position has passed all filters, otherwise a semicolon-separated list of codes for filters that fail',
@@ -233,10 +207,7 @@ function VariantFeatureDetails(props: any) {
   return (
     <Paper data-testid="variant-side-drawer">
       <FeatureDetails
-        feature={{
-          ...rest,
-          ALT: rest.ALT?.map((alt: string | Breakend) => toString(alt)),
-        }}
+        feature={rest}
         descriptions={{ ...basicDescriptions, ...descriptions }}
         {...props}
       />
@@ -244,7 +215,9 @@ function VariantFeatureDetails(props: any) {
       {feat.type === 'breakend' ? (
         <BreakendPanel
           feature={feat}
-          locStrings={feat.ALT.map((alt: any) => alt.MatePosition)}
+          locStrings={feat.ALT.map(
+            (alt: string) => parseBreakend(alt).MatePosition,
+          )}
           model={model}
         />
       ) : null}

--- a/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -148,7 +148,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
               >
                 <div
                   class="makeStyles-fieldDescription makeStyles-fieldName"
-                  title=" alternate base(s): Comma-separated list of alternate non-reference alleles"
+                  title="alternate base(s): Comma-separated list of alternate non-reference alleles"
                 >
                   ALT
                 </div>

--- a/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfFeature.ts
@@ -1,4 +1,5 @@
 import { Feature } from '@jbrowse/core/util/simpleFeature'
+import { parseBreakend } from '@gmod/vcf'
 
 /* eslint-disable no-underscore-dangle */
 
@@ -10,12 +11,7 @@ interface Samples {
     [key: string]: { values: string[] | number[] | null }
   }
 }
-export interface Breakend {
-  MateDirection: string
-  Replacement: string
-  MatePosition: string
-  Join: string
-}
+
 interface FeatureData {
   [key: string]: unknown
   refName: string
@@ -49,10 +45,9 @@ export default class VCFFeature implements Feature {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(field: string): any {
-    if (field === 'samples') {
-      return this.variant.SAMPLES
-    }
-    return this.data[field] || this.variant[field]
+    return field === 'samples'
+      ? this.variant.SAMPLES
+      : this.data[field] || this.variant[field]
   }
 
   set(): void {}
@@ -81,7 +76,7 @@ export default class VCFFeature implements Feature {
   dataFromVariant(variant: {
     REF: string
     POS: number
-    ALT: (string | Breakend)[]
+    ALT: string[]
     CHROM: string
     INFO: any // eslint-disable-line @typescript-eslint/no-explicit-any
     ID: string[]
@@ -90,16 +85,15 @@ export default class VCFFeature implements Feature {
     const start = POS - 1
     const [SO_term, description] = this._getSOTermAndDescription(REF, ALT)
     const isTRA = ALT?.some(f => f === '<TRA>')
-    const isSymbolic = ALT?.some(
-      f => typeof f === 'string' && f.indexOf('<') !== -1,
-    )
+    const isSymbolic = ALT?.some(f => f.indexOf('<') !== -1)
+
     return {
       refName: CHROM,
       start,
       end: isSymbolic && INFO.END && !isTRA ? +INFO.END[0] : start + REF.length,
       description,
       type: SO_term,
-      name: ID ? ID[0] : undefined,
+      name: ID?.join(','),
       aliases: ID && ID.length > 1 ? variant.ID.slice(1) : undefined,
     }
   }
@@ -109,15 +103,15 @@ export default class VCFFeature implements Feature {
    */
   _getSOTermAndDescription(
     ref: string,
-    alt: (string | Breakend)[],
+    alt: string[],
   ): [string, string] | [undefined, undefined] {
     // it's just a remark if there are no alternate alleles
     if (!alt || alt === []) {
       return ['remark', 'no alternative alleles']
     }
 
-    const soTerms: Set<string> = new Set()
-    let descriptions: Set<string> = new Set()
+    const soTerms = new Set<string>()
+    let descriptions = new Set<string>()
     alt.forEach(a => {
       let [soTerm, description] = this._getSOAndDescFromAltDefs(ref, a)
 
@@ -175,13 +169,8 @@ export default class VCFFeature implements Feature {
 
   _getSOAndDescFromAltDefs(
     ref: string,
-    alt: string | Breakend,
+    alt: string,
   ): [string, string] | [undefined, undefined] {
-    // not a symbolic ALT if doesn't begin with '<', so we'll have no definition
-    if (typeof alt === 'object') {
-      return ['breakend', alt.toString()]
-    }
-
     if (typeof alt === 'string' && !alt.startsWith('<')) {
       return [undefined, undefined]
     }
@@ -193,10 +182,6 @@ export default class VCFFeature implements Feature {
       soTerm = 'sequence_variant'
     }
     if (soTerm) {
-      // const metaDescription = this.parser.getMetadata('ALT', alt, 'Description')
-      // const description = metaDescription
-      //   ? `${alt} - ${metaDescription}`
-      //   : this._makeDescriptionString(soTerm, ref, alt)
       return [soTerm, alt]
     }
 
@@ -213,20 +198,16 @@ export default class VCFFeature implements Feature {
     return [undefined, undefined]
   }
 
-  _getSOAndDescByExamination(
-    ref: string,
-    alt: string | Breakend,
-  ): [string, string] {
-    if (typeof alt === 'object') {
-      return ['breakend', this._makeDescriptionString('breakend', ref, alt)]
-    }
-
-    if (ref.length === 1 && alt.length === 1) {
-      // use SNV because SO definition of SNP says abundance must be at
-      // least 1% in population, and can't be sure we meet that
+  // note: term SNV is used instead of SNP because SO definition of SNP says
+  // abundance must be at least 1% in population, and can't be sure we meet
+  // that
+  _getSOAndDescByExamination(ref: string, alt: string): [string, string] {
+    const bnd = parseBreakend(alt)
+    if (bnd) {
+      return ['breakend', alt]
+    } else if (ref.length === 1 && alt.length === 1) {
       return ['SNV', this._makeDescriptionString('SNV', ref, alt)]
-    }
-    if (alt === '<INS>') {
+    } else if (alt === '<INS>') {
       return ['insertion', alt]
     } else if (alt === '<DEL>') {
       return ['deletion', alt]
@@ -244,24 +225,16 @@ export default class VCFFeature implements Feature {
         'substitution',
         this._makeDescriptionString('substitution', ref, alt),
       ]
-    }
-
-    if (ref.length <= alt.length) {
+    } else if (ref.length <= alt.length) {
       return ['insertion', this._makeDescriptionString('insertion', ref, alt)]
-    }
-
-    if (ref.length > alt.length) {
+    } else if (ref.length > alt.length) {
       return ['deletion', this._makeDescriptionString('deletion', ref, alt)]
     }
 
     return ['indel', this._makeDescriptionString('indel', ref, alt)]
   }
 
-  _makeDescriptionString(
-    soTerm: string,
-    ref: string,
-    alt: string | Breakend,
-  ): string {
+  _makeDescriptionString(soTerm: string, ref: string, alt: string): string {
     return `${soTerm} ${ref} -> ${alt}`
   }
 

--- a/test_data/breakpoint/config.json
+++ b/test_data/breakpoint/config.json
@@ -7,12 +7,16 @@
         "type": "ReferenceSequenceTrack",
         "trackId": "Pd8Wh30ei9R",
         "adapter": {
-          "type": "ChromSizesAdapter",
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit"
+          },
           "chromSizesLocation": {
-            "uri": "../hg19.chrom.sizes"
+            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.chrom.sizes"
           }
         }
       },
+
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",

--- a/test_data/breakpoint/config.json
+++ b/test_data/breakpoint/config.json
@@ -7,16 +7,12 @@
         "type": "ReferenceSequenceTrack",
         "trackId": "Pd8Wh30ei9R",
         "adapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit"
-          },
+          "type": "ChromSizesAdapter",
           "chromSizesLocation": {
-            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.chrom.sizes"
+            "uri": "../hg19.chrom.sizes"
           }
         }
       },
-
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,10 +1918,10 @@
   resolved "https://registry.yarnpkg.com/@gmod/ucsc-hub/-/ucsc-hub-0.1.3.tgz#37d20b59be9e5153d68a529407237782ed15562d"
   integrity sha512-F60rkM5AdcOXiOqmiNG5ZdoMCwbAQAU6oGBs5UMFCE0vIX7X8i2Mv4X9HrQbmJupZJvyQRuXQNW6SEaUVa+KsQ==
 
-"@gmod/vcf@^4.0.0", "@gmod/vcf@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-4.0.3.tgz#f87d246c9aad82cf45943ec21fefe3a6ed690c5f"
-  integrity sha512-gMTI5f66M0kqspQJSvbuiJn54BZZ//LTl3bpfWkQYAQq5zHfzuV+QCZIXKul+Uby2vehFhMDoDgcNmjckctPZA==
+"@gmod/vcf@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-5.0.0.tgz#d883a28f1cf4a884c797c0c0e167e751e293a260"
+  integrity sha512-koF70T9r+/iaCpqi8A2ENID5AGXrzdnfPvHBF9XG7YtCDoEdvsGikp1LViElz8kLOf70JBDVvlfjEAPAocK9hw==
   dependencies:
     "@babel/runtime" "^7.3.1"
 


### PR DESCRIPTION
This PR works in tandem with a major version bump to @gmod/vcf
https://github.com/GMOD/vcf-js/pull/69

The reason I found this is because there were breakends in the COLO829 dataset (on config_demo.json, hg19) that I wanted to check out. They are actually representing an SVTYPE=DEL using breakend representation, and it was not possible to do breakend split view on this example.

To fix, my strategy was to have basically "point-of-use" breakend parsing: most usages of the breakends should know when they need it parsed out, and can do so at that point by importing parseBreakend from @gmod/vcf


Also, some notable other things:


FromConfigAdapter does not need to have logic for parsing out mate/bnd/chr2, it does not respond to getFeatures requests with data about those mates, and ref renaming for those entities actually has to be done on the client side (see https://github.com/GMOD/jbrowse-components/pull/1911#issuecomment-821243233)
 