### PR TITLE
Add a tooltip to desktop session path so you can see the full path if it's cut off

### DIFF
--- a/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/RecentSessionsPanel.tsx
@@ -124,7 +124,11 @@ function RecentSessionsList({
       flex: 0.7,
       renderCell: (params: GridCellParams) => {
         const { value } = params
-        return value
+        return (
+          <Tooltip title={String(value)}>
+            <div>{value}</div>
+          </Tooltip>
+        )
       },
     },
     {


### PR DESCRIPTION
This adds a tooltip to the "Session path" on the desktop start screen. This can help if the path is cut off so you can't see the end of it.

![image](https://user-images.githubusercontent.com/25592344/140586849-b98afc8b-70d0-4068-a00e-26326288899d.png)
