### PR TITLE
Fix wiggle tooltip crash on non-numerical inputs

### DIFF
--- a/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
+++ b/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
@@ -133,7 +133,7 @@ export default class BedTabixAdapter extends BaseFeatureDataAdapter {
           }
 
           if (this.scoreColumn) {
-            data.score = data[this.scoreColumn]
+            data.score = +data[this.scoreColumn]
           }
           delete data.chrom
           delete data.chromStart

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -7,8 +7,9 @@ import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { YSCALEBAR_LABEL_OFFSET } from '../models/model'
 import { usePopper } from 'react-popper'
 
+// convert to number, apply shortened precision, and render
 function toP(s = 0) {
-  return parseFloat(s.toPrecision(6))
+  return +(+s).toPrecision(6)
 }
 
 function round(value: number) {


### PR DESCRIPTION
It was seen in jbrowse-plugin-gwas that sometimes a stringified score can be passed to the tooltip https://github.com/cmdcolin/jbrowse-plugin-gwas/issues/4

This makes sure to convert to number first