### PR TITLE
Fix ability to search for tracks with parentheses in tracklist

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -9,9 +9,9 @@ const hasAnyOverlap = (a1 = [], a2 = []) =>
 function passesFilter(filter, config) {
   const name = getTrackName(config)
   const categories = readConfObject(config, 'category') || []
-  const regexp = new RegExp(filter, 'i')
   return (
-    !!name.match(regexp) || categories.filter(cat => !!cat.match(regexp)).length
+    !!name.includes(filter) ||
+    categories.filter(cat => !!cat.includes(filter)).length
   )
 }
 


### PR DESCRIPTION
This is a simple fix for #2515 

If we need to have a regex based search, we could possibly enable it as an option but it is probably ok to use a more simple string.includes check instead
