### PR TITLE
Fix linear synteny view import form failure

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -95,7 +95,6 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   showWidget?: Function
   addWidget?: Function
 
-  addTrackConf?: Function
   DialogComponent?: DialogComponentType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DialogProps: any
@@ -123,6 +122,18 @@ export function isSessionModelWithConfigEditing(
   thing: unknown,
 ): thing is SessionWithConfigEditing {
   return isSessionModel(thing) && 'editConfiguration' in thing
+}
+
+/** abstract interface for a session allows adding tracks */
+export interface SessionWithConfigEditing extends AbstractSessionModel {
+  addTrackConf(
+    configuration: AnyConfigurationModel | SnapshotIn<AnyConfigurationModel>,
+  ): void
+}
+export function isSessionWithAddTracks(
+  thing: unknown,
+): thing is SessionWithConfigEditing {
+  return isSessionModel(thing) && 'addTrackConf' in thing
 }
 
 export interface Widget {

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
+import { Button, Paper, Container, Grid, makeStyles } from '@material-ui/core'
 import { FileSelector } from '@jbrowse/core/ui'
 import { FileLocation } from '@jbrowse/core/util/types'
 import { observer } from 'mobx-react'
-import { getSession } from '@jbrowse/core/util'
+import { getSession, isSessionWithAddTracks } from '@jbrowse/core/util'
 import ErrorMessage from '@jbrowse/core/ui/ErrorMessage'
 import AssemblySelector from '@jbrowse/core/ui/AssemblySelector'
-import { Button, Paper, Container, Grid, makeStyles } from '@material-ui/core'
 import { DotplotViewModel } from '../model'
 
 const useStyles = makeStyles(theme => ({
@@ -34,6 +34,9 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
 
   function onOpenClick() {
     try {
+      if (!isSessionWithAddTracks(session)) {
+        return
+      }
       model.setViews([
         { bpPerPx: 0.1, offsetPx: 0 },
         { bpPerPx: 0.1, offsetPx: 0 },
@@ -45,8 +48,9 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
           ? trackData.uri.slice(trackData.uri.lastIndexOf('/') + 1)
           : 'MyTrack'
 
-      // @ts-ignore
-      const configuration = session.addTrackConf({
+      const trackId = `${fileName}-${Date.now()}`
+
+      session.addTrackConf({
         trackId: `${fileName}-${Date.now()}`,
         name: fileName,
         assemblyNames: selected,
@@ -57,7 +61,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
           assemblyNames: selected,
         },
       })
-      model.toggleTrack(configuration.trackId)
+      model.toggleTrack(trackId)
     } catch (e) {
       console.error(e)
       setError(e)

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -2,7 +2,6 @@ import {
   addDisposer,
   cast,
   getSnapshot,
-  getParent,
   getType,
   getPropertyMembers,
   getChildType,
@@ -555,19 +554,15 @@ export default function RootModel(
                   {
                     label: 'Open assembly manager',
                     icon: SettingsIcon,
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    onClick: (session: any) => {
-                      const rootModel = getParent(session)
-                      rootModel.setAssemblyEditing(true)
+                    onClick: () => {
+                      self.setAssemblyEditing(true)
                     },
                   },
                   {
                     label: 'Set default session',
                     icon: SettingsIcon,
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    onClick: (session: any) => {
-                      const rootModel = getParent(session)
-                      rootModel.setDefaultSessionEditing(true)
+                    onClick: () => {
+                      self.setDefaultSessionEditing(true)
                     },
                   },
                 ],


### PR DESCRIPTION
This has been broken since v1.3.1 when assembly.regions was made a volatile (speeded up loading)

Grepping through the codebase with a couple patterns didn't find any other references that were similar to this

The line had a @ts-ignore on it that caused it to not get caught probably by typechecking