### PR TITLE
Add a red background to the overview scale bar with cytobands

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
@@ -177,7 +177,7 @@ const SVGHeader = ({ model }: { model: LGV }) => {
           <Cytobands overview={overview} assembly={assembly} block={block} />
           <rect
             stroke="red"
-            fill="none"
+            fill="rgb(255,0,0,0.3)"
             width={Math.max(lastOverviewPx - firstOverviewPx, 0.5)}
             height={HEADER_OVERVIEW_HEIGHT - 1}
             x={firstOverviewPx}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -412,7 +412,9 @@ const ScaleBar = observer(
           style={{
             width: lastOverviewPx - firstOverviewPx,
             left: firstOverviewPx + cytobandOffset,
-            background: showCytobands ? undefined : alpha(scaleBarColor, 0.3),
+            background: showCytobands
+              ? alpha('#f00', 0.3)
+              : alpha(scaleBarColor, 0.3),
           }}
         />
         {/* this is the entire scale bar */}


### PR DESCRIPTION
helps it stand out a bit more

![localhost_3000__config=test_data%2Fconfig_demo json session=local-gz8RqfavL](https://user-images.githubusercontent.com/6511937/140531128-c5a3a863-0456-4d9a-88bb-801462197928.png)
![localhost_3000__config=test_data%2Fconfig_demo json session=local-gz8RqfavL (1)](https://user-images.githubusercontent.com/6511937/140531129-66df8aad-d68f-4db6-992e-e1e7e66a257d.png)
