### PR TITLE
Fix ability to change colors on wiggle track using the config

### DIFF
--- a/plugins/wiggle/src/DensityRenderer/index.ts
+++ b/plugins/wiggle/src/DensityRenderer/index.ts
@@ -24,11 +24,10 @@ export default class DensityRenderer extends WiggleBaseRenderer {
     const pivotValue = readConfObject(config, 'bicolorPivotValue')
     const negColor = readConfObject(config, 'negColor')
     const posColor = readConfObject(config, 'posColor')
+    const color = readConfObject(config, 'color')
     let colorCallback
-    let colorScale: ReturnType<typeof getScale>
-    if (readConfObject(config, 'color') === '#f0f') {
-      // default color, use posColor/negColor instead
-      colorScale =
+    if (color === '#f0f') {
+      const colorScale =
         pivot !== 'none'
           ? getScale({
               ...scaleOpts,

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
@@ -51,7 +51,8 @@ export default function SetColorDialog({
   return (
     <Dialog open onClose={handleClose}>
       <DialogTitle>
-        Select a color
+        Select either an overall color, or the positive/negative colors. Note
+        that density renderers only work properly with positive/negative colors
         <IconButton
           aria-label="close"
           className={classes.closeButton}
@@ -78,18 +79,26 @@ export default function SetColorDialog({
           <>
             <Typography>Positive color</Typography>
             <CompactPicker
-              onChange={event => model.setPosColor(serialize(event.rgb))}
+              onChange={event => {
+                model.setPosColor(serialize(event.rgb))
+                model.setColor(undefined)
+              }}
             />
             <Typography>Negative color</Typography>
             <CompactPicker
-              onChange={event => model.setNegColor(serialize(event.rgb))}
+              onChange={event => {
+                model.setNegColor(serialize(event.rgb))
+                model.setColor(undefined)
+              }}
             />
           </>
         ) : (
           <>
             <Typography>Overall color</Typography>
             <CompactPicker
-              onChange={event => model.setColor(serialize(event.rgb))}
+              onChange={event => {
+                model.setColor(serialize(event.rgb))
+              }}
             />
           </>
         )}

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import React, { useState } from 'react'
 import {
   Button,
   Dialog,
@@ -8,12 +7,14 @@ import {
   DialogTitle,
   IconButton,
   Typography,
+  FormControlLabel,
+  Radio,
+  makeStyles,
 } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
 import { CompactPicker, Color, RGBColor } from 'react-color'
 
 const useStyles = makeStyles(theme => ({
-  root: {},
   closeButton: {
     position: 'absolute',
     right: theme.spacing(1),
@@ -24,7 +25,7 @@ const useStyles = makeStyles(theme => ({
 
 // this is needed because passing a entire color object into the react-color
 // for alpha, can't pass in an rgba string for example
-function serializeColor(color: Color) {
+function serialize(color: Color) {
   if (color instanceof Object) {
     const { r, g, b } = color as RGBColor
     return `rgb(${r},${g},${b})`
@@ -32,15 +33,20 @@ function serializeColor(color: Color) {
   return color
 }
 
-export default function SetColorDialog(props: {
+export default function SetColorDialog({
+  model,
+  handleClose,
+}: {
   model: {
     color: number
-    setColor: Function
+    setColor: (arg?: string) => void
+    setPosColor: (arg?: string) => void
+    setNegColor: (arg?: string) => void
   }
   handleClose: () => void
 }) {
   const classes = useStyles()
-  const { model, handleClose } = props
+  const [posneg, setPosNeg] = useState(false)
 
   return (
     <Dialog open onClose={handleClose}>
@@ -55,24 +61,38 @@ export default function SetColorDialog(props: {
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        <Typography>Positive color</Typography>
-        <CompactPicker
-          onChange={event => {
-            model.setPosColor(serializeColor(event.rgb))
-          }}
+        <FormControlLabel
+          checked={!posneg}
+          onClick={() => setPosNeg(false)}
+          control={<Radio />}
+          label={'Overall color'}
         />
-        <Typography>Negative color</Typography>
-        <CompactPicker
-          onChange={event => {
-            model.setNegColor(serializeColor(event.rgb))
-          }}
+        <FormControlLabel
+          checked={posneg}
+          onClick={() => setPosNeg(true)}
+          control={<Radio />}
+          label={'Positive/negative color'}
         />
-        <Typography>Overall color</Typography>
-        <CompactPicker
-          onChange={event => {
-            model.setColor(serializeColor(event.rgb))
-          }}
-        />
+
+        {posneg ? (
+          <>
+            <Typography>Positive color</Typography>
+            <CompactPicker
+              onChange={event => model.setPosColor(serialize(event.rgb))}
+            />
+            <Typography>Negative color</Typography>
+            <CompactPicker
+              onChange={event => model.setNegColor(serialize(event.rgb))}
+            />
+          </>
+        ) : (
+          <>
+            <Typography>Overall color</Typography>
+            <CompactPicker
+              onChange={event => model.setColor(serialize(event.rgb))}
+            />
+          </>
+        )}
       </DialogContent>
       <DialogActions>
         <Button

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/SetColorDialog.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import {
+  Button,
   Dialog,
   DialogContent,
+  DialogActions,
   DialogTitle,
   IconButton,
-  Button,
+  Typography,
 } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
 import { CompactPicker, Color, RGBColor } from 'react-color'
@@ -24,8 +26,8 @@ const useStyles = makeStyles(theme => ({
 // for alpha, can't pass in an rgba string for example
 function serializeColor(color: Color) {
   if (color instanceof Object) {
-    const { r, g, b, a } = color as RGBColor
-    return `rgb(${r},${g},${b},${a})`
+    const { r, g, b } = color as RGBColor
+    return `rgb(${r},${g},${b})`
   }
   return color
 }
@@ -41,13 +43,8 @@ export default function SetColorDialog(props: {
   const { model, handleClose } = props
 
   return (
-    <Dialog
-      open
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">
+    <Dialog open onClose={handleClose}>
+      <DialogTitle>
         Select a color
         <IconButton
           aria-label="close"
@@ -57,37 +54,50 @@ export default function SetColorDialog(props: {
           <CloseIcon />
         </IconButton>
       </DialogTitle>
-      <DialogContent style={{ overflowX: 'hidden' }}>
-        <div className={classes.root}>
-          <CompactPicker
-            onChange={event => {
-              model.setColor(serializeColor(event.rgb))
-            }}
-          />
-          <br />
-          <div style={{ margin: 20 }}>
-            <Button
-              onClick={() => {
-                model.setColor(undefined)
-              }}
-              color="secondary"
-              variant="contained"
-            >
-              Restore default from config
-            </Button>
-            <Button
-              variant="contained"
-              color="primary"
-              type="submit"
-              onClick={() => {
-                handleClose()
-              }}
-            >
-              Submit
-            </Button>
-          </div>
-        </div>
+      <DialogContent>
+        <Typography>Positive color</Typography>
+        <CompactPicker
+          onChange={event => {
+            model.setPosColor(serializeColor(event.rgb))
+          }}
+        />
+        <Typography>Negative color</Typography>
+        <CompactPicker
+          onChange={event => {
+            model.setNegColor(serializeColor(event.rgb))
+          }}
+        />
+        <Typography>Overall color</Typography>
+        <CompactPicker
+          onChange={event => {
+            model.setColor(serializeColor(event.rgb))
+          }}
+        />
       </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            model.setPosColor(undefined)
+            model.setNegColor(undefined)
+            model.setColor(undefined)
+          }}
+          color="secondary"
+          variant="contained"
+        >
+          Restore default
+        </Button>
+
+        <Button
+          variant="contained"
+          color="primary"
+          type="submit"
+          onClick={() => {
+            handleClose()
+          }}
+        >
+          Submit
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -65,6 +65,8 @@ const stateModelFactory = (
         resolution: types.optional(types.number, 1),
         fill: types.maybe(types.boolean),
         color: types.maybe(types.string),
+        posColor: types.maybe(types.string),
+        negColor: types.maybe(types.string),
         summaryScoreMode: types.maybe(types.string),
         rendererTypeNameState: types.maybe(types.string),
         scale: types.maybe(types.string),
@@ -93,6 +95,12 @@ const stateModelFactory = (
       },
       setColor(color: string) {
         self.color = color
+      },
+      setPosColor(color: string) {
+        self.posColor = color
+      },
+      setNegColor(color: string) {
+        self.negColor = color
       },
 
       setLoading(aborter: AbortController) {
@@ -215,6 +223,8 @@ const stateModelFactory = (
             displayCrossHatches: self.displayCrossHatches,
             summaryScoreMode: self.summaryScoreMode,
             color: self.color,
+            posColor: self.posColor,
+            negColor: self.negColor,
           },
           getEnv(self),
         )

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -169,7 +169,7 @@ const stateModelFactory = (
       },
     }))
     .views(self => ({
-      get TooltipComponent(): React.FC {
+      get TooltipComponent() {
         return Tooltip as unknown as React.FC
       },
 
@@ -195,11 +195,6 @@ const stateModelFactory = (
       get scaleType() {
         return self.scale || getConf(self, 'scaleType')
       },
-      get filled() {
-        return typeof self.fill !== 'undefined'
-          ? self.fill
-          : readConfObject(this.rendererConfig, 'filled')
-      },
 
       get maxScore() {
         const { max } = self.constraints
@@ -210,21 +205,22 @@ const stateModelFactory = (
         const { min } = self.constraints
         return min !== undefined ? min : getConf(self, 'minScore')
       },
-
+    }))
+    .views(self => ({
       get rendererConfig() {
         const configBlob =
-          getConf(self, ['renderers', this.rendererTypeName]) || {}
+          getConf(self, ['renderers', self.rendererTypeName]) || {}
 
         return self.rendererType.configSchema.create(
           {
             ...configBlob,
             filled: self.fill,
-            scaleType: this.scaleType,
+            scaleType: self.scaleType,
             displayCrossHatches: self.displayCrossHatches,
             summaryScoreMode: self.summaryScoreMode,
-            color: self.color,
-            posColor: self.posColor,
-            negColor: self.negColor,
+            ...(self.color ? { color: self.color } : {}),
+            ...(self.negColor ? { negColor: self.negColor } : {}),
+            ...(self.posColor ? { posColor: self.posColor } : {}),
           },
           getEnv(self),
         )
@@ -233,6 +229,11 @@ const stateModelFactory = (
     .views(self => {
       let oldDomain: [number, number] = [0, 0]
       return {
+        get filled() {
+          return typeof self.fill !== 'undefined'
+            ? self.fill
+            : readConfObject(self.rendererConfig, 'filled')
+        },
         get summaryScoreModeSetting() {
           return (
             self.summaryScoreMode ||

--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -41,7 +41,6 @@ export function getScale({
     throw new Error('undefined scaleType')
   }
   scale.domain(pivotValue !== undefined ? [min, pivotValue, max] : [min, max])
-  // console.log('before', scale.domain())
   scale.nice()
 
   const [rangeMin, rangeMax] = range
@@ -49,8 +48,6 @@ export function getScale({
     throw new Error('invalid range')
   }
   scale.range(inverted ? range.slice().reverse() : range)
-
-  // console.log('after', scale.domain())
   return scale
 }
 /**


### PR DESCRIPTION
Add ability to set the "plus and minus colors"  in the wiggle dialog

![Screenshot from 2022-01-27 06-06-36](https://user-images.githubusercontent.com/6511937/151364868-9d7c6df4-717e-4490-af0c-0faeab3250b5.png)


Fixes #1818 

Also fixes #2621 (the renderProps override of the config colors passed e.g. posColor:undefined would override whatever setting was in the configBlog that is spread on the renderProps)