### PR TITLE
Draw deletion width

### DIFF
--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -682,11 +682,13 @@ export default class PileupRenderer extends BoxRendererType {
         const baseColor = colorForBase.deletion
         ctx.fillStyle = baseColor
         ctx.fillRect(leftPx, topPx, widthPx, heightPx)
-        if (widthPx >= charWidth && heightPx >= heightLim) {
+        const txt = `${mismatch.length}`
+        const rect = ctx.measureText(txt)
+        if (widthPx >= rect.width && heightPx >= heightLim) {
           ctx.fillStyle = theme.palette.getContrastText(baseColor)
           ctx.fillText(
-            mbase,
-            leftPx + (widthPx - charWidth) / 2 + 1,
+            txt,
+            leftPx + (rightPx - leftPx) / 2 - rect.width / 2,
             topPx + heightPx,
           )
         }


### PR DESCRIPTION
Before

![Screenshot from 2022-01-19 09-50-41](https://user-images.githubusercontent.com/6511937/150176760-d1d3e063-5edc-45d2-808a-bdc3bb05922f.png)

After

![Screenshot from 2022-01-19 09-50-24](https://user-images.githubusercontent.com/6511937/150176786-def11a68-7155-45bb-bae5-6660e77d0dd4.png)

This is especially nice for larger SVs, you can mentally get a little picture of the length of a deletion

Note it also labels this for smaller variants

before
![Screenshot from 2022-01-19 09-52-15](https://user-images.githubusercontent.com/6511937/150177097-7cb3b7ab-d8d3-491f-8b4c-dbaeb2aa0fc7.png)

after
![Screenshot from 2022-01-19 09-52-29](https://user-images.githubusercontent.com/6511937/150177101-d6a8f615-6a49-4e91-b2d3-5e90209f863d.png)

can compare to IGV, which does not label it for smaller variants, but does for larger ones. they also use a different style where they draw a thin line where the deletions are, sort of similar to the splice notation
