### PR TITLE
Less use of factory functions sv-inspector

### DIFF
--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -41,6 +41,7 @@
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",
     "@material-ui/core": "^4.12.2",
+    "mobx": "^5.0.0",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.js
@@ -1,38 +1,24 @@
 import OpenInNewIcon from '@material-ui/icons/OpenInNew'
-import breakpointSplitViewFromTableRowFactory from './breakpointSplitViewFromTableRow'
+import { getContainingView, getSession } from '@jbrowse/core/util'
+
+import { autorun, reaction } from 'mobx'
+import { readConfObject } from '@jbrowse/core/configuration'
+import { types, getParent, addDisposer } from 'mobx-state-tree'
+import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
+
+// locals
+import {
+  canOpenBreakpointSplitViewFromTableRow,
+  openBreakpointSplitViewFromTableRow,
+  getSerializedFeatureForRow,
+} from './breakpointSplitViewFromTableRow'
 
 function defaultOnChordClick(feature, chordTrack, pluginManager) {
-  const { jbrequire } = pluginManager
-  // const { getConf } = jbrequire('@jbrowse/core/configuration')
-  const { getContainingView, getSession } = jbrequire('@jbrowse/core/util')
-  // const { resolveIdentifier } = jbrequire('mobx-state-tree')
-
   const session = getSession(chordTrack)
   session.setSelection(feature)
   const view = getContainingView(chordTrack)
   const viewType = pluginManager.getViewType('BreakpointSplitView')
   const viewSnapshot = viewType.snapshotFromBreakendFeature(feature, view)
-
-  // disabling this for now since there isn't a way to set configRelationships
-  // on the generated chord display from the SV inspector
-
-  // // open any evidence tracks defined in configRelationships for this track
-  // const tracks = getConf(chordTrack, 'configRelationships')
-  //   .map(entry => {
-  //     const type = pluginManager.pluggableConfigSchemaType('track')
-  //     const trackConfig = resolveIdentifier(type, session, entry.target)
-  //     return trackConfig
-  //       ? {
-  //           type: trackConfig.type,
-  //           height: 100,
-  //           configuration: trackConfig.trackId,
-  //           selectedRendering: '',
-  //         }
-  //       : null
-  //   })
-  //   .filter(f => !!f)
-  // viewSnapshot.views[0].tracks = tracks
-  // viewSnapshot.views[1].tracks = tracks
 
   // try to center the offsetPx
   viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
@@ -43,15 +29,6 @@ function defaultOnChordClick(feature, chordTrack, pluginManager) {
 }
 
 const SvInspectorViewF = pluginManager => {
-  const { jbrequire } = pluginManager
-  const { autorun, reaction } = pluginManager.lib.mobx
-  const { types, getParent, addDisposer } = pluginManager.lib['mobx-state-tree']
-  const { BaseViewModel } = jbrequire(
-    '@jbrowse/core/pluggableElementTypes/models',
-  )
-  const { getSession } = jbrequire('@jbrowse/core/util')
-  const { readConfObject } = jbrequire('@jbrowse/core/configuration')
-
   const SpreadsheetViewType = pluginManager.getViewType('SpreadsheetView')
   const CircularViewType = pluginManager.getViewType('CircularView')
 
@@ -59,13 +36,6 @@ const SvInspectorViewF = pluginManager => {
   const defaultHeight = 500
   const headerHeight = 52
   const circularViewOptionsBarHeight = 52
-
-  const {
-    canOpenBreakpointSplitViewFromTableRow,
-    openBreakpointSplitViewFromTableRow,
-    getSerializedFeatureForRow,
-  } = jbrequire(breakpointSplitViewFromTableRowFactory)
-
   const model = types
     .model('SvInspectorView', {
       type: types.literal('SvInspectorView'),

--- a/plugins/sv-inspector/src/SvInspectorView/models/adhocFeatureUtils.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/adhocFeatureUtils.js
@@ -1,160 +1,152 @@
 // this file contains the rather verbose functions for
 // creating features from CSV/TSV lines
-export default ({ jbrequire }) => {
-  const { parseLocString } = jbrequire('@jbrowse/core/util')
+import { parseLocString } from '@jbrowse/core/util'
 
-  function makeAdHocFeature(
+export function makeAdHocFeature(
+  columns,
+  columnsAlreadyUsedInLocations,
+  row,
+  loc1,
+  loc2,
+  rowNumber,
+) {
+  // load all the other data in the row into an `otherData` object
+  const otherData = {}
+  columns.forEach((column, columnNumber) => {
+    if (columnsAlreadyUsedInLocations.includes(columnNumber)) {
+      return
+    }
+    let { text } = row.cells[columnNumber]
+    if (column.dataType.type === 'Number') {
+      text = parseFloat(text)
+    }
+    otherData[column.name] = text
+  })
+
+  // make the final feature data out of otherData + the parsed locations
+  return {
+    ...otherData,
+    uniqueId: `sv-inspector-adhoc-${rowNumber}`,
+    refName: loc1.refName,
+    start: loc1.start,
+    end: loc1.end,
+    mate: {
+      refName: loc2.refName,
+      start: loc2.start,
+      end: loc2.end,
+    },
+  }
+}
+
+export function makeAdHocSvFeatureFromTwoLocations(
+  columns,
+  locationColumnNumbers,
+  row,
+  rowNumber,
+  isValidRefName,
+) {
+  // use the first two locations we found (first according to *displayed* order)
+  const loc1 = parseLocString(
+    row.cells[locationColumnNumbers[0]].text,
+    isValidRefName,
+  )
+  const loc2 = parseLocString(
+    row.cells[locationColumnNumbers[1]].text,
+    isValidRefName,
+  )
+
+  const columnsAlreadyUsedInLocations = [
+    locationColumnNumbers[0],
+    locationColumnNumbers[1],
+  ]
+
+  return makeAdHocFeature(
     columns,
     columnsAlreadyUsedInLocations,
     row,
     loc1,
     loc2,
     rowNumber,
-  ) {
-    // load all the other data in the row into an `otherData` object
-    const otherData = {}
-    columns.forEach((column, columnNumber) => {
-      if (columnsAlreadyUsedInLocations.includes(columnNumber)) {
-        return
-      }
-      let { text } = row.cells[columnNumber]
-      if (column.dataType.type === 'Number') {
-        text = parseFloat(text)
-      }
-      otherData[column.name] = text
-    })
+  )
+}
 
-    // make the final feature data out of otherData + the parsed locations
-    return {
-      ...otherData,
-      uniqueId: `sv-inspector-adhoc-${rowNumber}`,
-      refName: loc1.refName,
-      start: loc1.start,
-      end: loc1.end,
-      mate: {
-        refName: loc2.refName,
-        start: loc2.start,
-        end: loc2.end,
-      },
-    }
+export function makeAdHocSvFeatureFromTwoRefStartEndSets(
+  columns,
+  locRefColumnNumbers,
+  locStartColumnNumbers,
+  locEndColumnNumbers,
+  row,
+  rowNumber,
+) {
+  const textOf = colno => row.cells[colno].text
+  const loc1 = {
+    refName: textOf(locRefColumnNumbers[0]),
+    start: parseInt(textOf(locStartColumnNumbers[0]), 10) - 1,
+    end: parseInt(textOf(locEndColumnNumbers[0]), 10),
   }
-
-  function makeAdHocSvFeatureFromTwoLocations(
+  const loc2 = {
+    refName: textOf(locRefColumnNumbers[1]),
+    start: parseInt(textOf(locStartColumnNumbers[1]), 10) - 1,
+    end: parseInt(textOf(locEndColumnNumbers[1]), 10),
+  }
+  const columnsAlreadyUsedInLocations = [
+    locRefColumnNumbers[0],
+    locStartColumnNumbers[0],
+    locEndColumnNumbers[0],
+    locRefColumnNumbers[1],
+    locStartColumnNumbers[1],
+    locEndColumnNumbers[1],
+  ]
+  return makeAdHocFeature(
     columns,
-    locationColumnNumbers,
+    columnsAlreadyUsedInLocations,
     row,
+    loc1,
+    loc2,
     rowNumber,
-    isValidRefName,
-  ) {
-    // use the first two locations we found (first according to *displayed* order)
-    const loc1 = parseLocString(
-      row.cells[locationColumnNumbers[0]].text,
-      isValidRefName,
-    )
-    const loc2 = parseLocString(
-      row.cells[locationColumnNumbers[1]].text,
-      isValidRefName,
-    )
+  )
+}
 
-    const columnsAlreadyUsedInLocations = [
-      locationColumnNumbers[0],
-      locationColumnNumbers[1],
-    ]
+// makes a feature data object (passed as `data` to a SimpleFeature constructor)
+// out of table row if the row has 2 location columns. undefined if not
+export function makeAdHocSvFeature(sheet, rowNumber, row, isValidRefName) {
+  const { columns, columnDisplayOrder } = sheet
+  const columnTypes = {}
+  columnDisplayOrder.forEach(columnNumber => {
+    const columnDefinition = columns[columnNumber]
+    if (!columnTypes[columnDefinition.dataType.type]) {
+      columnTypes[columnDefinition.dataType.type] = []
+    }
+    columnTypes[columnDefinition.dataType.type].push(columnNumber)
+  })
+  const locationColumnNumbers = columnTypes.LocString || []
+  const locStartColumnNumbers = columnTypes.LocStart || []
+  const locEndColumnNumbers = columnTypes.LocEnd || []
+  const locRefColumnNumbers = columnTypes.LocRef || []
 
-    return makeAdHocFeature(
+  // if we have 2 or more columns of type location, make a feature from them
+  if (locationColumnNumbers.length >= 2) {
+    return makeAdHocSvFeatureFromTwoLocations(
       columns,
-      columnsAlreadyUsedInLocations,
+      locationColumnNumbers,
       row,
-      loc1,
-      loc2,
+      rowNumber,
+      isValidRefName,
+    )
+  }
+  if (
+    locRefColumnNumbers.length >= 2 &&
+    locStartColumnNumbers.length >= 2 &&
+    locEndColumnNumbers.length >= 2
+  ) {
+    return makeAdHocSvFeatureFromTwoRefStartEndSets(
+      columns,
+      locRefColumnNumbers,
+      locStartColumnNumbers,
+      locEndColumnNumbers,
+      row,
       rowNumber,
     )
   }
-
-  function makeAdHocSvFeatureFromTwoRefStartEndSets(
-    columns,
-    locRefColumnNumbers,
-    locStartColumnNumbers,
-    locEndColumnNumbers,
-    row,
-    rowNumber,
-  ) {
-    const textOf = colno => row.cells[colno].text
-    const loc1 = {
-      refName: textOf(locRefColumnNumbers[0]),
-      start: parseInt(textOf(locStartColumnNumbers[0]), 10) - 1,
-      end: parseInt(textOf(locEndColumnNumbers[0]), 10),
-    }
-    const loc2 = {
-      refName: textOf(locRefColumnNumbers[1]),
-      start: parseInt(textOf(locStartColumnNumbers[1]), 10) - 1,
-      end: parseInt(textOf(locEndColumnNumbers[1]), 10),
-    }
-    const columnsAlreadyUsedInLocations = [
-      locRefColumnNumbers[0],
-      locStartColumnNumbers[0],
-      locEndColumnNumbers[0],
-      locRefColumnNumbers[1],
-      locStartColumnNumbers[1],
-      locEndColumnNumbers[1],
-    ]
-    return makeAdHocFeature(
-      columns,
-      columnsAlreadyUsedInLocations,
-      row,
-      loc1,
-      loc2,
-      rowNumber,
-    )
-  }
-
-  // makes a feature data object (passed as `data` to a SimpleFeature constructor)
-  // out of table row if the row has 2 location columns. undefined if not
-  function makeAdHocSvFeature(sheet, rowNumber, row, isValidRefName) {
-    const { columns, columnDisplayOrder } = sheet
-    const columnTypes = {}
-    columnDisplayOrder.forEach(columnNumber => {
-      const columnDefinition = columns[columnNumber]
-      if (!columnTypes[columnDefinition.dataType.type]) {
-        columnTypes[columnDefinition.dataType.type] = []
-      }
-      columnTypes[columnDefinition.dataType.type].push(columnNumber)
-    })
-    const locationColumnNumbers = columnTypes.LocString || []
-    const locStartColumnNumbers = columnTypes.LocStart || []
-    const locEndColumnNumbers = columnTypes.LocEnd || []
-    const locRefColumnNumbers = columnTypes.LocRef || []
-
-    // if we have 2 or more columns of type location, make a feature from them
-    if (locationColumnNumbers.length >= 2) {
-      return makeAdHocSvFeatureFromTwoLocations(
-        columns,
-        locationColumnNumbers,
-        row,
-        rowNumber,
-        isValidRefName,
-      )
-    }
-    if (
-      locRefColumnNumbers.length >= 2 &&
-      locStartColumnNumbers.length >= 2 &&
-      locEndColumnNumbers.length >= 2
-    ) {
-      return makeAdHocSvFeatureFromTwoRefStartEndSets(
-        columns,
-        locRefColumnNumbers,
-        locStartColumnNumbers,
-        locEndColumnNumbers,
-        row,
-        rowNumber,
-      )
-    }
-    return undefined
-  }
-
-  return {
-    makeAdHocSvFeature,
-    makeAdHocSvFeatureFromTwoLocations,
-    makeAdHocSvFeatureFromTwoRefStartEndSets,
-  }
+  return undefined
 }

--- a/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
+++ b/plugins/sv-inspector/src/SvInspectorView/models/breakpointSplitViewFromTableRow.js
@@ -1,73 +1,98 @@
 import SimpleFeature from '@jbrowse/core/util/simpleFeature'
-import adhocFeatureUtilsFactory from './adhocFeatureUtils'
+import { makeAdHocSvFeature } from './adhocFeatureUtils'
+import { getSession } from '@jbrowse/core/util'
+import { getEnv } from 'mobx-state-tree'
 
-export default pluginManager => {
-  const { jbrequire } = pluginManager
-  const { getSession } = jbrequire('@jbrowse/core/util')
+export function getSerializedFeatureForRow(
+  session,
+  spreadsheetView,
+  row,
+  rowNumber,
+) {
+  if (row.extendedData) {
+    if (row.extendedData.vcfFeature) {
+      return row.extendedData.vcfFeature
+    }
+    if (row.extendedData.feature) {
+      return row.extendedData.feature
+    }
+  }
+  const adhocFeature = makeAdHocSvFeature(
+    spreadsheetView.spreadsheet,
+    rowNumber,
+    row,
+    session.assemblyManager.isValidRefName,
+  )
+  if (adhocFeature) {
+    return adhocFeature
+  }
+  return undefined
+}
 
-  const { makeAdHocSvFeature } = jbrequire(adhocFeatureUtilsFactory)
-
-  function getSerializedFeatureForRow(
+export function breakpointSplitViewSnapshotFromTableRow(
+  svInspectorView,
+  spreadsheetView,
+  spreadsheet,
+  row,
+  rowNumber,
+) {
+  const { pluginManager } = getEnv(svInspectorView)
+  const session = getSession(spreadsheetView)
+  const featureData = getSerializedFeatureForRow(
     session,
-    spreadsheetView,
+    spreadsheet,
     row,
     rowNumber,
-  ) {
-    if (row.extendedData) {
-      if (row.extendedData.vcfFeature) {
-        return row.extendedData.vcfFeature
-      }
-      if (row.extendedData.feature) {
-        return row.extendedData.feature
-      }
-    }
-    const adhocFeature = makeAdHocSvFeature(
-      spreadsheetView.spreadsheet,
-      rowNumber,
-      row,
-      session.assemblyManager.isValidRefName,
-    )
-    if (adhocFeature) {
-      return adhocFeature
-    }
-    return undefined
-  }
+  )
 
-  function breakpointSplitViewSnapshotFromTableRow(
+  if (featureData) {
+    const feature = new SimpleFeature(featureData)
+    session.setSelection(feature)
+    const viewType = pluginManager.getViewType('BreakpointSplitView')
+    const { circularView } = svInspectorView
+
+    const viewSnapshot = viewType.snapshotFromBreakendFeature(
+      feature,
+      circularView,
+    )
+    return viewSnapshot
+  }
+  return undefined
+}
+
+export function openBreakpointSplitViewFromTableRow(
+  svInspectorView,
+  spreadsheetView,
+  spreadsheet,
+  row,
+  rowNumber,
+) {
+  const viewSnapshot = breakpointSplitViewSnapshotFromTableRow(
     svInspectorView,
     spreadsheetView,
     spreadsheet,
     row,
     rowNumber,
-  ) {
+  )
+  if (viewSnapshot) {
+    // try to center the offsetPx
+    const { circularView } = svInspectorView
+    viewSnapshot.views[0].offsetPx -= circularView.width / 2 + 100
+    viewSnapshot.views[1].offsetPx -= circularView.width / 2 + 100
+
     const session = getSession(spreadsheetView)
-    const featureData = getSerializedFeatureForRow(
-      session,
-      spreadsheet,
-      row,
-      rowNumber,
-    )
-    if (featureData) {
-      const feature = new SimpleFeature(featureData)
-      session.setSelection(feature)
-      const viewType = pluginManager.getViewType('BreakpointSplitView')
-      const { circularView } = svInspectorView
-      const viewSnapshot = viewType.snapshotFromBreakendFeature(
-        feature,
-        circularView,
-      )
-      return viewSnapshot
-    }
-    return undefined
+    session.addView('BreakpointSplitView', viewSnapshot)
   }
+}
 
-  function openBreakpointSplitViewFromTableRow(
-    svInspectorView,
-    spreadsheetView,
-    spreadsheet,
-    row,
-    rowNumber,
-  ) {
+export function canOpenBreakpointSplitViewFromTableRow(
+  svInspectorView,
+  spreadsheetView,
+  spreadsheet,
+  row,
+  rowNumber,
+) {
+  try {
     const viewSnapshot = breakpointSplitViewSnapshotFromTableRow(
       svInspectorView,
       spreadsheetView,
@@ -75,42 +100,9 @@ export default pluginManager => {
       row,
       rowNumber,
     )
-    if (viewSnapshot) {
-      // try to center the offsetPx
-      const { circularView } = svInspectorView
-      viewSnapshot.views[0].offsetPx -= circularView.width / 2 + 100
-      viewSnapshot.views[1].offsetPx -= circularView.width / 2 + 100
-
-      const session = getSession(spreadsheetView)
-      session.addView('BreakpointSplitView', viewSnapshot)
-    }
-  }
-
-  function canOpenBreakpointSplitViewFromTableRow(
-    svInspectorView,
-    spreadsheetView,
-    spreadsheet,
-    row,
-    rowNumber,
-  ) {
-    try {
-      const viewSnapshot = breakpointSplitViewSnapshotFromTableRow(
-        svInspectorView,
-        spreadsheetView,
-        spreadsheet,
-        row,
-        rowNumber,
-      )
-      return Boolean(viewSnapshot)
-    } catch (e) {
-      return false
-    }
-  }
-
-  return {
-    getSerializedFeatureForRow,
-    breakpointSplitViewSnapshotFromTableRow,
-    canOpenBreakpointSplitViewFromTableRow,
-    openBreakpointSplitViewFromTableRow,
+    return Boolean(viewSnapshot)
+  } catch (e) {
+    console.error('Unable to open breakpoint split view from table row', e)
+    return false
   }
 }


### PR DESCRIPTION
Small refactor of sv-inspector to have less usage of factory functions, which actually improves some of my text editor type checking and such

The git diff is very messy but I just removed the outer factory functions that jbrequire uses and used standard es6 requires