### PR TITLE
Remove desktop autosaves, prompt user to save when exiting unsaved session

### DIFF
--- a/products/jbrowse-desktop/src/StartScreen/LauncherPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/LauncherPanel.tsx
@@ -5,6 +5,7 @@ import { ipcRenderer } from 'electron'
 import QuickstartPanel from './QuickstartPanel'
 import OpenSequenceDialog from '../OpenSequenceDialog'
 import { loadPluginManager } from './util'
+import { DesktopRootModel } from './types'
 
 const useStyles = makeStyles(theme => ({
   form: {
@@ -51,16 +52,19 @@ export default function StartScreenOptionsPanel({
             if (conf) {
               // note this can throw before dialog closes, but this is handled
               // by the dialog itself
-              const path = await ipcRenderer.invoke(
-                'createInitialAutosaveFile',
-                {
-                  assemblies: [conf],
-                  defaultSession: {
-                    name: 'New Session ' + new Date().toLocaleString('en-US'),
-                  },
+              const path = await ipcRenderer.invoke('createUnsavedFile', {
+                assemblies: [conf],
+                defaultSession: {
+                  name: 'New Session ' + new Date().toLocaleString('en-US'),
+                  saved: false,
                 },
-              )
-              setPluginManager(await loadPluginManager(path))
+              })
+              const pluginManager = await loadPluginManager(path)
+              const { rootModel } = pluginManager
+              if (rootModel) {
+                ;(rootModel as DesktopRootModel).setUnsaved()
+              }
+              setPluginManager(pluginManager)
             }
             setSequenceDialogOpen(false)
           }}

--- a/products/jbrowse-desktop/src/StartScreen/QuickstartPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/QuickstartPanel.tsx
@@ -23,6 +23,7 @@ import deepmerge from 'deepmerge'
 
 // locals
 import { loadPluginManager } from './util'
+import { DesktopRootModel } from './types'
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -113,11 +114,15 @@ function QuickstartPanel({
             config.defaultSession.name = `New session ${new Date().toLocaleString(
               'en-US',
             )}`
-            const path = await ipcRenderer.invoke(
-              'createInitialAutosaveFile',
-              config,
-            )
-            setPluginManager(await loadPluginManager(path))
+            // @ts-ignore
+            config.defaultSession.saved = false
+            const path = await ipcRenderer.invoke('createUnsavedFile', config)
+            const pluginManager = await loadPluginManager(path)
+            const { rootModel } = pluginManager
+            if (rootModel) {
+              ;(rootModel as DesktopRootModel).setUnsaved()
+            }
+            setPluginManager(pluginManager)
           } catch (e) {
             console.error(e)
             setError(e)

--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import {
-  Checkbox,
   CircularProgress,
   FormControl,
-  FormControlLabel,
   Grid,
   IconButton,
   Link,
@@ -237,10 +235,6 @@ export default function RecentSessionPanel({
   const [updateSessionsList, setUpdateSessionsList] = useState(0)
   const [selectedSessions, setSelectedSessions] = useState<RecentSessions>()
   const [sessionsToDelete, setSessionsToDelete] = useState<RecentSessions>()
-  const [showAutosaves, setShowAutosaves] = useLocalStorage(
-    'showAutosaves',
-    'false',
-  )
 
   const sortedSessions = useMemo(
     () => sessions?.sort((a, b) => b.updated - a.updated),
@@ -250,17 +244,14 @@ export default function RecentSessionPanel({
   useEffect(() => {
     ;(async () => {
       try {
-        const sessions = await ipcRenderer.invoke(
-          'listSessions',
-          showAutosaves === 'true',
-        )
+        const sessions = await ipcRenderer.invoke('listSessions')
         setSessions(sessions)
       } catch (e) {
         console.error(e)
         setError(e)
       }
     })()
-  }, [setError, updateSessionsList, showAutosaves])
+  }, [setError, updateSessionsList])
 
   if (!sessions) {
     return (
@@ -339,18 +330,6 @@ export default function RecentSessionPanel({
           </ToggleButtonWithTooltip>
         </ToggleButtonGroup>
       </FormControl>
-
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={showAutosaves === 'true'}
-            onChange={() =>
-              setShowAutosaves(showAutosaves === 'true' ? 'false' : 'true')
-            }
-          />
-        }
-        label="Show autosaves"
-      />
 
       {sortedSessions.length ? (
         displayMode === 'grid' ? (

--- a/products/jbrowse-desktop/src/StartScreen/types.ts
+++ b/products/jbrowse-desktop/src/StartScreen/types.ts
@@ -1,0 +1,6 @@
+import { AbstractRootModel } from '@jbrowse/core/util/types'
+
+export interface DesktopRootModel extends AbstractRootModel {
+  setSaved(): void
+  setUnsaved(): void
+}


### PR DESCRIPTION
I am concerned exposing a combination of autosaved andd non-autosaved sessions to users. I feel like it may not be clear what autosaved sessions are. It's also unclear what the "Save" button does, since there's no user feedback. This is a proposal for an alternate model.
* Instead of autosaved sessions, if a user starts a new session from opening a quickstart or an assembly, the sessions is saved in "unsaved.jbrowse" in the user data directory
* When the user exits, returns to the start screen, or opens a new session and their current session is not saved, they are asked if they want to save their session
![image](https://user-images.githubusercontent.com/25592344/137422959-7bbbc973-18a3-48a9-8c62-8b2ef9362fb6.png)
* If the user does not save their session, the unsaved session is discarded.
* The "Save" menu entry is disabled and the text changed to "Autosaved" when working on a saved session

| Unsaved session | Saved session |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/25592344/137423194-712a2340-274f-4fee-a51e-5a1394817c97.png) | ![image](https://user-images.githubusercontent.com/25592344/137423238-9989868a-afc8-400b-8ab2-0298336850cf.png) |

This is currently based on the branch for #2409, but could be made separate if needed