### PR TITLE
Fix ability to use LocalFile on nodejs-based apps e.g. @jbrowse/img

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/crypto-js": "^4.0.1",
     "@types/d3-scale": "^2.2.0",
     "@types/deep-equal": "^1.0.1",
+    "@types/detect-node": "^2.0.0",
     "@types/dompurify": "^2.0.2",
     "@types/escape-html": "^0.0.20",
     "@types/express": "^4.17.8",

--- a/packages/core/util/io/declare.d.ts
+++ b/packages/core/util/io/declare.d.ts
@@ -1,1 +1,0 @@
-declare module 'detect-node'

--- a/packages/core/util/io/declare.d.ts
+++ b/packages/core/util/io/declare.d.ts
@@ -1,0 +1,1 @@
+declare module 'detect-node'

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -8,7 +8,7 @@ import {
   BlobLocation,
 } from '../types'
 import { getBlob } from '../tracks'
-import { isElectron } from '../../util'
+import isNode from 'detect-node'
 
 export const openUrl = (arg: string) => {
   return rangeFetcherOpenUrl(arg)
@@ -36,7 +36,7 @@ export function openLocation(location: FileLocation): GenericFilehandle {
     if (!location.localPath) {
       throw new Error('No local path provided')
     }
-    if (isElectron || typeof jest !== 'undefined') {
+    if (isNode) {
       return new LocalFile(location.localPath)
     } else {
       throw new Error("can't use local files in the browser")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,6 +4562,11 @@
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"
   integrity sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==
 
+"@types/detect-node@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/detect-node/-/detect-node-2.0.0.tgz#696e024ddd105c72bbc6a2e3f97902a2886f2c3f"
+  integrity sha512-+BozjlbPTACYITf1PWf62HLtDV79HbmZosUN1mv1gGrnjDCRwBXkDKka1sf6YQJvspmfPXVcy+X6tFW62KteeQ==
+
 "@types/dompurify@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.0.2.tgz#94b5c05dc9b8a682a0abb4a8d6f0b82df61baeac"


### PR DESCRIPTION
Currently jb2export is broken on local files because a check for allowing local files, around the time electron was changed to use normal webworker instead of electron windowworkers (79e799fece)


This PR makes it so that LocalFile is allowed anytime the environment detects isNode===true, not just if it is electron (e.g. jb2export is a plain nodejs process)