### PR TITLE
"Add custom plugin" dialog improvements

### DIFF
--- a/plugins/data-management/src/PluginStoreWidget/components/CustomPluginForm.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/CustomPluginForm.tsx
@@ -2,15 +2,22 @@ import React, { useState } from 'react'
 import { observer } from 'mobx-react'
 import { getRoot } from 'mobx-state-tree'
 
-import { makeStyles } from '@material-ui/core/styles'
-import Dialog from '@material-ui/core/Dialog'
-import DialogTitle from '@material-ui/core/DialogTitle'
-import TextField from '@material-ui/core/TextField'
-import Button from '@material-ui/core/Button'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
 
+// icons
 import IconButton from '@material-ui/core/IconButton'
 import CloseIcon from '@material-ui/icons/Close'
 
+// locals
 import { PluginStoreModel } from '../model'
 
 const useStyles = makeStyles(() => ({
@@ -32,69 +39,60 @@ function CustomPluginForm({
   model,
 }: {
   open: boolean
-  onClose: Function
+  onClose: () => void
   model: PluginStoreModel
 }) {
   const classes = useStyles()
-  const [formInput, setFormInput] = useState({
-    name: '',
-    url: '',
-  })
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setFormInput({
-      ...formInput,
-      [event.target.name]: event.target.value,
-    })
-  }
-
+  const [formName, setFormName] = useState<string>()
+  const [formUrl, setFormUrl] = useState<string>()
   const rootModel = getRoot(model)
   const { jbrowse } = rootModel
 
-  const handleSubmit = () => {
-    jbrowse.addPlugin({ name: formInput.name, url: formInput.url })
-  }
-
   return (
-    <Dialog open={open} onClose={() => onClose(false)}>
+    <Dialog open={open} onClose={() => onClose()}>
       <DialogTitle>
-        <IconButton
-          className={classes.closeDialog}
-          aria-label="close-dialog"
-          onClick={() => onClose(false)}
-        >
+        Add custom plugin
+        <IconButton className={classes.closeDialog} onClick={() => onClose()}>
           <CloseIcon />
         </IconButton>
       </DialogTitle>
 
-      <div className={classes.dialogContainer}>
-        <TextField
-          id="name-input"
-          name="name"
-          label="Plugin name"
-          variant="outlined"
-          value={formInput.name}
-          onChange={handleChange}
-          multiline
-        />
-        <TextField
-          id="url-input"
-          name="url"
-          label="Plugin URL"
-          variant="outlined"
-          value={formInput.url}
-          onChange={handleChange}
-          multiline
-        />
+      <DialogContent>
+        <div className={classes.dialogContainer}>
+          <Typography>
+            Specify the name and URL path of your plugin source
+          </Typography>
+          <TextField
+            label="Plugin name"
+            variant="outlined"
+            value={formName}
+            onChange={event => setFormName(event.target.value)}
+            multiline
+          />
+          <TextField
+            label="Plugin URL"
+            variant="outlined"
+            value={formUrl}
+            onChange={event => setFormUrl(event.target.value)}
+            multiline
+          />
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="contained" color="secondary" onClick={() => onClose()}>
+          Cancel
+        </Button>
         <Button
           variant="contained"
           color="primary"
-          style={{ marginTop: '1.5rem' }}
-          onClick={handleSubmit}
+          onClick={() => {
+            jbrowse.addPlugin({ name: formName, url: formUrl })
+            onClose()
+          }}
         >
-          Add plugin
+          Submit
         </Button>
-      </div>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/plugins/data-management/src/PluginStoreWidget/components/CustomPluginForm.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/CustomPluginForm.tsx
@@ -43,8 +43,8 @@ function CustomPluginForm({
   model: PluginStoreModel
 }) {
   const classes = useStyles()
-  const [formName, setFormName] = useState<string>()
-  const [formUrl, setFormUrl] = useState<string>()
+  const [formName, setFormName] = useState('')
+  const [formUrl, setFormUrl] = useState('')
   const rootModel = getRoot(model)
   const { jbrowse } = rootModel
 
@@ -63,18 +63,20 @@ function CustomPluginForm({
             Specify the name and URL path of your plugin source
           </Typography>
           <TextField
+            id="name-input"
+            name="name"
             label="Plugin name"
             variant="outlined"
             value={formName}
             onChange={event => setFormName(event.target.value)}
-            multiline
           />
           <TextField
+            id="url-input"
+            name="url"
             label="Plugin URL"
             variant="outlined"
             value={formUrl}
             onChange={event => setFormUrl(event.target.value)}
-            multiline
           />
         </div>
       </DialogContent>

--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
@@ -33,12 +33,16 @@ const useStyles = makeStyles(() => ({
   dialogContainer: {
     margin: 15,
   },
+  lockedPluginTooltip: {
+    marginRight: '0.5rem',
+  },
 }))
 
 function LockedPlugin() {
+  const classes = useStyles()
   return (
     <Tooltip
-      style={{ marginRight: '0.5rem' }}
+      className={classes.lockedPluginTooltip}
       title="This plugin was installed by an administrator, you cannot remove it."
     >
       <LockIcon />

--- a/plugins/data-management/src/PluginStoreWidget/components/PluginCard.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/PluginCard.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react'
+import PluginManager from '@jbrowse/core/PluginManager'
 import { observer } from 'mobx-react'
 import { getEnv, getParent } from 'mobx-state-tree'
-
-import { makeStyles } from '@material-ui/core/styles'
+import { getSession } from '@jbrowse/core/util'
+import { JBrowsePlugin } from '@jbrowse/core/util/types'
+import { isSessionWithSessionPlugins } from '@jbrowse/core/util/types'
 import {
   Card,
   CardActions,
@@ -10,18 +12,14 @@ import {
   Button,
   Link,
   Typography,
+  makeStyles,
 } from '@material-ui/core'
 
+// icons
 import PersonIcon from '@material-ui/icons/Person'
 import AddIcon from '@material-ui/icons/Add'
 import CheckIcon from '@material-ui/icons/Check'
-
-import PluginManager from '@jbrowse/core/PluginManager'
-import { getSession } from '@jbrowse/core/util'
-import type { JBrowsePlugin } from '@jbrowse/core/util/types'
-import { isSessionWithSessionPlugins } from '@jbrowse/core/util/types'
-
-import type { PluginStoreModel } from '../model'
+import { PluginStoreModel } from '../model'
 
 const useStyles = makeStyles(() => ({
   card: {

--- a/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.test.js
+++ b/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.test.js
@@ -76,7 +76,7 @@ describe('<PluginStoreWidget />', () => {
           'https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js',
       },
     })
-    fireEvent.click(getByText('Add plugin'))
+    fireEvent.click(getByText('Submit'))
 
     await waitFor(() => {
       expect(window.location.reload).toHaveBeenCalled()

--- a/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.js.snap
+++ b/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
-<div>
+<div
+  class="makeStyles-root"
+>
   <div
-    class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
+    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
   >
     <label
       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -116,9 +118,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -137,9 +138,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -158,9 +158,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -179,9 +178,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -200,9 +198,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -221,9 +218,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -242,9 +238,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -263,9 +258,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -284,9 +278,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -305,9 +298,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -326,9 +318,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -347,9 +338,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -368,9 +358,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -389,9 +378,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -410,9 +398,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -431,9 +418,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -452,9 +438,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -473,9 +458,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -494,9 +478,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -515,9 +498,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -536,9 +518,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -557,9 +538,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -578,9 +558,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -599,9 +578,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -620,9 +598,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >
@@ -641,9 +618,8 @@ exports[`<PluginStoreWidget /> renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root"
+                    class="MuiSvgIcon-root makeStyles-lockedPluginTooltip"
                     focusable="false"
-                    style="margin-right: 0.5rem;"
                     title="This plugin was installed by an administrator, you cannot remove it."
                     viewBox="0 0 24 24"
                   >


### PR DESCRIPTION
Small refactoring of the "Add custom plugin" dialog box

- combined formInput state split into two variables
- small margin added around the plugin widget
- title added to add custom plugin dialog box
- small instructional text
- submit and cancel boxes added