### PR TITLE
adding additional msging, truncate long names in ui, spacing

### DIFF
--- a/packages/core/ui/FileSelector.tsx
+++ b/packages/core/ui/FileSelector.tsx
@@ -137,7 +137,9 @@ const FileLocationEditor = observer(
                 <ToggleButton
                   value={displayedInternetAccount.internetAccountId}
                 >
-                  {displayedInternetAccount.name}
+                  {displayedInternetAccount.name.length > 12
+                    ? `${displayedInternetAccount.name.substring(0, 12)}...`
+                    : displayedInternetAccount.name}
                 </ToggleButton>
               )}
               <Button
@@ -190,7 +192,6 @@ const FileLocationEditor = observer(
                               setButtonOpen(false)
                             }}
                           >
-                            {placement}
                             {findChosenInternetAccount(
                               account.internetAccountId,
                               'autoDetect',
@@ -244,7 +245,7 @@ const FileLocationEditor = observer(
               )}
             </Popper>
           </Grid>
-          <Grid item style={{ paddingLeft: 20 }}>
+          <Grid item>
             <Tooltip title="Add Account for Authentication">
               <Button
                 color="primary"
@@ -256,21 +257,21 @@ const FileLocationEditor = observer(
               </Button>
             </Tooltip>
           </Grid>
-          <Grid item>
-            {currentState === 'file' ? (
-              <LocalFileChooser {...props} />
-            ) : (
-              <UrlChooser
-                {...props}
-                currentInternetAccount={
-                  currentState === displayedInternetAccount?.internetAccountId
-                    ? displayedInternetAccount
-                    : undefined
-                }
-              />
-            )}
-          </Grid>
         </Grid>
+        <div>
+          {currentState === 'file' ? (
+            <LocalFileChooser {...props} />
+          ) : (
+            <UrlChooser
+              {...props}
+              currentInternetAccount={
+                currentState === displayedInternetAccount?.internetAccountId
+                  ? displayedInternetAccount
+                  : undefined
+              }
+            />
+          )}
+        </div>
         {openNewInternetAccountDialog && (
           <AddNewInternetAccountDialog
             internetAccounts={internetAccounts}
@@ -306,6 +307,7 @@ const UrlChooser = (props: {
         fullWidth
         inputProps={{ 'data-testid': 'urlInput' }}
         defaultValue={location && isUriLocation(location) ? location.uri : ''}
+        label="Enter the URL of the data"
         onChange={event => {
           if (currentInternetAccount) {
             setLocation({
@@ -323,7 +325,7 @@ const UrlChooser = (props: {
         }}
       />
       {currentInternetAccount && (
-        <Grid item>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
           <Info />
           <Typography
             color="textSecondary"
@@ -332,7 +334,7 @@ const UrlChooser = (props: {
           >
             Your data will be authenticated using {currentInternetAccount.name}
           </Typography>
-        </Grid>
+        </div>
       )}
     </>
   )

--- a/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
@@ -33,7 +33,7 @@ function TrackSourceSelect({ model }: { model: AddTrackModel }) {
         />
         <FileSelector
           name="Index file"
-          description="Automatically inferred from the URL if not supplied"
+          description="The URL of the index file is automatically inferred from the URL of the main file if it is not supplied."
           location={model.indexTrackData}
           setLocation={model.setIndexTrackData}
           setName={model.setTrackName}


### PR DESCRIPTION
### Changes
- changed messaging for index file, to be more clear for the user what will happen
- spacing changes to the informational message when the user is on an internet account (i.e. the icon is centered now)
- condition for extra-long internet account names that they will be truncated if they exceed 12 characters (not in the dropdown menu, only on the ui display)
- added a label to the URL field, it really needs something there otherwise it looks completely empty, and I can see a user missing the field entirely
- moved the url field down below the grid containing the button group and add account button to make it consistent if the window is resized

**Here's what the UI would look like without term truncation:**
<img width="337" alt="Screen Shot 2021-09-23 at 10 38 46 AM" src="https://user-images.githubusercontent.com/83305007/134530339-0aa42e3c-4d7e-4cca-9f70-b756194e43a2.png">

**And with truncation:**
<img width="337" alt="Screen Shot 2021-09-23 at 10 38 46 AM" src="https://user-images.githubusercontent.com/83305007/134529049-abe30af1-3b56-4d35-a242-877a0d0ac99a.png">

**Full name preserved in the dropdown menu:**
<img width="357" alt="Screen Shot 2021-09-23 at 10 39 52 AM" src="https://user-images.githubusercontent.com/83305007/134529076-233d5e0a-a576-4acd-92d8-f86f95c300de.png">

**IMO, the add account button looks weird attached to the button group and I wish it was justified to the end but I can't accomplish that if we want to maintain the use of Grid on this component. It is a minor visual thing, but I think we should consider using flex for this entire component if this is troublesome.**
Also shows what shorter names look like.
<img width="335" alt="Screen Shot 2021-09-23 at 10 39 09 AM" src="https://user-images.githubusercontent.com/83305007/134529061-312e3ed8-8925-42ba-aae9-e9bb57ab7f2a.png">

