### PR TITLE
Use path.resolve to fix --load symlink in jbrowse CLI

### DIFF
--- a/products/jbrowse-cli/src/commands/add-assembly.ts
+++ b/products/jbrowse-cli/src/commands/add-assembly.ts
@@ -588,7 +588,7 @@ custom         Either a JSON file location or inline JSON that defines a custom
               return undefined
             }
             return symlink(
-              filePath,
+              path.resolve(filePath),
               path.join(path.dirname(destination), path.basename(filePath)),
             )
           }),

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -315,7 +315,7 @@ export default class AddTrack extends JBrowseCommand {
     const callbacks = {
       copy: (src: string, dest: string) => copyFile(src, dest, COPYFILE_EXCL),
       move: (src: string, dest: string) => rename(src, dest),
-      symlink: (src: string, dest: string) => symlink(src, dest),
+      symlink: (src: string, dest: string) => symlink(path.resolve(src), dest),
     }
 
     await Promise.all(


### PR DESCRIPTION
This fixes https://github.com/GMOD/jbrowse-components/issues/2685

This always creates a resolved, absolute path for a symlink

This makes the change for both add-assembly and add-track