### PR TITLE
Use new Codecov upload, old one is depracated

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Test codebase
         run: yarn test-ci
       - name: Upload coverage
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v2
       - name: Typecheck codebase
         run: yarn typecheck
 


### PR DESCRIPTION
The Codecov Bash uploader is being deprecated: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

This uses their GitHub action instead: https://github.com/marketplace/actions/codecov

The first run [didn't seem to work](https://github.com/GMOD/jbrowse-components/runs/3885147126#step:6:67), though, so this is still a draft. It seems to want a token, but a token shouldn't be needed for a public repo.