### PR TITLE
Set default session dialog redesign proposal

### DIFF
--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
@@ -32,7 +32,7 @@ describe('SetDefaultSession GUI', () => {
   it('closes when the return button is clicked', () => {
     const onClose = jest.fn()
     const { getByText } = render(
-      <SetDefaultSession rootModel={mockRootModel} open onClose={onClose} />,
+      <SetDefaultSession rootModel={mockRootModel} onClose={onClose} />,
     )
     fireEvent.click(getByText('Cancel'))
     expect(onClose).toHaveBeenCalled()
@@ -40,7 +40,7 @@ describe('SetDefaultSession GUI', () => {
 
   it('shows no sessions if none are saved', () => {
     const { getByText } = render(
-      <SetDefaultSession rootModel={mockRootModel} open onClose={() => {}} />,
+      <SetDefaultSession rootModel={mockRootModel} onClose={() => {}} />,
     )
     expect(getByText('No saved sessions found')).toBeTruthy()
   })
@@ -58,11 +58,7 @@ describe('SetDefaultSession GUI', () => {
       },
     }
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={MockSavedSessions}
-        open
-        onClose={() => {}}
-      />,
+      <SetDefaultSession rootModel={MockSavedSessions} onClose={() => {}} />,
     )
     expect(getByText('New session')).toBeTruthy()
   })
@@ -78,7 +74,7 @@ describe('SetDefaultSession GUI', () => {
       },
     }
     const { getByText } = render(
-      <SetDefaultSession rootModel={MockSession} open onClose={() => {}} />,
+      <SetDefaultSession rootModel={MockSession} onClose={() => {}} />,
     )
     fireEvent.click(getByText('Clear default session'))
     expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalledWith({

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
@@ -20,37 +20,48 @@ const mockRootModel = {
         },
       },
     ],
+    setDefaultSessionConf: jest.fn(),
   },
   session: {
-    savedSessions: [],
-    setDefaultSession: jest.fn(),
-    rpcManager: {},
-    configuration: {},
+    savedSessions: {},
   },
 }
-
-const session = mockRootModel.session
 
 describe('SetDefaultSession GUI', () => {
   it('renders succesfully', () => {
     const { getByText } = render(
-      <SetDefaultSession session={session} open onClose={() => {}} />,
+      <SetDefaultSession
+        rootModel={mockRootModel}
+        open
+        onClose={() => {}}
+        currentDefault="New session"
+      />,
     )
-    expect(getByText('Set default session')).toBeTruthy()
+    expect(getByText('Set Default Session')).toBeTruthy()
   })
 
   it('closes when the return button is clicked', () => {
     const onClose = jest.fn()
     const { getByText } = render(
-      <SetDefaultSession session={session} open onClose={onClose} />,
+      <SetDefaultSession
+        rootModel={mockRootModel}
+        open
+        onClose={onClose}
+        currentDefault="New session"
+      />,
     )
-    fireEvent.click(getByText('Cancel'))
+    fireEvent.click(getByText('Return'))
     expect(onClose).toHaveBeenCalled()
   })
 
   it('shows no sessions if none are saved', () => {
     const { getByText } = render(
-      <SetDefaultSession session={session} open onClose={() => {}} />,
+      <SetDefaultSession
+        rootModel={mockRootModel}
+        open
+        onClose={() => {}}
+        currentDefault="New session"
+      />,
     )
     expect(getByText('No saved sessions found')).toBeTruthy()
   })
@@ -59,7 +70,6 @@ describe('SetDefaultSession GUI', () => {
     const MockSavedSessions = {
       ...mockRootModel,
       session: {
-        ...mockRootModel.session,
         savedSessions: [
           {
             name: `New session`,
@@ -69,19 +79,40 @@ describe('SetDefaultSession GUI', () => {
     }
     const { getByText } = render(
       <SetDefaultSession
-        session={MockSavedSessions.session}
+        rootModel={MockSavedSessions}
         open
         onClose={() => {}}
+        currentDefault="New session"
       />,
     )
     expect(getByText('New session')).toBeTruthy()
+  })
+
+  it('sets to the default session when checked', () => {
+    const MockSession = {
+      ...mockRootModel,
+      session: {
+        name: `Moo session`,
+        savedSessions: [],
+        notify: jest.fn(),
+      },
+    }
+    const { getByRole } = render(
+      <SetDefaultSession
+        rootModel={MockSession}
+        open
+        onClose={() => {}}
+        currentDefault="New session"
+      />,
+    )
+    fireEvent.click(getByRole('radio'))
+    expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalled()
   })
 
   it('unsets to the default session with reset button', () => {
     const MockSession = {
       ...mockRootModel,
       session: {
-        ...mockRootModel.session,
         name: `Moo session`,
         savedSessions: [],
         notify: jest.fn(),
@@ -89,13 +120,14 @@ describe('SetDefaultSession GUI', () => {
     }
     const { getByText } = render(
       <SetDefaultSession
-        session={MockSession.session}
+        rootModel={MockSession}
         open
         onClose={() => {}}
+        currentDefault="New session"
       />,
     )
     fireEvent.click(getByText('Clear default session'))
-    expect(MockSession.session.setDefaultSession).toHaveBeenCalledWith({
+    expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalledWith({
       name: `New session`,
     })
   })

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
@@ -38,31 +38,6 @@ describe('SetDefaultSession GUI', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('shows no sessions if none are saved', () => {
-    const { getByText } = render(
-      <SetDefaultSession rootModel={mockRootModel} onClose={() => {}} />,
-    )
-    expect(getByText('No saved sessions found')).toBeTruthy()
-  })
-
-  it('lists the saved sessions', () => {
-    const MockSavedSessions = {
-      ...mockRootModel,
-      session: {
-        ...mockRootModel.session,
-        savedSessions: [
-          {
-            name: `New session`,
-          },
-        ],
-      },
-    }
-    const { getByText } = render(
-      <SetDefaultSession rootModel={MockSavedSessions} onClose={() => {}} />,
-    )
-    expect(getByText('New session')).toBeTruthy()
-  })
-
   it('unsets to the default session with reset button', () => {
     const MockSession = {
       ...mockRootModel,

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
@@ -23,45 +23,24 @@ const mockRootModel = {
     setDefaultSessionConf: jest.fn(),
   },
   session: {
-    savedSessions: {},
+    savedSessions: [],
+    notify: jest.fn(),
   },
 }
 
 describe('SetDefaultSession GUI', () => {
-  it('renders succesfully', () => {
-    const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
-    )
-    expect(getByText('Set Default Session')).toBeTruthy()
-  })
-
   it('closes when the return button is clicked', () => {
     const onClose = jest.fn()
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={onClose}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession rootModel={mockRootModel} open onClose={onClose} />,
     )
-    fireEvent.click(getByText('Return'))
+    fireEvent.click(getByText('Cancel'))
     expect(onClose).toHaveBeenCalled()
   })
 
   it('shows no sessions if none are saved', () => {
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession rootModel={mockRootModel} open onClose={() => {}} />,
     )
     expect(getByText('No saved sessions found')).toBeTruthy()
   })
@@ -70,6 +49,7 @@ describe('SetDefaultSession GUI', () => {
     const MockSavedSessions = {
       ...mockRootModel,
       session: {
+        ...mockRootModel.session,
         savedSessions: [
           {
             name: `New session`,
@@ -82,49 +62,23 @@ describe('SetDefaultSession GUI', () => {
         rootModel={MockSavedSessions}
         open
         onClose={() => {}}
-        currentDefault="New session"
       />,
     )
     expect(getByText('New session')).toBeTruthy()
-  })
-
-  it('sets to the default session when checked', () => {
-    const MockSession = {
-      ...mockRootModel,
-      session: {
-        name: `Moo session`,
-        savedSessions: [],
-        notify: jest.fn(),
-      },
-    }
-    const { getByRole } = render(
-      <SetDefaultSession
-        rootModel={MockSession}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
-    )
-    fireEvent.click(getByRole('radio'))
-    expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalled()
   })
 
   it('unsets to the default session with reset button', () => {
     const MockSession = {
       ...mockRootModel,
       session: {
+        ...mockRootModel.session,
         name: `Moo session`,
         savedSessions: [],
         notify: jest.fn(),
       },
     }
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={MockSession}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession rootModel={MockSession} open onClose={() => {}} />,
     )
     fireEvent.click(getByText('Clear default session'))
     expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalledWith({

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.test.tsx
@@ -20,48 +20,37 @@ const mockRootModel = {
         },
       },
     ],
-    setDefaultSessionConf: jest.fn(),
   },
   session: {
-    savedSessions: {},
+    savedSessions: [],
+    setDefaultSession: jest.fn(),
+    rpcManager: {},
+    configuration: {},
   },
 }
+
+const session = mockRootModel.session
 
 describe('SetDefaultSession GUI', () => {
   it('renders succesfully', () => {
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession session={session} open onClose={() => {}} />,
     )
-    expect(getByText('Set Default Session')).toBeTruthy()
+    expect(getByText('Set default session')).toBeTruthy()
   })
 
   it('closes when the return button is clicked', () => {
     const onClose = jest.fn()
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={onClose}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession session={session} open onClose={onClose} />,
     )
-    fireEvent.click(getByText('Return'))
+    fireEvent.click(getByText('Cancel'))
     expect(onClose).toHaveBeenCalled()
   })
 
   it('shows no sessions if none are saved', () => {
     const { getByText } = render(
-      <SetDefaultSession
-        rootModel={mockRootModel}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
+      <SetDefaultSession session={session} open onClose={() => {}} />,
     )
     expect(getByText('No saved sessions found')).toBeTruthy()
   })
@@ -70,6 +59,7 @@ describe('SetDefaultSession GUI', () => {
     const MockSavedSessions = {
       ...mockRootModel,
       session: {
+        ...mockRootModel.session,
         savedSessions: [
           {
             name: `New session`,
@@ -79,40 +69,19 @@ describe('SetDefaultSession GUI', () => {
     }
     const { getByText } = render(
       <SetDefaultSession
-        rootModel={MockSavedSessions}
+        session={MockSavedSessions.session}
         open
         onClose={() => {}}
-        currentDefault="New session"
       />,
     )
     expect(getByText('New session')).toBeTruthy()
-  })
-
-  it('sets to the default session when checked', () => {
-    const MockSession = {
-      ...mockRootModel,
-      session: {
-        name: `Moo session`,
-        savedSessions: [],
-        notify: jest.fn(),
-      },
-    }
-    const { getByRole } = render(
-      <SetDefaultSession
-        rootModel={MockSession}
-        open
-        onClose={() => {}}
-        currentDefault="New session"
-      />,
-    )
-    fireEvent.click(getByRole('radio'))
-    expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalled()
   })
 
   it('unsets to the default session with reset button', () => {
     const MockSession = {
       ...mockRootModel,
       session: {
+        ...mockRootModel.session,
         name: `Moo session`,
         savedSessions: [],
         notify: jest.fn(),
@@ -120,14 +89,13 @@ describe('SetDefaultSession GUI', () => {
     }
     const { getByText } = render(
       <SetDefaultSession
-        rootModel={MockSession}
+        session={MockSession.session}
         open
         onClose={() => {}}
-        currentDefault="New session"
       />,
     )
     fireEvent.click(getByText('Clear default session'))
-    expect(MockSession.jbrowse.setDefaultSessionConf).toHaveBeenCalledWith({
+    expect(MockSession.session.setDefaultSession).toHaveBeenCalledWith({
       name: `New session`,
     })
   })

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
@@ -6,46 +6,18 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  List,
-  ListSubheader,
   Typography,
-  makeStyles,
 } from '@material-ui/core'
-
-import pluralize from 'pluralize'
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    margin: theme.spacing(1),
-  },
-  message: {
-    padding: theme.spacing(3),
-  },
-}))
 
 function canSetDefaultSession(obj: unknown): obj is {
   jbrowse: { setDefaultSessionConf: Function }
-  session: {
-    notify: Function
-    savedSessions: {
-      name: string
-      views?: {
-        tracks: unknown[]
-      }[]
-    }[]
-  }
+  session: unknown
 } {
-  return (
-    typeof obj === 'object' &&
-    !!obj &&
-    'setDefaultSessionConf' in obj &&
-    'savedSessions' in obj
-  )
+  return typeof obj === 'object' && !!obj && 'jbrowse' in obj
 }
 
 const SetDefaultSession = observer(
   ({ rootModel, onClose }: { rootModel?: unknown; onClose: () => void }) => {
-    const classes = useStyles()
     if (!rootModel) {
       return null
     }
@@ -60,41 +32,10 @@ const SetDefaultSession = observer(
         <DialogTitle>Set default session</DialogTitle>
         <DialogContent>
           <Typography>
-            Choose a previously saved session (if any exist) or select "Set
-            current session as default" to make your current session saved to
-            the config file. You can also clear the defaultSession, which would
-            just take the user to the start screen instead of any preconfigured
-            default session.
+            Select "Set current session as default" to make your current session
+            saved to the config file. You can also hit "Clear default session",
+            which would remove the default session from the config.
           </Typography>
-          <List
-            subheader={<ListSubheader>Previously saved sessions</ListSubheader>}
-          >
-            {session.savedSessions.length ? (
-              session.savedSessions.map(snap => {
-                const { name, views = [] } = snap
-                const totalTracks = views
-                  .map(view => view.tracks.length)
-                  .reduce((a, b) => a + b, 0)
-
-                return (
-                  <div key={JSON.stringify(snap)}>
-                    <Button onClick={() => jbrowse.setDefaultSessionConf(snap)}>
-                      {name}
-                    </Button>
-                    {`${views.length} ${pluralize(
-                      'view',
-                      views.length,
-                    )}; ${totalTracks}
-                             open ${pluralize('track', totalTracks)}`}
-                  </div>
-                )
-              })
-            ) : (
-              <Typography className={classes.message}>
-                No saved sessions found
-              </Typography>
-            )}
-          </List>
         </DialogContent>
         <DialogActions>
           <Button
@@ -103,7 +44,6 @@ const SetDefaultSession = observer(
               jbrowse.setDefaultSessionConf({
                 name: `New session`,
               })
-              session.notify('Reset default session', 'success')
               onClose()
             }}
           >
@@ -121,7 +61,6 @@ const SetDefaultSession = observer(
             variant="contained"
             onClick={() => {
               jbrowse.setDefaultSessionConf(session)
-              session.notify('Reset default session', 'success')
               onClose()
             }}
           >

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
@@ -29,8 +29,8 @@ const SetDefaultSession = observer(
     open,
     onClose,
   }: {
-    rootModel: {
-      jbrowse: { setDefaultSessionConf: Function }
+    rootModel?: {
+      jbrowse: { setDefaultSessionConf?: Function }
       session?: {
         notify: Function
         savedSessions: {
@@ -45,8 +45,14 @@ const SetDefaultSession = observer(
     onClose: Function
   }) => {
     const classes = useStyles()
-    const { session } = rootModel
+    if (!rootModel) {
+      return null
+    }
+    const { jbrowse, session } = rootModel
     if (!session) {
+      return null
+    }
+    if (!('setDefaultSessionConf' in jbrowse)) {
       return null
     }
 
@@ -64,8 +70,8 @@ const SetDefaultSession = observer(
           <List
             subheader={<ListSubheader>Previously saved sessions</ListSubheader>}
           >
-            {session?.savedSessions.length ? (
-              session?.savedSessions.map(snap => {
+            {session.savedSessions.length ? (
+              session.savedSessions.map(snap => {
                 const { name, views = [] } = snap
                 const totalTracks = views
                   .map(view => view.tracks.length)

--- a/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
+++ b/plugins/data-management/src/SetDefaultSession/SetDefaultSession.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
 import {
   Dialog,
   DialogTitle,
@@ -31,12 +30,12 @@ const SetDefaultSession = observer(
     onClose,
   }: {
     rootModel: {
-      jbrowse: { setDefaultSession: Function }
-      session: {
+      jbrowse: { setDefaultSessionConf: Function }
+      session?: {
         notify: Function
         savedSessions: {
           name: string
-          views: {
+          views?: {
             tracks: unknown[]
           }[]
         }[]
@@ -47,6 +46,9 @@ const SetDefaultSession = observer(
   }) => {
     const classes = useStyles()
     const { session } = rootModel
+    if (!session) {
+      return null
+    }
 
     return (
       <Dialog open={open}>
@@ -72,7 +74,9 @@ const SetDefaultSession = observer(
                 return (
                   <div key={JSON.stringify(snap)}>
                     <Button
-                      onClick={() => rootModel.jbrowse.setDefaultSession(snap)}
+                      onClick={() =>
+                        rootModel.jbrowse.setDefaultSessionConf(snap)
+                      }
                     >
                       {name}
                     </Button>
@@ -95,7 +99,7 @@ const SetDefaultSession = observer(
           <Button
             variant="contained"
             onClick={() => {
-              rootModel.jbrowse.setDefaultSession({
+              rootModel.jbrowse.setDefaultSessionConf({
                 name: `New session`,
               })
               session.notify('Reset default session', 'success')
@@ -115,7 +119,7 @@ const SetDefaultSession = observer(
             color="primary"
             variant="contained"
             onClick={() => {
-              rootModel.jbrowse.setDefaultSession(session)
+              rootModel.jbrowse.setDefaultSessionConf(session)
               session.notify('Reset default session', 'success')
               onClose()
             }}

--- a/products/jbrowse-web/src/AdminComponent.tsx
+++ b/products/jbrowse-web/src/AdminComponent.tsx
@@ -7,12 +7,6 @@ import {
   SetDefaultSession,
 } from '@jbrowse/plugin-data-management'
 
-interface JBrowse {
-  defaultSession: {
-    name: string
-  }
-}
-
 function AdminComponent({ pluginManager }: { pluginManager: PluginManager }) {
   const { rootModel } = pluginManager
 
@@ -21,7 +15,6 @@ function AdminComponent({ pluginManager }: { pluginManager: PluginManager }) {
     isDefaultSessionEditing,
     setDefaultSessionEditing,
     setAssemblyEditing,
-    jbrowse,
   } = rootModel as AppRootModel
 
   return (
@@ -29,19 +22,15 @@ function AdminComponent({ pluginManager }: { pluginManager: PluginManager }) {
       {isAssemblyEditing ? (
         <AssemblyManager
           rootModel={rootModel}
-          onClose={() => {
-            setAssemblyEditing(false)
-          }}
+          onClose={() => setAssemblyEditing(false)}
         />
       ) : null}
-      <SetDefaultSession
-        rootModel={rootModel}
-        open={isDefaultSessionEditing}
-        onClose={() => {
-          setDefaultSessionEditing(false)
-        }}
-        currentDefault={(jbrowse as JBrowse).defaultSession.name}
-      />
+      {isDefaultSessionEditing ? (
+        <SetDefaultSession
+          rootModel={rootModel}
+          onClose={() => setDefaultSessionEditing(false)}
+        />
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
Small redesign proposal for the "Set default session" dialog


![localhost_3000__adminKey=f629996c71 adminServer=http%3A%2F%2Flocalhost%3A9090%2FupdateConfig config=test_data%2Fvolvox%2Fconfig json session=local-yMPn3hqHT](https://user-images.githubusercontent.com/6511937/139287870-4a5e1bb0-c148-4db9-b342-9f8c1b6e6c65.png)

current

![localhost_3000__adminKey=f629996c71 adminServer=http%3A%2F%2Flocalhost%3A9090%2FupdateConfig config=test_data%2Fvolvox%2Fconfig json session=local-yMPn3hqHT (1)](https://user-images.githubusercontent.com/6511937/139287967-f0981a31-25ff-4fb0-b3e2-7ade10447cef.png)


I think by making it clear that there are just a couple choices for the user, and having a little help text, it helps them make the right choice. It also removes the usage of displaying the saved sessions in the dialog