### PR TITLE
Fix crash when chromSizesLocation not specified when loading TwoBitAdapter in GUI

### DIFF
--- a/packages/core/util/types/mst.ts
+++ b/packages/core/util/types/mst.ts
@@ -94,11 +94,11 @@ export const FileLocation = types.snapshotProcessor(
         // @ts-ignore
         const { uri, localPath, blob } = rest
         let locationType = ''
-        if (uri) {
+        if (uri !== undefined) {
           locationType = 'UriLocation'
-        } else if (localPath) {
+        } else if (localPath !== undefined) {
           locationType = 'LocalPathLocation'
-        } else if (blob) {
+        } else if (blob !== undefined) {
           locationType = 'BlobLocation'
         }
 


### PR DESCRIPTION
Currently loading a twobit file from the desktop start screen fails, and fails with a big snapshot failure that crashes the app

There is a assumption in some usages of FileSelector where a "blank location object" is {uri:''}

Then, with TwoBitAdapter in particular, the "chromSizesLocation" is an optional entry that speeds up loading the twoBit, but if chromSizesLocation is not specified, then loading fails.

Specifically, it fails to go through the FileLocation preprocessor however because empty string doesn't pass the check

```
if(uri) {
}
```

This PR explicitly checks for

```
if(uri!==undefined) {
}
```

this helps the locationType get added, and therefore not have an big app crashing error