### PR TITLE
Display the total bp viewed in the header of the dotplot view

### DIFF
--- a/packages/core/data_adapters/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter.ts
@@ -4,10 +4,7 @@ import { isStateTreeNode, getSnapshot } from 'mobx-state-tree'
 import { ObservableCreate } from '../util/rxjs'
 import { checkAbortSignal, observeAbortSignal } from '../util'
 import { Feature } from '../util/simpleFeature'
-import {
-  AnyConfigurationModel,
-  ConfigurationSchema,
-} from '../configuration/configurationSchema'
+import { AnyConfigurationModel, ConfigurationSchema } from '../configuration'
 import { getSubAdapterType } from './dataAdapterCache'
 import { AugmentedRegion as Region, NoAssemblyRegion } from '../util/types'
 import { blankStats, rectifyStats, scoresToStats } from '../util/stats'

--- a/packages/core/ui/ErrorMessage.tsx
+++ b/packages/core/ui/ErrorMessage.tsx
@@ -20,26 +20,38 @@ const useStyles = makeStyles(theme => ({
 const ErrorMessage = ({ error }: { error: unknown }) => {
   const classes = useStyles()
 
-  let str = `${error}`
   let snapshotError = ''
+  let str = `${error}`
+  const findStr = 'is not assignable'
+  const idx = str.indexOf(findStr)
+  if (idx !== -1) {
+    const trim = str.slice(0, idx + findStr.length)
+    // best effort to make a better error message than the default
+    // mobx-state-tree
 
-  // best effort to make a better error message than the default
-  // mobx-state-tree
-  const match = str.match(/.*at path "(.*)" snapshot `(.*)` is not assignable/)
-  if (match) {
-    str = `Failed to load element at ${match[1]}`
-    snapshotError = match[2]
+    // case 1. element has a path
+    const match = trim.match(
+      /.*at path "(.*)" snapshot `(.*)` is not assignable/m,
+    )
+    if (match) {
+      str = `Failed to load element at ${match[1]}...Failed element had snapshot`
+      snapshotError = match[2]
+    }
+
+    // case 2. element has no path
+    const match2 = trim.match(/.*snapshot `(.*)` is not assignable/)
+    if (match2) {
+      str = `Failed to load element...Failed element had snapshot`
+      snapshotError = match2[1]
+    }
   }
   return (
     <div className={classes.message}>
       {str.slice(0, 10000)}
       {snapshotError ? (
-        <div>
-          ... Failed element had snapshot:
-          <pre className={classes.errorBox}>
-            {JSON.stringify(JSON.parse(snapshotError), null, 2)}
-          </pre>
-        </div>
+        <pre className={classes.errorBox}>
+          {JSON.stringify(JSON.parse(snapshotError), null, 2)}
+        </pre>
       ) : null}
     </div>
   )

--- a/packages/core/ui/ReturnToImportFormDialog.tsx
+++ b/packages/core/ui/ReturnToImportFormDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Typography,
+} from '@material-ui/core'
+import CloseIcon from '@material-ui/icons/Close'
+
+const useStyles = makeStyles(theme => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}))
+
+function ReturnToImportFormDialog({
+  model,
+  handleClose,
+}: {
+  model: { clearView: Function }
+  handleClose: () => void
+}) {
+  const classes = useStyles()
+  return (
+    <Dialog maxWidth="xl" open onClose={handleClose}>
+      <DialogTitle>
+        Reference sequence
+        {handleClose ? (
+          <IconButton
+            className={classes.closeButton}
+            onClick={() => handleClose()}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : null}
+      </DialogTitle>
+      <Divider />
+
+      <DialogContent>
+        <Typography>
+          Are you sure you want to return to the import form? This will lose
+          your current view
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            model.clearView()
+            handleClose()
+          }}
+          variant="contained"
+          color="primary"
+          autoFocus
+        >
+          OK
+        </Button>
+        <Button
+          onClick={() => handleClose()}
+          color="secondary"
+          variant="contained"
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default observer(ReturnToImportFormDialog)

--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -1,6 +1,7 @@
 export * from './theme'
 export { LogoFull, Logomark } from './Logo'
 export { default as App } from './App'
+export { default as ReturnToImportFormDialog } from './ReturnToImportFormDialog'
 export { default as ErrorMessage } from './ErrorMessage'
 export { default as AssemblySelector } from './AssemblySelector'
 export { default as FileSelector } from './FileSelector'

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -1,7 +1,7 @@
 import { types, cast, getSnapshot, Instance } from 'mobx-state-tree'
 import { clamp, viewBpToPx } from './index'
 import { Feature } from './simpleFeature'
-import { Region } from './types/mst'
+import { Region, ElementId } from './types/mst'
 import { Region as IRegion } from './types'
 import calculateDynamicBlocks from './calculateDynamicBlocks'
 import calculateStaticBlocks from './calculateStaticBlocks'
@@ -16,6 +16,7 @@ export interface BpOffset {
 
 const Base1DView = types
   .model('Base1DView', {
+    id: ElementId,
     displayedRegions: types.array(Region),
     bpPerPx: 0,
     offsetPx: 0,
@@ -40,6 +41,11 @@ const Base1DView = types
   .views(self => ({
     get width() {
       return self.volatileWidth
+    },
+    get assemblyNames() {
+      return [
+        ...new Set(self.displayedRegions.map(region => region.assemblyName)),
+      ]
     },
 
     get displayedRegionsTotalPx() {

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -7,7 +7,7 @@ import { Menu, ResizeHandle } from '@jbrowse/core/ui'
 import normalizeWheel from 'normalize-wheel'
 import { DotplotViewModel } from '../model'
 import ImportForm from './ImportForm'
-import Controls from './Controls'
+import Header from './Header'
 import { locstr } from './util'
 import { HorizontalAxis, VerticalAxis } from './Axes'
 
@@ -163,6 +163,19 @@ const DotplotViewInternal = observer(
     const mousecurr = getOffset(mousecurrClient, svg)
     const mouseup = getOffset(mouseupClient, svg)
     const mouserect = mouseup || mousecurr
+    let selection
+    if (mousedown && mousecurr) {
+      selection = {
+        width: Math.abs(mousedown[0] - mousecurr[0]),
+        height: Math.abs(mousedown[1] - mousecurr[1]),
+      }
+    }
+    if (mouseup && mousedown) {
+      selection = {
+        width: Math.abs(mouseup[0] - mousedown[0]),
+        height: Math.abs(mouseup[1] - mousedown[1]),
+      }
+    }
 
     // use non-React wheel handler to properly prevent body scrolling
     useEffect(() => {
@@ -265,7 +278,7 @@ const DotplotViewInternal = observer(
 
     return (
       <div>
-        <Controls model={model} />
+        <Header model={model} selection={selection} />
         <div
           ref={root}
           className={classes.root}
@@ -303,9 +316,10 @@ const DotplotViewInternal = observer(
                           : 0),
                     }}
                   >
-                    {`x-${locstr(mouserect[0], hview)}`}
+                    {`x - ${locstr(mouserect[0], hview)}`}
                     <br />
-                    {`y-${locstr(viewHeight - mouserect[1], vview)}`}
+                    {`y - ${locstr(viewHeight - mouserect[1], vview)}`}
+                    <br />
                   </div>
                 ) : null}
                 {mousedown &&
@@ -324,9 +338,10 @@ const DotplotViewInternal = observer(
                         (mouserect[1] - mousedown[1] < 0 ? 0 : rrect.height),
                     }}
                   >
-                    {`x-${locstr(mousedown[0], hview)}`}
+                    {`x - ${locstr(mousedown[0], hview)}`}
                     <br />
-                    {`y-${locstr(viewHeight - mousedown[1], vview)}`}
+                    {`y - ${locstr(viewHeight - mousedown[1], vview)}`}
+                    <br />
                   </div>
                 ) : null}
 

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+
+import { IconButton, Typography, makeStyles } from '@material-ui/core'
+
+// icons
+import ZoomOut from '@material-ui/icons/ZoomOut'
+import ZoomIn from '@material-ui/icons/ZoomIn'
+import ArrowUp from '@material-ui/icons/KeyboardArrowUp'
+import ArrowDown from '@material-ui/icons/KeyboardArrowDown'
+import ArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
+import ArrowRight from '@material-ui/icons/KeyboardArrowRight'
+import CropFreeIcon from '@material-ui/icons/CropFree'
+
+import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+
+import { observer } from 'mobx-react'
+import { DotplotViewModel } from '../model'
+
+const useStyles = makeStyles({
+  iconButton: {
+    margin: 5,
+  },
+  bp: {
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: 10,
+  },
+  spacer: {
+    flexGrow: 1,
+  },
+  headerBar: {
+    display: 'flex',
+  },
+})
+
+const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
+  const classes = useStyles()
+  return (
+    <div>
+      <IconButton
+        onClick={() => {
+          model.hview.scroll(-100)
+        }}
+        className={classes.iconButton}
+        title="left"
+        color="secondary"
+      >
+        <ArrowLeft />
+      </IconButton>
+
+      <IconButton
+        onClick={() => {
+          model.hview.scroll(100)
+        }}
+        className={classes.iconButton}
+        title="left"
+        color="secondary"
+      >
+        <ArrowRight />
+      </IconButton>
+      <IconButton
+        onClick={() => {
+          model.vview.scroll(100)
+        }}
+        className={classes.iconButton}
+        title="left"
+        color="secondary"
+      >
+        <ArrowDown />
+      </IconButton>
+      <IconButton
+        onClick={() => {
+          model.vview.scroll(-100)
+        }}
+        className={classes.iconButton}
+        title="left"
+        color="secondary"
+      >
+        <ArrowUp />
+      </IconButton>
+      <IconButton
+        onClick={model.zoomOutButton}
+        className={classes.iconButton}
+        color="secondary"
+      >
+        <ZoomOut />
+      </IconButton>
+
+      <IconButton
+        onClick={model.zoomInButton}
+        className={classes.iconButton}
+        title="zoom in"
+        color="secondary"
+      >
+        <ZoomIn />
+      </IconButton>
+
+      <IconButton
+        onClick={model.activateTrackSelector}
+        className={classes.iconButton}
+        title="Open track selector"
+        data-testid="circular_track_select"
+        color="secondary"
+      >
+        <TrackSelectorIcon />
+      </IconButton>
+
+      <IconButton
+        onClick={model.squareView}
+        className={classes.iconButton}
+        title="Square view"
+        color="secondary"
+      >
+        <CropFreeIcon />
+      </IconButton>
+    </div>
+  )
+})
+
+function px(bpPerPx: number, width: number) {
+  return Math.round(bpPerPx * width).toLocaleString('en-US')
+}
+
+const Header = observer(
+  ({
+    model,
+    selection,
+  }: {
+    model: DotplotViewModel
+    selection?: { width: number; height: number }
+  }) => {
+    const classes = useStyles()
+    return (
+      <div className={classes.headerBar}>
+        <DotplotControls model={model} />
+        <Typography
+          className={classes.bp}
+          variant="body2"
+          color="textSecondary"
+        >
+          x: {model.hview.assemblyNames.join(',')}{' '}
+          {Math.round(model.hview.totalBp).toLocaleString('en-US')}bp y:{' '}
+          {model.vview.assemblyNames.join(',')}{' '}
+          {Math.round(model.vview.totalBp).toLocaleString('en-US')}bp
+        </Typography>
+        {selection ? (
+          <Typography
+            className={classes.bp}
+            variant="body2"
+            color="textSecondary"
+          >
+            {`width:${px(model.hview.bpPerPx, selection.width)}bp`}{' '}
+            {`height:${px(model.vview.bpPerPx, selection.height)}bp`}
+          </Typography>
+        ) : null}
+        <div className={classes.spacer} />
+      </div>
+    )
+  },
+)
+export default Header

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -50,6 +50,7 @@
     "@jbrowse/plugin-bed": "^1.6.5",
     "@jbrowse/plugin-breakpoint-split-view": "^1.6.5",
     "@jbrowse/plugin-circular-view": "^1.6.5",
+    "@jbrowse/plugin-comparative-adapters": "^1.6.5",
     "@jbrowse/plugin-config": "^1.6.5",
     "@jbrowse/plugin-data-management": "^1.6.5",
     "@jbrowse/plugin-dotplot-view": "^1.6.5",

--- a/products/jbrowse-desktop/src/corePlugins.ts
+++ b/products/jbrowse-desktop/src/corePlugins.ts
@@ -11,6 +11,7 @@ import GtfPlugin from '@jbrowse/plugin-gtf'
 import LegacyJBrowse from '@jbrowse/plugin-legacy-jbrowse'
 import LinearGenomeView from '@jbrowse/plugin-linear-genome-view'
 import LinearComparativeView from '@jbrowse/plugin-linear-comparative-view'
+import ComparativeAdapters from '@jbrowse/plugin-comparative-adapters'
 import Lollipop from '@jbrowse/plugin-lollipop'
 import Arc from '@jbrowse/plugin-arc'
 import Menus from '@jbrowse/plugin-menus'
@@ -54,6 +55,7 @@ const corePlugins = [
   HicPlugin,
   TrixPlugin,
   GridBookmarkPlugin,
+  ComparativeAdapters,
 ]
 
 export default corePlugins


### PR DESCRIPTION
This adds a blurb in the header bar, that tells you in text form 

(a) the current totalBp of the width and current totalBp of the height
(b) if a click and drag is occuring, the totalBp of the width and height of the click and drag selection

Also adds a method to return to the import form via the view menu

We could also consider adding RefNameAutocomplete style components to the dotplot header also to facilitate navigation