### PR TITLE
Fix using global stats autoscale on wiggle tracks

### DIFF
--- a/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
+++ b/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
@@ -44,15 +44,8 @@ export class WiggleGetGlobalStats extends RpcMethodType {
       adapterConfig,
     )
 
-    if (dataAdapter instanceof BaseFeatureDataAdapter) {
-      // @ts-ignore
-      if (dataAdapter.capabilities.includes('hasGlobalStats')) {
-        // @ts-ignore
-        return dataAdapter.getGlobalStats(deserializedArgs)
-      }
-      throw new Error('Data adapter does not support global stats')
-    }
-    throw new Error('Data adapter not found')
+    // @ts-ignore
+    return dataAdapter.getGlobalStats(deserializedArgs)
   }
 }
 


### PR DESCRIPTION
Currently the wiggle track fails to use get global stats with the error

```
TypeError: Cannot read properties of undefined (reading 'includes')
    at WiggleGetGlobalStats.execute (070fac713102893201a0.worker.js:253449:36)
```

This uses an older adapter capabilities concept. The code already checks for the adapter capabilities (using the adapterCapabilities attribute on the pluggable element) inside of linearwiggledisplay model correctly already so this check is unneeded


