### PR TITLE
Add session tracks via url using session spec type URLs

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -109,13 +109,16 @@ export function Loader({
   const load = (param: string | null | undefined) =>
     param === null ? undefined : param
 
-  const [config] = useQueryParam('config', StringParam)
-  const [session] = useQueryParam('session', StringParam)
-  const [adminKey] = useQueryParam('adminKey', StringParam)
-  const [password, setPassword] = useQueryParam('password', StringParam)
-  const [loc, setLoc] = useQueryParam('loc', StringParam)
-  const [assembly, setAssembly] = useQueryParam('assembly', StringParam)
-  const [tracks, setTracks] = useQueryParam('tracks', StringParam)
+  const Str = StringParam
+
+  const [config] = useQueryParam('config', Str)
+  const [session] = useQueryParam('session', Str)
+  const [adminKey] = useQueryParam('adminKey', Str)
+  const [password, setPassword] = useQueryParam('password', Str)
+  const [loc, setLoc] = useQueryParam('loc', Str)
+  const [sessionTracks, setSessionTracks] = useQueryParam('sessionTracks', Str)
+  const [assembly, setAssembly] = useQueryParam('assembly', Str)
+  const [tracks, setTracks] = useQueryParam('tracks', Str)
 
   const loader = SessionLoader.create({
     configPath: load(config),
@@ -125,6 +128,7 @@ export function Loader({
     loc: load(loc),
     assembly: load(assembly),
     tracks: load(tracks),
+    sessionTracks: load(sessionTracks),
   })
 
   useEffect(() => {
@@ -132,7 +136,8 @@ export function Loader({
     setTracks(undefined)
     setAssembly(undefined)
     setPassword(undefined)
-  }, [setAssembly, setLoc, setTracks, setPassword])
+    setSessionTracks(undefined)
+  }, [setAssembly, setLoc, setTracks, setPassword, setSessionTracks])
 
   return (
     <Renderer


### PR DESCRIPTION
This is an add-on to #2165 

Allows saying &sessionTracks=[...array of track configs here...]

example




http://localhost:3000/?config=test_data/volvox/config.json&loc=ctgA:6000-7000&assembly=volvox&tracks=gff3tabix_genes,volvox_filtered_vcf,volvox_microarray,volvox_cram,url_track&sessionTracks=[{"type":"FeatureTrack","trackId":"url_track","name":"Test","assemblyNames":["volvox"],"adapter":{"type":"FromConfigAdapter","features":[{"uniqueId":"one","refName":"ctgA","start":190,"end":191,"type":"foo","score":200,"name":"Boris","note":"note for boris"},{"uniqueId":"two","refName":"ctgA","start":191,"end":192,"type":"bar","score":20,"name":"Theresa","note":"note for theresa"},{"uniqueId":"three","refName":"ctgA","start":210,"end":211,"type":"baz","score":300,"name":"Nigel","note":"note for nigel"},{"uniqueId":"four","refName":"ctgA","start":220,"end":221,"score":2,"type":"quux","name":"Geoffray","note":"note for geoffray"}]}}]

Adds a FromConfigAdapter

Would be useful for example for BLAST hits being displayed inline

