### PR TITLE
Make HTTPBasic dialog use a form

### DIFF
--- a/plugins/authentication/src/HTTPBasicModel/model.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/model.tsx
@@ -212,58 +212,60 @@ const HTTPBasicLoginForm = ({
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    if (username && password) {
+      handleClose(btoa(`${username}:${password}`))
+    } else {
+      handleClose()
+    }
+    event.preventDefault()
+  }
+
   return (
     <>
       <Dialog open maxWidth="xl" data-testid="login-httpbasic">
         <DialogTitle>Log In for {internetAccountId}</DialogTitle>
-        <DialogContent style={{ display: 'flex', flexDirection: 'column' }}>
-          <TextField
-            required
-            label="Username"
-            variant="outlined"
-            inputProps={{ 'data-testid': 'login-httpbasic-username' }}
-            onChange={event => {
-              setUsername(event.target.value)
-            }}
-            margin="dense"
-          />
-          <TextField
-            required
-            label="Password"
-            type="password"
-            autoComplete="current-password"
-            variant="outlined"
-            inputProps={{ 'data-testid': 'login-httpbasic-password' }}
-            onChange={event => {
-              setPassword(event.target.value)
-            }}
-            margin="dense"
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            variant="contained"
-            color="primary"
-            type="submit"
-            disabled={!username || !password}
-            onClick={() => {
-              if (username && password) {
-                handleClose(btoa(`${username}:${password}`))
-              }
-            }}
-          >
-            Submit
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => {
-              handleClose()
-            }}
-          >
-            Cancel
-          </Button>
-        </DialogActions>
+        <form onSubmit={onSubmit}>
+          <DialogContent style={{ display: 'flex', flexDirection: 'column' }}>
+            <TextField
+              required
+              label="Username"
+              variant="outlined"
+              inputProps={{ 'data-testid': 'login-httpbasic-username' }}
+              onChange={event => {
+                setUsername(event.target.value)
+              }}
+              margin="dense"
+            />
+            <TextField
+              required
+              label="Password"
+              type="password"
+              autoComplete="current-password"
+              variant="outlined"
+              inputProps={{ 'data-testid': 'login-httpbasic-password' }}
+              onChange={event => {
+                setPassword(event.target.value)
+              }}
+              margin="dense"
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button variant="contained" color="primary" type="submit">
+              Submit
+            </Button>
+            <Button
+              variant="contained"
+              color="default"
+              type="submit"
+              onClick={() => {
+                handleClose()
+              }}
+            >
+              Cancel
+            </Button>
+          </DialogActions>
+        </form>
       </Dialog>
     </>
   )


### PR DESCRIPTION
This is a small change so that the HTTP Basic account dialog uses a `<form>`. This allows the user to be able to submit with the <kbd>Enter</kbd> key as well as enabling the browser's built-in form validations.