### PR TITLE
Add layouts code to core re-exports

### DIFF
--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -31,6 +31,7 @@ export default [
   '@jbrowse/core/ui',
   '@jbrowse/core/util',
   '@jbrowse/core/util/color',
+  '@jbrowse/core/util/layouts',
   '@jbrowse/core/util/tracks',
   '@jbrowse/core/util/Base1DViewModel',
   '@jbrowse/core/util/io',

--- a/packages/core/ReExports/modules.ts
+++ b/packages/core/ReExports/modules.ts
@@ -72,6 +72,7 @@ import Plugin from '../Plugin'
 import * as coreUi from '../ui'
 import * as coreUtil from '../util'
 import * as coreColor from '../util/color'
+import * as coreLayouts from '../util/layouts'
 import * as trackUtils from '../util/tracks'
 import * as coreIo from '../util/io'
 import * as coreMstReflection from '../util/mst-reflection'
@@ -159,6 +160,7 @@ const libs = {
   '@jbrowse/core/ui': coreUi,
   '@jbrowse/core/util': coreUtil,
   '@jbrowse/core/util/color': coreColor,
+  '@jbrowse/core/util/layouts': coreLayouts,
   '@jbrowse/core/util/tracks': trackUtils,
   '@jbrowse/core/util/Base1DViewModel': Base1DView,
   '@jbrowse/core/util/io': coreIo,

--- a/packages/core/util/layouts/index.ts
+++ b/packages/core/util/layouts/index.ts
@@ -1,0 +1,7 @@
+export * from './BaseLayout'
+export { default as GranularRectLayout } from './GranularRectLayout'
+export { default as MultiLayout } from './MultiLayout'
+export { default as PrecomputedLayout } from './PrecomputedLayout'
+export type { Layout } from './PrecomputedLayout'
+export { default as PrecomputedMultiLayout } from './PrecomputedMultiLayout'
+export { default as SceneGraph } from './SceneGraph'


### PR DESCRIPTION
This adds the code in `packages/core/util/layouts` to the core re-exports so that external plugins can use it. All of the exports in that directory have been added to and index file, so the code should be imported from external plugins like:

```js
import { SceneGraph } from '@jbrowse/core/util/layouts'
```