### PR TITLE
Add RenderProps to core/pluggableElementTypes export

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/index.ts
+++ b/packages/core/pluggableElementTypes/renderers/index.ts
@@ -2,7 +2,7 @@ import BoxRendererType from './BoxRendererType'
 import CircularChordRendererType from './CircularChordRendererType'
 import ComparativeServerSideRendererType from './ComparativeServerSideRendererType'
 import FeatureRendererType from './FeatureRendererType'
-import RendererType from './RendererType'
+import RendererType, { RenderProps } from './RendererType'
 import ServerSideRenderedContent from './ServerSideRenderedContent'
 import ServerSideRendererType from './ServerSideRendererType'
 
@@ -15,3 +15,5 @@ export {
   ServerSideRenderedContent,
   ServerSideRendererType,
 }
+
+export type { RenderProps }


### PR DESCRIPTION
This adds another export that plugins might want to use (e.g. I might need it for Apollo).