### PR TITLE
Fix mouseover selection appearing across unrelated blocks

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -65,8 +65,8 @@ const stateModelFactory = (
           }
         },
 
-        getFeatureByID(id: string) {
-          return self.PileupDisplay.getFeatureByID(id)
+        getFeatureByID(blockKey: string, id: string) {
+          return self.PileupDisplay.getFeatureByID(blockKey, id)
         },
 
         get features() {

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -68,6 +68,9 @@ const stateModelFactory = (
         getFeatureByID(blockKey: string, id: string) {
           return self.PileupDisplay.getFeatureByID(blockKey, id)
         },
+        searchFeatureByID(id: string) {
+          return self.PileupDisplay.searchFeatureByID(id)
+        },
 
         get features() {
           return self.PileupDisplay.features

--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -53,7 +53,7 @@ function PileupRendering(props: {
     }
     ctx.clearRect(0, 0, canvas.width, canvas.height)
     const selectedRect = selectedFeatureId
-      ? displayModel.getFeatureByID?.(selectedFeatureId)
+      ? displayModel.getFeatureByID?.(blockKey, selectedFeatureId)
       : undefined
     if (selectedRect) {
       const [leftBp, topPx, rightBp, bottomPx] = selectedRect
@@ -75,7 +75,7 @@ function PileupRendering(props: {
     }
     const highlightedFeature = featureIdUnderMouse || contextMenuFeature?.id()
     const highlightedRect = highlightedFeature
-      ? displayModel.getFeatureByID?.(highlightedFeature)
+      ? displayModel.getFeatureByID?.(blockKey, highlightedFeature)
       : undefined
     if (highlightedRect) {
       const [leftBp, topPx, rightBp, bottomPx] = highlightedRect
@@ -88,6 +88,7 @@ function PileupRendering(props: {
   }, [
     bpPerPx,
     region,
+    blockKey,
     selectedFeatureId,
     displayModel,
     featureIdUnderMouse,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.test.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.test.tsx
@@ -32,7 +32,7 @@ const getView = () => {
             features: types.frozen(),
           })
           .views(self => ({
-            getFeatureByID(id: string) {
+            searchFeatureByID(id: string) {
               return self.layoutFeatures[id]
             },
           })),

--- a/plugins/breakpoint-split-view/src/model.test.tsx
+++ b/plugins/breakpoint-split-view/src/model.test.tsx
@@ -32,7 +32,7 @@ const getView = () => {
             layoutFeatures: types.frozen(),
           })
           .views(self => ({
-            getFeatureByID(id: string) {
+            searchFeatureByID(id: string) {
               return self.layoutFeatures[id]
             },
           })),

--- a/plugins/breakpoint-split-view/src/model.ts
+++ b/plugins/breakpoint-split-view/src/model.ts
@@ -231,7 +231,7 @@ export default function stateModelFactory(pluginManager: any) {
         const tracks = this.getMatchedTracks(trackConfigId)
 
         const calc = (track: any, feat: Feature) => {
-          return track.displays[0].getFeatureByID(feat.id())
+          return track.displays[0].searchFeatureByID(feat.id())
         }
 
         return features.map(c =>

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -142,6 +142,18 @@ export const BaseLinearDisplay = types
       getFeatureByID(blockKey: string, id: string): LayoutRecord | undefined {
         return self.blockState.get(blockKey)?.layout?.getByID(id)
       },
+
+      // if block key is not supplied, can look at all blocks
+      searchFeatureByID(id: string): LayoutRecord | undefined {
+        let ret
+        self.blockState.forEach(block => {
+          const val = block?.layout?.getByID(id)
+          if (val) {
+            ret = val
+          }
+        })
+        return ret
+      },
     }
   })
   .actions(self => ({

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -139,15 +139,8 @@ export const BaseLinearDisplay = types
         return self.blockState.get(blockKey)?.layout?.getByCoord(x, y)
       },
 
-      getFeatureByID(id: string): [number, number, number, number] | undefined {
-        let ret
-        self.blockState.forEach(block => {
-          const val = block?.layout?.getByID(id)
-          if (val) {
-            ret = val
-          }
-        })
-        return ret
+      getFeatureByID(blockKey: string, id: string): LayoutRecord | undefined {
+        return self.blockState.get(blockKey)?.layout?.getByID(id)
       },
     }
   })

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
@@ -8,7 +8,7 @@ type LayoutRecord = [number, number, number, number]
 interface SvgOverlayProps {
   region: Region
   displayModel: {
-    getFeatureByID: (arg0: string) => LayoutRecord
+    getFeatureByID: (arg0: string, arg1: string) => LayoutRecord
     selectedFeatureId?: string
     featureIdUnderMouse?: string
     contextMenuFeature?: SimpleFeature
@@ -215,7 +215,7 @@ function SvgOverlay({
     <>
       {mouseoverFeatureId ? (
         <OverlayRect
-          rect={displayModel.getFeatureByID?.(mouseoverFeatureId)}
+          rect={displayModel.getFeatureByID?.(blockKey, mouseoverFeatureId)}
           region={region}
           bpPerPx={bpPerPx}
           fill="#000"
@@ -236,7 +236,7 @@ function SvgOverlay({
       ) : null}
       {selectedFeatureId ? (
         <OverlayRect
-          rect={displayModel.getFeatureByID?.(selectedFeatureId)}
+          rect={displayModel.getFeatureByID?.(blockKey, selectedFeatureId)}
           region={region}
           bpPerPx={bpPerPx}
           stroke="#00b8ff"


### PR DESCRIPTION
Fixes #2308

The code mistakenly looked across blocks for feature highlights, resulting in feature highlights appearing in the wrong block

Was a bug introduced around the time of the this layout related PR #2099 (introduced bug in v1.3.1)