### PR TITLE
Fix broken feature layout due to async race condition on getRpcDriver

### DIFF
--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -48,11 +48,11 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
 
   WorkerClass: WebpackWorker
 
-  workerBootConfiguration: { plugins: PluginDefinition[]; userData?: string }
+  workerBootConfiguration: { plugins: PluginDefinition[] }
 
   constructor(
     args: WebWorkerRpcDriverConstructorArgs,
-    workerBootConfiguration: { plugins: PluginDefinition[]; userData?: string },
+    workerBootConfiguration: { plugins: PluginDefinition[] },
   ) {
     super(args)
     this.WorkerClass = args.WorkerClass


### PR DESCRIPTION
This appears to fix #2547 

The summary of #2547 is that multiple rpc drivers were being created due to the async change of getDriver

This changes it back to not being an async call, but loses the storing of ipc call to userData with this

If it is needed to have userData for other purposes in the code, it could be obtained in another way?

Alternatively, we could modify this PR to try to avoid double-creation of the drivers e.g. with a promise-singleton type pattern seen elsewhere in the codebase