### PR TITLE
Release draft announcement v1.5.6

### DIFF
--- a/website/release_announcement_drafts/v1.5.6.md
+++ b/website/release_announcement_drafts/v1.5.6.md
@@ -1,3 +1,6 @@
 Fixes a bug in usage of packages that caused usage of @jbrowse/core to fail due
 to a erroneous babel config (affecting v1.5.5 of
 @jbrowse/react-linear-genome-view and @jbrowse/react-circular-genome-view)
+
+
+Also we now can access the parent feature in jexl callbacks with parent(feature) or get(feature, 'parent') which is often needed when coloring subfeatures like exon/CDS features

--- a/website/release_announcement_drafts/v1.5.6.md
+++ b/website/release_announcement_drafts/v1.5.6.md
@@ -1,0 +1,3 @@
+Fixes a bug in usage of packages that caused usage of @jbrowse/core to fail due
+to a erroneous babel config (affecting v1.5.5 of
+@jbrowse/react-linear-genome-view and @jbrowse/react-circular-genome-view)


### PR DESCRIPTION
Our v1.5.5 has an issue with the babel config not compiling a new syntax that we used, which affected @jbrowse/core specifically, which makes usage of things like @jbrowse/react-linear-genome-view unusable