### PR TITLE
Fix ability to open breakpoint split view from a BEDPE row in SV inspector

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView.ts
@@ -11,7 +11,7 @@ import { parseBreakend } from '@gmod/vcf'
 class BreakpointSplitViewType extends ViewType {
   snapshotFromBreakendFeature(feature: Feature, view: LinearGenomeViewModel) {
     const alt = feature.get('ALT')?.[0]
-    const bnd = parseBreakend(alt)
+    const bnd = alt ? parseBreakend(alt) : undefined
     const startPos = feature.get('start')
     let endPos
     const bpPerPx = 10

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -160,9 +160,9 @@ describe('<Loader />', () => {
       () => {
         expect(sessionStorage.length).toBeGreaterThan(0)
       },
-      { timeout: 10000 },
+      { timeout: 20000 },
     )
-  }, 10000)
+  }, 20000)
 
   // minimal session with plugin in our plugins.json
   // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
@@ -182,9 +182,9 @@ describe('<Loader />', () => {
       () => {
         expect(sessionStorage.length).toBeGreaterThan(0)
       },
-      { timeout: 10000 },
+      { timeout: 20000 },
     )
-  }, 10000)
+  }, 20000)
 
   // minimal session,
   // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}


### PR DESCRIPTION
Currently the code was crashing on parseBreakend(undefined) for a BEDPE row accessed with breakpoint split view

This only calls parseBreakend if the string is defined

Additional typescripting (e.g. on @gmod/vcf) or unit tests could possibly catch errors such as this