### PR TITLE
Fix refName renaming on VcfAdapter for files that don't have ##contig lines

### DIFF
--- a/plugins/variants/src/VcfAdapter/VcfAdapter.ts
+++ b/plugins/variants/src/VcfAdapter/VcfAdapter.ts
@@ -2,34 +2,32 @@ import {
   BaseFeatureDataAdapter,
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { FileLocation, Region } from '@jbrowse/core/util/types'
+import { Region } from '@jbrowse/core/util/types'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import IntervalTree from '@flatten-js/interval-tree'
-import VcfFeature from '../VcfTabixAdapter/VcfFeature'
-import VCF from '@gmod/vcf'
 import { unzip } from '@gmod/bgzf-filehandle'
-import PluginManager from '@jbrowse/core/PluginManager'
-import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import VCF from '@gmod/vcf'
+import VcfFeature from '../VcfTabixAdapter/VcfFeature'
 
 const readVcf = (f: string) => {
   const lines = f.split('\n')
   const header: string[] = []
-  const refNames: string[] = []
   const rest: string[] = []
   lines.forEach(line => {
-    if (line.startsWith('##contig')) {
-      refNames.push(line.split('##contig=<ID=')[1].split(',')[0])
-    } else if (line.startsWith('#')) {
+    if (line.startsWith('#')) {
       header.push(line)
     } else if (line) {
       rest.push(line)
     }
   })
-  return { header: header.join('\n'), lines: rest, refNames }
+  return { header: header.join('\n'), lines: rest }
+}
+
+function isGzip(buf: Buffer) {
+  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
 }
 
 export default class VcfAdapter extends BaseFeatureDataAdapter {
@@ -37,39 +35,30 @@ export default class VcfAdapter extends BaseFeatureDataAdapter {
 
   protected vcfFeatures?: Promise<Record<string, IntervalTree>>
 
-  public constructor(
-    config: AnyConfigurationModel,
-    getSubAdapter?: getSubAdapterType,
-    pluginManager?: PluginManager,
-  ) {
-    super(config, getSubAdapter, pluginManager)
-  }
+  protected unzipped?: Promise<{ header: string; lines: string[] }>
 
   private async decodeFileContents() {
-    const vcfLocation = readConfObject(
-      this.config,
-      'vcfLocation',
-    ) as FileLocation
-
-    let fileContents = await openLocation(
-      vcfLocation,
-      this.pluginManager,
-    ).readFile()
-
-    if (
-      typeof fileContents[0] === 'number' &&
-      fileContents[0] === 31 &&
-      typeof fileContents[1] === 'number' &&
-      fileContents[1] === 139 &&
-      typeof fileContents[2] === 'number' &&
-      fileContents[2] === 8
-    ) {
-      fileContents = new TextDecoder().decode(await unzip(fileContents))
-    } else {
-      fileContents = fileContents.toString()
+    if (!this.unzipped) {
+      this.unzipped = openLocation(
+        readConfObject(this.config, 'vcfLocation'),
+        this.pluginManager,
+      )
+        .readFile()
+        .then(async buffer => {
+          const buf = isGzip(buffer as Buffer) ? await unzip(buffer) : buffer
+          // 512MB  max chrome string length is 512MB
+          if (buf.length > 536_870_888) {
+            throw new Error('Data exceeds maximum string length (512MB)')
+          }
+          return new TextDecoder().decode(buf)
+        })
+        .then(str => readVcf(str))
+        .catch(e => {
+          this.unzipped = undefined
+          throw e
+        })
     }
-
-    return readVcf(fileContents)
+    return this.unzipped
   }
 
   public async getHeader() {
@@ -84,83 +73,69 @@ export default class VcfAdapter extends BaseFeatureDataAdapter {
   }
 
   public async getLines() {
-    const { header, lines } = await this.decodeFileContents()
+    const { lines } = await this.decodeFileContents()
 
-    const parser = new VCF({ header: header })
-
-    return lines.map((line, index) => {
-      return new VcfFeature({
-        variant: parser.parseLine(line),
-        parser,
-        id: `${this.id}-vcf-${index}`,
-      })
+    return lines.map((line, id) => {
+      const [refName, startP, , ref, , , , info] = line.split('\t')
+      const start = +startP - 1
+      const end = +(info.match(/END=(\d+)/)?.[1].trim() || start + ref.length)
+      return { line, refName, start, end, id }
     })
   }
 
   public async setup() {
     if (!this.vcfFeatures) {
-      this.vcfFeatures = this.getLines().then(feats => {
-        return feats.reduce(
-          (acc: Record<string, IntervalTree>, obj: VcfFeature) => {
-            const key = obj.get('refName')
-            if (!acc[key]) {
-              acc[key] = new IntervalTree()
-            }
-            acc[key].insert([obj.get('start'), obj.get('end')], obj)
-            return acc
-          },
-          {},
+      this.vcfFeatures = this.getLines()
+        .then(feats =>
+          feats.reduce(
+            (
+              acc: Record<string, IntervalTree>,
+              obj: {
+                refName: string
+                start: number
+                end: number
+                line: string
+              },
+            ) => {
+              const key = obj.refName
+              if (!acc[key]) {
+                acc[key] = new IntervalTree()
+              }
+              acc[key].insert([obj.start, obj.end], obj)
+              return acc
+            },
+            {},
+          ),
         )
-      })
+        .catch(e => {
+          this.vcfFeatures = undefined
+          throw e
+        })
     }
     return this.vcfFeatures
   }
 
   public async getRefNames(_: BaseOptions = {}) {
-    const { refNames } = await this.decodeFileContents()
-    if (refNames.length === 0) {
-      return [
-        'chr1',
-        'chr2',
-        'chr3',
-        'chr4',
-        'chr5',
-        'chr6',
-        'chr7',
-        'chr8',
-        'chr9',
-        'chr10',
-        'chr11',
-        'chr12',
-        'chr13',
-        'chr14',
-        'chr15',
-        'chr16',
-        'chr17',
-        'chr18',
-        'chr19',
-        'chr20',
-        'chr21',
-        'chr22',
-        'chr23',
-        'chrX',
-        'chrY',
-        'chrMT',
-      ]
-    }
-    return refNames
+    const lines = await this.getLines()
+    return [...new Set(lines.map(line => line.refName))]
   }
 
   public getFeatures(region: Region, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       try {
+        const { header } = await this.decodeFileContents()
         const { start, end, refName } = region
+        const parser = new VCF({ header: header })
         const vcfFeatures = await this.setup()
-        const tree = vcfFeatures[refName]
-        const feats = tree.search([start, end]) //  expected array ['val1']
-        feats.forEach(f => {
-          observer.next(f)
-        })
+        vcfFeatures[refName]?.search([start, end]).forEach(f =>
+          observer.next(
+            new VcfFeature({
+              variant: parser.parseLine(f.line),
+              parser,
+              id: `${this.id}-${f.id}`,
+            }),
+          ),
+        )
         observer.complete()
       } catch (e) {
         observer.error(e)

--- a/plugins/variants/src/VcfAdapter/__snapshots__/VcfAdapter.test.ts.snap
+++ b/plugins/variants/src/VcfAdapter/__snapshots__/VcfAdapter.test.ts.snap
@@ -66,7 +66,7 @@ Array [
     },
     "start": 276,
     "type": "SNV",
-    "uniqueId": "test-vcf-0",
+    "uniqueId": "test-0",
   },
   Object {
     "ALT": Array [
@@ -132,7 +132,7 @@ Array [
     },
     "start": 1693,
     "type": "SNV",
-    "uniqueId": "test-vcf-1",
+    "uniqueId": "test-1",
   },
   Object {
     "ALT": Array [
@@ -198,7 +198,7 @@ Array [
     },
     "start": 2643,
     "type": "SNV",
-    "uniqueId": "test-vcf-2",
+    "uniqueId": "test-2",
   },
   Object {
     "ALT": Array [
@@ -258,7 +258,7 @@ Array [
     },
     "start": 3212,
     "type": "SNV",
-    "uniqueId": "test-vcf-3",
+    "uniqueId": "test-3",
   },
   Object {
     "ALT": Array [
@@ -319,7 +319,7 @@ Array [
     },
     "start": 3857,
     "type": "deletion",
-    "uniqueId": "test-vcf-4",
+    "uniqueId": "test-4",
   },
 ]
 `;


### PR DESCRIPTION
This fixes refName renaming for the VcfAdapter. Also adds the 512MB limit, and delays parsing into VcfFeatures until needed, which aided memory usage on large ClinVar VCF from ncbi e.g. https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh38_latest/refseq_identifiers/GRCh38_latest_clinvar.vcf.gz