### PR TITLE
Improve error handling on jbrowse desktop open sequence dialog

### DIFF
--- a/products/jbrowse-desktop/src/OpenSequenceDialog.tsx
+++ b/products/jbrowse-desktop/src/OpenSequenceDialog.tsx
@@ -375,13 +375,13 @@ const OpenSequenceDialog = ({
           onClick={async () => {
             try {
               let confs = assemblyConfs
-
-              // if we want to add another one
               if (assemblyName) {
-                setError(undefined)
                 const assemblyConf = await createAssemblyConfig()
                 confs = [...assemblyConfs, assemblyConf]
                 setAssemblyConfs(confs)
+              }
+              if (!confs.length) {
+                throw new Error('No assemblies specified')
               }
               await onClose(confs)
             } catch (e) {


### PR DESCRIPTION
I found if I pasted an incomplete assembly in the "Open sequence" dialog (e.g. just the url, and no assembly name) then it would allow me to hit submit but the assembly would not be added. This adds an error if no assembly was added (confs array is empty)

