### PR TITLE
authenticate files through spreadsheet view ;; skips stat() if it fails

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.js
@@ -17,6 +17,7 @@ import {
 } from '@material-ui/core'
 
 import { observer } from 'mobx-react'
+import { getRoot } from 'mobx-state-tree'
 import { getSession } from '@jbrowse/core/util'
 import { FileSelector } from '@jbrowse/core/ui'
 import AssemblySelector from '@jbrowse/core/ui/AssemblySelector'
@@ -72,6 +73,7 @@ const ImportForm = observer(({ model }) => {
   const [selected, setSelected] = useState(assemblyNames[0])
   const err = assemblyManager.get(selected)?.error
   const showRowControls = model.fileType === 'CSV' || model.fileType === 'TSV'
+  const rootModel = getRoot(model)
 
   return (
     <Container>
@@ -90,6 +92,7 @@ const ImportForm = observer(({ model }) => {
               <FileSelector
                 location={model.fileSource}
                 setLocation={model.setFileSource}
+                rootModel={rootModel}
               />
             </FormGroup>
           </FormControl>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -166,7 +166,7 @@ export default (pluginManager: PluginManager) => {
             }
           })
         } catch (e: any) {
-          // if stat() fails then the filesize cannot be determined and we continue
+          console.warn(e)
         }
         await filehandle
           .readFile()

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/ImportWizard.ts
@@ -165,7 +165,7 @@ export default (pluginManager: PluginManager) => {
               )
             }
           })
-        } catch (e: any) {
+        } catch (e) {
           console.warn(e)
         }
         await filehandle


### PR DESCRIPTION
reason for change:

GDC does not support stat(). when putting a GDC resource through the spreadsheet view, stat() cannot retrieve the size of the file and then errors and aborts the operation ;; spreadsheet view is required to visualize BEDPE files.

additional changes enable authentication to go through the spreadsheet component