### PR TITLE
Add help text and help dialog for the RefNameAutocomplete

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HelpDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HelpDialog.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  makeStyles,
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+
+export const useStyles = makeStyles(theme => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}))
+
+export default function HelpDialog({
+  handleClose,
+}: {
+  handleClose: () => void
+}) {
+  const classes = useStyles()
+  return (
+    <Dialog open maxWidth="xl" onClose={handleClose}>
+      <DialogTitle>
+        Using the search box
+        {handleClose ? (
+          <IconButton
+            data-testid="close-resultsDialog"
+            className={classes.closeButton}
+            onClick={() => {
+              handleClose()
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : null}
+      </DialogTitle>
+      <Divider />
+      <DialogContent>
+        <h3>Searching</h3>
+        <ul>
+          <li>
+            Jump to a feature or reference sequence by typing its name in the
+            location box and pressing Enter.
+          </li>
+          <li>
+            Jump to a specific region by typing the region into the location box
+            as: <code>ref:start..end</code> or <code>ref:start-end</code>.
+            Commas are allowed in the start and end coordinates.
+          </li>
+        </ul>
+        <h3>Example Searches</h3>
+        <ul>
+          <li>
+            <code>BRCA</code> - searches for the feature named BRCA
+          </li>
+          <li>
+            <code>chr4</code> - jumps to chromosome 4
+          </li>
+          <li>
+            <code>chr4:79,500,000..80,000,000</code> - jumps the region on
+            chromosome 4 between 79.5Mb and 80Mb.
+          </li>
+        </ul>
+      </DialogContent>
+      <Divider />
+      <DialogActions>
+        <Button onClick={() => handleClose()} color="primary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, lazy } from 'react'
 import { observer } from 'mobx-react'
 import { getSession } from '@jbrowse/core/util'
 import {
@@ -6,17 +6,18 @@ import {
   CircularProgress,
   Container,
   Grid,
-  Typography,
   makeStyles,
 } from '@material-ui/core'
 import { SearchType } from '@jbrowse/core/data_adapters/BaseAdapter'
 import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
 import AssemblySelector from '@jbrowse/core/ui/AssemblySelector'
+import ErrorMessage from '@jbrowse/core/ui/ErrorMessage'
+import CloseIcon from '@material-ui/icons/Close'
 
 // locals
 import RefNameAutocomplete from './RefNameAutocomplete'
-import SearchResultsDialog from './SearchResultsDialog'
 import { LinearGenomeViewModel } from '..'
+const SearchResultsDialog = lazy(() => import('./SearchResultsDialog'))
 
 const useStyles = makeStyles(theme => ({
   importFormContainer: {
@@ -28,14 +29,6 @@ const useStyles = makeStyles(theme => ({
 }))
 
 type LGV = LinearGenomeViewModel
-
-const ErrorDisplay = observer(({ error }: { error?: Error | string }) => {
-  return (
-    <Typography variant="h6" color="error">
-      {`${error}`}
-    </Typography>
-  )
-})
 
 const ImportForm = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
@@ -91,13 +84,11 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     return [...(refNameResults || []), ...(textSearchResults || [])]
   }
 
-  /**
-   * gets a string as input, or use stored option results from previous query,
-   * then re-query and
-   * 1) if it has multiple results: pop a dialog
-   * 2) if it's a single result navigate to it
-   * 3) else assume it's a locstring and navigate to it
-   */
+  // gets a string as input, or use stored option results from previous query,
+  // then re-query and
+  // 1) if it has multiple results: pop a dialog
+  // 2) if it's a single result navigate to it
+  // 3) else assume it's a locstring and navigate to it
   async function handleSelectedRegion(input: string) {
     if (!option) {
       return
@@ -132,13 +123,9 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   // having this wrapped in a form allows intuitive use of enter key to submit
   return (
     <div>
-      {err ? <ErrorDisplay error={err} /> : null}
+      {err ? <ErrorMessage error={err} /> : null}
       <Container className={classes.importFormContainer}>
-        <form
-          onSubmit={event => {
-            event.preventDefault()
-          }}
-        >
+        <form onSubmit={event => event.preventDefault()}>
           <Grid
             container
             spacing={1}
@@ -158,8 +145,8 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
             <Grid item>
               {selectedAsm ? (
                 err ? (
-                  <Typography color="error">X</Typography>
-                ) : selectedRegion && model.volatileWidth ? (
+                  <CloseIcon style={{ color: 'red' }} />
+                ) : selectedRegion ? (
                   <RefNameAutocomplete
                     fetchResults={fetchResults}
                     model={model}
@@ -182,6 +169,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                 )
               ) : null}
             </Grid>
+            <Grid item></Grid>
             <Grid item>
               <Button
                 type="submit"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -169,7 +169,8 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                     TextFieldProps={{
                       margin: 'normal',
                       variant: 'outlined',
-                      helperText: 'Enter a sequence or location',
+                      helperText:
+                        'Enter sequence name, feature name, or location',
                     }}
                   />
                 ) : (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -1,30 +1,31 @@
-import React, { useMemo, useEffect, useState } from 'react'
+import React, { lazy, useMemo, useEffect, useState } from 'react'
 import { observer } from 'mobx-react'
-
-// jbrowse core
 import { getSession, useDebounce, measureText } from '@jbrowse/core/util'
 import BaseResult, {
   RefSequenceResult,
 } from '@jbrowse/core/TextSearch/BaseResults'
-
-// material ui
 import {
   CircularProgress,
+  IconButton,
   InputAdornment,
   Popper,
+  PopperProps,
   TextField,
   TextFieldProps as TFP,
-  PopperProps,
   Typography,
 } from '@material-ui/core'
 
 // icons
 import SearchIcon from '@material-ui/icons/Search'
 import Autocomplete from '@material-ui/lab/Autocomplete'
+import HelpIcon from '@material-ui/icons/Help'
 
 // locals
 import { LinearGenomeViewModel } from '..'
 import { dedupe } from './util'
+
+// lazy
+const HelpDialog = lazy(() => import('./HelpDialog'))
 
 export interface Option {
   group?: string
@@ -84,6 +85,7 @@ function RefNameAutocomplete({
   const { assemblyManager } = session
   const [open, setOpen] = useState(false)
   const [loaded, setLoaded] = useState(true)
+  const [isHelpDialogDisplayed, setHelpDialogDisplayed] = useState(false)
   const [currentSearch, setCurrentSearch] = useState('')
   const [inputValue, setInputValue] = useState('')
   const [searchOptions, setSearchOptions] = useState<Option[]>()
@@ -146,115 +148,125 @@ function RefNameAutocomplete({
   // notes on implementation:
   // The selectOnFocus setting helps highlight the field when clicked
   return (
-    <Autocomplete
-      id={`refNameAutocomplete-${model.id}`}
-      data-testid="autocomplete"
-      disableListWrap
-      disableClearable
-      PopperComponent={MyPopper}
-      disabled={!assemblyName}
-      freeSolo
-      includeInputInList
-      selectOnFocus
-      style={{ ...style, width }}
-      value={inputBoxVal}
-      loading={!loaded}
-      inputValue={inputValue}
-      onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
-      loadingText="loading results"
-      open={open}
-      onOpen={() => setOpen(true)}
-      onClose={() => {
-        setOpen(false)
-        setLoaded(true)
-        if (hasDisplayedRegions) {
-          setCurrentSearch('')
-          setSearchOptions(undefined)
-        }
-      }}
-      onChange={(_event, selectedOption) => {
-        if (!selectedOption || !assemblyName) {
-          return
-        }
+    <>
+      <Autocomplete
+        id={`refNameAutocomplete-${model.id}`}
+        data-testid="autocomplete"
+        disableListWrap
+        disableClearable
+        PopperComponent={MyPopper}
+        disabled={!assemblyName}
+        freeSolo
+        includeInputInList
+        selectOnFocus
+        style={{ ...style, width }}
+        value={inputBoxVal}
+        loading={!loaded}
+        inputValue={inputValue}
+        onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
+        loadingText="loading results"
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => {
+          setOpen(false)
+          setLoaded(true)
+          if (hasDisplayedRegions) {
+            setCurrentSearch('')
+            setSearchOptions(undefined)
+          }
+        }}
+        onChange={(_event, selectedOption) => {
+          if (!selectedOption || !assemblyName) {
+            return
+          }
 
-        if (typeof selectedOption === 'string') {
-          // handles string inputs on keyPress enter
-          onSelect(new BaseResult({ label: selectedOption }))
-        } else {
-          onSelect(selectedOption.result)
-        }
-        setInputValue(inputBoxVal)
-      }}
-      options={!searchOptions?.length ? options : searchOptions}
-      getOptionDisabled={option => option?.group === 'limitOption'}
-      filterOptions={(options, params) => {
-        const filtered = filterOptions(
-          options,
-          params.inputValue.toLocaleLowerCase(),
-        )
-        return [
-          ...filtered.slice(0, 100),
-          ...(filtered.length > 100
-            ? [
-                {
-                  group: 'limitOption',
-                  result: new BaseResult({
-                    label: 'keep typing for more results',
-                  }),
-                },
-              ]
-            : []),
-        ]
-      }}
-      renderInput={params => {
-        const { helperText, InputProps = {} } = TextFieldProps
-        return (
-          <TextField
-            onBlur={() => {
-              // this is used to restore a refName or the non-user-typed input
-              // to the box on blurring
-              setInputValue(inputBoxVal)
-            }}
-            {...params}
-            {...TextFieldProps}
-            helperText={helperText}
-            InputProps={{
-              ...params.InputProps,
-              ...InputProps,
+          if (typeof selectedOption === 'string') {
+            // handles string inputs on keyPress enter
+            onSelect(new BaseResult({ label: selectedOption }))
+          } else {
+            onSelect(selectedOption.result)
+          }
+          setInputValue(inputBoxVal)
+        }}
+        options={!searchOptions?.length ? options : searchOptions}
+        getOptionDisabled={option => option?.group === 'limitOption'}
+        filterOptions={(options, params) => {
+          const filtered = filterOptions(
+            options,
+            params.inputValue.toLocaleLowerCase(),
+          )
+          return [
+            ...filtered.slice(0, 100),
+            ...(filtered.length > 100
+              ? [
+                  {
+                    group: 'limitOption',
+                    result: new BaseResult({
+                      label: 'keep typing for more results',
+                    }),
+                  },
+                ]
+              : []),
+          ]
+        }}
+        renderInput={params => {
+          const { helperText, InputProps = {} } = TextFieldProps
+          return (
+            <TextField
+              onBlur={() => {
+                // this is used to restore a refName or the non-user-typed input
+                // to the box on blurring
+                setInputValue(inputBoxVal)
+              }}
+              {...params}
+              {...TextFieldProps}
+              helperText={helperText}
+              InputProps={{
+                ...params.InputProps,
+                ...InputProps,
 
-              endAdornment: (
-                <>
-                  {regions.length === 0 ? (
-                    <CircularProgress color="inherit" size={20} />
-                  ) : (
-                    <InputAdornment position="end" style={{ marginRight: 7 }}>
-                      <SearchIcon />
-                    </InputAdornment>
-                  )}
-                  {params.InputProps.endAdornment}
-                </>
-              ),
-            }}
-            placeholder="Search for location"
-            onChange={e => {
-              setCurrentSearch(e.target.value)
-            }}
-          />
-        )
-      }}
-      renderOption={option => {
-        const { result } = option
-        const component = result.getRenderingComponent()
-        if (component && React.isValidElement(component)) {
-          return component
-        }
+                endAdornment: (
+                  <>
+                    {regions.length === 0 ? (
+                      <CircularProgress color="inherit" size={20} />
+                    ) : (
+                      <InputAdornment position="end" style={{ marginRight: 7 }}>
+                        <SearchIcon />
+                        <IconButton
+                          onClick={() => setHelpDialogDisplayed(true)}
+                        >
+                          <HelpIcon />
+                        </IconButton>
+                      </InputAdornment>
+                    )}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+              placeholder="Search for location"
+              onChange={e => {
+                setCurrentSearch(e.target.value)
+              }}
+            />
+          )
+        }}
+        renderOption={option => {
+          const { result } = option
+          const component = result.getRenderingComponent()
+          if (component && React.isValidElement(component)) {
+            return component
+          }
 
-        return <Typography noWrap>{result.getDisplayString()}</Typography>
-      }}
-      getOptionLabel={option =>
-        (typeof option === 'string' ? option : option.result.getLabel()) || ''
-      }
-    />
+          return <Typography noWrap>{result.getDisplayString()}</Typography>
+        }}
+        getOptionLabel={option =>
+          (typeof option === 'string' ? option : option.result.getLabel()) || ''
+        }
+      />
+      {isHelpDialogDisplayed ? (
+        <HelpDialog handleClose={() => setHelpDialogDisplayed(false)} />
+      ) : null}
+    </>
   )
 }
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -141,7 +141,7 @@ function RefNameAutocomplete({
   const inputBoxVal = coarseVisibleLocStrings || value || ''
 
   // heuristic, text width + icon width, minimum 200
-  const width = Math.min(Math.max(measureText(inputBoxVal, 16) + 25, 200), 550)
+  const width = Math.min(Math.max(measureText(inputBoxVal, 16) + 25, 270), 550)
 
   // notes on implementation:
   // The selectOnFocus setting helps highlight the field when clicked

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -171,7 +171,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             class="MuiAutocomplete-root"
             data-testid="autocomplete"
             role="combobox"
-            style="width: 200px;"
+            style="width: 270px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
@@ -207,6 +207,29 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                       d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                     />
                   </svg>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
                 </div>
                 <div
                   class="MuiAutocomplete-endAdornment"
@@ -751,7 +774,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             class="MuiAutocomplete-root"
             data-testid="autocomplete"
             role="combobox"
-            style="width: 235.22500000000002px;"
+            style="width: 270px;"
           >
             <div
               class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-fullWidth"
@@ -787,6 +810,29 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                       d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                     />
                   </svg>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
                 </div>
                 <div
                   class="MuiAutocomplete-endAdornment"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -255,7 +255,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="MuiAutocomplete-root"
                     data-testid="autocomplete"
                     role="combobox"
-                    style="width: 200px;"
+                    style="width: 270px;"
                   >
                     <div
                       class="MuiFormControl-root MuiTextField-root makeStyles-headerRefName MuiFormControl-marginDense MuiFormControl-fullWidth"
@@ -291,6 +291,29 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                               d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                             />
                           </svg>
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
                         </div>
                         <div
                           class="MuiAutocomplete-endAdornment"


### PR DESCRIPTION
This tries to help with #2527 by changing the help text on the import form for the lgv, and also adding a "help button" inside the RefNameAutocomplete that pops up a dialog, which contains some help text inspired by the jbrowse 1 help menu


This also increases the width of the RefNameAutocomplete to support the added help text and help button (otherwise it wraps to two lines of help text and makes it look a bit messy)


screenshot of how it looks now

![Screenshot from 2021-12-10 10-22-21](https://user-images.githubusercontent.com/6511937/145615689-d5fe1baf-5ce2-4c9a-aefb-88dfde772baa.png)
![Screenshot from 2021-12-10 10-23-04](https://user-images.githubusercontent.com/6511937/145615694-be7f0355-135e-46f6-8cba-b127769a2a95.png)
