### PR TITLE
Use TypeScript parameter properties

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,6 @@ module.exports = api => {
     comments: true,
     presets: [
       '@babel/preset-typescript',
-      'react-app',
       [
         '@babel/preset-env',
         {
@@ -15,6 +14,7 @@ module.exports = api => {
           },
         },
       ],
+      'react-app',
     ],
     ignore: [
       './node_modules',

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -79,27 +79,15 @@ type PluggableElementTypeGroup =
 class TypeRecord<ElementClass extends PluggableElementBase> {
   registeredTypes: { [name: string]: ElementClass } = {}
 
-  baseClass: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | { new (...args: any[]): ElementClass }
-    // covers abstract class case
-    | (Function & {
-        prototype: ElementClass
-      })
-
-  typeName: string
-
   constructor(
-    typeName: string,
-    elementType: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public typeName: string,
+    public baseClass: // eslint-disable-next-line @typescript-eslint/no-explicit-any
     | { new (...args: any[]): ElementClass }
       // covers abstract class case
       | (Function & {
           prototype: ElementClass
         }),
-  ) {
-    this.typeName = typeName
-    this.baseClass = elementType
-  }
+  ) {}
 
   add(name: string, t: ElementClass) {
     this.registeredTypes[name] = t

--- a/packages/core/TextSearch/TextSearchManager.ts
+++ b/packages/core/TextSearch/TextSearchManager.ts
@@ -24,10 +24,7 @@ export interface SearchScope {
 export default class TextSearchManager {
   adapterCache: QuickLRU
 
-  pluginManager: PluginManager
-
-  constructor(pluginManager: PluginManager) {
-    this.pluginManager = pluginManager
+  constructor(public pluginManager: PluginManager) {
     this.adapterCache = new QuickLRU({
       maxSize: 15,
     })

--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -57,20 +57,14 @@ export abstract class BaseAdapter {
 
   static capabilities = [] as string[]
 
-  config: AnyConfigurationModel
-
-  getSubAdapter?: getSubAdapterType
-
-  pluginManager: PluginManager | undefined
-
   constructor(
-    config: AnyConfigurationModel = ConfigurationSchema('empty', {}).create(),
-    getSubAdapter?: getSubAdapterType,
-    pluginManager?: PluginManager,
+    public config: AnyConfigurationModel = ConfigurationSchema(
+      'empty',
+      {},
+    ).create(),
+    public getSubAdapter?: getSubAdapterType,
+    public pluginManager?: PluginManager,
   ) {
-    this.config = config
-    this.getSubAdapter = getSubAdapter
-    this.pluginManager = pluginManager
     // note: we use switch on jest here for more simple feature IDs
     // in test environment
     if (typeof jest === 'undefined') {

--- a/packages/core/pluggableElementTypes/RpcMethodType.ts
+++ b/packages/core/pluggableElementTypes/RpcMethodType.ts
@@ -21,13 +21,10 @@ import {
 export type RpcMethodConstructor = new (pm: PluginManager) => RpcMethodType
 
 export default abstract class RpcMethodType extends PluggableElementBase {
-  pluginManager: PluginManager
-
   name = 'UNKNOWN'
 
-  constructor(pluginManager: PluginManager) {
+  constructor(public pluginManager: PluginManager) {
     super({ name: '' })
-    this.pluginManager = pluginManager
   }
 
   async serializeArguments(args: {}, _rpcDriverClassName: string): Promise<{}> {

--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -75,11 +75,7 @@ function detectHardwareConcurrency() {
 class LazyWorker {
   worker?: WorkerHandle
 
-  driver: BaseRpcDriver
-
-  constructor(driver: BaseRpcDriver) {
-    this.driver = driver
-  }
+  constructor(public driver: BaseRpcDriver) {}
 
   getWorker(pluginManager: PluginManager, rpcDriverClassName: string) {
     if (!this.worker) {

--- a/packages/core/rpc/RpcManager.ts
+++ b/packages/core/rpc/RpcManager.ts
@@ -27,23 +27,14 @@ export default class RpcManager {
 
   driverObjects: Map<string, DriverClass>
 
-  pluginManager: PluginManager
-
-  mainConfiguration: AnyConfigurationModel
-
-  backendConfigurations: BackendConfigurations
-
   constructor(
-    pluginManager: PluginManager,
-    mainConfiguration: AnyConfigurationModel,
-    backendConfigurations: BackendConfigurations,
+    public pluginManager: PluginManager,
+    public mainConfiguration: AnyConfigurationModel,
+    public backendConfigurations: BackendConfigurations,
   ) {
     if (!mainConfiguration) {
       throw new Error('RpcManager requires at least a main configuration')
     }
-    this.pluginManager = pluginManager
-    this.mainConfiguration = mainConfiguration
-    this.backendConfigurations = backendConfigurations
     this.driverObjects = new Map()
   }
 

--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -48,15 +48,12 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
 
   WorkerClass: WebpackWorker
 
-  workerBootConfiguration: { plugins: PluginDefinition[] }
-
   constructor(
     args: WebWorkerRpcDriverConstructorArgs,
-    workerBootConfiguration: { plugins: PluginDefinition[] },
+    public workerBootConfiguration: { plugins: PluginDefinition[] },
   ) {
     super(args)
     this.WorkerClass = args.WorkerClass
-    this.workerBootConfiguration = workerBootConfiguration
   }
 
   makeWorker() {

--- a/packages/core/util/blockTypes.ts
+++ b/packages/core/util/blockTypes.ts
@@ -1,11 +1,7 @@
 type Func<T> = (value: BaseBlock, index: number, array: BaseBlock[]) => T
 
 export class BlockSet {
-  blocks: BaseBlock[] = []
-
-  constructor(blocks: BaseBlock[] = []) {
-    this.blocks = blocks
-  }
+  constructor(public blocks: BaseBlock[] = []) {}
 
   push(block: BaseBlock) {
     if (block instanceof ElidedBlock) {

--- a/packages/core/util/compositeMap.ts
+++ b/packages/core/util/compositeMap.ts
@@ -1,11 +1,7 @@
 // takes an array or Map or Set (anything iterable with values()) of Maps
 // and lets you query them as one Map
 export default class CompositeMap<T, U> {
-  private submaps: Map<T, U>[]
-
-  constructor(submaps: Map<T, U>[]) {
-    this.submaps = submaps
-  }
+  constructor(private submaps: Map<T, U>[]) {}
 
   has(id: T) {
     for (const submap of this.submaps.values()) {

--- a/packages/core/util/layouts/MultiLayout.ts
+++ b/packages/core/util/layouts/MultiLayout.ts
@@ -4,8 +4,6 @@ import { BaseLayout, SerializedLayout } from './BaseLayout'
 export default class MultiLayout<SUB_LAYOUT_CLASS extends BaseLayout<T>, T> {
   subLayouts: Map<string, SUB_LAYOUT_CLASS> = new Map()
 
-  SubLayoutClass: new (...args: any[]) => SUB_LAYOUT_CLASS
-
   subLayoutConstructorArgs: Record<string, any> = {}
 
   /**
@@ -14,11 +12,10 @@ export default class MultiLayout<SUB_LAYOUT_CLASS extends BaseLayout<T>, T> {
    * `{ layout1: new GranularRectLayout(), layout2: new GranularRectLayout() ...}`
    */
   constructor(
-    SubLayoutClass: new (...args: any[]) => SUB_LAYOUT_CLASS,
+    public SubLayoutClass: new (...args: any[]) => SUB_LAYOUT_CLASS,
     layoutArgs: Record<string, any> = {},
   ) {
     this.subLayouts = new Map()
-    this.SubLayoutClass = SubLayoutClass
     this.subLayoutConstructorArgs = layoutArgs
   }
 

--- a/packages/core/util/layouts/SceneGraph.ts
+++ b/packages/core/util/layouts/SceneGraph.ts
@@ -11,19 +11,6 @@ interface AbsoluteCache {
 }
 
 export default class SceneGraph {
-  private name: string
-
-  public left: number
-
-  public top: number
-
-  public width: number
-
-  public height: number
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public data?: Record<string, any>
-
   private children: Map<string, SceneGraph>
 
   private absoluteCache: AbsoluteCache
@@ -34,13 +21,13 @@ export default class SceneGraph {
    * note: all coordinates are inter-base or inter-pixel coordinates
    */
   constructor(
-    name: string,
-    left: number,
-    top: number,
-    width: number,
-    height: number,
+    public name: string,
+    public left: number,
+    public top: number,
+    public width: number,
+    public height: number,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data?: Record<string, any>,
+    public data?: Record<string, any>,
   ) {
     if (
       inDevelopment &&
@@ -56,13 +43,6 @@ export default class SceneGraph {
     ) {
       throw new TypeError('invalid SceneGraph arguments')
     }
-
-    this.name = name
-    this.left = left
-    this.top = top
-    this.width = width
-    this.height = height
-    this.data = data
     this.children = new Map()
     this.absoluteCache = { dirty: true }
   }

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -341,10 +341,8 @@ export function isUriLocation(location: unknown): location is UriLocation {
 }
 
 export class AuthNeededError extends Error {
-  location: UriLocation
-  constructor(message: string, location: UriLocation) {
+  constructor(public message: string, public location: UriLocation) {
     super(message)
-    this.location = location
     this.name = 'AuthNeededError'
 
     Object.setPrototypeOf(this, AuthNeededError.prototype)
@@ -352,11 +350,8 @@ export class AuthNeededError extends Error {
 }
 
 export class RetryError extends Error {
-  internetAccountId: string
-  constructor(message: string, internetAccountId: string) {
+  constructor(public message: string, public internetAccountId: string) {
     super(message)
-    this.message = message
-    this.internetAccountId = internetAccountId
     this.name = 'RetryError'
   }
 }

--- a/plugins/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
@@ -15,17 +15,11 @@ import {
 import BamAdapter from './BamAdapter'
 
 export default class BamSlightlyLazyFeature implements Feature {
-  private record: BamRecord
-
-  private adapter: BamAdapter
-
-  private ref?: string
-
-  constructor(record: BamRecord, adapter: BamAdapter, ref?: string) {
-    this.record = record
-    this.adapter = adapter
-    this.ref = ref
-  }
+  constructor(
+    private record: BamRecord,
+    private adapter: BamAdapter,
+    private ref?: string,
+  ) {}
 
   _get_name() {
     return this.record.get('name')

--- a/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
@@ -18,14 +18,10 @@ export interface Mismatch {
 }
 
 export default class CramSlightlyLazyFeature implements Feature {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private record: any
-
   private _store: CramAdapter
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(record: any, store: CramAdapter) {
-    this.record = record
+  constructor(private record: any, store: CramAdapter) {
     this._store = store
   }
 

--- a/plugins/circular-view/src/CircularView/models/slices.ts
+++ b/plugins/circular-view/src/CircularView/models/slices.ts
@@ -9,8 +9,6 @@ import { thetaRangesOverlap } from './viewportVisibleRegion'
 export class Slice {
   key: string
 
-  region: Region & { widthBp: number; elided: boolean }
-
   offsetRadians: number
 
   startRadians: number
@@ -19,22 +17,18 @@ export class Slice {
 
   bpPerRadian: number
 
-  radianWidth: number
-
   flipped: boolean
 
   constructor(
     view: { bpPerRadian: number },
-    region: Region & { widthBp: number; elided: boolean },
+    public region: Region & { widthBp: number; elided: boolean },
     currentRadianOffset: number,
-    radianWidth: number,
+    public radianWidth: number,
   ) {
     const { bpPerRadian } = view
     this.key = assembleLocString(region)
-    this.region = region
     this.offsetRadians = currentRadianOffset
     this.bpPerRadian = bpPerRadian
-    this.radianWidth = radianWidth
     this.flipped = false
 
     this.startRadians = this.offsetRadians

--- a/plugins/dotplot-view/src/DotplotView/blockTypes.ts
+++ b/plugins/dotplot-view/src/DotplotView/blockTypes.ts
@@ -1,11 +1,7 @@
 type Func<T> = (value: BaseBlock, index: number, array: BaseBlock[]) => T
 
 export class BlockSet {
-  blocks: BaseBlock[] = []
-
-  constructor(blocks: BaseBlock[] = []) {
-    this.blocks = blocks
-  }
+  constructor(public blocks: BaseBlock[] = []) {}
 
   push(block: BaseBlock) {
     if (block instanceof ElidedBlock) {

--- a/plugins/hic/src/HicAdapter/HicAdapter.ts
+++ b/plugins/hic/src/HicAdapter/HicAdapter.ts
@@ -42,11 +42,7 @@ interface HicOptions extends BaseOptions {
 // in some ways, generic-filehandle wishes it was just this but it has
 // to adapt to the node.js fs promises API
 class GenericFilehandleWrapper {
-  private filehandle: GenericFilehandle
-
-  constructor(filehandle: GenericFilehandle) {
-    this.filehandle = filehandle
-  }
+  constructor(private filehandle: GenericFilehandle) {}
 
   async read(position: number, length: number) {
     const { buffer: b, bytesRead } = await this.filehandle.read(

--- a/plugins/legacy-jbrowse/src/NCListAdapter/NCListFeature.ts
+++ b/plugins/legacy-jbrowse/src/NCListAdapter/NCListFeature.ts
@@ -11,16 +11,12 @@ const jb1ToJb2 = { seq_id: 'refName' }
  * wrapper to adapt nclist features to act like jbrowse 2 features
  */
 export default class NCListFeature implements Feature {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private ncFeature: any
-
   private parentHandle?: Feature
 
   private uniqueId: string
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(ncFeature: any, parent?: Feature, id?: string) {
-    this.ncFeature = ncFeature
+  constructor(private ncFeature: any, parent?: Feature, id?: string) {
     this.uniqueId = id || ncFeature.id()
     this.parentHandle = parent
   }


### PR DESCRIPTION
I learned about Typescript's [parameter properties](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties) recently, and did a quick search in our code base to see if there was anywhere we could use them. This is a refactoring, so no functionality is changed. I think they are useful because they allow us to not have to declare types twice and make the code more concise. Basically how they work is that this:

```ts
class Person {
  public name: string

  constructor(name: string) {
    this.name = name
  }
}
```

can be written as this:

```ts
class Person {
  constructor(public name: string) {}
}
```

`this.name` is assigned automatically, so the constructor can be empty.

The only odd thing was that the tests wouldn't run with this change, and to fix it I had to change the order of the presets in `.babel.config.js`. This ends up running the "react-app" preset [before](https://babeljs.io/docs/en/presets/#preset-ordering) the "preset-env" preset.