### PR TITLE
Adjust label width on base feature detail to enforce better alignment

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -24,6 +24,8 @@ import { BaseCardProps, BaseProps } from './types'
 import { SimpleFeatureSerialized } from '../util/simpleFeature'
 import { ellipses } from './util'
 
+const MAX_FIELD_NAME_WIDTH = 170
+
 // these are always omitted as too detailed
 const globalOmit = [
   'length',
@@ -67,7 +69,6 @@ export const useStyles = makeStyles(theme => ({
   fieldName: {
     wordBreak: 'break-all',
     minWidth: '90px',
-    maxWidth: '150px',
     borderBottom: '1px solid #0003',
     background: theme.palette.grey[200],
     marginRight: theme.spacing(1),
@@ -119,10 +120,12 @@ export const FieldName = ({
   description,
   name,
   prefix = [],
+  width,
 }: {
   description?: React.ReactNode
   name: string
   prefix?: string[]
+  width?: number
 }) => {
   const classes = useStyles()
   const val = [...prefix, name].join('.')
@@ -133,7 +136,9 @@ export const FieldName = ({
       </div>
     </Tooltip>
   ) : (
-    <div className={classes.fieldName}>{val}</div>
+    <div className={classes.fieldName} style={{ width: width }}>
+      {val}
+    </div>
   )
 }
 
@@ -157,16 +162,23 @@ export const SimpleValue = ({
   value,
   description,
   prefix,
+  width,
 }: {
   description?: React.ReactNode
   name: string
   value: any
   prefix?: string[]
+  width?: number
 }) => {
   const classes = useStyles()
   return value !== null && value !== undefined ? (
     <div className={classes.field}>
-      <FieldName prefix={prefix} description={description} name={name} />
+      <FieldName
+        prefix={prefix}
+        description={description}
+        name={name}
+        width={width}
+      />
       <BasicValue value={value} />
     </div>
   ) : null
@@ -367,6 +379,19 @@ function accessNested(arr: string[], obj: Record<string, any> = {}) {
     : undefined
 }
 
+function generateMaxWidth(array: any, prefix: any) {
+  // @ts-ignore
+  let arr = []
+  array.forEach((key: any, value: any) => {
+    const val = [...prefix, key[0]].join('.')
+    console.log(key, val, measureText(val, 12))
+    arr.push(measureText(val, 12))
+  })
+
+  // @ts-ignore
+  return Math.ceil(Math.max(...arr)) + 10
+}
+
 export const Attributes: React.FunctionComponent<AttributeProps> = props => {
   const {
     attributes,
@@ -376,6 +401,16 @@ export const Attributes: React.FunctionComponent<AttributeProps> = props => {
     prefix = [],
   } = props
   const omits = [...omit, ...globalOmit]
+
+  const maxLabelWidth = generateMaxWidth(
+    Object.entries(attributes).filter(
+      ([k, v]) => v !== undefined && !omits.includes(k),
+    ),
+    prefix,
+  )
+
+  const labelWidth =
+    maxLabelWidth <= MAX_FIELD_NAME_WIDTH ? maxLabelWidth : MAX_FIELD_NAME_WIDTH
 
   return (
     <>
@@ -429,6 +464,7 @@ export const Attributes: React.FunctionComponent<AttributeProps> = props => {
               value={formatter(value, key)}
               description={description}
               prefix={prefix}
+              width={labelWidth}
             />
           )
         })}

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -381,10 +381,9 @@ function accessNested(arr: string[], obj: Record<string, any> = {}) {
 
 function generateMaxWidth(array: any, prefix: any) {
   // @ts-ignore
-  let arr = []
+  const arr = []
   array.forEach((key: any, value: any) => {
     const val = [...prefix, key[0]].join('.')
-    console.log(key, val, measureText(val, 12))
     arr.push(measureText(val, 12))
   })
 

--- a/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
+++ b/packages/core/BaseFeatureWidget/__snapshots__/index.test.js.snap
@@ -108,6 +108,7 @@ exports[`open up a widget 1`] = `
             >
               <div
                 class="makeStyles-fieldName"
+                style="width: 40px;"
               >
                 score
               </div>

--- a/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/__snapshots__/index.test.js.snap
@@ -147,6 +147,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   seq
                 </div>
@@ -163,6 +164,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   score
                 </div>
@@ -179,6 +181,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   qual
                 </div>
@@ -205,6 +208,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   MQ
                 </div>
@@ -221,6 +225,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   CIGAR
                 </div>
@@ -237,6 +242,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   length_on_ref
                 </div>
@@ -253,6 +259,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   template_length
                 </div>
@@ -269,6 +276,7 @@ exports[`open up a widget 1`] = `
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 96px;"
                 >
                   seq_length
                 </div>

--- a/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
+++ b/plugins/variants/src/VariantFeatureWidget/__snapshots__/VariantFeatureWidget.test.js.snap
@@ -182,6 +182,7 @@ exports[`VariantTrack widget renders with just the required model elements 1`] =
               >
                 <div
                   class="makeStyles-fieldName"
+                  style="width: 62px;"
                 >
                   INFO.MQ
                 </div>


### PR DESCRIPTION
It was pointed out in a demo that the alignment of the field labels in a BaseFeatureDetail window looks a little sloppy and makes the fields hard to read. This is because the styling was set to any length between 90 and 150px.

This PR uses measureText to determine the longest label in the field labels to be processed and uses that as the width of each field name. Any given label will be one of two values now: 90px at minimum, or the length of the longest string (or if that length exceeds 170px, 170px).

170px gives the labels a little more flexibility than 150px while still maintaining a maximum such that fields aren't going off the screen.

Before:
![image](https://user-images.githubusercontent.com/83305007/148417178-1338ec26-e262-4551-a7b8-b8f9e72b8dee.png)

After:

![image](https://user-images.githubusercontent.com/83305007/148417213-34a47ce8-4626-461c-bc11-8db4abd733c7.png)
