### PR TITLE
Avoid uninitialized state during stats estimation

### DIFF
--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -252,6 +252,9 @@ export abstract class BaseFeatureDataAdapter extends BaseAdapter {
   }
 
   public async estimateRegionsStats(regions: Region[], opts?: BaseOptions) {
+    if (!regions.length) {
+      throw new Error('No regions to estimate stats for')
+    }
     const region = regions[0]
     let lastTime = +Date.now()
     const statsFromInterval = async (length: number, expansionTime: number) => {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -387,7 +387,10 @@ export const BaseLinearDisplay = types
         self.setError()
         const aborter = new AbortController()
         const view = getContainingView(self) as LGV
-        if (!view.initialized) {
+
+        // extra check for contentBlocks.length
+        // https://github.com/GMOD/jbrowse-components/issues/2694
+        if (!view.initialized || !view.staticBlocks.contentBlocks.length) {
           return
         }
 


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/2694

I am not able to reproduce this locally, but the condition seen in the code seems like it would only happen if an empty array was passed to the estimateRegionsStats 

I wait until there is a region from staticBlocks and also throw a hard error if empty