### PR TITLE
Add link to PAG 2022 youtube tutorial on demos page and course archive

### DIFF
--- a/website/docs/pag2022_synteny_visualization.md
+++ b/website/docs/pag2022_synteny_visualization.md
@@ -1,0 +1,12 @@
+---
+id: pag2022_synteny_tutorial
+title: PAG2022 - Synteny visualization using JBrowse Desktop
+---
+
+We presented a tutorial of visualizing synteny with JBrowse Desktop at PAG 2022
+
+A guide to follow along is written here: http://gmod.org/wiki/JBrowse_2_Tutorial_PAG_2022
+
+The video recording of the presentation that we made is below
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/rYqTYcZ56xs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,6 +47,7 @@
           "type": "category",
           "label": "Archive",
           "items": [
+            "pag2022_synteny_tutorial",
             "bcc2020_plugin_development",
             {
               "type": "category",

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -53,7 +53,7 @@ Note: everything demonstrated here on the web can also be done in JBrowse deskto
 
 **Conference demos**
 
-- [PAG2022](http://jbrowse.org/demos/pag2022/)
+- [PAG2022](http://jbrowse.org/demos/pag2022/) (see also [workshop video tutorial here](../docs/pag2022_synteny_tutorial))
 - [BOG2021](http://jbrowse.org/demos/bog2021/)
 - [ASHG2020](http://jbrowse.org/demos/ashg2020/)
 - [ITCR2020](http://jbrowse.org/demos/itcr2020/)


### PR DESCRIPTION
Links to the PAG2022 tutorial from our demos page and adds a page for PAG2022 in our "course archive" in the sidebar which links out to the gmod.org tutorial


![Screenshot from 2022-01-18 12-57-57](https://user-images.githubusercontent.com/6511937/150009471-69b4a813-15ba-48df-964f-b6663b729672.png)

![Screenshot from 2022-01-18 12-57-50](https://user-images.githubusercontent.com/6511937/150009466-19f511a1-210a-4c91-846a-a5baa214ac03.png)
