### PR TITLE
Fix crash on launching a deleted quickstart

### DIFF
--- a/products/jbrowse-desktop/src/StartScreen/QuickstartPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/QuickstartPanel.tsx
@@ -68,6 +68,7 @@ function PreloadedDatasetSelector({
           setQuickstarts(quick)
         }
       } catch (e) {
+        console.error(e)
         setError(e)
       }
     }
@@ -99,20 +100,25 @@ function PreloadedDatasetSelector({
       <Button
         className={classes.button}
         onClick={async () => {
-          const config = deepmerge.all(
-            await Promise.all(
-              Object.keys(selected)
-                .filter(name => selected[name])
-                .map(entry => ipcRenderer.invoke('getQuickstart', entry)),
-            ),
-          )
+          try {
+            const config = deepmerge.all(
+              await Promise.all(
+                Object.keys(selected)
+                  .filter(name => selected[name] && quickstarts?.includes(name))
+                  .map(entry => ipcRenderer.invoke('getQuickstart', entry)),
+              ),
+            )
 
-          // @ts-ignore
-          config.defaultSession.name = `New session ${new Date().toLocaleString(
-            'en-US',
-          )}`
-          const pm = await createPluginManager(config)
-          setPluginManager(pm)
+            // @ts-ignore
+            config.defaultSession.name = `New session ${new Date().toLocaleString(
+              'en-US',
+            )}`
+            const pm = await createPluginManager(config)
+            setPluginManager(pm)
+          } catch (e) {
+            console.error(e)
+            setError(e)
+          }
         }}
         variant="contained"
         color="primary"


### PR DESCRIPTION
Fixes #2393

Catches errors in a nicer way, and filters out deleted quickstarts before trying to access them

There is a tension here between the observability, and fetching from the filesystem. We are not using mobx here, and since it is corresponding with the filesystem, and maybe even multiple instances of jbrowse, it wouldn't really be automatically solved by mobx, so this is just a best effort here to remain alive and consistent with the filesystem (again, it uses polling)
