### PR TITLE
Restore ability to load plugins from relative URL

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -78,7 +78,7 @@ export interface LoadedPlugin {
   default: PluginConstructor
 }
 
-function getGlobalObject(): WindowOrWorkerGlobalScope {
+function getGlobalObject(): Window {
   // Based on window-or-global
   // https://github.com/purposeindustries/window-or-global/blob/322abc71de0010c9e5d9d0729df40959e1ef8775/lib/index.js
   return (
@@ -128,7 +128,16 @@ export default class PluginLoader {
   async loadCJSPlugin(
     pluginDefinition: CJSPluginDefinition,
   ): Promise<LoadedPlugin> {
-    const parsedUrl = new URL(pluginDefinition.cjsUrl)
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(
+        pluginDefinition.cjsUrl,
+        getGlobalObject().location.href,
+      )
+    } catch (error) {
+      console.error(`Error parsing URL: ${pluginDefinition.cjsUrl}`)
+      throw error
+    }
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error(
         `cannot load plugins using protocol "${parsedUrl.protocol}"`,
@@ -179,7 +188,16 @@ export default class PluginLoader {
   }
 
   async loadESMPlugin(pluginDefinition: ESMPluginDefinition) {
-    const parsedUrl = new URL(pluginDefinition.esmUrl)
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(
+        pluginDefinition.esmUrl,
+        getGlobalObject().location.href,
+      )
+    } catch (error) {
+      console.error(`Error parsing URL: ${pluginDefinition.esmUrl}`)
+      throw error
+    }
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error(
         `cannot load plugins using protocol "${parsedUrl.protocol}"`,
@@ -197,11 +215,15 @@ export default class PluginLoader {
   async loadUMDPlugin(
     pluginDefinition: UMDPluginDefinition | LegacyUMDPluginDefinition,
   ) {
-    const parsedUrl = new URL(
-      'url' in pluginDefinition
-        ? pluginDefinition.url
-        : pluginDefinition.umdUrl,
-    )
+    const umdUrl =
+      'url' in pluginDefinition ? pluginDefinition.url : pluginDefinition.umdUrl
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(umdUrl, getGlobalObject().location.href)
+    } catch (error) {
+      console.error(`Error parsing URL: ${umdUrl}`)
+      throw error
+    }
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error(
         `cannot load plugins using protocol "${parsedUrl.protocol}"`,


### PR DESCRIPTION
Fixes #2562

This passes the window location as a second argument to the URL constructor. If a plugin definition has a full URL, the second argument gets ignored, but if a plugin definition has a relative URL it is resolved relative to the window location. Examples of how the resolution works are [here](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#examples).

It also logs an error message with the name of the failed URL since that's not included in the native error message.