### PR TITLE
Add ability to get parent feature in jexl syntax with either parent(feature) or get(feature,'parent')

### DIFF
--- a/packages/core/util/jexl.ts
+++ b/packages/core/util/jexl.ts
@@ -15,6 +15,9 @@ export default function (/* config?: any*/): JexlNonBuildable {
   j.addFunction('get', (feature: Feature, data: string) => {
     return feature.get(data)
   })
+  j.addFunction('parent', (feature: Feature) => {
+    return feature.parent()
+  })
 
   j.addFunction('id', (feature: Feature) => {
     return feature.id()

--- a/packages/core/util/simpleFeature.ts
+++ b/packages/core/util/simpleFeature.ts
@@ -149,7 +149,11 @@ export default class SimpleFeature implements Feature {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public get(name: string): any {
-    return name === 'subfeatures' ? this.subfeatures : this.data[name]
+    return name === 'subfeatures'
+      ? this.subfeatures
+      : name === 'parent'
+      ? this.parent()
+      : this.data[name]
   }
 
   /**


### PR DESCRIPTION
This adds two options for inspecting the parent feature in jexl callbacks

1. parent(feature), using an added jexl function
2. get(feature,'parent'), using an extra check to the get method in SimpleFeature
Fixes #2630 
