### PR TITLE
Add cancer demos to the demos page on website

### DIFF
--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -686,6 +686,34 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "ngmlr_splitters_cram",
+      "name": "SKBR3 pacbio (NGMLR) splitters only (CRAM)",
+      "assemblyNames": ["hg19"],
+      "category": ["SKBR3"],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/skbr3/reads_lr_skbr3.fa_ngmlr-0.2.3_mapped.splitters.cram"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/skbr3/reads_lr_skbr3.fa_ngmlr-0.2.3_mapped.splitters.cram.crai"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "ngmlr_downsample",
       "name": "SKBR3 pacbio (NGMLR) 0.3 downsample",
       "assemblyNames": ["hg19"],

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -27,6 +27,12 @@ Demo instances
 - <Link extra="?config=test_data/config_demo.json&session=share-oTyYRpz9fN&password=fYAbt">
     Human instance with HG002 insertion shown (many other tracks available too)
   </Link>
+- <Link extra="?config=test_data%2Fconfig_demo.json&session=share-pjaAq1hNxB&password=Z9teR">
+    SKBR3 breast cancer cell line translocation
+  </Link>
+- <Link extra="?config=test_data%2Fconfig_demo.json&session=share-MZj3d18lzH&password=3X7bS">
+    COLO829 melanoma tumor vs normal coverage profile
+  </Link>
 - <Link extra="?config=test_data%2Fconfig_demo.json&session=share-XyL52LPDoO&password=861E4">
     Human instance coloring methylation/modifications on nanopore reads
   </Link>


### PR DESCRIPTION
Adds a SKBR3 demo (breakpoint split view + sv inspector) and a COLO829 demo (tumor vs normal coverage profile) to the demos page