### PR TITLE
Fix issue where add track widget doesn't infer adapters the second time around

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -99,7 +99,7 @@ const UrlChooser = (props: {
       fullWidth
       inputProps={{ 'data-testid': 'urlInput' }}
       defaultValue={location && isUriLocation(location) ? location.uri : ''}
-      onChange={event => setLocation({ uri: event.target.value })}
+      onChange={event => setLocation({ uri: event.target.value.trim() })}
     />
   )
 }

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -8,7 +8,7 @@ import {
   UNSUPPORTED,
 } from '@jbrowse/core/util/tracks'
 
-function isAbsoluteUrl(url: string) {
+function isAbsoluteUrl(url = '') {
   try {
     new URL(url)
     return true
@@ -79,8 +79,8 @@ export default function f(pluginManager: PluginManager) {
         self.altTrackType = ''
         self.altAssemblyName = ''
         self.adapterHint = ''
-        self.indexTrackData = { uri: '' }
-        self.trackData = { uri: '' }
+        self.indexTrackData = undefined
+        self.trackData = undefined
       },
     }))
     .views(self => ({
@@ -102,30 +102,32 @@ export default function f(pluginManager: PluginManager) {
       get isFtp() {
         const { trackData: track, indexTrackData: index } = self
         return !!(
-          (index && 'uri' in index && index.uri.startsWith('ftp://')) ||
-          (track && 'uri' in track && track.uri.startsWith('ftp://'))
+          // @ts-ignore
+          (index?.uri?.startsWith('ftp://') || track?.uri?.startsWith('ftp://'))
         )
       },
 
       get isRelativeTrackUrl() {
-        const { trackData } = self
-        return trackData && 'uri' in trackData && !isAbsoluteUrl(trackData.uri)
+        // @ts-ignore
+        const uri = self.trackData?.uri
+        return uri ? !isAbsoluteUrl(uri) : false
       },
       get isRelativeIndexUrl() {
-        const { indexTrackData: index } = self
-        return index && 'uri' in index && !isAbsoluteUrl(index.uri)
+        // @ts-ignore
+        const uri = self.indexTrackData?.uri
+        return uri ? !isAbsoluteUrl(uri) : false
       },
       get isRelativeUrl() {
         return this.isRelativeIndexUrl || this.isRelativeTrackUrl
       },
 
       get trackHttp() {
-        const { trackData: track } = self
-        return track && 'uri' in track && track.uri.startsWith('http://')
+        // @ts-ignore
+        return self.trackData?.uri?.startsWith('http://')
       },
       get indexHttp() {
-        const { indexTrackData: index } = self
-        return index && 'uri' in index && index.uri.startsWith('http://')
+        // @ts-ignore
+        return self.indexTrackData?.uri?.startsWith('http://')
       },
 
       get wrongProtocol() {


### PR DESCRIPTION
The add track model improperly "clears" the trackData and indexTrackData state and this makes it so that the second time you use the form, the inference doesn't work

This fixes that

It also trims whitespace from the filename which fixes when you copy and paste with a string that has a space at the end or similar