### PR TITLE
Update to node12 requirement for @jbrowse/cli

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -268,7 +268,7 @@ an encoded format.
 
 We recommend that you have the following
 
-- Node v10+
+- Node v12+
 - Git
 - [Yarn](https://classic.yarnpkg.com/en/docs/install/#debian-stable)
 

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -11,7 +11,7 @@ In this guide, we'll get an instance of JBrowse running on your computer.
 ## Pre-requisites
 
 - Ability to run commands on the command line
-- Node.js 10.4+
+- Node.js 12+
 
 :::caution
 

--- a/website/docs/superquickstart_web.md
+++ b/website/docs/superquickstart_web.md
@@ -11,7 +11,7 @@ also assumes you have:
 
 - a web server that reads files from /var/www/html/ e.g. Apache or nginx (not
   strictly necessary for jbrowse to run, see footnote)
-- node 10+ installed
+- node 12+ installed
 - genometools installed e.g. `sudo apt install genometools` or `brew install brewsci/bio/genometools`, used for sorting GFF3 for creating tabix GFF
 - samtools installed e.g. `sudo apt install samtools` or `brew install samtools`, used for creating FASTA index and BAM/CRAM processing
 - tabix installed e.g. `sudo apt install tabix` or `brew install htslib`, used


### PR DESCRIPTION
I think an oclif update now recommend node 12. Can install under node 10 but it warns a lot

Example of use under node 10

```
❯❯ jbrowse admin-server
WARNING
WARNING Node version must be >=12.0.0 to use this CLI
WARNING Current node version: 10.24.1
WARNING

   ┌─────────────────────────────────────────────────────────────────────┐
   │                                                                     │
   │   Now serving JBrowse                                               │
   │   Navigate to the below URL to configure                            │
   │                                                                     │
   │   - Local:            http://localhost:9090?adminKey=b9742c57bc     │
   │   - On Your Network:  http://192.168.0.7:9090?adminKey=b9742c57bc   │
   │                                                                     │
   └─────────────────────────────────────────────────────────────────────┘

If you are running yarn start you can launch http://localhost:3000?adminKey=b9742c57bc&adminServer=http://localhost:9090/updateConfig

```