### PR TITLE
Fix ability to use authenticated assembly files

### DIFF
--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -212,8 +212,8 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
                   resolve = r
                   reject = x
                 })
-                token = await openLocationPromise
               }
+              token = await openLocationPromise
             }
           }
           resolve()


### PR DESCRIPTION
This fixes the ability to use authenticated files in an assembly. They differ from other files because the adapter is created on the main thread and not on the webworker, so they don't go through the RPC steps that handle authentication. Basically the logic now is that if there is a UriLocation that doesn't have any auth information, and it can find a root model, it checks if any of the configured internet accounts handle that URI.

Also fixes a small bug in the OAuth model I found while testing this change using a Dropbox file.