### PR TITLE
Fix display of cytobands when horizontally flipped

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -181,7 +181,7 @@ const Cytobands = observer(
     assembly?: Assembly
     block: ContentBlock
   }) => {
-    const { offsetPx } = block
+    const { offsetPx, reversed } = block
     const cytobands = assembly?.cytobands
       ?.map(f => ({
         refName: assembly.getCanonicalRefName(f.get('refName')),
@@ -204,6 +204,9 @@ const Cytobands = observer(
           type,
         ]
       })
+
+    const lcap = reversed ? cytobands.length - 1 : 0
+    const rcap = reversed ? 0 : cytobands.length - 1
 
     let firstCent = true
     return cytobands ? (
@@ -238,7 +241,7 @@ const Cytobands = observer(
             )
           }
 
-          if (index === 0) {
+          if (lcap == index) {
             return (
               <path
                 key={key}
@@ -252,7 +255,7 @@ const Cytobands = observer(
                 fill={colorMap[type]}
               />
             )
-          } else if (index === cytobands.length - 1) {
+          } else if (rcap == index) {
             return (
               <path
                 key={key}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -205,8 +205,9 @@ const Cytobands = observer(
         ]
       })
 
-    const lcap = reversed ? cytobands.length - 1 : 0
-    const rcap = reversed ? 0 : cytobands.length - 1
+    const arr = cytobands || []
+    const lcap = reversed ? arr.length - 1 : 0
+    const rcap = reversed ? 0 : arr.length - 1
 
     let firstCent = true
     return cytobands ? (
@@ -241,7 +242,7 @@ const Cytobands = observer(
             )
           }
 
-          if (lcap == index) {
+          if (lcap === index) {
             return (
               <path
                 key={key}
@@ -255,7 +256,7 @@ const Cytobands = observer(
                 fill={colorMap[type]}
               />
             )
-          } else if (rcap == index) {
+          } else if (rcap === index) {
             return (
               <path
                 key={key}


### PR DESCRIPTION
Currently the little "caps" on the ends of the cytobands are in the wrong orientation if the view is horizontally flipped

This fixes that

Note that we could also consider making a better indication of horizontally flipped status when cytobands are visible. The <<< chevrons from when the cytoband is not present are not used when the cytoband is present