### PR TITLE
Change border on non-cytoband OverviewScaleBar visible region back to blue and cytoband OverviewScaleBar to a little lighter fill

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
@@ -177,7 +177,7 @@ const SVGHeader = ({ model }: { model: LGV }) => {
           <Cytobands overview={overview} assembly={assembly} block={block} />
           <rect
             stroke="red"
-            fill="rgb(255,0,0,0.3)"
+            fill="rgb(255,0,0,0.1)"
             width={Math.max(lastOverviewPx - firstOverviewPx, 0.5)}
             height={HEADER_OVERVIEW_HEIGHT - 1}
             x={firstOverviewPx}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles(theme => {
       height: HEADER_OVERVIEW_HEIGHT,
       pointerEvents: 'none',
       zIndex: 100,
-      border: '1px solid red',
+      border: '1px solid',
     },
     overview: {
       height: HEADER_BAR_HEIGHT,
@@ -405,6 +405,9 @@ const ScaleBar = observer(
         coord: last.reversed ? last.start : last.end,
       }) || 0
 
+    const color = showCytobands ? '#f00' : scaleBarColor
+    const transparency = showCytobands ? 0.1 : 0.3
+
     return (
       <div className={classes.scaleBar}>
         <div
@@ -412,9 +415,8 @@ const ScaleBar = observer(
           style={{
             width: lastOverviewPx - firstOverviewPx,
             left: firstOverviewPx + cytobandOffset,
-            background: showCytobands
-              ? alpha('#f00', 0.3)
-              : alpha(scaleBarColor, 0.3),
+            background: alpha(color, transparency),
+            borderColor: color,
           }}
         />
         {/* this is the entire scale bar */}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -17,7 +17,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         >
           <div
             class="makeStyles-scaleBarVisibleRegion"
-            style="width: 800px; left: 0px; background: rgba(121, 134, 203, 0.3);"
+            style="width: 800px; left: 0px; background: rgba(121, 134, 203, 0.3); border-color: #7986cb;"
           />
           <div
             class="makeStyles-scaleBarContig"
@@ -581,7 +581,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         >
           <div
             class="makeStyles-scaleBarVisibleRegion"
-            style="width: 580px; left: 0px; background: rgba(121, 134, 203, 0.3);"
+            style="width: 580px; left: 0px; background: rgba(121, 134, 203, 0.3); border-color: #7986cb;"
           />
           <div
             class="makeStyles-scaleBarContig"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <div
                     class="makeStyles-scaleBarVisibleRegion"
-                    style="width: 267px; left: 0px; background: rgba(66, 119, 127, 0.3);"
+                    style="width: 267px; left: 0px; background: rgba(66, 119, 127, 0.3); border-color: rgb(66, 119, 127);"
                   />
                   <div
                     class="makeStyles-scaleBarContig"


### PR DESCRIPTION
Changes the border color for non-cytoband OverviewScaleBar back to blue (was red when cytoband was added) and lightens the fill alpha on the cytoband overview rect (0.3->0.1)

after
![localhost_3000__config=test_data%2Fvolvox%2Fconfig json](https://user-images.githubusercontent.com/6511937/143324887-431c4cf3-8e25-4ca4-9892-8e849e9e5a63.png)

before
![localhost_3000__config=test_data%2Fvolvox%2Fconfig json (1)](https://user-images.githubusercontent.com/6511937/143324888-b27f78c1-efa7-4149-81b9-98d1d747bc25.png)


after
![localhost_3000__config=test_data%2Fconfig_demo json (1)](https://user-images.githubusercontent.com/6511937/143324952-5d144fe3-fa29-4641-b79f-bdeaa5e35ef7.png)

before
![localhost_3000__config=test_data%2Fconfig_demo json (2)](https://user-images.githubusercontent.com/6511937/143324953-b642c14c-6fe1-4aa7-a5ff-4ccaaf5adbf1.png)
