### PR TITLE
Increase memory allocation jest on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "check-format": "prettier --check .",
     "typecheck": "tsc --noEmit",
     "pretest-ci": "cd products/jbrowse-react-linear-genome-view;yarn build;cd ../../",
-    "test-ci": "jest --ci --coverage && jest --testMatch '**/*testmod.js'",
+    "test-ci": "cross-env NODE_OPTIONS='--max-old-space-size=7000' jest --ci --coverage && jest --testMatch '**/*testmod.js'",
     "built-test-ci": "jest --ci integration.test.js",
-    "test": "DEBUG_PRINT_LIMIT=0 jest"
+    "test": "jest"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Not exactly sure if this will help but saw a test failure here was memory related. Try to increase memory allotment on test

https://github.com/GMOD/jbrowse-components/runs/4051597092?check_suite_focus=true 