### PR TITLE
Use sparse array for SNPCoverageAdapter

### DIFF
--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -171,14 +171,6 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
     // delskips are elements that don't contribute to coverage, but should be
     // reported also (and are not interbase)
     type BinType = { total: number; strands: { [key: string]: number } }
-    const initBins = Array.from({ length: binMax }, () => ({
-      total: 0,
-      lowqual: {} as BinType,
-      cov: {} as BinType,
-      delskips: {} as BinType,
-      noncov: {} as BinType,
-      ref: {} as BinType,
-    }))
 
     // request an extra +1 on the end to get CpG crossing region boundary
     let regionSeq: string | undefined
@@ -189,7 +181,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
           refName: originalRefName || refName,
           start,
           end: end + 1,
-          assemblyName: 'na',
+          assemblyName: region.assemblyName,
         })
         .pipe(toArray())
         .toPromise()
@@ -198,172 +190,199 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
 
     const bins = await features
       .pipe(
-        reduce((bins, feature) => {
-          const cigar = feature.get('CIGAR')
-          const fstart = feature.get('start')
-          const fend = feature.get('end')
-          const fstrand = feature.get('strand')
-          const cigarOps = parseCigar(cigar)
-
-          for (let j = fstart; j < fend; j++) {
-            const i = j - region.start
-            if (i >= 0 && i < bins.length) {
-              const bin = bins[i]
-              bin.total++
-              inc(bin, fstrand, 'ref', 'ref')
-            }
-          }
-
-          if (colorBy?.type === 'modifications') {
-            const seq = feature.get('seq')
-            const mm = getTagAlt(feature, 'MM', 'Mm') || ''
-
-            const ml =
-              (getTagAlt(feature, 'ML', 'Ml') as number[] | string) || []
-
-            const probabilities = ml
-              ? (typeof ml === 'string' ? ml.split(',').map(e => +e) : ml).map(
-                  e => e / 255,
-                )
-              : (getTagAlt(feature, 'MP', 'Mp') as string)
-                  .split('')
-                  .map(s => s.charCodeAt(0) - 33)
-                  .map(elt => Math.min(1, elt / 50))
-
-            let probIndex = 0
-            getModificationPositions(mm, seq, fstrand).forEach(
-              ({ type, positions }) => {
-                const mod = `mod_${type}`
-                for (const pos of getNextRefPos(cigarOps, positions)) {
-                  const epos = pos + fstart - region.start
-                  if (epos >= 0 && epos < bins.length && pos + fstart < fend) {
-                    const bin = bins[epos]
-                    if (probabilities[probIndex] > 0.5) {
-                      inc(bin, fstrand, 'cov', mod)
-                    } else {
-                      inc(bin, fstrand, 'lowqual', mod)
-                    }
-                  }
-                  probIndex++
-                }
-              },
-            )
-          }
-
-          // methylation based coloring takes into account both reference
-          // sequence CpG detection and reads
-          else if (colorBy?.type === 'methylation') {
-            if (!regionSeq) {
-              throw new Error(
-                'no region sequence detected, need sequenceAdapter configuration',
-              )
-            }
-            const seq = feature.get('seq')
-            const mm = getTagAlt(feature, 'MM', 'Mm') || ''
-            const methBins = new Array(region.end - region.start).fill(0)
-
-            getModificationPositions(mm, seq, fstrand).forEach(
-              ({ type, positions }) => {
-                // we are processing methylation
-                if (type === 'm') {
-                  for (const pos of getNextRefPos(cigarOps, positions)) {
-                    const epos = pos + fstart - region.start
-                    if (epos >= 0 && epos < methBins.length) {
-                      methBins[epos] = 1
-                    }
-                  }
-                }
-              },
-            )
+        reduce(
+          (bins, feature) => {
+            const cigar = feature.get('CIGAR')
+            const fstart = feature.get('start')
+            const fend = feature.get('end')
+            const fstrand = feature.get('strand')
+            const cigarOps = parseCigar(cigar)
 
             for (let j = fstart; j < fend; j++) {
               const i = j - region.start
-              if (i >= 0 && i < bins.length - 1) {
-                const l1 = regionSeq[i].toLowerCase()
-                const l2 = regionSeq[i + 1].toLowerCase()
-                const bin = bins[i]
-                const bin1 = bins[i + 1]
-
-                // color
-                if (l1 === 'c' && l2 === 'g') {
-                  if (methBins[i] || methBins[i + 1]) {
-                    inc(bin, fstrand, 'cov', 'meth')
-                    inc(bin1, fstrand, 'cov', 'meth')
-                    dec(bin, fstrand, 'ref', 'ref')
-                    dec(bin1, fstrand, 'ref', 'ref')
-                  } else {
-                    inc(bin, fstrand, 'cov', 'unmeth')
-                    inc(bin1, fstrand, 'cov', 'unmeth')
-                    dec(bin, fstrand, 'ref', 'ref')
-                    dec(bin1, fstrand, 'ref', 'ref')
-                  }
+              if (i >= 0 && i < binMax) {
+                const bin = bins[i] || {
+                  total: 0,
+                  lowqual: {} as BinType,
+                  cov: {} as BinType,
+                  delskips: {} as BinType,
+                  noncov: {} as BinType,
+                  ref: {} as BinType,
                 }
+                bin.total++
+                inc(bin, fstrand, 'ref', 'ref')
+                bins[i] = bin
               }
             }
-          }
 
-          // normal SNP based coloring
-          else {
-            const mismatches = feature.get('mismatches') as
-              | Mismatch[]
-              | undefined
+            if (colorBy?.type === 'modifications') {
+              const seq = feature.get('seq')
+              const mm = getTagAlt(feature, 'MM', 'Mm') || ''
 
-            if (mismatches) {
-              for (let i = 0; i < mismatches.length; i++) {
-                const mismatch = mismatches[i]
-                const mstart = fstart + mismatch.start
-                for (let j = mstart; j < mstart + mismatchLen(mismatch); j++) {
-                  const epos = j - region.start
-                  if (epos >= 0 && epos < bins.length) {
-                    const bin = bins[epos]
-                    const { base, type } = mismatch
-                    const interbase = isInterbase(type)
-                    if (!interbase) {
+              const ml =
+                (getTagAlt(feature, 'ML', 'Ml') as number[] | string) || []
+
+              const probabilities = ml
+                ? (typeof ml === 'string'
+                    ? ml.split(',').map(e => +e)
+                    : ml
+                  ).map(e => e / 255)
+                : (getTagAlt(feature, 'MP', 'Mp') as string)
+                    .split('')
+                    .map(s => s.charCodeAt(0) - 33)
+                    .map(elt => Math.min(1, elt / 50))
+
+              let probIndex = 0
+              getModificationPositions(mm, seq, fstrand).forEach(
+                ({ type, positions }) => {
+                  const mod = `mod_${type}`
+                  for (const pos of getNextRefPos(cigarOps, positions)) {
+                    const epos = pos + fstart - region.start
+                    if (
+                      epos >= 0 &&
+                      epos < bins.length &&
+                      pos + fstart < fend
+                    ) {
+                      const bin = bins[epos]
+                      if (probabilities[probIndex] > 0.5) {
+                        inc(bin, fstrand, 'cov', mod)
+                      } else {
+                        inc(bin, fstrand, 'lowqual', mod)
+                      }
+                    }
+                    probIndex++
+                  }
+                },
+              )
+            }
+
+            // methylation based coloring takes into account both reference
+            // sequence CpG detection and reads
+            else if (colorBy?.type === 'methylation') {
+              if (!regionSeq) {
+                throw new Error(
+                  'no region sequence detected, need sequenceAdapter configuration',
+                )
+              }
+              const seq = feature.get('seq')
+              const mm = getTagAlt(feature, 'MM', 'Mm') || ''
+              const methBins = new Array(region.end - region.start).fill(0)
+
+              getModificationPositions(mm, seq, fstrand).forEach(
+                ({ type, positions }) => {
+                  // we are processing methylation
+                  if (type === 'm') {
+                    for (const pos of getNextRefPos(cigarOps, positions)) {
+                      const epos = pos + fstart - region.start
+                      if (epos >= 0 && epos < methBins.length) {
+                        methBins[epos] = 1
+                      }
+                    }
+                  }
+                },
+              )
+
+              for (let j = fstart; j < fend; j++) {
+                const i = j - region.start
+                if (i >= 0 && i < bins.length - 1) {
+                  const l1 = regionSeq[i].toLowerCase()
+                  const l2 = regionSeq[i + 1].toLowerCase()
+                  const bin = bins[i]
+                  const bin1 = bins[i + 1]
+
+                  // color
+                  if (l1 === 'c' && l2 === 'g') {
+                    if (methBins[i] || methBins[i + 1]) {
+                      inc(bin, fstrand, 'cov', 'meth')
+                      inc(bin1, fstrand, 'cov', 'meth')
                       dec(bin, fstrand, 'ref', 'ref')
+                      dec(bin1, fstrand, 'ref', 'ref')
                     } else {
-                      inc(bin, fstrand, 'noncov', type)
-                    }
-
-                    if (type === 'deletion' || type === 'skip') {
-                      inc(bin, fstrand, 'delskips', type)
-                      bin.total--
-                    } else if (!interbase) {
-                      inc(bin, fstrand, 'cov', base)
+                      inc(bin, fstrand, 'cov', 'unmeth')
+                      inc(bin1, fstrand, 'cov', 'unmeth')
+                      dec(bin, fstrand, 'ref', 'ref')
+                      dec(bin1, fstrand, 'ref', 'ref')
                     }
                   }
                 }
               }
-
-              mismatches
-                .filter(mismatch => mismatch.type === 'skip')
-                .forEach(mismatch => {
-                  const mstart = feature.get('start') + mismatch.start
-                  const start = mstart
-                  const end = mstart + mismatch.length
-                  const strand = feature.get('strand')
-                  const hash = `${start}_${end}_${strand}`
-                  if (!skipmap[hash]) {
-                    skipmap[hash] = {
-                      feature: feature,
-                      start,
-                      end,
-                      strand,
-                      xs:
-                        feature.get('xs') ||
-                        feature.get('ts') ||
-                        feature.get('tags').XS ||
-                        feature.get('tags').TS,
-                      score: 1,
-                    }
-                  } else {
-                    skipmap[hash].score++
-                  }
-                })
             }
-          }
 
-          return bins
-        }, initBins),
+            // normal SNP based coloring
+            else {
+              const mismatches = feature.get('mismatches') as
+                | Mismatch[]
+                | undefined
+
+              if (mismatches) {
+                for (let i = 0; i < mismatches.length; i++) {
+                  const mismatch = mismatches[i]
+                  const mstart = fstart + mismatch.start
+                  for (
+                    let j = mstart;
+                    j < mstart + mismatchLen(mismatch);
+                    j++
+                  ) {
+                    const epos = j - region.start
+                    if (epos >= 0 && epos < bins.length) {
+                      const bin = bins[epos]
+                      const { base, type } = mismatch
+                      const interbase = isInterbase(type)
+                      if (!interbase) {
+                        dec(bin, fstrand, 'ref', 'ref')
+                      } else {
+                        inc(bin, fstrand, 'noncov', type)
+                      }
+
+                      if (type === 'deletion' || type === 'skip') {
+                        inc(bin, fstrand, 'delskips', type)
+                        bin.total--
+                      } else if (!interbase) {
+                        inc(bin, fstrand, 'cov', base)
+                      }
+                    }
+                  }
+                }
+
+                mismatches
+                  .filter(mismatch => mismatch.type === 'skip')
+                  .forEach(mismatch => {
+                    const mstart = feature.get('start') + mismatch.start
+                    const start = mstart
+                    const end = mstart + mismatch.length
+                    const strand = feature.get('strand')
+                    const hash = `${start}_${end}_${strand}`
+                    if (!skipmap[hash]) {
+                      skipmap[hash] = {
+                        feature: feature,
+                        start,
+                        end,
+                        strand,
+                        xs:
+                          feature.get('xs') ||
+                          feature.get('ts') ||
+                          feature.get('tags').XS ||
+                          feature.get('tags').TS,
+                        score: 1,
+                      }
+                    } else {
+                      skipmap[hash].score++
+                    }
+                  })
+              }
+            }
+
+            return bins
+          },
+          [] as {
+            total: number
+            lowqual: BinType
+            cov: BinType
+            delskips: BinType
+            noncov: BinType
+            ref: BinType
+          }[],
+        ),
       )
       .toPromise()
 


### PR DESCRIPTION
Fixes #2730 

Instead of pre-allocating the array, this PR uses a sparse array (that would fill up at particular positions as needed)

If interested, a speed comparison could be done for this, but in worst case scenarios like #2730 (where it tries to allocate a very large array that would ultimately be filled with nothing) this is effective in fixing the issue