### PR TITLE
Improve organization on docs landing page

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -4,7 +4,7 @@ id: cli
 toplevel: true
 ---
 
-This document covers the CLI tools.
+This document covers the CLI tools. Note: for @jbrowse/img static export tool, see https://www.npmjs.com/package/@jbrowse/img
 
 ## Installation
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -7,21 +7,33 @@ toplevel: true
 
 Welcome to the JBrowse 2 documentation.
 
-We provide
+Resources for desktop users
 
-- [Quick start for desktop](quickstart_desktop) - a quick-start guide to getting JBrowse desktop running on your machine
-- [Super-quick start guide](superquickstart_web) - super brief setup
-  instructions e.g. 10 lines of CLI commands to help admins who are familiar
-  with jbrowse with getting set up
-- [Quick start guide](quickstart_web) - a more thourough quick-start guide to
-  help admins setting up JBrowse 2 on their website
+- [Quick-start for JBrowse desktop](quickstart_desktop) - a quick-start guide to
+  getting JBrowse desktop running on your machine
+
+Resources for both desktop/web users
+
 - [User guide](user_guide) - screenshots of the app and general usage
+
+Resources for web developers and admins
+
+- [Quick-start for JBrowse web](quickstart_web) - a quick-start guide to
+  help admins setting up JBrowse 2 on their website
+- [Cheatsheet for JBrowse web](superquickstart_web) - brief setup instructions
+  for admins who are familiar with jbrowse with getting set up
 - [Configuration guide](config_guide) - for detailed configuration settings
-- [Developer guide](developer_guide) - for developers of plugins and
-  core codebase topics
+- [Developer guide](developer_guide) - for developers of plugins
+
+Other resources
+
 - [FAQ](faq) - Some Q&A for troubleshooting or other topics
-- [@jbrowse/linear-genome-view docs](https://jbrowse.org/storybook/lgv/main/) -
+- [@jbrowse/cli](cli) - docs for our CLI tools for loading tracks,
+  assemblies, text indexing, and more
+- [@jbrowse/linear-genome-view](https://jbrowse.org/storybook/lgv/main/) -
   Docs for the reusable linear genome view React component
+- [@jbrowse/img](https://www.npmjs.com/package/@jbrowse/img) - Docs for our
+  static image export tool
 
 We also keep a log of our previous training classes in the sidebar
 


### PR DESCRIPTION
There are a lot of things on the "docs intro page" e.g. the landing page when a user clicks docs in the header bar. I thought it might be good to organize it a bit into 


Before

![jbrowse org_jb2_docs_](https://user-images.githubusercontent.com/6511937/140329387-1e3256b7-c8c3-44a5-bb70-9509978560bc.png)

After
![localhost_3000_jb2_docs_](https://user-images.githubusercontent.com/6511937/140329406-3de07b17-357d-4ca1-8932-eca79ab6a984.png)

also incorporates a suggestion from @scottcain to link to @jbrowse/img on cli
