### PR TITLE
Add ability to auto-generate a GC content track in jbrowse cli

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -102,6 +102,9 @@ OPTIONS
   --faiLocation=faiLocation
       [default: <fastaLocation>.fai] FASTA index file or URL
 
+  --gc
+      Add a GC content track to the assembly
+
   --gziLocation=gziLocation
       [default: <fastaLocation>.gzi] FASTA gzip index file or URL
 

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -101,6 +101,7 @@ export interface TextSearching {
 }
 export interface Track {
   trackId: string
+  type: string
   name: string
   assemblyNames: string[]
   adapter: Gff3TabixAdapter | GtfAdapter | VcfTabixAdapter

--- a/website/docs/quickstart_cli.md
+++ b/website/docs/quickstart_cli.md
@@ -47,6 +47,8 @@ mythicus_, that you can use.
 jbrowse add-assembly http://jbrowse.org.s3.amazonaws.com/genomes/volvox/volvox.fa
 ```
 
+If we want a GC content track, you can add --gc to this command
+
 :::caution
 
 A FASTA must have an index to work in JBrowse 2. This command assumes that the

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -51,6 +51,9 @@ samtools faidx genome.fa
 jbrowse add-assembly genome.fa --out /var/www/html/jbrowse2 --load copy
 ```
 
+Note: you can add --gc to the add-assembly command to automatically create a
+GCContent track from your assembly
+
 ### Loading a BAM file
 
 ```


### PR DESCRIPTION
This PR adds the option to specify --gc on the add-assembly CLI command to auto-generate a GC content track

Currently we cannot  e.g. a computed view to create a GC content track (because of use of resolveIdentifier and similar when looking at tracks, the computeds will not resolve as they are not actually of the tree). We can, alternatively, add an option to the add-assembly procedure, which this PR does

It also updates the grape and peach synteny demo with GC content tracks