### PR TITLE
Fix adapterType dropdown in add track widget

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -164,10 +164,7 @@ export function guessAdapter(
   model?: IAnyStateTreeNode,
 ) {
   if (model) {
-    // @ts-ignore
-    const session = getSession(model)
-
-    const adapterGuesser = getEnv(session).pluginManager.evaluateExtensionPoint(
+    const adapterGuesser = getEnv(model).pluginManager.evaluateExtensionPoint(
       'Core-guessAdapterForLocation',
       (
         _file: FileLocation,

--- a/plugins/alignments/src/index.ts
+++ b/plugins/alignments/src/index.ts
@@ -60,12 +60,15 @@ export default class AlignmentsPlugin extends Plugin {
           const regexGuess = /\.cram$/i
           const adapterName = 'CramAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              cramLocation: file,
-              craiLocation: index || makeIndex(file, '.crai'),
-            }
+          const obj = {
+            type: adapterName,
+            cramLocation: file,
+            craiLocation: index || makeIndex(file, '.crai'),
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }
@@ -84,15 +87,19 @@ export default class AlignmentsPlugin extends Plugin {
           const adapterName = 'BamAdapter'
           const fileName = getFileName(file)
           const indexName = index && getFileName(index)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              bamLocation: file,
-              index: {
-                location: index || makeIndex(file, '.bai'),
-                indexType: makeIndexType(indexName, 'CSI', 'BAI'),
-              },
-            }
+
+          const obj = {
+            type: adapterName,
+            bamLocation: file,
+            index: {
+              location: index || makeIndex(file, '.bai'),
+              indexType: makeIndexType(indexName, 'CSI', 'BAI'),
+            },
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/bed/src/index.ts
+++ b/plugins/bed/src/index.ts
@@ -35,11 +35,15 @@ export default class BedPlugin extends Plugin {
           const regexGuess = /\.(bb|bigbed)$/i
           const adapterName = 'BigBedAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              bigBedLocation: file,
-            }
+          const obj = {
+            type: adapterName,
+            bigBedLocation: file,
+          }
+
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
@@ -112,7 +112,9 @@ const TrackAdapterSelector = observer(({ model }: { model: AddTrackModel }) => {
       helperText="Select an adapter type"
       select
       fullWidth
-      onChange={event => model.setAdapterHint(event.target.value)}
+      onChange={event => {
+        model.setAdapterHint(event.target.value)
+      }}
       SelectProps={{
         // @ts-ignore
         SelectDisplayProps: { 'data-testid': 'adapterTypeSelect' },

--- a/plugins/gff3/src/index.ts
+++ b/plugins/gff3/src/index.ts
@@ -71,11 +71,14 @@ export default class extends Plugin {
           const regexGuess = /\.gff3?$/i
           const adapterName = 'Gff3Adapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              gffLocation: file,
-            }
+          const obj = {
+            type: adapterName,
+            gffLocation: file,
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/gtf/src/index.ts
+++ b/plugins/gtf/src/index.ts
@@ -29,11 +29,15 @@ export default class GtfPlugin extends Plugin {
           const regexGuess = /\.gtf(\.gz)?$/i
           const adapterName = 'GtfAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              gtfLocation: file,
-            }
+
+          const obj = {
+            type: adapterName,
+            gtfLocation: file,
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/hic/src/index.ts
+++ b/plugins/hic/src/index.ts
@@ -50,11 +50,15 @@ export default class HicPlugin extends Plugin {
           const regexGuess = /\.hic/i
           const adapterName = 'HicAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              hicLocation: file,
-            }
+          const obj = {
+            type: adapterName,
+            hicLocation: file,
+          }
+
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/sequence/src/index.ts
+++ b/plugins/sequence/src/index.ts
@@ -71,11 +71,14 @@ export default class SequencePlugin extends Plugin {
           const regexGuess = /\.2bit$/i
           const adapterName = 'TwoBitAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              twoBitLocation: file,
-            }
+          const obj = {
+            type: adapterName,
+            twoBitLocation: file,
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }
@@ -139,12 +142,16 @@ export default class SequencePlugin extends Plugin {
           const regexGuess = /\.(fa|fasta|fas|fna|mfa)$/i
           const adapterName = 'IndexedFastaAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              fastaLocation: file,
-              faiLocation: index || makeIndex(file, '.fai'),
-            }
+          const obj = {
+            type: adapterName,
+            fastaLocation: file,
+            faiLocation: index || makeIndex(file, '.fai'),
+          }
+
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }
@@ -191,12 +198,16 @@ export default class SequencePlugin extends Plugin {
           const regexGuess = /\.(fa|fasta|fas|fna|mfa)\.b?gz$/i
           const adapterName = 'BgzipFastaAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              faiLocation: makeIndex(file, '.fai'),
-              gziLocation: makeIndex(file, '.gzi'),
-            }
+          const obj = {
+            type: adapterName,
+            faiLocation: makeIndex(file, '.fai'),
+            gziLocation: makeIndex(file, '.gzi'),
+          }
+
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/variants/src/index.ts
+++ b/plugins/variants/src/index.ts
@@ -57,15 +57,18 @@ export default class VariantsPlugin extends Plugin {
           const adapterName = 'VcfTabixAdapter'
           const fileName = getFileName(file)
           const indexName = index && getFileName(index)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              vcfGzLocation: file,
-              index: {
-                location: index || makeIndex(file, '.tbi'),
-                indexType: makeIndexType(indexName, 'CSI', 'TBI'),
-              },
-            }
+          const obj = {
+            type: adapterName,
+            vcfGzLocation: file,
+            index: {
+              location: index || makeIndex(file, '.tbi'),
+              indexType: makeIndexType(indexName, 'CSI', 'TBI'),
+            },
+          }
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
           }
           return adapterGuesser(file, index, adapterHint)
         }

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -103,12 +103,17 @@ export default class WigglePlugin extends Plugin {
           const regexGuess = /\.(bw|bigwig)$/i
           const adapterName = 'BigWigAdapter'
           const fileName = getFileName(file)
-          if (regexGuess.test(fileName) || adapterHint === adapterName) {
-            return {
-              type: adapterName,
-              bigWigLocation: file,
-            }
+          const obj = {
+            type: adapterName,
+            bigWigLocation: file,
           }
+
+          if (regexGuess.test(fileName) && !adapterHint) {
+            return obj
+          } else if (adapterHint === adapterName) {
+            return obj
+          }
+
           return adapterGuesser(file, index, adapterHint)
         }
       },


### PR DESCRIPTION
xref https://github.com/GMOD/jbrowse-plugin-apollo/issues/38


Makes the regex less specific, so that if adapterHint is GtfAdapter and it visits VcfAdapter's Core-guessAdapterType, the regex doesn't say that it is a VcfAdapter.