### PR TITLE
Fix core by not using absolute runtime in babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,7 @@ module.exports = api => {
           },
         },
       ],
-      'react-app',
+      ['react-app', { absoluteRuntime: false }],
     ],
     ignore: [
       './node_modules',


### PR DESCRIPTION
For some reason the default of `babel-preset-react-app` is to use [absolute paths for babel runtime stuff](https://github.com/facebook/create-react-app/tree/main/packages/babel-preset-react-app#absolute-runtime-paths), so when run on another machine from the one it was built on, it failed. That's why the errors say they can't find: `'/data/jbrowse-components2/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties.js'`. With this change that will be `'@babel/runtime/helpers/esm/objectWithoutProperties.js'` instead.

We could also try using `@babel/preset-react` instead of `babel-preset-react-app` like `core` used before, but I'm not sure if that will change much.