### PR TITLE
Improve usability of the search result autocomplete when typing in via keyboard

### DIFF
--- a/packages/core/TextSearch/TextSearchManager.ts
+++ b/packages/core/TextSearch/TextSearchManager.ts
@@ -8,8 +8,8 @@ import { SearchType, BaseTextSearchAdapter } from '../data_adapters/BaseAdapter'
 import { readConfObject } from '../configuration'
 
 export interface BaseArgs {
-  searchType: SearchType
   queryString: string
+  searchType?: SearchType
   signal?: AbortSignal
   limit?: number
   pageNumber?: number

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -126,22 +126,20 @@ const LinearGenomeViewHeader = observer(
         console.warn('No text search manager')
       }
 
-      console.log('t1', assembly?.refNames)
-      return [
-        ...(
-          assembly?.refNames?.filter(refName => refName.includes(query)) || []
-        ).map(r => new BaseResult({ label: r })),
-        ...dedupe(
-          await textSearchManager?.search(
-            {
-              queryString: query,
-              searchType: 'exact',
-            },
-            searchScope,
-            rankSearchResults,
-          ),
-        ),
-      ]
+      const textSearchResults = await textSearchManager?.search(
+        {
+          queryString: query,
+          searchType: 'exact',
+        },
+        searchScope,
+        rankSearchResults,
+      )
+
+      const refNameResults = assembly?.refNames
+        ?.filter(refName => refName.includes(query))
+        .map(r => new BaseResult({ label: r }))
+
+      return [...(refNameResults || []), ...(textSearchResults || [])]
     }
 
     async function handleSelectedRegion(option: BaseResult) {
@@ -181,6 +179,7 @@ const LinearGenomeViewHeader = observer(
           <RefNameAutocomplete
             onSelect={handleSelectedRegion}
             assemblyName={assemblyName}
+            fetchResults={fetchResults}
             model={model}
             TextFieldProps={{
               variant: 'outlined',

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -139,6 +139,7 @@ const LinearGenomeViewHeader = observer(
       const refNameResults = assembly?.refNames
         ?.filter(refName => refName.includes(query))
         .map(r => new BaseResult({ label: r }))
+        .slice(0, 10)
 
       return dedupe(
         [...(refNameResults || []), ...(textSearchResults || [])],

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -21,7 +21,6 @@ import { LinearGenomeViewModel, HEADER_BAR_HEIGHT } from '..'
 import RefNameAutocomplete from './RefNameAutocomplete'
 import OverviewScaleBar from './OverviewScaleBar'
 import ZoomControls from './ZoomControls'
-import { dedupe } from './util'
 
 const WIDGET_HEIGHT = 32
 const SPACING = 7
@@ -129,7 +128,6 @@ const LinearGenomeViewHeader = observer(
       const textSearchResults = await textSearchManager?.search(
         {
           queryString: query,
-          searchType: 'exact',
         },
         searchScope,
         rankSearchResults,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -121,19 +121,27 @@ const LinearGenomeViewHeader = observer(
     const assembly = assemblyManager.get(assemblyName)
     const searchScope = model.searchScope(assemblyName)
 
-    async function fetchResults(queryString: string) {
+    async function fetchResults(query: string) {
       if (!textSearchManager) {
         console.warn('No text search manager')
       }
-      const results = await textSearchManager?.search(
-        {
-          queryString: queryString.toLowerCase(),
-          searchType: 'exact',
-        },
-        searchScope,
-        rankSearchResults,
-      )
-      return dedupe(results)
+
+      console.log('t1', assembly?.refNames)
+      return [
+        ...(
+          assembly?.refNames?.filter(refName => refName.includes(query)) || []
+        ).map(r => new BaseResult({ label: r })),
+        ...dedupe(
+          await textSearchManager?.search(
+            {
+              queryString: query,
+              searchType: 'exact',
+            },
+            searchScope,
+            rankSearchResults,
+          ),
+        ),
+      ]
     }
 
     async function handleSelectedRegion(option: BaseResult) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -136,8 +136,8 @@ const LinearGenomeViewHeader = observer(
         rankSearchResults,
       )
 
-      const refNameResults = assembly?.refNames
-        ?.filter(refName => refName.includes(query))
+      const refNameResults = assembly?.allRefNames
+        ?.filter(refName => refName.startsWith(query))
         .map(r => new BaseResult({ label: r }))
         .slice(0, 10)
 
@@ -152,7 +152,7 @@ const LinearGenomeViewHeader = observer(
       let location = option.getLocation()
       const label = option.getLabel()
       try {
-        if (assembly?.refNames?.includes(location)) {
+        if (assembly?.allRefNames?.includes(location)) {
           model.navToLocString(location)
         } else {
           const results = await fetchResults(label, 'exact')

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -49,7 +49,6 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   } = model
   const [selectedAsm, setSelectedAsm] = useState(assemblyNames[0])
   const [error, setError] = useState<typeof modelError | undefined>(modelError)
-  const message = !assemblyNames.length ? 'No configured assemblies' : ''
   const searchScope = model.searchScope(selectedAsm)
 
   const assembly = assemblyManager.get(selectedAsm)
@@ -59,7 +58,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   const regions = assembly?.regions || []
   const err = assemblyError || error
 
-  const [myOption, setOption] = useState<BaseResult | undefined>()
+  const [myOption, setOption] = useState<BaseResult>()
 
   // use this instead of useState initializer because the useState initializer
   // won't update in response to an observable
@@ -80,7 +79,6 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const textSearchResults = await textSearchManager?.search(
       {
         queryString: query,
-        searchType: 'exact',
       },
       searchScope,
       rankSearchResults,
@@ -163,12 +161,11 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                   <Typography color="error">X</Typography>
                 ) : selectedRegion && model.volatileWidth ? (
                   <RefNameAutocomplete
+                    fetchResults={fetchResults}
                     model={model}
-                    assemblyName={message ? undefined : selectedAsm}
+                    assemblyName={assemblyError ? undefined : selectedAsm}
                     value={selectedRegion}
-                    onSelect={option => {
-                      setOption(option)
-                    }}
+                    onSelect={option => setOption(option)}
                     TextFieldProps={{
                       margin: 'normal',
                       variant: 'outlined',
@@ -220,9 +217,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
         <SearchResultsDialog
           model={model}
           optAssemblyName={selectedAsm}
-          handleClose={() => {
-            model.setSearchResults(undefined, undefined)
-          }}
+          handleClose={() => model.setSearchResults(undefined, undefined)}
         />
       ) : null}
     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -72,20 +72,25 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
 
   const selectedRegion = option?.getLocation()
 
-  async function fetchResults(queryString: string) {
+  async function fetchResults(query: string) {
     if (!textSearchManager) {
       console.warn('No text search manager')
     }
-    const results = await textSearchManager?.search(
+
+    const textSearchResults = await textSearchManager?.search(
       {
-        queryString: queryString.toLowerCase(),
+        queryString: query,
         searchType: 'exact',
       },
       searchScope,
       rankSearchResults,
     )
 
-    return dedupe(results)
+    const refNameResults = assembly?.refNames
+      ?.filter(refName => refName.includes(query))
+      .map(r => new BaseResult({ label: r }))
+
+    return [...(refNameResults || []), ...(textSearchResults || [])]
   }
 
   /**

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -1,10 +1,6 @@
 import React, { useState } from 'react'
 import { observer } from 'mobx-react'
 import { getSession } from '@jbrowse/core/util'
-import BaseResult, {
-  RefSequenceResult,
-} from '@jbrowse/core/TextSearch/BaseResults'
-import AssemblySelector from '@jbrowse/core/ui/AssemblySelector'
 import {
   Button,
   CircularProgress,
@@ -13,11 +9,14 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core'
-// other
+import { SearchType } from '@jbrowse/core/data_adapters/BaseAdapter'
+import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
+import AssemblySelector from '@jbrowse/core/ui/AssemblySelector'
+
+// locals
 import RefNameAutocomplete from './RefNameAutocomplete'
 import SearchResultsDialog from './SearchResultsDialog'
 import { LinearGenomeViewModel } from '..'
-import { dedupe } from './util'
 
 const useStyles = makeStyles(theme => ({
   importFormContainer: {
@@ -64,14 +63,13 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   // won't update in response to an observable
   const option =
     myOption ||
-    new RefSequenceResult({
-      refName: regions[0]?.refName,
+    new BaseResult({
       label: regions[0]?.refName,
     })
 
   const selectedRegion = option?.getLocation()
 
-  async function fetchResults(query: string) {
+  async function fetchResults(query: string, searchType?: SearchType) {
     if (!textSearchManager) {
       console.warn('No text search manager')
     }
@@ -79,6 +77,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const textSearchResults = await textSearchManager?.search(
       {
         queryString: query,
+        searchType,
       },
       searchScope,
       rankSearchResults,
@@ -108,7 +107,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
       if (assembly?.refNames?.includes(location)) {
         model.navToLocString(location, selectedAsm)
       } else {
-        const results = await fetchResults(input)
+        const results = await fetchResults(input, 'exact')
         if (results && results.length > 1) {
           model.setSearchResults(results, input.toLowerCase())
           return

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -86,6 +86,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const refNameResults = assembly?.refNames
       ?.filter(refName => refName.includes(query))
       .map(r => new BaseResult({ label: r }))
+      .slice(0, 10)
 
     return [...(refNameResults || []), ...(textSearchResults || [])]
   }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -83,8 +83,8 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
       rankSearchResults,
     )
 
-    const refNameResults = assembly?.refNames
-      ?.filter(refName => refName.includes(query))
+    const refNameResults = assembly?.allRefNames
+      ?.filter(refName => refName.startsWith(query))
       .map(r => new BaseResult({ label: r }))
       .slice(0, 10)
 
@@ -105,7 +105,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     let trackId = option.getTrackId()
     let location = input || option.getLocation() || ''
     try {
-      if (assembly?.refNames?.includes(location)) {
+      if (assembly?.allRefNames?.includes(location)) {
         model.navToLocString(location, selectedAsm)
       } else {
         const results = await fetchResults(input, 'exact')

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -17,6 +17,8 @@ import {
   PopperProps,
   Typography,
 } from '@material-ui/core'
+
+// icons
 import SearchIcon from '@material-ui/icons/Search'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 
@@ -116,7 +118,11 @@ function RefNameAutocomplete({
         setLoaded(false)
         const results = await fetchResults(debouncedSearch)
         if (active) {
-          setSearchOptions(dedupe(results).map(result => ({ result })))
+          setSearchOptions(
+            dedupe(results, r => r.getDisplayString()).map(result => ({
+              result,
+            })),
+          )
           setLoaded(true)
         }
       } catch (e) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -1,9 +1,10 @@
 import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
 
-export function dedupe(results: BaseResult[] = []) {
+export function dedupe(
+  results: BaseResult[] = [],
+  cb: (result: BaseResult) => string,
+) {
   return results.filter(
-    (elt, idx, self) =>
-      idx ===
-      self.findIndex(t => t.getDisplayString() === elt.getDisplayString()),
+    (elt, idx, self) => idx === self.findIndex(t => cb(t) === cb(elt)),
   )
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -2,6 +2,8 @@ import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
 
 export function dedupe(results: BaseResult[] = []) {
   return results.filter(
-    (elt, idx, self) => idx === self.findIndex(t => t.getId() === elt.getId()),
+    (elt, idx, self) =>
+      idx ===
+      self.findIndex(t => t.getDisplayString() === elt.getDisplayString()),
   )
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -1,8 +1,7 @@
 import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
 
-export function dedupe(results?: BaseResult[]) {
-  return results?.filter(
-    (elem, index, self) =>
-      index === self.findIndex(t => t.getId() === elem.getId()),
+export function dedupe(results: BaseResult[] = []) {
+  return results.filter(
+    (elt, idx, self) => idx === self.findIndex(t => t.getId() === elt.getId()),
   )
 }

--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -57,7 +57,7 @@ export default class TrixTextSearchAdapter
    * limit of results to return, searchType...prefix | full | exact", etc.
    */
   async searchIndex(args: BaseArgs) {
-    const results = await this.trixJs.search(args.queryString)
+    const results = await this.trixJs.search(args.queryString.toLowerCase())
     const formatted = results.map(entry => {
       const [term, data] = entry.split(',')
       const result = JSON.parse(data.replace(/\|/g, ',')) as string[]


### PR DESCRIPTION
This is a proposed fix for #2429 

The problem shown in that issue is that: when the user is trying to type in a refName e.g. typing 10<ENTER>, the search results from trix may come in and clobber their attempt at navigating by refName (hitting ENTER would then navigate to whatever is in the trix results)

Try typing e.g. 10 here https://jbrowse.org/code/jb2/v1.5.0/?config=test_data%2Fconfig_demo.json&session=share-Uk4KG8ocZC&password=VXmsd


Functionally, the change on this branch is that if you type something that matches a refname, it will return the matching refnames first in the list (sliced to limit 10 results, arbitrary limit to just balance trix/refname result if they were trying to query trix) and after that in the list, any matching search results from trix.

Internally, we have remove a little bit of duplication of the "fetchResults" function which has appeared in refnameautocomplete,lineargenomeview, and importform. Instead, now we make it so that the user now actually supplies fetchResults as a callback prop, which reduces duplication somewhat and allows a little inversion of control (https://en.wikipedia.org/wiki/Inversion_of_control). 


This PR tries to strike a balance between using the search box for navigating by refnames via keyboard and still allow intuitive searching behavior, with the assumption that in most cases, the what the user types in to navigate to a refname shouldn't collide too much with what they type in to search for a search for a feature