### PR TITLE
Check that session is a valid .jbrowse file when loading

### DIFF
--- a/products/jbrowse-desktop/public/electron.ts
+++ b/products/jbrowse-desktop/public/electron.ts
@@ -315,7 +315,13 @@ ipcMain.handle('loadExternalConfig', (_event: unknown, sessionPath) => {
 })
 
 ipcMain.handle('loadSession', async (_event: unknown, sessionPath: string) => {
-  return JSON.parse(await readFile(sessionPath, 'utf8'))
+  const sessionSnapshot = JSON.parse(await readFile(sessionPath, 'utf8'))
+  if (!sessionSnapshot.assemblies) {
+    throw new Error(
+      `File at ${sessionPath} does not appear to be a JBrowse session. It does not contain any assemblies.`,
+    )
+  }
+  return sessionSnapshot
 })
 
 ipcMain.handle(


### PR DESCRIPTION
I noticed that on desktop you can open any valid JSON file, so for example a file that only contained `{}` could be opened and it would open it with a default session. The file could be an unrelated JSON file, though, and opening it would overwrite the contents of the file with the JBrowse session.  This adds a check to make sure the session file at least has an "assemblies" key to help prevent something that's not a session file from being opened and overwritten.