### PR TITLE
Use ../ for all doc links and use trailing slash to fix links

### DIFF
--- a/website/docs/bcc2020_plugin_development.md
+++ b/website/docs/bcc2020_plugin_development.md
@@ -118,7 +118,7 @@ Interaction data is often displayed using arcs to connect enhancer to gene. We
 will create a custom renderer to illustrate this
 
 But what is a renderer? It is code that performs drawing. See the renderer docs
-here for more details [on creating renderers](developer_guide#creating-custom-renderers)
+here for more details [on creating renderers](../developer_guide#creating-custom-renderers)
 
 Let's clone a working arc renderer plugin
 

--- a/website/docs/developer_guide.md
+++ b/website/docs/developer_guide.md
@@ -111,7 +111,7 @@ below
 
 Adapters basically are parsers for a given data format. We will review
 what adapters the alignments plugin has (to write your own adapter,
-see [creating adapters](developer_guide#creating-adapters))
+see [creating adapters](#creating-adapters))
 
 Example adapters: the `@jbrowse/plugin-alignments` plugin creates
 multiple adapter types
@@ -150,7 +150,7 @@ Renderers are a new concept in JBrowse 2, and are related to the concept of
 server side rendering (SSR), but can be used not just on the server but also in
 contexts like the web worker (e.g. the webworker can draw the features to an
 OffscreenCanvas). For more info see [creating
-renderers](developer_guide#creating-custom-renderers)
+renderers](#creating-custom-renderers)
 
 Example renderers: the `@jbrowse/plugin-alignments` exports several
 renderer types
@@ -916,7 +916,7 @@ like human chromosomes which have, for example, chr1 vs 1.
 
 Returning the refNames used by a given file or resource allows JBrowse to
 automatically smooth these small naming disparities over. See [reference
-renaming](config_guide#configuring-reference-renaming)
+renaming](../config_guide#configuring-reference-renaming)
 
 #### getFeatures
 
@@ -991,7 +991,7 @@ JBrowse 2 plugins can be used to add new pluggable elements (views, tracks,
 adapters, etc), and to modify behavior of the application by adding code
 that watches the application's state. For the full list of what kinds of
 pluggable element types plugins can add, see the [pluggable
-elements](developer_guide#pluggable-elements) page.
+elements](#pluggable-elements) page.
 
 The first thing that we have is a `src/index.js` which exports a default class
 containing the plugin registration code

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -47,7 +47,7 @@ this.
 
 #### How can I setup JBrowse 2 on my web server
 
-We recommend following the steps in the [quickstart web](quickstart_web) guide.
+We recommend following the steps in the [quickstart web](../quickstart_web) guide.
 
 The general procedure is using the `jbrowse create /var/www/html/jb2` and this
 will download the latest version of jbrowse to your web folder e.g. in
@@ -92,7 +92,7 @@ directory
 For other things, like add-assembly and add-track, you can manually edit the
 config.json, reviewing the config docs and sample configs will be valuable
 
-Understanding the [config basics](config_guide#intro-to-the-configjson) will
+Understanding the [config basics](../config_guide#intro-to-the-configjson) will
 come in handy also because you can manually edit in advanced configs after your
 tracks are loaded however be careful because corrupt configs can produce hard
 to understand errors, because our config system is strongly typed

--- a/website/docs/quickstart_cli.md
+++ b/website/docs/quickstart_cli.md
@@ -14,15 +14,15 @@ the JBrowse CLI.
 :::note
 
 You can also do this configuration with graphical configuration editing
-interface built into JBrowse 2. See that guide [here](quickstart_gui).
+interface built into JBrowse 2. See that guide [here](../quickstart_gui).
 
 :::
 
 ## Pre-requisites
 
-- [JBrowse CLI](quickstart_web#installing-the-cli-tools)
+- [JBrowse CLI](../quickstart_web#installing-the-cli-tools)
 
-- [JBrowse 2 web application](quickstart_web#using-jbrowse-create-to-download-jbrowse-2)
+- [JBrowse 2 web application](../quickstart_web#using-jbrowse-create-to-download-jbrowse-2)
 
 ## Adding a genome assembly
 
@@ -63,7 +63,7 @@ options.
 
 JBrowse 2 also supports other assembly file formats, such as bgzip-compressed
 indexed FASTA (e.g. `.fa.gz`, `.fa.gz.fai`, and `.fa.gz.gzi` files) and 2BIT
-files. See [configuring assemblies](config_guide#assembly-config) for more info
+files. See [configuring assemblies](../config_guide#assembly-config) for more info
 on formats supported for the sequence file.
 
 :::note
@@ -88,7 +88,7 @@ For more info about `bgzip` and `samtools`, see https://www.htslib.org/.
 :::
 
 If you have your JBrowse 2
-[running as described](quickstart_web#running-jbrowse-2) in the JBrowse web
+[running as described](../quickstart_web#running-jbrowse-2) in the JBrowse web
 quickstart, you can refresh the page and an add a linear genome view. You will
 now see your config in the Assembly dropdown.
 
@@ -116,8 +116,8 @@ the file name with the names of your data files.
 For this track we will assume the data is on your computer at the locations
 `/data/volvox.bam` and `/data/volvox.bam.bai`. You can download these file here
 if you want to run this example:
-[BAM](http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.bam) and
-[BAM index](http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.bam.bai).
+[BAM](https://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.bam) and
+[BAM index](https://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.bam.bai).
 
 To add the track, run
 
@@ -151,7 +151,7 @@ For more info about `samtools`, see https://www.htslib.org/.
 :::
 
 If you have your JBrowse 2
-[running as described](quickstart_web#running-jbrowse-2) in the JBrowse web
+[running as described](../quickstart_web#running-jbrowse-2) in the JBrowse web
 quickstart, you can refresh the page and an add a linear genome view of the
 volvox assembly. Then open track selector, and you will see the alignments
 track.
@@ -165,8 +165,8 @@ example, we will use a VCF file for the track. JBrowse 2 expects VCFs to be
 compressed with `bgzip` and indexed. Similar to the above example, we will
 assume the files are at `/data/volvox.vcf.gz` and `/data/volvox.vcf.gz.tbi`. You
 can download these file here:
-[VCF](http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.vcf.gz) and
-[VCF index](http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.vcf.gz.tbi).
+[VCF](https://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.vcf.gz) and
+[VCF index](https://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.vcf.gz.tbi).
 
 To add the track, run
 
@@ -207,7 +207,7 @@ https://www.htslib.org/.
 :::
 
 If you have your JBrowse 2
-[running as described](quickstart_web#running-jbrowse-2) in the JBrowse web
+[running as described](../quickstart_web#running-jbrowse-2) in the JBrowse web
 quickstart, you can refresh the page and an add a linear genome view of the
 volvox assembly. Then open track selector, and you will see the variant track.
 
@@ -218,7 +218,7 @@ volvox assembly. Then open track selector, and you will see the variant track.
 Probably one of the most simple track types to load is a BigWig/BigBed file
 since it does not have any external index file, it is just a single file
 
-An example file is here http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox-sorted.bam.coverage.bw
+An example file is here https://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox-sorted.bam.coverage.bw
 
 ```sh-session
 ## Download bigwig or bigbed file
@@ -258,12 +258,12 @@ This will also update your config.json so after it completes, you can type a
 gene name into the "search box" in the linear genome view or other views and
 quickly navigate to genes by gene name.
 
-See the [text-index](cli#jbrowse-text-index) command docs for more info. Also
-see the [FAQ entries for text searching](faq#text-searching)
+See the [text-index](../cli#jbrowse-text-index) command docs for more info. Also
+see the [FAQ entries for text searching](../faq#text-searching)
 
 ## Conclusion
 
 Now that you have JBrowse configured with an assembly and a couple of tracks,
 you can start customizing it further. Check out the rest of the docs for more
-information, especially the [JBrowse CLI](cli) docs for more details on some of
+information, especially the [JBrowse CLI](../cli) docs for more details on some of
 the steps shown here.

--- a/website/docs/quickstart_gui.md
+++ b/website/docs/quickstart_gui.md
@@ -14,7 +14,7 @@ the JBrowse 2's graphical configuration editing.
 :::note
 
 You can also do this configuration with JBrowse CLI. See that guide
-[here](quickstart_cli).
+[here](../quickstart_cli).
 
 :::
 
@@ -22,9 +22,9 @@ You can also do this configuration with JBrowse CLI. See that guide
 
 This tutorial requires having the following software installed
 
-- [JBrowse CLI](quickstart_web#install-the-cli-tools)
+- [JBrowse CLI](../quickstart_web#install-the-cli-tools)
 
-- [JBrowse 2 web application](quickstart_web#using-jbrowse-create-to-install-jbrowse)
+- [JBrowse 2 web application](../quickstart_web#using-jbrowse-create-to-install-jbrowse)
 
 ## Starting JBrowse 2 admin server
 
@@ -164,9 +164,9 @@ select the currently open session, or any of your previously saved sessions.
 ## Additional resources
 
 There are a number of additional features for configuring JBrowse 2. Make sure
-to refer to the [config guide](config_guide.md) for topics such as
-[adding tracks](config_guide.md#adding-tracks-and-connections) or
-[adding an assembly with the CLI](config_guide.md#adding-an-assembly-with-the-cli)
+to refer to the [config guide](../config_guide) for topics such as
+[adding tracks](../config_guide#adding-tracks-and-connections) or
+[adding an assembly with the CLI](../config_guide#adding-an-assembly-with-the-cli)
 
 ## Conclusion
 

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -135,5 +135,5 @@ Congratulations! You're running JBrowse 2.
 
 Now that JBrowse 2 is set up, you can configure it with your own genomes and
 tracks. There are two ways you can configure JBrowse 2: with the JBrowse CLI
-(guide [here](quickstart_cli)) or with JBrowse 2's built-in graphical
-configuration editing (guide [here](quickstart_gui)).
+(guide [here](../quickstart_cli)) or with JBrowse 2's built-in graphical
+configuration editing (guide [here](../quickstart_gui)).

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -155,7 +155,7 @@ You can now visit http://localhost/jbrowse2 and your genome should be ready!
 This guide is meant to be a super-quick conceptual overview for getting JBrowse
 2 set up, but if you are new to the command line or to jbrowse in general, you
 might want to start with the slightly longer quick-start guide
-[here](quickstart_cli).
+[here](../quickstart_cli).
 
 ## Footnote
 
@@ -164,4 +164,4 @@ compatible" meaning it uses no server code and can run on any static
 website hosting. For example, you can upload the jbrowse folder that we
 prepared here in /var/www/html/jbrowse2 to Amazon S3, and it will work there
 too. See the FAQ for [what webserver do I
-need](faq#what-web-server-do-i-need-to-run-jbrowse-2) for more info.
+need](../faq#what-web-server-do-i-need-to-run-jbrowse-2) for more info.

--- a/website/docs/user_guide.md
+++ b/website/docs/user_guide.md
@@ -26,7 +26,7 @@ You can also use the search box to search by gene name (if it is configured)
 
 In order to enable name searching, you or the admin on the instance will need to
 create a "text index". See the [quickstart
-guide](quickstart_cli#indexing-feature-names-for-searching) for more info.
+guide](../quickstart_cli#indexing-feature-names-for-searching) for more info.
 
 #### Scrolling
 
@@ -86,8 +86,8 @@ as filename+'.bai' for example, but if it is different than this, make sure to
 specify the index file explicitly.
 
 Note: If you are an administrator, you can add tracks with the command line or
-with the admin server [add-track](cli#jbrowse-add-track) or [admin-server
-guide](quickstart_gui)
+with the admin server [add-track](../cli#jbrowse-add-track) or [admin-server
+guide](../quickstart_gui)
 
 ### Sharing sessions
 
@@ -381,7 +381,7 @@ assemblies in the PAFAdapter
 
 <Figure caption="Example of a dotplot visualization of the grape vs the peach genome" src="/img/dotplot.png" />
 
-See the [dotplot configuration](config_guide#dotplot-view-config) for more
+See the [dotplot configuration](../config_guide#dotplot-view-config) for more
 detailed descriptions
 
 ### Opening a linear synteny view
@@ -395,7 +395,7 @@ File->Add->Linear synteny view
 <Figure caption="Example screenshot showing the linear synteny view for grape vs peach" src="/img/linear_synteny.png" />
 
 See the [linear synteny
-configuration](config_guide#configuring-linear-synteny-views) for more details
+configuration](../config_guide#configuring-linear-synteny-views) for more details
 on manually configuring the synteny view
 
 ### Opening a synteny view from a dotplot view
@@ -428,7 +428,7 @@ the Juicebox software suite. It uses the hic-straw module developed by the
 juicebox/igv.js team to visualize it in jbrowse.
 
 Currently configuration options are basic for Hi-C tracks, see
-[configuration](config_guide#hictrack-config) for info about configuring Hi-C
+[configuration](../config_guide#hictrack-config) for info about configuring Hi-C
 tracks
 
 <Figure caption="Screenshot of a Hi-C track" src="/img/hic_track.png" />

--- a/website/docusaurus.config.json
+++ b/website/docusaurus.config.json
@@ -4,6 +4,8 @@
   "url": "https://jbrowse.com",
   "baseUrl": "/jb2/",
   "favicon": "img/favicon.ico",
+  "trailingSlash": true,
+  "onBrokenLinks": "ignore",
   "organizationName": "GMOD",
   "projectName": "jbrowse-components",
   "customFields": {

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,8 @@
     "make": "make -C docs"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.5",
-    "@docusaurus/preset-classic": "^2.0.0-beta.5",
+    "@docusaurus/core": "^2.0.0-beta.6",
+    "@docusaurus/preset-classic": "^2.0.0-beta.6",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.2",
     "acorn": "^8.1.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2034,10 +2034,10 @@
     "@docsearch/css" "3.0.0-alpha.39"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-beta.5", "@docusaurus/core@^2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.5.tgz#a8ccb489d75f777de59fdb698f93de9263928594"
-  integrity sha512-LERPgERVmui0Fb/aIEsd0/1O8VMWW2+vokoPJFHsCswNkk+63C+Ko6luu2z1QoXhbUGAVEJKTb4Z2NAZ5eSF5Q==
+"@docusaurus/core@2.0.0-beta.6", "@docusaurus/core@^2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.6.tgz#9847ae211a04f1d2b057f8e5ba650e76b9c2df83"
+  integrity sha512-XMeI+lJKeJBGYBNOfO/Tc+5FMf21E5p1xZjfe75cgYcfZdERZ+W7aemXquwReno8xxHb4Rnfmi9dxkbOLDjqDA==
   dependencies:
     "@babel/core" "^7.12.16"
     "@babel/generator" "^7.12.15"
@@ -2049,12 +2049,12 @@
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.13"
     "@babel/traverse" "^7.12.13"
-    "@docusaurus/cssnano-preset" "2.0.0-beta.5"
+    "@docusaurus/cssnano-preset" "2.0.0-beta.6"
     "@docusaurus/react-loadable" "5.5.0"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-common" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-common" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     "@slorber/static-site-generator-webpack-plugin" "^4.0.0"
     "@svgr/webpack" "^5.5.0"
     autoprefixer "^10.2.5"
@@ -2119,24 +2119,24 @@
     webpack-merge "^5.8.0"
     webpackbar "^5.0.0-3"
 
-"@docusaurus/cssnano-preset@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.5.tgz#9f0e89662ac470cadf78bb1c90ad746ad5f6d5b3"
-  integrity sha512-qbGj3X5jcAuA/Nr6EKGRFUGYnMXAuuBg0PyJpKGXLi9/wuIGGuuO/FED2L3f9AONWXZmZuwtKQGXeGtVN8sKEg==
+"@docusaurus/cssnano-preset@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.6.tgz#0c277854f0262dca7bcb3daf99866e8a49e29118"
+  integrity sha512-RCizp2NAbADopkX5nUz1xrAbU6hGZzziQk9RdSDGJLzMgVCN6RDotq9odS8VgzNa9x2Lx3WN527UxeEbzc2GVQ==
   dependencies:
     cssnano-preset-advanced "^5.1.1"
     postcss "^8.2.15"
     postcss-sort-media-queries "^3.10.11"
 
-"@docusaurus/mdx-loader@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.5.tgz#e2b0678d52878dcbc0227489526996f67000358a"
-  integrity sha512-6e1SPIIEuXomdpYnP3dkAu/6Y6aInu5vRBBc1GjLvy1RzrX1NTLdQtNdjjaEctP0eyddkyc9tkQwH0p2Wav8Zw==
+"@docusaurus/mdx-loader@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.6.tgz#a5aeee5be0d04bb273752c893366cc6cffeb2b32"
+  integrity sha512-yO6N+OESR77WZ/pXz7muOJGLletYYksx7s7wrwrr0x+A8tzdSwiHZ9op0NyjjpW5AnItU/WQQfcjv37qv4K6HA==
   dependencies:
     "@babel/parser" "^7.12.16"
     "@babel/traverse" "^7.12.13"
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
     chalk "^4.1.1"
@@ -2152,16 +2152,16 @@
     url-loader "^4.1.1"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-content-blog@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.5.tgz#6f9e47eb72d4169ff36a8d0f26348caf18fa48dc"
-  integrity sha512-gZmsBKibSE6/0LeGtpPtcRCvbl8XnRwsWhDGVf13CswnKSwmyE7FWq1ymAzgA4xJx//UamaRzZB9449+l2HVCg==
+"@docusaurus/plugin-content-blog@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.6.tgz#54ae1c96a8e95dbc58484157c259e8aaf47a3fcb"
+  integrity sha512-ohfMt7+rPiFQImc4Clpvc9m/1yWUQAjpG3e/coJywlJYbDXvi1pmH0VKkDUMBSe/35Wtz9457DYgNFG81lhV7Q==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/mdx-loader" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/mdx-loader" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     chalk "^4.1.1"
     escape-string-regexp "^4.0.0"
     feed "^4.2.2"
@@ -2175,16 +2175,16 @@
     tslib "^2.2.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-content-docs@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.5.tgz#22bf5fc4b6dc91019a9393008b3272c763cf9216"
-  integrity sha512-9WXa+UK4/oOnGdk2aWLfE/151v6tf4jgxgRSM+V9jH9FQiluG5APDz0lH62wSTZbl8PjflK5BBhl17tCjGvvgQ==
+"@docusaurus/plugin-content-docs@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.6.tgz#38fd58e42fe39e2a0cc738df077917a6fcd4e7ee"
+  integrity sha512-cM5WWogWmX+qKPKv332eDWGRVVT5OjskbmFKe2QimwoaON3Cv6XY8Fo2xdYopqGIU0r0z8dVtRmoGS0ji7zB7w==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/mdx-loader" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/mdx-loader" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     chalk "^4.1.1"
     combine-promises "^1.1.0"
     escape-string-regexp "^4.0.0"
@@ -2201,76 +2201,77 @@
     utility-types "^3.10.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-content-pages@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.5.tgz#3aa5e752699fcafe9b59b27fe011b7f86453e2af"
-  integrity sha512-1amYXgCc+ZqU8KScwG5zXWIGcy9OdrmmhB6LUuE+vfn+jVOdn8oVTkR8JTVMqmvLhyxmL30ixO06UsstQvKAJQ==
+"@docusaurus/plugin-content-pages@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.6.tgz#254e6ee60a8a2b4d85c4fa8408388d585eea0507"
+  integrity sha512-N6wARzOA8gTFeBXZSKbAN5s1Ej6R/pVg+J946E8GCYefXTFikTNRQ8+OPhax4MRzgzoOvhTQbLbRCSoAzSmjig==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/mdx-loader" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/mdx-loader" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     globby "^11.0.2"
     lodash "^4.17.20"
     remark-admonitions "^1.2.1"
     tslib "^2.1.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-debug@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.5.tgz#649449ccf33209ba0b723361d86459b45e4f760f"
-  integrity sha512-ITrgRNic+NY9HMzUKzYhh6Mz/tgKQjdJYVizA/kbP5pkjB8FunE+0B12km9UNBzuT4ETGdNKgQGAqzrcrjpnag==
+"@docusaurus/plugin-debug@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.6.tgz#dc5ebc3c5c1c144b924ab3282fedbfc44cc78be0"
+  integrity sha512-TJXDBR2Gr/mhBrcj+/4+rTShSm/Qg56Jfezbm/2fFvuPgVlUwy6oj08s2/kYSTmkfG7G+c4iX1GBHjtyo1KxZA==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    fs-extra "^9.1.0"
     react-json-view "^1.21.3"
     tslib "^2.1.0"
 
-"@docusaurus/plugin-google-analytics@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.5.tgz#a54197e7e60ab785dd14fb4e1a02887fc162d9c1"
-  integrity sha512-ncG+SCafoqFhtOMJwk9IZbzZCdy1bgmOjNCSfF6mmDp9laYYJBplBtqItIBQTuycIyKCxznKzi2q8l9989uMrA==
+"@docusaurus/plugin-google-analytics@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.6.tgz#fcb8608c09920131e4dd56b5b343f23cd07a7eee"
+  integrity sha512-AHbMNPN3gkWXYFnmHL9MBcRODByAgzHZoH/5v3xwbSV2FOZo6kx4Hp94I6oFM0o5mp+i6X7slDncgGTWSGxCMg==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
 
-"@docusaurus/plugin-google-gtag@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.5.tgz#415a4f98776e0ece17e96ca7e823022b5bf98316"
-  integrity sha512-FMWAXCLCUwEk7wykOAcM6vs3tHWVIU/T1PElqcoD7fh9521ocZ/5L8yyWWfJ+nX/90TVs+7nOFY0vNl2I2MYZg==
+"@docusaurus/plugin-google-gtag@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.6.tgz#ccde43934d5a193711d118058092d4251965079d"
+  integrity sha512-uJyQ30sXbVRS3TGtVJFA0s1ozrluuREu6NK2Z3TLtKpeT2NTe5iaqXN0Xp749hr3bjbgpEe6gMixVh//jg503w==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
 
-"@docusaurus/plugin-sitemap@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.5.tgz#2ab02a85e66e8b5dd8ce5f19023c005be2ec073b"
-  integrity sha512-QcIIMNmyMnOm5q/zyzidixNIB+yE7/ouUi/62wr5+ZkO/rvvObVe+r9Tdl90SmvsJH17y290EWEy9kunoRyG0w==
+"@docusaurus/plugin-sitemap@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.6.tgz#5dd74bc8a5845c0e7eac7bfce05a18f57e0b3ed2"
+  integrity sha512-jpTaODqyCgg+20RtMw8gSvCKQOvH18FpKhIu6FG+z4zgHP33qaJouVM7/1ZKPrfNt4z7xDOyBNUzzdmpssHA8A==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-common" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-common" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     fs-extra "^10.0.0"
     sitemap "^7.0.0"
     tslib "^2.2.0"
 
-"@docusaurus/preset-classic@^2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.5.tgz#7594167507ee7ff7aa78c3188bab4dfba6e8b551"
-  integrity sha512-hcPLYwMEMDuc/lNloDRh3SKpZneQLaz0Zj8CI7jsislp4iBz9QtbWZzruoXsJe7noSfqsBcTJqRlNw7/UwEyTA==
+"@docusaurus/preset-classic@^2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.6.tgz#528c98939589ae5edfc2a7e01e9f87561e5d5c01"
+  integrity sha512-riqQRcNssNH7oto8nAjYIO79/ZucidexHTDlgD+trP56ploHLJp4kIlxb44IGOmx3es8/z4egWtM+acY/39N2Q==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.5"
-    "@docusaurus/plugin-debug" "2.0.0-beta.5"
-    "@docusaurus/plugin-google-analytics" "2.0.0-beta.5"
-    "@docusaurus/plugin-google-gtag" "2.0.0-beta.5"
-    "@docusaurus/plugin-sitemap" "2.0.0-beta.5"
-    "@docusaurus/theme-classic" "2.0.0-beta.5"
-    "@docusaurus/theme-search-algolia" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.6"
+    "@docusaurus/plugin-debug" "2.0.0-beta.6"
+    "@docusaurus/plugin-google-analytics" "2.0.0-beta.6"
+    "@docusaurus/plugin-google-gtag" "2.0.0-beta.6"
+    "@docusaurus/plugin-sitemap" "2.0.0-beta.6"
+    "@docusaurus/theme-classic" "2.0.0-beta.6"
+    "@docusaurus/theme-search-algolia" "2.0.0-beta.6"
 
 "@docusaurus/react-loadable@5.5.0":
   version "5.5.0"
@@ -2279,20 +2280,20 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.5.tgz#1c51cfc953eb7e3e7da8886ab62f99cd2a8cede0"
-  integrity sha512-AtBifB1mRMI5W0ORlY5M/QEnHUB/wvGLRkLegBbgBAiTy2IGr99GUXRRminQI2AQuFTwYAMLQoSVSeJ0w1q49g==
+"@docusaurus/theme-classic@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.6.tgz#4ae476e90cf875bb13eba5daedbd71d0cfdd8194"
+  integrity sha512-fMb6gAKUdaojInZabimIJE+yPWs8dQfmZII7v/LHmgxafh/FylmrBkKhyJfa2ix4QRibo9E01LGX44/aKzemxw==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.5"
-    "@docusaurus/theme-common" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-common" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.6"
+    "@docusaurus/theme-common" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-common" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
     chalk "^4.1.1"
@@ -2300,7 +2301,7 @@
     copy-text-to-clipboard "^3.0.1"
     fs-extra "^10.0.0"
     globby "^11.0.2"
-    infima "0.2.0-alpha.31"
+    infima "0.2.0-alpha.33"
     lodash "^4.17.20"
     parse-numeric-range "^1.2.0"
     postcss "^8.2.15"
@@ -2310,40 +2311,40 @@
     react-router-dom "^5.2.0"
     rtlcss "^3.1.2"
 
-"@docusaurus/theme-common@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-beta.5.tgz#c6376de88bd0ac6f9803da25ab6212d4b5fc3afb"
-  integrity sha512-6XEM8NzpR2Q42qkhPdI46M/7lLcZcOCgqmQfmj319sGmKkfhPuYPuIUvNqorxldZqLYuV8/9q7WAPjAgj+wawA==
+"@docusaurus/theme-common@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-beta.6.tgz#17cbf38400d752e264cdbebbc57a92f2bdfc7052"
+  integrity sha512-53nFWMjpFdyHEvBfQQQoDm9rNKgGangy7vSp1B/F3+uRyYAItE7O4l8MdOALXFALlddiiPYvCtI1qGx2dnzndA==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.5"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.5"
-    "@docusaurus/types" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.6"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.6"
+    "@docusaurus/types" "2.0.0-beta.6"
     clsx "^1.1.1"
     fs-extra "^10.0.0"
     tslib "^2.1.0"
 
-"@docusaurus/theme-search-algolia@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.5.tgz#889a10e3b849cf3d5a17b3cf735ccdc454a71af6"
-  integrity sha512-+3XG4SHJ4xukvv/WDKRejf3qSTVa3ufOv6hlZ32H8RAmfJmI/Rmsm/oueB86xBw/OkznIXx6M8HzchfYCHWxSA==
+"@docusaurus/theme-search-algolia@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.6.tgz#c92214a075a23fe9fb87cfbc6f037ca07e83f628"
+  integrity sha512-GaaYdf6EEKL3jwmt9LRyiMtNvobOhw4vGuYJKbJcgba/M75kOJSbZPRrhALBAe6o4gOYbV44afzFC/jUUp7dsA==
   dependencies:
     "@docsearch/react" "^3.0.0-alpha.39"
-    "@docusaurus/core" "2.0.0-beta.5"
-    "@docusaurus/theme-common" "2.0.0-beta.5"
-    "@docusaurus/utils" "2.0.0-beta.5"
-    "@docusaurus/utils-validation" "2.0.0-beta.5"
+    "@docusaurus/core" "2.0.0-beta.6"
+    "@docusaurus/theme-common" "2.0.0-beta.6"
+    "@docusaurus/utils" "2.0.0-beta.6"
+    "@docusaurus/utils-validation" "2.0.0-beta.6"
     algoliasearch "^4.8.4"
     algoliasearch-helper "^3.3.4"
     clsx "^1.1.1"
     eta "^1.12.1"
     lodash "^4.17.20"
 
-"@docusaurus/types@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-beta.5.tgz#668ddfaa7f23d74522a58aac99d62436b555fbc6"
-  integrity sha512-WtwR5O67cTK6wo9KnSxqBpgC26M6Z90PgX5Gun/Re8Ix+GVEqIzzev9C/2P2Da2TW0sgSkjWNr1tHaNxNMPLkQ==
+"@docusaurus/types@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-beta.6.tgz#f92a61cc42e5921d325114ebc7b30c5e8c368683"
+  integrity sha512-TrwxyI93XTZEhOmdEI8FPKDbGV61zE9PzXCdE1alwz1NOV+YXwcv+9sRTZEVLqBpr+TIja+IeeS6mxnyen/Ptg==
   dependencies:
     commander "^5.1.0"
     joi "^17.4.0"
@@ -2351,30 +2352,30 @@
     webpack "^5.40.0"
     webpack-merge "^5.8.0"
 
-"@docusaurus/utils-common@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.0-beta.5.tgz#afadd9426372292e0b6d28778613410e3fd58aa4"
-  integrity sha512-LUHEfZ9QGwBCpmGfLiPz5ENipxicsBlzIu+jUuB6I+ljX4Cd2OFkjDVmL0kjHR80sh0KJzNizpjsVj3l3jN9RA==
+"@docusaurus/utils-common@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.0-beta.6.tgz#afd26a9f67b16479058ead66a310738c21293ae5"
+  integrity sha512-MKm6bJxvsYWRl072jLR60z+71tTWSxoERh2eTmCYlegFnu3Tby3HOC8I3jDcC6VpVuoDGsBGNoQbOgy2LqQbXQ==
   dependencies:
-    "@docusaurus/types" "2.0.0-beta.5"
+    "@docusaurus/types" "2.0.0-beta.6"
     tslib "^2.2.0"
 
-"@docusaurus/utils-validation@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.5.tgz#fe7efefdb518bc19fb6cb9c79492bd84cfc4a59a"
-  integrity sha512-VWj1BRYejcGewWP3BKSm3a5dVzQWA9w9MDQUCylR2NxywOxonoUPo9nz5g9bN+C3rwuelfA5u3MORu2q2+rbLw==
+"@docusaurus/utils-validation@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.6.tgz#7b98216de844138e9606a128c09182185ed84621"
+  integrity sha512-v0nk9bpawUd2JFDFyiHDmZuMG+/O1UvxtxvcRbvrxrul+rlzD7Q9CGxMgW3Grp2OCKQ4yFXRidBIccwqON5AVw==
   dependencies:
-    "@docusaurus/utils" "2.0.0-beta.5"
+    "@docusaurus/utils" "2.0.0-beta.6"
     chalk "^4.1.1"
     joi "^17.4.0"
     tslib "^2.1.0"
 
-"@docusaurus/utils@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-beta.5.tgz#68859f070ca6bf7875f4a4121e314269211a876b"
-  integrity sha512-hIzuARFMqXqljTdbF19bYRw+fqqK2gHlzepeC9uJfLLaGmirPFDPjr+BN9oiajBhNx2CgvJVl/66lEx4hrd7uQ==
+"@docusaurus/utils@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-beta.6.tgz#1438df9f28b632fe7a4f50663340b463cff07cab"
+  integrity sha512-S72/o7VDaTvrXJy+NpfuctghGGoMW30m94PMkrL3I6V+o5eE2Uzax7dbM++moclmHvi0/Khv+TXmRIQs6ZvwgQ==
   dependencies:
-    "@docusaurus/types" "2.0.0-beta.5"
+    "@docusaurus/types" "2.0.0-beta.6"
     "@types/github-slugger" "^1.3.0"
     chalk "^4.1.1"
     escape-string-regexp "^4.0.0"
@@ -3221,6 +3222,11 @@ async@^2.6.2:
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -5254,6 +5260,16 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -5887,10 +5903,10 @@ indexes-of@^1.0.1:
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-infima@0.2.0-alpha.31:
-  version "0.2.0-alpha.31"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.31.tgz#c5b66ef1797551471c49b636d6ed270f981d276e"
-  integrity sha512-ggOAeyiQIFKZeYnH9lbhDBHFZhcYOa0LFKSMLgot33X21aJRu7ruwVUVwYg4kJnZRLGLeAjC5BVgLxKoLixuNQ==
+infima@0.2.0-alpha.33:
+  version "0.2.0-alpha.33"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.33.tgz#8d1a77ea916bedcebffa60dcd2dffbe382e09abf"
+  integrity sha512-iLZI8/vGTbbhbeFhlWv1zwvrqfNDLAayuEdqZqNqCyGuh0IW469dRIRm0FLZ98YyLikt2njzuKfy6xUrBWRXcg==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
Currently I found there are links that can end up broken if you click through the docs

Especially if you follow a link someone gives you e.g. https://jbrowse.org/jb2/docs/quickstart_cli#indexing-feature-names-for-searching

And then you go on to click the link to the CLI docs

This fails with a 404

There is a subtle behavior where the browser or server automatically adds a slash


So if you copy and paste https://jbrowse.org/jb2/docs/quickstart_cli into the browser, then it becomes
https://jbrowse.org/jb2/docs/quickstart_cli/
and then navigating to
./cli
is
https://jbrowse.org/jb2/docs/quickstart_cli/cli
when it should be
https://jbrowse.org/jb2/docs/cli

However it is subtle also because currently, clicking on
https://jbrowse.org/jb2/docs/
Then clicking quickstart_cli, gives you
https://jbrowse.org/jb2/docs/quickstart_cli 
No slash is added


This PR takes an approach that is kind of weird

It turns on a setting for trailingSlash, so that a trailingSlash is always added

Then it makes all docs use ../ to refer to each other

This is not a great outcome for doc usability, it is just unclear why the ../ is needed. We could also use absolute paths with / if interested

However, this would fix our issues on the website

I created https://github.com/cmdcolin/docusaurus-nav-issue/blob/master/README.md to demo the issue in docusaurus and a follow up here https://github.com/slorber/trailing-slash-guide/pull/6#issuecomment-919263203