### PR TITLE
Fix hot reload using yarn resolution on react-error-overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,5 +149,8 @@
     "worker-loader": "^2.0.0"
   },
   "version": "0.0.0",
-  "dependencies": {}
+  "dependencies": {},
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18309,15 +18309,10 @@ react-error-boundary@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-error-overlay@^5.1.4:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
-  integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
-
-react-error-overlay@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
-  integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
+react-error-overlay@6.0.9, react-error-overlay@^5.1.4, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
after observing that hot reload wasn't working, I also noticed that it correlated with this error in the dev console for "process is not defined"

googling stackoverflow for this turned up
https://stackoverflow.com/questions/70357360/process-is-not-defined-on-hot-reload/70402397


adding this resoluton to the root package.json for react-error-overlay fixed it for me

fixes #2656 