### PR TITLE
Fix drawer widget minimized button when overlapping with a view

### DIFF
--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -55,11 +55,13 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
   },
   fabLeft: {
+    zIndex: 10000,
     position: 'fixed',
     bottom: theme.spacing(2),
     left: theme.spacing(2),
   },
   fabRight: {
+    zIndex: 10000,
     position: 'fixed',
     bottom: theme.spacing(2),
     right: theme.spacing(2),


### PR DESCRIPTION
Basically appears to be overridden by the zIndex. Adds an arbitrarily higher number for zIndex. Fixes #2532 