### PR TITLE
Add a check for empty content blocks to fix rare empty stats estimation

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -426,7 +426,12 @@ export const BaseLinearDisplay = types
                 const aborter = new AbortController()
                 const view = getContainingView(self) as LGV
 
-                if (!view.initialized) {
+                // extra check for contentBlocks.length
+                // https://github.com/GMOD/jbrowse-components/issues/2694
+                if (
+                  !view.initialized ||
+                  !view.staticBlocks.contentBlocks.length
+                ) {
                   return
                 }
 


### PR DESCRIPTION
Adds a fix that was missed in https://github.com/GMOD/jbrowse-components/pull/2719/files to check for empty regions in the autorun