### PR TITLE
Add engines 16 to @jbrowse/img

### DIFF
--- a/products/jbrowse-img/package.json
+++ b/products/jbrowse-img/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "author": "JBrowse Team",
   "license": "Apache-2.0",
+  "engines": ">=16",
   "bin": {
     "jb2export": "./dist/bin.js"
   },


### PR DESCRIPTION
This is required, unless we want to add a AbortController poly/ponyfill 

On node 12 and node 14 it produces this error

```
 jb2export --bigwig src/jbrowse-components/test_data/volvox/volvox-sorted.bam.coverage.bw --loc ctgA:1000-2000 --fasta src/jbrowse-components/test_data/volvox/volvox.fa
(node:1965899) UnhandledPromiseRejectionWarning: ReferenceError: AbortController is not defined
    at _callee$ (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@jbrowse/core/util/index.js:881:15)
    at tryCatch (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/regenerator-runtime/runtime.js:63:40)
    at Generator.invoke [as _invoke] (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/regenerator-runtime/runtime.js:294:22)
    at Generator.next (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/regenerator-runtime/runtime.js:119:21)
    at asyncGeneratorStep (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
    at /home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
    at new Promise (<anonymous>)
    at /home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12
    at /home/cdiesh/.nvm/versions/node/v12.22.7/lib/node_modules/@jbrowse/img/node_modules/@jbrowse/core/util/index.js:918:19
(node:1965899) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:1965899) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```
