### PR TITLE
Add ID to add-track log message

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -331,9 +331,11 @@ export default class AddTrack extends JBrowseCommand {
     await this.writeJsonFile(this.target, configContents)
 
     this.log(
-      `${idx !== -1 ? 'Overwrote' : 'Added'} track "${name}" ${
-        idx !== -1 ? 'in' : 'to'
-      } ${this.target}`,
+      `${
+        idx !== -1 ? 'Overwrote' : 'Added'
+      } track "${name}" with ID "${trackId}" ${idx !== -1 ? 'in' : 'to'} ${
+        this.target
+      }`,
     )
   }
 

--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -333,9 +333,9 @@ export default class AddTrack extends JBrowseCommand {
     this.log(
       `${
         idx !== -1 ? 'Overwrote' : 'Added'
-      } track "${name}" with ID "${trackId}" ${idx !== -1 ? 'in' : 'to'} ${
-        this.target
-      }`,
+      } track with name "${name}" and trackId "${trackId}" ${
+        idx !== -1 ? 'in' : 'to'
+      } ${this.target}`,
     )
   }
 


### PR DESCRIPTION
I'm not sure if this makes the message too long, but I thought I'd see what people think. This adds the ID to the output when running `add-track`, so that instead of
```
Added track "volvox.sort.gff3" to ./config.json
```
it would look like
```
Added track "volvox.sort.gff3" with ID "volvox.sort.gff3" to ./config.json
```

The hope is that this will reduce confusion in cases like https://github.com/GMOD/jbrowse-components/issues/2704