### PR TITLE
Add missing dependency to CLI

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@gmod/gff": "^1.1.2",
     "@oclif/command": "^1",
+    "@oclif/errors": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
     "boxen": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3216,7 +3216,7 @@
     qqjs "^0.3.10"
     tslib "^2.0.3"
 
-"@oclif/errors@^1.2.1", "@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3":
+"@oclif/errors@^1", "@oclif/errors@^1.2.1", "@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
   integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==


### PR DESCRIPTION
If you're using Yarn 2 and install `@jbrowse/cli` as a devDependency, it fails when you try to use it because the code uses `@oclif/errors` and it's not listed as a dependency. It's still installed by way of being a dependency of a dependency, but Yarn 2 is more strict about those things.