### PR TITLE
Use an X offset in overviewscalebar when cytobands are viewed

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
@@ -184,7 +184,7 @@ const SVGHeader = ({ model }: { model: LGV }) => {
             y={1}
           />
           <g transform={`translate(0,${HEADER_OVERVIEW_HEIGHT})`}>
-            <Polygon overview={overview} model={model} />
+            <Polygon overview={overview} model={model} useOffset={false} />
           </g>
         </g>
       ) : null}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -67,8 +67,11 @@ const HoverTooltip = observer(
     overview: Base1DViewModel
   }) => {
     const classes = useStyles()
+    const { showCytobands } = model
     const { assemblyManager } = getSession(model)
-    const px = overview.pxToBp(guideX)
+
+    const offset = showCytobands ? 30 : 0
+    const px = overview.pxToBp(guideX - offset)
     const assembly = assemblyManager.get(px.assemblyName)
     const cytoband = assembly?.cytobands?.find(
       f =>
@@ -104,6 +107,7 @@ function OverviewRubberBand({
   overview: Base1DViewModel
   ControlComponent?: React.ReactElement
 }) {
+  const { showCytobands } = model
   const [startX, setStartX] = useState<number>()
   const [currentX, setCurrentX] = useState<number>()
   const [guideX, setGuideX] = useState<number>()
@@ -111,12 +115,13 @@ function OverviewRubberBand({
   const rubberBandRef = useRef(null)
   const classes = useStyles()
   const mouseDragging = startX !== undefined
+  const offset = showCytobands ? 30 : 0
 
   useEffect(() => {
     function globalMouseMove(event: MouseEvent) {
-      if (controlsRef.current && mouseDragging) {
-        const relativeX =
-          event.clientX - controlsRef.current.getBoundingClientRect().left
+      const ref = controlsRef.current
+      if (ref && mouseDragging) {
+        const relativeX = event.clientX - ref.getBoundingClientRect().left
         setCurrentX(relativeX)
       }
     }
@@ -129,8 +134,8 @@ function OverviewRubberBand({
       ) {
         if (Math.abs(currentX - startX) > 3) {
           model.zoomToDisplayedRegions(
-            overview.pxToBp(startX),
-            overview.pxToBp(currentX),
+            overview.pxToBp(startX - offset),
+            overview.pxToBp(currentX - offset),
           )
         }
       }
@@ -232,8 +237,8 @@ function OverviewRubberBand({
   let leftBpOffset
   let rightBpOffset
   if (startX) {
-    leftBpOffset = overview.pxToBp(startX)
-    rightBpOffset = overview.pxToBp(startX + width)
+    leftBpOffset = overview.pxToBp(startX - offset)
+    rightBpOffset = overview.pxToBp(startX + width - offset)
     if (currentX && currentX < startX) {
       ;[leftBpOffset, rightBpOffset] = [rightBpOffset, leftBpOffset]
     }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -67,11 +67,10 @@ const HoverTooltip = observer(
     overview: Base1DViewModel
   }) => {
     const classes = useStyles()
-    const { showCytobands } = model
+    const { cytobandOffset } = model
     const { assemblyManager } = getSession(model)
 
-    const offset = showCytobands ? 30 : 0
-    const px = overview.pxToBp(guideX - offset)
+    const px = overview.pxToBp(guideX - cytobandOffset)
     const assembly = assemblyManager.get(px.assemblyName)
     const cytoband = assembly?.cytobands?.find(
       f =>
@@ -107,7 +106,7 @@ function OverviewRubberBand({
   overview: Base1DViewModel
   ControlComponent?: React.ReactElement
 }) {
-  const { showCytobands } = model
+  const { cytobandOffset } = model
   const [startX, setStartX] = useState<number>()
   const [currentX, setCurrentX] = useState<number>()
   const [guideX, setGuideX] = useState<number>()
@@ -115,7 +114,6 @@ function OverviewRubberBand({
   const rubberBandRef = useRef(null)
   const classes = useStyles()
   const mouseDragging = startX !== undefined
-  const offset = showCytobands ? 30 : 0
 
   useEffect(() => {
     function globalMouseMove(event: MouseEvent) {
@@ -134,8 +132,8 @@ function OverviewRubberBand({
       ) {
         if (Math.abs(currentX - startX) > 3) {
           model.zoomToDisplayedRegions(
-            overview.pxToBp(startX - offset),
-            overview.pxToBp(currentX - offset),
+            overview.pxToBp(startX - cytobandOffset),
+            overview.pxToBp(currentX - cytobandOffset),
           )
         }
       }
@@ -237,8 +235,8 @@ function OverviewRubberBand({
   let leftBpOffset
   let rightBpOffset
   if (startX) {
-    leftBpOffset = overview.pxToBp(startX - offset)
-    rightBpOffset = overview.pxToBp(startX + width - offset)
+    leftBpOffset = overview.pxToBp(startX - cytobandOffset)
+    rightBpOffset = overview.pxToBp(startX + width - cytobandOffset)
     if (currentX && currentX < startX) {
       ;[leftBpOffset, rightBpOffset] = [rightBpOffset, leftBpOffset]
     }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberBand.tsx
@@ -176,7 +176,7 @@ function OverviewRubberBand({
       }
     }
     return () => {}
-  }, [mouseDragging, currentX, startX, model, overview])
+  }, [mouseDragging, currentX, startX, model, overview, cytobandOffset])
 
   function mouseDown(event: React.MouseEvent<HTMLDivElement>) {
     event.preventDefault()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -172,13 +172,13 @@ function leftRoundedRect(x:number, y:number, width:number, height:number, radius
 }
 
 const colorMap: { [key: string]: string | undefined } = {
-  gneg: '#ccc',
-  gpos25: '#aaa',
-  gpos50: '#888',
-  gpos100: '#333',
-  gpos75: '#666',
-  gvar: 'black',
-  stalk: '#999',
+  gneg: 'rgb(227,227,227)',
+  gpos25: 'rgb(142,142,142)',
+  gpos50: 'rgb(85,85,85)',
+  gpos100: 'rgb(0,0,0)',
+  gpos75: 'rgb(57,57,57)',
+  gvar: 'rgb(0,0,0)',
+  stalk: 'rgb(127,127,127)',
   acen: '#800',
 }
 
@@ -215,6 +215,8 @@ const Cytobands = observer(
           type,
         ]
       })
+
+    console.log({ cytobands })
 
     let firstCent = true
     return cytobands ? (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -80,12 +80,15 @@ const Polygon = observer(
   ({
     model,
     overview,
+    useOffset = true,
   }: {
     model: LGV
     overview: Instance<Base1DViewModel>
+    useOffset?: boolean
   }) => {
     const theme = useTheme()
     const classes = useStyles()
+    const multiplier = Number(useOffset)
     const {
       interRegionPaddingWidth,
       offsetPx,
@@ -105,12 +108,14 @@ const Polygon = observer(
       (overview.bpToPx({
         ...first,
         coord: first.reversed ? first.end : first.start,
-      }) || 0) + cytobandOffset
+      }) || 0) +
+      cytobandOffset * multiplier
     const topRight =
       (overview.bpToPx({
         ...last,
         coord: last.reversed ? last.start : last.end,
-      }) || 0) + cytobandOffset
+      }) || 0) +
+      cytobandOffset * multiplier
 
     const startPx = Math.max(0, -offsetPx)
     const endPx =

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -19,7 +19,6 @@ import { chooseGridPitch } from '../util'
 import OverviewRubberBand from './OverviewRubberBand'
 
 const wholeSeqSpacer = 2
-const offset = 30
 
 const useStyles = makeStyles(theme => {
   return {
@@ -88,10 +87,10 @@ const Polygon = observer(
     const theme = useTheme()
     const classes = useStyles()
     const {
-      showCytobands,
       interRegionPaddingWidth,
       offsetPx,
       dynamicBlocks,
+      cytobandOffset,
     } = model
     const { contentBlocks, totalWidthPxWithoutBorders } = dynamicBlocks
     const { tertiary, primary } = theme.palette
@@ -106,12 +105,12 @@ const Polygon = observer(
       (overview.bpToPx({
         ...first,
         coord: first.reversed ? first.end : first.start,
-      }) || 0) + (showCytobands ? offset : 0)
+      }) || 0) + cytobandOffset
     const topRight =
       (overview.bpToPx({
         ...last,
         coord: last.reversed ? last.start : last.end,
-      }) || 0) + (showCytobands ? offset : 0)
+      }) || 0) + cytobandOffset
 
     const startPx = Math.max(0, -offsetPx)
     const endPx =
@@ -305,7 +304,7 @@ const OverviewBox = observer(
     overview: Base1DViewModel
   }) => {
     const classes = useStyles()
-    const { showCytobands } = model
+    const { cytobandOffset, showCytobands } = model
     const { start, end, reversed, refName, assemblyName } = block
     const { majorPitch } = chooseGridPitch(scale, 120, 15)
     const { assemblyManager } = getSession(model)
@@ -338,7 +337,7 @@ const OverviewBox = observer(
             !showCytobands ? classes.scaleBarBorder : undefined,
           )}
           style={{
-            left: block.offsetPx + (showCytobands ? offset : 0),
+            left: block.offsetPx + cytobandOffset,
             width: block.widthPx,
             borderColor: refNameColor,
           }}
@@ -387,7 +386,7 @@ const ScaleBar = observer(
   }) => {
     const classes = useStyles()
     const theme = useTheme()
-    const { dynamicBlocks, showCytobands } = model
+    const { dynamicBlocks, showCytobands, cytobandOffset } = model
     const visibleRegions = dynamicBlocks.contentBlocks
     const overviewVisibleRegions = overview.dynamicBlocks
     const { tertiary, primary } = theme.palette
@@ -416,7 +415,7 @@ const ScaleBar = observer(
           className={classes.scaleBarVisibleRegion}
           style={{
             width: lastOverviewPx - firstOverviewPx,
-            left: firstOverviewPx + (showCytobands ? offset : 0),
+            left: firstOverviewPx + cytobandOffset,
             background: showCytobands ? undefined : alpha(scaleBarColor, 0.3),
           }}
         />
@@ -457,7 +456,7 @@ function OverviewScaleBar({
   children: React.ReactNode
 }) {
   const classes = useStyles()
-  const { totalBp, width, showCytobands, displayedRegions } = model
+  const { totalBp, width, cytobandOffset, displayedRegions } = model
 
   const overview = Base1DView.create({
     displayedRegions: JSON.parse(JSON.stringify(displayedRegions)),
@@ -465,7 +464,7 @@ function OverviewScaleBar({
     minimumBlockWidth: model.minimumBlockWidth,
   })
 
-  let modWidth = width - (showCytobands ? offset : 0)
+  const modWidth = width - cytobandOffset
   overview.setVolatileWidth(modWidth)
   overview.showAllRegions()
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -88,12 +88,8 @@ const Polygon = observer(
     const theme = useTheme()
     const classes = useStyles()
     const multiplier = Number(useOffset)
-    const {
-      interRegionPaddingWidth,
-      offsetPx,
-      dynamicBlocks,
-      cytobandOffset,
-    } = model
+    const { interRegionPaddingWidth, offsetPx, dynamicBlocks, cytobandOffset } =
+      model
     const { contentBlocks, totalWidthPxWithoutBorders } = dynamicBlocks
     const { tertiary, primary } = theme.palette
     const polygonColor = tertiary ? tertiary.light : primary.light
@@ -215,8 +211,6 @@ const Cytobands = observer(
           type,
         ]
       })
-
-    console.log({ cytobands })
 
     let firstCent = true
     return cytobands ? (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -45,7 +45,6 @@ const useStyles = makeStyles(theme => {
 
     scaleBarRefName: {
       position: 'absolute',
-      left: 5,
       fontWeight: 'bold',
       pointerEvents: 'none',
       zIndex: 100,
@@ -326,7 +325,10 @@ const OverviewBox = observer(
       <div>
         {/* name of sequence */}
         <Typography
-          style={{ color: showCytobands ? 'black' : refNameColor }}
+          style={{
+            left: block.offsetPx + 3,
+            color: showCytobands ? 'black' : refNameColor,
+          }}
           className={classes.scaleBarRefName}
         >
           {refName}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -23,46 +23,48 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             class="makeStyles-scaleBarContig"
             style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
           />
-          <div
-            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
-            style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
-          >
+          <div>
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-              style="color: rgb(153, 102, 0);"
+              style="left: 3px; color: rgb(153, 102, 0);"
             >
               ctgA
             </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
+            <div
+              class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
+              style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
             >
-              20
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
-            >
-              40
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
-            >
-              60
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
-            >
-              80
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
-            >
-              100
-            </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
+              >
+                20
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
+              >
+                40
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
+              >
+                60
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
+              >
+                80
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
+              >
+                100
+              </p>
+            </div>
           </div>
           <div
             class="makeStyles-scaleBarContig"
@@ -77,7 +79,6 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
       <svg
         class="makeStyles-overviewSvg"
         height="48"
-        width="100%"
       >
         <svg
           class="makeStyles-overviewSvg"
@@ -592,60 +593,64 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             class="makeStyles-scaleBarContig"
             style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
           />
-          <div
-            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
-            style="left: 0px; width: 72.72727272727273px; border-color: rgb(153, 102, 0);"
-          >
+          <div>
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-              style="color: rgb(153, 102, 0);"
+              style="left: 3px; color: rgb(153, 102, 0);"
             >
               ctgA
             </p>
+            <div
+              class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
+              style="left: 0px; width: 72.72727272727273px; border-color: rgb(153, 102, 0);"
+            />
           </div>
           <div
             class="makeStyles-scaleBarContig"
             style="width: 0px; left: 72.72727272727273px; background-color: rgb(153, 153, 153);"
           />
-          <div
-            class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
-            style="left: 72.72727272727273px; width: 727.2727272727273px;"
-          >
+          <div>
             <p
               class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
+              style="left: 75.72727272727273px;"
             >
               ctgB
             </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 145.0909090909091px; pointer-events: none;"
+            <div
+              class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
+              style="left: 72.72727272727273px; width: 727.2727272727273px;"
             >
-              1,200
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 290.1818181818182px; pointer-events: none;"
-            >
-              1,400
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 435.27272727272725px; pointer-events: none;"
-            >
-              1,600
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 580.3636363636364px; pointer-events: none;"
-            >
-              1,800
-            </p>
-            <p
-              class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-              style="left: 725.4545454545454px; pointer-events: none;"
-            >
-              2,000
-            </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 145.0909090909091px; pointer-events: none;"
+              >
+                1,200
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 290.1818181818182px; pointer-events: none;"
+              >
+                1,400
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 435.27272727272725px; pointer-events: none;"
+              >
+                1,600
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 580.3636363636364px; pointer-events: none;"
+              >
+                1,800
+              </p>
+              <p
+                class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                style="left: 725.4545454545454px; pointer-events: none;"
+              >
+                2,000
+              </p>
+            </div>
           </div>
           <div
             class="makeStyles-scaleBarContig"
@@ -660,7 +665,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
       <svg
         class="makeStyles-overviewSvg"
         height="48"
-        width="100%"
       >
         <svg
           class="makeStyles-overviewSvg"

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -557,8 +557,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
         initialSnapshot = {},
         displayInitialSnapshot = {},
       ) {
-        const trackConfigSchema =
-          pluginManager.pluggableConfigSchemaType('track')
+        const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
+          'track',
+        )
         const configuration = resolveIdentifier(
           trackConfigSchema,
           getRoot(self),
@@ -607,8 +608,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
 
       hideTrack(trackId: string) {
-        const trackConfigSchema =
-          pluginManager.pluggableConfigSchemaType('track')
+        const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
+          'track',
+        )
         const configuration = resolveIdentifier(
           trackConfigSchema,
           getRoot(self),
@@ -1233,6 +1235,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
         return assemblyNames.some(
           asm => assemblyManager.get(asm)?.cytobands?.length,
         )
+      },
+
+      get cytobandOffset() {
+        return this.showCytobands
+          ? self.displayedRegions[0].refName.length * 15 + 15
+          : 0
       },
     }))
     .views(self => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -557,9 +557,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
         initialSnapshot = {},
         displayInitialSnapshot = {},
       ) {
-        const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
-          'track',
-        )
+        const trackConfigSchema =
+          pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(
           trackConfigSchema,
           getRoot(self),
@@ -608,9 +607,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
 
       hideTrack(trackId: string) {
-        const trackConfigSchema = pluginManager.pluggableConfigSchemaType(
-          'track',
-        )
+        const trackConfigSchema =
+          pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(
           trackConfigSchema,
           getRoot(self),

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -101,52 +101,54 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="makeStyles-scaleBarContig"
                     style="width: 0px; left: 0px; background-color: rgb(153, 153, 153);"
                   />
-                  <div
-                    class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
-                    style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
-                  >
+                  <div>
                     <p
                       class="MuiTypography-root makeStyles-scaleBarRefName MuiTypography-body1"
-                      style="color: rgb(153, 102, 0);"
+                      style="left: 3px; color: rgb(153, 102, 0);"
                     >
                       ctgA
                     </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
+                    <div
+                      class="makeStyles-scaleBarContig makeStyles-scaleBarContigForward makeStyles-scaleBarBorder"
+                      style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
                     >
-                      20
-                    </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
-                    >
-                      40
-                    </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
-                    >
-                      60
-                    </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
-                    >
-                      80
-                    </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
-                    >
-                      100
-                    </p>
-                    <p
-                      class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
-                      style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
-                    >
-                      120
-                    </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        20
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        40
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        60
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        80
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        100
+                      </p>
+                      <p
+                        class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
+                        style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
+                      >
+                        120
+                      </p>
+                    </div>
                   </div>
                   <div
                     class="makeStyles-scaleBarContig"
@@ -161,7 +163,6 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               <svg
                 class="makeStyles-overviewSvg"
                 height="48"
-                width="100%"
               >
                 <svg
                   class="makeStyles-overviewSvg"


### PR DESCRIPTION
This makes it so that the chromosome name is displayed to the left of the cytoband/ideogram in the overview scale bar

Cytobands are only visible when one chromosome (displayedRegion) is used


Also changes one of the cytoband colors ("stalk") from brown to grey to match UCSC (brown also looked very much like centromere, the dark red)


This has to apply a "cytobandOffset" to move the display to the left in several different places but since we have control over all these pieces, it seems like the effect of this is contained, and also the benefit for the user I think is also good

Before
![localhost_3000__config=test_data%2Fconfig_demo json session=local-hvfJ_oKXW (2)](https://user-images.githubusercontent.com/6511937/140092382-8c633099-e8d6-4d33-ab6e-33cff682d2a4.png)

After
![localhost_3000__config=test_data%2Fconfig_demo json session=local-hvfJ_oKXW (1)](https://user-images.githubusercontent.com/6511937/140092406-7fabd6b6-bf73-4731-93b2-de01e40c05c7.png)


