### PR TITLE
Desktop bug fixes and UI updates

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -86,7 +86,8 @@
     "react-dom": "^17.0.0",
     "react-error-boundary": "^3.0.0",
     "react-sizeme": "^2.6.7",
-    "rxjs": "^6.5.2"
+    "rxjs": "^6.5.2",
+    "timeago.js": "^4.0.2"
   },
   "browserslist": [
     "last 1 chrome version"

--- a/products/jbrowse-desktop/public/electron.ts
+++ b/products/jbrowse-desktop/public/electron.ts
@@ -233,7 +233,8 @@ ipcMain.handle('saveSession', async (_event: unknown, snap: SessionSnap) => {
   const page = await mainWindow?.capturePage()
   const name = snap.defaultSession.name
   if (page) {
-    await writeFile(getPath(name, 'thumbnail'), page.toDataURL())
+    const resizedPage = page.resize({ width: 250 })
+    await writeFile(getPath(name, 'thumbnail'), resizedPage.toDataURL())
   }
   await writeFile(getPath(name), JSON.stringify(snap, null, 2))
 })

--- a/products/jbrowse-desktop/src/StartScreen/PreloadedDatasetSelector.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/PreloadedDatasetSelector.tsx
@@ -56,8 +56,10 @@ function PreloadedDatasetSelector({
         className={classes.button}
         onClick={async () => {
           const config = deepmerge.all(
-            // @ts-ignore
-            Object.keys(selected).map(name => preloadedConfigs[name]),
+            Object.keys(selected).map(name =>
+              // @ts-ignore
+              selected[name] ? preloadedConfigs[name] : {},
+            ),
           )
 
           // @ts-ignore
@@ -69,6 +71,7 @@ function PreloadedDatasetSelector({
         }}
         variant="contained"
         color="primary"
+        disabled={!Object.values(selected).some(Boolean)}
       >
         Go
       </Button>

--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -16,6 +16,7 @@ import {
   ToggleButtonProps,
 } from '@material-ui/lab'
 import PluginManager from '@jbrowse/core/PluginManager'
+import { format } from 'timeago.js'
 import { ipcRenderer } from 'electron'
 
 // icons
@@ -121,8 +122,22 @@ function RecentSessionsList({
     {
       field: 'lastModified',
       headerName: 'Last modified',
-      renderCell: ({ value }: GridCellParams) =>
-        !value ? null : `${value.toLocaleString('en-US')}`,
+      renderCell: ({ value }: GridCellParams) => {
+        if (!value) {
+          return null
+        }
+        const lastModified = value as Date
+        const now = Date.now()
+        const oneDayLength = 24 * 60 * 60 * 1000
+        if (now - lastModified.getTime() < oneDayLength) {
+          return (
+            <Tooltip title={lastModified.toLocaleString('en-US')}>
+              <div>{format(lastModified)}</div>
+            </Tooltip>
+          )
+        }
+        return lastModified.toLocaleString('en-US')
+      },
       width: 150,
     },
   ]

--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -58,9 +58,11 @@ function RecentSessionsList({
   const columns = [
     {
       field: 'delete',
+      minWidth: 40,
       width: 40,
       sortable: false,
       filterable: false,
+      headerName: ' ',
       renderCell: (params: GridCellParams) => {
         const { value } = params
         return (
@@ -74,9 +76,11 @@ function RecentSessionsList({
     },
     {
       field: 'rename',
+      minWidth: 40,
       width: 40,
       sortable: false,
       filterable: false,
+      headerName: ' ',
       renderCell: (params: GridCellParams) => {
         const { value } = params
         return (

--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -10,7 +10,11 @@ import {
   makeStyles,
 } from '@material-ui/core'
 import { DataGrid, GridCellParams } from '@material-ui/data-grid'
-import { ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
+import {
+  ToggleButtonGroup,
+  ToggleButton,
+  ToggleButtonProps,
+} from '@material-ui/lab'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { ipcRenderer } from 'electron'
 
@@ -179,6 +183,15 @@ function RecentSessionsCards({
   )
 }
 
+function ToggleButtonWithTooltip(props: ToggleButtonProps) {
+  const { title, children, ...other } = props
+  return (
+    <Tooltip title={title || ''}>
+      <ToggleButton {...other}>{children}</ToggleButton>
+    </Tooltip>
+  )
+}
+
 export default function RecentSessionPanel({
   setError,
   sortedSessions,
@@ -202,16 +215,12 @@ export default function RecentSessionPanel({
           value={displayMode}
           onChange={(_, newVal) => setDisplayMode(newVal)}
         >
-          <ToggleButton value={'grid'}>
-            <Tooltip title="Grid view">
-              <ViewComfyIcon />
-            </Tooltip>
-          </ToggleButton>
-          <ToggleButton value={'list'}>
-            <Tooltip title="List view">
-              <ListIcon />
-            </Tooltip>
-          </ToggleButton>
+          <ToggleButtonWithTooltip value="grid" title="Grid view">
+            <ViewComfyIcon />
+          </ToggleButtonWithTooltip>
+          <ToggleButtonWithTooltip value="list" title="List view">
+            <ListIcon />
+          </ToggleButtonWithTooltip>
         </ToggleButtonGroup>
       </FormControl>
 

--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-function RecentSessionsTable({
+function RecentSessionsList({
   setError,
   sortedSessions,
   setSessionToDelete,
@@ -193,7 +193,7 @@ export default function RecentSessionPanel({
   setPluginManager: (pm: PluginManager) => void
 }) {
   const classes = useStyles()
-  const [displayMode, setDisplayMode] = useLocalStorage('displayMode', 'table')
+  const [displayMode, setDisplayMode] = useLocalStorage('displayMode', 'list')
   return (
     <div>
       <FormControl className={classes.formControl}>
@@ -207,8 +207,8 @@ export default function RecentSessionPanel({
               <ViewComfyIcon />
             </Tooltip>
           </ToggleButton>
-          <ToggleButton value={'table'}>
-            <Tooltip title="Table view">
+          <ToggleButton value={'list'}>
+            <Tooltip title="List view">
               <ListIcon />
             </Tooltip>
           </ToggleButton>
@@ -225,7 +225,7 @@ export default function RecentSessionPanel({
             setSessionToRename={setSessionToRename}
           />
         ) : (
-          <RecentSessionsTable
+          <RecentSessionsList
             setPluginManager={setPluginManager}
             sortedSessions={sortedSessions}
             setError={setError}

--- a/products/jbrowse-desktop/src/StartScreen/data/preloadedConfigs.js
+++ b/products/jbrowse-desktop/src/StartScreen/data/preloadedConfigs.js
@@ -498,6 +498,9 @@ const preloadedConfigs = {
         },
       },
     ],
+    defaultSession: {
+      name: 'New Session',
+    },
   },
 }
 

--- a/products/jbrowse-desktop/src/StartScreen/index.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/index.tsx
@@ -7,6 +7,7 @@ import {
   ListItemIcon,
   Menu,
   MenuItem,
+  Paper,
   Typography,
   makeStyles,
 } from '@material-ui/core'
@@ -46,7 +47,6 @@ const useStyles = makeStyles(theme => ({
   panel: {
     margin: theme.spacing(1),
     padding: theme.spacing(4),
-    border: '1px solid black',
   },
 
   settings: {
@@ -178,13 +178,13 @@ export default function StartScreen({
       <div className={classes.root}>
         <Grid container spacing={3}>
           <Grid item xs={4}>
-            <div className={classes.panel}>
+            <Paper elevation={6} className={classes.panel}>
               <Typography variant="h5">Launch new session</Typography>
               <LauncherPanel setPluginManager={setPluginManager} />
-            </div>
+            </Paper>
           </Grid>
           <Grid item xs={8}>
-            <div className={classes.panel}>
+            <Paper elevation={6} className={classes.panel}>
               <Typography variant="h5">Recently opened sessions</Typography>
               <RecentSessionPanel
                 setPluginManager={setPluginManager}
@@ -193,7 +193,7 @@ export default function StartScreen({
                 setSessionToRename={setSessionToRename}
                 setError={setError}
               />
-            </div>
+            </Paper>
           </Grid>
         </Grid>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -20781,6 +20781,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+timeago.js@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
+  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"


### PR DESCRIPTION
This PR has several small changes I wanted to propose after working with the desktop app:

- Reduce size of saved session thumbnail image. Now saves at a width of 250 (the size of the preview image in the card) instead of full window width.
- Fix bug in mm10 preloaded config where it would not open by itself because it didn't have a defaultSession
- Fix bug where if you checked and then un-checked an assembly, it would still be in the session (also disable "Go" button while no assemblies are checked)
- Move tooltip on toggle button from the contents to the toggle button itself, so that the tooltip will show up even if hovering over the edges of the button.
- Rename "table view" to "list view" in start screen. Small survey (at least my OS's file explorer and Google Drive) shows this to be the commonly used term.
- Show "time ago" last modified time for times less than 24 hours ago (with actual time as a tooltip)

| Before | After |
|:-----------:|:-----------:|
![image](https://user-images.githubusercontent.com/25592344/135856767-eb553211-1844-4685-982e-39e6c55d45c9.png) | ![image](https://user-images.githubusercontent.com/25592344/135858341-4d53d339-94e0-4c78-a89b-125dafc9f024.png)

- Use Paper for start screen division to match style of other parts of app

| Before | After |
|:-----------:|:-----------:|
![image](https://user-images.githubusercontent.com/25592344/135857256-f6542bde-b6ea-45cc-b045-2212ae3c68af.png) | ![image](https://user-images.githubusercontent.com/25592344/135858432-81f1837c-aacc-463d-b6c2-6f6144c447ce.png)