### PR TITLE
Allow track to not have adapter

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -247,6 +247,8 @@ export const BaseLinearDisplay = types
       const { rpcManager } = getSession(self)
       const { adapterConfig } = self
       if (!adapterConfig) {
+        // A track extending the base track might not have an adapter config
+        // e.g. Apollo tracks don't use adapters
         return Promise.resolve({})
       }
       const sessionId = getRpcSessionId(self)

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -246,6 +246,9 @@ export const BaseLinearDisplay = types
 
       const { rpcManager } = getSession(self)
       const { adapterConfig } = self
+      if (!Object.keys(adapterConfig).length) {
+        return Promise.resolve({})
+      }
       const sessionId = getRpcSessionId(self)
 
       const params = {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -246,7 +246,7 @@ export const BaseLinearDisplay = types
 
       const { rpcManager } = getSession(self)
       const { adapterConfig } = self
-      if (!Object.keys(adapterConfig).length) {
+      if (!adapterConfig) {
         return Promise.resolve({})
       }
       const sessionId = getRpcSessionId(self)


### PR DESCRIPTION
Since #2571, if a track doesn't have an adapter, it throws an error. This adds a check in `estimateRegionStats` that allows a track to work without an adapter.

The context for this change is Apollo, which doesn't get its track data from a typical adapter.