### PR TITLE
Use encodeURIComponent for trix encoding instead of base64

### DIFF
--- a/plugins/trix/package.json
+++ b/plugins/trix/package.json
@@ -45,6 +45,6 @@
   },
   "private": true,
   "dependencies": {
-    "@gmod/trix": "^0.2.1"
+    "@gmod/trix": "^0.2.2"
   }
 }

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -44,10 +44,7 @@ export default class TrixTextSearchAdapter
   async searchIndex(args: BaseArgs) {
     const results = await this.trixJs.search(args.queryString)
     const formatted = this.formatResults(
-      results.map(
-        data =>
-          JSON.parse(Buffer.from(data, 'base64').toString('utf8')) as string[],
-      ),
+      results.map(data => JSON.parse(decodeURIComponent(data)) as string[]),
     )
     if (args.searchType === 'exact') {
       return formatted.filter(
@@ -62,7 +59,9 @@ export default class TrixTextSearchAdapter
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formatResults(results: Array<any>) {
     return results.map(result => {
-      const [locString, trackId, name, id] = result
+      const [locString, trackId, name, id] = result.map((record: string) =>
+        decodeURIComponent(record),
+      )
       return new LocStringResult({
         locString,
         label: name || id,

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -44,7 +44,7 @@ export default class TrixTextSearchAdapter
   async searchIndex(args: BaseArgs) {
     const results = await this.trixJs.search(args.queryString)
     const formatted = this.formatResults(
-      results.map(data => JSON.parse(decodeURIComponent(data)) as string[]),
+      results.map(data => JSON.parse(data.replaceAll('|', ',')) as string[]),
     )
     if (args.searchType === 'exact') {
       return formatted.filter(
@@ -56,14 +56,13 @@ export default class TrixTextSearchAdapter
     return formatted
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  formatResults(results: Array<any>) {
+  formatResults(results: string[][]) {
     return results.map(result => {
-      const [locString, trackId, name, id] = result.map((record: string) =>
+      const [loc, trackId, name, id] = result.map(record =>
         decodeURIComponent(record),
       )
       return new LocStringResult({
-        locString,
+        locString: loc,
         label: name || id,
         matchedAttribute: 'name',
         matchedObject: result,

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -42,7 +42,7 @@ export default class TrixTextSearchAdapter
   async searchIndex(args: BaseArgs) {
     const results = await this.trixJs.search(args.queryString)
     const formatted = results
-      .map(data => JSON.parse(data.replaceAll('|', ',')) as string[])
+      .map(data => JSON.parse(data.replace(/\|/g, ',')) as string[])
       .map(result => {
         const [loc, trackId, name, id] = result.map(record =>
           decodeURIComponent(record),

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -54,7 +54,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "follow-redirects": "^1.14.1",
-    "ixixx": "^1.0.14",
+    "ixixx": "^1.0.15",
     "json-parse-better-errors": "^1.0.2",
     "node-fetch": "^2.6.0",
     "tslib": "^1",

--- a/products/jbrowse-cli/src/commands/__snapshots__/text-index.test.ts.snap
+++ b/products/jbrowse-cli/src/commands/__snapshots__/text-index.test.ts.snap
@@ -1,33 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`text-index Indexes a local non-gz gff3 file 1`] = `
-"au9.g1000 [\\"Group1.36%3A168255..173951\\",\\"au9_scaffold\\",\\"au9.g1000\\",\\"au9.g1000\\"],1
-au9.g1000.t1 [\\"Group1.36%3A168255..173951\\",\\"au9_scaffold\\",\\"au9.g1000.t1\\",\\"au9.g1000.t1\\"],1
-au9.g1001 [\\"Group1.36%3A174364..176304\\",\\"au9_scaffold\\",\\"au9.g1001\\",\\"au9.g1001\\"],1
-au9.g1001.t1 [\\"Group1.36%3A174364..176304\\",\\"au9_scaffold\\",\\"au9.g1001.t1\\",\\"au9.g1001.t1\\"],1
-au9.g1002 [\\"Group1.36%3A176975..180744\\",\\"au9_scaffold\\",\\"au9.g1002\\",\\"au9.g1002\\"],1
-au9.g1002.t1 [\\"Group1.36%3A176975..180744\\",\\"au9_scaffold\\",\\"au9.g1002.t1\\",\\"au9.g1002.t1\\"],1
-au9.g1003 [\\"Group1.36%3A180846..184854\\",\\"au9_scaffold\\",\\"au9.g1003\\",\\"au9.g1003\\"],1
-au9.g1003.t1 [\\"Group1.36%3A180846..184854\\",\\"au9_scaffold\\",\\"au9.g1003.t1\\",\\"au9.g1003.t1\\"],1
-au9.g1004 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004\\",\\"au9.g1004\\"],1
-au9.g1004.t1 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004.t1\\",\\"au9.g1004.t1\\"],1
-au9.g1004.t2 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004.t2\\",\\"au9.g1004.t2\\"],1
-au9.g1005 [\\"Group1.36%3A195248..197254\\",\\"au9"
+"au9.g1000 [\\"Group1.36%3A168255..173951\\"|\\"au9_scaffold\\"|\\"au9.g1000\\"|\\"au9.g1000\\"],1
+au9.g1000.t1 [\\"Group1.36%3A168255..173951\\"|\\"au9_scaffold\\"|\\"au9.g1000.t1\\"|\\"au9.g1000.t1\\"],1
+au9.g1001 [\\"Group1.36%3A174364..176304\\"|\\"au9_scaffold\\"|\\"au9.g1001\\"|\\"au9.g1001\\"],1
+au9.g1001.t1 [\\"Group1.36%3A174364..176304\\"|\\"au9_scaffold\\"|\\"au9.g1001.t1\\"|\\"au9.g1001.t1\\"],1
+au9.g1002 [\\"Group1.36%3A176975..180744\\"|\\"au9_scaffold\\"|\\"au9.g1002\\"|\\"au9.g1002\\"],1
+au9.g1002.t1 [\\"Group1.36%3A176975..180744\\"|\\"au9_scaffold\\"|\\"au9.g1002.t1\\"|\\"au9.g1002.t1\\"],1
+au9.g1003 [\\"Group1.36%3A180846..184854\\"|\\"au9_scaffold\\"|\\"au9.g1003\\"|\\"au9.g1003\\"],1
+au9.g1003.t1 [\\"Group1.36%3A180846..184854\\"|\\"au9_scaffold\\"|\\"au9.g1003.t1\\"|\\"au9.g1003.t1\\"],1
+au9.g1004 [\\"Group1.36%3A187115..195224\\"|\\"au9_scaffold\\"|\\"au9.g1004\\"|\\"au9.g1004\\"],1
+au9.g1004.t1 [\\"Group1.36%3A187115..195224\\"|\\"au9_scaffold\\"|\\"au9.g1004.t1\\"|\\"au9.g1004.t1\\"],1
+au9.g1004.t2 [\\"Group1.36%3A187115..195224\\"|\\"au9_scaffold\\"|\\"au9.g1004.t2\\"|\\"au9.g1004.t2\\"],1
+au9.g1005 [\\"Group1.36%3A195248..197254\\"|\\"au9"
 `;
 
 exports[`text-index Indexes a local non-gz gff3 file 2`] = `
-"9.g994 [\\"Group1.36%3A135249..142374\\",\\"au9_scaffold\\",\\"au9.g994\\",\\"au9.g994\\"],1
-au9.g994.t1 [\\"Group1.36%3A135249..142374\\",\\"au9_scaffold\\",\\"au9.g994.t1\\",\\"au9.g994.t1\\"],1
-au9.g995 [\\"Group1.36%3A147520..150414\\",\\"au9_scaffold\\",\\"au9.g995\\",\\"au9.g995\\"],1
-au9.g995.t1 [\\"Group1.36%3A147520..150414\\",\\"au9_scaffold\\",\\"au9.g995.t1\\",\\"au9.g995.t1\\"],1
-au9.g996 [\\"Group1.36%3A150539..152854\\",\\"au9_scaffold\\",\\"au9.g996\\",\\"au9.g996\\"],1
-au9.g996.t1 [\\"Group1.36%3A150539..152854\\",\\"au9_scaffold\\",\\"au9.g996.t1\\",\\"au9.g996.t1\\"],1
-au9.g997 [\\"Group1.36%3A154495..156294\\",\\"au9_scaffold\\",\\"au9.g997\\",\\"au9.g997\\"],1
-au9.g997.t1 [\\"Group1.36%3A154495..156294\\",\\"au9_scaffold\\",\\"au9.g997.t1\\",\\"au9.g997.t1\\"],1
-au9.g998 [\\"Group1.36%3A157495..164685\\",\\"au9_scaffold\\",\\"au9.g998\\",\\"au9.g998\\"],1
-au9.g998.t1 [\\"Group1.36%3A157495..164685\\",\\"au9_scaffold\\",\\"au9.g998.t1\\",\\"au9.g998.t1\\"],1
-au9.g999 [\\"Group1.36%3A165558..166984\\",\\"au9_scaffold\\",\\"au9.g999\\",\\"au9.g999\\"],1
-au9.g999.t1 [\\"Group1.36%3A165558..166984\\",\\"au9_scaffold\\",\\"au9.g999.t1\\",\\"au9.g999.t1\\"],1
+"9.g994 [\\"Group1.36%3A135249..142374\\"|\\"au9_scaffold\\"|\\"au9.g994\\"|\\"au9.g994\\"],1
+au9.g994.t1 [\\"Group1.36%3A135249..142374\\"|\\"au9_scaffold\\"|\\"au9.g994.t1\\"|\\"au9.g994.t1\\"],1
+au9.g995 [\\"Group1.36%3A147520..150414\\"|\\"au9_scaffold\\"|\\"au9.g995\\"|\\"au9.g995\\"],1
+au9.g995.t1 [\\"Group1.36%3A147520..150414\\"|\\"au9_scaffold\\"|\\"au9.g995.t1\\"|\\"au9.g995.t1\\"],1
+au9.g996 [\\"Group1.36%3A150539..152854\\"|\\"au9_scaffold\\"|\\"au9.g996\\"|\\"au9.g996\\"],1
+au9.g996.t1 [\\"Group1.36%3A150539..152854\\"|\\"au9_scaffold\\"|\\"au9.g996.t1\\"|\\"au9.g996.t1\\"],1
+au9.g997 [\\"Group1.36%3A154495..156294\\"|\\"au9_scaffold\\"|\\"au9.g997\\"|\\"au9.g997\\"],1
+au9.g997.t1 [\\"Group1.36%3A154495..156294\\"|\\"au9_scaffold\\"|\\"au9.g997.t1\\"|\\"au9.g997.t1\\"],1
+au9.g998 [\\"Group1.36%3A157495..164685\\"|\\"au9_scaffold\\"|\\"au9.g998\\"|\\"au9.g998\\"],1
+au9.g998.t1 [\\"Group1.36%3A157495..164685\\"|\\"au9_scaffold\\"|\\"au9.g998.t1\\"|\\"au9.g998.t1\\"],1
+au9.g999 [\\"Group1.36%3A165558..166984\\"|\\"au9_scaffold\\"|\\"au9.g999\\"|\\"au9.g999\\"],1
+au9.g999.t1 [\\"Group1.36%3A165558..166984\\"|\\"au9_scaffold\\"|\\"au9.g999.t1\\"|\\"au9.g999.t1\\"],1
 "
 `;
 
@@ -39,18 +39,18 @@ exports[`text-index Indexes a local non-gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a local gz gff3 file 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"gff3tabix_genes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"gff3tabix_genes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],3
 apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes a local gz gff3 file 2`] = `
-"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
-seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
+"A%3A47449..47829\\"|\\"gff3tabix_genes\\"|\\"seg14\\"|\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],1 [\\"ctgA%3A39753..40034\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 
@@ -62,18 +62,18 @@ exports[`text-index tracks Indexes a local gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a remote and a local file 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"gff3tabix_genes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"gff3tabix_genes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],3
 apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes a remote and a local file 2`] = `
-"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
-seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
+"A%3A47449..47829\\"|\\"gff3tabix_genes\\"|\\"seg14\\"|\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],1 [\\"ctgA%3A39753..40034\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 
@@ -87,16 +87,16 @@ seg0900000202D1
 `;
 
 exports[`text-index tracks Indexes a remote gz gff3 file 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"online_gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"online_gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"online_gff3t"
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"online_gff3tabix_genes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"online_gff3tabix_genes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"online_gff3t"
 `;
 
 exports[`text-index tracks Indexes a remote gz gff3 file 2`] = `
-"[\\"ctgA%3A39753..40034\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
+"[\\"ctgA%3A39753..40034\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 
@@ -108,31 +108,31 @@ exports[`text-index tracks Indexes a remote gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a remote non-gz gff3 file 1`] = `
-"au9.g1000 [\\"Group1.36%3A168255..173951\\",\\"online_au9_scaffold\\",\\"au9.g1000\\",\\"au9.g1000\\"],1
-au9.g1000.t1 [\\"Group1.36%3A168255..173951\\",\\"online_au9_scaffold\\",\\"au9.g1000.t1\\",\\"au9.g1000.t1\\"],1
-au9.g1001 [\\"Group1.36%3A174364..176304\\",\\"online_au9_scaffold\\",\\"au9.g1001\\",\\"au9.g1001\\"],1
-au9.g1001.t1 [\\"Group1.36%3A174364..176304\\",\\"online_au9_scaffold\\",\\"au9.g1001.t1\\",\\"au9.g1001.t1\\"],1
-au9.g1002 [\\"Group1.36%3A176975..180744\\",\\"online_au9_scaffold\\",\\"au9.g1002\\",\\"au9.g1002\\"],1
-au9.g1002.t1 [\\"Group1.36%3A176975..180744\\",\\"online_au9_scaffold\\",\\"au9.g1002.t1\\",\\"au9.g1002.t1\\"],1
-au9.g1003 [\\"Group1.36%3A180846..184854\\",\\"online_au9_scaffold\\",\\"au9.g1003\\",\\"au9.g1003\\"],1
-au9.g1003.t1 [\\"Group1.36%3A180846..184854\\",\\"online_au9_scaffold\\",\\"au9.g1003.t1\\",\\"au9.g1003.t1\\"],1
-au9.g1004 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\",\\"au9.g1004\\",\\"au9.g1004\\"],1
-au9.g1004.t1 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\",\\"au9.g1004.t1\\",\\"au9.g1004.t1\\"],1
-au9.g1004.t2 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\","
+"au9.g1000 [\\"Group1.36%3A168255..173951\\"|\\"online_au9_scaffold\\"|\\"au9.g1000\\"|\\"au9.g1000\\"],1
+au9.g1000.t1 [\\"Group1.36%3A168255..173951\\"|\\"online_au9_scaffold\\"|\\"au9.g1000.t1\\"|\\"au9.g1000.t1\\"],1
+au9.g1001 [\\"Group1.36%3A174364..176304\\"|\\"online_au9_scaffold\\"|\\"au9.g1001\\"|\\"au9.g1001\\"],1
+au9.g1001.t1 [\\"Group1.36%3A174364..176304\\"|\\"online_au9_scaffold\\"|\\"au9.g1001.t1\\"|\\"au9.g1001.t1\\"],1
+au9.g1002 [\\"Group1.36%3A176975..180744\\"|\\"online_au9_scaffold\\"|\\"au9.g1002\\"|\\"au9.g1002\\"],1
+au9.g1002.t1 [\\"Group1.36%3A176975..180744\\"|\\"online_au9_scaffold\\"|\\"au9.g1002.t1\\"|\\"au9.g1002.t1\\"],1
+au9.g1003 [\\"Group1.36%3A180846..184854\\"|\\"online_au9_scaffold\\"|\\"au9.g1003\\"|\\"au9.g1003\\"],1
+au9.g1003.t1 [\\"Group1.36%3A180846..184854\\"|\\"online_au9_scaffold\\"|\\"au9.g1003.t1\\"|\\"au9.g1003.t1\\"],1
+au9.g1004 [\\"Group1.36%3A187115..195224\\"|\\"online_au9_scaffold\\"|\\"au9.g1004\\"|\\"au9.g1004\\"],1
+au9.g1004.t1 [\\"Group1.36%3A187115..195224\\"|\\"online_au9_scaffold\\"|\\"au9.g1004.t1\\"|\\"au9.g1004.t1\\"],1
+au9.g1004.t2 [\\"Group1.36%3A187115..195224\\"|\\"online_au9_scaffold\\"|"
 `;
 
 exports[`text-index tracks Indexes a remote non-gz gff3 file 2`] = `
-"au9.g994.t1 [\\"Group1.36%3A135249..142374\\",\\"online_au9_scaffold\\",\\"au9.g994.t1\\",\\"au9.g994.t1\\"],1
-au9.g995 [\\"Group1.36%3A147520..150414\\",\\"online_au9_scaffold\\",\\"au9.g995\\",\\"au9.g995\\"],1
-au9.g995.t1 [\\"Group1.36%3A147520..150414\\",\\"online_au9_scaffold\\",\\"au9.g995.t1\\",\\"au9.g995.t1\\"],1
-au9.g996 [\\"Group1.36%3A150539..152854\\",\\"online_au9_scaffold\\",\\"au9.g996\\",\\"au9.g996\\"],1
-au9.g996.t1 [\\"Group1.36%3A150539..152854\\",\\"online_au9_scaffold\\",\\"au9.g996.t1\\",\\"au9.g996.t1\\"],1
-au9.g997 [\\"Group1.36%3A154495..156294\\",\\"online_au9_scaffold\\",\\"au9.g997\\",\\"au9.g997\\"],1
-au9.g997.t1 [\\"Group1.36%3A154495..156294\\",\\"online_au9_scaffold\\",\\"au9.g997.t1\\",\\"au9.g997.t1\\"],1
-au9.g998 [\\"Group1.36%3A157495..164685\\",\\"online_au9_scaffold\\",\\"au9.g998\\",\\"au9.g998\\"],1
-au9.g998.t1 [\\"Group1.36%3A157495..164685\\",\\"online_au9_scaffold\\",\\"au9.g998.t1\\",\\"au9.g998.t1\\"],1
-au9.g999 [\\"Group1.36%3A165558..166984\\",\\"online_au9_scaffold\\",\\"au9.g999\\",\\"au9.g999\\"],1
-au9.g999.t1 [\\"Group1.36%3A165558..166984\\",\\"online_au9_scaffold\\",\\"au9.g999.t1\\",\\"au9.g999.t1\\"],1
+"au9.g994.t1 [\\"Group1.36%3A135249..142374\\"|\\"online_au9_scaffold\\"|\\"au9.g994.t1\\"|\\"au9.g994.t1\\"],1
+au9.g995 [\\"Group1.36%3A147520..150414\\"|\\"online_au9_scaffold\\"|\\"au9.g995\\"|\\"au9.g995\\"],1
+au9.g995.t1 [\\"Group1.36%3A147520..150414\\"|\\"online_au9_scaffold\\"|\\"au9.g995.t1\\"|\\"au9.g995.t1\\"],1
+au9.g996 [\\"Group1.36%3A150539..152854\\"|\\"online_au9_scaffold\\"|\\"au9.g996\\"|\\"au9.g996\\"],1
+au9.g996.t1 [\\"Group1.36%3A150539..152854\\"|\\"online_au9_scaffold\\"|\\"au9.g996.t1\\"|\\"au9.g996.t1\\"],1
+au9.g997 [\\"Group1.36%3A154495..156294\\"|\\"online_au9_scaffold\\"|\\"au9.g997\\"|\\"au9.g997\\"],1
+au9.g997.t1 [\\"Group1.36%3A154495..156294\\"|\\"online_au9_scaffold\\"|\\"au9.g997.t1\\"|\\"au9.g997.t1\\"],1
+au9.g998 [\\"Group1.36%3A157495..164685\\"|\\"online_au9_scaffold\\"|\\"au9.g998\\"|\\"au9.g998\\"],1
+au9.g998.t1 [\\"Group1.36%3A157495..164685\\"|\\"online_au9_scaffold\\"|\\"au9.g998.t1\\"|\\"au9.g998.t1\\"],1
+au9.g999 [\\"Group1.36%3A165558..166984\\"|\\"online_au9_scaffold\\"|\\"au9.g999\\"|\\"au9.g999\\"],1
+au9.g999.t1 [\\"Group1.36%3A165558..166984\\"|\\"online_au9_scaffold\\"|\\"au9.g999.t1\\"|\\"au9.g999.t1\\"],1
 "
 `;
 
@@ -143,24 +143,24 @@ exports[`text-index tracks Indexes a remote non-gz gff3 file 4`] = `
 "
 `;
 
-exports[`text-index tracks Indexes a track using only the attributes tag 1`] = `" [\\"ctgA%3A1..50001\\",\\"noAttributes\\",\\"ctgA\\",\\"\\"],1 [\\"ctgA%3A1000..2000\\",\\"noAttributes\\",\\"Remark%3Ahga\\",\\"\\"],2 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],4 [\\"ctgA%3A1100..2000\\",\\"noAttributes\\",\\"Gene%3Ahga\\",\\"\\"],5 [\\"ctgA%3A1150..1500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],6 [\\"ctgA%3A11911..15561\\",\\"noAttributes\\",\\"m11\\",\\"\\"],7 [\\"ctgA%3A1200..1900\\",\\"noAttributes\\",\\"Protein%3AHGA\\",\\"\\"],8 [\\"ctgA%3A12531..12895\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],9 [\\"ctgA%3A13122..13449\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],10 [\\"ctgA%3A13280..16394\\",\\"noAttributes\\",\\"f08\\",\\"\\"],11 [\\"ctgA%3A13452..13745\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],12 [\\"ctgA%3A13801..14007\\",\\"noAttributes\\",\\"m05\\",\\"\\"],13 [\\"ctgA%3A13908..13965\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],14 [\\"ctgA%3A13998..14488\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],15 [\\"ctgA%3A14564..14899\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],16 [\\"ctgA%3A14731..17239\\",\\"noAttributes\\",\\"m14\\",\\"\\"],17 [\\"ctgA%3A15185..15276\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],18 [\\"ctgA%3A15329..15533\\",\\"noAttributes\\",\\"f10\\",\\"\\"],19"`;
+exports[`text-index tracks Indexes a track using only the attributes tag 1`] = `" [\\"ctgA%3A1..50001\\"|\\"noAttributes\\"|\\"ctgA\\"|\\"\\"],1 [\\"ctgA%3A1000..2000\\"|\\"noAttributes\\"|\\"Remark%3Ahga\\"|\\"\\"],2 [\\"ctgA%3A1050..1500\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A1050..1500\\"|\\"noAttributes\\"|\\"agt830.5\\"|\\"\\"],4 [\\"ctgA%3A1100..2000\\"|\\"noAttributes\\"|\\"Gene%3Ahga\\"|\\"\\"],5 [\\"ctgA%3A1150..1500\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"\\"],6 [\\"ctgA%3A11911..15561\\"|\\"noAttributes\\"|\\"m11\\"|\\"\\"],7 [\\"ctgA%3A1200..1900\\"|\\"noAttributes\\"|\\"Protein%3AHGA\\"|\\"\\"],8 [\\"ctgA%3A12531..12895\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],9 [\\"ctgA%3A13122..13449\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],10 [\\"ctgA%3A13280..16394\\"|\\"noAttributes\\"|\\"f08\\"|\\"\\"],11 [\\"ctgA%3A13452..13745\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],12 [\\"ctgA%3A13801..14007\\"|\\"noAttributes\\"|\\"m05\\"|\\"\\"],13 [\\"ctgA%3A13908..13965\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],14 [\\"ctgA%3A13998..14488\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],15 [\\"ctgA%3A14564..14899\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],16 [\\"ctgA%3A14731..17239\\"|\\"noAttributes\\"|\\"m14\\"|\\"\\"],17 [\\"ctgA%3A15185..15276\\"|\\"noAttributes\\"|\\"seg12\\"|\\"\\"],18 [\\"ctgA%3A15329..15533\\"|\\"noAttributes\\"|\\"f10\\"|\\"\\"],19"`;
 
 exports[`text-index tracks Indexes a track using only the attributes tag 2`] = `
-"ibutes\\",\\"f06\\",\\"\\"],199 [\\"ctgB%3A4715..5968\\",\\"noAttributes\\",\\"f05\\",\\"\\"],200
-b101.2 [\\"ctgA%3A1000..20000\\",\\"noAttributes\\",\\"b101.2\\",\\"b101.2\\"],1
-cds-apple2 [\\"ctgA%3A13000..17200\\",\\"noAttributes\\",\\"Apple2\\",\\"cds-Apple2\\"],1
-eden [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN\\",\\"EDEN\\"],1
-eden.1 [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN.1\\",\\"EDEN.1\\"],1
-eden.2 [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN.2\\",\\"EDEN.2\\"],1
-eden.3 [\\"ctgA%3A1300..9000\\",\\"noAttributes\\",\\"EDEN.3\\",\\"EDEN.3\\"],1
-fakesnp1 [\\"ctgA%3A1000..1000\\",\\"noAttributes\\",\\"FakeSNP\\",\\"FakeSNP1\\"],1
-match1 [\\"ctgA%3A1050..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"Match1\\"],1
-match2 [\\"ctgA%3A5410..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"Match2\\"],1
-match3 [\\"ctgA%3A1050..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"Match3\\"],1
-match4 [\\"ctgA%3A7500..8000\\",\\"noAttributes\\",\\"agt221.3\\",\\"Match4\\"],1
-match5 [\\"ctgA%3A1150..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"Match5\\"],1
-match6 [\\"ctgA%3A8000..9000\\",\\"noAttributes\\",\\"agt767.3\\",\\"Match6\\"],1
-rna-apple3 [\\"ctgA%3A17400..23000\\",\\"noAttributes\\",\\"Apple3\\",\\"rna-Apple3\\"],1
+"ibutes\\"|\\"f06\\"|\\"\\"],199 [\\"ctgB%3A4715..5968\\"|\\"noAttributes\\"|\\"f05\\"|\\"\\"],200
+b101.2 [\\"ctgA%3A1000..20000\\"|\\"noAttributes\\"|\\"b101.2\\"|\\"b101.2\\"],1
+cds-apple2 [\\"ctgA%3A13000..17200\\"|\\"noAttributes\\"|\\"Apple2\\"|\\"cds-Apple2\\"],1
+eden [\\"ctgA%3A1050..9000\\"|\\"noAttributes\\"|\\"EDEN\\"|\\"EDEN\\"],1
+eden.1 [\\"ctgA%3A1050..9000\\"|\\"noAttributes\\"|\\"EDEN.1\\"|\\"EDEN.1\\"],1
+eden.2 [\\"ctgA%3A1050..9000\\"|\\"noAttributes\\"|\\"EDEN.2\\"|\\"EDEN.2\\"],1
+eden.3 [\\"ctgA%3A1300..9000\\"|\\"noAttributes\\"|\\"EDEN.3\\"|\\"EDEN.3\\"],1
+fakesnp1 [\\"ctgA%3A1000..1000\\"|\\"noAttributes\\"|\\"FakeSNP\\"|\\"FakeSNP1\\"],1
+match1 [\\"ctgA%3A1050..3202\\"|\\"noAttributes\\"|\\"agt830.5\\"|\\"Match1\\"],1
+match2 [\\"ctgA%3A5410..7503\\"|\\"noAttributes\\"|\\"agt830.3\\"|\\"Match2\\"],1
+match3 [\\"ctgA%3A1050..7300\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"Match3\\"],1
+match4 [\\"ctgA%3A7500..8000\\"|\\"noAttributes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+match5 [\\"ctgA%3A1150..7200\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"Match5\\"],1
+match6 [\\"ctgA%3A8000..9000\\"|\\"noAttributes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+rna-apple3 [\\"ctgA%3A17400..23000\\"|\\"noAttributes\\"|\\"Apple3\\"|\\"rna-Apple3\\"],1
 "
 `;
 
@@ -172,18 +172,18 @@ exports[`text-index tracks Indexes a track using only the attributes tag 4`] = `
 `;
 
 exports[`text-index tracks Indexes a track with no attributes in the config 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"noAttributes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"noAttributes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"noAttributes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],3
-apple2 [\\"ctgA%3A13000..17200\\",\\"noAttributes\\",\\"Apple2\\",\\"cds-App"
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"noAttributes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"noAttributes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"noAttributes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"noAttributes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"noAttributes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"noAttributes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"noAttributes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"noAttributes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"noAttributes\\"|\\"agt830.5\\"|\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\"|\\"noAttributes\\"|\\"agt830.5\\"|\\"\\"],3
+apple2 [\\"ctgA%3A13000..17200\\"|\\"noAttributes\\"|\\"Apple2\\"|\\"cds-App"
 `;
 
 exports[`text-index tracks Indexes a track with no attributes in the config 2`] = `
-"gA%3A46816..46992\\",\\"noAttributes\\",\\"seg14\\",\\"\\"],11 [\\"ctgA%3A47449..47829\\",\\"noAttributes\\",\\"seg14\\",\\"\\"],12
-seg15 [\\"ctgA%3A39265..39361\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],17
+"gA%3A46816..46992\\"|\\"noAttributes\\"|\\"seg14\\"|\\"\\"],11 [\\"ctgA%3A47449..47829\\"|\\"noAttributes\\"|\\"seg14\\"|\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],1 [\\"ctgA%3A39753..40034\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"noAttributes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 
@@ -195,18 +195,18 @@ exports[`text-index tracks Indexes a track with no attributes in the config 4`] 
 `;
 
 exports[`text-index tracks Indexes multiple local gff3 files 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"gff3tabix_genes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"gff3tabix_genes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\"|\\"gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],3
 apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes multiple local gff3 files 2`] = `
-"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
-seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
+"A%3A47449..47829\\"|\\"gff3tabix_genes\\"|\\"seg14\\"|\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],1 [\\"ctgA%3A39753..40034\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 
@@ -219,16 +219,16 @@ au9.g000000046C
 `;
 
 exports[`text-index tracks Indexes multiple remote gff3 file 1`] = `
-"agt221.3 [\\"ctgA%3A7500..8000\\",\\"online_gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
-agt221.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
-agt767.3 [\\"ctgA%3A8000..9000\\",\\"online_gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
-agt767.5 [\\"ctgA%3A1150..1500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
-agt830.3 [\\"ctgA%3A5410..5500\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
-agt830.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"online_gff3t"
+"agt221.3 [\\"ctgA%3A7500..8000\\"|\\"online_gff3tabix_genes\\"|\\"agt221.3\\"|\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],1 [\\"ctgA%3A1050..7300\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7300\\"|\\"online_gff3tabix_genes\\"|\\"agt221.5\\"|\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\"|\\"online_gff3tabix_genes\\"|\\"agt767.3\\"|\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],1 [\\"ctgA%3A1150..7200\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],3 [\\"ctgA%3A7000..7200\\"|\\"online_gff3tabix_genes\\"|\\"agt767.5\\"|\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],1 [\\"ctgA%3A5410..7503\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\"|\\"online_gff3tabix_genes\\"|\\"agt830.3\\"|\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\"|\\"online_gff3tabix_genes\\"|\\"agt830.5\\"|\\"\\"],1 [\\"ctgA%3A1050..3202\\"|\\"online_gff3t"
 `;
 
 exports[`text-index tracks Indexes multiple remote gff3 file 2`] = `
-"[\\"ctgA%3A39753..40034\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
+"[\\"ctgA%3A39753..40034\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],2 [\\"ctgA%3A40515..40954\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],3 [\\"ctgA%3A41252..41365\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],4 [\\"ctgA%3A41492..41504\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],5 [\\"ctgA%3A41941..42377\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],6 [\\"ctgA%3A42748..42954\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],7 [\\"ctgA%3A43401..43897\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],8 [\\"ctgA%3A44043..44113\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],9 [\\"ctgA%3A44399..44888\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],10 [\\"ctgA%3A45281..45375\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],11 [\\"ctgA%3A45711..46041\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],12 [\\"ctgA%3A46425..46564\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],13 [\\"ctgA%3A46738..47087\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],14 [\\"ctgA%3A47329..47595\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],15 [\\"ctgA%3A47858..47979\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],16 [\\"ctgA%3A48169..48453\\"|\\"online_gff3tabix_genes\\"|\\"seg15\\"|\\"\\"],17
 "
 `;
 

--- a/products/jbrowse-cli/src/commands/__snapshots__/text-index.test.ts.snap
+++ b/products/jbrowse-cli/src/commands/__snapshots__/text-index.test.ts.snap
@@ -1,33 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`text-index Indexes a local non-gz gff3 file 1`] = `
-"au9.g1000 WyJHcm91cDEuMzY6MTY4MjU1Li4xNzM5NTEiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDAiLCJhdTkuZzEwMDAiXQ==,1
-au9.g1000.t1 WyJHcm91cDEuMzY6MTY4MjU1Li4xNzM5NTEiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDAudDEiLCJhdTkuZzEwMDAudDEiXQ==,1
-au9.g1001 WyJHcm91cDEuMzY6MTc0MzY0Li4xNzYzMDQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDEiLCJhdTkuZzEwMDEiXQ==,1
-au9.g1001.t1 WyJHcm91cDEuMzY6MTc0MzY0Li4xNzYzMDQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDEudDEiLCJhdTkuZzEwMDEudDEiXQ==,1
-au9.g1002 WyJHcm91cDEuMzY6MTc2OTc1Li4xODA3NDQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDIiLCJhdTkuZzEwMDIiXQ==,1
-au9.g1002.t1 WyJHcm91cDEuMzY6MTc2OTc1Li4xODA3NDQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDIudDEiLCJhdTkuZzEwMDIudDEiXQ==,1
-au9.g1003 WyJHcm91cDEuMzY6MTgwODQ2Li4xODQ4NTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDMiLCJhdTkuZzEwMDMiXQ==,1
-au9.g1003.t1 WyJHcm91cDEuMzY6MTgwODQ2Li4xODQ4NTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDMudDEiLCJhdTkuZzEwMDMudDEiXQ==,1
-au9.g1004 WyJHcm91cDEuMzY6MTg3MTE1Li4xOTUyMjQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzEwMDQiLCJhdTkuZzEwMDQiXQ==,1
-au9.g1004.t"
+"au9.g1000 [\\"Group1.36%3A168255..173951\\",\\"au9_scaffold\\",\\"au9.g1000\\",\\"au9.g1000\\"],1
+au9.g1000.t1 [\\"Group1.36%3A168255..173951\\",\\"au9_scaffold\\",\\"au9.g1000.t1\\",\\"au9.g1000.t1\\"],1
+au9.g1001 [\\"Group1.36%3A174364..176304\\",\\"au9_scaffold\\",\\"au9.g1001\\",\\"au9.g1001\\"],1
+au9.g1001.t1 [\\"Group1.36%3A174364..176304\\",\\"au9_scaffold\\",\\"au9.g1001.t1\\",\\"au9.g1001.t1\\"],1
+au9.g1002 [\\"Group1.36%3A176975..180744\\",\\"au9_scaffold\\",\\"au9.g1002\\",\\"au9.g1002\\"],1
+au9.g1002.t1 [\\"Group1.36%3A176975..180744\\",\\"au9_scaffold\\",\\"au9.g1002.t1\\",\\"au9.g1002.t1\\"],1
+au9.g1003 [\\"Group1.36%3A180846..184854\\",\\"au9_scaffold\\",\\"au9.g1003\\",\\"au9.g1003\\"],1
+au9.g1003.t1 [\\"Group1.36%3A180846..184854\\",\\"au9_scaffold\\",\\"au9.g1003.t1\\",\\"au9.g1003.t1\\"],1
+au9.g1004 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004\\",\\"au9.g1004\\"],1
+au9.g1004.t1 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004.t1\\",\\"au9.g1004.t1\\"],1
+au9.g1004.t2 [\\"Group1.36%3A187115..195224\\",\\"au9_scaffold\\",\\"au9.g1004.t2\\",\\"au9.g1004.t2\\"],1
+au9.g1005 [\\"Group1.36%3A195248..197254\\",\\"au9"
 `;
 
 exports[`text-index Indexes a local non-gz gff3 file 2`] = `
-"NhZmZvbGQiLCJhdTkuZzk5NSIsImF1OS5nOTk1Il0=,1
-au9.g995.t1 WyJHcm91cDEuMzY6MTQ3NTIwLi4xNTA0MTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5NS50MSIsImF1OS5nOTk1LnQxIl0=,1
-au9.g996 WyJHcm91cDEuMzY6MTUwNTM5Li4xNTI4NTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5NiIsImF1OS5nOTk2Il0=,1
-au9.g996.t1 WyJHcm91cDEuMzY6MTUwNTM5Li4xNTI4NTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5Ni50MSIsImF1OS5nOTk2LnQxIl0=,1
-au9.g997 WyJHcm91cDEuMzY6MTU0NDk1Li4xNTYyOTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5NyIsImF1OS5nOTk3Il0=,1
-au9.g997.t1 WyJHcm91cDEuMzY6MTU0NDk1Li4xNTYyOTQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5Ny50MSIsImF1OS5nOTk3LnQxIl0=,1
-au9.g998 WyJHcm91cDEuMzY6MTU3NDk1Li4xNjQ2ODUiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5OCIsImF1OS5nOTk4Il0=,1
-au9.g998.t1 WyJHcm91cDEuMzY6MTU3NDk1Li4xNjQ2ODUiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5OC50MSIsImF1OS5nOTk4LnQxIl0=,1
-au9.g999 WyJHcm91cDEuMzY6MTY1NTU4Li4xNjY5ODQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5OSIsImF1OS5nOTk5Il0=,1
-au9.g999.t1 WyJHcm91cDEuMzY6MTY1NTU4Li4xNjY5ODQiLCJhdTlfc2NhZmZvbGQiLCJhdTkuZzk5OS50MSIsImF1OS5nOTk5LnQxIl0=,1
+"9.g994 [\\"Group1.36%3A135249..142374\\",\\"au9_scaffold\\",\\"au9.g994\\",\\"au9.g994\\"],1
+au9.g994.t1 [\\"Group1.36%3A135249..142374\\",\\"au9_scaffold\\",\\"au9.g994.t1\\",\\"au9.g994.t1\\"],1
+au9.g995 [\\"Group1.36%3A147520..150414\\",\\"au9_scaffold\\",\\"au9.g995\\",\\"au9.g995\\"],1
+au9.g995.t1 [\\"Group1.36%3A147520..150414\\",\\"au9_scaffold\\",\\"au9.g995.t1\\",\\"au9.g995.t1\\"],1
+au9.g996 [\\"Group1.36%3A150539..152854\\",\\"au9_scaffold\\",\\"au9.g996\\",\\"au9.g996\\"],1
+au9.g996.t1 [\\"Group1.36%3A150539..152854\\",\\"au9_scaffold\\",\\"au9.g996.t1\\",\\"au9.g996.t1\\"],1
+au9.g997 [\\"Group1.36%3A154495..156294\\",\\"au9_scaffold\\",\\"au9.g997\\",\\"au9.g997\\"],1
+au9.g997.t1 [\\"Group1.36%3A154495..156294\\",\\"au9_scaffold\\",\\"au9.g997.t1\\",\\"au9.g997.t1\\"],1
+au9.g998 [\\"Group1.36%3A157495..164685\\",\\"au9_scaffold\\",\\"au9.g998\\",\\"au9.g998\\"],1
+au9.g998.t1 [\\"Group1.36%3A157495..164685\\",\\"au9_scaffold\\",\\"au9.g998.t1\\",\\"au9.g998.t1\\"],1
+au9.g999 [\\"Group1.36%3A165558..166984\\",\\"au9_scaffold\\",\\"au9.g999\\",\\"au9.g999\\"],1
+au9.g999.t1 [\\"Group1.36%3A165558..166984\\",\\"au9_scaffold\\",\\"au9.g999.t1\\",\\"au9.g999.t1\\"],1
 "
 `;
 
-exports[`text-index Indexes a local non-gz gff3 file 3`] = `144314`;
+exports[`text-index Indexes a local non-gz gff3 file 3`] = `113448`;
 
 exports[`text-index Indexes a local non-gz gff3 file 4`] = `
 "au9.g0000000000
@@ -35,19 +39,22 @@ exports[`text-index Indexes a local non-gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a local gz gff3 file 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,1 WyJjdGdBOjExNTAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,1 WyJjdGdBOjU0MTAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,2 WyJjdGdBOjcwMDAuLjc1MDMiLCJnZmYzdGF"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes a local gz gff3 file 2`] = `
-"E1IixudWxsXQ==,4 WyJjdGdBOjQ1MjgxLi40NTM3NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,5 WyJjdGdBOjQ1NzExLi40NjA0MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,17
+"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes a local gz gff3 file 3`] = `17144`;
+exports[`text-index tracks Indexes a local gz gff3 file 3`] = `12854`;
 
 exports[`text-index tracks Indexes a local gz gff3 file 4`] = `
 "agt220000000000
@@ -55,41 +62,45 @@ exports[`text-index tracks Indexes a local gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a remote and a local file 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,1 WyJjdGdBOjExNTAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,1 WyJjdGdBOjU0MTAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,2 WyJjdGdBOjcwMDAuLjc1MDMiLCJnZmYzdGF"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes a remote and a local file 2`] = `
-"E1IixudWxsXQ==,4 WyJjdGdBOjQ1MjgxLi40NTM3NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,5 WyJjdGdBOjQ1NzExLi40NjA0MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,17
+"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes a remote and a local file 3`] = `172114`;
+exports[`text-index tracks Indexes a remote and a local file 3`] = `135374`;
 
 exports[`text-index tracks Indexes a remote and a local file 4`] = `
 "agt220000000000
-au9.g00000005BA
-b101.0000026314
+au9.g000000046C
+seg0900000202D1
 "
 `;
 
 exports[`text-index tracks Indexes a remote gz gff3 file 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjMiLCJNYXRjaDQiXQ==,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,1 WyJjdGdBOjEwNTAuLjczMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLCJNYXRjaDMiXQ==,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,3 WyJjdGdBOjcwMDAuLjczMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjMiLCJNYXRjaDYiXQ==,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,1 WyJjdGdBOjExNTAuLjcyMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLCJNYXRjaDUiXQ==,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0ODMwLjMiLG51bGxd,1 WyJjdGdBOj"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"online_gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"online_gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"online_gff3t"
 `;
 
 exports[`text-index tracks Indexes a remote gz gff3 file 2`] = `
-"dGdBOjQ1NzExLi40NjA0MSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,17
+"[\\"ctgA%3A39753..40034\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes a remote gz gff3 file 3`] = `19004`;
+exports[`text-index tracks Indexes a remote gz gff3 file 3`] = `14415`;
 
 exports[`text-index tracks Indexes a remote gz gff3 file 4`] = `
 "agt220000000000
@@ -97,57 +108,63 @@ exports[`text-index tracks Indexes a remote gz gff3 file 4`] = `
 `;
 
 exports[`text-index tracks Indexes a remote non-gz gff3 file 1`] = `
-"au9.g1000 WyJHcm91cDEuMzY6MTY4MjU1Li4xNzM5NTEiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAwIiwiYXU5LmcxMDAwIl0=,1
-au9.g1000.t1 WyJHcm91cDEuMzY6MTY4MjU1Li4xNzM5NTEiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAwLnQxIiwiYXU5LmcxMDAwLnQxIl0=,1
-au9.g1001 WyJHcm91cDEuMzY6MTc0MzY0Li4xNzYzMDQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAxIiwiYXU5LmcxMDAxIl0=,1
-au9.g1001.t1 WyJHcm91cDEuMzY6MTc0MzY0Li4xNzYzMDQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAxLnQxIiwiYXU5LmcxMDAxLnQxIl0=,1
-au9.g1002 WyJHcm91cDEuMzY6MTc2OTc1Li4xODA3NDQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAyIiwiYXU5LmcxMDAyIl0=,1
-au9.g1002.t1 WyJHcm91cDEuMzY6MTc2OTc1Li4xODA3NDQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAyLnQxIiwiYXU5LmcxMDAyLnQxIl0=,1
-au9.g1003 WyJHcm91cDEuMzY6MTgwODQ2Li4xODQ4NTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAzIiwiYXU5LmcxMDAzIl0=,1
-au9.g1003.t1 WyJHcm91cDEuMzY6MTgwODQ2Li4xODQ4NTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5LmcxMDAzLnQxIiwiYXU5LmcxMDAzLnQxIl0=,1
-au9.g1004 WyJHcm91cDEuMzY6MTg3MTE1Li4xOTUyMjQiLCJvbm"
+"au9.g1000 [\\"Group1.36%3A168255..173951\\",\\"online_au9_scaffold\\",\\"au9.g1000\\",\\"au9.g1000\\"],1
+au9.g1000.t1 [\\"Group1.36%3A168255..173951\\",\\"online_au9_scaffold\\",\\"au9.g1000.t1\\",\\"au9.g1000.t1\\"],1
+au9.g1001 [\\"Group1.36%3A174364..176304\\",\\"online_au9_scaffold\\",\\"au9.g1001\\",\\"au9.g1001\\"],1
+au9.g1001.t1 [\\"Group1.36%3A174364..176304\\",\\"online_au9_scaffold\\",\\"au9.g1001.t1\\",\\"au9.g1001.t1\\"],1
+au9.g1002 [\\"Group1.36%3A176975..180744\\",\\"online_au9_scaffold\\",\\"au9.g1002\\",\\"au9.g1002\\"],1
+au9.g1002.t1 [\\"Group1.36%3A176975..180744\\",\\"online_au9_scaffold\\",\\"au9.g1002.t1\\",\\"au9.g1002.t1\\"],1
+au9.g1003 [\\"Group1.36%3A180846..184854\\",\\"online_au9_scaffold\\",\\"au9.g1003\\",\\"au9.g1003\\"],1
+au9.g1003.t1 [\\"Group1.36%3A180846..184854\\",\\"online_au9_scaffold\\",\\"au9.g1003.t1\\",\\"au9.g1003.t1\\"],1
+au9.g1004 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\",\\"au9.g1004\\",\\"au9.g1004\\"],1
+au9.g1004.t1 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\",\\"au9.g1004.t1\\",\\"au9.g1004.t1\\"],1
+au9.g1004.t2 [\\"Group1.36%3A187115..195224\\",\\"online_au9_scaffold\\","
 `;
 
 exports[`text-index tracks Indexes a remote non-gz gff3 file 2`] = `
-"6MTQ3NTIwLi4xNTA0MTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTUudDEiLCJhdTkuZzk5NS50MSJd,1
-au9.g996 WyJHcm91cDEuMzY6MTUwNTM5Li4xNTI4NTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTYiLCJhdTkuZzk5NiJd,1
-au9.g996.t1 WyJHcm91cDEuMzY6MTUwNTM5Li4xNTI4NTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTYudDEiLCJhdTkuZzk5Ni50MSJd,1
-au9.g997 WyJHcm91cDEuMzY6MTU0NDk1Li4xNTYyOTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTciLCJhdTkuZzk5NyJd,1
-au9.g997.t1 WyJHcm91cDEuMzY6MTU0NDk1Li4xNTYyOTQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTcudDEiLCJhdTkuZzk5Ny50MSJd,1
-au9.g998 WyJHcm91cDEuMzY6MTU3NDk1Li4xNjQ2ODUiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTgiLCJhdTkuZzk5OCJd,1
-au9.g998.t1 WyJHcm91cDEuMzY6MTU3NDk1Li4xNjQ2ODUiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTgudDEiLCJhdTkuZzk5OC50MSJd,1
-au9.g999 WyJHcm91cDEuMzY6MTY1NTU4Li4xNjY5ODQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTkiLCJhdTkuZzk5OSJd,1
-au9.g999.t1 WyJHcm91cDEuMzY6MTY1NTU4Li4xNjY5ODQiLCJvbmxpbmVfYXU5X3NjYWZmb2xkIiwiYXU5Lmc5OTkudDEiLCJhdTkuZzk5OS50MSJd,1
+"au9.g994.t1 [\\"Group1.36%3A135249..142374\\",\\"online_au9_scaffold\\",\\"au9.g994.t1\\",\\"au9.g994.t1\\"],1
+au9.g995 [\\"Group1.36%3A147520..150414\\",\\"online_au9_scaffold\\",\\"au9.g995\\",\\"au9.g995\\"],1
+au9.g995.t1 [\\"Group1.36%3A147520..150414\\",\\"online_au9_scaffold\\",\\"au9.g995.t1\\",\\"au9.g995.t1\\"],1
+au9.g996 [\\"Group1.36%3A150539..152854\\",\\"online_au9_scaffold\\",\\"au9.g996\\",\\"au9.g996\\"],1
+au9.g996.t1 [\\"Group1.36%3A150539..152854\\",\\"online_au9_scaffold\\",\\"au9.g996.t1\\",\\"au9.g996.t1\\"],1
+au9.g997 [\\"Group1.36%3A154495..156294\\",\\"online_au9_scaffold\\",\\"au9.g997\\",\\"au9.g997\\"],1
+au9.g997.t1 [\\"Group1.36%3A154495..156294\\",\\"online_au9_scaffold\\",\\"au9.g997.t1\\",\\"au9.g997.t1\\"],1
+au9.g998 [\\"Group1.36%3A157495..164685\\",\\"online_au9_scaffold\\",\\"au9.g998\\",\\"au9.g998\\"],1
+au9.g998.t1 [\\"Group1.36%3A157495..164685\\",\\"online_au9_scaffold\\",\\"au9.g998.t1\\",\\"au9.g998.t1\\"],1
+au9.g999 [\\"Group1.36%3A165558..166984\\",\\"online_au9_scaffold\\",\\"au9.g999\\",\\"au9.g999\\"],1
+au9.g999.t1 [\\"Group1.36%3A165558..166984\\",\\"online_au9_scaffold\\",\\"au9.g999.t1\\",\\"au9.g999.t1\\"],1
 "
 `;
 
-exports[`text-index tracks Indexes a remote non-gz gff3 file 3`] = `154970`;
+exports[`text-index tracks Indexes a remote non-gz gff3 file 3`] = `122520`;
 
 exports[`text-index tracks Indexes a remote non-gz gff3 file 4`] = `
 "au9.g0000000000
 "
 `;
 
-exports[`text-index tracks Indexes a track using only the attributes tag 1`] = `" WyJjdGdBOjE0NTY0Li4xNDg5OSIsIm5vQXR0cmlidXRlcyIsInNlZzEyIixudWxsXQ==,1 WyJjdGdBOjE0NzMxLi4xNzIzOSIsIm5vQXR0cmlidXRlcyIsIm0xNCIsbnVsbF0=,2 WyJjdGdBOjE1MTg1Li4xNTI3NiIsIm5vQXR0cmlidXRlcyIsInNlZzEyIixudWxsXQ==,3 WyJjdGdBOjE1MzI5Li4xNTUzMyIsIm5vQXR0cmlidXRlcyIsImYxMCIsbnVsbF0=,4 WyJjdGdBOjE1Mzk2Li4xNjE1OSIsIm5vQXR0cmlidXRlcyIsIm0wMyIsbnVsbF0=,5 WyJjdGdBOjE1NjM5Li4xNTczNiIsIm5vQXR0cmlidXRlcyIsInNlZzEyIixudWxsXQ==,6 WyJjdGdBOjE1NzQ1Li4xNTg3MCIsIm5vQXR0cmlidXRlcyIsInNlZzEyIixudWxsXQ==,7 WyJjdGdBOjE2MDAuLjMwMDAiLCJub0F0dHJpYnV0ZXMiLCJHZW5lOmhnYiIsbnVsbF0=,8 WyJjdGdBOjE2NTkuLjE5ODQiLCJub0F0dHJpYnV0ZXMiLCJmMDciLG51bGxd,9 WyJjdGdBOjE3MDIzLi4xNzY3NSIsIm5vQXR0cmlidXRlcyIsIm0wOCIsbnVsbF0=,10 WyJjdGdBOjE3NjY3Li4xNzY5MCIsIm5vQXR0cmlidXRlcyIsIm0xMyIsbnVsbF0=,11 WyJjdGdBOjE4MDAuLjI5MDAiLCJub0F0dHJpYnV0ZXMiLCJQcm90ZWluOkhHQiIsbnVsbF0=,12 WyJjdGdBOjE4MDQ4Li4xODU1MiIsIm5vQXR0cmlidXRlcyIsIm0wNyIsbnVsbF0=,13 WyJjdGdBOjE4NTA5Li4xODk4NSIsIm5vQXR0cmlidXRlcyIsInNlZzA4IixudWxsXQ==,14 WyJjdGdBOjE4OTg5Li4xOTM4OCIs"`;
+exports[`text-index tracks Indexes a track using only the attributes tag 1`] = `" [\\"ctgA%3A1..50001\\",\\"noAttributes\\",\\"ctgA\\",\\"\\"],1 [\\"ctgA%3A1000..2000\\",\\"noAttributes\\",\\"Remark%3Ahga\\",\\"\\"],2 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],4 [\\"ctgA%3A1100..2000\\",\\"noAttributes\\",\\"Gene%3Ahga\\",\\"\\"],5 [\\"ctgA%3A1150..1500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],6 [\\"ctgA%3A11911..15561\\",\\"noAttributes\\",\\"m11\\",\\"\\"],7 [\\"ctgA%3A1200..1900\\",\\"noAttributes\\",\\"Protein%3AHGA\\",\\"\\"],8 [\\"ctgA%3A12531..12895\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],9 [\\"ctgA%3A13122..13449\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],10 [\\"ctgA%3A13280..16394\\",\\"noAttributes\\",\\"f08\\",\\"\\"],11 [\\"ctgA%3A13452..13745\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],12 [\\"ctgA%3A13801..14007\\",\\"noAttributes\\",\\"m05\\",\\"\\"],13 [\\"ctgA%3A13908..13965\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],14 [\\"ctgA%3A13998..14488\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],15 [\\"ctgA%3A14564..14899\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],16 [\\"ctgA%3A14731..17239\\",\\"noAttributes\\",\\"m14\\",\\"\\"],17 [\\"ctgA%3A15185..15276\\",\\"noAttributes\\",\\"seg12\\",\\"\\"],18 [\\"ctgA%3A15329..15533\\",\\"noAttributes\\",\\"f10\\",\\"\\"],19"`;
 
 exports[`text-index tracks Indexes a track using only the attributes tag 2`] = `
-"iXQ==,1
-eden WyJjdGdBOjEwNTAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJFREVOIiwiRURFTiJd,1
-eden.1 WyJjdGdBOjEwNTAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJFREVOLjEiLCJFREVOLjEiXQ==,1
-eden.2 WyJjdGdBOjEwNTAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJFREVOLjIiLCJFREVOLjIiXQ==,1
-eden.3 WyJjdGdBOjEzMDAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJFREVOLjMiLCJFREVOLjMiXQ==,1
-fakesnp1 WyJjdGdBOjEwMDAuLjEwMDAiLCJub0F0dHJpYnV0ZXMiLCJGYWtlU05QIiwiRmFrZVNOUDEiXQ==,1
-match1 WyJjdGdBOjEwNTAuLjMyMDIiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q4MzAuNSIsIk1hdGNoMSJd,1
-match2 WyJjdGdBOjU0MTAuLjc1MDMiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,1
-match3 WyJjdGdBOjEwNTAuLjczMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,1
-match4 WyJjdGdBOjc1MDAuLjgwMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-match5 WyJjdGdBOjExNTAuLjcyMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,1
-match6 WyJjdGdBOjgwMDAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-rna-apple3 WyJjdGdBOjE3NDAwLi4yMzAwMCIsIm5vQXR0cmlidXRlcyIsIkFwcGxlMyIsInJuYS1BcHBsZTMiXQ==,1
+"ibutes\\",\\"f06\\",\\"\\"],199 [\\"ctgB%3A4715..5968\\",\\"noAttributes\\",\\"f05\\",\\"\\"],200
+b101.2 [\\"ctgA%3A1000..20000\\",\\"noAttributes\\",\\"b101.2\\",\\"b101.2\\"],1
+cds-apple2 [\\"ctgA%3A13000..17200\\",\\"noAttributes\\",\\"Apple2\\",\\"cds-Apple2\\"],1
+eden [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN\\",\\"EDEN\\"],1
+eden.1 [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN.1\\",\\"EDEN.1\\"],1
+eden.2 [\\"ctgA%3A1050..9000\\",\\"noAttributes\\",\\"EDEN.2\\",\\"EDEN.2\\"],1
+eden.3 [\\"ctgA%3A1300..9000\\",\\"noAttributes\\",\\"EDEN.3\\",\\"EDEN.3\\"],1
+fakesnp1 [\\"ctgA%3A1000..1000\\",\\"noAttributes\\",\\"FakeSNP\\",\\"FakeSNP1\\"],1
+match1 [\\"ctgA%3A1050..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"Match1\\"],1
+match2 [\\"ctgA%3A5410..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"Match2\\"],1
+match3 [\\"ctgA%3A1050..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"Match3\\"],1
+match4 [\\"ctgA%3A7500..8000\\",\\"noAttributes\\",\\"agt221.3\\",\\"Match4\\"],1
+match5 [\\"ctgA%3A1150..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"Match5\\"],1
+match6 [\\"ctgA%3A8000..9000\\",\\"noAttributes\\",\\"agt767.3\\",\\"Match6\\"],1
+rna-apple3 [\\"ctgA%3A17400..23000\\",\\"noAttributes\\",\\"Apple3\\",\\"rna-Apple3\\"],1
 "
 `;
 
-exports[`text-index tracks Indexes a track using only the attributes tag 3`] = `15453`;
+exports[`text-index tracks Indexes a track using only the attributes tag 3`] = `11541`;
 
 exports[`text-index tracks Indexes a track using only the attributes tag 4`] = `
 "     0000000000
@@ -155,20 +172,22 @@ exports[`text-index tracks Indexes a track using only the attributes tag 4`] = `
 `;
 
 exports[`text-index tracks Indexes a track with no attributes in the config 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjczMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjczMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,1 WyJjdGdBOjExNTAuLjcyMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,1 WyJjdGdBOjU0MTAuLjc1MDMiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,2 WyJjdGdBOjcwMDAuLjc1MDMiLCJub0F0dHJpYnV0ZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,3
-agt830.5 WyJ"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"noAttributes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"noAttributes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"noAttributes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"noAttributes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"noAttributes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"noAttributes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"noAttributes\\",\\"agt830.5\\",\\"\\"],3
+apple2 [\\"ctgA%3A13000..17200\\",\\"noAttributes\\",\\"Apple2\\",\\"cds-App"
 `;
 
 exports[`text-index tracks Indexes a track with no attributes in the config 2`] = `
-"JjdGdBOjQ0Mzk5Li40NDg4OCIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,4 WyJjdGdBOjQ1MjgxLi40NTM3NSIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,5 WyJjdGdBOjQ1NzExLi40NjA0MSIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsIm5vQXR0cmlidXRlcyIsInNlZzE1IixudWxsXQ==,17
+"gA%3A46816..46992\\",\\"noAttributes\\",\\"seg14\\",\\"\\"],11 [\\"ctgA%3A47449..47829\\",\\"noAttributes\\",\\"seg14\\",\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"noAttributes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes a track with no attributes in the config 3`] = `16252`;
+exports[`text-index tracks Indexes a track with no attributes in the config 3`] = `12185`;
 
 exports[`text-index tracks Indexes a track with no attributes in the config 4`] = `
 "agt220000000000
@@ -176,45 +195,48 @@ exports[`text-index tracks Indexes a track with no attributes in the config 4`] 
 `;
 
 exports[`text-index tracks Indexes multiple local gff3 files 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,1 WyJjdGdBOjExNTAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,1 WyJjdGdBOjU0MTAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,2 WyJjdGdBOjcwMDAuLjc1MDMiLCJnZmYzdGF"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"Match1\\"],2 [\\"ctgA%3A3000..3202\\",\\"gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],3
+apple2 [\\"ctgA%"
 `;
 
 exports[`text-index tracks Indexes multiple local gff3 files 2`] = `
-"E1IixudWxsXQ==,4 WyJjdGdBOjQ1MjgxLi40NTM3NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,5 WyJjdGdBOjQ1NzExLi40NjA0MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,17
+"A%3A47449..47829\\",\\"gff3tabix_genes\\",\\"seg14\\",\\"\\"],12
+seg15 [\\"ctgA%3A39265..39361\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],1 [\\"ctgA%3A39753..40034\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes multiple local gff3 files 3`] = `161458`;
+exports[`text-index tracks Indexes multiple local gff3 files 3`] = `126302`;
 
 exports[`text-index tracks Indexes multiple local gff3 files 4`] = `
 "agt220000000000
-au9.g00000005BA
-b101.0000023974
+au9.g000000046C
 "
 `;
 
 exports[`text-index tracks Indexes multiple remote gff3 file 1`] = `
-"agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjMiLCJNYXRjaDQiXQ==,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,1 WyJjdGdBOjEwNTAuLjczMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLCJNYXRjaDMiXQ==,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,3 WyJjdGdBOjcwMDAuLjczMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0MjIxLjUiLG51bGxd,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjMiLCJNYXRjaDYiXQ==,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,1 WyJjdGdBOjExNTAuLjcyMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLCJNYXRjaDUiXQ==,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0NzY3LjUiLG51bGxd,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJvbmxpbmVfZ2ZmM3RhYml4X2dlbmVzIiwiYWd0ODMwLjMiLG51bGxd,1 WyJjdGdBOj"
+"agt221.3 [\\"ctgA%3A7500..8000\\",\\"online_gff3tabix_genes\\",\\"agt221.3\\",\\"Match4\\"],1
+agt221.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],1 [\\"ctgA%3A1050..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"Match3\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],3 [\\"ctgA%3A7000..7300\\",\\"online_gff3tabix_genes\\",\\"agt221.5\\",\\"\\"],4
+agt767.3 [\\"ctgA%3A8000..9000\\",\\"online_gff3tabix_genes\\",\\"agt767.3\\",\\"Match6\\"],1
+agt767.5 [\\"ctgA%3A1150..1500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],1 [\\"ctgA%3A1150..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"Match5\\"],2 [\\"ctgA%3A5000..5500\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],3 [\\"ctgA%3A7000..7200\\",\\"online_gff3tabix_genes\\",\\"agt767.5\\",\\"\\"],4
+agt830.3 [\\"ctgA%3A5410..5500\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],1 [\\"ctgA%3A5410..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"Match2\\"],2 [\\"ctgA%3A7000..7503\\",\\"online_gff3tabix_genes\\",\\"agt830.3\\",\\"\\"],3
+agt830.5 [\\"ctgA%3A1050..1500\\",\\"online_gff3tabix_genes\\",\\"agt830.5\\",\\"\\"],1 [\\"ctgA%3A1050..3202\\",\\"online_gff3t"
 `;
 
 exports[`text-index tracks Indexes multiple remote gff3 file 2`] = `
-"dGdBOjQ1NzExLi40NjA0MSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsIm9ubGluZV9nZmYzdGFiaXhfZ2VuZXMiLCJzZWcxNSIsbnVsbF0=,17
+"[\\"ctgA%3A39753..40034\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],2 [\\"ctgA%3A40515..40954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],3 [\\"ctgA%3A41252..41365\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],4 [\\"ctgA%3A41492..41504\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],5 [\\"ctgA%3A41941..42377\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],6 [\\"ctgA%3A42748..42954\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],7 [\\"ctgA%3A43401..43897\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],8 [\\"ctgA%3A44043..44113\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],9 [\\"ctgA%3A44399..44888\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],10 [\\"ctgA%3A45281..45375\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],11 [\\"ctgA%3A45711..46041\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],12 [\\"ctgA%3A46425..46564\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],13 [\\"ctgA%3A46738..47087\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],14 [\\"ctgA%3A47329..47595\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],15 [\\"ctgA%3A47858..47979\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],16 [\\"ctgA%3A48169..48453\\",\\"online_gff3tabix_genes\\",\\"seg15\\",\\"\\"],17
 "
 `;
 
-exports[`text-index tracks Indexes multiple remote gff3 file 3`] = `173974`;
+exports[`text-index tracks Indexes multiple remote gff3 file 3`] = `136935`;
 
 exports[`text-index tracks Indexes multiple remote gff3 file 4`] = `
 "agt220000000000
-au9.g0000000662
-b101.00000263BC
+au9.g00000004EA
+seg070000020109
 "
 `;

--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -91,7 +91,7 @@ export async function* indexGff3(
           encodeURIComponent(trackId),
           encodeURIComponent(name || ''),
           encodeURIComponent(id || ''),
-        ])
+        ]).replaceAll(',', '|')
         yield `${record} ${[...new Set(attrs)].join(' ')}\n`
       }
     }

--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -91,7 +91,7 @@ export async function* indexGff3(
           encodeURIComponent(trackId),
           encodeURIComponent(name || ''),
           encodeURIComponent(id || ''),
-        ]).replaceAll(',', '|')
+        ]).replace(/,/g, '|')
         yield `${record} ${[...new Set(attrs)].join(' ')}\n`
       }
     }

--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -86,9 +86,13 @@ export async function* indexGff3(
         )
         .filter(f => !!f)
       if (name || id) {
-        const record = JSON.stringify([locStr, trackId, name, id])
-        const buff = Buffer.from(record).toString('base64')
-        yield `${buff} ${[...new Set(attrs)].join(' ')}\n`
+        const record = JSON.stringify([
+          encodeURIComponent(locStr),
+          encodeURIComponent(trackId),
+          encodeURIComponent(name || ''),
+          encodeURIComponent(id || ''),
+        ])
+        yield `${record} ${[...new Set(attrs)].join(' ')}\n`
       }
     }
   }

--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -23,7 +23,7 @@ export async function* indexGff3(
   const progressBar = new SingleBar(
     {
       format: '{bar} ' + trackId + ' {percentage}% | ETA: {eta}s',
-      etaBuffer: 200,
+      etaBuffer: 2000,
     },
     Presets.shades_classic,
   )

--- a/products/jbrowse-cli/src/types/gtfAdapter.ts
+++ b/products/jbrowse-cli/src/types/gtfAdapter.ts
@@ -23,7 +23,7 @@ export async function* indexGtf(
   const progressBar = new SingleBar(
     {
       format: '{bar} ' + trackId + ' {percentage}% | ETA: {eta}s',
-      etaBuffer: 200,
+      etaBuffer: 2000,
     },
     Presets.shades_classic,
   )

--- a/products/jbrowse-cli/src/types/vcfAdapter.ts
+++ b/products/jbrowse-cli/src/types/vcfAdapter.ts
@@ -78,9 +78,13 @@ export async function* indexVcf(
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i]
       const attrs = [id]
-      const record = JSON.stringify([locStr, trackId, undefined, id])
-      const buff = Buffer.from(record).toString('base64')
-      yield `${buff} ${[...new Set(attrs)].join(' ')}\n`
+      const record = JSON.stringify([
+        encodeURIComponent(locStr),
+        encodeURIComponent(trackId),
+        encodeURIComponent(''),
+        encodeURIComponent(id || ''),
+      ])
+      yield `${record} ${[...new Set(attrs)].join(' ')}\n`
     }
   }
 

--- a/products/jbrowse-cli/src/types/vcfAdapter.ts
+++ b/products/jbrowse-cli/src/types/vcfAdapter.ts
@@ -83,7 +83,7 @@ export async function* indexVcf(
         encodeURIComponent(trackId),
         encodeURIComponent(''),
         encodeURIComponent(id || ''),
-      ])
+      ]).replace(/,/g, '|')
       yield `${record} ${[...new Set(attrs)].join(' ')}\n`
     }
   }

--- a/products/jbrowse-cli/src/types/vcfAdapter.ts
+++ b/products/jbrowse-cli/src/types/vcfAdapter.ts
@@ -23,7 +23,7 @@ export async function* indexVcf(
   const progressBar = new SingleBar(
     {
       format: '{bar} ' + trackId + ' {percentage}% | ETA: {eta}s',
-      etaBuffer: 200,
+      etaBuffer: 2000,
     },
     Presets.shades_classic,
   )

--- a/test_data/volvox/trix/volvox.ix
+++ b/test_data/volvox/trix/volvox.ix
@@ -1,142 +1,142 @@
-agt221.3 WyJjdGdBOjc1MDAuLjgwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-agt221.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsbnVsbF0=,4
-agt767.3 WyJjdGdBOjgwMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-agt767.5 WyJjdGdBOjExNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,1 WyJjdGdBOjExNTAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,2 WyJjdGdBOjUwMDAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,3 WyJjdGdBOjcwMDAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsbnVsbF0=,4
-agt830.3 WyJjdGdBOjU0MTAuLjU1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,1 WyJjdGdBOjU0MTAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,2 WyJjdGdBOjcwMDAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsbnVsbF0=,3
-agt830.5 WyJjdGdBOjEwNTAuLjE1MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuNSIsbnVsbF0=,1 WyJjdGdBOjEwNTAuLjMyMDIiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuNSIsIk1hdGNoMSJd,2 WyJjdGdBOjMwMDAuLjMyMDIiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuNSIsbnVsbF0=,3
-apple2 WyJjdGdBOjEzMDAwLi4xNzIwMCIsImdmZjN0YWJpeF9nZW5lcyIsIkFwcGxlMiIsImNkcy1BcHBsZTIiXQ==,1
-apple3 WyJjdGdBOjE3NDAwLi4yMzAwMCIsImdmZjN0YWJpeF9nZW5lcyIsIkFwcGxlMyIsInJuYS1BcHBsZTMiXQ==,1
-b101.2 WyJjdGdBOjEwMDAuLjIwMDAwIiwiZ2ZmM3RhYml4X2dlbmVzIiwiYjEwMS4yIiwiYjEwMS4yIl0=,1
-bnd_a WyJBOjI3MDAuLjI3MDEiLCJ2b2x2b3hfc3ZfdGVzdF9yZW5hbWVkIixudWxsLCJibmRfQSJd,1 WyJjdGdBOjI3MDAuLjI3MDEiLCJ2b2x2b3hfc3ZfdGVzdCIsbnVsbCwiYm5kX0EiXQ==,2
-bnd_b WyJBOjM0MjAwLi4zNDIwMSIsInZvbHZveF9zdl90ZXN0X3JlbmFtZWQiLG51bGwsImJuZF9CIl0=,1 WyJjdGdBOjM0MjAwLi4zNDIwMSIsInZvbHZveF9zdl90ZXN0IixudWxsLCJibmRfQiJd,2
-bnd_u WyJBOjIzNDU2Li4yMzQ1NyIsInZvbHZveF9zdl90ZXN0X3JlbmFtZWQiLG51bGwsImJuZF9VIl0=,1 WyJjdGdBOjIzNDU2Li4yMzQ1NyIsInZvbHZveF9zdl90ZXN0IixudWxsLCJibmRfVSJd,2
-bnd_v WyJBOjIxNjgyLi4yMTY4MyIsInZvbHZveF9zdl90ZXN0X3JlbmFtZWQiLG51bGwsImJuZF9WIl0=,1 WyJjdGdBOjIxNjgyLi4yMTY4MyIsInZvbHZveF9zdl90ZXN0IixudWxsLCJibmRfViJd,2
-bnd_w WyJBOjIxNjgxLi4yMTY4MiIsInZvbHZveF9zdl90ZXN0X3JlbmFtZWQiLG51bGwsImJuZF9XIl0=,1 WyJjdGdBOjIxNjgxLi4yMTY4MiIsInZvbHZveF9zdl90ZXN0IixudWxsLCJibmRfVyJd,2
-bnd_x WyJBOjIzNDU3Li4yMzQ1OCIsInZvbHZveF9zdl90ZXN0X3JlbmFtZWQiLG51bGwsImJuZF9YIl0=,1 WyJjdGdBOjIzNDU3Li4yMzQ1OCIsInZvbHZveF9zdl90ZXN0IixudWxsLCJibmRfWCJd,2
-bnd_y WyJCOjE5ODIuLjE5ODMiLCJ2b2x2b3hfc3ZfdGVzdF9yZW5hbWVkIixudWxsLCJibmRfWSJd,1 WyJjdGdCOjE5ODIuLjE5ODMiLCJ2b2x2b3hfc3ZfdGVzdCIsbnVsbCwiYm5kX1kiXQ==,2
-bnd_z WyJCOjE5ODMuLjE5ODQiLCJ2b2x2b3hfc3ZfdGVzdF9yZW5hbWVkIixudWxsLCJibmRfWiJd,1 WyJjdGdCOjE5ODMuLjE5ODQiLCJ2b2x2b3hfc3ZfdGVzdCIsbnVsbCwiYm5kX1oiXQ==,2
-cds-apple2 WyJjdGdBOjEzMDAwLi4xNzIwMCIsImdmZjN0YWJpeF9nZW5lcyIsIkFwcGxlMiIsImNkcy1BcHBsZTIiXQ==,1
-ctga WyJjdGdBOjEuLjUwMDAxIiwiZ2ZmM3RhYml4X2dlbmVzIiwiY3RnQSIsbnVsbF0=,1
-ctgb WyJjdGdCOjEuLjYwNzkiLCJnZmYzdGFiaXhfZ2VuZXMiLCJjdGdCIixudWxsXQ==,1
-eden WyJjdGdBOjEwNTAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJFREVOIiwiRURFTiJd,1
-eden.1 WyJjdGdBOjEwNTAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJFREVOLjEiLCJFREVOLjEiXQ==,1
-eden.2 WyJjdGdBOjEwNTAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJFREVOLjIiLCJFREVOLjIiXQ==,1
-eden.3 WyJjdGdBOjEzMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJFREVOLjMiLCJFREVOLjMiXQ==,1
-f01 WyJjdGdBOjQ0NzA1Li40NzcxMyIsImdmZjN0YWJpeF9nZW5lcyIsImYwMSIsbnVsbF0=,1
-f02 WyJjdGdBOjI0NTYyLi4yODMzOCIsImdmZjN0YWJpeF9nZW5lcyIsImYwMiIsbnVsbF0=,1
-f03 WyJjdGdBOjM2NjQ5Li40MDQ0MCIsImdmZjN0YWJpeF9nZW5lcyIsImYwMyIsbnVsbF0=,1
-f04 WyJjdGdBOjM3MjQyLi4zODY1MyIsImdmZjN0YWJpeF9nZW5lcyIsImYwNCIsbnVsbF0=,1
-f05 WyJjdGdBOjQ3MTUuLjU5NjgiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDUiLG51bGxd,1 WyJjdGdCOjQ3MTUuLjU5NjgiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDUiLG51bGxd,2
-f06 WyJjdGdBOjMwMTQuLjYxMzAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDYiLG51bGxd,1 WyJjdGdCOjMwMTQuLjYxMzAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDYiLG51bGxd,2
-f07 WyJjdGdBOjE2NTkuLjE5ODQiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDciLG51bGxd,1 WyJjdGdCOjE2NTkuLjE5ODQiLCJnZmYzdGFiaXhfZ2VuZXMiLCJmMDciLG51bGxd,2
-f08 WyJjdGdBOjEzMjgwLi4xNjM5NCIsImdmZjN0YWJpeF9nZW5lcyIsImYwOCIsbnVsbF0=,1
-f09 WyJjdGdBOjM2MDM0Li4zODE2NyIsImdmZjN0YWJpeF9nZW5lcyIsImYwOSIsbnVsbF0=,1
-f10 WyJjdGdBOjE1MzI5Li4xNTUzMyIsImdmZjN0YWJpeF9nZW5lcyIsImYxMCIsbnVsbF0=,1
-f11 WyJjdGdBOjQ2OTkwLi40ODQxMCIsImdmZjN0YWJpeF9nZW5lcyIsImYxMSIsbnVsbF0=,1
-f12 WyJjdGdBOjQ5NzU4Li41MDAwMCIsImdmZjN0YWJpeF9nZW5lcyIsImYxMiIsbnVsbF0=,1
-f13 WyJjdGdBOjE5MTU3Li4yMjkxNSIsImdmZjN0YWJpeF9nZW5lcyIsImYxMyIsbnVsbF0=,1
-f14 WyJjdGdBOjIzMDcyLi4yMzE4NSIsImdmZjN0YWJpeF9nZW5lcyIsImYxNCIsbnVsbF0=,1
-f15 WyJjdGdBOjIyMTMyLi4yNDYzMyIsImdmZjN0YWJpeF9nZW5lcyIsImYxNSIsbnVsbF0=,1
-fakesnp WyJjdGdBOjEwMDAuLjEwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJGYWtlU05QIiwiRmFrZVNOUDEiXQ==,1
-fakesnp1 WyJjdGdBOjEwMDAuLjEwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJGYWtlU05QIiwiRmFrZVNOUDEiXQ==,1
-gene1 WyJjdGdBOjEyMDEuLjE1MDAiLCJzaW5nbGVfZXhvbl9nZW5lIixudWxsLCJnZW5lMSJd,1
-gene2 WyJjdGdBOjEyMDEuLjM5MDIiLCJzaW5nbGVfZXhvbl9nZW5lIixudWxsLCJnZW5lMiJd,1
-gene:hga WyJjdGdBOjExMDAuLjIwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJHZW5lOmhnYSIsbnVsbF0=,1
-gene:hgb WyJjdGdBOjE2MDAuLjMwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJHZW5lOmhnYiIsbnVsbF0=,1
-inv134 WyJjdGdBOjI3MDAuLjEwMDAwIiwidm9sdm94Lmludi52Y2YiLG51bGwsImludjEzNCJd,1
-inv135 WyJjdGdBOjYwMDAuLjkwMDAiLCJ2b2x2b3guaW52LnZjZiIsbnVsbCwiaW52MTM1Il0=,1 WyJjdGdBOjYwMDAuLjkwMDAiLCJ2b2x2b3guaW52LnZjZiIsbnVsbCwiaW52MTM1Il0=,2
-m01 WyJjdGdBOjQ4MjUzLi40ODM2NiIsImdmZjN0YWJpeF9nZW5lcyIsIm0wMSIsbnVsbF0=,1
-m02 WyJjdGdBOjI4MzMyLi4zMDAzMyIsImdmZjN0YWJpeF9nZW5lcyIsIm0wMiIsbnVsbF0=,1
-m03 WyJjdGdBOjE1Mzk2Li4xNjE1OSIsImdmZjN0YWJpeF9nZW5lcyIsIm0wMyIsbnVsbF0=,1
-m04 WyJjdGdBOjMzMzI1Li4zNTc5MSIsImdmZjN0YWJpeF9nZW5lcyIsIm0wNCIsbnVsbF0=,1
-m05 WyJjdGdBOjEzODAxLi4xNDAwNyIsImdmZjN0YWJpeF9nZW5lcyIsIm0wNSIsbnVsbF0=,1
-m06 WyJjdGdBOjMwNTc4Li4zMTc0OCIsImdmZjN0YWJpeF9nZW5lcyIsIm0wNiIsbnVsbF0=,1
-m07 WyJjdGdBOjE4MDQ4Li4xODU1MiIsImdmZjN0YWJpeF9nZW5lcyIsIm0wNyIsbnVsbF0=,1
-m08 WyJjdGdBOjE3MDIzLi4xNzY3NSIsImdmZjN0YWJpeF9nZW5lcyIsIm0wOCIsbnVsbF0=,1
-m09 WyJjdGdBOjQ2MDEyLi40ODg1MSIsImdmZjN0YWJpeF9nZW5lcyIsIm0wOSIsbnVsbF0=,1
-m10 WyJjdGdBOjI4MzQyLi4yODQ0NyIsImdmZjN0YWJpeF9nZW5lcyIsIm0xMCIsbnVsbF0=,1
-m11 WyJjdGdBOjExOTExLi4xNTU2MSIsImdmZjN0YWJpeF9nZW5lcyIsIm0xMSIsbnVsbF0=,1
-m12 WyJjdGdBOjIxNzQ4Li4yNTYxMiIsImdmZjN0YWJpeF9nZW5lcyIsIm0xMiIsbnVsbF0=,1
-m13 WyJjdGdBOjE3NjY3Li4xNzY5MCIsImdmZjN0YWJpeF9nZW5lcyIsIm0xMyIsbnVsbF0=,1
-m14 WyJjdGdBOjE0NzMxLi4xNzIzOSIsImdmZjN0YWJpeF9nZW5lcyIsIm0xNCIsbnVsbF0=,1
-m15 WyJjdGdBOjM3NDk3Li40MDU1OSIsImdmZjN0YWJpeF9nZW5lcyIsIm0xNSIsbnVsbF0=,1
-match1 WyJjdGdBOjEwNTAuLjMyMDIiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuNSIsIk1hdGNoMSJd,1
-match2 WyJjdGdBOjU0MTAuLjc1MDMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q4MzAuMyIsIk1hdGNoMiJd,1
-match3 WyJjdGdBOjEwNTAuLjczMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuNSIsIk1hdGNoMyJd,1
-match4 WyJjdGdBOjc1MDAuLjgwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3QyMjEuMyIsIk1hdGNoNCJd,1
-match5 WyJjdGdBOjExNTAuLjcyMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuNSIsIk1hdGNoNSJd,1
-match6 WyJjdGdBOjgwMDAuLjkwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJhZ3Q3NjcuMyIsIk1hdGNoNiJd,1
-mrna1 WyJjdGdBOjEyMDEuLjE1MDAiLCJzaW5nbGVfZXhvbl9nZW5lIixudWxsLCJtUk5BMSJd,1
-mrna2 WyJjdGdBOjEyMDEuLjM5MDIiLCJzaW5nbGVfZXhvbl9nZW5lIixudWxsLCJtUk5BMiJd,1
-protein:hga WyJjdGdBOjEyMDAuLjE5MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJQcm90ZWluOkhHQSIsbnVsbF0=,1
-protein:hgb WyJjdGdBOjE4MDAuLjI5MDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJQcm90ZWluOkhHQiIsbnVsbF0=,1
-remark:hga WyJjdGdBOjEwMDAuLjIwMDAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJSZW1hcms6aGdhIixudWxsXQ==,1
-rna-apple3 WyJjdGdBOjE3NDAwLi4yMzAwMCIsImdmZjN0YWJpeF9nZW5lcyIsIkFwcGxlMyIsInJuYS1BcHBsZTMiXQ==,1
-rs1041740 WyJjb250aWdBOjExMzQwLi4xMTM0MSIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxMDQxNzQwIl0=,1
-rs10432782 WyJjb250aWdBOjc1NjkuLjc1NzAiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTA0MzI3ODIiXQ==,1
-rs112989936 WyJjb250aWdBOjEwNjg0Li4xMDY4NSIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxMTI5ODk5MzYiXQ==,1
-rs114905802 WyJjb250aWdBOjQwMzUuLjQwMzYiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTE0OTA1ODAyIl0=,1
-rs11567845 WyJjb250aWdBOjg3NDIuLjg3NDMiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTE1Njc4NDUiXQ==,1
-rs116260263 WyJjb250aWdBOjY4MzQuLjY4MzUiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTE2MjYwMjYzIl0=,1
-rs117304270 WyJjb250aWdBOjExODMyLi4xMTgzMyIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxMTczMDQyNzAiXQ==,1
-rs117466144 WyJjb250aWdBOjExMjQxLi4xMTI0MiIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxMTc0NjYxNDQiXQ==,1
-rs118132937 WyJjb250aWdBOjkxMzYuLjkxMzciLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTE4MTMyOTM3Il0=,1
-rs16988404 WyJjb250aWdBOjcxNzMuLjcxNzQiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTY5ODg0MDQiXQ==,1
-rs17878802 WyJjb250aWdBOjUyODEuLjUyODIiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4Nzg4MDIiXQ==,1
-rs17878855 WyJjb250aWdBOjMxMDUuLjMxMDYiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4Nzg4NTUiXQ==,1
-rs17880044 WyJjb250aWdBOjExNzc0Li4xMTc3NSIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4MDA0NCJd,1
-rs17880487 WyJjb250aWdBOjEyNDA4Li4xMjQwOSIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4MDQ4NyJd,1
-rs17880490 WyJjb250aWdBOjgwNzcuLjgwNzgiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODA0OTAiXQ==,1
-rs17880795 WyJjb250aWdBOjQyNjAuLjQyNjEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODA3OTUiXQ==,1
-rs17881180 WyJjb250aWdBOjM0NjUuLjM0NjYiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODExODAiXQ==,1
-rs17881581 WyJjb250aWdBOjMxNzEuLjMxNzIiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODE1ODEiXQ==,1
-rs17881732 WyJjb250aWdBOjExMzM1Li4xMTMzNiIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4MTczMiJd,1
-rs17881807 WyJjb250aWdBOjUzNDkuLjUzNTAiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODE4MDciXQ==,1
-rs17882967 WyJjb250aWdBOjUwMDYuLjUwMDciLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODI5NjciXQ==,1
-rs17883234 WyJjb250aWdBOjExMTgyLi4xMTE4MyIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4MzIzNCJd,1
-rs17883270 WyJjb250aWdBOjUyNjAuLjUyNjEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODMyNzAiXQ==,1
-rs17883296 WyJjb250aWdBOjMwMDAuLjMwMDEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODMyOTYiXQ==,1
-rs17883461 WyJjb250aWdBOjgyMTAuLjgyMTEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODM0NjEiXQ==,1
-rs17883998 WyJjb250aWdBOjk4NTMuLjk4NTQiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODM5OTgiXQ==,1
-rs17884040 WyJjb250aWdBOjQyNDguLjQyNDkiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODQwNDAiXQ==,1
-rs17884233 WyJjb250aWdBOjcxNDEuLjcxNDIiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODQyMzMiXQ==,1
-rs17884260 WyJjb250aWdBOjQwNzQuLjQwNzUiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODQyNjAiXQ==,1
-rs17884462 WyJjb250aWdBOjExNjg5Li4xMTY5MCIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4NDQ2MiJd,1
-rs17885219 WyJjb250aWdBOjQ5MDEuLjQ5MDIiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODUyMTkiXQ==,1
-rs17885303 WyJjb250aWdBOjkwNDguLjkwNDkiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODUzMDMiXQ==,1
-rs17885634 WyJjb250aWdBOjEwMjUyLi4xMDI1MyIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4NTYzNCJd,1
-rs17885833 WyJjb250aWdBOjk5MjAuLjk5MjEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODU4MzMiXQ==,1
-rs17886025 WyJjb250aWdBOjgxMzIuLjgxMzMiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODYwMjUiXQ==,1
-rs17886606 WyJjb250aWdBOjgzMjguLjgzMjkiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzMTc4ODY2MDYiXQ==,1
-rs17886692 WyJjb250aWdBOjEwODc1Li4xMDg3NiIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMxNzg4NjY5MiJd,1
-rs2070424 WyJjb250aWdBOjEwNDk4Li4xMDQ5OSIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMyMDcwNDI0Il0=,1
-rs2234694 WyJjb250aWdBOjEwMDQzLi4xMDA0NCIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnMyMjM0Njk0Il0=,1
-rs4816405 WyJjb250aWdBOjQxNzkuLjQxODAiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNDgxNjQwNSJd,1
-rs4816407 WyJjb250aWdBOjExMjA3Li4xMTIwOCIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnM0ODE2NDA3Il0=,1
-rs4817420 WyJjb250aWdBOjExNTQ5Li4xMTU1MCIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnM0ODE3NDIwIl0=,1
-rs4998557 WyJjb250aWdBOjYwNzAuLjYwNzEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNDk5ODU1NyJd,1
-rs6650814 WyJjb250aWdBOjQxNjYuLjQxNjciLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNjY1MDgxNCJd,1
-rs7277748 WyJjb250aWdBOjMxNTIuLjMxNTMiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNzI3Nzc0OCJd,1
-rs76067554 WyJjb250aWdBOjg1MjQuLjg1MjUiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNzYwNjc1NTQiXQ==,1
-rs76734991 WyJjb250aWdBOjExMDk1Li4xMTA5NiIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnM3NjczNDk5MSJd,1
-rs77112488 WyJjb250aWdBOjk4ODQuLjk4ODUiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNzcxMTI0ODgiXQ==,1
-rs77319474 WyJjb250aWdBOjEwMjE3Li4xMDIxOCIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnM3NzMxOTQ3NCJd,1
-rs78694163 WyJjb250aWdBOjg4MTYuLjg4MTciLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzNzg2OTQxNjMiXQ==,1
-rs80265967 WyJjb250aWdBOjEwNzgxLi4xMDc4MiIsInZvbHZveF90ZXN0X3ZjZiIsbnVsbCwicnM4MDI2NTk2NyJd,1
-rs8133032 WyJjb250aWdBOjk1MjUuLjk1MjYiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzODEzMzAzMiJd,1
-rs9967983 WyJjb250aWdBOjg2NjAuLjg2NjEiLCJ2b2x2b3hfdGVzdF92Y2YiLG51bGwsInJzOTk2Nzk4MyJd,1
-seg01 WyJjdGdBOjMyMzI5Li4zMjM1OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAxIixudWxsXQ==,1
-seg02 WyJjdGdBOjI2MTIyLi4yNjEyNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,1 WyJjdGdBOjI2NDk3Li4yNjg2OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,2 WyJjdGdBOjI3MjAxLi4yNzMyNSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,3 WyJjdGdBOjI3MzcyLi4yNzQzMyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,4 WyJjdGdBOjI3NTY1Li4yNzU2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,5 WyJjdGdBOjI3ODEzLi4yODA5MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,6 WyJjdGdBOjI4MDkzLi4yODIwMSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,7 WyJjdGdBOjI4MzI5Li4yODM3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,8 WyJjdGdBOjI4ODI5Li4yOTE5NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,9 WyJjdGdBOjI5NTE3Li4yOTcwMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,10 WyJjdGdBOjI5NzEzLi4zMDA2MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,11 WyJjdGdBOjM0NDAxLi4zNDQ2NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,12 WyJjdGdBOjMwMzI5Li4zMDc3NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,13 WyJjdGdBOjMwODA4Li4zMTMwNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,14 WyJjdGdBOjMxNTE2Li4zMTcyOSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,15 WyJjdGdBOjMxNzUzLi4zMjE1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,16 WyJjdGdBOjMyNTk1Li4zMjY5NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,17 WyJjdGdBOjMyODkyLi4zMjkwMSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,18 WyJjdGdBOjMzMTI3Li4zMzM4OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,19 WyJjdGdBOjMzNDM5Li4zMzQ0MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,20 WyJjdGdBOjMzNzU5Li4zNDIwOSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzAyIixudWxsXQ==,21
-seg03 WyJjdGdBOjY4ODUuLjcyNDEiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwMyIsbnVsbF0=,1 WyJjdGdBOjc0MTAuLjc3MzciLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwMyIsbnVsbF0=,2 WyJjdGdBOjgwNTUuLjgwODAiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwMyIsbnVsbF0=,3 WyJjdGdBOjgzMDYuLjg5OTkiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwMyIsbnVsbF0=,4
-seg04 WyJjdGdBOjU4MDAuLjYxMDEiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,1 WyJjdGdBOjUyMzMuLjUzMDIiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,2 WyJjdGdBOjY0NDIuLjY4NTQiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,3 WyJjdGdBOjc2OTUuLjgxNzciLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,4 WyJjdGdBOjcxMDYuLjcyMTEiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,5 WyJjdGdBOjg1NDUuLjg3ODMiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,6 WyJjdGdBOjg4NjkuLjg5MzUiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,7 WyJjdGdBOjk0MDQuLjk4MjUiLCJnZmYzdGFiaXhfZ2VuZXMiLCJzZWcwNCIsbnVsbF0=,8
-seg05 WyJjdGdBOjI2NTAzLi4yNjc5OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,1 WyJjdGdBOjI3MTcyLi4yNzE4NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,2 WyJjdGdBOjI3NDQ4Li4yNzg2MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,3 WyJjdGdBOjI3ODg3Li4yODA3NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,4 WyJjdGdBOjI4MjI1Li4yODMxNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,5 WyJjdGdBOjI4Nzc3Li4yOTA1OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,6 WyJjdGdBOjI5NTEzLi4yOTY0NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,7 WyJjdGdBOjM0MjQ0Li4zNDMxMyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,8 WyJjdGdBOjM0NjA1Li4zNDk4MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,9 WyJjdGdBOjM1MzMzLi4zNTUwNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,10 WyJjdGdBOjM1NjQyLi4zNTkwNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,11 WyJjdGdBOjMwMTA4Li4zMDIxNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,12 WyJjdGdBOjMwNDY1Li4zMDc5OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,13 WyJjdGdBOjMxMjMyLi4zMTIzNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,14 WyJjdGdBOjMxNDIxLi4zMTgxNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,15 WyJjdGdBOjMyMDEwLi4zMjA1NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,16 WyJjdGdBOjMyMjA4Li4zMjY4MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,17 WyJjdGdBOjMzMDUzLi4zMzMyNSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,18 WyJjdGdBOjMzNDM4Li4zMzg2OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA1IixudWxsXQ==,19
-seg06 WyJjdGdBOjE5MjQ5Li4xOTU1OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,1 WyJjdGdBOjE5OTc1Li4yMDI2MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,2 WyJjdGdBOjIwMzc5Li4yMDQ5MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,3 WyJjdGdBOjIwNTMzLi4yMTAwNSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,4 WyJjdGdBOjIxMTIyLi4yMTMzMSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,5 WyJjdGdBOjIxNjgyLi4yMjE3NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,6 WyJjdGdBOjIyMzc0Li4yMjU3MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,7 WyJjdGdBOjIzMDI1Li4yMzQyNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA2IixudWxsXQ==,8
-seg07 WyJjdGdBOjQ0MTkxLi40NDUxNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,1 WyJjdGdBOjQ0NTUyLi40NTA0MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,2 WyJjdGdBOjQ1MzczLi40NTYwMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,3 WyJjdGdBOjQ1ODk3Li40NjMxNSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,4 WyJjdGdBOjQ2NDkxLi40Njg5MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,5 WyJjdGdBOjQ3MTI2Li40NzI5NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,6 WyJjdGdBOjQ3NzM1Li40Nzk4MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,7 WyJjdGdBOjQ4NDQ3Li40ODcwOSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,8 WyJjdGdBOjQ4OTMxLi40OTE4NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,9 WyJjdGdBOjQ5NDcyLi40OTY5OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,10 WyJjdGdBOjQ5OTU3Li41MDAwMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,11 WyJjdGdBOjQ5OTU3Li41MDAwMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA3IixudWxsXQ==,12
-seg08 WyJjdGdBOjE4NTA5Li4xODk4NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,1 WyJjdGdBOjE4OTg5Li4xOTM4OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,2 WyJjdGdBOjE5NDk2Li4xOTk2MiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,3 WyJjdGdBOjI0MzI4Li4yNDc4NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,4 WyJjdGdBOjI1MjI4Li4yNTM2NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,5 WyJjdGdBOjIwMDkzLi4yMDU4MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,6 WyJjdGdBOjIwOTcwLi4yMTA1MiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,7 WyJjdGdBOjIxMjcwLi4yMTI3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,8 WyJjdGdBOjIxNjg1Li4yMjE2OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,9 WyJjdGdBOjIyNTY0Li4yMjg2OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,10 WyJjdGdBOjIyOTU4Li4yMzI5OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,11 WyJjdGdBOjIzNDEyLi4yMzQ2OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,12 WyJjdGdBOjIzOTMyLi4yMzkzMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA4IixudWxsXQ==,13
-seg09 WyJjdGdBOjM2NjE2Li4zNzA1NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA5IixudWxsXQ==,1 WyJjdGdBOjM3MjA4Li4zNzIyNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzA5IixudWxsXQ==,2
-seg10 WyJjdGdBOjI5NzcxLi4yOTk0MiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEwIixudWxsXQ==,1 WyJjdGdBOjMwMDQyLi4zMDM0MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEwIixudWxsXQ==,2 WyJjdGdBOjMwODEwLi4zMTMwNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEwIixudWxsXQ==,3 WyJjdGdBOjMxNzYxLi4zMTk4NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEwIixudWxsXQ==,4 WyJjdGdBOjMyMzc0Li4zMjkzNyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEwIixudWxsXQ==,5
-seg11 WyJjdGdBOjI0MjI4Li4yNDUxMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,1 WyJjdGdBOjI0ODY4Li4yNTAxMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,2 WyJjdGdBOjI1MjEyLi4yNTQyNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,3 WyJjdGdBOjI1Nzk0Li4yNTg3NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,4 WyJjdGdBOjI2MDc1Li4yNjUxOSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,5 WyJjdGdBOjI2OTMwLi4yNjk0MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,6 WyJjdGdBOjI2OTc1Li4yNzA2MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,7 WyJjdGdBOjI3NDE1Li4yNzc5OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,8 WyJjdGdBOjI3ODgwLi4yNzk0MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,9 WyJjdGdBOjI4MjI1Li4yODM0NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,10 WyJjdGdBOjI4Mzc1Li4yODU3MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,11 WyJjdGdBOjI4NzU4Li4yOTA0MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,12 WyJjdGdBOjI5MTAxLi4yOTMwMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,13 WyJjdGdBOjI5NjA0Li4yOTcwMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,14 WyJjdGdBOjI5ODY3Li4yOTg4NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,15 WyJjdGdBOjMwMjQxLi4zMDI0NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,16 WyJjdGdBOjMwNTc1Li4zMDczOCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzExIixudWxsXQ==,17
-seg12 WyJjdGdBOjE0NTY0Li4xNDg5OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,1 WyJjdGdBOjE1MTg1Li4xNTI3NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,2 WyJjdGdBOjE1NjM5Li4xNTczNiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,3 WyJjdGdBOjE1NzQ1Li4xNTg3MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,4 WyJjdGdBOjEyNTMxLi4xMjg5NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,5 WyJjdGdBOjEzMTIyLi4xMzQ0OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,6 WyJjdGdBOjEzNDUyLi4xMzc0NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,7 WyJjdGdBOjEzOTA4Li4xMzk2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,8 WyJjdGdBOjEzOTk4Li4xNDQ4OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEyIixudWxsXQ==,9
-seg13 WyJjdGdBOjQ5NDA2Li40OTQ3NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEzIixudWxsXQ==,1 WyJjdGdBOjQ5NzYyLi41MDAwMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzEzIixudWxsXQ==,2
-seg14 WyJjdGdBOjQ0MDY1Li40NDU1NiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,1 WyJjdGdBOjQ0NzYzLi40NTAzMCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,2 WyJjdGdBOjQ1MjMxLi40NTQ4OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,3 WyJjdGdBOjQ1NzkwLi40NjAyMiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,4 WyJjdGdBOjQ2MDkyLi40NjMxOCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,5 WyJjdGdBOjQ2ODE2Li40Njk5MiIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,6 WyJjdGdBOjQ3NDQ5Li40NzgyOSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,7 WyJjdGdBOjQxMTM3Li40MTMxOCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,8 WyJjdGdBOjQxNzU0Li40MTk0OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,9 WyJjdGdBOjQyMDU3Li40MjQ3NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,10 WyJjdGdBOjQyODkwLi40MzI3MCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,11 WyJjdGdBOjQzMzk1Li40MzgxMSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE0IixudWxsXQ==,12
-seg15 WyJjdGdBOjM5MjY1Li4zOTM2MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,1 WyJjdGdBOjM5NzUzLi40MDAzNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,2 WyJjdGdBOjQ0MDQzLi40NDExMyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,3 WyJjdGdBOjQ0Mzk5Li40NDg4OCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,4 WyJjdGdBOjQ1MjgxLi40NTM3NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,5 WyJjdGdBOjQ1NzExLi40NjA0MSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,6 WyJjdGdBOjQ2NDI1Li40NjU2NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,7 WyJjdGdBOjQ2NzM4Li40NzA4NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,8 WyJjdGdBOjQ3MzI5Li40NzU5NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,9 WyJjdGdBOjQ3ODU4Li40Nzk3OSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,10 WyJjdGdBOjQ4MTY5Li40ODQ1MyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,11 WyJjdGdBOjQwNTE1Li40MDk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,12 WyJjdGdBOjQxMjUyLi40MTM2NSIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,13 WyJjdGdBOjQxNDkyLi40MTUwNCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,14 WyJjdGdBOjQxOTQxLi40MjM3NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,15 WyJjdGdBOjQyNzQ4Li40Mjk1NCIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,16 WyJjdGdBOjQzNDAxLi40Mzg5NyIsImdmZjN0YWJpeF9nZW5lcyIsInNlZzE1IixudWxsXQ==,17
+agt221.3 ["ctgA%3A7500..8000","gff3tabix_genes","agt221.3","Match4"],1
+agt221.5 ["ctgA%3A1050..1500","gff3tabix_genes","agt221.5",""],1 ["ctgA%3A1050..7300","gff3tabix_genes","agt221.5","Match3"],2 ["ctgA%3A5000..5500","gff3tabix_genes","agt221.5",""],3 ["ctgA%3A7000..7300","gff3tabix_genes","agt221.5",""],4
+agt767.3 ["ctgA%3A8000..9000","gff3tabix_genes","agt767.3","Match6"],1
+agt767.5 ["ctgA%3A1150..1500","gff3tabix_genes","agt767.5",""],1 ["ctgA%3A1150..7200","gff3tabix_genes","agt767.5","Match5"],2 ["ctgA%3A5000..5500","gff3tabix_genes","agt767.5",""],3 ["ctgA%3A7000..7200","gff3tabix_genes","agt767.5",""],4
+agt830.3 ["ctgA%3A5410..5500","gff3tabix_genes","agt830.3",""],1 ["ctgA%3A5410..7503","gff3tabix_genes","agt830.3","Match2"],2 ["ctgA%3A7000..7503","gff3tabix_genes","agt830.3",""],3
+agt830.5 ["ctgA%3A1050..1500","gff3tabix_genes","agt830.5",""],1 ["ctgA%3A1050..3202","gff3tabix_genes","agt830.5","Match1"],2 ["ctgA%3A3000..3202","gff3tabix_genes","agt830.5",""],3
+apple2 ["ctgA%3A13000..17200","gff3tabix_genes","Apple2","cds-Apple2"],1
+apple3 ["ctgA%3A17400..23000","gff3tabix_genes","Apple3","rna-Apple3"],1
+b101.2 ["ctgA%3A1000..20000","gff3tabix_genes","b101.2","b101.2"],1
+bnd_a ["A%3A2700..2701","volvox_sv_test_renamed","","bnd_A"],1 ["ctgA%3A2700..2701","volvox_sv_test","","bnd_A"],2
+bnd_b ["A%3A34200..34201","volvox_sv_test_renamed","","bnd_B"],1 ["ctgA%3A34200..34201","volvox_sv_test","","bnd_B"],2
+bnd_u ["A%3A23456..23457","volvox_sv_test_renamed","","bnd_U"],1 ["ctgA%3A23456..23457","volvox_sv_test","","bnd_U"],2
+bnd_v ["A%3A21682..21683","volvox_sv_test_renamed","","bnd_V"],1 ["ctgA%3A21682..21683","volvox_sv_test","","bnd_V"],2
+bnd_w ["A%3A21681..21682","volvox_sv_test_renamed","","bnd_W"],1 ["ctgA%3A21681..21682","volvox_sv_test","","bnd_W"],2
+bnd_x ["A%3A23457..23458","volvox_sv_test_renamed","","bnd_X"],1 ["ctgA%3A23457..23458","volvox_sv_test","","bnd_X"],2
+bnd_y ["B%3A1982..1983","volvox_sv_test_renamed","","bnd_Y"],1 ["ctgB%3A1982..1983","volvox_sv_test","","bnd_Y"],2
+bnd_z ["B%3A1983..1984","volvox_sv_test_renamed","","bnd_Z"],1 ["ctgB%3A1983..1984","volvox_sv_test","","bnd_Z"],2
+cds-apple2 ["ctgA%3A13000..17200","gff3tabix_genes","Apple2","cds-Apple2"],1
+ctga ["ctgA%3A1..50001","gff3tabix_genes","ctgA",""],1
+ctgb ["ctgB%3A1..6079","gff3tabix_genes","ctgB",""],1
+eden ["ctgA%3A1050..9000","gff3tabix_genes","EDEN","EDEN"],1
+eden.1 ["ctgA%3A1050..9000","gff3tabix_genes","EDEN.1","EDEN.1"],1
+eden.2 ["ctgA%3A1050..9000","gff3tabix_genes","EDEN.2","EDEN.2"],1
+eden.3 ["ctgA%3A1300..9000","gff3tabix_genes","EDEN.3","EDEN.3"],1
+f01 ["ctgA%3A44705..47713","gff3tabix_genes","f01",""],1
+f02 ["ctgA%3A24562..28338","gff3tabix_genes","f02",""],1
+f03 ["ctgA%3A36649..40440","gff3tabix_genes","f03",""],1
+f04 ["ctgA%3A37242..38653","gff3tabix_genes","f04",""],1
+f05 ["ctgA%3A4715..5968","gff3tabix_genes","f05",""],1 ["ctgB%3A4715..5968","gff3tabix_genes","f05",""],2
+f06 ["ctgA%3A3014..6130","gff3tabix_genes","f06",""],1 ["ctgB%3A3014..6130","gff3tabix_genes","f06",""],2
+f07 ["ctgA%3A1659..1984","gff3tabix_genes","f07",""],1 ["ctgB%3A1659..1984","gff3tabix_genes","f07",""],2
+f08 ["ctgA%3A13280..16394","gff3tabix_genes","f08",""],1
+f09 ["ctgA%3A36034..38167","gff3tabix_genes","f09",""],1
+f10 ["ctgA%3A15329..15533","gff3tabix_genes","f10",""],1
+f11 ["ctgA%3A46990..48410","gff3tabix_genes","f11",""],1
+f12 ["ctgA%3A49758..50000","gff3tabix_genes","f12",""],1
+f13 ["ctgA%3A19157..22915","gff3tabix_genes","f13",""],1
+f14 ["ctgA%3A23072..23185","gff3tabix_genes","f14",""],1
+f15 ["ctgA%3A22132..24633","gff3tabix_genes","f15",""],1
+fakesnp ["ctgA%3A1000..1000","gff3tabix_genes","FakeSNP","FakeSNP1"],1
+fakesnp1 ["ctgA%3A1000..1000","gff3tabix_genes","FakeSNP","FakeSNP1"],1
+gene1 ["ctgA%3A1201..1500","single_exon_gene","","gene1"],1
+gene2 ["ctgA%3A1201..3902","single_exon_gene","","gene2"],1
+gene:hga ["ctgA%3A1100..2000","gff3tabix_genes","Gene%3Ahga",""],1
+gene:hgb ["ctgA%3A1600..3000","gff3tabix_genes","Gene%3Ahgb",""],1
+inv134 ["ctgA%3A2700..10000","volvox.inv.vcf","","inv134"],1
+inv135 ["ctgA%3A6000..9000","volvox.inv.vcf","","inv135"],1 ["ctgA%3A6000..9000","volvox.inv.vcf","","inv135"],2
+m01 ["ctgA%3A48253..48366","gff3tabix_genes","m01",""],1
+m02 ["ctgA%3A28332..30033","gff3tabix_genes","m02",""],1
+m03 ["ctgA%3A15396..16159","gff3tabix_genes","m03",""],1
+m04 ["ctgA%3A33325..35791","gff3tabix_genes","m04",""],1
+m05 ["ctgA%3A13801..14007","gff3tabix_genes","m05",""],1
+m06 ["ctgA%3A30578..31748","gff3tabix_genes","m06",""],1
+m07 ["ctgA%3A18048..18552","gff3tabix_genes","m07",""],1
+m08 ["ctgA%3A17023..17675","gff3tabix_genes","m08",""],1
+m09 ["ctgA%3A46012..48851","gff3tabix_genes","m09",""],1
+m10 ["ctgA%3A28342..28447","gff3tabix_genes","m10",""],1
+m11 ["ctgA%3A11911..15561","gff3tabix_genes","m11",""],1
+m12 ["ctgA%3A21748..25612","gff3tabix_genes","m12",""],1
+m13 ["ctgA%3A17667..17690","gff3tabix_genes","m13",""],1
+m14 ["ctgA%3A14731..17239","gff3tabix_genes","m14",""],1
+m15 ["ctgA%3A37497..40559","gff3tabix_genes","m15",""],1
+match1 ["ctgA%3A1050..3202","gff3tabix_genes","agt830.5","Match1"],1
+match2 ["ctgA%3A5410..7503","gff3tabix_genes","agt830.3","Match2"],1
+match3 ["ctgA%3A1050..7300","gff3tabix_genes","agt221.5","Match3"],1
+match4 ["ctgA%3A7500..8000","gff3tabix_genes","agt221.3","Match4"],1
+match5 ["ctgA%3A1150..7200","gff3tabix_genes","agt767.5","Match5"],1
+match6 ["ctgA%3A8000..9000","gff3tabix_genes","agt767.3","Match6"],1
+mrna1 ["ctgA%3A1201..1500","single_exon_gene","","mRNA1"],1
+mrna2 ["ctgA%3A1201..3902","single_exon_gene","","mRNA2"],1
+protein:hga ["ctgA%3A1200..1900","gff3tabix_genes","Protein%3AHGA",""],1
+protein:hgb ["ctgA%3A1800..2900","gff3tabix_genes","Protein%3AHGB",""],1
+remark:hga ["ctgA%3A1000..2000","gff3tabix_genes","Remark%3Ahga",""],1
+rna-apple3 ["ctgA%3A17400..23000","gff3tabix_genes","Apple3","rna-Apple3"],1
+rs1041740 ["contigA%3A11340..11341","volvox_test_vcf","","rs1041740"],1
+rs10432782 ["contigA%3A7569..7570","volvox_test_vcf","","rs10432782"],1
+rs112989936 ["contigA%3A10684..10685","volvox_test_vcf","","rs112989936"],1
+rs114905802 ["contigA%3A4035..4036","volvox_test_vcf","","rs114905802"],1
+rs11567845 ["contigA%3A8742..8743","volvox_test_vcf","","rs11567845"],1
+rs116260263 ["contigA%3A6834..6835","volvox_test_vcf","","rs116260263"],1
+rs117304270 ["contigA%3A11832..11833","volvox_test_vcf","","rs117304270"],1
+rs117466144 ["contigA%3A11241..11242","volvox_test_vcf","","rs117466144"],1
+rs118132937 ["contigA%3A9136..9137","volvox_test_vcf","","rs118132937"],1
+rs16988404 ["contigA%3A7173..7174","volvox_test_vcf","","rs16988404"],1
+rs17878802 ["contigA%3A5281..5282","volvox_test_vcf","","rs17878802"],1
+rs17878855 ["contigA%3A3105..3106","volvox_test_vcf","","rs17878855"],1
+rs17880044 ["contigA%3A11774..11775","volvox_test_vcf","","rs17880044"],1
+rs17880487 ["contigA%3A12408..12409","volvox_test_vcf","","rs17880487"],1
+rs17880490 ["contigA%3A8077..8078","volvox_test_vcf","","rs17880490"],1
+rs17880795 ["contigA%3A4260..4261","volvox_test_vcf","","rs17880795"],1
+rs17881180 ["contigA%3A3465..3466","volvox_test_vcf","","rs17881180"],1
+rs17881581 ["contigA%3A3171..3172","volvox_test_vcf","","rs17881581"],1
+rs17881732 ["contigA%3A11335..11336","volvox_test_vcf","","rs17881732"],1
+rs17881807 ["contigA%3A5349..5350","volvox_test_vcf","","rs17881807"],1
+rs17882967 ["contigA%3A5006..5007","volvox_test_vcf","","rs17882967"],1
+rs17883234 ["contigA%3A11182..11183","volvox_test_vcf","","rs17883234"],1
+rs17883270 ["contigA%3A5260..5261","volvox_test_vcf","","rs17883270"],1
+rs17883296 ["contigA%3A3000..3001","volvox_test_vcf","","rs17883296"],1
+rs17883461 ["contigA%3A8210..8211","volvox_test_vcf","","rs17883461"],1
+rs17883998 ["contigA%3A9853..9854","volvox_test_vcf","","rs17883998"],1
+rs17884040 ["contigA%3A4248..4249","volvox_test_vcf","","rs17884040"],1
+rs17884233 ["contigA%3A7141..7142","volvox_test_vcf","","rs17884233"],1
+rs17884260 ["contigA%3A4074..4075","volvox_test_vcf","","rs17884260"],1
+rs17884462 ["contigA%3A11689..11690","volvox_test_vcf","","rs17884462"],1
+rs17885219 ["contigA%3A4901..4902","volvox_test_vcf","","rs17885219"],1
+rs17885303 ["contigA%3A9048..9049","volvox_test_vcf","","rs17885303"],1
+rs17885634 ["contigA%3A10252..10253","volvox_test_vcf","","rs17885634"],1
+rs17885833 ["contigA%3A9920..9921","volvox_test_vcf","","rs17885833"],1
+rs17886025 ["contigA%3A8132..8133","volvox_test_vcf","","rs17886025"],1
+rs17886606 ["contigA%3A8328..8329","volvox_test_vcf","","rs17886606"],1
+rs17886692 ["contigA%3A10875..10876","volvox_test_vcf","","rs17886692"],1
+rs2070424 ["contigA%3A10498..10499","volvox_test_vcf","","rs2070424"],1
+rs2234694 ["contigA%3A10043..10044","volvox_test_vcf","","rs2234694"],1
+rs4816405 ["contigA%3A4179..4180","volvox_test_vcf","","rs4816405"],1
+rs4816407 ["contigA%3A11207..11208","volvox_test_vcf","","rs4816407"],1
+rs4817420 ["contigA%3A11549..11550","volvox_test_vcf","","rs4817420"],1
+rs4998557 ["contigA%3A6070..6071","volvox_test_vcf","","rs4998557"],1
+rs6650814 ["contigA%3A4166..4167","volvox_test_vcf","","rs6650814"],1
+rs7277748 ["contigA%3A3152..3153","volvox_test_vcf","","rs7277748"],1
+rs76067554 ["contigA%3A8524..8525","volvox_test_vcf","","rs76067554"],1
+rs76734991 ["contigA%3A11095..11096","volvox_test_vcf","","rs76734991"],1
+rs77112488 ["contigA%3A9884..9885","volvox_test_vcf","","rs77112488"],1
+rs77319474 ["contigA%3A10217..10218","volvox_test_vcf","","rs77319474"],1
+rs78694163 ["contigA%3A8816..8817","volvox_test_vcf","","rs78694163"],1
+rs80265967 ["contigA%3A10781..10782","volvox_test_vcf","","rs80265967"],1
+rs8133032 ["contigA%3A9525..9526","volvox_test_vcf","","rs8133032"],1
+rs9967983 ["contigA%3A8660..8661","volvox_test_vcf","","rs9967983"],1
+seg01 ["ctgA%3A32329..32359","gff3tabix_genes","seg01",""],1
+seg02 ["ctgA%3A26122..26126","gff3tabix_genes","seg02",""],1 ["ctgA%3A26497..26869","gff3tabix_genes","seg02",""],2 ["ctgA%3A27201..27325","gff3tabix_genes","seg02",""],3 ["ctgA%3A27372..27433","gff3tabix_genes","seg02",""],4 ["ctgA%3A27565..27565","gff3tabix_genes","seg02",""],5 ["ctgA%3A27813..28091","gff3tabix_genes","seg02",""],6 ["ctgA%3A28093..28201","gff3tabix_genes","seg02",""],7 ["ctgA%3A28329..28377","gff3tabix_genes","seg02",""],8 ["ctgA%3A28829..29194","gff3tabix_genes","seg02",""],9 ["ctgA%3A29517..29702","gff3tabix_genes","seg02",""],10 ["ctgA%3A29713..30061","gff3tabix_genes","seg02",""],11 ["ctgA%3A30329..30774","gff3tabix_genes","seg02",""],12 ["ctgA%3A30808..31306","gff3tabix_genes","seg02",""],13 ["ctgA%3A31516..31729","gff3tabix_genes","seg02",""],14 ["ctgA%3A31753..32154","gff3tabix_genes","seg02",""],15 ["ctgA%3A32595..32696","gff3tabix_genes","seg02",""],16 ["ctgA%3A32892..32901","gff3tabix_genes","seg02",""],17 ["ctgA%3A33127..33388","gff3tabix_genes","seg02",""],18 ["ctgA%3A33439..33443","gff3tabix_genes","seg02",""],19 ["ctgA%3A33759..34209","gff3tabix_genes","seg02",""],20 ["ctgA%3A34401..34466","gff3tabix_genes","seg02",""],21
+seg03 ["ctgA%3A6885..7241","gff3tabix_genes","seg03",""],1 ["ctgA%3A7410..7737","gff3tabix_genes","seg03",""],2 ["ctgA%3A8055..8080","gff3tabix_genes","seg03",""],3 ["ctgA%3A8306..8999","gff3tabix_genes","seg03",""],4
+seg04 ["ctgA%3A5233..5302","gff3tabix_genes","seg04",""],1 ["ctgA%3A5800..6101","gff3tabix_genes","seg04",""],2 ["ctgA%3A6442..6854","gff3tabix_genes","seg04",""],3 ["ctgA%3A7106..7211","gff3tabix_genes","seg04",""],4 ["ctgA%3A7695..8177","gff3tabix_genes","seg04",""],5 ["ctgA%3A8545..8783","gff3tabix_genes","seg04",""],6 ["ctgA%3A8869..8935","gff3tabix_genes","seg04",""],7 ["ctgA%3A9404..9825","gff3tabix_genes","seg04",""],8
+seg05 ["ctgA%3A26503..26799","gff3tabix_genes","seg05",""],1 ["ctgA%3A27172..27185","gff3tabix_genes","seg05",""],2 ["ctgA%3A27448..27860","gff3tabix_genes","seg05",""],3 ["ctgA%3A27887..28076","gff3tabix_genes","seg05",""],4 ["ctgA%3A28225..28316","gff3tabix_genes","seg05",""],5 ["ctgA%3A28777..29058","gff3tabix_genes","seg05",""],6 ["ctgA%3A29513..29647","gff3tabix_genes","seg05",""],7 ["ctgA%3A30108..30216","gff3tabix_genes","seg05",""],8 ["ctgA%3A30465..30798","gff3tabix_genes","seg05",""],9 ["ctgA%3A31232..31236","gff3tabix_genes","seg05",""],10 ["ctgA%3A31421..31817","gff3tabix_genes","seg05",""],11 ["ctgA%3A32010..32057","gff3tabix_genes","seg05",""],12 ["ctgA%3A32208..32680","gff3tabix_genes","seg05",""],13 ["ctgA%3A33053..33325","gff3tabix_genes","seg05",""],14 ["ctgA%3A33438..33868","gff3tabix_genes","seg05",""],15 ["ctgA%3A34244..34313","gff3tabix_genes","seg05",""],16 ["ctgA%3A34605..34983","gff3tabix_genes","seg05",""],17 ["ctgA%3A35333..35507","gff3tabix_genes","seg05",""],18 ["ctgA%3A35642..35904","gff3tabix_genes","seg05",""],19
+seg06 ["ctgA%3A19249..19559","gff3tabix_genes","seg06",""],1 ["ctgA%3A19975..20260","gff3tabix_genes","seg06",""],2 ["ctgA%3A20379..20491","gff3tabix_genes","seg06",""],3 ["ctgA%3A20533..21005","gff3tabix_genes","seg06",""],4 ["ctgA%3A21122..21331","gff3tabix_genes","seg06",""],5 ["ctgA%3A21682..22176","gff3tabix_genes","seg06",""],6 ["ctgA%3A22374..22570","gff3tabix_genes","seg06",""],7 ["ctgA%3A23025..23427","gff3tabix_genes","seg06",""],8
+seg07 ["ctgA%3A44191..44514","gff3tabix_genes","seg07",""],1 ["ctgA%3A44552..45043","gff3tabix_genes","seg07",""],2 ["ctgA%3A45373..45600","gff3tabix_genes","seg07",""],3 ["ctgA%3A45897..46315","gff3tabix_genes","seg07",""],4 ["ctgA%3A46491..46890","gff3tabix_genes","seg07",""],5 ["ctgA%3A47126..47297","gff3tabix_genes","seg07",""],6 ["ctgA%3A47735..47983","gff3tabix_genes","seg07",""],7 ["ctgA%3A48447..48709","gff3tabix_genes","seg07",""],8 ["ctgA%3A48931..49186","gff3tabix_genes","seg07",""],9 ["ctgA%3A49472..49699","gff3tabix_genes","seg07",""],10 ["ctgA%3A49957..50000","gff3tabix_genes","seg07",""],11 ["ctgA%3A49957..50000","gff3tabix_genes","seg07",""],12
+seg08 ["ctgA%3A18509..18985","gff3tabix_genes","seg08",""],1 ["ctgA%3A18989..19388","gff3tabix_genes","seg08",""],2 ["ctgA%3A19496..19962","gff3tabix_genes","seg08",""],3 ["ctgA%3A20093..20580","gff3tabix_genes","seg08",""],4 ["ctgA%3A20970..21052","gff3tabix_genes","seg08",""],5 ["ctgA%3A21270..21277","gff3tabix_genes","seg08",""],6 ["ctgA%3A21685..22168","gff3tabix_genes","seg08",""],7 ["ctgA%3A22564..22869","gff3tabix_genes","seg08",""],8 ["ctgA%3A22958..23298","gff3tabix_genes","seg08",""],9 ["ctgA%3A23412..23469","gff3tabix_genes","seg08",""],10 ["ctgA%3A23932..23932","gff3tabix_genes","seg08",""],11 ["ctgA%3A24328..24787","gff3tabix_genes","seg08",""],12 ["ctgA%3A25228..25367","gff3tabix_genes","seg08",""],13
+seg09 ["ctgA%3A36616..37057","gff3tabix_genes","seg09",""],1 ["ctgA%3A37208..37227","gff3tabix_genes","seg09",""],2
+seg10 ["ctgA%3A29771..29942","gff3tabix_genes","seg10",""],1 ["ctgA%3A30042..30340","gff3tabix_genes","seg10",""],2 ["ctgA%3A30810..31307","gff3tabix_genes","seg10",""],3 ["ctgA%3A31761..31984","gff3tabix_genes","seg10",""],4 ["ctgA%3A32374..32937","gff3tabix_genes","seg10",""],5
+seg11 ["ctgA%3A24228..24510","gff3tabix_genes","seg11",""],1 ["ctgA%3A24868..25012","gff3tabix_genes","seg11",""],2 ["ctgA%3A25212..25426","gff3tabix_genes","seg11",""],3 ["ctgA%3A25794..25874","gff3tabix_genes","seg11",""],4 ["ctgA%3A26075..26519","gff3tabix_genes","seg11",""],5 ["ctgA%3A26930..26940","gff3tabix_genes","seg11",""],6 ["ctgA%3A26975..27063","gff3tabix_genes","seg11",""],7 ["ctgA%3A27415..27799","gff3tabix_genes","seg11",""],8 ["ctgA%3A27880..27943","gff3tabix_genes","seg11",""],9 ["ctgA%3A28225..28346","gff3tabix_genes","seg11",""],10 ["ctgA%3A28375..28570","gff3tabix_genes","seg11",""],11 ["ctgA%3A28758..29041","gff3tabix_genes","seg11",""],12 ["ctgA%3A29101..29302","gff3tabix_genes","seg11",""],13 ["ctgA%3A29604..29702","gff3tabix_genes","seg11",""],14 ["ctgA%3A29867..29885","gff3tabix_genes","seg11",""],15 ["ctgA%3A30241..30246","gff3tabix_genes","seg11",""],16 ["ctgA%3A30575..30738","gff3tabix_genes","seg11",""],17
+seg12 ["ctgA%3A12531..12895","gff3tabix_genes","seg12",""],1 ["ctgA%3A13122..13449","gff3tabix_genes","seg12",""],2 ["ctgA%3A13452..13745","gff3tabix_genes","seg12",""],3 ["ctgA%3A13908..13965","gff3tabix_genes","seg12",""],4 ["ctgA%3A13998..14488","gff3tabix_genes","seg12",""],5 ["ctgA%3A14564..14899","gff3tabix_genes","seg12",""],6 ["ctgA%3A15185..15276","gff3tabix_genes","seg12",""],7 ["ctgA%3A15639..15736","gff3tabix_genes","seg12",""],8 ["ctgA%3A15745..15870","gff3tabix_genes","seg12",""],9
+seg13 ["ctgA%3A49406..49476","gff3tabix_genes","seg13",""],1 ["ctgA%3A49762..50000","gff3tabix_genes","seg13",""],2
+seg14 ["ctgA%3A41137..41318","gff3tabix_genes","seg14",""],1 ["ctgA%3A41754..41948","gff3tabix_genes","seg14",""],2 ["ctgA%3A42057..42474","gff3tabix_genes","seg14",""],3 ["ctgA%3A42890..43270","gff3tabix_genes","seg14",""],4 ["ctgA%3A43395..43811","gff3tabix_genes","seg14",""],5 ["ctgA%3A44065..44556","gff3tabix_genes","seg14",""],6 ["ctgA%3A44763..45030","gff3tabix_genes","seg14",""],7 ["ctgA%3A45231..45488","gff3tabix_genes","seg14",""],8 ["ctgA%3A45790..46022","gff3tabix_genes","seg14",""],9 ["ctgA%3A46092..46318","gff3tabix_genes","seg14",""],10 ["ctgA%3A46816..46992","gff3tabix_genes","seg14",""],11 ["ctgA%3A47449..47829","gff3tabix_genes","seg14",""],12
+seg15 ["ctgA%3A39265..39361","gff3tabix_genes","seg15",""],1 ["ctgA%3A39753..40034","gff3tabix_genes","seg15",""],2 ["ctgA%3A40515..40954","gff3tabix_genes","seg15",""],3 ["ctgA%3A41252..41365","gff3tabix_genes","seg15",""],4 ["ctgA%3A41492..41504","gff3tabix_genes","seg15",""],5 ["ctgA%3A41941..42377","gff3tabix_genes","seg15",""],6 ["ctgA%3A42748..42954","gff3tabix_genes","seg15",""],7 ["ctgA%3A43401..43897","gff3tabix_genes","seg15",""],8 ["ctgA%3A44043..44113","gff3tabix_genes","seg15",""],9 ["ctgA%3A44399..44888","gff3tabix_genes","seg15",""],10 ["ctgA%3A45281..45375","gff3tabix_genes","seg15",""],11 ["ctgA%3A45711..46041","gff3tabix_genes","seg15",""],12 ["ctgA%3A46425..46564","gff3tabix_genes","seg15",""],13 ["ctgA%3A46738..47087","gff3tabix_genes","seg15",""],14 ["ctgA%3A47329..47595","gff3tabix_genes","seg15",""],15 ["ctgA%3A47858..47979","gff3tabix_genes","seg15",""],16 ["ctgA%3A48169..48453","gff3tabix_genes","seg15",""],17

--- a/test_data/volvox/trix/volvox.ix
+++ b/test_data/volvox/trix/volvox.ix
@@ -1,12 +1,12 @@
-agt221.3 ["ctgA%3A7500..8000","gff3tabix_genes","agt221.3","Match4"],1
-agt221.5 ["ctgA%3A1050..1500","gff3tabix_genes","agt221.5",""],1 ["ctgA%3A1050..7300","gff3tabix_genes","agt221.5","Match3"],2 ["ctgA%3A5000..5500","gff3tabix_genes","agt221.5",""],3 ["ctgA%3A7000..7300","gff3tabix_genes","agt221.5",""],4
-agt767.3 ["ctgA%3A8000..9000","gff3tabix_genes","agt767.3","Match6"],1
-agt767.5 ["ctgA%3A1150..1500","gff3tabix_genes","agt767.5",""],1 ["ctgA%3A1150..7200","gff3tabix_genes","agt767.5","Match5"],2 ["ctgA%3A5000..5500","gff3tabix_genes","agt767.5",""],3 ["ctgA%3A7000..7200","gff3tabix_genes","agt767.5",""],4
-agt830.3 ["ctgA%3A5410..5500","gff3tabix_genes","agt830.3",""],1 ["ctgA%3A5410..7503","gff3tabix_genes","agt830.3","Match2"],2 ["ctgA%3A7000..7503","gff3tabix_genes","agt830.3",""],3
-agt830.5 ["ctgA%3A1050..1500","gff3tabix_genes","agt830.5",""],1 ["ctgA%3A1050..3202","gff3tabix_genes","agt830.5","Match1"],2 ["ctgA%3A3000..3202","gff3tabix_genes","agt830.5",""],3
-apple2 ["ctgA%3A13000..17200","gff3tabix_genes","Apple2","cds-Apple2"],1
-apple3 ["ctgA%3A17400..23000","gff3tabix_genes","Apple3","rna-Apple3"],1
-b101.2 ["ctgA%3A1000..20000","gff3tabix_genes","b101.2","b101.2"],1
+agt221.3 ["ctgA%3A7500..8000"|"gff3tabix_genes"|"agt221.3"|"Match4"],1
+agt221.5 ["ctgA%3A1050..1500"|"gff3tabix_genes"|"agt221.5"|""],1 ["ctgA%3A1050..7300"|"gff3tabix_genes"|"agt221.5"|"Match3"],2 ["ctgA%3A5000..5500"|"gff3tabix_genes"|"agt221.5"|""],3 ["ctgA%3A7000..7300"|"gff3tabix_genes"|"agt221.5"|""],4
+agt767.3 ["ctgA%3A8000..9000"|"gff3tabix_genes"|"agt767.3"|"Match6"],1
+agt767.5 ["ctgA%3A1150..1500"|"gff3tabix_genes"|"agt767.5"|""],1 ["ctgA%3A1150..7200"|"gff3tabix_genes"|"agt767.5"|"Match5"],2 ["ctgA%3A5000..5500"|"gff3tabix_genes"|"agt767.5"|""],3 ["ctgA%3A7000..7200"|"gff3tabix_genes"|"agt767.5"|""],4
+agt830.3 ["ctgA%3A5410..5500"|"gff3tabix_genes"|"agt830.3"|""],1 ["ctgA%3A5410..7503"|"gff3tabix_genes"|"agt830.3"|"Match2"],2 ["ctgA%3A7000..7503"|"gff3tabix_genes"|"agt830.3"|""],3
+agt830.5 ["ctgA%3A1050..1500"|"gff3tabix_genes"|"agt830.5"|""],1 ["ctgA%3A1050..3202"|"gff3tabix_genes"|"agt830.5"|"Match1"],2 ["ctgA%3A3000..3202"|"gff3tabix_genes"|"agt830.5"|""],3
+apple2 ["ctgA%3A13000..17200"|"gff3tabix_genes"|"Apple2"|"cds-Apple2"],1
+apple3 ["ctgA%3A17400..23000"|"gff3tabix_genes"|"Apple3"|"rna-Apple3"],1
+b101.2 ["ctgA%3A1000..20000"|"gff3tabix_genes"|"b101.2"|"b101.2"],1
 bnd_a ["A%3A2700..2701","volvox_sv_test_renamed","","bnd_A"],1 ["ctgA%3A2700..2701","volvox_sv_test","","bnd_A"],2
 bnd_b ["A%3A34200..34201","volvox_sv_test_renamed","","bnd_B"],1 ["ctgA%3A34200..34201","volvox_sv_test","","bnd_B"],2
 bnd_u ["A%3A23456..23457","volvox_sv_test_renamed","","bnd_U"],1 ["ctgA%3A23456..23457","volvox_sv_test","","bnd_U"],2
@@ -15,63 +15,63 @@ bnd_w ["A%3A21681..21682","volvox_sv_test_renamed","","bnd_W"],1 ["ctgA%3A21681.
 bnd_x ["A%3A23457..23458","volvox_sv_test_renamed","","bnd_X"],1 ["ctgA%3A23457..23458","volvox_sv_test","","bnd_X"],2
 bnd_y ["B%3A1982..1983","volvox_sv_test_renamed","","bnd_Y"],1 ["ctgB%3A1982..1983","volvox_sv_test","","bnd_Y"],2
 bnd_z ["B%3A1983..1984","volvox_sv_test_renamed","","bnd_Z"],1 ["ctgB%3A1983..1984","volvox_sv_test","","bnd_Z"],2
-cds-apple2 ["ctgA%3A13000..17200","gff3tabix_genes","Apple2","cds-Apple2"],1
-ctga ["ctgA%3A1..50001","gff3tabix_genes","ctgA",""],1
-ctgb ["ctgB%3A1..6079","gff3tabix_genes","ctgB",""],1
-eden ["ctgA%3A1050..9000","gff3tabix_genes","EDEN","EDEN"],1
-eden.1 ["ctgA%3A1050..9000","gff3tabix_genes","EDEN.1","EDEN.1"],1
-eden.2 ["ctgA%3A1050..9000","gff3tabix_genes","EDEN.2","EDEN.2"],1
-eden.3 ["ctgA%3A1300..9000","gff3tabix_genes","EDEN.3","EDEN.3"],1
-f01 ["ctgA%3A44705..47713","gff3tabix_genes","f01",""],1
-f02 ["ctgA%3A24562..28338","gff3tabix_genes","f02",""],1
-f03 ["ctgA%3A36649..40440","gff3tabix_genes","f03",""],1
-f04 ["ctgA%3A37242..38653","gff3tabix_genes","f04",""],1
-f05 ["ctgA%3A4715..5968","gff3tabix_genes","f05",""],1 ["ctgB%3A4715..5968","gff3tabix_genes","f05",""],2
-f06 ["ctgA%3A3014..6130","gff3tabix_genes","f06",""],1 ["ctgB%3A3014..6130","gff3tabix_genes","f06",""],2
-f07 ["ctgA%3A1659..1984","gff3tabix_genes","f07",""],1 ["ctgB%3A1659..1984","gff3tabix_genes","f07",""],2
-f08 ["ctgA%3A13280..16394","gff3tabix_genes","f08",""],1
-f09 ["ctgA%3A36034..38167","gff3tabix_genes","f09",""],1
-f10 ["ctgA%3A15329..15533","gff3tabix_genes","f10",""],1
-f11 ["ctgA%3A46990..48410","gff3tabix_genes","f11",""],1
-f12 ["ctgA%3A49758..50000","gff3tabix_genes","f12",""],1
-f13 ["ctgA%3A19157..22915","gff3tabix_genes","f13",""],1
-f14 ["ctgA%3A23072..23185","gff3tabix_genes","f14",""],1
-f15 ["ctgA%3A22132..24633","gff3tabix_genes","f15",""],1
-fakesnp ["ctgA%3A1000..1000","gff3tabix_genes","FakeSNP","FakeSNP1"],1
-fakesnp1 ["ctgA%3A1000..1000","gff3tabix_genes","FakeSNP","FakeSNP1"],1
-gene1 ["ctgA%3A1201..1500","single_exon_gene","","gene1"],1
-gene2 ["ctgA%3A1201..3902","single_exon_gene","","gene2"],1
-gene:hga ["ctgA%3A1100..2000","gff3tabix_genes","Gene%3Ahga",""],1
-gene:hgb ["ctgA%3A1600..3000","gff3tabix_genes","Gene%3Ahgb",""],1
+cds-apple2 ["ctgA%3A13000..17200"|"gff3tabix_genes"|"Apple2"|"cds-Apple2"],1
+ctga ["ctgA%3A1..50001"|"gff3tabix_genes"|"ctgA"|""],1
+ctgb ["ctgB%3A1..6079"|"gff3tabix_genes"|"ctgB"|""],1
+eden ["ctgA%3A1050..9000"|"gff3tabix_genes"|"EDEN"|"EDEN"],1
+eden.1 ["ctgA%3A1050..9000"|"gff3tabix_genes"|"EDEN.1"|"EDEN.1"],1
+eden.2 ["ctgA%3A1050..9000"|"gff3tabix_genes"|"EDEN.2"|"EDEN.2"],1
+eden.3 ["ctgA%3A1300..9000"|"gff3tabix_genes"|"EDEN.3"|"EDEN.3"],1
+f01 ["ctgA%3A44705..47713"|"gff3tabix_genes"|"f01"|""],1
+f02 ["ctgA%3A24562..28338"|"gff3tabix_genes"|"f02"|""],1
+f03 ["ctgA%3A36649..40440"|"gff3tabix_genes"|"f03"|""],1
+f04 ["ctgA%3A37242..38653"|"gff3tabix_genes"|"f04"|""],1
+f05 ["ctgA%3A4715..5968"|"gff3tabix_genes"|"f05"|""],1 ["ctgB%3A4715..5968"|"gff3tabix_genes"|"f05"|""],2
+f06 ["ctgA%3A3014..6130"|"gff3tabix_genes"|"f06"|""],1 ["ctgB%3A3014..6130"|"gff3tabix_genes"|"f06"|""],2
+f07 ["ctgA%3A1659..1984"|"gff3tabix_genes"|"f07"|""],1 ["ctgB%3A1659..1984"|"gff3tabix_genes"|"f07"|""],2
+f08 ["ctgA%3A13280..16394"|"gff3tabix_genes"|"f08"|""],1
+f09 ["ctgA%3A36034..38167"|"gff3tabix_genes"|"f09"|""],1
+f10 ["ctgA%3A15329..15533"|"gff3tabix_genes"|"f10"|""],1
+f11 ["ctgA%3A46990..48410"|"gff3tabix_genes"|"f11"|""],1
+f12 ["ctgA%3A49758..50000"|"gff3tabix_genes"|"f12"|""],1
+f13 ["ctgA%3A19157..22915"|"gff3tabix_genes"|"f13"|""],1
+f14 ["ctgA%3A23072..23185"|"gff3tabix_genes"|"f14"|""],1
+f15 ["ctgA%3A22132..24633"|"gff3tabix_genes"|"f15"|""],1
+fakesnp ["ctgA%3A1000..1000"|"gff3tabix_genes"|"FakeSNP"|"FakeSNP1"],1
+fakesnp1 ["ctgA%3A1000..1000"|"gff3tabix_genes"|"FakeSNP"|"FakeSNP1"],1
+gene1 ["ctgA%3A1201..1500"|"single_exon_gene"|""|"gene1"],1
+gene2 ["ctgA%3A1201..3902"|"single_exon_gene"|""|"gene2"],1
+gene:hga ["ctgA%3A1100..2000"|"gff3tabix_genes"|"Gene%3Ahga"|""],1
+gene:hgb ["ctgA%3A1600..3000"|"gff3tabix_genes"|"Gene%3Ahgb"|""],1
 inv134 ["ctgA%3A2700..10000","volvox.inv.vcf","","inv134"],1
 inv135 ["ctgA%3A6000..9000","volvox.inv.vcf","","inv135"],1 ["ctgA%3A6000..9000","volvox.inv.vcf","","inv135"],2
-m01 ["ctgA%3A48253..48366","gff3tabix_genes","m01",""],1
-m02 ["ctgA%3A28332..30033","gff3tabix_genes","m02",""],1
-m03 ["ctgA%3A15396..16159","gff3tabix_genes","m03",""],1
-m04 ["ctgA%3A33325..35791","gff3tabix_genes","m04",""],1
-m05 ["ctgA%3A13801..14007","gff3tabix_genes","m05",""],1
-m06 ["ctgA%3A30578..31748","gff3tabix_genes","m06",""],1
-m07 ["ctgA%3A18048..18552","gff3tabix_genes","m07",""],1
-m08 ["ctgA%3A17023..17675","gff3tabix_genes","m08",""],1
-m09 ["ctgA%3A46012..48851","gff3tabix_genes","m09",""],1
-m10 ["ctgA%3A28342..28447","gff3tabix_genes","m10",""],1
-m11 ["ctgA%3A11911..15561","gff3tabix_genes","m11",""],1
-m12 ["ctgA%3A21748..25612","gff3tabix_genes","m12",""],1
-m13 ["ctgA%3A17667..17690","gff3tabix_genes","m13",""],1
-m14 ["ctgA%3A14731..17239","gff3tabix_genes","m14",""],1
-m15 ["ctgA%3A37497..40559","gff3tabix_genes","m15",""],1
-match1 ["ctgA%3A1050..3202","gff3tabix_genes","agt830.5","Match1"],1
-match2 ["ctgA%3A5410..7503","gff3tabix_genes","agt830.3","Match2"],1
-match3 ["ctgA%3A1050..7300","gff3tabix_genes","agt221.5","Match3"],1
-match4 ["ctgA%3A7500..8000","gff3tabix_genes","agt221.3","Match4"],1
-match5 ["ctgA%3A1150..7200","gff3tabix_genes","agt767.5","Match5"],1
-match6 ["ctgA%3A8000..9000","gff3tabix_genes","agt767.3","Match6"],1
-mrna1 ["ctgA%3A1201..1500","single_exon_gene","","mRNA1"],1
-mrna2 ["ctgA%3A1201..3902","single_exon_gene","","mRNA2"],1
-protein:hga ["ctgA%3A1200..1900","gff3tabix_genes","Protein%3AHGA",""],1
-protein:hgb ["ctgA%3A1800..2900","gff3tabix_genes","Protein%3AHGB",""],1
-remark:hga ["ctgA%3A1000..2000","gff3tabix_genes","Remark%3Ahga",""],1
-rna-apple3 ["ctgA%3A17400..23000","gff3tabix_genes","Apple3","rna-Apple3"],1
+m01 ["ctgA%3A48253..48366"|"gff3tabix_genes"|"m01"|""],1
+m02 ["ctgA%3A28332..30033"|"gff3tabix_genes"|"m02"|""],1
+m03 ["ctgA%3A15396..16159"|"gff3tabix_genes"|"m03"|""],1
+m04 ["ctgA%3A33325..35791"|"gff3tabix_genes"|"m04"|""],1
+m05 ["ctgA%3A13801..14007"|"gff3tabix_genes"|"m05"|""],1
+m06 ["ctgA%3A30578..31748"|"gff3tabix_genes"|"m06"|""],1
+m07 ["ctgA%3A18048..18552"|"gff3tabix_genes"|"m07"|""],1
+m08 ["ctgA%3A17023..17675"|"gff3tabix_genes"|"m08"|""],1
+m09 ["ctgA%3A46012..48851"|"gff3tabix_genes"|"m09"|""],1
+m10 ["ctgA%3A28342..28447"|"gff3tabix_genes"|"m10"|""],1
+m11 ["ctgA%3A11911..15561"|"gff3tabix_genes"|"m11"|""],1
+m12 ["ctgA%3A21748..25612"|"gff3tabix_genes"|"m12"|""],1
+m13 ["ctgA%3A17667..17690"|"gff3tabix_genes"|"m13"|""],1
+m14 ["ctgA%3A14731..17239"|"gff3tabix_genes"|"m14"|""],1
+m15 ["ctgA%3A37497..40559"|"gff3tabix_genes"|"m15"|""],1
+match1 ["ctgA%3A1050..3202"|"gff3tabix_genes"|"agt830.5"|"Match1"],1
+match2 ["ctgA%3A5410..7503"|"gff3tabix_genes"|"agt830.3"|"Match2"],1
+match3 ["ctgA%3A1050..7300"|"gff3tabix_genes"|"agt221.5"|"Match3"],1
+match4 ["ctgA%3A7500..8000"|"gff3tabix_genes"|"agt221.3"|"Match4"],1
+match5 ["ctgA%3A1150..7200"|"gff3tabix_genes"|"agt767.5"|"Match5"],1
+match6 ["ctgA%3A8000..9000"|"gff3tabix_genes"|"agt767.3"|"Match6"],1
+mrna1 ["ctgA%3A1201..1500"|"single_exon_gene"|""|"mRNA1"],1
+mrna2 ["ctgA%3A1201..3902"|"single_exon_gene"|""|"mRNA2"],1
+protein:hga ["ctgA%3A1200..1900"|"gff3tabix_genes"|"Protein%3AHGA"|""],1
+protein:hgb ["ctgA%3A1800..2900"|"gff3tabix_genes"|"Protein%3AHGB"|""],1
+remark:hga ["ctgA%3A1000..2000"|"gff3tabix_genes"|"Remark%3Ahga"|""],1
+rna-apple3 ["ctgA%3A17400..23000"|"gff3tabix_genes"|"Apple3"|"rna-Apple3"],1
 rs1041740 ["contigA%3A11340..11341","volvox_test_vcf","","rs1041740"],1
 rs10432782 ["contigA%3A7569..7570","volvox_test_vcf","","rs10432782"],1
 rs112989936 ["contigA%3A10684..10685","volvox_test_vcf","","rs112989936"],1
@@ -125,18 +125,18 @@ rs78694163 ["contigA%3A8816..8817","volvox_test_vcf","","rs78694163"],1
 rs80265967 ["contigA%3A10781..10782","volvox_test_vcf","","rs80265967"],1
 rs8133032 ["contigA%3A9525..9526","volvox_test_vcf","","rs8133032"],1
 rs9967983 ["contigA%3A8660..8661","volvox_test_vcf","","rs9967983"],1
-seg01 ["ctgA%3A32329..32359","gff3tabix_genes","seg01",""],1
-seg02 ["ctgA%3A26122..26126","gff3tabix_genes","seg02",""],1 ["ctgA%3A26497..26869","gff3tabix_genes","seg02",""],2 ["ctgA%3A27201..27325","gff3tabix_genes","seg02",""],3 ["ctgA%3A27372..27433","gff3tabix_genes","seg02",""],4 ["ctgA%3A27565..27565","gff3tabix_genes","seg02",""],5 ["ctgA%3A27813..28091","gff3tabix_genes","seg02",""],6 ["ctgA%3A28093..28201","gff3tabix_genes","seg02",""],7 ["ctgA%3A28329..28377","gff3tabix_genes","seg02",""],8 ["ctgA%3A28829..29194","gff3tabix_genes","seg02",""],9 ["ctgA%3A29517..29702","gff3tabix_genes","seg02",""],10 ["ctgA%3A29713..30061","gff3tabix_genes","seg02",""],11 ["ctgA%3A30329..30774","gff3tabix_genes","seg02",""],12 ["ctgA%3A30808..31306","gff3tabix_genes","seg02",""],13 ["ctgA%3A31516..31729","gff3tabix_genes","seg02",""],14 ["ctgA%3A31753..32154","gff3tabix_genes","seg02",""],15 ["ctgA%3A32595..32696","gff3tabix_genes","seg02",""],16 ["ctgA%3A32892..32901","gff3tabix_genes","seg02",""],17 ["ctgA%3A33127..33388","gff3tabix_genes","seg02",""],18 ["ctgA%3A33439..33443","gff3tabix_genes","seg02",""],19 ["ctgA%3A33759..34209","gff3tabix_genes","seg02",""],20 ["ctgA%3A34401..34466","gff3tabix_genes","seg02",""],21
-seg03 ["ctgA%3A6885..7241","gff3tabix_genes","seg03",""],1 ["ctgA%3A7410..7737","gff3tabix_genes","seg03",""],2 ["ctgA%3A8055..8080","gff3tabix_genes","seg03",""],3 ["ctgA%3A8306..8999","gff3tabix_genes","seg03",""],4
-seg04 ["ctgA%3A5233..5302","gff3tabix_genes","seg04",""],1 ["ctgA%3A5800..6101","gff3tabix_genes","seg04",""],2 ["ctgA%3A6442..6854","gff3tabix_genes","seg04",""],3 ["ctgA%3A7106..7211","gff3tabix_genes","seg04",""],4 ["ctgA%3A7695..8177","gff3tabix_genes","seg04",""],5 ["ctgA%3A8545..8783","gff3tabix_genes","seg04",""],6 ["ctgA%3A8869..8935","gff3tabix_genes","seg04",""],7 ["ctgA%3A9404..9825","gff3tabix_genes","seg04",""],8
-seg05 ["ctgA%3A26503..26799","gff3tabix_genes","seg05",""],1 ["ctgA%3A27172..27185","gff3tabix_genes","seg05",""],2 ["ctgA%3A27448..27860","gff3tabix_genes","seg05",""],3 ["ctgA%3A27887..28076","gff3tabix_genes","seg05",""],4 ["ctgA%3A28225..28316","gff3tabix_genes","seg05",""],5 ["ctgA%3A28777..29058","gff3tabix_genes","seg05",""],6 ["ctgA%3A29513..29647","gff3tabix_genes","seg05",""],7 ["ctgA%3A30108..30216","gff3tabix_genes","seg05",""],8 ["ctgA%3A30465..30798","gff3tabix_genes","seg05",""],9 ["ctgA%3A31232..31236","gff3tabix_genes","seg05",""],10 ["ctgA%3A31421..31817","gff3tabix_genes","seg05",""],11 ["ctgA%3A32010..32057","gff3tabix_genes","seg05",""],12 ["ctgA%3A32208..32680","gff3tabix_genes","seg05",""],13 ["ctgA%3A33053..33325","gff3tabix_genes","seg05",""],14 ["ctgA%3A33438..33868","gff3tabix_genes","seg05",""],15 ["ctgA%3A34244..34313","gff3tabix_genes","seg05",""],16 ["ctgA%3A34605..34983","gff3tabix_genes","seg05",""],17 ["ctgA%3A35333..35507","gff3tabix_genes","seg05",""],18 ["ctgA%3A35642..35904","gff3tabix_genes","seg05",""],19
-seg06 ["ctgA%3A19249..19559","gff3tabix_genes","seg06",""],1 ["ctgA%3A19975..20260","gff3tabix_genes","seg06",""],2 ["ctgA%3A20379..20491","gff3tabix_genes","seg06",""],3 ["ctgA%3A20533..21005","gff3tabix_genes","seg06",""],4 ["ctgA%3A21122..21331","gff3tabix_genes","seg06",""],5 ["ctgA%3A21682..22176","gff3tabix_genes","seg06",""],6 ["ctgA%3A22374..22570","gff3tabix_genes","seg06",""],7 ["ctgA%3A23025..23427","gff3tabix_genes","seg06",""],8
-seg07 ["ctgA%3A44191..44514","gff3tabix_genes","seg07",""],1 ["ctgA%3A44552..45043","gff3tabix_genes","seg07",""],2 ["ctgA%3A45373..45600","gff3tabix_genes","seg07",""],3 ["ctgA%3A45897..46315","gff3tabix_genes","seg07",""],4 ["ctgA%3A46491..46890","gff3tabix_genes","seg07",""],5 ["ctgA%3A47126..47297","gff3tabix_genes","seg07",""],6 ["ctgA%3A47735..47983","gff3tabix_genes","seg07",""],7 ["ctgA%3A48447..48709","gff3tabix_genes","seg07",""],8 ["ctgA%3A48931..49186","gff3tabix_genes","seg07",""],9 ["ctgA%3A49472..49699","gff3tabix_genes","seg07",""],10 ["ctgA%3A49957..50000","gff3tabix_genes","seg07",""],11 ["ctgA%3A49957..50000","gff3tabix_genes","seg07",""],12
-seg08 ["ctgA%3A18509..18985","gff3tabix_genes","seg08",""],1 ["ctgA%3A18989..19388","gff3tabix_genes","seg08",""],2 ["ctgA%3A19496..19962","gff3tabix_genes","seg08",""],3 ["ctgA%3A20093..20580","gff3tabix_genes","seg08",""],4 ["ctgA%3A20970..21052","gff3tabix_genes","seg08",""],5 ["ctgA%3A21270..21277","gff3tabix_genes","seg08",""],6 ["ctgA%3A21685..22168","gff3tabix_genes","seg08",""],7 ["ctgA%3A22564..22869","gff3tabix_genes","seg08",""],8 ["ctgA%3A22958..23298","gff3tabix_genes","seg08",""],9 ["ctgA%3A23412..23469","gff3tabix_genes","seg08",""],10 ["ctgA%3A23932..23932","gff3tabix_genes","seg08",""],11 ["ctgA%3A24328..24787","gff3tabix_genes","seg08",""],12 ["ctgA%3A25228..25367","gff3tabix_genes","seg08",""],13
-seg09 ["ctgA%3A36616..37057","gff3tabix_genes","seg09",""],1 ["ctgA%3A37208..37227","gff3tabix_genes","seg09",""],2
-seg10 ["ctgA%3A29771..29942","gff3tabix_genes","seg10",""],1 ["ctgA%3A30042..30340","gff3tabix_genes","seg10",""],2 ["ctgA%3A30810..31307","gff3tabix_genes","seg10",""],3 ["ctgA%3A31761..31984","gff3tabix_genes","seg10",""],4 ["ctgA%3A32374..32937","gff3tabix_genes","seg10",""],5
-seg11 ["ctgA%3A24228..24510","gff3tabix_genes","seg11",""],1 ["ctgA%3A24868..25012","gff3tabix_genes","seg11",""],2 ["ctgA%3A25212..25426","gff3tabix_genes","seg11",""],3 ["ctgA%3A25794..25874","gff3tabix_genes","seg11",""],4 ["ctgA%3A26075..26519","gff3tabix_genes","seg11",""],5 ["ctgA%3A26930..26940","gff3tabix_genes","seg11",""],6 ["ctgA%3A26975..27063","gff3tabix_genes","seg11",""],7 ["ctgA%3A27415..27799","gff3tabix_genes","seg11",""],8 ["ctgA%3A27880..27943","gff3tabix_genes","seg11",""],9 ["ctgA%3A28225..28346","gff3tabix_genes","seg11",""],10 ["ctgA%3A28375..28570","gff3tabix_genes","seg11",""],11 ["ctgA%3A28758..29041","gff3tabix_genes","seg11",""],12 ["ctgA%3A29101..29302","gff3tabix_genes","seg11",""],13 ["ctgA%3A29604..29702","gff3tabix_genes","seg11",""],14 ["ctgA%3A29867..29885","gff3tabix_genes","seg11",""],15 ["ctgA%3A30241..30246","gff3tabix_genes","seg11",""],16 ["ctgA%3A30575..30738","gff3tabix_genes","seg11",""],17
-seg12 ["ctgA%3A12531..12895","gff3tabix_genes","seg12",""],1 ["ctgA%3A13122..13449","gff3tabix_genes","seg12",""],2 ["ctgA%3A13452..13745","gff3tabix_genes","seg12",""],3 ["ctgA%3A13908..13965","gff3tabix_genes","seg12",""],4 ["ctgA%3A13998..14488","gff3tabix_genes","seg12",""],5 ["ctgA%3A14564..14899","gff3tabix_genes","seg12",""],6 ["ctgA%3A15185..15276","gff3tabix_genes","seg12",""],7 ["ctgA%3A15639..15736","gff3tabix_genes","seg12",""],8 ["ctgA%3A15745..15870","gff3tabix_genes","seg12",""],9
-seg13 ["ctgA%3A49406..49476","gff3tabix_genes","seg13",""],1 ["ctgA%3A49762..50000","gff3tabix_genes","seg13",""],2
-seg14 ["ctgA%3A41137..41318","gff3tabix_genes","seg14",""],1 ["ctgA%3A41754..41948","gff3tabix_genes","seg14",""],2 ["ctgA%3A42057..42474","gff3tabix_genes","seg14",""],3 ["ctgA%3A42890..43270","gff3tabix_genes","seg14",""],4 ["ctgA%3A43395..43811","gff3tabix_genes","seg14",""],5 ["ctgA%3A44065..44556","gff3tabix_genes","seg14",""],6 ["ctgA%3A44763..45030","gff3tabix_genes","seg14",""],7 ["ctgA%3A45231..45488","gff3tabix_genes","seg14",""],8 ["ctgA%3A45790..46022","gff3tabix_genes","seg14",""],9 ["ctgA%3A46092..46318","gff3tabix_genes","seg14",""],10 ["ctgA%3A46816..46992","gff3tabix_genes","seg14",""],11 ["ctgA%3A47449..47829","gff3tabix_genes","seg14",""],12
-seg15 ["ctgA%3A39265..39361","gff3tabix_genes","seg15",""],1 ["ctgA%3A39753..40034","gff3tabix_genes","seg15",""],2 ["ctgA%3A40515..40954","gff3tabix_genes","seg15",""],3 ["ctgA%3A41252..41365","gff3tabix_genes","seg15",""],4 ["ctgA%3A41492..41504","gff3tabix_genes","seg15",""],5 ["ctgA%3A41941..42377","gff3tabix_genes","seg15",""],6 ["ctgA%3A42748..42954","gff3tabix_genes","seg15",""],7 ["ctgA%3A43401..43897","gff3tabix_genes","seg15",""],8 ["ctgA%3A44043..44113","gff3tabix_genes","seg15",""],9 ["ctgA%3A44399..44888","gff3tabix_genes","seg15",""],10 ["ctgA%3A45281..45375","gff3tabix_genes","seg15",""],11 ["ctgA%3A45711..46041","gff3tabix_genes","seg15",""],12 ["ctgA%3A46425..46564","gff3tabix_genes","seg15",""],13 ["ctgA%3A46738..47087","gff3tabix_genes","seg15",""],14 ["ctgA%3A47329..47595","gff3tabix_genes","seg15",""],15 ["ctgA%3A47858..47979","gff3tabix_genes","seg15",""],16 ["ctgA%3A48169..48453","gff3tabix_genes","seg15",""],17
+seg01 ["ctgA%3A32329..32359"|"gff3tabix_genes"|"seg01"|""],1
+seg02 ["ctgA%3A26122..26126"|"gff3tabix_genes"|"seg02"|""],1 ["ctgA%3A26497..26869"|"gff3tabix_genes"|"seg02"|""],2 ["ctgA%3A27201..27325"|"gff3tabix_genes"|"seg02"|""],3 ["ctgA%3A27372..27433"|"gff3tabix_genes"|"seg02"|""],4 ["ctgA%3A27565..27565"|"gff3tabix_genes"|"seg02"|""],5 ["ctgA%3A27813..28091"|"gff3tabix_genes"|"seg02"|""],6 ["ctgA%3A28093..28201"|"gff3tabix_genes"|"seg02"|""],7 ["ctgA%3A28329..28377"|"gff3tabix_genes"|"seg02"|""],8 ["ctgA%3A28829..29194"|"gff3tabix_genes"|"seg02"|""],9 ["ctgA%3A29517..29702"|"gff3tabix_genes"|"seg02"|""],10 ["ctgA%3A29713..30061"|"gff3tabix_genes"|"seg02"|""],11 ["ctgA%3A30329..30774"|"gff3tabix_genes"|"seg02"|""],12 ["ctgA%3A30808..31306"|"gff3tabix_genes"|"seg02"|""],13 ["ctgA%3A31516..31729"|"gff3tabix_genes"|"seg02"|""],14 ["ctgA%3A31753..32154"|"gff3tabix_genes"|"seg02"|""],15 ["ctgA%3A32595..32696"|"gff3tabix_genes"|"seg02"|""],16 ["ctgA%3A32892..32901"|"gff3tabix_genes"|"seg02"|""],17 ["ctgA%3A33127..33388"|"gff3tabix_genes"|"seg02"|""],18 ["ctgA%3A33439..33443"|"gff3tabix_genes"|"seg02"|""],19 ["ctgA%3A33759..34209"|"gff3tabix_genes"|"seg02"|""],20 ["ctgA%3A34401..34466"|"gff3tabix_genes"|"seg02"|""],21
+seg03 ["ctgA%3A6885..7241"|"gff3tabix_genes"|"seg03"|""],1 ["ctgA%3A7410..7737"|"gff3tabix_genes"|"seg03"|""],2 ["ctgA%3A8055..8080"|"gff3tabix_genes"|"seg03"|""],3 ["ctgA%3A8306..8999"|"gff3tabix_genes"|"seg03"|""],4
+seg04 ["ctgA%3A5233..5302"|"gff3tabix_genes"|"seg04"|""],1 ["ctgA%3A5800..6101"|"gff3tabix_genes"|"seg04"|""],2 ["ctgA%3A6442..6854"|"gff3tabix_genes"|"seg04"|""],3 ["ctgA%3A7106..7211"|"gff3tabix_genes"|"seg04"|""],4 ["ctgA%3A7695..8177"|"gff3tabix_genes"|"seg04"|""],5 ["ctgA%3A8545..8783"|"gff3tabix_genes"|"seg04"|""],6 ["ctgA%3A8869..8935"|"gff3tabix_genes"|"seg04"|""],7 ["ctgA%3A9404..9825"|"gff3tabix_genes"|"seg04"|""],8
+seg05 ["ctgA%3A26503..26799"|"gff3tabix_genes"|"seg05"|""],1 ["ctgA%3A27172..27185"|"gff3tabix_genes"|"seg05"|""],2 ["ctgA%3A27448..27860"|"gff3tabix_genes"|"seg05"|""],3 ["ctgA%3A27887..28076"|"gff3tabix_genes"|"seg05"|""],4 ["ctgA%3A28225..28316"|"gff3tabix_genes"|"seg05"|""],5 ["ctgA%3A28777..29058"|"gff3tabix_genes"|"seg05"|""],6 ["ctgA%3A29513..29647"|"gff3tabix_genes"|"seg05"|""],7 ["ctgA%3A30108..30216"|"gff3tabix_genes"|"seg05"|""],8 ["ctgA%3A30465..30798"|"gff3tabix_genes"|"seg05"|""],9 ["ctgA%3A31232..31236"|"gff3tabix_genes"|"seg05"|""],10 ["ctgA%3A31421..31817"|"gff3tabix_genes"|"seg05"|""],11 ["ctgA%3A32010..32057"|"gff3tabix_genes"|"seg05"|""],12 ["ctgA%3A32208..32680"|"gff3tabix_genes"|"seg05"|""],13 ["ctgA%3A33053..33325"|"gff3tabix_genes"|"seg05"|""],14 ["ctgA%3A33438..33868"|"gff3tabix_genes"|"seg05"|""],15 ["ctgA%3A34244..34313"|"gff3tabix_genes"|"seg05"|""],16 ["ctgA%3A34605..34983"|"gff3tabix_genes"|"seg05"|""],17 ["ctgA%3A35333..35507"|"gff3tabix_genes"|"seg05"|""],18 ["ctgA%3A35642..35904"|"gff3tabix_genes"|"seg05"|""],19
+seg06 ["ctgA%3A19249..19559"|"gff3tabix_genes"|"seg06"|""],1 ["ctgA%3A19975..20260"|"gff3tabix_genes"|"seg06"|""],2 ["ctgA%3A20379..20491"|"gff3tabix_genes"|"seg06"|""],3 ["ctgA%3A20533..21005"|"gff3tabix_genes"|"seg06"|""],4 ["ctgA%3A21122..21331"|"gff3tabix_genes"|"seg06"|""],5 ["ctgA%3A21682..22176"|"gff3tabix_genes"|"seg06"|""],6 ["ctgA%3A22374..22570"|"gff3tabix_genes"|"seg06"|""],7 ["ctgA%3A23025..23427"|"gff3tabix_genes"|"seg06"|""],8
+seg07 ["ctgA%3A44191..44514"|"gff3tabix_genes"|"seg07"|""],1 ["ctgA%3A44552..45043"|"gff3tabix_genes"|"seg07"|""],2 ["ctgA%3A45373..45600"|"gff3tabix_genes"|"seg07"|""],3 ["ctgA%3A45897..46315"|"gff3tabix_genes"|"seg07"|""],4 ["ctgA%3A46491..46890"|"gff3tabix_genes"|"seg07"|""],5 ["ctgA%3A47126..47297"|"gff3tabix_genes"|"seg07"|""],6 ["ctgA%3A47735..47983"|"gff3tabix_genes"|"seg07"|""],7 ["ctgA%3A48447..48709"|"gff3tabix_genes"|"seg07"|""],8 ["ctgA%3A48931..49186"|"gff3tabix_genes"|"seg07"|""],9 ["ctgA%3A49472..49699"|"gff3tabix_genes"|"seg07"|""],10 ["ctgA%3A49957..50000"|"gff3tabix_genes"|"seg07"|""],11 ["ctgA%3A49957..50000"|"gff3tabix_genes"|"seg07"|""],12
+seg08 ["ctgA%3A18509..18985"|"gff3tabix_genes"|"seg08"|""],1 ["ctgA%3A18989..19388"|"gff3tabix_genes"|"seg08"|""],2 ["ctgA%3A19496..19962"|"gff3tabix_genes"|"seg08"|""],3 ["ctgA%3A20093..20580"|"gff3tabix_genes"|"seg08"|""],4 ["ctgA%3A20970..21052"|"gff3tabix_genes"|"seg08"|""],5 ["ctgA%3A21270..21277"|"gff3tabix_genes"|"seg08"|""],6 ["ctgA%3A21685..22168"|"gff3tabix_genes"|"seg08"|""],7 ["ctgA%3A22564..22869"|"gff3tabix_genes"|"seg08"|""],8 ["ctgA%3A22958..23298"|"gff3tabix_genes"|"seg08"|""],9 ["ctgA%3A23412..23469"|"gff3tabix_genes"|"seg08"|""],10 ["ctgA%3A23932..23932"|"gff3tabix_genes"|"seg08"|""],11 ["ctgA%3A24328..24787"|"gff3tabix_genes"|"seg08"|""],12 ["ctgA%3A25228..25367"|"gff3tabix_genes"|"seg08"|""],13
+seg09 ["ctgA%3A36616..37057"|"gff3tabix_genes"|"seg09"|""],1 ["ctgA%3A37208..37227"|"gff3tabix_genes"|"seg09"|""],2
+seg10 ["ctgA%3A29771..29942"|"gff3tabix_genes"|"seg10"|""],1 ["ctgA%3A30042..30340"|"gff3tabix_genes"|"seg10"|""],2 ["ctgA%3A30810..31307"|"gff3tabix_genes"|"seg10"|""],3 ["ctgA%3A31761..31984"|"gff3tabix_genes"|"seg10"|""],4 ["ctgA%3A32374..32937"|"gff3tabix_genes"|"seg10"|""],5
+seg11 ["ctgA%3A24228..24510"|"gff3tabix_genes"|"seg11"|""],1 ["ctgA%3A24868..25012"|"gff3tabix_genes"|"seg11"|""],2 ["ctgA%3A25212..25426"|"gff3tabix_genes"|"seg11"|""],3 ["ctgA%3A25794..25874"|"gff3tabix_genes"|"seg11"|""],4 ["ctgA%3A26075..26519"|"gff3tabix_genes"|"seg11"|""],5 ["ctgA%3A26930..26940"|"gff3tabix_genes"|"seg11"|""],6 ["ctgA%3A26975..27063"|"gff3tabix_genes"|"seg11"|""],7 ["ctgA%3A27415..27799"|"gff3tabix_genes"|"seg11"|""],8 ["ctgA%3A27880..27943"|"gff3tabix_genes"|"seg11"|""],9 ["ctgA%3A28225..28346"|"gff3tabix_genes"|"seg11"|""],10 ["ctgA%3A28375..28570"|"gff3tabix_genes"|"seg11"|""],11 ["ctgA%3A28758..29041"|"gff3tabix_genes"|"seg11"|""],12 ["ctgA%3A29101..29302"|"gff3tabix_genes"|"seg11"|""],13 ["ctgA%3A29604..29702"|"gff3tabix_genes"|"seg11"|""],14 ["ctgA%3A29867..29885"|"gff3tabix_genes"|"seg11"|""],15 ["ctgA%3A30241..30246"|"gff3tabix_genes"|"seg11"|""],16 ["ctgA%3A30575..30738"|"gff3tabix_genes"|"seg11"|""],17
+seg12 ["ctgA%3A12531..12895"|"gff3tabix_genes"|"seg12"|""],1 ["ctgA%3A13122..13449"|"gff3tabix_genes"|"seg12"|""],2 ["ctgA%3A13452..13745"|"gff3tabix_genes"|"seg12"|""],3 ["ctgA%3A13908..13965"|"gff3tabix_genes"|"seg12"|""],4 ["ctgA%3A13998..14488"|"gff3tabix_genes"|"seg12"|""],5 ["ctgA%3A14564..14899"|"gff3tabix_genes"|"seg12"|""],6 ["ctgA%3A15185..15276"|"gff3tabix_genes"|"seg12"|""],7 ["ctgA%3A15639..15736"|"gff3tabix_genes"|"seg12"|""],8 ["ctgA%3A15745..15870"|"gff3tabix_genes"|"seg12"|""],9
+seg13 ["ctgA%3A49406..49476"|"gff3tabix_genes"|"seg13"|""],1 ["ctgA%3A49762..50000"|"gff3tabix_genes"|"seg13"|""],2
+seg14 ["ctgA%3A41137..41318"|"gff3tabix_genes"|"seg14"|""],1 ["ctgA%3A41754..41948"|"gff3tabix_genes"|"seg14"|""],2 ["ctgA%3A42057..42474"|"gff3tabix_genes"|"seg14"|""],3 ["ctgA%3A42890..43270"|"gff3tabix_genes"|"seg14"|""],4 ["ctgA%3A43395..43811"|"gff3tabix_genes"|"seg14"|""],5 ["ctgA%3A44065..44556"|"gff3tabix_genes"|"seg14"|""],6 ["ctgA%3A44763..45030"|"gff3tabix_genes"|"seg14"|""],7 ["ctgA%3A45231..45488"|"gff3tabix_genes"|"seg14"|""],8 ["ctgA%3A45790..46022"|"gff3tabix_genes"|"seg14"|""],9 ["ctgA%3A46092..46318"|"gff3tabix_genes"|"seg14"|""],10 ["ctgA%3A46816..46992"|"gff3tabix_genes"|"seg14"|""],11 ["ctgA%3A47449..47829"|"gff3tabix_genes"|"seg14"|""],12
+seg15 ["ctgA%3A39265..39361"|"gff3tabix_genes"|"seg15"|""],1 ["ctgA%3A39753..40034"|"gff3tabix_genes"|"seg15"|""],2 ["ctgA%3A40515..40954"|"gff3tabix_genes"|"seg15"|""],3 ["ctgA%3A41252..41365"|"gff3tabix_genes"|"seg15"|""],4 ["ctgA%3A41492..41504"|"gff3tabix_genes"|"seg15"|""],5 ["ctgA%3A41941..42377"|"gff3tabix_genes"|"seg15"|""],6 ["ctgA%3A42748..42954"|"gff3tabix_genes"|"seg15"|""],7 ["ctgA%3A43401..43897"|"gff3tabix_genes"|"seg15"|""],8 ["ctgA%3A44043..44113"|"gff3tabix_genes"|"seg15"|""],9 ["ctgA%3A44399..44888"|"gff3tabix_genes"|"seg15"|""],10 ["ctgA%3A45281..45375"|"gff3tabix_genes"|"seg15"|""],11 ["ctgA%3A45711..46041"|"gff3tabix_genes"|"seg15"|""],12 ["ctgA%3A46425..46564"|"gff3tabix_genes"|"seg15"|""],13 ["ctgA%3A46738..47087"|"gff3tabix_genes"|"seg15"|""],14 ["ctgA%3A47329..47595"|"gff3tabix_genes"|"seg15"|""],15 ["ctgA%3A47858..47979"|"gff3tabix_genes"|"seg15"|""],16 ["ctgA%3A48169..48453"|"gff3tabix_genes"|"seg15"|""],17

--- a/test_data/volvox/trix/volvox_meta.json
+++ b/test_data/volvox/trix/volvox_meta.json
@@ -1,5 +1,5 @@
 {
-  "dateCreated": "Mon Sep 06 2021 14:20:21 GMT-0400 (Eastern Daylight Time)",
+  "dateCreated": "Mon Sep 06 2021 14:47:39 GMT-0400 (Eastern Daylight Time)",
   "tracks": [
     {
       "trackId": "volvox_sv_test",

--- a/test_data/volvox/trix/volvox_meta.json
+++ b/test_data/volvox/trix/volvox_meta.json
@@ -1,5 +1,5 @@
 {
-  "dateCreated": "Fri Aug 27 2021 20:00:35 GMT-0400 (Eastern Daylight Time)",
+  "dateCreated": "Mon Sep 06 2021 14:20:21 GMT-0400 (Eastern Daylight Time)",
   "tracks": [
     {
       "trackId": "volvox_sv_test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     long "^4.0.0"
     quick-lru "^2.0.0"
 
-"@gmod/trix@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@gmod/trix/-/trix-0.2.1.tgz#28e3296e39e18d4cb76d38f274c2ec558fc282a0"
-  integrity sha512-rkQI2K/QXzf0sIjsylcdQUVG/JGIT8K1EkjW4xX1TvUXp2jesngeyo8ZywUjkFHvg4Dtkn073gdYzmca8M8dRw==
+"@gmod/trix@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@gmod/trix/-/trix-0.2.2.tgz#428601d3c79c1bae4555172a986d6dcbc810b28a"
+  integrity sha512-IArGHGLbatpHvV7uOMC3iYcFVa/Q8GLsgkyxwtd++2ZxsGeXxMoEEX8jRmqWJCjkLE2/Fafy5oa7t13MeSQbQw==
 
 "@gmod/twobit@^1.1.10":
   version "1.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13060,10 +13060,10 @@ iterate-value@^1.0.0:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
-ixixx@^1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/ixixx/-/ixixx-1.0.14.tgz#73e9c7386d2ac39334a10f45d8e7c4bd7cb8cdde"
-  integrity sha512-+yd38ikgqZX8Y7rCixV8RadBS8P89JTw1dmAjaEXIkTid+1kkV+xhXFi8GCiOFLFtIzTMRbCVvF7O0ZBaJ0XVA==
+ixixx@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/ixixx/-/ixixx-1.0.15.tgz#e52cd9d18705a5cf8ae5c373b38750f73539e726"
+  integrity sha512-gA2pQjK5PINkAuTapymNp8fy7BsVHYZi+gjlgh0PricM2KH35T9Xq7xKKIXFoJC8my3e7jeLVPZEF9HFHo5g6w==
   dependencies:
     external-sorting "^1.2.0"
     tmp "^0.2.1"


### PR DESCRIPTION
This makes the trix index files about 25% smaller but also, more human readable