### PR TITLE
Fix "module" of embedded React views

### DIFF
--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -16,7 +16,7 @@
   },
   "author": "JBrowse Team",
   "main": "dist/index.js",
-  "module": "dist/jbrowse-react-circular-genome-view.esm.js",
+  "module": "dist/react-circular-genome-view.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -16,7 +16,7 @@
   },
   "author": "JBrowse Team",
   "main": "dist/index.js",
-  "module": "dist/jbrowse-react-linear-genome-view.esm.js",
+  "module": "dist/react-linear-genome-view.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Fixes the name of the "module" build in the React linear and circular views. It looks like webpack might silently fall back to "main" if it doesn't find module, so that's probably why we've never noticed this before.

Noted in https://github.com/GMOD/jbrowse-components/issues/2617#issuecomment-1014374339