### PR TITLE
Add `http-range-fetcher` back

### DIFF
--- a/packages/core/declare.d.ts
+++ b/packages/core/declare.d.ts
@@ -1,1 +1,2 @@
+declare module 'http-range-fetcher'
 declare module 'load-script2'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "fast-deep-equal": "^3.1.3",
     "file-uri-to-path": "^1.0.0",
     "generic-filehandle": "^2.2.0",
+    "http-range-fetcher": "^1.2.2",
     "is-object": "^1.0.1",
     "jexl": "^2.3.0",
     "json-stable-stringify": "^1.0.1",

--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -1,7 +1,8 @@
 import { Instance, types } from 'mobx-state-tree'
 import { getConf } from '../../configuration'
+import { RemoteFileWithRangeCache } from '../../util/io'
 import { ElementId } from '../../util/types/mst'
-import { GenericFilehandle, RemoteFile } from 'generic-filehandle'
+import { GenericFilehandle } from 'generic-filehandle'
 import { FileLocation, UriLocation } from '@jbrowse/core/util/types'
 
 export const InternetAccount = types
@@ -30,7 +31,7 @@ export const InternetAccount = types
   }))
   .actions(self => ({
     openLocation(location: UriLocation): GenericFilehandle {
-      return new RemoteFile(String(location.uri))
+      return new RemoteFileWithRangeCache(String(location.uri))
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async getPreAuthorizationInformation(location: UriLocation) {

--- a/packages/core/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/util/io/RemoteFileWithRangeCache.ts
@@ -1,0 +1,125 @@
+import { HttpRangeFetcher } from 'http-range-fetcher'
+import { Buffer } from 'buffer'
+import { RemoteFile, PolyfilledResponse } from 'generic-filehandle'
+
+type BinaryRangeFetch = (
+  url: string,
+  start: number,
+  end: number,
+  options?: { headers?: HeadersInit; signal?: AbortSignal },
+) => Promise<BinaryRangeResponse>
+
+interface BinaryRangeResponse {
+  headers: Record<string, string>
+  requestDate: Date
+  responseDate: Date
+  buffer: Buffer
+}
+
+let fetchers: Record<string, BinaryRangeFetch> = {}
+
+function binaryRangeFetch(
+  url: string,
+  start: number,
+  end: number,
+  options: { headers?: HeadersInit; signal?: AbortSignal } = {},
+): Promise<BinaryRangeResponse> {
+  const fetcher = fetchers[url]
+  if (!fetcher) {
+    throw new Error(`fetch not registered for ${url}`)
+  }
+  return fetcher(url, start, end, options)
+}
+
+const globalRangeCache = new HttpRangeFetcher({
+  fetch: binaryRangeFetch,
+  size: 500 * 1024 ** 2, // 500MiB
+  chunkSize: 128 * 124, // 128KiB
+  maxFetchSize: 100 * 1024 ** 2, // 100MiB
+  minimumTTL: 24 * 60 * 60 * 1000, // 1 day
+})
+
+export function clearCache() {
+  globalRangeCache.reset()
+  fetchers = {}
+}
+
+export class RemoteFileWithRangeCache extends RemoteFile {
+  public async fetch(
+    url: RequestInfo,
+    init?: RequestInit,
+  ): Promise<PolyfilledResponse> {
+    if (!fetchers[String(url)]) {
+      fetchers[String(url)] = this.fetchBinaryRange.bind(this)
+    }
+    // if it is a range request, route it through the range cache
+    const requestHeaders = init && init.headers
+    let range
+    if (requestHeaders) {
+      if (requestHeaders instanceof Headers) {
+        range = requestHeaders.get('range')
+      } else if (Array.isArray(requestHeaders)) {
+        ;[, range] = requestHeaders.find(([key]) => key === 'range') || [
+          undefined,
+          undefined,
+        ]
+      } else {
+        range = requestHeaders.range
+      }
+    }
+    if (range) {
+      const rangeParse = /bytes=(\d+)-(\d+)/.exec(range)
+      if (rangeParse) {
+        const [, start, end] = rangeParse
+        const s = parseInt(start, 10)
+        const e = parseInt(end, 10)
+        const response = await (globalRangeCache.getRange(url, s, e - s + 1, {
+          signal: init && init.signal,
+        }) as Promise<BinaryRangeResponse>)
+        const { headers } = response
+        return new Response(response.buffer, { status: 206, headers })
+      }
+    }
+    return super.fetch(url, init)
+  }
+
+  public async fetchBinaryRange(
+    url: string,
+    start: number,
+    end: number,
+    options: { headers?: HeadersInit; signal?: AbortSignal } = {},
+  ): Promise<BinaryRangeResponse> {
+    const requestDate = new Date()
+    const requestHeaders = {
+      ...options.headers,
+      range: `bytes=${start}-${end}`,
+    }
+    const res = await super.fetch(url, {
+      ...options,
+      headers: requestHeaders,
+    })
+    const responseDate = new Date()
+    if (res.status !== 206) {
+      const errorMessage = `HTTP ${res.status} (${res.statusText}) when fetching ${url} bytes ${start}-${end}`
+      const hint = ' (should be 206 for range requests)'
+      throw new Error(`${errorMessage}${res.status === 200 ? hint : ''}`)
+    }
+
+    // translate the Headers object into a regular key -> value object.
+    // will miss duplicate headers of course
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const headers: Record<string, any> = {}
+    for (const [k, v] of res.headers.entries()) {
+      headers[k] = v
+    }
+
+    // return the response headers, and the data buffer
+    const arrayBuffer = await res.arrayBuffer()
+    return {
+      headers,
+      requestDate,
+      responseDate,
+      buffer: Buffer.from(arrayBuffer),
+    }
+  }
+}

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -1,9 +1,5 @@
-import {
-  BlobFile,
-  LocalFile,
-  GenericFilehandle,
-  RemoteFile,
-} from 'generic-filehandle'
+import { BlobFile, LocalFile, GenericFilehandle } from 'generic-filehandle'
+import { RemoteFileWithRangeCache } from './RemoteFileWithRangeCache'
 import {
   FileLocation,
   LocalPathLocation,
@@ -16,6 +12,8 @@ import { BaseInternetAccountModel } from '../../pluggableElementTypes/models'
 import { getBlob } from '../tracks'
 import PluginManager from '../../PluginManager'
 import isNode from 'detect-node'
+
+export { RemoteFileWithRangeCache }
 
 function isLocalPathLocation(
   location: FileLocation,
@@ -136,7 +134,7 @@ export function openLocation(
     const url = location.baseUri
       ? new URL(location.uri, location.baseUri).href
       : location.uri
-    return new RemoteFile(url, { fetch: newFetch })
+    return new RemoteFileWithRangeCache(url, { fetch: newFetch })
   }
   throw new Error('invalid fileLocation')
 }

--- a/plugins/authentication/src/DropboxOAuthModel/model.tsx
+++ b/plugins/authentication/src/DropboxOAuthModel/model.tsx
@@ -1,7 +1,7 @@
 import { ConfigurationReference } from '@jbrowse/core/configuration'
+import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
 import { Instance, types } from 'mobx-state-tree'
-import { RemoteFile } from 'generic-filehandle'
 import { DropboxOAuthInternetAccountConfigModel } from './configSchema'
 import baseModel from '../OAuthModel/model'
 import { configSchema as OAuthConfigSchema } from '../OAuthModel'
@@ -138,7 +138,7 @@ const stateModelFactory = (
         const preAuthInfo =
           location.internetAccountPreAuthorization || self.generateAuthInfo()
         self.uriToPreAuthInfoMap.set(location.uri, preAuthInfo)
-        return new RemoteFile(location.uri, {
+        return new RemoteFileWithRangeCache(location.uri, {
           fetch: this.dropboxFetch,
         })
       },

--- a/plugins/authentication/src/DropboxOAuthModel/model.tsx
+++ b/plugins/authentication/src/DropboxOAuthModel/model.tsx
@@ -6,6 +6,23 @@ import { DropboxOAuthInternetAccountConfigModel } from './configSchema'
 import baseModel from '../OAuthModel/model'
 import { configSchema as OAuthConfigSchema } from '../OAuthModel'
 
+interface DropboxError {
+  error_summary: string
+  error: {
+    '.tag': string
+  }
+}
+
+// Error messages from https://www.dropbox.com/developers/documentation/http/documentation#sharing-get_shared_link_file
+const dropboxErrorMessages: Record<string, string | undefined> = {
+  shared_link_not_found: "The shared link wasn't found.",
+  shared_link_access_denied:
+    'The caller is not allowed to access this shared link.',
+  unsupported_link_type:
+    'This type of link is not supported; use files/export instead.',
+  shared_link_is_directory: 'Directories cannot be retrieved by this endpoint.',
+}
+
 const stateModelFactory = (
   configSchema: DropboxOAuthInternetAccountConfigModel,
 ) => {
@@ -25,6 +42,29 @@ const stateModelFactory = (
       },
     }))
     .actions(self => ({
+      async processBadResponse(response: Response) {
+        let errorMessage
+        try {
+          errorMessage = await response.text()
+        } catch (error) {
+          errorMessage = ''
+        }
+        if (errorMessage) {
+          let errorMessageParsed: DropboxError | undefined
+          try {
+            errorMessageParsed = JSON.parse(errorMessage)
+          } catch (error) {
+            errorMessageParsed = undefined
+          }
+          if (errorMessageParsed) {
+            const messageTag = errorMessageParsed.error['.tag']
+            errorMessage = dropboxErrorMessages[messageTag] || messageTag
+          }
+        }
+        throw new Error(
+          `Network response failure — ${response.status} (${errorMessage})`,
+        )
+      },
       // for Dropbox, used to check if token is still valid for the file
       async fetchFile(locationUri: string, accessToken: string) {
         if (!locationUri || !accessToken) {
@@ -44,11 +84,7 @@ const stateModelFactory = (
           },
         )
         if (!response.ok) {
-          throw new Error(
-            `Network response failure: ${
-              response.status
-            } (${await response.text()})`,
-          )
+          await this.processBadResponse(response)
         }
         return locationUri
       },
@@ -89,10 +125,14 @@ const stateModelFactory = (
           newOpts.headers = headers
         }
 
-        return fetch(
+        const response = await fetch(
           'https://content.dropboxapi.com/2/sharing/get_shared_link_file',
           { method: 'GET', credentials: 'same-origin', ...newOpts },
         )
+        if (!response.ok) {
+          await this.processBadResponse(response)
+        }
+        return response
       },
       openLocation(location: UriLocation) {
         const preAuthInfo =

--- a/plugins/authentication/src/ExternalTokenModel/model.tsx
+++ b/plugins/authentication/src/ExternalTokenModel/model.tsx
@@ -1,5 +1,6 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes/models'
+import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
 import { ExternalTokenInternetAccountConfigModel } from './configSchema'
 import { Instance, types, getParent } from 'mobx-state-tree'
@@ -10,7 +11,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogActions from '@material-ui/core/DialogActions'
 import TextField from '@material-ui/core/TextField'
-import { RemoteFile } from 'generic-filehandle'
 
 const inWebWorker = typeof sessionStorage === 'undefined'
 
@@ -160,7 +160,7 @@ const stateModelFactory = (
         openLocation(location: UriLocation) {
           preAuthInfo =
             location.internetAccountPreAuthorization || self.generateAuthInfo()
-          return new RemoteFile(String(location.uri), {
+          return new RemoteFileWithRangeCache(String(location.uri), {
             fetch: this.getFetcher,
           })
         },

--- a/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
+++ b/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
@@ -1,8 +1,8 @@
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { Instance, types } from 'mobx-state-tree'
+import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
 import {
-  RemoteFile,
   FilehandleOptions,
   Stats,
   PolyfilledResponse,
@@ -36,7 +36,7 @@ interface GoogleDriveError {
   }
 }
 
-class GoogleDriveFile extends RemoteFile {
+class GoogleDriveFile extends RemoteFileWithRangeCache {
   private statsPromise: Promise<{ size: number }>
   constructor(source: string, opts: GoogleDriveFilehandleOptions) {
     super(source, opts)

--- a/plugins/authentication/src/HTTPBasicModel/model.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/model.tsx
@@ -1,5 +1,6 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes/models'
+import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
 import { getParent } from 'mobx-state-tree'
 import { HTTPBasicInternetAccountConfigModel } from './configSchema'
@@ -11,7 +12,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogActions from '@material-ui/core/DialogActions'
 import TextField from '@material-ui/core/TextField'
-import { RemoteFile } from 'generic-filehandle'
 
 const inWebWorker = typeof sessionStorage === 'undefined'
 
@@ -152,7 +152,7 @@ const stateModelFactory = (
         openLocation(location: UriLocation) {
           preAuthInfo =
             location.internetAccountPreAuthorization || self.generateAuthInfo()
-          return new RemoteFile(String(location.uri), {
+          return new RemoteFileWithRangeCache(String(location.uri), {
             fetch: this.getFetcher,
           })
         },

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -489,7 +489,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           if (!triedRefreshToken && location) {
             await this.exchangeRefreshForAccessToken(location)
           } else {
-            throw new Error(error)
+            throw error
           }
         },
       }

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -5,8 +5,8 @@ import { isElectron } from '@jbrowse/core/util'
 import { OAuthInternetAccountConfigModel } from './configSchema'
 import crypto from 'crypto'
 import { Instance, types } from 'mobx-state-tree'
+import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
-import { RemoteFile } from 'generic-filehandle'
 
 interface OAuthData {
   client_id: string
@@ -403,7 +403,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           const preAuthInfo =
             location.internetAccountPreAuthorization || self.generateAuthInfo()
           self.uriToPreAuthInfoMap.set(location.uri, preAuthInfo)
-          return new RemoteFile(String(location.uri), {
+          return new RemoteFileWithRangeCache(String(location.uri), {
             fetch: this.getFetcher,
           })
         },

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -197,14 +197,7 @@ Object {
       "authEndpoint": "https://www.dropbox.com/oauth2/authorize",
       "clientId": "50knr6xrjfc39sk",
       "description": "OAuth Info for Dropbox",
-      "hasRefreshToken": true,
-      "internetAccountId": "dropboxOAuth",
-      "name": "Dropbox",
-      "needsAuthorization": true,
-      "needsPKCE": true,
-      "tokenEndpoint": "https://api.dropbox.com/oauth2/token",
-      "type": "DropboxOAuthInternetAccount",
-      "validDomains": Array [
+      "domains": Array [
         "addtodropbox.com",
         "db.tt",
         "dropbox.com",
@@ -213,20 +206,27 @@ Object {
         "dropbox.tech",
         "getdropbox.com",
       ],
+      "hasRefreshToken": true,
+      "internetAccountId": "dropboxOAuth",
+      "name": "Dropbox",
+      "needsAuthorization": true,
+      "needsPKCE": true,
+      "tokenEndpoint": "https://api.dropbox.com/oauth2/token",
+      "type": "DropboxOAuthInternetAccount",
     },
     Object {
       "authEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
       "clientId": "109518325434-udfch80a0v70mgu65d5fejqsq5kvhm1b.apps.googleusercontent.com",
       "description": "OAuth Info for Google Drive",
+      "domains": Array [
+        "drive.google.com",
+      ],
       "internetAccountId": "googleOAuth",
       "name": "Google",
       "needsAuthorization": true,
       "responseType": "token",
       "scopes": "https://www.googleapis.com/auth/drive.readonly",
       "type": "GoogleDriveOAuthInternetAccount",
-      "validDomains": Array [
-        "drive.google.com",
-      ],
     },
     Object {
       "description": "External Token for testing",
@@ -1146,6 +1146,58 @@ Object {
       ],
       "name": "wiggle_track xyplot dropbox",
       "trackId": "volvox_microarray_dropbox",
+      "type": "QuantitativeTrack",
+    },
+    Object {
+      "adapter": Object {
+        "bigWigLocation": Object {
+          "internetAccountId": "dropboxOAuth",
+          "internetAccountPreAuthorization": undefined,
+          "locationType": "UriLocation",
+          "uri": "https://www.dropbox.com/s/96wflrzcbmf7nlj/volvox.bw?dl=0",
+        },
+        "type": "BigWigAdapter",
+      },
+      "assemblyNames": Array [
+        "volvox",
+      ],
+      "category": Array [
+        "Authentication",
+      ],
+      "displays": Array [
+        Object {
+          "displayId": "dropbox_bigwig-LinearWiggleDisplay",
+          "type": "LinearWiggleDisplay",
+        },
+      ],
+      "name": "Dropbox BigWig",
+      "trackId": "dropbox_bigwig",
+      "type": "QuantitativeTrack",
+    },
+    Object {
+      "adapter": Object {
+        "bigWigLocation": Object {
+          "internetAccountId": "googleOAuth",
+          "internetAccountPreAuthorization": undefined,
+          "locationType": "UriLocation",
+          "uri": "https://drive.google.com/file/d/1PIvZCOJioK9eBL1Vuvfa4L_Fv9zTooHk/view?usp=sharing",
+        },
+        "type": "BigWigAdapter",
+      },
+      "assemblyNames": Array [
+        "volvox",
+      ],
+      "category": Array [
+        "Authentication",
+      ],
+      "displays": Array [
+        Object {
+          "displayId": "google_bigwig-LinearWiggleDisplay",
+          "type": "LinearWiggleDisplay",
+        },
+      ],
+      "name": "Google Drive BigWig",
+      "trackId": "google_bigwig",
       "type": "QuantitativeTrack",
     },
     Object {

--- a/products/jbrowse-web/src/tests/Reload.test.js
+++ b/products/jbrowse-web/src/tests/Reload.test.js
@@ -8,6 +8,7 @@ import { LocalFile } from 'generic-filehandle'
 
 // locals
 import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import { clearCache } from '@jbrowse/core/util/io/RemoteFileWithRangeCache'
 import JBrowse from '../JBrowse'
 import { setup, getPluginManager, generateReadBuffer } from './util'
 
@@ -22,6 +23,7 @@ const readBuffer = generateReadBuffer(url => {
 })
 
 beforeEach(() => {
+  clearCache()
   clearAdapterCache()
   fetch.resetMocks()
   fetch.mockResponse(readBuffer)

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -591,8 +591,24 @@
     },
     {
       "type": "QuantitativeTrack",
+      "trackId": "dropbox_bigwig",
+      "name": "Dropbox BigWig",
+      "category": ["Authentication"],
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "https://www.dropbox.com/s/96wflrzcbmf7nlj/volvox.bw?dl=0",
+          "locationType": "UriLocation",
+          "internetAccountId": "dropboxOAuth"
+        }
+      }
+    },
+    {
+      "type": "QuantitativeTrack",
       "trackId": "google_bigwig",
       "name": "Google Drive BigWig",
+      "category": ["Authentication"],
       "assemblyNames": ["volvox"],
       "adapter": {
         "type": "BigWigAdapter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8222,6 +8222,14 @@ cross-env@^7.0.2:
   dependencies:
     cross-spawn "^7.0.1"
 
+cross-fetch@^2.2.2:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.5.tgz#afaf5729f3b6c78d89c9296115c9f142541a5705"
+  integrity sha512-xqYAhQb4NhCJSRym03dwxpP1bYXpK3y7UN83Bo2WFi3x1Zmzn0SL/6xGoPr+gpt4WmNrgCCX3HPysvOwFOW36w==
+  dependencies:
+    node-fetch "2.6.1"
+    whatwg-fetch "2.0.4"
+
 cross-fetch@^3.0.0, cross-fetch@^3.0.2, cross-fetch@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
@@ -12004,6 +12012,17 @@ http-proxy@^1.17.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
+http-range-fetcher@^1.2.2:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/http-range-fetcher/-/http-range-fetcher-1.2.5.tgz#f6d28f6ebf49dd379680e6ccc74af65bde92d6d4"
+  integrity sha512-XOE+q+zcJdWL3dLPAKxz81/odp2SQK8rwbn3NKfaRtDm9snZje20jvu0mC7PKXxvpdzsyqCRFQ9TpKtYRZUJig==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    abortcontroller-polyfill "^1.2.9"
+    cross-fetch "^2.2.2"
+    object.entries-ponyfill "^1.0.1"
+    quick-lru "^2.0.0"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -15576,7 +15595,7 @@ node-fetch@2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -22072,6 +22091,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@^3.0.0, whatwg-fetch@^3.4.1:
   version "3.6.2"


### PR DESCRIPTION
This adds `http-range-fetcher` back due to concerns described in [this comment](https://github.com/GMOD/jbrowse-components/pull/2279#issuecomment-921322346).

To handle various authentication models needing to use their own `fetch`es with auth headers, etc., it adds it back in a different way. It extends `RemoteFile` to `RemoteFileWithRangeCache`, and anything that wants to use the global range cache can use that class instead of `RemoteFile`. This does not require any changes to `http-range-fetcher`