### PR TITLE
custom glyphs should be applied to features without subfeatures

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -41,16 +41,17 @@ export function chooseGlyphComponent(
       return ProcessedTranscript
     }
 
-    if (typeof extraGlyphs != 'undefined') {
-      for (const extraGlyph of extraGlyphs) {
-        if (extraGlyph.validator(feature) === true) {
-          return extraGlyph.glyph
-        }
-      }
-    }
-
     return Segments
   }
+
+  if (extraGlyphs) {
+    for (const extraGlyph of extraGlyphs) {
+      if (extraGlyph.validator(feature) === true) {
+        return extraGlyph.glyph
+      }
+    }
+  }
+
   return [1, -1].includes(strand) ? Chevron : Box
 }
 


### PR DESCRIPTION
@cmdcolin This is related to #2509. The issue is that in the current code, extraGlyphs are only considered when the feature has subfeatures. I think that's incorrect, and we should be testing/applying the custom glyph only if the feature lacks subfeatures.