### PR TITLE
Add more exports that can be used by plugins

### DIFF
--- a/packages/core/pluggableElementTypes/index.ts
+++ b/packages/core/pluggableElementTypes/index.ts
@@ -10,6 +10,7 @@ import InternetAccountType from './InternetAccountType'
 import TextSearchAdapterType from './TextSearchAdapterType'
 
 export * from './renderers'
+export * from './models'
 
 export {
   AdapterType,
@@ -20,6 +21,7 @@ export {
   DisplayType,
   ViewType,
   RpcMethodType,
+  InternetAccountType,
   TextSearchAdapterType,
 }
 

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -12,7 +12,7 @@ import { reaction, IReactionPublic, IReactionOptions } from 'mobx'
 import fromEntries from 'object.fromentries'
 import { useEffect, useRef, useState } from 'react'
 import merge from 'deepmerge'
-import { Feature } from './simpleFeature'
+import SimpleFeature, { Feature, isFeature } from './simpleFeature'
 import {
   TypeTestedByPredicate,
   isSessionModel,
@@ -28,6 +28,7 @@ export * from './types'
 export * from './aborting'
 export * from './when'
 export * from './range'
+export { SimpleFeature, isFeature }
 
 export * from './offscreenCanvasPonyfill'
 export * from './offscreenCanvasUtils'


### PR DESCRIPTION
I was looking at the GDC plugin to see how hard it would be to convert to the new plugin build system, and found a few things from core that it was using that weren't in our current exports. That means it must have been compiling those into the build, but with these it can use the runtime versions of them.