### PR TITLE
Increase admin-server payload limit

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -321,15 +321,19 @@ USAGE
   $ jbrowse admin-server
 
 OPTIONS
-  -h, --help       show CLI help
+  -h, --help                     show CLI help
 
-  -p, --port=port  Specifified port to start the server on;
-                   Default is 9090.
+  -p, --port=port                Specifified port to start the server on;
+                                 Default is 9090.
 
-  --out=out        synonym for target
+  --bodySizeLimit=bodySizeLimit  [default: 25mb] Size limit of the update message; may need to increase if config is
+                                 large.
+                                 Argument is passed to bytes library for parsing: https://www.npmjs.com/package/bytes.
 
-  --target=target  path to config file in JB2 installation directory to write out to.
-                   Creates ./config.json if nonexistent
+  --out=out                      synonym for target
+
+  --target=target                path to config file in JB2 installation directory to write out to.
+                                 Creates ./config.json if nonexistent
 
 EXAMPLES
   $ jbrowse admin-server

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -35,13 +35,18 @@ export default class AdminServer extends JBrowseCommand {
     out: flags.string({
       description: 'synonym for target',
     }),
+    bodySizeLimit: flags.string({
+      description:
+        'Size limit of the update message; may need to increase if config is large.\nArgument is passed to bytes library for parsing: https://www.npmjs.com/package/bytes.',
+      default: '25mb',
+    }),
 
     help: flags.help({ char: 'h' }),
   }
 
   async run() {
     const { flags: runFlags } = this.parse(AdminServer)
-    const { target, out } = runFlags
+    const { target, out, bodySizeLimit } = runFlags
 
     const output = target || out || '.'
     const isDir = fs.lstatSync(output).isDirectory()
@@ -77,7 +82,7 @@ export default class AdminServer extends JBrowseCommand {
     app.use(cors())
 
     // POST route to save config
-    app.use(express.json({ limit: '25mb' }))
+    app.use(express.json({ limit: bodySizeLimit }))
     app.post('/updateConfig', async (req, res) => {
       if (adminKey === req.body.adminKey) {
         this.debug('Admin key matches')

--- a/products/jbrowse-cli/src/commands/admin-server.ts
+++ b/products/jbrowse-cli/src/commands/admin-server.ts
@@ -77,7 +77,7 @@ export default class AdminServer extends JBrowseCommand {
     app.use(cors())
 
     // POST route to save config
-    app.use(express.json())
+    app.use(express.json({ limit: '25mb' }))
     app.post('/updateConfig', async (req, res) => {
       if (adminKey === req.body.adminKey) {
         this.debug('Admin key matches')


### PR DESCRIPTION
By default `app.use(express.json())` enforces a limit of 100kb (see [here](https://expressjs.com/en/api.html#express.json)) on request body size. For reference, our config_demo.json human config is 132kb. This PR increases the limit to an (admittedly arbitrary) 25mb.

Problem with limit originally noted in https://github.com/GMOD/jbrowse-components/discussions/2703