### PR TITLE
Update docs for embedded components

### DIFF
--- a/website/docs/embedded_components.md
+++ b/website/docs/embedded_components.md
@@ -6,6 +6,8 @@ toplevel: true
 
 JBrowse 2 is a pluggable open-source platform for visualizing, integrating, and sharing biological data.
 
+## JBrowse2 React Linear Genome View
+
 Resources for the reusable linear genome view React component
 
 - [@jbrowse/linear-genome-view](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view) - linear genome browser view React component on NPM

--- a/website/docs/embedded_components.md
+++ b/website/docs/embedded_components.md
@@ -6,7 +6,7 @@ toplevel: true
 
 JBrowse 2 is a pluggable open-source platform for visualizing, integrating, and sharing biological data.
 
-## JBrowse2 React Linear Genome View
+## JBrowse React Linear Genome View
 
 This component consists of a single JBrowse 2 linear view.
 

--- a/website/docs/embedded_components.md
+++ b/website/docs/embedded_components.md
@@ -1,0 +1,12 @@
+---
+id: embedded_components
+title: Embedded components
+toplevel: true
+---
+
+JBrowse 2 is a pluggable open-source platform for visualizing, integrating, and sharing biological data.
+
+Resources for the reusable linear genome view React component
+
+- [@jbrowse/linear-genome-view](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view) - linear genome browser view React component on NPM
+- [Storybook](https://jbrowse.org/storybook/lgv/main/) - docs for the reusable linear genome view React component

--- a/website/docs/embedded_components.md
+++ b/website/docs/embedded_components.md
@@ -8,7 +8,7 @@ JBrowse 2 is a pluggable open-source platform for visualizing, integrating, and 
 
 ## JBrowse2 React Linear Genome View
 
-Resources for the reusable linear genome view React component
+This component consists of a single JBrowse 2 linear view.
 
-- [@jbrowse/linear-genome-view](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view) - linear genome browser view React component on NPM
+- [@jbrowse/linear-genome-view](https://www.npmjs.com/package/@jbrowse/react-linear-genome-view) - linear genome view React component on NPM
 - [Storybook](https://jbrowse.org/storybook/lgv/main/) - docs for the reusable linear genome view React component

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -18,8 +18,8 @@ Resources for both desktop/web users
 
 Resources for users of the embedded components
 
-- [Embedded Components](embedded_components) -
-  Docs for the reusable linear genome view React component
+- [Embedded components](embedded_components) - Docs for our reusable React
+  components
 
 Resources for web developers and admins
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -18,7 +18,7 @@ Resources for both desktop/web users
 
 Resources for users of the embedded components
 
-- [@jbrowse/linear-genome-view](https://jbrowse.org/storybook/lgv/main/) -
+- [Embedded Components](embedded_components) -
   Docs for the reusable linear genome view React component
 
 Resources for web developers and admins

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -16,6 +16,11 @@ Resources for both desktop/web users
 
 - [User guide](user_guide) - screenshots of the app and general usage
 
+Resources for users of the embedded components
+
+- [@jbrowse/linear-genome-view](https://jbrowse.org/storybook/lgv/main/) -
+  Docs for the reusable linear genome view React component
+
 Resources for web developers and admins
 
 - [Quick-start for JBrowse web](quickstart_web) - a quick-start guide to
@@ -30,8 +35,6 @@ Other resources
 - [FAQ](faq) - Some Q&A for troubleshooting or other topics
 - [@jbrowse/cli](cli) - docs for our CLI tools for loading tracks,
   assemblies, text indexing, and more
-- [@jbrowse/linear-genome-view](https://jbrowse.org/storybook/lgv/main/) -
-  Docs for the reusable linear genome view React component
 - [@jbrowse/img](https://www.npmjs.com/package/@jbrowse/img) - Docs for our
   static image export tool
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,10 +3,6 @@
     "introduction",
     "combined",
     "combined_pdf",
-    "cli",
-    "config_guide",
-    "developer_guide",
-    "user_guide",
     {
       "type": "category",
       "label": "Quickstart guides",
@@ -18,6 +14,10 @@
         "quickstart_desktop"
       ]
     },
+    "cli",
+    "config_guide",
+    "developer_guide",
+    "user_guide",
     {
       "type": "category",
       "label": "Developer tutorials",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,6 +3,10 @@
     "introduction",
     "combined",
     "combined_pdf",
+    "cli",
+    "config_guide",
+    "developer_guide",
+    "user_guide",
     {
       "type": "category",
       "label": "Quickstart guides",
@@ -14,10 +18,6 @@
         "quickstart_desktop"
       ]
     },
-    "user_guide",
-    "config_guide",
-    "cli",
-    "developer_guide",
     {
       "type": "category",
       "label": "Developer tutorials",
@@ -39,7 +39,6 @@
         }
       ]
     },
-    "faq",
     {
       "type": "category",
       "label": "JBrowse educational courses",
@@ -68,6 +67,7 @@
           ]
         }
       ]
-    }
+    },
+    "faq"
   ]
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,7 +2,6 @@
   "sidebar": [
     "introduction",
     "combined",
-    "combined_pdf",
     {
       "type": "category",
       "label": "Quickstart guides",
@@ -15,6 +14,7 @@
       ]
     },
     "cli",
+    "embedded_components",
     "config_guide",
     "developer_guide",
     "user_guide",

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -139,7 +139,7 @@ export const DownloadCardContainer = () => {
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
 You can also use the jbrowse CLI for things like adding tracks too.
 
-### JBrowse 2 CLI tools
+### JBrowse CLI tools
 
 ```
 npm install -g @jbrowse/cli

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -139,7 +139,7 @@ export const DownloadCardContainer = () => {
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
 You can also use the jbrowse CLI for things like adding tracks too.
 
-### JBrowse2 CLI tools
+### JBrowse CLI tools
 
 ```
 npm install -g @jbrowse/cli

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -139,7 +139,7 @@ export const DownloadCardContainer = () => {
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
 You can also use the jbrowse CLI for things like adding tracks too.
 
-### JBrowse CLI tools
+### JBrowse 2 CLI tools
 
 ```
 npm install -g @jbrowse/cli

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -139,6 +139,8 @@ export const DownloadCardContainer = () => {
 To get started with JBrowse Web, we recommend using the jbrowse CLI tools.
 You can also use the jbrowse CLI for things like adding tracks too.
 
+### JBrowse2 CLI tools
+
 ```
 npm install -g @jbrowse/cli
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -81,7 +81,7 @@ function Home() {
                   embedded components
                 </Link>
                 , and our{' '}
-                <Link href="/jb2/download/#jbrowse2-cli-tools">
+                <Link href="/jb2/download/#jbrowse-cli-tools">
                   command line tools
                 </Link>
                 .

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -81,7 +81,7 @@ function Home() {
                   embedded components
                 </Link>
                 , and our{' '}
-                <Link href="/jb2/download/#jbrowse-2-web">
+                <Link href="/jb2/download/#jbrowse2-cli-tools">
                   command line tools
                 </Link>
                 .

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -77,7 +77,7 @@ function Home() {
               <Typography variant="caption">
                 Also check out our{' '}
                 <Link href="/jb2/blog">latest release blogpost</Link>, our{' '}
-                <Link href="/jb2/download/#jbrowse-2-embedded-components">
+                <Link href="/jb2/download/#embedded-components">
                   embedded components
                 </Link>
                 , and our{' '}


### PR DESCRIPTION
Found during pairing with @rbuels 

After updating the website for desktop release,  the embedded components docs got buried and it can be hard to quickly find storybook links.

<img width="700" alt="Screen Shot 2021-11-09 at 5 34 07 PM" src="https://user-images.githubusercontent.com/45598764/141033598-820a6b12-ae75-43eb-b569-dfefcfbb056e.png">

Clicking on links above does not direct you to the appropriate section in the downloads docs. It can be confusing to click on embedded components and see desktop as the first thing. The link to "other platforms" directs you to the latest github tag/release? Maybe this could be a link to the introduction page of the docs.

<img width="1423" alt="Screen Shot 2021-11-09 at 4 10 55 PM" src="https://user-images.githubusercontent.com/45598764/141033747-a3433cc0-b0d9-4817-90da-3020aca06ce2.png">

Could be worth making a small little page for embedded docs once we add [Circular View embedded docs](https://github.com/GMOD/jbrowse-components/issues/2462)

Related Issue [Make Embedded docs more visible](https://github.com/GMOD/jbrowse-components/issues/2507)