### PR TITLE
Add assembly and trackId deduplicating for quickstart merges

### DIFF
--- a/products/jbrowse-desktop/src/StartScreen/util.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/util.tsx
@@ -84,13 +84,34 @@ export async function createPluginManager(
 
   const jbrowse = deepmerge(configSnapshot, {
     internetAccounts: defaultInternetAccounts,
-  })
+    assemblies: [],
+    tracks: []
+  }) as {
+    internetAccounts: { internetAccountId: string }[]
+    assemblies: { name: string }[]
+    tracks: { trackId: string }[]
+  }
 
-  const ids = jbrowse.internetAccounts.map(o => o.internetAccountId)
+  const internetAccountIds = jbrowse.internetAccounts.map(
+    o => o.internetAccountId,
+  )
 
   // remove duplicates while mixing in default internet accounts
   jbrowse.internetAccounts = jbrowse.internetAccounts.filter(
-    (arg, index) => !ids.includes(arg.internetAccountId, index + 1),
+    ({ internetAccountId }, index) =>
+      !internetAccountIds.includes(internetAccountId, index + 1),
+  )
+
+  const assemblyNames = jbrowse.assemblies.map(o => o.name)
+
+  jbrowse.assemblies = jbrowse.assemblies.filter(
+    ({ name }, index) => !assemblyNames.includes(name, index + 1),
+  )
+
+  const trackIds = jbrowse.tracks.map(o => o.trackId)
+
+  jbrowse.tracks = jbrowse.tracks.filter(
+    ({ trackId }, index) => !trackIds.includes(trackId, index + 1),
   )
 
   const rootModel = JBrowseRootModel.create(


### PR DESCRIPTION
Fixes #2394 

Deduplicates both assembly and trackIds. This is a best effort since the collision may not be the exact same data, but without a safer way to merge, this seems the way to go. The alternative is we disallow merging quickstarts. The benefit of merging quickstarts is, to my mind, primarily for synteny data, but given that arbitrary contents can appear in quickstarts now, it could be somewhat more awkward to merge the sessions