### PR TITLE
Fix bugs preventing embedded circular genome view from rendering in some circumstances

### DIFF
--- a/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.js
+++ b/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.js
@@ -37,7 +37,7 @@ const Chord = observer(function Chord({
   let endPosition
   let endBlock
   const alt = feature.get('ALT')?.[0]
-  const bnd = parseBreakend(alt)
+  const bnd = alt && parseBreakend(alt)
   if (bnd) {
     // VCF BND
     const matePosition = bnd.MatePosition.split(':')
@@ -92,6 +92,7 @@ const Chord = observer(function Chord({
         onMouseOut={evt => {
           if (!selected) {
             evt.target.style.stroke = strokeColor
+            evt.target.style.strokeWidth = 1
           }
         }}
       />

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
@@ -97,7 +97,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
       get views() {
         return [self.view]
       },
-      get renderProps() {
+      renderProps() {
         return { theme: readConfObject(this.configuration, 'theme') }
       },
       get visibleWidget() {


### PR DESCRIPTION
- Handle feature.get('ALT') being undefined so that non-VCF features can be used
- Set stroke width back to 1 when chord is no longer being hovered over
- Make renderProps not a getter to match recent changes