### PR TITLE
Add a --clean argument to `jbrowse upgrade` to clean up old files

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/react-color": "^3.0.4",
     "@types/react-dom": "^17.0.0",
     "@types/react-virtualized-auto-sizer": "^1.0.0",
+    "@types/rimraf": "^3.0.2",
     "@types/rollup-plugin-node-builtins": "^2.1.2",
     "@types/rollup-plugin-node-globals": "^1.4.1",
     "@types/set-value": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash.merge": "^4.6.6",
     "@types/long": "^4.0.0",
-    "@types/node": "14.0.13",
+    "@types/node": "^14.14.0",
     "@types/node-fetch": "^2.5.7",
     "@types/normalize-wheel": "^1.0.0",
     "@types/object.fromentries": "^2.0.0",

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -518,6 +518,8 @@ OPTIONS
 
   --branch=branch     Download a development build from a named git branch
 
+  --clean             Removes old js,map,and LICENSE files in the installation
+
   --nightly           Download the latest development build from the main branch
 
 EXAMPLES

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -57,6 +57,7 @@
     "ixixx": "^1.0.19",
     "json-parse-better-errors": "^1.0.2",
     "node-fetch": "^2.6.0",
+    "rimraf": "^3.0.2",
     "object.fromentries": "^2.0.5",
     "tslib": "^2.3.1",
     "unzipper": "^0.10.11"

--- a/products/jbrowse-cli/src/base.ts
+++ b/products/jbrowse-cli/src/base.ts
@@ -291,7 +291,7 @@ export default abstract class JBrowseCommand extends Command {
       }
       return file
     }
-    return this.error(`Error: Could not find version: ${response.statusText}`, {
+    return this.error(`Could not find version: ${response.statusText}`, {
       exit: 90,
     })
   }

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -5,6 +5,8 @@ import fetch from 'node-fetch'
 import unzip from 'unzipper'
 import JBrowseCommand from '../base'
 
+const { rm } = fs.promises
+
 export default class Upgrade extends JBrowseCommand {
   static description = 'Upgrades JBrowse 2 to latest version'
 
@@ -55,6 +57,9 @@ export default class Upgrade extends JBrowseCommand {
     nightly: flags.boolean({
       description: 'Download the latest development build from the main branch',
     }),
+    clean: flags.boolean({
+      description: 'Removes old js,map,and LICENSE files in the installation',
+    }),
     url: flags.string({
       char: 'u',
       description: 'A direct URL to a JBrowse 2 release',
@@ -64,13 +69,10 @@ export default class Upgrade extends JBrowseCommand {
   async run() {
     const { args: runArgs, flags: runFlags } = this.parse(Upgrade)
     const { localPath: argsPath } = runArgs as { localPath: string }
-
-    const { listVersions, tag, url, branch, nightly } = runFlags
+    const { clean, listVersions, tag, url, branch, nightly } = runFlags
 
     if (listVersions) {
-      const versions = (await this.fetchGithubVersions()).map(
-        version => version.tag_name,
-      )
+      const versions = (await this.fetchGithubVersions()).map(v => v.tag_name)
       this.log(`All JBrowse versions:\n${versions.join('\n')}`)
       this.exit()
     }
@@ -111,6 +113,14 @@ export default class Upgrade extends JBrowseCommand {
       )
     }
 
+    if (clean) {
+      this.log('Note: Clean requires node.js 14+')
+      await rm(path.join(argsPath, 'static'), { force: true, recursive: true })
+      const files = fs.readdirSync(argsPath)
+      files
+        .filter(f => f.includes('worker.js'))
+        .forEach(f => fs.unlinkSync(path.join(argsPath, f)))
+    }
     await response.body.pipe(unzip.Extract({ path: argsPath })).promise()
     this.log(`Unpacked ${locationUrl} at ${argsPath}`)
   }

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -1,11 +1,10 @@
 import { flags } from '@oclif/command'
+import rimraf from 'rimraf'
 import fs from 'fs'
 import path from 'path'
 import fetch from 'node-fetch'
 import unzip from 'unzipper'
 import JBrowseCommand from '../base'
-
-const { rm } = fs.promises
 
 export default class Upgrade extends JBrowseCommand {
   static description = 'Upgrades JBrowse 2 to latest version'
@@ -114,10 +113,8 @@ export default class Upgrade extends JBrowseCommand {
     }
 
     if (clean) {
-      this.log('Note: Clean requires node.js 14+')
-      await rm(path.join(argsPath, 'static'), { force: true, recursive: true })
-      const files = fs.readdirSync(argsPath)
-      files
+      rimraf.sync(path.join(argsPath, 'static'))
+      fs.readdirSync(argsPath)
         .filter(f => f.includes('worker.js'))
         .forEach(f => fs.unlinkSync(path.join(argsPath, f)))
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,6 +4928,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/rollup-plugin-node-builtins@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz#d702de68f4aa7ab072845ab65e51fd7f1c0b4786"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,12 +4750,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
   integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
 
-"@types/node@14.0.13":
-  version "14.0.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
-  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
-
-"@types/node@^14.0.10", "@types/node@^14.6.2":
+"@types/node@^14.0.10", "@types/node@^14.14.0", "@types/node@^14.6.2":
   version "14.18.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
   integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==


### PR DESCRIPTION
Adds a --clean argument to `jbrowse upgrade `

Uses rimraf to clean the static directory


Fixes #2337 

We could also consider making this the default behavior and not using --clean as an extra argument but it's maybe the 'safest' option since it would ensure that we don't delete anything unless a user confirms they want to delete stuff