### PR TITLE
v1.6.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v1.6.0.md
+++ b/website/release_announcement_drafts/v1.6.0.md
@@ -1,7 +1,9 @@
 This release has a couple long awaited features!
 
-- Ability to load a session from a URL in JBrowse Web e.g.
-  http://yoursite.com/jbrowse2/?loc=chr1:1-100&assembly=hg19&tracks=track1,track2
+- Ability to load a session from a URL in JBrowse Web, for example,
+  https://jbrowse.org/code/jb2/v1.6.0/?config=test_data/volvox/config.json&loc=ctgA:2000-40000&assembly=volvox&tracks=gff3tabix_genes,volvox_filtered_vcf,volvox_microarray,volvox_cram
+  (note: the embedded components do not make any assumptions about the URL, so
+  do not have this functionality. Just the JBrowse Web package)
 - Stats estimation, tracks will try to estimate how much data they have to load
   and hide themselves if it is determined to be too much
 
@@ -9,11 +11,8 @@ There are also some improvements to synteny and dotplot views. The synteny view
 can now render curvy lines and "square" the views (so they each have the same
 zoom level), and have individual search panels in the synteny view. You can now
 also vertically resize the linear synteny view panel allowing for a taller or
-shorter view!
-
-The rendering has also been sped up in both linear synteny and dotplot views with
-certain code paths being up to 40x faster
-
-Preview
+shorter view! The rendering has also been sped up in both linear synteny and
+dotplot views with certain code paths being up to 40x faster
 
 ![](https://user-images.githubusercontent.com/6511937/151449824-8993a755-cc44-440f-bd98-8d251f144c58.png)
+Screenshot showing the new curvy lines of the synteny view with the grape vs peach demo http://jbrowse.org/code/jb2/v1.6.0/?config=test_data%2Fconfig_synteny_grape_peach.json&session=share-EdWfJj5aIY&password=S8PGj

--- a/website/release_announcement_drafts/v1.6.0.md
+++ b/website/release_announcement_drafts/v1.6.0.md
@@ -1,0 +1,4 @@
+This release has a couple long awaited features
+
+- Ability to load a session from a URL in JBrowse Web e.g. http://yoursite.com/jbrowse2/?loc=chr1:1-100&assembly=hg19&tracks=track1,track2
+- Stats estimation, tracks will try to estimate how much data they have to load and hide themselves if it is determined to be too much

--- a/website/release_announcement_drafts/v1.6.0.md
+++ b/website/release_announcement_drafts/v1.6.0.md
@@ -1,4 +1,19 @@
-This release has a couple long awaited features
+This release has a couple long awaited features!
 
-- Ability to load a session from a URL in JBrowse Web e.g. http://yoursite.com/jbrowse2/?loc=chr1:1-100&assembly=hg19&tracks=track1,track2
-- Stats estimation, tracks will try to estimate how much data they have to load and hide themselves if it is determined to be too much
+- Ability to load a session from a URL in JBrowse Web e.g.
+  http://yoursite.com/jbrowse2/?loc=chr1:1-100&assembly=hg19&tracks=track1,track2
+- Stats estimation, tracks will try to estimate how much data they have to load
+  and hide themselves if it is determined to be too much
+
+There are also some improvements to synteny and dotplot views. The synteny view
+can now render curvy lines and "square" the views (so they each have the same
+zoom level), and have individual search panels in the synteny view. You can now
+also vertically resize the linear synteny view panel allowing for a taller or
+shorter view!
+
+The rendering has also been sped up in both linear synteny and dotplot views with
+certain code paths being up to 40x faster
+
+Preview
+
+![](https://user-images.githubusercontent.com/6511937/151267591-bb5d9bee-73e2-4d79-a1d5-5742249aca26.png)

--- a/website/release_announcement_drafts/v1.6.0.md
+++ b/website/release_announcement_drafts/v1.6.0.md
@@ -16,4 +16,4 @@ certain code paths being up to 40x faster
 
 Preview
 
-![](https://user-images.githubusercontent.com/6511937/151267591-bb5d9bee-73e2-4d79-a1d5-5742249aca26.png)
+![](https://user-images.githubusercontent.com/6511937/151449824-8993a755-cc44-440f-bd98-8d251f144c58.png)


### PR DESCRIPTION
current yarn changelog

```
## Unreleased (2022-01-27)

#### :rocket: Enhancement
* `core`
  * [#2679](https://github.com/GMOD/jbrowse-components/pull/2679) Optimizations and usability improvements to synteny view ([@cmdcolin](https://github.com/cmdcolin))
  * [#2677](https://github.com/GMOD/jbrowse-components/pull/2677) Save user settings from LGV ([@cmdcolin](https://github.com/cmdcolin))
  * [#2571](https://github.com/GMOD/jbrowse-components/pull/2571) Add stats estimation to JB2 ([@cmdcolin](https://github.com/cmdcolin))
  * [#2666](https://github.com/GMOD/jbrowse-components/pull/2666) Add option to display curved lines and to square the dotplot and synteny views ([@cmdcolin](https://github.com/cmdcolin))
  * [#2672](https://github.com/GMOD/jbrowse-components/pull/2672) Optimize dot plot rendering ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2680](https://github.com/GMOD/jbrowse-components/pull/2680) Improve error handling on jbrowse desktop open sequence dialog ([@cmdcolin](https://github.com/cmdcolin))
  * [#2670](https://github.com/GMOD/jbrowse-components/pull/2670) Add mashmap PAF support ([@cmdcolin](https://github.com/cmdcolin))
  * [#2659](https://github.com/GMOD/jbrowse-components/pull/2659) Draw size of deletion on reads in alignments track ([@cmdcolin](https://github.com/cmdcolin))
* `__mocks__`, `core`
  * [#2165](https://github.com/GMOD/jbrowse-components/pull/2165) Add ability to create new sessions solely from a "session spec" in the URL ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#2654](https://github.com/GMOD/jbrowse-components/pull/2654) Fix broken @jbrowse/img by adding babel config back to core ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2660](https://github.com/GMOD/jbrowse-components/pull/2660) Fix custom glyphs to apply to features without subfeatures ([@bbimber](https://github.com/bbimber))
  * [#2652](https://github.com/GMOD/jbrowse-components/pull/2652) Fix "module" of embedded React views ([@garrettjstevens](https://github.com/garrettjstevens))

#### :memo: Documentation
* [#2663](https://github.com/GMOD/jbrowse-components/pull/2663) Add documentation for URL params and session spec ([@cmdcolin](https://github.com/cmdcolin))
* [#2655](https://github.com/GMOD/jbrowse-components/pull/2655) Add link to PAG 2022 youtube tutorial on demos page and course archive ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* `core`
  * [#2649](https://github.com/GMOD/jbrowse-components/pull/2649) Add Cypress test of package that uses embedded components ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2648](https://github.com/GMOD/jbrowse-components/pull/2648) Avoid console.warns in tests due to writing to MST nodes that are not alive ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2657](https://github.com/GMOD/jbrowse-components/pull/2657) Fix hot reload using yarn resolution on react-error-overlay ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
- [@bbimber](https://github.com/bbimber)
Done in 2.16s.


```