### PR TITLE
Automatically provide sequenceAdapter to configs

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -64,6 +64,7 @@ async function loadRefNameMap(
     {
       adapterConfig: adapterConf,
       signal,
+      assemblyName: assembly.name,
       ...options,
     },
     { timeout: 1000000 },

--- a/packages/core/configuration/configurationSlot.ts
+++ b/packages/core/configuration/configurationSlot.ts
@@ -237,7 +237,7 @@ export default function ConfigSlot(
       },
     }))
     .preProcessSnapshot(val =>
-      typeof val === 'object' && val.name === slotName
+      typeof val === 'object' && val && val.name === slotName
         ? val
         : {
             name: slotName,

--- a/packages/core/pluggableElementTypes/RpcMethodType.ts
+++ b/packages/core/pluggableElementTypes/RpcMethodType.ts
@@ -28,6 +28,7 @@ export default abstract class RpcMethodType extends PluggableElementBase {
   async serializeArguments(args: {}, _rpcDriverClassName: string): Promise<{}> {
     const blobMap = getBlobMap()
     await this.augmentLocationObjects(args)
+
     return { ...args, blobMap }
   }
 

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -1,4 +1,5 @@
 import { toArray } from 'rxjs/operators'
+import { getConf } from '@jbrowse/core/configuration'
 import {
   freeAdapterResources,
   getAdapter,
@@ -22,6 +23,27 @@ import SimpleFeature, { SimpleFeatureSerialized } from '../util/simpleFeature'
 export class CoreGetRefNames extends RpcMethodType {
   name = 'CoreGetRefNames'
 
+  async serializeArguments(args: RenderArgs, rpcDriverClassName: string) {
+    const assemblyManager =
+      this.pluginManager.rootModel?.session?.assemblyManager
+
+    if (!assemblyManager) {
+      console.warn('no assembly manager available')
+      return args
+    }
+    const ret = await super.serializeArguments(args, rpcDriverClassName)
+
+    // @ts-ignore
+    const assembly = assemblyManager.get(args.assemblyName)
+
+    // @ts-ignore
+    ret.adapterConfig.sequenceAdapter = getConf(assembly, [
+      'sequence',
+      'adapter',
+    ])
+    return ret
+  }
+
   async execute(
     args: {
       sessionId: string
@@ -40,11 +62,11 @@ export class CoreGetRefNames extends RpcMethodType {
       sessionId,
       adapterConfig,
     )
-
-    if (dataAdapter instanceof BaseFeatureDataAdapter) {
-      return dataAdapter.getRefNames(deserializedArgs)
+    if (!(dataAdapter instanceof BaseFeatureDataAdapter)) {
+      throw new Error('unrecognized dataAdapter type for getRefNames')
     }
-    return []
+
+    return dataAdapter.getRefNames(deserializedArgs)
   }
 }
 
@@ -96,6 +118,7 @@ export class CoreGetMetadata extends RpcMethodType {
       sessionId,
       adapterConfig,
     )
+
     return isFeatureAdapter(dataAdapter)
       ? dataAdapter.getMetadata(deserializedArgs)
       : null
@@ -172,9 +195,6 @@ export class CoreFreeResources extends RpcMethodType {
 
     return deleteCount
   }
-  async serializeArguments(args: {}, _rpcDriverClassName: string): Promise<{}> {
-    return args
-  }
 }
 
 export interface RenderArgs extends ServerSideRenderArgs {
@@ -247,14 +267,19 @@ export class CoreRender extends RpcMethodType {
   async serializeArguments(args: RenderArgs, rpcDriverClassName: string) {
     const assemblyManager =
       this.pluginManager.rootModel?.session?.assemblyManager
-    const renamedArgs = assemblyManager
-      ? await renameRegionsIfNeeded(assemblyManager, args)
-      : args
+
+    if (!assemblyManager) {
+      console.warn('no assembly manager available')
+      return args
+    }
+
+    const renamedArgs = await renameRegionsIfNeeded(assemblyManager, args)
 
     const superArgs = (await super.serializeArguments(
       renamedArgs,
       rpcDriverClassName,
     )) as RenderArgs
+
     if (rpcDriverClassName === 'MainThreadRpcDriver') {
       return superArgs
     }
@@ -265,6 +290,14 @@ export class CoreRender extends RpcMethodType {
       rendererType,
       this.pluginManager.getRendererType(rendererType),
     )
+    // @ts-ignore
+    const assembly = assemblyManager.get(args.assemblyName)
+
+    // @ts-ignore
+    superArgs.adapterConfig.sequenceAdapter = getConf(assembly, [
+      'sequence',
+      'adapter',
+    ])
 
     return RendererType.serializeArgsInClient(superArgs)
   }

--- a/plugins/alignments/src/CramAdapter/configSchema.ts
+++ b/plugins/alignments/src/CramAdapter/configSchema.ts
@@ -25,7 +25,10 @@ export default (pluginManager: PluginManager) => {
             locationType: 'UriLocation',
           },
         },
-        sequenceAdapter: pluginManager.pluggableConfigSchemaType('adapter'),
+        sequenceAdapter: {
+          type: 'frozen',
+          defaultValue: null,
+        },
       },
       { explicitlyTyped: true },
     ),

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -49,11 +49,12 @@ function dec(bin: any, strand: number, type: string, field: string) {
 export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
   protected async configure() {
     const subadapterConfig = readConfObject(this.config, 'subadapter')
-    const sequenceConf = readConfObject(this.config, [
-      'subadapter',
-      'sequenceAdapter',
-    ])
-    const dataAdapter = await this.getSubAdapter?.(subadapterConfig)
+    const sequenceConf = readConfObject(this.config, 'sequenceAdapter')
+
+    const dataAdapter = await this.getSubAdapter?.({
+      ...subadapterConfig,
+      sequenceAdapter: sequenceConf,
+    })
 
     const sequenceAdapter = sequenceConf
       ? await this.getSubAdapter?.(sequenceConf)

--- a/plugins/alignments/src/SNPCoverageAdapter/configSchema.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/configSchema.ts
@@ -8,6 +8,10 @@ export default (pluginManager: PluginManager) =>
       'SNPCoverageAdapter',
       {
         subadapter: pluginManager.pluggableConfigSchemaType('adapter'),
+        sequenceAdapter: {
+          type: 'frozen',
+          defaultValue: null,
+        },
       },
       { explicitlyTyped: true },
     ),

--- a/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
+++ b/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
@@ -76,15 +76,16 @@ export class WiggleGetMultiRegionStats extends RpcMethodType {
     args: RenderArgs & { signal?: AbortSignal; statusCallback?: Function },
     rpcDriverClassName: string,
   ) {
-    const assemblyManager =
-      this.pluginManager.rootModel?.session?.assemblyManager
+    const assemblyManager = this.pluginManager.rootModel?.session
+      ?.assemblyManager
+
     if (!assemblyManager) {
+      console.warn('no assembly manager available')
       return args
     }
-
     const renamedArgs = await renameRegionsIfNeeded(assemblyManager, {
       ...args,
-      filters: args.filters && args.filters.toJSON().filters,
+      filters: args.filters?.toJSON().filters,
     })
 
     return super.serializeArguments(renamedArgs, rpcDriverClassName)

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -140,13 +140,6 @@
         "craiLocation": {
           "uri": "volvox-sorted-altname.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -169,13 +162,7 @@
           "uri": "volvox-sorted-altname.cram.crai",
           "locationType": "UriLocation"
         },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
-        },
+
         "fetchSizeLimit": 1000
       },
       "displays": [
@@ -200,13 +187,6 @@
         "craiLocation": {
           "uri": "volvox-sorted-altname.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       },
       "displays": [
@@ -231,13 +211,6 @@
         "craiLocation": {
           "uri": "volvox-sorted.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -256,13 +229,6 @@
         "craiLocation": {
           "uri": "volvox-sorted.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       },
       "displays": [
@@ -287,13 +253,6 @@
         "craiLocation": {
           "uri": "volvox-sorted.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       },
       "displays": [
@@ -758,13 +717,6 @@
         "craiLocation": {
           "uri": "volvox-long-reads-sv.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -783,13 +735,6 @@
         "craiLocation": {
           "uri": "volvox-long-reads.fastq.sorted.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -828,13 +773,6 @@
         "craiLocation": {
           "uri": "volvox-samspec.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -873,13 +811,6 @@
         "craiLocation": {
           "uri": "volvox-sv.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -952,13 +883,6 @@
         "craiLocation": {
           "uri": "volvox-sorted.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1313,13 +1237,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1338,13 +1255,6 @@
         "craiLocation": {
           "uri": "volvox-rg.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1418,13 +1328,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1446,13 +1349,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1474,13 +1370,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1502,13 +1391,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     },
@@ -1585,13 +1467,6 @@
         "craiLocation": {
           "uri": "deep_sequencing.cram.crai",
           "locationType": "UriLocation"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       },
       "displays": [
@@ -1687,13 +1562,6 @@
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
-        },
-        "sequenceAdapter": {
-          "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "volvox.2bit",
-            "locationType": "UriLocation"
-          }
         }
       }
     }


### PR DESCRIPTION
this is a proof of concept PR where the sequenceAdapter is automatically provided to the adapters

this is used primarily in CRAM (where we need to use the reference sequence to render data) and BAM (for tracks that have no MD string, we also need the reference sequence)

this PR reduces the configuration slot duplication, and ends up reducing config file size

the sequence adapter is provided in CoreGetRefNames and CoreRender methods

if the adapter needs to pass the sequenceAdapter along to a subadapter, it can do so manually inside that adapter code, which is done in SNPCoverageAdapter