### PR TITLE
Extra header components via prop in @jbrowse/react-linear-genome-view

### DIFF
--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
@@ -19,7 +19,13 @@ const useStyles = makeStyles(() => ({
 }))
 
 const JBrowseLinearGenomeView = observer(
-  ({ viewState }: { viewState: ViewModel }) => {
+  ({
+    viewState,
+    HeaderComponent,
+  }: {
+    viewState: ViewModel
+    HeaderComponent?: React.ReactNode
+  }) => {
     const classes = useStyles()
     const { session } = viewState
     const { view } = session
@@ -37,7 +43,11 @@ const JBrowseLinearGenomeView = observer(
       <ThemeProvider theme={theme}>
         <div className={classes.avoidParentStyle}>
           <ScopedCssBaseline>
-            <ViewContainer key={`view-${view.id}`} view={view}>
+            <ViewContainer
+              key={`view-${view.id}`}
+              view={view}
+              HeaderComponent={HeaderComponent}
+            >
               <Suspense fallback={<div>Loading...</div>}>
                 <ReactComponent model={view} session={session} />
               </Suspense>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
@@ -9,13 +9,15 @@ import {
   useTheme,
   alpha,
 } from '@material-ui/core'
-import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
 import useMeasure from 'react-use-measure'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
+
+// icons
+import MenuIcon from '@material-ui/icons/Menu'
 
 const useStyles = makeStyles(theme => ({
   viewContainer: {
@@ -51,10 +53,12 @@ const ViewMenu = observer(
     model,
     IconButtonProps,
     IconProps,
+    HeaderComponent,
   }: {
     model: IBaseViewModel
     IconButtonProps: IconButtonPropsType
     IconProps: SvgIconProps
+    HeaderComponent?: React.ReactNode
   }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement>()
 
@@ -88,13 +92,22 @@ const ViewMenu = observer(
           }}
           menuItems={model.menuItems()}
         />
+        {HeaderComponent}
       </>
     )
   },
 )
 
 const ViewContainer = observer(
-  ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
+  ({
+    view,
+    children,
+    HeaderComponent,
+  }: {
+    view: IBaseViewModel
+    children: React.ReactNode
+    HeaderComponent?: React.ReactNode
+  }) => {
     const [ref, { width }] = useMeasure()
     const classes = useStyles()
     const theme = useTheme()
@@ -129,6 +142,7 @@ const ViewContainer = observer(
               edge: 'start',
             }}
             IconProps={{ className: classes.icon }}
+            HeaderComponent={HeaderComponent}
           />
           <div className={classes.grow} />
           {view.displayName ? (

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import React, { useEffect, useState } from 'react'
 import { observer } from 'mobx-react'
+import { Button } from '@material-ui/core'
 import { PluginRecord } from '@jbrowse/core/PluginLoader'
 import { Region } from '@jbrowse/core/util/types'
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
@@ -52,6 +53,7 @@ const longReadsSession = {
   ...defaultSession,
   view: volvoxSession.session.views[0],
 }
+
 export const OneLinearGenomeView = () => {
   const state = createViewState({
     assembly,
@@ -567,6 +569,33 @@ export const WithExternalPlugins = () => {
     },
   })
   return <JBrowseLinearGenomeView viewState={state} />
+}
+
+export const WithExtraHeaderComponent = () => {
+  const state = createViewState({
+    assembly,
+    tracks,
+    defaultSession,
+    // use 1-based coordinates for locstring
+    location: 'ctgA:1105..1221',
+    onChange: patch => {
+      console.log('patch', patch)
+    },
+  })
+  return (
+    <JBrowseLinearGenomeView
+      viewState={state}
+      HeaderComponent={
+        <Button
+          color="secondary"
+          variant="contained"
+          onClick={() => alert('Hello world')}
+        >
+          Click me
+        </Button>
+      }
+    />
+  )
 }
 
 const JBrowseLinearGenomeViewStories = {


### PR DESCRIPTION
Possible helper for @bbimber

Note

>"We have an embedded ReactLinearGenomeView. The component has a menu in the upper-right, which can have items added to it. Is there a way to inject another item into the menu bar itself? Specifically, because we show this viewer full-screen, I want to put some kind of button/link that is very obviously has the text "Return to Site"."


![Screenshot from 2021-11-17 17-26-32](https://user-images.githubusercontent.com/6511937/142292432-8257b24f-2b80-4311-ac84-6c8a2caab045.png)
