### PR TITLE
Make file chooser more configurable by internet accounts

### DIFF
--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -3,7 +3,11 @@ import { getConf } from '../../configuration'
 import { RemoteFileWithRangeCache } from '../../util/io'
 import { ElementId } from '../../util/types/mst'
 import { GenericFilehandle } from 'generic-filehandle'
-import { FileLocation, UriLocation } from '@jbrowse/core/util/types'
+import {
+  FileLocation,
+  UriLocation,
+  AnyReactComponentType,
+} from '@jbrowse/core/util/types'
 
 export const InternetAccount = types
   .model('InternetAccount', {
@@ -22,6 +26,15 @@ export const InternetAccount = types
     },
     get accountConfig() {
       return getConf(self)
+    },
+    get toggleContents(): React.ReactNode {
+      return null
+    },
+    get SelectorComponent(): AnyReactComponentType | undefined {
+      return undefined
+    },
+    get selectorLabel(): string | undefined {
+      return undefined
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/ui/FileSelector/FileSelector.tsx
+++ b/packages/core/ui/FileSelector/FileSelector.tsx
@@ -21,14 +21,14 @@ import {
 } from '@material-ui/core'
 import { ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
 import { observer } from 'mobx-react'
-import { isElectron } from '../util'
+import { isElectron } from '../../util'
 import {
   LocalPathLocation,
   FileLocation,
   BlobLocation,
   isUriLocation,
-} from '../util/types'
-import { getBlob, storeBlobLocation } from '../util/tracks'
+} from '../../util/types'
+import { getBlob, storeBlobLocation } from '../../util/tracks'
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown'
 import AddIcon from '@material-ui/icons/Add'
 import { Info } from '@material-ui/icons'

--- a/packages/core/ui/FileSelector/FileSelector.tsx
+++ b/packages/core/ui/FileSelector/FileSelector.tsx
@@ -5,7 +5,6 @@ import {
   FormHelperText,
   InputLabel,
   TextField,
-  Typography,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -21,31 +20,15 @@ import {
 } from '@material-ui/core'
 import { ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
 import { observer } from 'mobx-react'
-import { isElectron } from '../../util'
-import {
-  LocalPathLocation,
-  FileLocation,
-  BlobLocation,
-  isUriLocation,
-} from '../../util/types'
-import { getBlob, storeBlobLocation } from '../../util/tracks'
+import { FileLocation, isUriLocation } from '../../util/types'
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown'
 import AddIcon from '@material-ui/icons/Add'
-import { Info } from '@material-ui/icons'
+import LocalFileChooser from './LocalFileChooser'
+import UrlChooser from './UrlChooser'
 
 interface Account {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
-}
-
-function isLocalPathLocation(
-  location: FileLocation,
-): location is LocalPathLocation {
-  return 'localPath' in location
-}
-
-function isBlobLocation(location: FileLocation): location is BlobLocation {
-  return 'blobId' in location
 }
 
 const FileLocationEditor = observer(
@@ -268,111 +251,6 @@ const FileLocationEditor = observer(
           {description}
         </FormHelperText>
       </>
-    )
-  },
-)
-
-const UrlChooser = (props: {
-  location?: FileLocation
-  setLocation: Function
-  currentInternetAccount: Account | undefined
-}) => {
-  const { location, setLocation, currentInternetAccount } = props
-
-  return (
-    <>
-      <TextField
-        fullWidth
-        inputProps={{ 'data-testid': 'urlInput' }}
-        defaultValue={location && isUriLocation(location) ? location.uri : ''}
-        label="Enter URL"
-        onChange={event => {
-          if (currentInternetAccount) {
-            setLocation({
-              uri: event.target.value,
-              baseAuthUri: event.target.value,
-              internetAccountId: currentInternetAccount.internetAccountId || '',
-              locationType: 'UriLocation',
-            })
-          } else {
-            setLocation({
-              uri: event.target.value.trim(),
-              locationType: 'UriLocation',
-            })
-          }
-        }}
-      />
-      {currentInternetAccount && (
-        <Grid item>
-          <Info />
-          <Typography
-            color="textSecondary"
-            variant="caption"
-            style={{ paddingLeft: '4px' }}
-          >
-            Your data will be authenticated using {currentInternetAccount.name}
-          </Typography>
-        </Grid>
-      )}
-    </>
-  )
-}
-
-const LocalFileChooser = observer(
-  (props: { location?: FileLocation; setLocation: Function }) => {
-    const { location, setLocation } = props
-
-    const filename =
-      location &&
-      ((isBlobLocation(location) && location.name) ||
-        (isLocalPathLocation(location) && location.localPath))
-
-    const needToReload =
-      location && isBlobLocation(location) && !getBlob(location.blobId)
-
-    return (
-      <div style={{ position: 'relative' }}>
-        <Button variant="outlined" component="label">
-          Choose File
-          <input
-            type="file"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              opacity: 0,
-            }}
-            onChange={({ target }) => {
-              const file = target && target.files && target.files[0]
-              if (file) {
-                if (isElectron) {
-                  setLocation({
-                    localPath: (file as File & { path: string }).path,
-                    locationType: 'LocalPathLocation',
-                  })
-                } else {
-                  setLocation(storeBlobLocation({ blob: file }))
-                }
-              }
-            }}
-          />
-        </Button>
-        {filename ? (
-          <>
-            <Typography
-              style={{ marginLeft: '0.4rem' }}
-              variant="body1"
-              component="span"
-            >
-              {filename}
-            </Typography>
-            {needToReload ? (
-              <Typography color="error">(need to reload)</Typography>
-            ) : null}
-          </>
-        ) : null}
-      </div>
     )
   },
 )

--- a/packages/core/ui/FileSelector/LocalFileChooser.tsx
+++ b/packages/core/ui/FileSelector/LocalFileChooser.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Button, Typography } from '@material-ui/core'
+import {
+  Box,
+  Button,
+  Typography,
+  FormControl,
+  makeStyles,
+} from '@material-ui/core'
 import { isElectron } from '../../util'
 import { LocalPathLocation, FileLocation, BlobLocation } from '../../util/types'
 import { getBlob, storeBlobLocation } from '../../util/tracks'
@@ -14,10 +20,17 @@ function isBlobLocation(location: FileLocation): location is BlobLocation {
   return 'blobId' in location
 }
 
+const useStyles = makeStyles(theme => ({
+  filename: {
+    marginLeft: theme.spacing(1),
+  },
+}))
+
 function LocalFileChooser(props: {
   location?: FileLocation
   setLocation: Function
 }) {
+  const classes = useStyles()
   const { location, setLocation } = props
 
   const filename =
@@ -29,48 +42,44 @@ function LocalFileChooser(props: {
     location && isBlobLocation(location) && !getBlob(location.blobId)
 
   return (
-    <div style={{ position: 'relative' }}>
-      <Button variant="outlined" component="label">
-        Choose File
-        <input
-          type="file"
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            opacity: 0,
-          }}
-          onChange={({ target }) => {
-            const file = target && target.files && target.files[0]
-            if (file) {
-              if (isElectron) {
-                setLocation({
-                  localPath: (file as File & { path: string }).path,
-                  locationType: 'LocalPathLocation',
-                })
-              } else {
-                setLocation(storeBlobLocation({ blob: file }))
-              }
-            }
-          }}
-        />
-      </Button>
-      {filename ? (
-        <>
-          <Typography
-            style={{ marginLeft: '0.4rem' }}
-            variant="body1"
-            component="span"
-          >
-            {filename}
-          </Typography>
-          {needToReload ? (
-            <Typography color="error">(need to reload)</Typography>
-          ) : null}
-        </>
-      ) : null}
-    </div>
+    <Box display="flex" flexDirection="row" alignItems="center">
+      <Box>
+        <FormControl fullWidth>
+          <Button variant="outlined" component="label">
+            Choose File
+            <input
+              type="file"
+              hidden
+              onChange={({ target }) => {
+                const file = target && target.files && target.files[0]
+                if (file) {
+                  if (isElectron) {
+                    setLocation({
+                      localPath: (file as File & { path: string }).path,
+                      locationType: 'LocalPathLocation',
+                    })
+                  } else {
+                    setLocation(storeBlobLocation({ blob: file }))
+                  }
+                }
+              }}
+            />
+          </Button>
+        </FormControl>
+      </Box>
+      <Box>
+        <Typography
+          component="span"
+          className={classes.filename}
+          color={filename ? 'initial' : 'textSecondary'}
+        >
+          {filename || 'No file chosen'}
+        </Typography>
+        {needToReload ? (
+          <Typography color="error">(need to reload)</Typography>
+        ) : null}
+      </Box>
+    </Box>
   )
 }
 

--- a/packages/core/ui/FileSelector/LocalFileChooser.tsx
+++ b/packages/core/ui/FileSelector/LocalFileChooser.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { Button, Typography } from '@material-ui/core'
+import { isElectron } from '../../util'
+import { LocalPathLocation, FileLocation, BlobLocation } from '../../util/types'
+import { getBlob, storeBlobLocation } from '../../util/tracks'
+
+function isLocalPathLocation(
+  location: FileLocation,
+): location is LocalPathLocation {
+  return 'localPath' in location
+}
+
+function isBlobLocation(location: FileLocation): location is BlobLocation {
+  return 'blobId' in location
+}
+
+function LocalFileChooser(props: {
+  location?: FileLocation
+  setLocation: Function
+}) {
+  const { location, setLocation } = props
+
+  const filename =
+    location &&
+    ((isBlobLocation(location) && location.name) ||
+      (isLocalPathLocation(location) && location.localPath))
+
+  const needToReload =
+    location && isBlobLocation(location) && !getBlob(location.blobId)
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <Button variant="outlined" component="label">
+        Choose File
+        <input
+          type="file"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            opacity: 0,
+          }}
+          onChange={({ target }) => {
+            const file = target && target.files && target.files[0]
+            if (file) {
+              if (isElectron) {
+                setLocation({
+                  localPath: (file as File & { path: string }).path,
+                  locationType: 'LocalPathLocation',
+                })
+              } else {
+                setLocation(storeBlobLocation({ blob: file }))
+              }
+            }
+          }}
+        />
+      </Button>
+      {filename ? (
+        <>
+          <Typography
+            style={{ marginLeft: '0.4rem' }}
+            variant="body1"
+            component="span"
+          >
+            {filename}
+          </Typography>
+          {needToReload ? (
+            <Typography color="error">(need to reload)</Typography>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export default LocalFileChooser

--- a/packages/core/ui/FileSelector/UrlChooser.tsx
+++ b/packages/core/ui/FileSelector/UrlChooser.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { Grid, TextField, Typography } from '@material-ui/core'
+import { TextField } from '@material-ui/core'
 import { observer } from 'mobx-react'
 import { FileLocation, isUriLocation } from '../../util/types'
-import { Info } from '@material-ui/icons'
 
 interface Account {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,45 +11,25 @@ interface Account {
 function UrlChooser(props: {
   location?: FileLocation
   setLocation: Function
-  currentInternetAccount: Account | undefined
+  label?: string
 }) {
-  const { location, setLocation, currentInternetAccount } = props
+  const { location, setLocation, label } = props
 
   return (
     <>
       <TextField
         fullWidth
+        variant="outlined"
         inputProps={{ 'data-testid': 'urlInput' }}
         defaultValue={location && isUriLocation(location) ? location.uri : ''}
-        label="Enter URL"
+        label={label || 'Enter URL'}
         onChange={event => {
-          if (currentInternetAccount) {
-            setLocation({
-              uri: event.target.value,
-              baseAuthUri: event.target.value,
-              internetAccountId: currentInternetAccount.internetAccountId || '',
-              locationType: 'UriLocation',
-            })
-          } else {
-            setLocation({
-              uri: event.target.value.trim(),
-              locationType: 'UriLocation',
-            })
-          }
+          setLocation({
+            uri: event.target.value.trim(),
+            locationType: 'UriLocation',
+          })
         }}
       />
-      {currentInternetAccount && (
-        <Grid item>
-          <Info />
-          <Typography
-            color="textSecondary"
-            variant="caption"
-            style={{ paddingLeft: '4px' }}
-          >
-            Your data will be authenticated using {currentInternetAccount.name}
-          </Typography>
-        </Grid>
-      )}
     </>
   )
 }

--- a/packages/core/ui/FileSelector/UrlChooser.tsx
+++ b/packages/core/ui/FileSelector/UrlChooser.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Grid, TextField, Typography } from '@material-ui/core'
+import { observer } from 'mobx-react'
+import { FileLocation, isUriLocation } from '../../util/types'
+import { Info } from '@material-ui/icons'
+
+interface Account {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+function UrlChooser(props: {
+  location?: FileLocation
+  setLocation: Function
+  currentInternetAccount: Account | undefined
+}) {
+  const { location, setLocation, currentInternetAccount } = props
+
+  return (
+    <>
+      <TextField
+        fullWidth
+        inputProps={{ 'data-testid': 'urlInput' }}
+        defaultValue={location && isUriLocation(location) ? location.uri : ''}
+        label="Enter URL"
+        onChange={event => {
+          if (currentInternetAccount) {
+            setLocation({
+              uri: event.target.value,
+              baseAuthUri: event.target.value,
+              internetAccountId: currentInternetAccount.internetAccountId || '',
+              locationType: 'UriLocation',
+            })
+          } else {
+            setLocation({
+              uri: event.target.value.trim(),
+              locationType: 'UriLocation',
+            })
+          }
+        }}
+      />
+      {currentInternetAccount && (
+        <Grid item>
+          <Info />
+          <Typography
+            color="textSecondary"
+            variant="caption"
+            style={{ paddingLeft: '4px' }}
+          >
+            Your data will be authenticated using {currentInternetAccount.name}
+          </Typography>
+        </Grid>
+      )}
+    </>
+  )
+}
+
+export default observer(UrlChooser)

--- a/packages/core/ui/FileSelector/index.ts
+++ b/packages/core/ui/FileSelector/index.ts
@@ -1,0 +1,3 @@
+import FileSelector from './FileSelector'
+
+export default FileSelector

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -239,6 +239,7 @@ export interface AppRootModel extends AbstractRootModel {
   isDefaultSessionEditing: boolean
   setAssemblyEditing: (arg: boolean) => boolean
   setDefaultSessionEditing: (arg: boolean) => boolean
+  internetAccounts: BaseInternetAccountModel[]
   findAppropriateInternetAccount(
     location: UriLocation,
   ): BaseInternetAccountModel | undefined

--- a/plugins/authentication/src/DropboxOAuthModel/model.tsx
+++ b/plugins/authentication/src/DropboxOAuthModel/model.tsx
@@ -1,6 +1,8 @@
+import React from 'react'
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
+import { SvgIconProps, SvgIcon } from '@material-ui/core'
 import { Instance, types } from 'mobx-state-tree'
 import { DropboxOAuthInternetAccountConfigModel } from './configSchema'
 import baseModel from '../OAuthModel/model'
@@ -23,6 +25,14 @@ const dropboxErrorMessages: Record<string, string | undefined> = {
   shared_link_is_directory: 'Directories cannot be retrieved by this endpoint.',
 }
 
+export function DropboxIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M3 6.2L8 9.39L13 6.2L8 3L3 6.2M13 6.2L18 9.39L23 6.2L18 3L13 6.2M3 12.55L8 15.74L13 12.55L8 9.35L3 12.55M18 9.35L13 12.55L18 15.74L23 12.55L18 9.35M8.03 16.8L13.04 20L18.04 16.8L13.04 13.61L8.03 16.8Z" />
+    </SvgIcon>
+  )
+}
+
 const stateModelFactory = (
   configSchema: DropboxOAuthInternetAccountConfigModel,
 ) => {
@@ -39,6 +49,12 @@ const stateModelFactory = (
     .views(() => ({
       get internetAccountType() {
         return 'DropboxOAuthInternetAccount'
+      },
+      get toggleContents() {
+        return <DropboxIcon />
+      },
+      get selectorLabel() {
+        return 'Enter Dropbox share link'
       },
     }))
     .actions(self => ({

--- a/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
+++ b/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
@@ -1,7 +1,9 @@
+import React from 'react'
 import { ConfigurationReference } from '@jbrowse/core/configuration'
 import { Instance, types } from 'mobx-state-tree'
 import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
+import { SvgIconProps, SvgIcon } from '@material-ui/core'
 import {
   FilehandleOptions,
   Stats,
@@ -57,6 +59,14 @@ class GoogleDriveFile extends RemoteFileWithRangeCache {
   }
 }
 
+function GoogleDriveIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M7.71,3.5L1.15,15L4.58,21L11.13,9.5M9.73,15L6.3,21H19.42L22.85,15M22.28,14L15.42,2H8.58L8.57,2L15.43,14H22.28Z" />
+    </SvgIcon>
+  )
+}
+
 const stateModelFactory = (
   configSchema: GoogleDriveOAuthInternetAccountConfigModel,
 ) => {
@@ -73,6 +83,12 @@ const stateModelFactory = (
     .views(() => ({
       get internetAccountType() {
         return 'GoogleDriveOAuthInternetAccount'
+      },
+      get toggleContents() {
+        return <GoogleDriveIcon />
+      },
+      get selectorLabel() {
+        return 'Enter Google Drive share link'
       },
     }))
     .actions(self => ({

--- a/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
@@ -7,12 +7,13 @@ import { getRoot } from 'mobx-state-tree'
 import { observer } from 'mobx-react'
 
 const useStyles = makeStyles(theme => ({
-  root: {
+  paper: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  paper: {
     padding: theme.spacing(1),
+  },
+  spacer: {
+    height: theme.spacing(8),
   },
 }))
 
@@ -21,26 +22,25 @@ function TrackSourceSelect({ model }: { model: AddTrackModel }) {
   const rootModel = getRoot(model)
 
   return (
-    <div className={classes.root}>
-      <Paper className={classes.paper}>
-        <FileSelector
-          name="Main file"
-          description=""
-          location={model.trackData}
-          setLocation={model.setTrackData}
-          setName={model.setTrackName}
-          internetAccounts={rootModel.internetAccounts}
-        />
-        <FileSelector
-          name="Index file"
-          description="The URL of the index file is automatically inferred from the URL of the main file if it is not supplied."
-          location={model.indexTrackData}
-          setLocation={model.setIndexTrackData}
-          setName={model.setTrackName}
-          internetAccounts={rootModel.internetAccounts}
-        />
-      </Paper>
-    </div>
+    <Paper className={classes.paper}>
+      <FileSelector
+        name="Main file"
+        description=""
+        location={model.trackData}
+        setLocation={model.setTrackData}
+        setName={model.setTrackName}
+        rootModel={rootModel}
+      />
+      <div className={classes.spacer} />
+      <FileSelector
+        name="Index file"
+        description="(Optional) The URL of the index file is automatically inferred from the URL of the main file if it is not supplied."
+        location={model.indexTrackData}
+        setLocation={model.setIndexTrackData}
+        setName={model.setTrackName}
+        rootModel={rootModel}
+      />
+    </Paper>
   )
 }
 

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1623,7 +1623,7 @@
     {
       "type": "GoogleDriveOAuthInternetAccount",
       "internetAccountId": "googleOAuth",
-      "name": "Google",
+      "name": "Google Drive",
       "description": "OAuth Info for Google Drive",
       "authEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
       "needsAuthorization": true,
@@ -1631,13 +1631,6 @@
       "scopes": "https://www.googleapis.com/auth/drive.readonly",
       "responseType": "token",
       "domains": ["drive.google.com"]
-    },
-    {
-      "type": "ExternalTokenInternetAccount",
-      "internetAccountId": "ExternalTokenTest",
-      "name": "External token",
-      "description": "External Token for testing",
-      "domains": []
     }
   ]
 }


### PR DESCRIPTION
This is a proposal for more adjustments to the file selector UI. I wanted to make the UI easier for the most common cases. I think that the large majority of users will have either no internet accounts configured (default for web) or Google Drive and Dropbox configured (possible future default for desktop). There does need to be some way to handle many configured accounts in the UI, but since that's an uncommon case, in this branch that particular UI does not show up until three or more accounts are configured. By default with two accounts configured, the UI looks like this (all four possible states):

![image](https://user-images.githubusercontent.com/25592344/134997408-3d3199af-e049-4f12-b4af-0236283a046a.png)

With more accounts, there is a "More" button, and selecting an account from that menu moves it to be the last displayed account.

![image](https://user-images.githubusercontent.com/25592344/134998797-1795e22f-f0e3-43e2-8ef0-6c3ff779f436.png)

![image](https://user-images.githubusercontent.com/25592344/134998828-aaf07c61-ce7e-4f3b-ba38-af1c651b3942.png)

In discussion earlier with @peterkxie and @carolinebridge-oicr, it came up that using text instead of icons might be more clear, but I think that because this is designed to be a compact UI, the ability to use icons makes it cleaner and easier for the user to understand. There are tooltips on the icons:

![image](https://user-images.githubusercontent.com/25592344/134999220-a1ca4924-e5b8-4070-a989-4cbeefe1d60d.png)

The icons and the label text (e.g. "Enter Dropbox share link") are now optional parts of the account model, so each account can define them. It also allows internet accounts to provide their own component for selecting a location, so it could use something besides the URL input box. No accounts currently use this, but it allows for adding things like a custom file picker for some resource.

This PR also splits the file selector components up into multiple files since it was getting large.

Also missing is the "Add account for authentication" button. I think this will be necessary in the future, but not for the first release. Users can add an HTTP Basic account by entering the URL in the normal URL field, and the account will get added when the track tries to access the resource. We don't have a UI for configuring the other account types, so we can't add them in the track selector for now. I think once we have an internet account manager UI, there should be a button in the file selector that opens that UI where users can add or manage any type of account.

Also removes the external token account from the volvox config since it doesn't have a usable example.