### PR TITLE
Don't sort sequences in FromConfigSequenceAdapter

### DIFF
--- a/plugins/config/src/FromConfigAdapter/FromConfigSequenceAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigSequenceAdapter.ts
@@ -4,7 +4,7 @@ import { NoAssemblyRegion } from '@jbrowse/core/util/types'
 import { toArray } from 'rxjs/operators'
 import FromConfigAdapter from './FromConfigAdapter'
 
-export default class FromSequenceConfigAdapter extends FromConfigAdapter {
+export default class FromConfigSequenceAdapter extends FromConfigAdapter {
   /**
    * Fetch features for a certain region
    * @param region - Region
@@ -72,9 +72,6 @@ export default class FromSequenceConfigAdapter extends FromConfigAdapter {
         regions.push(currentRegion)
       }
     }
-
-    // sort the regions by refName
-    regions.sort((a, b) => a.refName.localeCompare(b.refName))
 
     return regions
   }


### PR DESCRIPTION
A user using the FromConfigSequenceAdapter and the React Circular Genome View noted that it was unexpected that the regions around the circle were not in the same order specified in the adapter config. I agree that this seems unexpected and propose that we don't sort and instead keep the sequences in the same order they are specified.