### PR TITLE
Alt abort fix

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  addDisposer,
   getParent,
-  isAlive,
-  IAnyStateTreeNode,
   getSnapshot,
   hasParent,
-  addDisposer,
+  isAlive,
   isStateTreeNode,
+  IAnyStateTreeNode,
 } from 'mobx-state-tree'
 import { reaction, IReactionPublic, IReactionOptions } from 'mobx'
 import fromEntries from 'object.fromentries'
@@ -14,13 +14,13 @@ import { useEffect, useRef, useState } from 'react'
 import merge from 'deepmerge'
 import { Feature } from './simpleFeature'
 import {
-  TypeTestedByPredicate,
   isSessionModel,
   isDisplayModel,
   isViewModel,
   isTrackModel,
   Region,
   AssemblyManager,
+  TypeTestedByPredicate,
 } from './types'
 import { isAbortException, checkAbortSignal } from './aborting'
 
@@ -685,7 +685,8 @@ export function makeAbortableReaction<T, U, V>(
         }
       } catch (e) {
         if (thisInProgress && !thisInProgress.signal.aborted) {
-          thisInProgress.abort()
+          console.error(e)
+          errorFunction(new Error('Received an unexpected abort exception'))
         }
         handleError(e)
       }

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -684,7 +684,11 @@ export function makeAbortableReaction<T, U, V>(
           successFunction(result)
         }
       } catch (e) {
-        if (thisInProgress && !thisInProgress.signal.aborted) {
+        if (
+          isAbortException(e) &&
+          thisInProgress &&
+          !thisInProgress.signal.aborted
+        ) {
           console.error(e)
           errorFunction(new Error('Received an unexpected abort exception'))
         }

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -689,6 +689,9 @@ export function makeAbortableReaction<T, U, V>(
           thisInProgress &&
           !thisInProgress.signal.aborted
         ) {
+          // the stance of this is that aborts from other places in the code
+          // should not land here, and they should catch their own abort
+          // exceptions. otherwise, can cause errors such as #2540
           console.error(e)
           errorFunction(new Error('Received an unexpected abort exception'))
         }

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -36,11 +36,7 @@ export function openLocation(
     const response = await fetch(url, opts)
     if (response.status === 401) {
       const authHeaders = response.headers.get('WWW-Authenticate')
-      if (
-        isUriLocation(location) &&
-        authHeaders &&
-        authHeaders.includes('Basic')
-      ) {
+      if (isUriLocation(location)) {
         throw new AuthNeededError(
           'Accessing HTTPBasic resource without authentication',
           location,

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -36,7 +36,11 @@ export function openLocation(
     const response = await fetch(url, opts)
     if (response.status === 401) {
       const authHeaders = response.headers.get('WWW-Authenticate')
-      if (isUriLocation(location)) {
+      if (
+        isUriLocation(location) &&
+        authHeaders &&
+        authHeaders.includes('Basic')
+      ) {
         throw new AuthNeededError(
           'Accessing HTTPBasic resource without authentication',
           location,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
@@ -286,7 +286,6 @@ export async function renderToSvg(model: LGV, opts: ExportSvgOptions) {
   const displayResults = await Promise.all(
     tracks.map(async track => {
       const display = track.displays[0]
-      await when(() => (display.ready !== undefined ? display.ready : true))
       const result = await display.renderSvg(opts)
       return { track, result }
     }),

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -16,7 +16,7 @@ import {
   BaseLinearDisplay,
   LinearGenomeViewModel,
 } from '@jbrowse/plugin-linear-genome-view'
-import { observable, when } from 'mobx'
+import { observable } from 'mobx'
 import {
   isAlive,
   types,
@@ -612,8 +612,12 @@ const stateModelFactory = (
           )
         },
         async renderSvg(opts: ExportSvgOpts) {
-          await when(() => self.ready && !!self.regionCannotBeRenderedText)
-          const { needsScalebar, stats } = self
+          // instead of waiting on model.ready, we manually estimate stats here
+          // because the makeAbortableReaction doesn't work under @jbrowse/cli,
+          // see #2540
+          const stats = await getStats(getStatsData())
+          self.updateStats(stats)
+          const { needsScalebar } = self
           const { offsetPx } = getContainingView(self) as LGV
           return (
             <>

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -103,12 +103,8 @@ const stateModelFactory = (
         self.color = color
       },
 
-      setLoading(aborter: AbortController) {
-        // const { statsFetchInProgress: statsFetch } = self
-        // if (statsFetch !== undefined && !statsFetch.signal.aborted) {
-        //   statsFetch.abort()
-        // }
-        // self.statsFetchInProgress = aborter
+      setLoading(_aborter: AbortController) {
+        // do nothing currently
       },
 
       // this overrides the BaseLinearDisplayModel to avoid popping up a

--- a/products/jbrowse-web/src/tests/Authentication.test.js
+++ b/products/jbrowse-web/src/tests/Authentication.test.js
@@ -120,7 +120,7 @@ describe('authentication', () => {
       await findByTestId('htsTrackEntry-volvox_microarray_externaltoken'),
     )
     const { findByText: findByTextWithin } = within(
-      await findByTestId('externalToken-form'),
+      await findByTestId('externalToken-form', {}, { timeout: 10000 }),
     )
     fireEvent.change(await findByTestId('entry-externalToken'), {
       target: { value: 'testentry' },

--- a/products/jbrowse-web/src/tests/Authentication.test.js
+++ b/products/jbrowse-web/src/tests/Authentication.test.js
@@ -171,14 +171,11 @@ describe('authentication', () => {
     const { findByTestId, findAllByTestId, findByText } = render(
       <JBrowse pluginManager={pluginManager} />,
     )
-    // state.internetAccounts[1].fetchFile = jest
-    //   .fn()
-    //   .mockReturnValue('volvox_microarray_dropbox.bw')
     state.session.views[0].setNewView(5, 0)
     fireEvent.click(
       await findByTestId('htsTrackEntry-volvox_microarray_httpbasic'),
     )
-    await findByTestId('login-httpbasic')
+    await findByTestId('login-httpbasic', {}, { timeout: 10000 })
     fireEvent.change(await findByTestId('login-httpbasic-username'), {
       target: { value: 'username' },
     })
@@ -208,5 +205,5 @@ describe('authentication', () => {
       failureThreshold: 0.05,
       failureThresholdType: 'percent',
     })
-  })
-}, 25000)
+  }, 25000)
+})

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.js
@@ -51,7 +51,7 @@ describe('valid file tests', () => {
 
     const dlg = await findByText(/The Evolutionary Software Foundation/)
     expect(dlg).toBeTruthy()
-  })
+  }, 10000)
 
   it('click and drag to move sideways', async () => {
     const pluginManager = getPluginManager()


### PR DESCRIPTION
This is a possible alternative approach to #2517 that I went over with @rbuels 

It changes an autorun for getting stats in wiggle to an abortable reaction (with makeAbortableReaction)

This appears to fix some of the observed failures in #2517 

There appear to be some issues still with authentication workflows in CI and in manual tests so may need to investigate further