### PR TITLE
Add bezierCurveTo to offscreen canvas ponyfill to fix sashimi arcs rendering in alignments track in webkit and firefox

### DIFF
--- a/packages/core/util/offscreenCanvasPonyfill.js
+++ b/packages/core/util/offscreenCanvasPonyfill.js
@@ -51,6 +51,10 @@ export class PonyfillOffscreenContext {
     this.commands.push({ type: 'arcTo', args })
   }
 
+  bezierCurveTo(...args) {
+    this.commands.push({ type: 'bezierCurveTo', args })
+  }
+
   beginPath(...args) {
     this.commands.push({ type: 'beginPath', args })
   }

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -727,9 +727,14 @@ export default class PileupRenderer extends BoxRendererType {
             widthPx - (bpPerPx > 10 ? 1.5 : 0),
             heightPx,
           )
+          ctx.fillStyle = '#333'
+          ctx.fillRect(
+            Math.max(0, leftPx),
+            topPx + heightPx / 2 - 1,
+            widthPx + (leftPx < 0 ? leftPx : 0),
+            2,
+          )
         }
-        ctx.fillStyle = '#333'
-        ctx.fillRect(leftPx, topPx + heightPx / 2, widthPx, 2)
       }
     }
 

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -716,22 +716,18 @@ export default class PileupRenderer extends BoxRendererType {
           ctx.fillText(`(${mismatch.base})`, leftPx + 2, topPx + heightPx)
         }
       } else if (mismatch.type === 'skip') {
-        // fix to avoid bad rendering
-        // note that this was also related to chrome bug https://bugs.chromium.org/p/chro>
-        // ref #1236
+        // fix to avoid bad rendering note that this was also related to chrome
+        // bug https://bugs.chromium.org/p/chromium/issues/detail?id=1131528
+        // also affected firefox ref #1236 #2750
         if (leftPx + widthPx > 0) {
           // make small exons more visible when zoomed far out
-          ctx.clearRect(
-            leftPx,
-            topPx,
-            widthPx - (bpPerPx > 10 ? 1.5 : 0),
-            heightPx,
-          )
+          const adjustPx = widthPx - (bpPerPx > 10 ? 1.5 : 0)
+          ctx.clearRect(leftPx, topPx, adjustPx, heightPx)
           ctx.fillStyle = '#333'
           ctx.fillRect(
             Math.max(0, leftPx),
             topPx + heightPx / 2 - 1,
-            widthPx + (leftPx < 0 ? leftPx : 0),
+            adjustPx + (leftPx < 0 ? leftPx : 0),
             2,
           )
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18335,12 +18335,7 @@ react-error-boundary@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-error-overlay@^5.1.4:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
-  integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
-
-react-error-overlay@^6.0.9:
+react-error-overlay@6.0.9, react-error-overlay@^5.1.4, react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==


### PR DESCRIPTION
Fixes mailing list issue noted here https://sourceforge.net/p/gmod/mailman/message/37611106/
