### PR TITLE
Add better display of error state in dotplot view and load gzipped PAF files

### DIFF
--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -35,6 +35,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
+    "@gmod/bgzf-filehandle": "^1.4.2",
     "@material-ui/icons": "^4.9.1",
     "abortable-promise-cache": "^1.1.3",
     "clsx": "^1.0.0",

--- a/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
+++ b/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
@@ -16,16 +16,15 @@ const DotplotDisplay: React.FC<{
   const left = -(view.hview.offsetPx - offsetX)
   return (
     <div style={{ position: 'relative' }}>
-      <div
+      <model.ReactComponent2
+        {...props}
         style={{
           position: 'absolute',
           top,
           left,
         }}
-      >
-        <model.ReactComponent2 {...props} />
-        {children}
-      </div>
+      />
+      {children}
     </div>
   )
 }

--- a/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
+++ b/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import { getContainingView } from '@jbrowse/core/util'
 import { DotplotDisplayModel } from '..'
+import { DotplotViewModel } from '../../DotplotView/model'
 
 const DotplotDisplay: React.FC<{
   model: DotplotDisplayModel
@@ -9,8 +10,7 @@ const DotplotDisplay: React.FC<{
 }> = props => {
   const { model, children } = props
   const { offsetX = 0, offsetY = 0 } = model.data || {}
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const view = getContainingView(model) as any
+  const view = getContainingView(model) as DotplotViewModel
   const top = view.vview.offsetPx - offsetY
   const left = -(view.hview.offsetPx - offsetX)
   return (

--- a/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
+++ b/plugins/dotplot-view/src/DotplotDisplay/components/DotplotDisplay.tsx
@@ -1,6 +1,5 @@
-import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
-import PropTypes from 'prop-types'
 import React from 'react'
+import { observer } from 'mobx-react'
 import { getContainingView } from '@jbrowse/core/util'
 import { DotplotDisplayModel } from '..'
 
@@ -28,12 +27,5 @@ const DotplotDisplay: React.FC<{
     </div>
   )
 }
-DotplotDisplay.propTypes = {
-  model: MobxPropTypes.objectOrObservableObject.isRequired,
-  children: PropTypes.element,
-}
 
-DotplotDisplay.defaultProps = {
-  children: null,
-}
 export default observer(DotplotDisplay)

--- a/plugins/dotplot-view/src/DotplotDisplay/index.ts
+++ b/plugins/dotplot-view/src/DotplotDisplay/index.ts
@@ -70,7 +70,7 @@ export function stateModelFactory(configSchema: any) {
           message: undefined as string | undefined,
           renderingComponent: undefined as any,
           ReactComponent2:
-            ServerSideRenderedBlockContent as unknown as React.FC,
+            ServerSideRenderedBlockContent as unknown as React.FC<any>,
         })),
     )
     .views(self => ({

--- a/plugins/dotplot-view/src/DotplotDisplay/index.ts
+++ b/plugins/dotplot-view/src/DotplotDisplay/index.ts
@@ -5,6 +5,7 @@ import {
   ConfigurationReference,
   ConfigurationSchema,
 } from '@jbrowse/core/configuration'
+import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
 import {
   getParentRenderProps,
   getRpcSessionId,
@@ -16,12 +17,27 @@ import {
   getSession,
   makeAbortableReaction,
 } from '@jbrowse/core/util'
+import PluginManager from '@jbrowse/core/PluginManager'
 import React from 'react'
 
 import ServerSideRenderedBlockContent from '../ServerSideRenderedBlockContent'
 import { DotplotViewModel } from '../DotplotView/model'
 
-export { default as ReactComponent } from './components/DotplotDisplay'
+import ReactComponent from './components/DotplotDisplay'
+
+export default (pluginManager: PluginManager) => {
+  pluginManager.addDisplayType(() => {
+    const configSchema = configSchemaFactory(pluginManager)
+    return new DisplayType({
+      name: 'DotplotDisplay',
+      configSchema,
+      stateModel: stateModelFactory(configSchema),
+      trackType: 'SyntenyTrack',
+      viewType: 'DotplotView',
+      ReactComponent,
+    })
+  })
+}
 
 export function configSchemaFactory(pluginManager: any) {
   return ConfigurationSchema(

--- a/plugins/dotplot-view/src/DotplotReadVsRef.ts
+++ b/plugins/dotplot-view/src/DotplotReadVsRef.ts
@@ -1,0 +1,153 @@
+import {
+  getClip,
+  getTag,
+  getLengthOnRef,
+  getLength,
+  getLengthSansClipping,
+  gatherOverlaps,
+  ReducedFeature,
+} from './util'
+import { getConf } from '@jbrowse/core/configuration'
+import { getSession } from '@jbrowse/core/util'
+import { Feature } from '@jbrowse/core/util/simpleFeature'
+import { LinearPileupDisplayModel } from '@jbrowse/plugin-alignments'
+
+export function onClick(feature: Feature, self: LinearPileupDisplayModel) {
+  const session = getSession(self)
+  try {
+    const cigar = feature.get('CIGAR')
+    const clipPos = getClip(cigar, 1)
+    const flags = feature.get('flags')
+    const origStrand = feature.get('strand')
+    const readName = feature.get('name')
+    const readAssembly = `${readName}_assembly_${Date.now()}`
+    const { parentTrack } = self
+    const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
+    const assemblyNames = [trackAssembly, readAssembly]
+    const trackId = `track-${Date.now()}`
+    const trackName = `${readName}_vs_${trackAssembly}`
+    const SA: string = getTag(feature, 'SA') || ''
+    const SAs = SA.split(';')
+      .filter(aln => !!aln)
+      .map((aln, index) => {
+        const [saRef, saStart, saStrand, saCigar] = aln.split(',')
+        const saLengthOnRef = getLengthOnRef(saCigar)
+        const saLength = getLength(saCigar)
+        const saLengthSansClipping = getLengthSansClipping(saCigar)
+        const saStrandNormalized = saStrand === '-' ? -1 : 1
+        const saClipPos = getClip(saCigar, saStrandNormalized * origStrand)
+        const saRealStart = +saStart - 1
+        return {
+          refName: saRef,
+          start: saRealStart,
+          end: saRealStart + saLengthOnRef,
+          seqLength: saLength,
+          clipPos: saClipPos,
+          CIGAR: saCigar,
+          assemblyName: trackAssembly,
+          strand: origStrand * saStrandNormalized,
+          uniqueId: `${feature.id()}_SA${index}`,
+          mate: {
+            start: saClipPos,
+            end: saClipPos + saLengthSansClipping,
+            refName: readName,
+          },
+        }
+      })
+
+    const feat = feature.toJSON()
+    feat.strand = 1
+    feat.mate = {
+      refName: readName,
+      start: clipPos,
+      end: clipPos + getLengthSansClipping(cigar),
+    }
+
+    // if secondary alignment or supplementary, calculate length from SA[0]'s
+    // CIGAR which is the primary alignments. otherwise it is the primary
+    // alignment just use seq.length if primary alignment
+    const totalLength = getLength(flags & 2048 ? SAs[0].CIGAR : cigar)
+
+    const features = [feat, ...SAs] as ReducedFeature[]
+
+    features.sort((a, b) => a.clipPos - b.clipPos)
+
+    const refLength = features.reduce((a, f) => a + f.end - f.start, 0)
+
+    session.addView('DotplotView', {
+      type: 'DotplotView',
+      hview: {
+        offsetPx: 0,
+        bpPerPx: refLength / 800,
+        displayedRegions: gatherOverlaps(
+          features.map((f, index) => {
+            const { start, end, refName } = f
+            return {
+              start,
+              end,
+              refName,
+              index,
+              assemblyName: trackAssembly,
+            }
+          }),
+        ),
+      },
+      vview: {
+        offsetPx: 0,
+        bpPerPx: totalLength / 400,
+        minimumBlockWidth: 0,
+        interRegionPaddingWidth: 0,
+        displayedRegions: [
+          {
+            assemblyName: readAssembly,
+            start: 0,
+            end: totalLength,
+            refName: readName,
+          },
+        ],
+      },
+      viewTrackConfigs: [
+        {
+          type: 'SyntenyTrack',
+          assemblyNames,
+          adapter: {
+            type: 'FromConfigAdapter',
+            features,
+          },
+          trackId,
+          name: trackName,
+        },
+      ],
+      viewAssemblyConfigs: [
+        {
+          name: readAssembly,
+          sequence: {
+            type: 'ReferenceSequenceTrack',
+            trackId: `${readName}_${Date.now()}`,
+            adapter: {
+              type: 'FromConfigSequenceAdapter',
+              features: [feature.toJSON()],
+            },
+          },
+        },
+      ],
+      assemblyNames,
+      tracks: [
+        {
+          configuration: trackId,
+          type: 'SyntenyTrack',
+          displays: [
+            {
+              type: 'DotplotDisplay',
+              configuration: `${trackId}-DotplotDisplay`,
+            },
+          ],
+        },
+      ],
+      displayName: `${readName} vs ${trackAssembly}`,
+    })
+  } catch (e) {
+    console.error(e)
+    session.notify(`${e}`, 'error')
+  }
+}

--- a/plugins/dotplot-view/src/DotplotRenderer/index.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/index.ts
@@ -1,3 +1,16 @@
-export { default as ReactComponent } from './components/DotplotRendering'
-export { default as configSchema } from './configSchema'
-export { default } from './DotplotRenderer'
+import PluginManager from '@jbrowse/core/PluginManager'
+import ReactComponent from './components/DotplotRendering'
+import configSchema from './configSchema'
+import DotplotRenderer from './DotplotRenderer'
+
+export default (pluginManager: PluginManager) => {
+  pluginManager.addRendererType(
+    () =>
+      new DotplotRenderer({
+        name: 'DotplotRenderer',
+        configSchema: configSchema,
+        ReactComponent: ReactComponent,
+        pluginManager,
+      }),
+  )
+}

--- a/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
@@ -37,7 +37,10 @@ export const HorizontalAxis = observer(
       viewWidth,
       hview.offsetPx,
     )
-    const ticks = makeTicks(hview.staticBlocks.contentBlocks, hview.bpPerPx)
+    const ticks =
+      hview.staticBlocks.contentBlocks.length > 5
+        ? []
+        : makeTicks(hview.staticBlocks.contentBlocks, hview.bpPerPx)
     return (
       <svg width={viewWidth} height={borderY} className={classes.htext}>
         <g>
@@ -58,11 +61,12 @@ export const HorizontalAxis = observer(
                   dominantBaseline="hanging"
                   textAnchor="end"
                 >
-                  {`${region.refName}:${
-                    region.start !== 0
-                      ? Math.floor(region.start).toLocaleString('en-US')
-                      : ''
-                  }`}
+                  {[
+                    region.refName,
+                    region.start !== 0 ? Math.floor(region.start) : '',
+                  ]
+                    .filter(f => !!f)
+                    .join(':')}
                 </text>
               )
             })}
@@ -122,7 +126,10 @@ export const VerticalAxis = observer(
       viewHeight,
       vview.offsetPx,
     )
-    const ticks = makeTicks(vview.staticBlocks.contentBlocks, vview.bpPerPx)
+    const ticks =
+      vview.staticBlocks.contentBlocks.length > 5
+        ? []
+        : makeTicks(vview.staticBlocks.contentBlocks, vview.bpPerPx)
     return (
       <svg className={classes.vtext} width={borderX} height={viewHeight}>
         <g>
@@ -140,9 +147,12 @@ export const VerticalAxis = observer(
                   fill="#000000"
                   textAnchor="end"
                 >
-                  {`${region.refName}:${
-                    region.start !== 0 ? Math.floor(region.start) : ''
-                  }`}
+                  {[
+                    region.refName,
+                    region.start !== 0 ? Math.floor(region.start) : '',
+                  ]
+                    .filter(f => !!f)
+                    .join(':')}
                 </text>
               )
             })}

--- a/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
@@ -43,76 +43,73 @@ export const HorizontalAxis = observer(
         : makeTicks(hview.staticBlocks.contentBlocks, hview.bpPerPx)
     return (
       <svg width={viewWidth} height={borderY} className={classes.htext}>
-        <g>
-          {hview.dynamicBlocks.contentBlocks
-            .filter(region => !hide.includes(region.key))
-            .map(region => {
-              const x = region.offsetPx
-              const y = 0
-              return (
-                <text
-                  transform={`rotate(${htextRotation},${
-                    x - hview.offsetPx
-                  },${y})`}
-                  key={JSON.stringify(region)}
-                  x={x - hview.offsetPx}
-                  y={y + 1}
-                  fill="#000000"
-                  dominantBaseline="hanging"
-                  textAnchor="end"
-                >
-                  {[
-                    region.refName,
-                    region.start !== 0 ? Math.floor(region.start) : '',
-                  ]
-                    .filter(f => !!f)
-                    .join(':')}
-                </text>
-              )
-            })}
-          {ticks.map(tick => {
+        {hview.dynamicBlocks.contentBlocks
+          .filter(region => !hide.includes(region.key))
+          .map(region => {
+            const x = region.offsetPx
+            const y = 0
+            const xoff = x - hview.offsetPx
+            return (
+              <text
+                transform={`rotate(${htextRotation},${xoff},${y})`}
+                key={JSON.stringify(region)}
+                x={xoff}
+                y={y + 1}
+                fill="#000000"
+                dominantBaseline="hanging"
+                textAnchor="end"
+              >
+                {[
+                  region.refName,
+                  region.start !== 0 ? Math.floor(region.start) : '',
+                ]
+                  .filter(f => !!f)
+                  .join(':')}
+              </text>
+            )
+          })}
+        {ticks.map(tick => {
+          const x =
+            (hview.bpToPx({ refName: tick.refName, coord: tick.base }) || 0) -
+            hview.offsetPx
+          return (
+            <line
+              key={`line-${JSON.stringify(tick)}`}
+              x1={x}
+              x2={x}
+              y1={0}
+              y2={tick.type === 'major' ? 6 : 4}
+              strokeWidth={1}
+              stroke={tick.type === 'major' ? '#555' : '#999'}
+              className={
+                tick.type === 'major' ? classes.majorTick : classes.minorTick
+              }
+              data-bp={tick.base}
+            />
+          )
+        })}
+        {ticks
+          .filter(tick => tick.type === 'major')
+          .map(tick => {
             const x =
               (hview.bpToPx({ refName: tick.refName, coord: tick.base }) || 0) -
               hview.offsetPx
+            const y = 0
             return (
-              <line
-                key={`line-${JSON.stringify(tick)}`}
-                x1={x}
-                x2={x}
-                y1={0}
-                y2={tick.type === 'major' ? 6 : 4}
-                strokeWidth={1}
-                stroke={tick.type === 'major' ? '#555' : '#999'}
-                className={
-                  tick.type === 'major' ? classes.majorTick : classes.minorTick
-                }
-                data-bp={tick.base}
-              />
+              <text
+                x={x - 7}
+                y={y}
+                transform={`rotate(${htextRotation},${x},${y})`}
+                key={`text-${JSON.stringify(tick)}`}
+                style={{ fontSize: '11px' }}
+                className={classes.majorTickLabel}
+                dominantBaseline="middle"
+                textAnchor="end"
+              >
+                {(tick.base + 1).toLocaleString('en-US')}
+              </text>
             )
           })}
-          {ticks
-            .filter(tick => tick.type === 'major')
-            .map(tick => {
-              const x =
-                (hview.bpToPx({ refName: tick.refName, coord: tick.base }) ||
-                  0) - hview.offsetPx
-              const y = 0
-              return (
-                <text
-                  x={x - 7}
-                  y={y}
-                  transform={`rotate(${htextRotation},${x},${y})`}
-                  key={`text-${JSON.stringify(tick)}`}
-                  style={{ fontSize: '11px' }}
-                  className={classes.majorTickLabel}
-                  dominantBaseline="middle"
-                  textAnchor="end"
-                >
-                  {(tick.base + 1).toLocaleString('en-US')}
-                </text>
-              )
-            })}
-        </g>
       </svg>
     )
   },
@@ -132,71 +129,69 @@ export const VerticalAxis = observer(
         : makeTicks(vview.staticBlocks.contentBlocks, vview.bpPerPx)
     return (
       <svg className={classes.vtext} width={borderX} height={viewHeight}>
-        <g>
-          {vview.dynamicBlocks.contentBlocks
-            .filter(region => !hide.includes(region.key))
-            .map(region => {
-              const y = region.offsetPx
-              const x = borderX
-              return (
-                <text
-                  transform={`rotate(${vtextRotation},${x},${y})`}
-                  key={JSON.stringify(region)}
-                  x={borderX}
-                  y={viewHeight - y + vview.offsetPx}
-                  fill="#000000"
-                  textAnchor="end"
-                >
-                  {[
-                    region.refName,
-                    region.start !== 0 ? Math.floor(region.start) : '',
-                  ]
-                    .filter(f => !!f)
-                    .join(':')}
-                </text>
-              )
-            })}
-          {ticks.map(tick => {
+        {vview.dynamicBlocks.contentBlocks
+          .filter(region => !hide.includes(region.key))
+          .map(region => {
+            const y = region.offsetPx
+            const x = borderX
+            return (
+              <text
+                transform={`rotate(${vtextRotation},${x},${y})`}
+                key={JSON.stringify(region)}
+                x={x}
+                y={viewHeight - y + vview.offsetPx}
+                fill="#000000"
+                textAnchor="end"
+              >
+                {[
+                  region.refName,
+                  region.start !== 0 ? Math.floor(region.start) : '',
+                ]
+                  .filter(f => !!f)
+                  .join(':')}
+              </text>
+            )
+          })}
+        {ticks.map(tick => {
+          const y =
+            (vview.bpToPx({ refName: tick.refName, coord: tick.base }) || 0) -
+            vview.offsetPx
+          return (
+            <line
+              key={`line-${JSON.stringify(tick)}`}
+              y1={viewHeight - y}
+              y2={viewHeight - y}
+              x1={borderX}
+              x2={borderX - (tick.type === 'major' ? 6 : 4)}
+              strokeWidth={1}
+              stroke={tick.type === 'major' ? '#555' : '#999'}
+              className={
+                tick.type === 'major' ? classes.majorTick : classes.minorTick
+              }
+              data-bp={tick.base}
+            />
+          )
+        })}
+        {ticks
+          .filter(tick => tick.type === 'major')
+          .map(tick => {
             const y =
               (vview.bpToPx({ refName: tick.refName, coord: tick.base }) || 0) -
               vview.offsetPx
             return (
-              <line
-                key={`line-${JSON.stringify(tick)}`}
-                y1={viewHeight - y}
-                y2={viewHeight - y}
-                x1={borderX}
-                x2={borderX - (tick.type === 'major' ? 6 : 4)}
-                strokeWidth={1}
-                stroke={tick.type === 'major' ? '#555' : '#999'}
-                className={
-                  tick.type === 'major' ? classes.majorTick : classes.minorTick
-                }
-                data-bp={tick.base}
-              />
+              <text
+                y={viewHeight - y - 3}
+                x={borderX - 7}
+                key={`text-${JSON.stringify(tick)}`}
+                textAnchor="end"
+                dominantBaseline="hanging"
+                style={{ fontSize: '11px' }}
+                className={classes.majorTickLabel}
+              >
+                {(tick.base + 1).toLocaleString('en-US')}
+              </text>
             )
           })}
-          {ticks
-            .filter(tick => tick.type === 'major')
-            .map(tick => {
-              const y =
-                (vview.bpToPx({ refName: tick.refName, coord: tick.base }) ||
-                  0) - vview.offsetPx
-              return (
-                <text
-                  y={viewHeight - y - 3}
-                  x={borderX - 7}
-                  key={`text-${JSON.stringify(tick)}`}
-                  textAnchor="end"
-                  dominantBaseline="hanging"
-                  style={{ fontSize: '11px' }}
-                  className={classes.majorTickLabel}
-                >
-                  {(tick.base + 1).toLocaleString('en-US')}
-                </text>
-              )
-            })}
-        </g>
       </svg>
     )
   },

--- a/plugins/dotplot-view/src/DotplotView/index.ts
+++ b/plugins/dotplot-view/src/DotplotView/index.ts
@@ -1,0 +1,15 @@
+import { lazy } from 'react'
+import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
+import PluginManager from '@jbrowse/core/PluginManager'
+// locals
+import stateModelFactory from './model'
+
+export default function (pluginManager: PluginManager) {
+  pluginManager.addViewType(() => {
+    return new ViewType({
+      name: 'DotplotView',
+      stateModel: stateModelFactory(pluginManager),
+      ReactComponent: lazy(() => import('./components/DotplotView')),
+    })
+  })
+}

--- a/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.test.ts
+++ b/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.test.ts
@@ -2,6 +2,15 @@ import { toArray } from 'rxjs/operators'
 import Adapter from './PAFAdapter'
 import MyConfigSchema from './configSchema'
 
+import { TextEncoder, TextDecoder } from 'web-encoding'
+
+if (!window.TextEncoder) {
+  window.TextEncoder = TextEncoder
+}
+if (!window.TextDecoder) {
+  window.TextDecoder = TextDecoder
+}
+
 test('adapter can fetch features from peach_grape.paf', async () => {
   const adapter = new Adapter(
     MyConfigSchema.create({

--- a/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
@@ -125,7 +125,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
           const { extra, records } = pafRecords[i]
           const { start, end, refName } = records[index]
           if (
-            records[index].refName === region.refName &&
+            refName === region.refName &&
             doesIntersect2(region.start, region.end, start, end)
           ) {
             observer.next(

--- a/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/dotplot-view/src/PAFAdapter/PAFAdapter.ts
@@ -8,6 +8,7 @@ import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
+import { unzip } from '@gmod/bgzf-filehandle'
 
 interface PafRecord {
   records: NoAssemblyRegion[]
@@ -17,6 +18,10 @@ interface PafRecord {
     numMatches: number
     strand: number
   }
+}
+
+function isGzip(buf: Buffer) {
+  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
 }
 
 export default class PAFAdapter extends BaseFeatureDataAdapter {
@@ -39,10 +44,13 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
       readConfObject(this.config, 'pafLocation'),
       this.pluginManager,
     )
-    const text = await pafLocation.readFile({
-      encoding: 'utf8',
-      ...opts,
-    })
+    const buffer = (await pafLocation.readFile(opts)) as Buffer
+    const buf = isGzip(buffer) ? await unzip(buffer) : buffer
+    // 512MB  max chrome string length is 512MB
+    if (buf.length > 536_870_888) {
+      throw new Error('Data exceeds maximum string length (512MB)')
+    }
+    const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
 
     // mashmap produces PAF-like data that is space separated instead of tab
     const hasTab = text.indexOf('\t')

--- a/plugins/dotplot-view/src/PAFAdapter/index.ts
+++ b/plugins/dotplot-view/src/PAFAdapter/index.ts
@@ -1,2 +1,22 @@
-export { default as AdapterClass } from './PAFAdapter'
-export { default as configSchema } from './configSchema'
+import PluginManager from '@jbrowse/core/PluginManager'
+import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
+
+import AdapterClass from './PAFAdapter'
+import configSchema from './configSchema'
+
+export default (pluginManager: PluginManager) => {
+  pluginManager.addAdapterType(
+    () =>
+      new AdapterType({
+        name: 'PAFAdapter',
+        configSchema,
+        adapterMetadata: {
+          category: null,
+          hiddenFromGUI: true,
+          displayName: null,
+          description: null,
+        },
+        AdapterClass,
+      }),
+  )
+}

--- a/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
@@ -10,17 +10,9 @@ const useStyles = makeStyles({
     backgroundColor: '#f1f1f1',
     backgroundImage:
       'repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(255,255,255,.5) 5px, rgba(255,255,255,.5) 10px)',
-    height: '100%',
-    width: '100%',
     textAlign: 'center',
   },
-  error: {
-    display: 'block',
-    color: 'red',
-    width: '30em',
-    wordWrap: 'normal',
-    whiteSpace: 'normal',
-  },
+
   blockMessage: {
     background: '#f1f1f1',
     padding: '10px',
@@ -57,9 +49,6 @@ function BlockMessage({ messageText }: { messageText: string }) {
     </div>
   )
 }
-BlockMessage.propTypes = {
-  messageText: PropTypes.string.isRequired,
-}
 
 function BlockError({ error }: { error: Error }) {
   const classes = useStyles()
@@ -71,17 +60,19 @@ function BlockError({ error }: { error: Error }) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ServerSideRenderedBlockContent = observer(({ model }: { model: any }) => {
-  if (model.error) {
-    return <BlockError error={model.error} data-testid="reload_button" />
-  }
-  if (model.message) {
-    return <BlockMessage messageText={model.message} />
-  }
-  if (!model.filled) {
-    return <LoadingMessage />
-  }
-  return model.reactElement
-})
+const ServerSideRenderedBlockContent = observer(
+  ({ model, style }: { model: any; style: any }) => {
+    if (model.error) {
+      return <BlockError error={model.error} data-testid="reload_button" />
+    }
+    if (model.message) {
+      return <BlockMessage messageText={model.message} />
+    }
+    if (!model.filled) {
+      return <LoadingMessage />
+    }
+    return <div style={style}>{model.reactElement}</div>
+  },
+)
 
 export default ServerSideRenderedBlockContent

--- a/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { Typography, LinearProgress } from '@material-ui/core'
 import { observer } from 'mobx-react'
-import PropTypes from 'prop-types'
 
 const useStyles = makeStyles({
   loading: {
@@ -59,8 +58,8 @@ function BlockError({ error }: { error: Error }) {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ServerSideRenderedBlockContent = observer(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ({ model, style }: { model: any; style: any }) => {
     if (model.error) {
       return <BlockError error={model.error} data-testid="reload_button" />

--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -1,37 +1,19 @@
-import { lazy } from 'react'
 import Plugin from '@jbrowse/core/Plugin'
-import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
-import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
 
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
+import DisplayType from '@jbrowse/core/pluggableElementTypes/DisplayType'
+import DotplotViewF from './DotplotView'
+import DotplotDisplayF from './DotplotDisplay'
+import PAFAdapterF from './PAFAdapter'
+import DotplotRendererF from './DotplotRenderer'
+
 import AddIcon from '@material-ui/icons/Add'
 import PluginManager from '@jbrowse/core/PluginManager'
-import {
-  AbstractSessionModel,
-  isAbstractMenuManager,
-  getSession,
-} from '@jbrowse/core/util'
+import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
 
-import { getConf } from '@jbrowse/core/configuration'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
 import TimelineIcon from '@material-ui/icons/Timeline'
-import { MismatchParser } from '@jbrowse/plugin-alignments'
 import { FileLocation } from '@jbrowse/core/util/types'
-import {
-  configSchemaFactory as dotplotDisplayConfigSchemaFactory,
-  stateModelFactory as dotplotDisplayStateModelFactory,
-  ReactComponent as DotplotDisplayReactComponent,
-} from './DotplotDisplay'
-import DotplotRenderer, {
-  configSchema as dotplotRendererConfigSchema,
-  ReactComponent as DotplotRendererReactComponent,
-} from './DotplotRenderer'
-import stateModelFactory from './DotplotView/model'
 
-import {
-  configSchema as PAFAdapterConfigSchema,
-  AdapterClass as PAFAdapter,
-} from './PAFAdapter'
 import ComparativeRender from './DotplotRenderer/ComparativeRenderRpc'
 import { PluggableElementType } from '@jbrowse/core/pluggableElementTypes'
 import { LinearPileupDisplayModel } from '@jbrowse/plugin-alignments'
@@ -41,319 +23,17 @@ import {
   TrackTypeGuesser,
 } from '@jbrowse/core/util/tracks'
 
-const { parseCigar } = MismatchParser
-
-function getLengthOnRef(cigar: string) {
-  const cigarOps = parseCigar(cigar)
-  let lengthOnRef = 0
-  for (let i = 0; i < cigarOps.length; i += 2) {
-    const len = +cigarOps[i]
-    const op = cigarOps[i + 1]
-    if (op !== 'H' && op !== 'S' && op !== 'I') {
-      lengthOnRef += len
-    }
-  }
-  return lengthOnRef
-}
-
-function getLength(cigar: string) {
-  const cigarOps = parseCigar(cigar)
-  let length = 0
-  for (let i = 0; i < cigarOps.length; i += 2) {
-    const len = +cigarOps[i]
-    const op = cigarOps[i + 1]
-    if (op !== 'D' && op !== 'N') {
-      length += len
-    }
-  }
-  return length
-}
-
-function getLengthSansClipping(cigar: string) {
-  const cigarOps = parseCigar(cigar)
-  let length = 0
-  for (let i = 0; i < cigarOps.length; i += 2) {
-    const len = +cigarOps[i]
-    const op = cigarOps[i + 1]
-    if (op !== 'H' && op !== 'S' && op !== 'D' && op !== 'N') {
-      length += len
-    }
-  }
-  return length
-}
-
-function getClip(cigar: string, strand: number) {
-  return strand === -1
-    ? +(cigar.match(/(\d+)[SH]$/) || [])[1] || 0
-    : +(cigar.match(/^(\d+)([SH])/) || [])[1] || 0
-}
-
-function getTag(f: Feature, tag: string) {
-  const tags = f.get('tags')
-  return tags ? tags[tag] : f.get(tag)
-}
-
-function mergeIntervals<T extends { start: number; end: number }>(
-  intervals: T[],
-  w = 5000,
-) {
-  // test if there are at least 2 intervals
-  if (intervals.length <= 1) {
-    return intervals
-  }
-
-  const stack = []
-  let top = null
-
-  // sort the intervals based on their start values
-  intervals = intervals.sort((a, b) => a.start - b.start)
-
-  // push the 1st interval into the stack
-  stack.push(intervals[0])
-
-  // start from the next interval and merge if needed
-  for (let i = 1; i < intervals.length; i++) {
-    // get the top element
-    top = stack[stack.length - 1]
-
-    // if the current interval doesn't overlap with the
-    // stack top element, push it to the stack
-    if (top.end + w < intervals[i].start - w) {
-      stack.push(intervals[i])
-    }
-    // otherwise update the end value of the top element
-    // if end of current interval is higher
-    else if (top.end < intervals[i].end) {
-      top.end = Math.max(top.end, intervals[i].end)
-      stack.pop()
-      stack.push(top)
-    }
-  }
-
-  return stack
-}
-
-interface BasicFeature {
-  end: number
-  start: number
-  refName: string
-}
-
-function gatherOverlaps(regions: BasicFeature[]) {
-  const groups = regions.reduce((memo, x) => {
-    if (!memo[x.refName]) {
-      memo[x.refName] = []
-    }
-    memo[x.refName].push(x)
-    return memo
-  }, {} as { [key: string]: BasicFeature[] })
-
-  return Object.values(groups)
-    .map(group => mergeIntervals(group.sort((a, b) => a.start - b.start)))
-    .flat()
-}
-
-interface ReducedFeature {
-  refName: string
-  start: number
-  clipPos: number
-  end: number
-  seqLength: number
-}
-
-function onClick(feature: Feature, self: LinearPileupDisplayModel) {
-  const session = getSession(self)
-  try {
-    const cigar = feature.get('CIGAR')
-    const clipPos = getClip(cigar, 1)
-    const flags = feature.get('flags')
-    const origStrand = feature.get('strand')
-    const readName = feature.get('name')
-    const readAssembly = `${readName}_assembly_${Date.now()}`
-    const { parentTrack } = self
-    const [trackAssembly] = getConf(parentTrack, 'assemblyNames')
-    const assemblyNames = [trackAssembly, readAssembly]
-    const trackId = `track-${Date.now()}`
-    const trackName = `${readName}_vs_${trackAssembly}`
-    const SA: string = getTag(feature, 'SA') || ''
-    const supplementaryAlignments = SA.split(';')
-      .filter(aln => !!aln)
-      .map((aln, index) => {
-        const [saRef, saStart, saStrand, saCigar] = aln.split(',')
-        const saLengthOnRef = getLengthOnRef(saCigar)
-        const saLength = getLength(saCigar)
-        const saLengthSansClipping = getLengthSansClipping(saCigar)
-        const saStrandNormalized = saStrand === '-' ? -1 : 1
-        const saClipPos = getClip(saCigar, saStrandNormalized * origStrand)
-        const saRealStart = +saStart - 1
-        return {
-          refName: saRef,
-          start: saRealStart,
-          end: saRealStart + saLengthOnRef,
-          seqLength: saLength,
-          clipPos: saClipPos,
-          CIGAR: saCigar,
-          assemblyName: trackAssembly,
-          strand: origStrand * saStrandNormalized,
-          uniqueId: `${feature.id()}_SA${index}`,
-          mate: {
-            start: saClipPos,
-            end: saClipPos + saLengthSansClipping,
-            refName: readName,
-          },
-        }
-      })
-
-    const feat = feature.toJSON()
-    feat.strand = 1
-    feat.mate = {
-      refName: readName,
-      start: clipPos,
-      end: clipPos + getLengthSansClipping(cigar),
-    }
-
-    // if secondary alignment or supplementary, calculate length
-    // from SA[0]'s CIGAR which is the primary alignments.
-    // otherwise it is the primary alignment just use seq.length if
-    // primary alignment
-    const totalLength = getLength(
-      flags & 2048 ? supplementaryAlignments[0].CIGAR : cigar,
-    )
-
-    const features = [feat, ...supplementaryAlignments] as ReducedFeature[]
-
-    features.sort((a, b) => a.clipPos - b.clipPos)
-
-    const refLength = features.reduce((a, f) => a + f.end - f.start, 0)
-
-    session.addView('DotplotView', {
-      type: 'DotplotView',
-      hview: {
-        offsetPx: 0,
-        bpPerPx: refLength / 800,
-        displayedRegions: gatherOverlaps(
-          features.map((f, index) => {
-            const { start, end, refName } = f
-            return {
-              start,
-              end,
-              refName,
-              index,
-              assemblyName: trackAssembly,
-            }
-          }),
-        ),
-      },
-      vview: {
-        offsetPx: 0,
-        bpPerPx: totalLength / 400,
-        minimumBlockWidth: 0,
-        interRegionPaddingWidth: 0,
-        displayedRegions: [
-          {
-            assemblyName: readAssembly,
-            start: 0,
-            end: totalLength,
-            refName: readName,
-          },
-        ],
-      },
-      viewTrackConfigs: [
-        {
-          type: 'SyntenyTrack',
-          assemblyNames,
-          adapter: {
-            type: 'FromConfigAdapter',
-            features,
-          },
-          trackId,
-          name: trackName,
-        },
-      ],
-      viewAssemblyConfigs: [
-        {
-          name: readAssembly,
-          sequence: {
-            type: 'ReferenceSequenceTrack',
-            trackId: `${readName}_${Date.now()}`,
-            adapter: {
-              type: 'FromConfigSequenceAdapter',
-              features: [feature.toJSON()],
-            },
-          },
-        },
-      ],
-      assemblyNames,
-      tracks: [
-        {
-          configuration: trackId,
-          type: 'SyntenyTrack',
-          displays: [
-            {
-              type: 'DotplotDisplay',
-              configuration: `${trackId}-DotplotDisplay`,
-            },
-          ],
-        },
-      ],
-      displayName: `${readName} vs ${trackAssembly}`,
-    })
-  } catch (e) {
-    console.error(e)
-    session.notify(`${e}`, 'error')
-  }
-}
+import { onClick } from './DotplotReadVsRef'
 
 export default class DotplotPlugin extends Plugin {
   name = 'DotplotPlugin'
 
   install(pluginManager: PluginManager) {
-    pluginManager.addViewType(() => {
-      return new ViewType({
-        name: 'DotplotView',
-        stateModel: stateModelFactory(pluginManager),
-        ReactComponent: lazy(
-          () => import('./DotplotView/components/DotplotView'),
-        ),
-      })
-    })
+    DotplotViewF(pluginManager)
+    DotplotDisplayF(pluginManager)
+    DotplotRendererF(pluginManager)
+    PAFAdapterF(pluginManager)
 
-    pluginManager.addDisplayType(() => {
-      const configSchema = dotplotDisplayConfigSchemaFactory(pluginManager)
-      return new DisplayType({
-        name: 'DotplotDisplay',
-        configSchema,
-        stateModel: dotplotDisplayStateModelFactory(configSchema),
-        trackType: 'SyntenyTrack',
-        viewType: 'DotplotView',
-        ReactComponent: DotplotDisplayReactComponent,
-      })
-    })
-
-    pluginManager.addRendererType(
-      () =>
-        new DotplotRenderer({
-          name: 'DotplotRenderer',
-          configSchema: dotplotRendererConfigSchema,
-          ReactComponent: DotplotRendererReactComponent,
-          pluginManager,
-        }),
-    )
-
-    pluginManager.addAdapterType(
-      () =>
-        new AdapterType({
-          name: 'PAFAdapter',
-          configSchema: PAFAdapterConfigSchema,
-          adapterMetadata: {
-            category: null,
-            hiddenFromGUI: true,
-            displayName: null,
-            description: null,
-          },
-          AdapterClass: PAFAdapter,
-        }),
-    )
     pluginManager.addToExtensionPoint(
       'Core-guessAdapterForLocation',
       (adapterGuesser: AdapterGuesser) => {

--- a/plugins/dotplot-view/src/util.ts
+++ b/plugins/dotplot-view/src/util.ts
@@ -1,5 +1,5 @@
 import { MismatchParser } from '@jbrowse/plugin-alignments'
-import { Feature } from '@jbrowse/core/util'
+import { Feature } from '@jbrowse/core/util/simpleFeature'
 const { parseCigar } = MismatchParser
 
 export function getLengthOnRef(cigar: string) {

--- a/plugins/dotplot-view/src/util.ts
+++ b/plugins/dotplot-view/src/util.ts
@@ -1,0 +1,124 @@
+import { MismatchParser } from '@jbrowse/plugin-alignments'
+import { Feature } from '@jbrowse/core/util'
+const { parseCigar } = MismatchParser
+
+export function getLengthOnRef(cigar: string) {
+  const cigarOps = parseCigar(cigar)
+  let lengthOnRef = 0
+  for (let i = 0; i < cigarOps.length; i += 2) {
+    const len = +cigarOps[i]
+    const op = cigarOps[i + 1]
+    if (op !== 'H' && op !== 'S' && op !== 'I') {
+      lengthOnRef += len
+    }
+  }
+  return lengthOnRef
+}
+
+export function getLength(cigar: string) {
+  const cigarOps = parseCigar(cigar)
+  let length = 0
+  for (let i = 0; i < cigarOps.length; i += 2) {
+    const len = +cigarOps[i]
+    const op = cigarOps[i + 1]
+    if (op !== 'D' && op !== 'N') {
+      length += len
+    }
+  }
+  return length
+}
+
+export function getLengthSansClipping(cigar: string) {
+  const cigarOps = parseCigar(cigar)
+  let length = 0
+  for (let i = 0; i < cigarOps.length; i += 2) {
+    const len = +cigarOps[i]
+    const op = cigarOps[i + 1]
+    if (op !== 'H' && op !== 'S' && op !== 'D' && op !== 'N') {
+      length += len
+    }
+  }
+  return length
+}
+
+export function getClip(cigar: string, strand: number) {
+  return strand === -1
+    ? +(cigar.match(/(\d+)[SH]$/) || [])[1] || 0
+    : +(cigar.match(/^(\d+)([SH])/) || [])[1] || 0
+}
+
+export function getTag(f: Feature, tag: string) {
+  const tags = f.get('tags')
+  return tags ? tags[tag] : f.get(tag)
+}
+
+interface Interval {
+  start: number
+  end: number
+}
+
+// source https://gist.github.com/vrachieru/5649bce26004d8a4682b
+export function mergeIntervals<T extends Interval>(intervals: T[], w = 5000) {
+  // test if there are at least 2 intervals
+  if (intervals.length <= 1) {
+    return intervals
+  }
+
+  const stack = []
+  let top = null
+
+  // sort the intervals based on their start values
+  intervals = intervals.sort((a, b) => a.start - b.start)
+
+  // push the 1st interval into the stack
+  stack.push(intervals[0])
+
+  // start from the next interval and merge if needed
+  for (let i = 1; i < intervals.length; i++) {
+    // get the top element
+    top = stack[stack.length - 1]
+
+    // if the current interval doesn't overlap with the
+    // stack top element, push it to the stack
+    if (top.end + w < intervals[i].start - w) {
+      stack.push(intervals[i])
+    }
+    // otherwise update the end value of the top element
+    // if end of current interval is higher
+    else if (top.end < intervals[i].end) {
+      top.end = Math.max(top.end, intervals[i].end)
+      stack.pop()
+      stack.push(top)
+    }
+  }
+
+  return stack
+}
+
+export interface BasicFeature {
+  end: number
+  start: number
+  refName: string
+}
+
+export function gatherOverlaps(regions: BasicFeature[]) {
+  const groups = regions.reduce((memo, x) => {
+    if (!memo[x.refName]) {
+      memo[x.refName] = []
+    }
+    memo[x.refName].push(x)
+    return memo
+  }, {} as { [key: string]: BasicFeature[] })
+
+  return Object.values(groups)
+    .map(group => mergeIntervals(group.sort((a, b) => a.start - b.start)))
+    .flat()
+}
+
+export interface ReducedFeature {
+  refName: string
+  start: number
+  clipPos: number
+  end: number
+  seqLength: number
+}

--- a/products/jbrowse-predefined-sessions/sessions.json
+++ b/products/jbrowse-predefined-sessions/sessions.json
@@ -535,58 +535,5 @@
     "defaultSession": {
       "name": "New Session"
     }
-  },
-  "t2t-chm13-v1.1": {
-    "assemblies": [
-      {
-        "name": "t2t-chm13-v1.1",
-        "displayName": "Homo sapiens (t2t-chm13-v1.1)",
-        "sequence": {
-          "type": "ReferenceSequenceTrack",
-          "trackId": "t2t-chm13-v1.1-asm",
-          "adapter": {
-            "type": "BgzipFastaAdapter",
-            "fastaLocation": {
-              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz",
-              "locationType": "UriLocation"
-            },
-            "faiLocation": {
-              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.fai",
-              "locationType": "UriLocation"
-            },
-            "gziLocation": {
-              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.gzi",
-              "locationType": "UriLocation"
-            }
-          }
-        }
-      }
-    ],
-    "tracks": [
-      {
-        "type": "FeatureTrack",
-        "trackId": "genes",
-        "name": "Gene annotation v4",
-        "category": ["Annotation"],
-        "assemblyNames": ["t2t-chm13-v1.1"],
-        "adapter": {
-          "type": "Gff3TabixAdapter",
-          "gffGzLocation": {
-            "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz",
-            "locationType": "UriLocation"
-          },
-          "index": {
-            "location": {
-              "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz.tbi",
-              "locationType": "UriLocation"
-            },
-            "indexType": "TBI"
-          }
-        }
-      }
-    ],
-    "defaultSession": {
-      "name": "New Session"
-    }
   }
 }

--- a/products/jbrowse-predefined-sessions/sessions.json
+++ b/products/jbrowse-predefined-sessions/sessions.json
@@ -535,5 +535,58 @@
     "defaultSession": {
       "name": "New Session"
     }
+  },
+  "t2t-chm13-v1.1": {
+    "assemblies": [
+      {
+        "name": "t2t-chm13-v1.1",
+        "displayName": "Homo sapiens (t2t-chm13-v1.1)",
+        "sequence": {
+          "type": "ReferenceSequenceTrack",
+          "trackId": "t2t-chm13-v1.1-asm",
+          "adapter": {
+            "type": "BgzipFastaAdapter",
+            "fastaLocation": {
+              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz",
+              "locationType": "UriLocation"
+            },
+            "faiLocation": {
+              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.fai",
+              "locationType": "UriLocation"
+            },
+            "gziLocation": {
+              "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.gzi",
+              "locationType": "UriLocation"
+            }
+          }
+        }
+      }
+    ],
+    "tracks": [
+      {
+        "type": "FeatureTrack",
+        "trackId": "genes",
+        "name": "Gene annotation v4",
+        "category": ["Annotation"],
+        "assemblyNames": ["t2t-chm13-v1.1"],
+        "adapter": {
+          "type": "Gff3TabixAdapter",
+          "gffGzLocation": {
+            "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz",
+            "locationType": "UriLocation"
+          },
+          "index": {
+            "location": {
+              "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz.tbi",
+              "locationType": "UriLocation"
+            },
+            "indexType": "TBI"
+          }
+        }
+      }
+    ],
+    "defaultSession": {
+      "name": "New Session"
+    }
   }
 }

--- a/products/jbrowse-web/src/tests/Dotplot.test.js
+++ b/products/jbrowse-web/src/tests/Dotplot.test.js
@@ -5,8 +5,9 @@ import { LocalFile } from 'generic-filehandle'
 import { clearCache } from '@jbrowse/core/util/io/RemoteFileWithRangeCache'
 import { clearAdapterCache } from '@jbrowse/core/data_adapters/dataAdapterCache'
 import { toMatchImageSnapshot } from 'jest-image-snapshot'
-import dotplotConfig from '../../test_data/config_dotplot.json'
+import { TextEncoder, TextDecoder } from 'web-encoding'
 
+import dotplotConfig from '../../test_data/config_dotplot.json'
 import {
   JBrowse,
   setup,
@@ -15,6 +16,12 @@ import {
   getPluginManager,
 } from './util'
 
+if (!window.TextEncoder) {
+  window.TextEncoder = TextEncoder
+}
+if (!window.TextDecoder) {
+  window.TextDecoder = TextDecoder
+}
 dotplotConfig.configuration = {
   rpc: {
     defaultDriver: 'MainThreadRpcDriver',

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -69,7 +69,7 @@ const readBuffer = async (url: string, args: RequestInit) => {
   }
   try {
     const file = getFile(url)
-    const maxRangeRequest = 1000000 // kind of arbitrary, part of the rangeParser
+    const maxRangeRequest = 2000000 // kind of arbitrary, part of the rangeParser
     if (args.headers && 'range' in args.headers) {
       const range = rangeParser(maxRangeRequest, args.headers.range)
       if (range === -2 || range === -1) {
@@ -139,8 +139,8 @@ describe('<Loader />', () => {
       </QueryParamProvider>,
     )
 
-    await findByText('Help')
-  })
+    await findByText('Help', {}, { timeout: 20000 })
+  }, 20000)
 
   it('can use config from a url with shared session ', async () => {
     const { findByText } = render(
@@ -155,7 +155,7 @@ describe('<Loader />', () => {
       </QueryParamProvider>,
     )
 
-    await findByText('Help')
+    await findByText('Help', {}, { timeout: 20000 })
     await waitFor(
       () => {
         expect(sessionStorage.length).toBeGreaterThan(0)
@@ -201,7 +201,7 @@ describe('<Loader />', () => {
       </QueryParamProvider>,
     )
     await findByTestId('session-warning-modal')
-  }, 10000)
+  }, 20000)
 
   it('can use config from a url with nonexistent share param ', async () => {
     const { findAllByText } = render(
@@ -217,8 +217,8 @@ describe('<Loader />', () => {
         </QueryParamProvider>
       </ErrorBoundary>,
     )
-    await findAllByText(/Error/)
-  }, 10000)
+    await findAllByText(/Error/, {}, { timeout: 20000 })
+  }, 20000)
 
   it('can catch error from loading a bad config', async () => {
     const { findAllByText } = render(
@@ -235,7 +235,7 @@ describe('<Loader />', () => {
       </ErrorBoundary>,
     )
     await findAllByText(/Failed to load/)
-  }, 10000)
+  }, 20000)
 
   it('can use a spec url', async () => {
     const { findByText, findByPlaceholderText } = render(
@@ -250,11 +250,13 @@ describe('<Loader />', () => {
       </QueryParamProvider>,
     )
 
-    await findByText('Help')
+    await findByText('Help', {}, { timeout: 20000 })
     await findByText(/volvox-sorted.bam/)
     const elt = await findByPlaceholderText('Search for location')
 
     // @ts-ignore
-    await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'))
+    await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'), {
+      timeout: 20000,
+    })
   }, 20000)
 })

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -95,6 +95,29 @@
           }
         }
       }
+    },
+    {
+      "name": "t2t-chm13-v1.1",
+      "displayName": "Homo sapiens (t2t-chm13-v1.1)",
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "t2t-chm13-v1.1-asm",
+        "adapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz",
+            "locationType": "UriLocation"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.fai",
+            "locationType": "UriLocation"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13.draft_v1.1.fasta.gz.gzi",
+            "locationType": "UriLocation"
+          }
+        }
+      }
     }
   ],
   "tracks": [
@@ -3804,6 +3827,27 @@
           "displayId": "LinearBasicDisplay"
         }
       ]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "genes",
+      "name": "Gene annotation v4",
+      "category": ["Annotation"],
+      "assemblyNames": ["t2t-chm13-v1.1"],
+      "adapter": {
+        "type": "Gff3TabixAdapter",
+        "gffGzLocation": {
+          "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/CHM13/genes/chm13.draft_v1.1.gene_annotation.v4.sorted.gff.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      }
     }
   ],
   "connections": [],


### PR DESCRIPTION
This is a small refactoring to the dotplot view that moves code out of plugins/dotplot/src/index.ts into other source files. The lengthy plugin registration can get bogged down with a lot of code so this splits it into multiple files (similar thing was done in plugins/alignments recently)

It also makes sure to display the error state in dotplot views and allows loading gzipped PAF files

