### PR TITLE
Remove session related menu items from jbrowse-desktop

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -99,6 +99,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   DialogProps: any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setDialogComponent: (dlg?: DialogComponentType, props?: any) => void
+  name: string
 }
 export function isSessionModel(thing: unknown): thing is AbstractSessionModel {
   return (

--- a/plugins/menus/src/index.ts
+++ b/plugins/menus/src/index.ts
@@ -2,20 +2,11 @@ import { lazy } from 'react'
 import WidgetType from '@jbrowse/core/pluggableElementTypes/WidgetType'
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
-import {
-  AbstractSessionModel,
-  SessionWithWidgets,
-  isAbstractMenuManager,
-} from '@jbrowse/core/util'
-import FileCopyIcon from '@material-ui/icons/FileCopy'
-import FolderOpenIcon from '@material-ui/icons/FolderOpen'
-import GetAppIcon from '@material-ui/icons/GetApp'
+import { SessionWithWidgets, isAbstractMenuManager } from '@jbrowse/core/util'
+
 import HelpIcon from '@material-ui/icons/Help'
 import InfoIcon from '@material-ui/icons/Info'
-import PublishIcon from '@material-ui/icons/Publish'
-import SaveIcon from '@material-ui/icons/Save'
-import { saveAs } from 'file-saver'
-import { getSnapshot, IAnyStateTreeNode } from 'mobx-state-tree'
+
 import {
   configSchema as aboutConfigSchema,
   stateModel as aboutStateModel,
@@ -104,76 +95,6 @@ export default class extends Plugin {
           session.showWidget(widget)
         },
       })
-      pluginManager.rootModel.insertInMenu(
-        'File',
-        {
-          label: 'Export session',
-          icon: GetAppIcon,
-          onClick: (session: IAnyStateTreeNode) => {
-            const sessionBlob = new Blob(
-              [JSON.stringify({ session: getSnapshot(session) }, null, 2)],
-              { type: 'text/plain;charset=utf-8' },
-            )
-            saveAs(sessionBlob, 'session.json')
-          },
-        },
-        1,
-      )
-      pluginManager.rootModel.insertInMenu(
-        'File',
-        {
-          label: 'Import session…',
-          icon: PublishIcon,
-          onClick: (session: SessionWithWidgets) => {
-            const widget = session.addWidget(
-              'ImportSessionWidget',
-              'importSessionWidget',
-            )
-            session.showWidget(widget)
-          },
-        },
-        1,
-      )
-      pluginManager.rootModel.insertInMenu(
-        'File',
-        {
-          label: 'Open session…',
-          icon: FolderOpenIcon,
-          onClick: (session: SessionWithWidgets) => {
-            const widget = session.addWidget('SessionManager', 'sessionManager')
-            session.showWidget(widget)
-          },
-        },
-        1,
-      )
-      pluginManager.rootModel.insertInMenu(
-        'File',
-        {
-          label: 'Save session',
-          icon: SaveIcon,
-          onClick: (session: SessionWithWidgets) => {
-            // @ts-ignore
-            if (session.saveSessionToLocalStorage) {
-              // @ts-ignore
-              session.saveSessionToLocalStorage()
-              // @ts-ignore
-              session.notify(`Saved session "${session.name}"`, 'success')
-            }
-          },
-        },
-        1,
-      )
-      pluginManager.rootModel.insertInMenu(
-        'File',
-        {
-          label: 'Duplicate session',
-          icon: FileCopyIcon,
-          onClick: (session: AbstractSessionModel) => {
-            session.duplicateCurrentSession?.()
-          },
-        },
-        1,
-      )
     }
   }
 }

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "rescripts --max-http-header-size=100000 start",
     "build": "cross-env NODE_OPTIONS='--max-old-space-size=7000' rescripts build",
+    "postbuild": "node -e \"fs.writeFileSync('build/version.txt',JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version)\"",
     "test": "rescripts test",
     "eject": "rescripts eject",
     "checktypes": "tsc --noEmit",

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -26,6 +26,66 @@ Array [
             "render": [Function],
           },
         },
+        "label": "Import session…",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Export session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Open session…",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Save session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Duplicate session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
         "label": "Return to splash screen",
         "onClick": [Function],
       },
@@ -49,6 +109,66 @@ Array [
           },
         },
         "label": "New session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Import session…",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Export session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Open session…",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Save session",
+        "onClick": [Function],
+      },
+      Object {
+        "icon": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+        },
+        "label": "Duplicate session",
         "onClick": [Function],
       },
       Object {

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -17,20 +17,27 @@ import {
   SnapshotIn,
   types,
 } from 'mobx-state-tree'
+
+import { saveAs } from 'file-saver'
 import { observable, autorun } from 'mobx'
-// jbrowse
 import assemblyManagerFactory, {
   assemblyConfigSchemas as AssemblyConfigSchemasFactory,
 } from '@jbrowse/core/assemblyManager'
 import PluginManager from '@jbrowse/core/PluginManager'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'
 import TextSearchManager from '@jbrowse/core/TextSearch/TextSearchManager'
-import { AbstractSessionModel } from '@jbrowse/core/util'
-// material ui
+import { AbstractSessionModel, SessionWithWidgets } from '@jbrowse/core/util'
 import { MenuItem } from '@jbrowse/core/ui'
+
+// icons
 import AddIcon from '@material-ui/icons/Add'
 import SettingsIcon from '@material-ui/icons/Settings'
 import AppsIcon from '@material-ui/icons/Apps'
+import FileCopyIcon from '@material-ui/icons/FileCopy'
+import FolderOpenIcon from '@material-ui/icons/FolderOpen'
+import GetAppIcon from '@material-ui/icons/GetApp'
+import PublishIcon from '@material-ui/icons/Publish'
+import SaveIcon from '@material-ui/icons/Save'
 
 // other
 import corePlugins from './corePlugins'
@@ -341,6 +348,59 @@ export default function RootModel(
                   localStorage.setItem(self.previousAutosaveId, lastAutosave)
                 }
                 session.setDefaultSession()
+              },
+            },
+            {
+              label: 'Import session…',
+              icon: PublishIcon,
+              onClick: (session: SessionWithWidgets) => {
+                const widget = session.addWidget(
+                  'ImportSessionWidget',
+                  'importSessionWidget',
+                )
+                session.showWidget(widget)
+              },
+            },
+            {
+              label: 'Export session',
+              icon: GetAppIcon,
+              onClick: (session: IAnyStateTreeNode) => {
+                const sessionBlob = new Blob(
+                  [JSON.stringify({ session: getSnapshot(session) }, null, 2)],
+                  { type: 'text/plain;charset=utf-8' },
+                )
+                saveAs(sessionBlob, 'session.json')
+              },
+            },
+            {
+              label: 'Open session…',
+              icon: FolderOpenIcon,
+              onClick: (session: SessionWithWidgets) => {
+                const widget = session.addWidget(
+                  'SessionManager',
+                  'sessionManager',
+                )
+                session.showWidget(widget)
+              },
+            },
+            {
+              label: 'Save session',
+              icon: SaveIcon,
+              onClick: (session: SessionWithWidgets) => {
+                // @ts-ignore
+                if (session.saveSessionToLocalStorage) {
+                  // @ts-ignore
+                  session.saveSessionToLocalStorage()
+                  // @ts-ignore
+                  session.notify(`Saved session "${session.name}"`, 'success')
+                }
+              },
+            },
+            {
+              label: 'Duplicate session',
+              icon: FileCopyIcon,
+              onClick: (session: AbstractSessionModel) => {
+                session.duplicateCurrentSession?.()
               },
             },
             {

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -387,13 +387,8 @@ export default function RootModel(
               label: 'Save session',
               icon: SaveIcon,
               onClick: (session: SessionWithWidgets) => {
-                // @ts-ignore
-                if (session.saveSessionToLocalStorage) {
-                  // @ts-ignore
-                  session.saveSessionToLocalStorage()
-                  // @ts-ignore
-                  session.notify(`Saved session "${session.name}"`, 'success')
-                }
+                self.saveSessionToLocalStorage()
+                session.notify(`Saved session "${session.name}"`, 'success')
               },
             },
             {


### PR DESCRIPTION
The menus plugin adds some menu items by default but it was recognized by @garrettjstevens that maybe the logic doesn't necessarily apply the same way for desktop now that a session on desktop is more like a full config

This removes the session options in the File menu on desktop, and for jbrowse-web, moves the code for adding those menu items to the products/jbrowse-web/ app