### PR TITLE
Add vertical resize handle to dotplot view

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 import { transaction } from 'mobx'
 import { makeStyles, LinearProgress } from '@material-ui/core'
 import { getConf } from '@jbrowse/core/configuration'
-import { Menu } from '@jbrowse/core/ui'
+import { Menu, ResizeHandle } from '@jbrowse/core/ui'
 import normalizeWheel from 'normalize-wheel'
 import { DotplotViewModel } from '../model'
 import ImportForm from './ImportForm'
@@ -21,9 +21,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(1),
     overflow: 'hidden',
   },
-  viewContainer: {
-    marginTop: '3px',
-  },
+
   container: {
     display: 'grid',
     padding: 5,
@@ -405,6 +403,15 @@ const DotplotViewInternal = observer(
             />
           </div>
         </div>
+        <ResizeHandle
+          onDrag={n => model.setHeight(model.height + n)}
+          style={{
+            height: 4,
+            background: '#ccc',
+            boxSizing: 'border-box',
+            borderTop: '1px solid #fafafa',
+          }}
+        />
       </div>
     )
   },

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -178,9 +178,11 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       },
       setWidth(newWidth: number) {
         self.volatileWidth = newWidth
+        return self.volatileWidth
       },
       setHeight(newHeight: number) {
         self.height = newHeight
+        return self.height
       },
 
       setError(e: Error) {


### PR DESCRIPTION
Can help with #2631 

This does not proportionally adjust the bpPerPx of the vertical view while increasing the height, it just adds more blank space at the top, but if needed could try to adjust the bpPerPx perhaps too. Note that similar things like closing the drawer do not proportionally adjust bpPerPx