### PR TITLE
Make core snackbar notifications module with auto-dismissing info/success level notifications

### DIFF
--- a/packages/core/ui/SnackbarModel.ts
+++ b/packages/core/ui/SnackbarModel.ts
@@ -1,0 +1,42 @@
+import { IAnyModelType } from 'mobx-state-tree'
+import { observable } from 'mobx'
+import { NotificationLevel } from '../util/types'
+
+export default function addSnackbarToModel(tree: IAnyModelType) {
+  return tree.extend(() => {
+    const snackbarMessages = observable.array()
+
+    return {
+      views: {
+        get snackbarMessages() {
+          return snackbarMessages
+        },
+      },
+      actions: {
+        notify(message: string, level?: NotificationLevel) {
+          this.pushSnackbarMessage(message, level)
+          if (level === 'info' || level === 'success') {
+            setTimeout(() => {
+              this.removeSnackbarMessage(message)
+            }, 5000)
+          }
+        },
+
+        pushSnackbarMessage(message: string, level?: NotificationLevel) {
+          return snackbarMessages.push([message, level])
+        },
+
+        popSnackbarMessage() {
+          return snackbarMessages.pop()
+        },
+
+        removeSnackbarMessage(message: string) {
+          const element = snackbarMessages.find(f => f[0] === message)
+          if (element) {
+            snackbarMessages.remove(element)
+          }
+        },
+      },
+    }
+  })
+}

--- a/packages/core/ui/SnackbarModel.ts
+++ b/packages/core/ui/SnackbarModel.ts
@@ -1,42 +1,57 @@
-import { IAnyModelType } from 'mobx-state-tree'
-import { observable } from 'mobx'
+import { IModelType, ModelProperties } from 'mobx-state-tree'
+import { IObservableArray, observable } from 'mobx'
 import { NotificationLevel } from '../util/types'
 
-export default function addSnackbarToModel(tree: IAnyModelType) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeExtension(snackbarMessages: IObservableArray<any>) {
+  return {
+    views: {
+      get snackbarMessages() {
+        return snackbarMessages
+      },
+    },
+    actions: {
+      notify(message: string, level?: NotificationLevel) {
+        this.pushSnackbarMessage(message, level)
+        if (level === 'info' || level === 'success') {
+          setTimeout(() => {
+            this.removeSnackbarMessage(message)
+          }, 5000)
+        }
+      },
+
+      pushSnackbarMessage(message: string, level?: NotificationLevel) {
+        return snackbarMessages.push([message, level])
+      },
+
+      popSnackbarMessage() {
+        return snackbarMessages.pop()
+      },
+
+      removeSnackbarMessage(message: string) {
+        const element = snackbarMessages.find(f => f[0] === message)
+        if (element) {
+          snackbarMessages.remove(element)
+        }
+      },
+    },
+  }
+}
+
+export default function addSnackbarToModel<
+  PROPS extends ModelProperties,
+  OTHERS,
+>(
+  tree: IModelType<PROPS, OTHERS>,
+): IModelType<
+  PROPS,
+  OTHERS &
+    ReturnType<typeof makeExtension>['actions'] &
+    ReturnType<typeof makeExtension>['views']
+> {
   return tree.extend(() => {
     const snackbarMessages = observable.array()
 
-    return {
-      views: {
-        get snackbarMessages() {
-          return snackbarMessages
-        },
-      },
-      actions: {
-        notify(message: string, level?: NotificationLevel) {
-          this.pushSnackbarMessage(message, level)
-          if (level === 'info' || level === 'success') {
-            setTimeout(() => {
-              this.removeSnackbarMessage(message)
-            }, 5000)
-          }
-        },
-
-        pushSnackbarMessage(message: string, level?: NotificationLevel) {
-          return snackbarMessages.push([message, level])
-        },
-
-        popSnackbarMessage() {
-          return snackbarMessages.pop()
-        },
-
-        removeSnackbarMessage(message: string) {
-          const element = snackbarMessages.find(f => f[0] === message)
-          if (element) {
-            snackbarMessages.remove(element)
-          }
-        },
-      },
-    }
+    return makeExtension(snackbarMessages)
   })
 }

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -7,10 +7,10 @@ import {
 } from '@jbrowse/core/configuration'
 import {
   Region,
-  NotificationLevel,
   TrackViewModel,
   DialogComponentType,
 } from '@jbrowse/core/util/types'
+import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
 import { getContainingView } from '@jbrowse/core/util'
 import { observable } from 'mobx'
 import {
@@ -545,30 +545,7 @@ export default function sessionModelFactory(
         return getParent(self).setSession(sessionSnapshot)
       },
     }))
-    .extend(() => {
-      const snackbarMessages = observable.array()
 
-      return {
-        views: {
-          get snackbarMessages() {
-            return snackbarMessages
-          },
-        },
-        actions: {
-          notify(message: string, level?: NotificationLevel) {
-            return this.pushSnackbarMessage(message, level)
-          },
-
-          pushSnackbarMessage(message: string, level?: NotificationLevel) {
-            return snackbarMessages.push([message, level])
-          },
-
-          popSnackbarMessage() {
-            return snackbarMessages.pop()
-          },
-        },
-      }
-    })
     .views(self => ({
       getTrackActionMenuItems(config: any) {
         const session = self
@@ -620,7 +597,7 @@ export default function sessionModelFactory(
       },
     }))
 
-  return types.snapshotProcessor(sessionModel, {
+  return types.snapshotProcessor(addSnackbarToModel(sessionModel), {
     // @ts-ignore
     preProcessor(snapshot) {
       if (snapshot) {

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
@@ -2,13 +2,11 @@
 import { lazy } from 'react'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import {
-  NotificationLevel,
   AbstractSessionModel,
   TrackViewModel,
   DialogComponentType,
 } from '@jbrowse/core/util/types'
 import { getContainingView } from '@jbrowse/core/util'
-import { observable } from 'mobx'
 import {
   getMembers,
   getParent,
@@ -26,11 +24,12 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { readConfObject } from '@jbrowse/core/configuration'
 import InfoIcon from '@material-ui/icons/Info'
 import { ReferringNode } from '../types'
+import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
 
 const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
-  return types
+  const model = types
     .model('ReactCircularGenomeViewSession', {
       name: types.identifier,
       view: pluginManager.getViewType('CircularView').stateModel,
@@ -343,30 +342,8 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         ]
       },
     }))
-    .extend(() => {
-      const snackbarMessages = observable.array()
 
-      return {
-        views: {
-          get snackbarMessages() {
-            return snackbarMessages
-          },
-        },
-        actions: {
-          notify(message: string, level?: NotificationLevel) {
-            return this.pushSnackbarMessage(message, level)
-          },
-
-          pushSnackbarMessage(message: string, level?: NotificationLevel) {
-            return snackbarMessages.push([message, level])
-          },
-
-          popSnackbarMessage() {
-            return snackbarMessages.pop()
-          },
-        },
-      }
-    })
+  return addSnackbarToModel(model)
 }
 
 export type SessionStateModel = ReturnType<typeof sessionModelFactory>

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { lazy } from 'react'
 import {
-  NotificationLevel,
   AbstractSessionModel,
   TrackViewModel,
   DialogComponentType,
 } from '@jbrowse/core/util/types'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
 import { getContainingView } from '@jbrowse/core/util'
 import { readConfObject } from '@jbrowse/core/configuration'
-import { observable } from 'mobx'
 import {
   getMembers,
   getParent,
@@ -31,7 +30,7 @@ import { ReferringNode } from '../types'
 const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
-  return types
+  const model = types
     .model('ReactLinearGenomeViewSession', {
       name: types.identifier,
       margin: 0,
@@ -348,30 +347,8 @@ export default function sessionModelFactory(pluginManager: PluginManager) {
         ]
       },
     }))
-    .extend(() => {
-      const snackbarMessages = observable.array()
 
-      return {
-        views: {
-          get snackbarMessages() {
-            return snackbarMessages
-          },
-        },
-        actions: {
-          notify(message: string, level?: NotificationLevel) {
-            return this.pushSnackbarMessage(message, level)
-          },
-
-          pushSnackbarMessage(message: string, level?: NotificationLevel) {
-            return snackbarMessages.push([message, level])
-          },
-
-          popSnackbarMessage() {
-            return snackbarMessages.pop()
-          },
-        },
-      }
-    })
+  return addSnackbarToModel(model)
 }
 
 export type SessionStateModel = ReturnType<typeof sessionModelFactory>

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -8,12 +8,13 @@ import {
 } from '@jbrowse/core/configuration'
 import {
   Region,
-  NotificationLevel,
   AbstractSessionModel,
   TrackViewModel,
   JBrowsePlugin,
   DialogComponentType,
 } from '@jbrowse/core/util/types'
+
+import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
 import { getContainingView } from '@jbrowse/core/util'
 import { observable } from 'mobx'
 import {
@@ -622,30 +623,7 @@ export default function sessionModelFactory(
         return getParent(self).setSession(sessionSnapshot)
       },
     }))
-    .extend(() => {
-      const snackbarMessages = observable.array()
 
-      return {
-        views: {
-          get snackbarMessages() {
-            return snackbarMessages
-          },
-        },
-        actions: {
-          notify(message: string, level?: NotificationLevel) {
-            return this.pushSnackbarMessage(message, level)
-          },
-
-          pushSnackbarMessage(message: string, level?: NotificationLevel) {
-            return snackbarMessages.push([message, level])
-          },
-
-          popSnackbarMessage() {
-            return snackbarMessages.pop()
-          },
-        },
-      }
-    })
     .actions(self => ({
       /**
        * opens a configuration editor to configure the given thing,
@@ -745,7 +723,7 @@ export default function sessionModelFactory(
       },
     }))
 
-  return types.snapshotProcessor(sessionModel, {
+  return types.snapshotProcessor(addSnackbarToModel(sessionModel), {
     // @ts-ignore
     preProcessor(snapshot) {
       if (snapshot) {


### PR DESCRIPTION
This proposes refactoring the snackbar code into a reusable unit in @jbrowse/core that different products use. It is essentially identical across modules currently, so this avoids a bit of code duplication

It also fixes #2568 by auto dismissing info and success messages after 5 seconds