### PR TITLE
Fix GUI color editor rgba string format

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/ColorEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ColorEditor.tsx
@@ -11,7 +11,7 @@ const ColorPicker = lazy(() => import('./ColorPicker'))
 function serializeColor(color: Color) {
   if (color instanceof Object) {
     const { r, g, b, a } = color as RGBColor
-    return `rgb(${r},${g},${b},${a})`
+    return a === undefined ? `rgb(${r},${g},${b})` : `rgba(${r},${g},${b},${a})`
   }
   return color
 }


### PR DESCRIPTION
Before this fix, if you changed the color in the config editor GUI, it would update the color to something like `rgb(44,0,255,1)`, which isn't valid since you need to use `rgba` instead of `rgb` if you're specifying an alpha level. This resulted in wiggle density tracks having a solid color instead of a color range if you picked their color with the GUI. This fixes it by using `rgba` instead of `rgb` if `a` is defined.