### PR TITLE
Fix leftover imports being in CJS and ESM bundles

### DIFF
--- a/packages/development-tools/package.json
+++ b/packages/development-tools/package.json
@@ -45,6 +45,7 @@
     "babel-plugin-polyfill-regenerator": "^0.2.3",
     "babel-plugin-transform-rename-import": "^2.3.0",
     "builtin-modules": "^3.2.0",
+    "chalk": "^4.1.1",
     "cross-spawn": "^7.0.3",
     "lodash.merge": "^4.6.2",
     "patch-package": "^6.2.2",

--- a/packages/development-tools/src/createRollupConfig.ts
+++ b/packages/development-tools/src/createRollupConfig.ts
@@ -47,11 +47,13 @@ function createGlobalMap(jbrowseGlobals: string[], dotSyntax = false) {
   return globalMap
 }
 
+let tsDeclarationGenerated = false
+
 function getPlugins(
   mode: 'umd' | 'cjs' | 'npm' | 'esmBundle',
   jbrowseGlobals: string[],
 ): Plugin[] {
-  return [
+  const plugins = [
     resolve({
       mainFields: ['module', 'main', 'browser'],
       extensions: [...RESOLVE_DEFAULTS.extensions, '.jsx'],
@@ -83,9 +85,9 @@ function getPlugins(
       tsconfig: './tsconfig.json',
       outDir: distPath,
       target: 'esnext',
-      ...(mode === 'esmBundle' || mode === 'umd'
-        ? { declaration: false, declarationMap: false }
-        : { declarationDir: './' }),
+      ...(tsDeclarationGenerated
+        ? { declarationDir: './' }
+        : { declaration: false, declarationMap: false }),
     }),
     (mode === 'cjs' || mode === 'esmBundle') &&
       externalGlobals(createGlobalMap(jbrowseGlobals)),
@@ -122,6 +124,11 @@ if (process.env.NODE_ENV === 'production') {
     (mode === 'esmBundle' || mode === 'umd') && globals(),
     (mode === 'esmBundle' || mode === 'umd') && builtins(),
   ].filter(Boolean)
+
+  if (tsDeclarationGenerated === false) {
+    tsDeclarationGenerated = true
+  }
+  return plugins
 }
 
 export function createRollupConfig(
@@ -246,6 +253,7 @@ export function createRollupConfig(
           format: 'esm',
           freeze: false,
           esModule: true,
+          sourcemap: true,
           exports: 'named',
         },
       ],
@@ -275,6 +283,7 @@ export function createRollupConfig(
           format: 'cjs',
           freeze: false,
           esModule: true,
+          sourcemap: true,
           exports: 'named',
         },
       ],

--- a/packages/development-tools/src/createRollupConfig.ts
+++ b/packages/development-tools/src/createRollupConfig.ts
@@ -238,7 +238,7 @@ export function createRollupConfig(
         }
         return isExternal
       },
-      treeshake: { propertyReadSideEffects: false },
+      treeshake: { propertyReadSideEffects: false, moduleSideEffects: false },
       plugins: getPlugins('esmBundle', jbrowseGlobals),
       output: [
         {
@@ -267,7 +267,7 @@ export function createRollupConfig(
         }
         return isExternal
       },
-      treeshake: { propertyReadSideEffects: false },
+      treeshake: { propertyReadSideEffects: false, moduleSideEffects: false },
       plugins: getPlugins('cjs', jbrowseGlobals),
       output: [
         {

--- a/packages/development-tools/src/util.ts
+++ b/packages/development-tools/src/util.ts
@@ -1,4 +1,7 @@
+import fs from 'fs'
 import path from 'path'
+import chalk from 'chalk'
+import { Plugin } from 'rollup'
 
 export function safePackageName(name: string) {
   return name
@@ -11,4 +14,54 @@ export function external(id: string) {
     return false
   }
   return !id.startsWith('.') && !path.isAbsolute(id)
+}
+
+export function writeIndex(packageName: string, distPath: string): Plugin {
+  return {
+    name: 'write-index-file',
+    generateBundle() {
+      const baseLine = `module.exports = require('./${packageName}`
+      const contents = `'use strict'
+
+if (process.env.NODE_ENV === 'production') {
+${baseLine}.cjs.production.min.js')
+} else {
+${baseLine}.cjs.development.js')
+}
+`
+      if (!fs.existsSync(distPath)) {
+        fs.mkdirSync(distPath, { recursive: true })
+      }
+      return fs.writeFileSync(path.join(distPath, 'index.js'), contents)
+    },
+  }
+}
+
+export function omitUnresolved(): Plugin {
+  const suffix = '?unresolved'
+  return {
+    name: 'logger',
+    async resolveId(source, importer, options) {
+      const resolution = await this.resolve(source, importer, {
+        skipSelf: true,
+        ...options,
+      })
+      if (!resolution) {
+        return `${source}${suffix}`
+      }
+      return null
+    },
+    load(id) {
+      if (id.endsWith(suffix)) {
+        const importee = id.slice(0, -suffix.length)
+        console.warn(
+          chalk.bold.yellow(
+            `Omitting ${importee} from the build because it could not be resolved`,
+          ),
+        )
+        return `export default {};`
+      }
+      return null
+    },
+  }
 }


### PR DESCRIPTION
Sometimes when bundling certain dependencies, there would be leftover import/require statements in the generated bundle that looked something like:

```js
import 'react';
```

These would make it so the plugin couldn't load, since it expects everything to be bundled in and there to be no external imports. It turns out rollup was keeping those around since it thought they had side effects, but there is a `moduleSideEffects` setting in rollup that fixed it for our use case.

Leaving as draft while I run through some more packages and check that this works.