### PR TITLE
Start looking for parents with parent, not self in findParentThat

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -97,7 +97,7 @@ export function findParentThat(
   node: IAnyStateTreeNode,
   predicate: (thing: IAnyStateTreeNode) => boolean,
 ) {
-  if (!hasParent) {
+  if (!hasParent(node)) {
     throw new Error('node does not have parent')
   }
   let currentNode: IAnyStateTreeNode | undefined = getParent(node)

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -97,7 +97,10 @@ export function findParentThat(
   node: IAnyStateTreeNode,
   predicate: (thing: IAnyStateTreeNode) => boolean,
 ) {
-  let currentNode: IAnyStateTreeNode | undefined = node
+  if (!hasParent) {
+    throw new Error('node does not have parent')
+  }
+  let currentNode: IAnyStateTreeNode | undefined = getParent(node)
   while (currentNode && isAlive(currentNode)) {
     if (predicate(currentNode)) {
       return currentNode

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.test.js
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.test.js
@@ -10,9 +10,10 @@ describe('<AboutWidget />', () => {
       .model({
         configuration: ConfigurationSchema('Null', {}),
         rpcManager: types.frozen({}),
+        widgetModel: types.model({ type: types.literal('AboutWidget') }),
       })
       .create(
-        {},
+        { widgetModel: { type: 'AboutWidget' } },
         {
           pluginManager: {
             pluginMetadata: {},
@@ -26,7 +27,7 @@ describe('<AboutWidget />', () => {
           },
         },
       )
-    const { container } = render(<AboutWidget model={session} />)
+    const { container } = render(<AboutWidget model={session.widgetModel} />)
     expect(container.firstChild).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This is a fix for `findParentThat`, which is used by `getContainingView`, `getContainingTrack`, etc. Previously, it would start searching at the given node, and not its parent, so `getContainingView(self)` called from a view would return itself, even if it was nested inside another view. With this change it start searching at the first parent instead.