### PR TITLE
Add show descriptions toggle box to most feature tracks

### DIFF
--- a/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
@@ -17,6 +17,7 @@ const stateModelFactory = (configSchema: AnyConfigurationSchemaType) =>
       types.model({
         type: types.literal('LinearBasicDisplay'),
         trackShowLabels: types.maybe(types.boolean),
+        trackShowDescriptions: types.maybe(types.boolean),
         trackDisplayMode: types.maybe(types.string),
         trackMaxHeight: types.maybe(types.number),
         configuration: ConfigurationReference(configSchema),
@@ -32,6 +33,13 @@ const stateModelFactory = (configSchema: AnyConfigurationSchemaType) =>
         return self.trackShowLabels !== undefined
           ? self.trackShowLabels
           : showLabels
+      },
+
+      get showDescriptions() {
+        const showDescriptions = getConf(self, ['renderer', 'showLabels'])
+        return self.trackShowDescriptions !== undefined
+          ? self.trackShowDescriptions
+          : showDescriptions
       },
 
       get maxHeight() {
@@ -54,6 +62,7 @@ const stateModelFactory = (configSchema: AnyConfigurationSchemaType) =>
           {
             ...configBlob,
             showLabels: this.showLabels,
+            showDescriptions: this.showDescriptions,
             displayMode: this.displayMode,
             maxHeight: this.maxHeight,
           },
@@ -65,6 +74,9 @@ const stateModelFactory = (configSchema: AnyConfigurationSchemaType) =>
     .actions(self => ({
       toggleShowLabels() {
         self.trackShowLabels = !self.showLabels
+      },
+      toggleShowDescriptions() {
+        self.trackShowDescriptions = !self.showDescriptions
       },
       setDisplayMode(val: string) {
         self.trackDisplayMode = val
@@ -98,6 +110,15 @@ const stateModelFactory = (configSchema: AnyConfigurationSchemaType) =>
               checked: self.showLabels,
               onClick: () => {
                 self.toggleShowLabels()
+              },
+            },
+            {
+              label: 'Show descriptions',
+              icon: VisibilityIcon,
+              type: 'checkbox',
+              checked: self.showDescriptions,
+              onClick: () => {
+                self.toggleShowDescriptions()
               },
             },
             {

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -45,6 +45,7 @@ function RenderedFeatureGlyph(props) {
   let expansion
   if (labelsAllowed) {
     const showLabels = readConfObject(config, 'showLabels')
+    const showDescriptions = readConfObject(config, 'showDescriptions')
     fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature })
     expansion = readConfObject(config, 'maxFeatureGlyphExpansion') || 0
     name = readConfObject(config, ['labels', 'name'], { feature }) || ''
@@ -52,7 +53,8 @@ function RenderedFeatureGlyph(props) {
 
     description =
       readConfObject(config, ['labels', 'description'], { feature }) || ''
-    shouldShowDescription = /\S/.test(description) && showLabels
+    shouldShowDescription =
+      /\S/.test(description) && showLabels && showDescriptions
 
     let nameWidth = 0
     if (shouldShowName) {

--- a/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
@@ -34,6 +34,10 @@ export default ConfigurationSchema(
       type: 'boolean',
       defaultValue: true,
     },
+    showDescriptions: {
+      type: 'boolean',
+      defaultValue: true,
+    },
     labels: ConfigurationSchema('SvgFeatureLabels', {
       name: {
         type: 'string',


### PR DESCRIPTION
There is currently a "Show labels" toggle box that hides both label and description

This adds a "Show description" toggle box that just hides the description part of the feature label