### PR TITLE
Add tooltip with track description to track selector

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -17,6 +17,7 @@ import {
   Menu,
   MenuItem,
   TextField,
+  Tooltip,
   Typography,
   makeStyles,
 } from '@material-ui/core'
@@ -121,6 +122,7 @@ const Node = props => {
   const marginLeft = nestingLevel * width + (isLeaf ? width : 0)
   const unsupported =
     name && (name.endsWith('(Unsupported)') || name.endsWith('(Unknown)'))
+  const description = (conf && readConfObject(conf, ['description'])) || ''
 
   return (
     <div style={style} className={!isLeaf ? classes.accordionBase : undefined}>
@@ -153,22 +155,24 @@ const Node = props => {
             </div>
           ) : (
             <>
-              <FormControlLabel
-                className={classes.checkboxLabel}
-                control={
-                  <Checkbox
-                    className={classes.compactCheckbox}
-                    checked={checked}
-                    onChange={() => onChange(id)}
-                    color="primary"
-                    disabled={unsupported}
-                    inputProps={{
-                      'data-testid': `htsTrackEntry-${id}`,
-                    }}
-                  />
-                }
-                label={name}
-              />
+              <Tooltip title={description} placement="left">
+                <FormControlLabel
+                  className={classes.checkboxLabel}
+                  control={
+                    <Checkbox
+                      className={classes.compactCheckbox}
+                      checked={checked}
+                      onChange={() => onChange(id)}
+                      color="primary"
+                      disabled={unsupported}
+                      inputProps={{
+                        'data-testid': `htsTrackEntry-${id}`,
+                      }}
+                    />
+                  }
+                  label={name}
+                />
+              </Tooltip>
               <IconButton
                 onClick={e => onMoreInfo({ target: e.currentTarget, id, conf })}
                 color="secondary"


### PR DESCRIPTION
When looking at https://github.com/GMOD/jbrowse-components/discussions/2367 and thinking about how people can differentiate their tracks, I realized there is no tooltip on the current track selector entries (there were on previous iterations of the track selector). This adds such a tooltip. I think this can be a useful way for people to keep information about their tracks easily accessible.

![image](https://user-images.githubusercontent.com/25592344/135668026-e7ce016b-6c83-4616-8684-922c8f6e5cce.png)
