### PR TITLE
Fix ability to access BigWig tracks on http basic auth for some cases

### DIFF
--- a/plugins/authentication/src/HTTPBasicModel/model.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/model.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
+import { RemoteFile } from 'generic-filehandle'
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes/models'
-import { RemoteFileWithRangeCache } from '@jbrowse/core/util/io'
 import { UriLocation } from '@jbrowse/core/util/types'
 import { getParent } from 'mobx-state-tree'
 import { HTTPBasicInternetAccountConfigModel } from './configSchema'
@@ -154,7 +154,7 @@ const stateModelFactory = (
         openLocation(location: UriLocation) {
           preAuthInfo =
             location.internetAccountPreAuthorization || self.generateAuthInfo()
-          return new RemoteFileWithRangeCache(String(location.uri), {
+          return new RemoteFile(String(location.uri), {
             fetch: this.getFetcher,
           })
         },


### PR DESCRIPTION
This is the one way @peterkxie and I were able to solve #2541 for bigwig files

We tried several alternative approaches

1) Making the "new BigWig" object get recreated inside the setup function instead of in BigWigAdapter constructor
2) Removing AbortablePromiseCache from getHeader in bbi.ts inside of @GMOD/bbi
3) lots of console.logging elsewhere in the code

None of these worked though

With this PR though, it does work. It does have the result of making many small range requests that are not saying they are read from disk cache in chrome, so could result in slowness, but would fix BigWig tracks for http basic

Note that we only saw issues with BigWig files. BAM tracks with SNPCoverage work for example, even with the LinearSNPCoverageDisplay only showing.

If needed we could do even deeper dive to fix