### PR TITLE
Fix disabled state on the linear genome view track labels dropdown menu

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.test.ts
+++ b/packages/core/rpc/BaseRpcDriver.test.ts
@@ -140,6 +140,7 @@ export class MockRendererShort extends RpcMethodType {
 
 test('test RPC driver operation timeout and worker replace', async () => {
   console.error = jest.fn()
+  console.warn = jest.fn()
   expect.assertions(1)
   const config = ConfigurationSchema('Mock', {}).create()
   const driver = new MockRpcDriver({ config })
@@ -158,6 +159,7 @@ test('test RPC driver operation timeout and worker replace', async () => {
 
 test('remote abort', async () => {
   console.error = jest.fn()
+  console.warn = jest.fn()
   expect.assertions(1)
   const config = ConfigurationSchema('Mock', {}).create()
   const driver = new MockRpcDriver({ config })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -102,7 +102,10 @@ const TrackLabel = React.forwardRef(
       handleClose()
     }
 
-    const items = track.trackMenuItems()
+    const items = [
+      ...session.getTrackActionMenuItems?.(trackConf),
+      ...track.trackMenuItems(),
+    ].sort((a, b) => (b.priority || 0) - (a.priority || 0))
 
     return (
       <>
@@ -138,6 +141,7 @@ const TrackLabel = React.forwardRef(
             className={classes.iconButton}
             color="secondary"
             data-testid="track_menu_icon"
+            disabled={!items.length}
           >
             <MoreVertIcon />
           </IconButton>
@@ -147,10 +151,7 @@ const TrackLabel = React.forwardRef(
           onMenuItemClick={handleMenuItemClick}
           open={Boolean(anchorEl)}
           onClose={handleClose}
-          menuItems={[
-            ...session.getTrackActionMenuItems?.(trackConf),
-            ...items,
-          ].sort((a, b) => (b.priority || 0) - (a.priority || 0))}
+          menuItems={items}
         />
       </>
     )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -138,7 +138,6 @@ const TrackLabel = React.forwardRef(
             className={classes.iconButton}
             color="secondary"
             data-testid="track_menu_icon"
-            disabled={!items.length}
           >
             <MoreVertIcon />
           </IconButton>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -505,10 +505,9 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         <button
           aria-controls="simple-menu"
           aria-haspopup="true"
-          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary"
           data-testid="track_menu_icon"
-          disabled=""
-          tabindex="-1"
+          tabindex="0"
           type="button"
         >
           <span
@@ -525,6 +524,9 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               />
             </svg>
           </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
         </button>
       </div>
       <div
@@ -1397,10 +1399,9 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <button
           aria-controls="simple-menu"
           aria-haspopup="true"
-          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary"
           data-testid="track_menu_icon"
-          disabled=""
-          tabindex="-1"
+          tabindex="0"
           type="button"
         >
           <span
@@ -1417,6 +1418,9 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               />
             </svg>
           </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
         </button>
       </div>
       <div
@@ -1551,10 +1555,9 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <button
           aria-controls="simple-menu"
           aria-haspopup="true"
-          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton MuiIconButton-colorSecondary"
           data-testid="track_menu_icon"
-          disabled=""
-          tabindex="-1"
+          tabindex="0"
           type="button"
         >
           <span
@@ -1571,6 +1574,9 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               />
             </svg>
           </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
         </button>
       </div>
       <div

--- a/products/jbrowse-web/src/tests/Alignments.test.js
+++ b/products/jbrowse-web/src/tests/Alignments.test.js
@@ -104,7 +104,7 @@ describe('alignments track', () => {
     )
 
     const { findByTestId: findByTestId1 } = within(
-      await findByTestId('Blockset-snpcoverage'),
+      await findByTestId('Blockset-snpcoverage', {}, delay),
     )
 
     expectCanvasMatch(


### PR DESCRIPTION
Currently the track menu can be disabled in embedded mode if there are no "items" but there should always be at least an "About track" dialog

