### PR TITLE
Don't fail if offline on starting jbrowse-desktop

### DIFF
--- a/products/jbrowse-desktop/public/electron.ts
+++ b/products/jbrowse-desktop/public/electron.ts
@@ -101,23 +101,29 @@ interface SessionSnap {
 
 let mainWindow: electron.BrowserWindow | null
 
-async function createWindow() {
-  const response = await fetch('https://jbrowse.org/genomes/sessions.json')
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} ${response.statusText}`)
-  }
-  const data = await response.json()
-  Object.entries(data).forEach(([key, value]) => {
-    // if there is not a 'gravestone' (.deleted file), then repopulate it on
-    // startup, this allows the user to delete even defaults if they want to
-    if (!fs.existsSync(getQuickstartPath(key) + '.deleted')) {
-      fs.writeFileSync(
-        getQuickstartPath(key),
-        JSON.stringify(value, null, 2),
-        'utf8',
-      )
+async function updatePreconfiguredSessions() {
+  try {
+    const response = await fetch('https://jbrowse.org/genomes/sessions.json')
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`)
     }
-  })
+    const data = await response.json()
+    Object.entries(data).forEach(([key, value]) => {
+      // if there is not a 'gravestone' (.deleted file), then repopulate it on
+      // startup, this allows the user to delete even defaults if they want to
+      if (!fs.existsSync(getQuickstartPath(key) + '.deleted')) {
+        fs.writeFileSync(getQuickstartPath(key), JSON.stringify(value, null, 2))
+      }
+    })
+  } catch (e) {
+    // just console.error
+    console.error('Failed to fetch sessions.json', e)
+  }
+}
+
+async function createWindow() {
+  // no need to await, just update in background
+  updatePreconfiguredSessions()
 
   const mainWindowState = windowStateKeeper({
     defaultWidth: 1400,


### PR DESCRIPTION
Currently we "await fetch" the preconfigured sessions file before the app starts, but instead, we can fetch this and the app polls the disk for updates, so no need to wait. This prevents a failure starting the app when offline