### PR TITLE
Workaround for Google Drive not exposing Content-Range

### DIFF
--- a/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
+++ b/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
@@ -1,8 +1,28 @@
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { Instance, types } from 'mobx-state-tree'
+import { UriLocation } from '@jbrowse/core/util/types'
+import { RemoteFile, FilehandleOptions, Stats } from 'generic-filehandle'
 import { GoogleDriveOAuthInternetAccountConfigModel } from './configSchema'
 import baseModel from '../OAuthModel/model'
 import { configSchema as OAuthConfigSchema } from '../OAuthModel'
+
+interface GoogleDriveFilehandleOptions extends FilehandleOptions {
+  sizeFetch: Function
+}
+
+class GoogleDriveFile extends RemoteFile {
+  private statsPromise: Promise<{ size: number }>
+  constructor(source: string, opts: GoogleDriveFilehandleOptions) {
+    super(source, opts)
+    this.statsPromise = opts
+      .sizeFetch(source)
+      .then((response: Response) => response.json())
+  }
+
+  async stat(): Promise<Stats> {
+    return this.statsPromise
+  }
+}
 
 const stateModelFactory = (
   configSchema: GoogleDriveOAuthInternetAccountConfigModel,
@@ -22,32 +42,68 @@ const stateModelFactory = (
         return 'GoogleDriveOAuthInternetAccount'
       },
     }))
-    .actions(() => ({
-      async fetchFile(locationUri: string, accessToken: string) {
-        if (!locationUri || !accessToken) {
-          return
-        }
-        const urlId = locationUri.match(/[-\w]{25,}/)
+    .actions(self => ({
+      makeFetcher(location: UriLocation, metadataOnly = false) {
+        return async (
+          url: RequestInfo,
+          opts?: RequestInit,
+        ): Promise<Response> => {
+          const urlId = String(url).match(/[-\w]{25,}/)
 
-        const response = await fetch(
-          `https://www.googleapis.com/drive/v2/files/${urlId}`,
+          const preAuthInfo = self.uriToPreAuthInfoMap.get(location.uri)
+          if (!preAuthInfo || !preAuthInfo.authInfo) {
+            throw new Error(
+              'Failed to obtain authorization information needed to fetch',
+            )
+          }
+
+          let foundTokens = {
+            token: '',
+            refreshToken: '',
+          }
+          try {
+            foundTokens = await self.checkToken(preAuthInfo.authInfo, {
+              uri: String(url),
+              locationType: 'UriLocation',
+            })
+          } catch (e) {
+            await self.handleError(e)
+          }
+
+          const newOpts = opts || {}
+
+          if (foundTokens.token) {
+            const tokenInfoString = self.tokenType
+              ? `${self.tokenType} ${foundTokens.token}`
+              : `${foundTokens.token}`
+            const headers = new Headers(opts?.headers)
+            headers.append(self.authHeader, tokenInfoString)
+
+            newOpts.headers = headers
+          }
+
+          const driveUrl = `https://www.googleapis.com/drive/v3/files/${urlId}?${
+            metadataOnly ? 'fields=size' : 'alt=media'
+          }`
+          return fetch(driveUrl, {
+            method: 'GET',
+            credentials: 'same-origin',
+            ...newOpts,
+          })
+        }
+      },
+      openLocation(location: UriLocation) {
+        const urlId = String(location.uri).match(/[-\w]{25,}/)
+        const preAuthInfo =
+          location.internetAccountPreAuthorization || self.generateAuthInfo()
+        self.uriToPreAuthInfoMap.set(location.uri, preAuthInfo)
+        return new GoogleDriveFile(
+          `https://www.googleapis.com/drive/v3/files/${urlId}?alt=media`,
           {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'Content-Type': 'application/x-www-form-urlencoded',
-            },
+            fetch: this.makeFetcher(location),
+            sizeFetch: this.makeFetcher(location, true),
           },
         )
-
-        if (!response.ok) {
-          throw new Error(
-            `Network response failure: ${
-              response.status
-            } (${await response.text()})`,
-          )
-        }
-        const fileMetadata = await response.json()
-        return fileMetadata.downloadUrl
       },
     }))
 }

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -591,6 +591,20 @@
     },
     {
       "type": "QuantitativeTrack",
+      "trackId": "google_bigwig",
+      "name": "Google Drive BigWig",
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "locationType": "UriLocation",
+          "uri": "https://drive.google.com/file/d/1PIvZCOJioK9eBL1Vuvfa4L_Fv9zTooHk/view?usp=sharing",
+          "internetAccountId": "googleOAuth"
+        }
+      }
+    },
+    {
+      "type": "QuantitativeTrack",
       "trackId": "volvox_microarray_externaltoken",
       "name": "wiggle_track xyplot external token",
       "category": ["Integration test", "Wiggle"],


### PR DESCRIPTION
I was able to load a BigWig from Google Drive just fine, but CRAM didn't work. This ended up being because Google Drive doesn't expose the Content-Range header, so whenever the filehandle called `stat` (which it does on CRAM but not BigWig), it errored out.

This workaround provides a custom `openLocation` for Google Drive accounts that uses a custom filehandle that overrides the `stat` method. This `stat` gets the file size by getting the file metadata from the Google Drive API, since it can't get the size from the Content-Range header.

It also switches to using a different endpoint for the file contents so that v3 of the Google Drive API is used instead of v2. @peterkxie this will probably need to be fixed to restore `fetchFile` like you fixed my Dropbox code in 36ab6f59b578b63fb538d0d6c7cebd1a4f27631d.

This has been tested by logging in with the file owner's account and logging in with a different account when the file is shared and both scenarios work.