### PR TITLE
Fix broken published build of jbrowse/development-tools

### DIFF
--- a/packages/development-tools/package.json
+++ b/packages/development-tools/package.json
@@ -28,7 +28,9 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "tsc"
+    "prebuild": "rimraf dist",
+    "build": "tsc",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
Adds a `prepack` script so the build gets properly created on publish.