### PR TITLE
Pass extraGlyphs prop to all calls of chooseGlyphComponent

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.js
@@ -153,6 +153,7 @@ ProcessedTranscript.layOut = ({
   bpPerPx,
   reversed,
   config,
+  extraGlyphs,
 }) => {
   const subLayout = layOutFeature({
     layout,
@@ -160,6 +161,7 @@ ProcessedTranscript.layOut = ({
     bpPerPx,
     reversed,
     config,
+    extraGlyphs,
   })
   const subfeatures = getSubparts(feature, config)
   layOutSubfeatures({
@@ -168,6 +170,7 @@ ProcessedTranscript.layOut = ({
     bpPerPx,
     reversed,
     config,
+    extraGlyphs,
   })
   return subLayout
 }

--- a/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
@@ -41,7 +41,14 @@ Subfeatures.defaultProps = {
   reversed: false,
 }
 
-Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs, }) => {
+Subfeatures.layOut = ({
+  layout,
+  feature,
+  bpPerPx,
+  reversed,
+  config,
+  extraGlyphs,
+}) => {
   const subLayout = layOutFeature({
     layout,
     feature,
@@ -55,7 +62,10 @@ Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs,
     const subfeatures = feature.get('subfeatures') || []
     let topOffset = 0
     subfeatures.forEach(subfeature => {
-      const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs,)
+      const SubfeatureGlyphComponent = chooseGlyphComponent(
+        subfeature,
+        extraGlyphs,
+      )
       const subfeatureHeight = readConfObject(config, 'height', {
         feature: subfeature,
       })

--- a/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { chooseGlyphComponent, layOut, layOutFeature } from './util'
 
 function Subfeatures(props) {
-  const { feature, featureLayout, selected } = props
+  const { feature, featureLayout, selected, extraGlyph} = props
 
   return (
     <>
@@ -41,20 +41,21 @@ Subfeatures.defaultProps = {
   reversed: false,
 }
 
-Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config }) => {
+Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs }) => {
   const subLayout = layOutFeature({
     layout,
     feature,
     bpPerPx,
     reversed,
     config,
+    extraGlyphs,
   })
   const displayMode = readConfObject(config, 'displayMode')
   if (displayMode !== 'reducedRepresentation') {
     const subfeatures = feature.get('subfeatures') || []
     let topOffset = 0
     subfeatures.forEach(subfeature => {
-      const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature)
+      const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs)
       const subfeatureHeight = readConfObject(config, 'height', {
         feature: subfeature,
       })
@@ -65,6 +66,7 @@ Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config }) => {
         bpPerPx,
         reversed,
         config,
+        extraGlyphs,
       })
       subSubLayout.move(0, topOffset)
       topOffset +=

--- a/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { chooseGlyphComponent, layOut, layOutFeature } from './util'
 
 function Subfeatures(props) {
-  const { feature, featureLayout, selected, extraGlyph} = props
+  const { feature, featureLayout, selected } = props
 
   return (
     <>
@@ -41,7 +41,7 @@ Subfeatures.defaultProps = {
   reversed: false,
 }
 
-Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs }) => {
+Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs, }) => {
   const subLayout = layOutFeature({
     layout,
     feature,
@@ -55,7 +55,7 @@ Subfeatures.layOut = ({ layout, feature, bpPerPx, reversed, config, extraGlyphs 
     const subfeatures = feature.get('subfeatures') || []
     let topOffset = 0
     subfeatures.forEach(subfeature => {
-      const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs)
+      const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs,)
       const subfeatureHeight = readConfObject(config, 'height', {
         feature: subfeature,
       })

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -37,7 +37,7 @@ function RenderedFeatureGlyph(props) {
     bpPerPx,
     reversed,
     config,
-    extraGlyphs
+    extraGlyphs,
   })
   let shouldShowName
   let shouldShowDescription

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.js
@@ -37,6 +37,7 @@ function RenderedFeatureGlyph(props) {
     bpPerPx,
     reversed,
     config,
+    extraGlyphs
   })
   let shouldShowName
   let shouldShowDescription

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -31,7 +31,7 @@ export function chooseGlyphComponent(
       return !!subfeature.get('subfeatures')
     })
     if (hasSubSub) {
-      return Subfeatures(extraGlyphs)
+      return Subfeatures
     }
     const transcriptTypes = ['mRNA', 'transcript']
     if (

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -31,7 +31,7 @@ export function chooseGlyphComponent(
       return !!subfeature.get('subfeatures')
     })
     if (hasSubSub) {
-      return Subfeatures
+      return Subfeatures(extraGlyphs)
     }
     const transcriptTypes = ['mRNA', 'transcript']
     if (
@@ -59,15 +59,17 @@ interface BaseLayOutArgs {
   layout: SceneGraph
   bpPerPx: number
   reversed: boolean
-  config: AnyConfigurationModel
+  config: AnyConfigurationModel,
 }
 
 interface FeatureLayOutArgs extends BaseLayOutArgs {
-  feature: Feature
+  feature: Feature,
+  extraGlyphs: ExtraGlyphValidator[]
 }
 
 interface SubfeatureLayOutArgs extends BaseLayOutArgs {
-  subfeatures: Feature[]
+  subfeatures: Feature[],
+  extraGlyphs: ExtraGlyphValidator[]
 }
 
 export function layOut({
@@ -76,6 +78,7 @@ export function layOut({
   bpPerPx,
   reversed,
   config,
+  extraGlyphs
 }: FeatureLayOutArgs): SceneGraph {
   const displayMode = readConfObject(config, 'displayMode')
   const subLayout = layOutFeature({
@@ -84,6 +87,7 @@ export function layOut({
     bpPerPx,
     reversed,
     config,
+    extraGlyphs
   })
   if (displayMode !== 'reducedRepresentation') {
     layOutSubfeatures({
@@ -92,18 +96,19 @@ export function layOut({
       bpPerPx,
       reversed,
       config,
+      extraGlyphs
     })
   }
   return subLayout
 }
 
 export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
-  const { layout, feature, bpPerPx, reversed, config } = args
+  const { layout, feature, bpPerPx, reversed, config, extraGlyphs } = args
   const displayMode = readConfObject(config, 'displayMode')
   const GlyphComponent =
     displayMode === 'reducedRepresentation'
       ? Chevron
-      : chooseGlyphComponent(feature)
+      : chooseGlyphComponent(feature, extraGlyphs)
   const parentFeature = feature.parent()
   let x = 0
   if (parentFeature) {
@@ -127,15 +132,16 @@ export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
 }
 
 export function layOutSubfeatures(args: SubfeatureLayOutArgs): void {
-  const { layout: subLayout, subfeatures, bpPerPx, reversed, config } = args
+  const { layout: subLayout, subfeatures, bpPerPx, reversed, config, extraGlyphs } = args
   subfeatures.forEach(subfeature => {
-    const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature)
+    const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs)
     ;(SubfeatureGlyphComponent.layOut || layOut)({
       layout: subLayout,
       feature: subfeature,
       bpPerPx,
       reversed,
       config,
+      extraGlyphs,
     })
   })
 }

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -59,16 +59,16 @@ interface BaseLayOutArgs {
   layout: SceneGraph
   bpPerPx: number
   reversed: boolean
-  config: AnyConfigurationModel,
+  config: AnyConfigurationModel
 }
 
 interface FeatureLayOutArgs extends BaseLayOutArgs {
-  feature: Feature,
+  feature: Feature
   extraGlyphs: ExtraGlyphValidator[]
 }
 
 interface SubfeatureLayOutArgs extends BaseLayOutArgs {
-  subfeatures: Feature[],
+  subfeatures: Feature[]
   extraGlyphs: ExtraGlyphValidator[]
 }
 
@@ -78,7 +78,7 @@ export function layOut({
   bpPerPx,
   reversed,
   config,
-  extraGlyphs
+  extraGlyphs,
 }: FeatureLayOutArgs): SceneGraph {
   const displayMode = readConfObject(config, 'displayMode')
   const subLayout = layOutFeature({
@@ -87,7 +87,7 @@ export function layOut({
     bpPerPx,
     reversed,
     config,
-    extraGlyphs
+    extraGlyphs,
   })
   if (displayMode !== 'reducedRepresentation') {
     layOutSubfeatures({
@@ -96,14 +96,14 @@ export function layOut({
       bpPerPx,
       reversed,
       config,
-      extraGlyphs
+      extraGlyphs,
     })
   }
   return subLayout
 }
 
 export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
-  const { layout, feature, bpPerPx, reversed, config, extraGlyphs } = args
+  const { layout, feature, bpPerPx, reversed, config, extraGlyphs, } = args
   const displayMode = readConfObject(config, 'displayMode')
   const GlyphComponent =
     displayMode === 'reducedRepresentation'
@@ -132,7 +132,7 @@ export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
 }
 
 export function layOutSubfeatures(args: SubfeatureLayOutArgs): void {
-  const { layout: subLayout, subfeatures, bpPerPx, reversed, config, extraGlyphs } = args
+  const { layout: subLayout, subfeatures, bpPerPx, reversed, config, extraGlyphs, } = args
   subfeatures.forEach(subfeature => {
     const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs)
     ;(SubfeatureGlyphComponent.layOut || layOut)({

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -103,7 +103,7 @@ export function layOut({
 }
 
 export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
-  const { layout, feature, bpPerPx, reversed, config, extraGlyphs, } = args
+  const { layout, feature, bpPerPx, reversed, config, extraGlyphs } = args
   const displayMode = readConfObject(config, 'displayMode')
   const GlyphComponent =
     displayMode === 'reducedRepresentation'
@@ -132,9 +132,19 @@ export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
 }
 
 export function layOutSubfeatures(args: SubfeatureLayOutArgs): void {
-  const { layout: subLayout, subfeatures, bpPerPx, reversed, config, extraGlyphs, } = args
+  const {
+    layout: subLayout,
+    subfeatures,
+    bpPerPx,
+    reversed,
+    config,
+    extraGlyphs,
+  } = args
   subfeatures.forEach(subfeature => {
-    const SubfeatureGlyphComponent = chooseGlyphComponent(subfeature, extraGlyphs)
+    const SubfeatureGlyphComponent = chooseGlyphComponent(
+      subfeature,
+      extraGlyphs,
+    )
     ;(SubfeatureGlyphComponent.layOut || layOut)({
       layout: subLayout,
       feature: subfeature,


### PR DESCRIPTION
This is related to our [original PR](https://github.com/GMOD/jbrowse-components/pull/2509) for providing arbitrary user-defined glyphs, which modifies the `chooseGlyphComponent` function in order to allow the additional glyphs to be rendered. 

There are several locations in the SVG module where `chooseGlyphComponent` is called without access to the `extraGlyphs` prop, which causes the custom glyphs to be skipped in several cases where they should be rendered. This PR passes `extraGlyphs` to every call of `chooseGlyphComponent` by propagating it into the relevant `layOut` calls and adding it to `FeatureLayOutArgs` and `SubfeatureLayOutArgs`.