### PR TITLE
Fix embedded crash when opening dialogs

### DIFF
--- a/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
@@ -60,7 +60,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
        */
       task: undefined,
 
-      queueOfDialogs: observable.array([] as [DialogComponentType, any][]),
+      queueOfDialogs: [] as [DialogComponentType, any][],
     }))
     .views(self => ({
       get DialogComponent() {
@@ -150,9 +150,12 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         callback: (doneCallback: Function) => [DialogComponentType, any],
       ): void {
         const [component, props] = callback(() => {
-          self.queueOfDialogs.shift()
+          this.removeActiveDialog()
         })
-        self.queueOfDialogs.push([component, props])
+        self.queueOfDialogs = [...self.queueOfDialogs, [component, props]]
+      },
+      removeActiveDialog() {
+        self.queueOfDialogs = self.queueOfDialogs.slice(1)
       },
       makeConnection(
         configuration: AnyConfigurationModel,

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -62,7 +62,7 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
        */
       task: undefined,
 
-      queueOfDialogs: observable.array([] as [DialogComponentType, any][]),
+      queueOfDialogs: [] as [DialogComponentType, any][],
     }))
     .views(self => ({
       get DialogComponent() {
@@ -155,9 +155,12 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         callback: (doneCallback: Function) => [DialogComponentType, any],
       ): void {
         const [component, props] = callback(() => {
-          self.queueOfDialogs.shift()
+          this.removeActiveDialog()
         })
-        self.queueOfDialogs.push([component, props])
+        self.queueOfDialogs = [...self.queueOfDialogs, [component, props]]
+      },
+      removeActiveDialog() {
+        self.queueOfDialogs = self.queueOfDialogs.slice(1)
       },
       makeConnection(
         configuration: AnyConfigurationModel,


### PR DESCRIPTION
Fixes #2466

This doesn't update the babel configuration (I tried that without any luck), but changes the code to avoid what is probably a weird bug in babel. It makes the volatile `queueOfDialogs` array not observable, and re-assigns the variable each time it's altered so the volatile's top-level observability is sufficient.

Came up with this with @cmdcolin during a pairing.