### PR TITLE
Restore track selector filter case-insensitivity

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -9,9 +9,10 @@ const hasAnyOverlap = (a1 = [], a2 = []) =>
 function passesFilter(filter, config) {
   const name = getTrackName(config)
   const categories = readConfObject(config, 'category') || []
+  const filterLower = filter.toLowerCase()
   return (
-    !!name.includes(filter) ||
-    categories.filter(cat => !!cat.includes(filter)).length
+    !!name.toLowerCase().includes(filterLower) ||
+    categories.filter(cat => !!cat.toLowerCase().includes(filterLower)).length
   )
 }
 


### PR DESCRIPTION
This restores the case-insensitivity of the track selector filter that was lost when the filter was change to use `includes` instead of regexp in 7ee926ec06d53af4af138a57fcc028e4f0287c2f.