### PR TITLE
Add polyfill for text-index compatibility with node 10

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -57,6 +57,7 @@
     "ixixx": "^1.0.17",
     "json-parse-better-errors": "^1.0.2",
     "node-fetch": "^2.6.0",
+    "object.fromentries": "^2.0.5",
     "tslib": "^1",
     "unzipper": "^0.10.11"
   },

--- a/products/jbrowse-cli/src/commands/text-index.ts
+++ b/products/jbrowse-cli/src/commands/text-index.ts
@@ -11,6 +11,12 @@ import {
   supported,
   guessAdapterFromFileName,
 } from '../types/common'
+import fromEntries from 'object.fromentries'
+
+if (!Object.fromEntries) {
+  // @ts-ignore
+  fromEntries.shim()
+}
 
 function readConf(confFilePath: string) {
   return JSON.parse(fs.readFileSync(confFilePath, 'utf8')) as Config

--- a/yarn.lock
+++ b/yarn.lock
@@ -16073,7 +16073,7 @@ object.entries@^1.1.0, object.entries@^1.1.4:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-object.fromentries@^2.0.0, "object.fromentries@^2.0.0 || ^1.0.0", object.fromentries@^2.0.4:
+object.fromentries@^2.0.0, "object.fromentries@^2.0.0 || ^1.0.0", object.fromentries@^2.0.4, object.fromentries@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.5.tgz#7b37b205109c21e741e605727fe8b0ad5fa08251"
   integrity sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==


### PR DESCRIPTION
This adds a Object.fromEntries polyfill for use in text-index for the CLI

Our CLI currently says it is compatible with node 10.4+ which needs a Object.fromEntries polyfill

xref https://github.com/GMOD/jbrowse-components/discussions/2359

We could also bump min to node 12 but this isn't too bad for now