### PR TITLE
Fix ability to use "Color by methylation" on files that require refname renaming

### DIFF
--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -9,7 +9,7 @@ import {
   ConfigurationSchema,
 } from '../configuration/configurationSchema'
 import { getSubAdapterType } from './dataAdapterCache'
-import { Region, NoAssemblyRegion } from '../util/types'
+import { AugmentedRegion as Region, NoAssemblyRegion } from '../util/types'
 import { blankStats, rectifyStats, scoresToStats } from '../util/stats'
 import BaseResult from '../TextSearch/BaseResults'
 import idMaker from '../util/idMaker'

--- a/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
@@ -4,7 +4,7 @@ import SimpleFeature, {
   Feature,
   SimpleFeatureSerialized,
 } from '../../util/simpleFeature'
-import { Region } from '../../util/types'
+import { AugmentedRegion as Region } from '../../util/types'
 import { getAdapter } from '../../data_adapters/dataAdapterCache'
 import ServerSideRendererType, {
   RenderArgs as ServerSideRenderArgs,

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -326,13 +326,8 @@ export interface NoAssemblyRegion
 
 export interface Region extends SnapshotIn<typeof MUIRegion> {}
 
-export interface AugmentedRegion {
-  refName: string
-  start: number
-  end: number
-  assemblyName: string
+export interface AugmentedRegion extends Region {
   originalRefName?: string
-  reversed?: boolean
 }
 
 export interface LocalPathLocation

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -326,6 +326,15 @@ export interface NoAssemblyRegion
 
 export interface Region extends SnapshotIn<typeof MUIRegion> {}
 
+export interface AugmentedRegion {
+  refName: string
+  start: number
+  end: number
+  assemblyName: string
+  originalRefName?: string
+  reversed?: boolean
+}
+
 export interface LocalPathLocation
   extends SnapshotIn<typeof MULocalPathLocation> {}
 

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -587,6 +587,8 @@ export default class PileupRenderer extends BoxRendererType {
 
     this.drawRect(ctx, feat, props)
 
+    console.log({ props })
+
     // second pass for color types that render per-base things that go over the
     // existing drawing
     switch (colorType) {
@@ -937,6 +939,7 @@ export default class PileupRenderer extends BoxRendererType {
     const layoutRecords = this.layoutFeats({ ...renderProps, features, layout })
     const [region] = regions
     let regionSequence: string | undefined
+    const { end, start, originalRefName, refName } = region
 
     if (sequenceAdapter) {
       const { dataAdapter } = await getAdapter(
@@ -946,13 +949,17 @@ export default class PileupRenderer extends BoxRendererType {
       )
 
       const feats = await (dataAdapter as BaseFeatureDataAdapter)
-        .getFeatures({ ...region, end: region.end + 1 })
+        .getFeatures({
+          ...region,
+          refName: originalRefName || refName,
+          end: region.end + 1,
+        })
         .pipe(toArray())
         .toPromise()
       regionSequence = feats[0]?.get('seq')
     }
 
-    const width = (region.end - region.start) / bpPerPx
+    const width = (end - start) / bpPerPx
     const height = Math.max(layout.getTotalHeight(), 1)
 
     const res = await renderToAbstractCanvas(

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -587,8 +587,6 @@ export default class PileupRenderer extends BoxRendererType {
 
     this.drawRect(ctx, feat, props)
 
-    console.log({ props })
-
     // second pass for color types that render per-base things that go over the
     // existing drawing
     switch (colorType) {

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -2,7 +2,7 @@ import {
   BaseFeatureDataAdapter,
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { Region } from '@jbrowse/core/util/types'
+import { AugmentedRegion as Region } from '@jbrowse/core/util/types'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
 import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
@@ -126,7 +126,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
   ) {
     const { colorBy } = opts
     const { sequenceAdapter } = await this.configure()
-    const { refName, start, end } = region
+    const { originalRefName, refName, start, end } = region
     const binMax = Math.ceil(region.end - region.start)
 
     // bins contain cov feature if they contribute to coverage, or noncov which
@@ -148,7 +148,12 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
 
     if (sequenceAdapter) {
       const [feat] = await sequenceAdapter
-        .getFeatures({ refName, start, end: end + 1, assemblyName: 'na' })
+        .getFeatures({
+          refName: originalRefName || refName,
+          start,
+          end: end + 1,
+          assemblyName: 'na',
+        })
         .pipe(toArray())
         .toPromise()
       regionSeq = feat?.get('seq')

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.test.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.test.ts
@@ -19,6 +19,7 @@ describe('adapter can fetch features from volvox.bw', () => {
       refName: 'ctgA',
       start: 0,
       end: 20000,
+      assemblyName: 'volvox',
     })
     expect(await adapter.refIdToName(0)).toBe('ctgA')
     expect(await adapter.refIdToName(1)).toBe(undefined)

--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -3,7 +3,7 @@ import {
   BaseFeatureDataAdapter,
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { NoAssemblyRegion } from '@jbrowse/core/util/types'
+import { AugmentedRegion as Region } from '@jbrowse/core/util/types'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
@@ -66,7 +66,7 @@ export default class BigWigAdapter extends BaseFeatureDataAdapter {
     return rectifyStats(header.totalSummary as UnrectifiedFeatureStats)
   }
 
-  public getFeatures(region: NoAssemblyRegion, opts: WiggleOptions = {}) {
+  public getFeatures(region: Region, opts: WiggleOptions = {}) {
     const { refName, start, end } = region
     const {
       bpPerPx = 0,


### PR DESCRIPTION
The colorByMethylation currently fails on files that require ref renaming

Example: "Nanopolish modbam_test.reference 20:10000000" in config demo


This fixes that by querying the sequenceAdapter with originalRefName instead of refName

It also tries to formalize that the originalRefName is an attribute that flows through the system, even at the level of BaseAdapter
