### PR TITLE
Add mashmap PAF support

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -105,7 +105,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
               </a>{' '}
               file for the dotplot view. Note that the first assembly should be
               the left column of the PAF and the second assembly should be the
-              right column
+              right column. PAF-like files from MashMap (.out) are also allowed
             </p>
             <Grid container justifyContent="center">
               <Grid item>

--- a/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
@@ -61,9 +61,14 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
       encoding: 'utf8',
       ...opts,
     })
-    const pafRecords: PafRecord[] = []
-    text.split('\n').forEach((line: string, index: number) => {
-      if (line.length) {
+
+    // mashmap produces PAF-like data that is space separated instead of tab
+    const hasTab = text.indexOf('\t')
+    const splitChar = hasTab !== -1 ? '\t' : ' '
+    return text
+      .split('\n')
+      .filter(line => !!line)
+      .map(line => {
         const [
           chr1,
           ,
@@ -78,7 +83,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
           blockLen,
           mappingQual,
           ...fields
-        ] = line.split('\t')
+        ] = line.split(splitChar)
 
         const rest = Object.fromEntries(
           fields.map(field => {
@@ -89,7 +94,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
           }),
         )
 
-        pafRecords[index] = {
+        return {
           records: [
             { refName: chr1, start: +start1, end: +end1 },
             { refName: chr2, start: +start2, end: +end2 },
@@ -101,10 +106,8 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
             mappingQual: +mappingQual,
             ...rest,
           },
-        }
-      }
-    })
-    return pafRecords
+        } as PafRecord
+      })
   }
 
   async hasDataForRefName() {

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -137,7 +137,8 @@ const ImportForm = observer(({ model }: { model: LinearSyntenyViewModel }) => {
             </a>{' '}
             file for the linear synteny view. Note that the first assembly
             should be the left column of the PAF and the second assembly should
-            be the right column
+            be the right column. PAF-like files from MashMap (.out) are also
+            allowed
           </Typography>
           <Grid item>
             <FileSelector


### PR DESCRIPTION
This is a small fix that allows loading mashmap files. The mashmap paf are space separated rather than tab separated. I assume that if a file does not have any tabs, it is a mashmap paf