### PR TITLE
Handle .bgz file extension for text-index

### DIFF
--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -50,7 +50,7 @@ export async function* indexGff3(
   })
 
   const rl = readline.createInterface({
-    input: uri.endsWith('.gz')
+    input: uri.match(/.b?gz$/)
       ? fileDataStream.pipe(createGunzip())
       : fileDataStream,
   })

--- a/products/jbrowse-cli/src/types/gtfAdapter.ts
+++ b/products/jbrowse-cli/src/types/gtfAdapter.ts
@@ -49,7 +49,7 @@ export async function* indexGtf(
     progressBar.update(receivedBytes)
   })
 
-  const gzStream = uri.endsWith('.gz')
+  const gzStream = uri.match(/.b?gz$/)
     ? fileDataStream.pipe(createGunzip())
     : fileDataStream
 

--- a/products/jbrowse-cli/src/types/vcfAdapter.ts
+++ b/products/jbrowse-cli/src/types/vcfAdapter.ts
@@ -49,7 +49,7 @@ export async function* indexVcf(
     progressBar.update(receivedBytes)
   })
 
-  const gzStream = uri.endsWith('.gz')
+  const gzStream = uri.match(/.b?gz$/)
     ? fileDataStream.pipe(createGunzip())
     : fileDataStream
 


### PR DESCRIPTION
Currently the code explicitly checks for .gz, but this helps allow .gz extensions. It could be more advanced and detect a gzip encoding regardless of file extension but this may help

Fixes #2718