### PR TITLE
Fix blogpost url formats

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,10 +56,11 @@ mv tmp.md CHANGELOG.md
 
 # Blog post text
 NOTES=$(cat "$BLOGPOST_DRAFT")
-DATE=$(date +"%Y-%m-%d %H:%M:%S")
+DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
+DATE=$(date +"%Y-%m-%d")
 ## Blogpost run after lerna version, to get the accurate tags
 BLOGPOST_FILENAME=website/blog/${DATE}-${RELEASE_TAG}-release.md
-RELEASE_TAG=$RELEASE_TAG DATE=$DATE NOTES=$NOTES CHANGELOG=$CHANGELOG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
+RELEASE_TAG=$RELEASE_TAG DATE=$DATETIME NOTES=$NOTES CHANGELOG=$CHANGELOG perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' <scripts/blog_template.txt >"$BLOGPOST_FILENAME"
 
 yarn format
 git add .


### PR DESCRIPTION
The current blogpost url format got a little weird in https://github.com/GMOD/jbrowse-components/commit/41b9f3e460dddb9a292986736e71b3ffe8e196de#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389

This was unintentional, it was thought this would just be a datestamp in the blogpost itself

Now the filename is containing date only, blogpost can have datetime