### PR TITLE
Implement prop interface for providing arbitrary user-defined glyphs

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -22,7 +22,8 @@ const textVerticalPadding = 2
 const svgHeightPadding = 100
 
 function RenderedFeatureGlyph(props) {
-  const { feature, bpPerPx, region, config, displayMode, layout, extraGlyphs } = props
+  const { feature, bpPerPx, region, config, displayMode, layout, extraGlyphs } =
+    props
   const { reversed } = region
   const start = feature.get(reversed ? 'end' : 'start')
   const startPx = bpToPx(start, region, bpPerPx)
@@ -138,19 +139,25 @@ RenderedFeatureGlyph.propTypes = {
     get: ReactPropTypes.func.isRequired,
   }).isRequired,
   config: CommonPropTypes.ConfigSchema.isRequired,
-  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
-    glyph: ReactPropTypes.elementType.isRequired,
-    validator: ReactPropTypes.func.isRequired,
-  }))
+  extraGlyphs: ReactPropTypes.arrayOf(
+    ReactPropTypes.shape({
+      glyph: ReactPropTypes.elementType.isRequired,
+      validator: ReactPropTypes.func.isRequired,
+    }),
+  ),
 }
 
 const RenderedFeatures = observer(props => {
   const { features, isFeatureDisplayed } = props
   const featuresRendered = []
   for (const feature of features.values()) {
-    if(isFeatureDisplayed(feature)) {
+    if (isFeatureDisplayed(feature)) {
       featuresRendered.push(
-        <RenderedFeatureGlyph key={feature.id()} feature={feature} {...props} />,
+        <RenderedFeatureGlyph
+          key={feature.id()}
+          feature={feature}
+          {...props}
+        />,
       )
     }
   }
@@ -165,17 +172,19 @@ RenderedFeatures.propTypes = {
     addRect: ReactPropTypes.func.isRequired,
     getTotalHeight: ReactPropTypes.func.isRequired,
   }).isRequired,
-  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
-    glyph: ReactPropTypes.elementType.isRequired,
-    validator: ReactPropTypes.func.isRequired,
-  })),
-  isFeatureDisplayed: ReactPropTypes.func
+  extraGlyphs: ReactPropTypes.arrayOf(
+    ReactPropTypes.shape({
+      glyph: ReactPropTypes.elementType.isRequired,
+      validator: ReactPropTypes.func.isRequired,
+    }),
+  ),
+  isFeatureDisplayed: ReactPropTypes.func,
 }
 
 RenderedFeatures.defaultProps = {
   features: [],
   extraGlyphs: [],
-  isFeatureDisplayed: (feature) => true
+  isFeatureDisplayed: () => true,
 }
 
 function SvgFeatureRendering(props) {
@@ -188,7 +197,7 @@ function SvgFeatureRendering(props) {
     config,
     displayModel,
     exportSVG,
-    featureDisplayHandler
+    featureDisplayHandler,
   } = props
   const [region] = regions || []
   const width = (region.end - region.start) / bpPerPx
@@ -411,11 +420,13 @@ SvgFeatureRendering.propTypes = {
   onFeatureContextMenu: ReactPropTypes.func,
   blockKey: ReactPropTypes.string,
   exportSVG: ReactPropTypes.shape({}),
-  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
-    glyph: ReactPropTypes.elementType.isRequired,
-    validator: ReactPropTypes.func.isRequired,
-  })),
-  featureDisplayHandler: ReactPropTypes.func
+  extraGlyphs: ReactPropTypes.arrayOf(
+    ReactPropTypes.shape({
+      glyph: ReactPropTypes.elementType.isRequired,
+      validator: ReactPropTypes.func.isRequired,
+    }),
+  ),
+  featureDisplayHandler: ReactPropTypes.func,
 }
 
 SvgFeatureRendering.defaultProps = {
@@ -437,7 +448,7 @@ SvgFeatureRendering.defaultProps = {
   onFeatureClick: undefined,
   onFeatureContextMenu: undefined,
   extraGlyphs: [],
-  featureDisplayHandler: (feature) => true
+  featureDisplayHandler: () => true,
 }
 
 export default observer(SvgFeatureRendering)

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -22,14 +22,14 @@ const textVerticalPadding = 2
 const svgHeightPadding = 100
 
 function RenderedFeatureGlyph(props) {
-  const { feature, bpPerPx, region, config, displayMode, layout } = props
+  const { feature, bpPerPx, region, config, displayMode, layout, extraGlyphs } = props
   const { reversed } = region
   const start = feature.get(reversed ? 'end' : 'start')
   const startPx = bpToPx(start, region, bpPerPx)
   const labelsAllowed = displayMode !== 'compact' && displayMode !== 'collapsed'
 
   const rootLayout = new SceneGraph('root', 0, 0, 0, 0)
-  const GlyphComponent = chooseGlyphComponent(feature)
+  const GlyphComponent = chooseGlyphComponent(feature, extraGlyphs)
   const featureLayout = (GlyphComponent.layOut || layOut)({
     layout: rootLayout,
     feature,
@@ -138,15 +138,21 @@ RenderedFeatureGlyph.propTypes = {
     get: ReactPropTypes.func.isRequired,
   }).isRequired,
   config: CommonPropTypes.ConfigSchema.isRequired,
+  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
+    glyph: ReactPropTypes.elementType.isRequired,
+    validator: ReactPropTypes.func.isRequired,
+  }))
 }
 
 const RenderedFeatures = observer(props => {
-  const { features } = props
+  const { features, isFeatureDisplayed } = props
   const featuresRendered = []
   for (const feature of features.values()) {
-    featuresRendered.push(
-      <RenderedFeatureGlyph key={feature.id()} feature={feature} {...props} />,
-    )
+    if(isFeatureDisplayed(feature)) {
+      featuresRendered.push(
+        <RenderedFeatureGlyph key={feature.id()} feature={feature} {...props} />,
+      )
+    }
   }
   return <>{featuresRendered}</>
 })
@@ -159,10 +165,17 @@ RenderedFeatures.propTypes = {
     addRect: ReactPropTypes.func.isRequired,
     getTotalHeight: ReactPropTypes.func.isRequired,
   }).isRequired,
+  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
+    glyph: ReactPropTypes.elementType.isRequired,
+    validator: ReactPropTypes.func.isRequired,
+  })),
+  isFeatureDisplayed: ReactPropTypes.func
 }
 
 RenderedFeatures.defaultProps = {
   features: [],
+  extraGlyphs: [],
+  isFeatureDisplayed: (feature) => true
 }
 
 function SvgFeatureRendering(props) {
@@ -175,6 +188,7 @@ function SvgFeatureRendering(props) {
     config,
     displayModel,
     exportSVG,
+    featureDisplayHandler
   } = props
   const [region] = regions || []
   const width = (region.end - region.start) / bpPerPx
@@ -325,6 +339,7 @@ function SvgFeatureRendering(props) {
       <RenderedFeatures
         features={features}
         displayMode={displayMode}
+        isFeatureDisplayed={featureDisplayHandler}
         {...props}
         region={region}
       />
@@ -355,6 +370,7 @@ function SvgFeatureRendering(props) {
           {...props}
           region={region}
           movedDuringLastMouseDown={movedDuringLastMouseDown}
+          isFeatureDisplayed={featureDisplayHandler}
         />
         <SvgOverlay {...props} region={region} />
       </svg>
@@ -395,6 +411,11 @@ SvgFeatureRendering.propTypes = {
   onFeatureContextMenu: ReactPropTypes.func,
   blockKey: ReactPropTypes.string,
   exportSVG: ReactPropTypes.shape({}),
+  extraGlyphs: ReactPropTypes.arrayOf(ReactPropTypes.shape({
+    glyph: ReactPropTypes.elementType.isRequired,
+    validator: ReactPropTypes.func.isRequired,
+  })),
+  featureDisplayHandler: ReactPropTypes.func
 }
 
 SvgFeatureRendering.defaultProps = {
@@ -415,6 +436,8 @@ SvgFeatureRendering.defaultProps = {
   onContextMenu: undefined,
   onFeatureClick: undefined,
   onFeatureContextMenu: undefined,
+  extraGlyphs: [],
+  featureDisplayHandler: (feature) => true
 }
 
 export default observer(SvgFeatureRendering)

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -13,7 +13,12 @@ interface Glyph extends React.FunctionComponent {
   layOut?: Function
 }
 
-export function chooseGlyphComponent(feature: Feature): Glyph {
+interface ExtraGlyphValidator {
+  glyph: Glyph
+  validator: (feature: Feature) => boolean
+}
+
+export function chooseGlyphComponent(feature: Feature, extraGlyphs?: ExtraGlyphValidator[]): Glyph {
   const type = feature.get('type')
   const strand = feature.get('strand')
   const subfeatures: Feature[] = feature.get('subfeatures')
@@ -32,6 +37,13 @@ export function chooseGlyphComponent(feature: Feature): Glyph {
     ) {
       return ProcessedTranscript
     }
+
+    for (const extraGlyph of extraGlyphs) {
+      if(extraGlyph.validator(feature) === true) {
+        return extraGlyph.glyph
+      }
+    }
+
     return Segments
   }
   return [1, -1].includes(strand) ? Chevron : Box

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -38,9 +38,11 @@ export function chooseGlyphComponent(feature: Feature, extraGlyphs?: ExtraGlyphV
       return ProcessedTranscript
     }
 
-    for (const extraGlyph of extraGlyphs) {
-      if(extraGlyph.validator(feature) === true) {
-        return extraGlyph.glyph
+    if(typeof(extraGlyphs) != "undefined") {
+      for (const extraGlyph of extraGlyphs) {
+        if(extraGlyph.validator(feature) === true) {
+          return extraGlyph.glyph
+        }
       }
     }
 

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -18,7 +18,10 @@ interface ExtraGlyphValidator {
   validator: (feature: Feature) => boolean
 }
 
-export function chooseGlyphComponent(feature: Feature, extraGlyphs?: ExtraGlyphValidator[]): Glyph {
+export function chooseGlyphComponent(
+  feature: Feature,
+  extraGlyphs?: ExtraGlyphValidator[],
+): Glyph {
   const type = feature.get('type')
   const strand = feature.get('strand')
   const subfeatures: Feature[] = feature.get('subfeatures')
@@ -38,9 +41,9 @@ export function chooseGlyphComponent(feature: Feature, extraGlyphs?: ExtraGlyphV
       return ProcessedTranscript
     }
 
-    if(typeof(extraGlyphs) != "undefined") {
+    if (typeof extraGlyphs != 'undefined') {
       for (const extraGlyph of extraGlyphs) {
-        if(extraGlyph.validator(feature) === true) {
+        if (extraGlyph.validator(feature) === true) {
           return extraGlyph.glyph
         }
       }


### PR DESCRIPTION
We have two requirements where extending the SVG feature renderer would be useful:

- Custom glyphs with our own logic controlling when to render them instead of the provided ones
- Custom logic around whether or not a feature should be rendered. In particular, we have a feature filtration system, which means we need more control over which features are rendered based on filtration logic on our end

In order to do this, in this PR we define two optional props on the `SvgFeatureRendering` component and some of its children:

The `extraGlyphs` prop contains a list of custom glyphs and an associated validator for each. Then, when choosing which glyph to render in `chooseGlyphComponent`, we iterate the list and check each validator. The first one that succeeds is the custom glyph that gets returned. By default, this prop is an empty list, and the iteration is skipped.

The `featureDisplayHandler` prop contains a function that's checked when pushing to the `featuresRendered` list, which allows us to provide custom filtration logic on our end. This prop defaults to a function that always returns true, so no logic should change unless the prop is passed.