### PR TITLE
Update the "Browse web demo instance" link to go to an LGV

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -64,7 +64,7 @@ function Home() {
                 variant="contained"
                 color="secondary"
                 startIcon={<OpenInBrowserIcon />}
-                href={`https://jbrowse.org/code/jb2/${currentVersion}/`}
+                href={`https://jbrowse.org/code/jb2/${currentVersion}/?session=share-HShsEcnq3i&password=nYzTU`}
                 sx={{
                   fontSize: { xs: 'x-small', sm: 'x-small', md: 'small' },
                 }}
@@ -75,12 +75,12 @@ function Home() {
             </Box>
             <Box sx={{ textAlign: 'center' }}>
               <Typography variant="caption">
-                Also check out our&nbsp;
-                <Link href="/jb2/blog">latest release blogpost</Link>, our&nbsp;
+                Also check out our{' '}
+                <Link href="/jb2/blog">latest release blogpost</Link>, our{' '}
                 <Link href="/jb2/download/#jbrowse-2-embedded-components">
                   embedded components
                 </Link>
-                , and our&nbsp;
+                , and our{' '}
                 <Link href="/jb2/download/#jbrowse-2-web">
                   command line tools
                 </Link>


### PR DESCRIPTION
This adds cytobands, text searching, and makes the "Browse web demo link" on the website go straight to an LGV using a share link

Idea being that it is just nicer to drop them into something that looks interesting rather than the bare bones start screen and having them find it themselves