### PR TITLE
Create core snapshot error message component

### DIFF
--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -21,29 +21,13 @@ export default class AddAssembly extends JBrowseCommand {
   static description = 'Add an assembly to a JBrowse 2 configuration'
 
   static examples = [
-    '# add assembly to installation in current directory. assumes .fai file also exists',
     '$ jbrowse add-assembly GRCh38.fa --load copy',
-    '',
-    '# add assembly to a specific jb2 installation path using --out',
-    '$ jbrowse add-assembly GRCh38.fa --out /path/to/jb2/ --load copy',
-    '',
-    '# force indexedFasta for add-assembly without relying on file extension',
-    '$ jbrowse add-assembly GRCh38.xyz --type indexedFasta --load copy',
-    '',
-    '# add displayName and alias for an assembly',
-    '$ jbrowse add-assembly myFile.fa.gz --name hg38 --displayName "Homo sapiens (hg38)"',
-    '',
-    '# add a chrom.sizes file for assembly',
+    '$ jbrowse add-assembly GRCh38.fasta.with.custom.extension.xyz --type indexedFasta --load move',
+    '$ jbrowse add-assembly myFile.fa.gz --name hg38 --alias GRCh38 --displayName "Homo sapiens (hg38)" --load inPlace',
     '$ jbrowse add-assembly GRCh38.chrom.sizes --load inPlace',
-    '',
-    '# add assembly from preconfigured json file, expert option',
     '$ jbrowse add-assembly GRCh38.config.json --load copy',
-    '',
-    '# add assembly from a 2bit file, also note pointing direct to a URL',
     '$ jbrowse add-assembly https://example.com/data/sample.2bit',
-    '',
-    '# add a bgzip indexed fasta inferred by fa.gz extension. assumes .fa.gz.gzi and .fa.gz.fai files also exists',
-    '$ jbrowse add-assembly myfile.fa.gz --load copy',
+    '$ jbrowse add-assembly GRCh38.fa --target /path/to/jb2/installation/customconfig.json --load copy',
   ]
 
   static args = [

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -37,28 +37,23 @@ export default class AddTrack extends JBrowseCommand {
   static description = 'Add a track to a JBrowse 2 configuration'
 
   static examples = [
-    '# copy /path/to/my.bam and /path/to/my.bam.bai to current directory and adds track to config.json',
-    '$ jbrowse add-track /path/to/my.bam --load copy',
-    '',
-
-    '# copy /path/to/my.bam and /path/to/my.bam.bai to myDir and adds track to config.json',
-    '$ jbrowse add-track /path/to/my.bam --load copy --out myDir',
-    '',
+    `# --load copy copies my.bam and my.bam.bai to current directory and adds track to config.json`,
+    '$ jbrowse add-track /path/to/my.bam --load copy\n',
 
     `# same as above, but specify path to bai file`,
-    '$ jbrowse add-track /path/to/my.bam --indexFile /path/to/my.bai --load copy',
-    '',
+    '$ jbrowse add-track /path/to/my.bam --indexFile /path/to/my.bai --load copy\n',
 
-    '# creates symlink for /path/to/my.bam and adds track to config.json',
-    '$ jbrowse add-track /path/to/my.bam --load symlink',
-    '',
+    `# --load symlink creates symlink in /path/to/jb2/ directory for this file, and adds track to config.json`,
+    '$ jbrowse add-track /path/to/my.bam --target /path/to/jb2/config.json --load symlink\n',
 
-    '# add track from URL to config.json, no --load flag needed',
-    '$ jbrowse add-track https://mywebsite.com/my.bam',
-    '',
+    `# no --load flag to add literal URL for this track to config.json`,
+    '$ jbrowse add-track https://mywebsite.com/my.bam\n',
 
-    '# --load inPlace adds a track without doing file operations',
-    '$ jbrowse add-track /url/relative/path.bam --load inPlace',
+    `# --load move to move the file `,
+    `$ jbrowse add-track /path/to/my.bam --name 'New Track' --load move\n`,
+
+    `# --load inPlace puts /url/relative/path.bam in the config without performing any file operations`,
+    `$ jbrowse add-track /url/relative/path.bam --trackId AlignmentsTrack1 --load url --overwrite`,
   ]
 
   static args = [

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -10,20 +10,11 @@ export default class Create extends JBrowseCommand {
   static description = 'Downloads and installs the latest JBrowse 2 release'
 
   static examples = [
-    '# Download latest release from github, and put in specific path',
     '$ jbrowse create /path/to/new/installation',
-    '',
-    '# Download latest release from github and force overwrite existing contents at path',
     '$ jbrowse create /path/to/new/installation --force',
-    '',
-    '# Download latest release from a specific URL',
     '$ jbrowse create /path/to/new/installation --url url.com/directjbrowselink.zip',
-    '',
-    '# Download a specific tag from github',
     '$ jbrowse create /path/to/new/installation --tag v1.0.0',
-    '',
-    '# List available versions',
-    '$ jbrowse create --listVersions',
+    '$ jbrowse create --listVersions # Lists out all available versions of JBrowse 2',
   ]
 
   static args = [

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -9,23 +9,11 @@ export default class Upgrade extends JBrowseCommand {
   static description = 'Upgrades JBrowse 2 to latest version'
 
   static examples = [
-    '# Upgrades current directory to latest jbrowse release',
-    '$ jbrowse upgrade',
-    '',
-    '# Upgrade jbrowse instance at a specific filesystem path',
+    '$ jbrowse upgrade # Upgrades current directory to latest jbrowse release',
     '$ jbrowse upgrade /path/to/jbrowse2/installation',
-    '',
-    '# Upgrade to a specific tag',
     '$ jbrowse upgrade /path/to/jbrowse2/installation --tag v1.0.0',
-    '',
-    '# List versions available on github',
-    '$ jbrowse upgrade --listVersions',
-    '',
-    '# Upgrade from a specific URL',
+    '$ jbrowse upgrade --listVersions # Lists out all available versions of JBrowse 2',
     '$ jbrowse upgrade --url https://sample.com/jbrowse2.zip',
-    '',
-    '# Get nightly release from main branch',
-    '$ jbrowse upgrade --nightly',
   ]
 
   static args = [
@@ -34,6 +22,12 @@ export default class Upgrade extends JBrowseCommand {
       required: false,
       description: `Location where JBrowse 2 is installed`,
       default: '.',
+    },
+    {
+      name: 'placeholder',
+      required: false,
+      description: `Placeholder for config file migration scripts`,
+      hidden: true,
     },
   ]
 

--- a/products/jbrowse-desktop/src/Loader.tsx
+++ b/products/jbrowse-desktop/src/Loader.tsx
@@ -5,7 +5,6 @@ import { CssBaseline, ThemeProvider } from '@material-ui/core'
 import { createJBrowseTheme } from '@jbrowse/core/ui'
 import ErrorMessage from '@jbrowse/core/ui/ErrorMessage'
 import { StringParam, useQueryParam } from 'use-query-params'
-import { ipcRenderer } from 'electron'
 
 // locals
 import { loadPluginManager } from './StartScreen/util'


### PR DESCRIPTION
The web and desktop components check for whether there is a snapshot error by running a regex over the error message

This moves the ErrorMessage component to core since it's used in 3 different places now (desktop loader, desktop OpenSequenceDialog (this one might not be strictly needed but it for example alerts if the assembly has no name when they are entering an assembly, and web loader)
