### PR TITLE
v1.6.6 release announcement

### DIFF
--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -665,26 +665,189 @@ Example SyntenyTrack config
   "adapter": {
     "type": "PAFAdapter",
     "pafLocation": {
-      "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf",
-      "locationType": "UriLocation"
+      "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf"
     },
     "assemblyNames": ["YJM1447", "R64"]
   }
 }
 ```
 
-We can add a SyntenyTrack from PAF with the CLI e.g. with
+We can load a SyntenyTrack from PAF with the CLI e.g. with
 
 ```sh
 jbrowse add-track myfile.paf --type SyntenyTrack --assemblyNames \
     grape,peach --load copy --out /var/www/html/jbrowse2
 ```
 
+The first assembly is the "target" and the second assembly is the "query"
+
+See the [super quickstart guide](../superquickstart_web) for more recipes on
+loading synteny tracks with the CLI.
+
+### PAFAdapter config
+
+The PAF adapter reflects a pairwise alignment, and is outputted by tools like
+minimap2. It can be used for SyntenyTracks
+
+```json
+{
+  "type": "PAFAdapter",
+  "pafLocation": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf"
+  },
+  "assemblyNames": ["YJM1447", "R64"]
+}
+```
+
+Slots
+
+- pafLocation - the location of the PAF file. The pafLocation can refer to a
+  gzipped or unzipped delta file. It will be read into memory entirely as it is
+  not an indexed file format.
+- assemblyNames - list of assembly names, typically two (first in list is
+  target, second is query)
+- queryAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+- targetAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+
+### DeltaAdapter config
+
+The DeltaAdapter is used to load .delta files from MUMmer/nucmer. It can be
+used for SyntenyTracks
+
+```json
+{
+  "type": "DeltaAdapter",
+  "deltaLocation": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf"
+  },
+  "assemblyNames": ["YJM1447", "R64"]
+}
+```
+
+Slots
+
+- deltaLocation - the location of the delta file. The deltaLocation can refer to a
+  gzipped or unzipped delta file. It will be read into memory entirely as it is
+  not an indexed file format.
+- assemblyNames - list of assembly names, typically two (first in list is
+  target, second is query)
+- queryAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+- targetAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+
+### ChainAdapter config
+
+The ChainAdapter is used to load .chain files from MUMmer/nucmer. It can be
+used for SyntenyTracks
+
+```json
+{
+  "type": "DeltaAdapter",
+  "deltaLocation": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/YJM1447_vs_R64.paf"
+  },
+  "assemblyNames": ["YJM1447", "R64"]
+}
+```
+
+Slots
+
+- chainLocation - the location of the UCSC chain file. The chainLocation can
+  refer to a gzipped or unzipped delta file. It will be read into memory
+  entirely as it is not an indexed file format.
+- assemblyNames - list of assembly names, typically two (first in list is
+  target, second is query)
+- queryAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+- targetAssembly - alternative to assemblyNames: just the assemblyName of the
+  query
+
+### MCScanAnchorsAdapter
+
+The .anchors file from MCScan refers to pairs of homologous genes and can be loaded into synteny tracks in jbrowse 2
+
+```json
+{
+  "type": "MCScanAnchorsAdapter",
+  "mcscanAnchorsLocation": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape.peach.anchors.gz"
+  },
+  "bed1Location": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape_vs_peach/grape.bed.gz"
+  },
+  "bed2Location": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape_vs_peach/peach.bed.gz"
+  },
+  "assemblyNames": ["grape", "peach"]
+}
+```
+
+The guide at https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)
+shows a demonstration of how to create the anchors and bed files (the .bed
+files are intermediate steps in creating the anchors files and are required by
+the MCScanAnchorsAdapter)
+
+Slots
+
+- mcscanAnchorsLocation - the location of the .anchors file from the MCScan
+  workflow. The .anchors file has three columns. It can be gzipped or
+  ungzipped, and is read into memory whole
+- bed1Location - the location of the first assemblies .bed file from the MCScan
+  workflow. It can be gzipped or ungzipped, and is read into memory whole. This
+  would refer to the gene names on the "left" side of the .anchors file.
+- bed2Location - the location of the second assemblies .bed file from the
+  MCScan workflow. It can be gzipped or ungzipped, and is read into memory
+  whole. This would refer to the gene names on the "right" side of the .anchors
+  file.
+
+### MCScanSimpleAnchorsAdapter
+
+The "simple" .anchors.simple file from MCScan refers to pairs of homologous
+genes and can be loaded into synteny tracks in jbrowse 2
+
+```json
+{
+  "type": "MCScanSimpleAnchorsAdapter",
+  "mcscanSimpleAnchorsLocation": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape.peach.anchors.simple.gz"
+  },
+  "bed1Location": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape_vs_peach/grape.bed.gz"
+  },
+  "bed2Location": {
+    "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/grape_vs_peach/peach.bed.gz"
+  },
+  "assemblyNames": ["grape", "peach"]
+}
+```
+
+The guide at https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)
+shows a demonstration of how to create the anchors and bed files (the .bed
+files are intermediate steps in creating the anchors.simple files and are
+required by the MCScanSimpleAnchorsAdapter)
+
+Slots
+
+- `mcscanSimpleAnchorsLocation` - the location of the .anchors.simple file from
+  the MCScan workflow (this file has 5 columns, start and end gene from bed1,
+  start and end genes from bed2, and score). It can be gzipped or ungzipped,
+  and is read into memory whole
+- `bed1Location` - the location of the first assemblies .bed file from the MCScan
+  workflow. It can be gzipped or ungzipped, and is read into memory whole. This
+  would refer to the gene names on the "left" side of the .anchors file.
+- `bed2Location` - the location of the second assemblies .bed file from the
+  MCScan workflow. It can be gzipped or ungzipped, and is read into memory
+  whole. This would refer to the gene names on the "right" side of the .anchors
+  file.
+
 ### Advanced adapters
 
 There are two useful adapter types that can be used for more advanced use
 cases, such as generating configuration for data returned by an API. These are
-the FromConfigAdapter and FromConfigSequenceAdapter. They can be used as the
+the `FromConfigAdapter` and `FromConfigSequenceAdapter`. They can be used as the
 `adapter` value for any track type.
 
 #### FromConfigAdapter
@@ -692,7 +855,7 @@ the FromConfigAdapter and FromConfigSequenceAdapter. They can be used as the
 This adapter can be used to generate features directly from values stored in
 the configuration.
 
-Example FromConfigAdapter
+Example `FromConfigAdapter`
 
 ```json
 {
@@ -714,10 +877,10 @@ Example FromConfigAdapter
 
 #### FromConfigSequenceAdapter
 
-Similar behavior to FromConfigAdapter, with a specific emphasis on performance
+Similar behavior to `FromConfigAdapter`, with a specific emphasis on performance
 when the features are sequences.
 
-Example FromConfigSequenceAdapter
+Example `FromConfigSequenceAdapter`
 
 ```json
 {
@@ -872,392 +1035,13 @@ index created by generate-names.pl
 
 ## DotplotView config
 
-The configuration of a view is technically a configuration of the "state of the
-view" but it can be added to the `defaultSession`
-
-An example of a dotplot config can help explain. This is relatively advanced so
-let's look at an example
-
-```json
-{
-  "assemblies": [
-    {
-      "name": "grape",
-      "sequence": {
-        "trackId": "grape_seq",
-        "type": "ReferenceSequenceTrack",
-        "adapter": {
-          "type": "ChromSizesAdapter",
-          "chromSizesLocation": {
-            "uri": "grape.chrom.sizes",
-            "locationType": "UriLocation"
-          }
-        }
-      }
-    },
-    {
-      "name": "peach",
-      "sequence": {
-        "trackId": "peach_seq",
-        "type": "ReferenceSequenceTrack",
-        "adapter": {
-          "type": "ChromSizesAdapter",
-          "chromSizesLocation": {
-            "uri": "peach.chrom.sizes",
-            "locationType": "UriLocation"
-          }
-        }
-      }
-    }
-  ],
-  "tracks": [
-    {
-      "trackId": "grape_peach_synteny_mcscan",
-      "type": "SyntenyTrack",
-      "assemblyNames": ["peach", "grape"],
-      "trackIds": [],
-      "renderDelay": 100,
-      "adapter": {
-        "mcscanAnchorsLocation": {
-          "uri": "grape.peach.anchors",
-          "locationType": "UriLocation"
-        },
-        "subadapters": [
-          {
-            "type": "NCListAdapter",
-            "rootUrlTemplate": {
-              "uri": "https://jbrowse.org/genomes/synteny/peach_gene/{refseq}/trackData.json",
-              "locationType": "UriLocation"
-            }
-          },
-          {
-            "type": "NCListAdapter",
-            "rootUrlTemplate": {
-              "uri": "https://jbrowse.org/genomes/synteny/grape_gene/{refseq}/trackData.json",
-              "locationType": "UriLocation"
-            }
-          }
-        ],
-        "assemblyNames": ["peach", "grape"],
-        "type": "MCScanAnchorsAdapter"
-      },
-      "name": "Grape peach synteny (MCScan)",
-      "category": ["Annotation"]
-    },
-    {
-      "trackId": "grape_peach_paf",
-      "type": "SyntenyTrack",
-      "name": "Grape vs Peach (PAF)",
-      "assemblyNames": ["peach", "grape"],
-      "adapter": {
-        "type": "PAFAdapter",
-        "pafLocation": {
-          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/synteny/peach_grape.paf",
-          "locationType": "UriLocation"
-        },
-        "assemblyNames": ["peach", "grape"]
-      }
-    },
-    {
-      "type": "SyntenyTrack",
-      "trackId": "dotplot_track_small",
-      "name": "Grape vs peach small (PAF)",
-      "assemblyNames": ["grape", "peach"],
-      "adapter": {
-        "type": "PAFAdapter",
-        "pafLocation": {
-          "uri": "peach_grape_small.paf",
-          "locationType": "UriLocation"
-        },
-        "assemblyNames": ["peach", "grape"]
-      }
-    }
-  ],
-  "defaultSession": {
-    "name": "Grape vs Peach (small)",
-    "views": [
-      {
-        "id": "MiDMyyWpp",
-        "type": "DotplotView",
-        "assemblyNames": ["peach", "grape"],
-        "hview": {
-          "displayedRegions": [],
-          "bpPerPx": 100000,
-          "offsetPx": 0
-        },
-        "vview": {
-          "displayedRegions": [],
-          "bpPerPx": 100000,
-          "offsetPx": 0
-        },
-        "tracks": [
-          {
-            "type": "SyntenyTrack",
-            "configuration": "dotplot_track_small",
-            "displays": [
-              {
-                "type": "DotplotDisplay",
-                "configuration": "dotplot_track_small-DotplotDisplay"
-              }
-            ]
-          }
-        ],
-        "displayName": "Grape vs Peach dotplot"
-      }
-    ]
-  }
-}
-```
-
-Note that configuring the dotplot involves creating a "defaultSession"
-
-Users can also open synteny views using the File->Add->Dotplot view workflow,
-and create their own synteny view outside of the default configuration
+It is recommended to use the DotplotView's importform or a session spec to
+initialize a dotplot view.
 
 ## LinearSyntenyView config
 
-Currently, configuring synteny is made by pre-configuring a session in the view
-and adding synteny tracks
-
-```json
-{
-  "defaultSession": {
-    "name": "Grape vs Peach Demo",
-    "drawerWidth": 384,
-    "views": [
-      {
-        "type": "LinearSyntenyView",
-        "id": "test1",
-        "headerHeight": 44,
-        "datasetName": "grape_vs_peach_dataset",
-        "tracks": [
-          {
-            "type": "SyntenyTrack",
-            "configuration": "grape_peach_synteny_mcscan",
-            "displays": [
-              {
-                "configuration": "grape_peach_synteny_mcscan-LinearSyntenyDisplay",
-                "height": 100,
-                "type": "LinearSyntenyDisplay"
-              }
-            ]
-          }
-        ],
-        "height": 400,
-        "displayName": "Grape vs Peach",
-        "trackSelectorType": "hierarchical",
-        "views": [
-          {
-            "type": "LinearGenomeView",
-            "id": "test1_1",
-            "offsetPx": 28249,
-            "bpPerPx": 1000,
-            "displayedRegions": [
-              {
-                "refName": "Pp01",
-                "assemblyName": "peach",
-                "start": 0,
-                "end": 100000000
-              }
-            ],
-            "tracks": [
-              {
-                "type": "FeatureTrack",
-                "configuration": "peach_genes",
-                "displays": [
-                  {
-                    "configuration": "peach_genes_linear",
-                    "height": 100,
-                    "type": "LinearBasicDisplay"
-                  }
-                ]
-              }
-            ],
-            "hideControls": false,
-            "hideHeader": true,
-            "hideCloseButton": true,
-            "trackSelectorType": "hierarchical"
-          },
-          {
-            "type": "LinearGenomeView",
-            "id": "test1_2",
-            "offsetPx": 0,
-            "bpPerPx": 1000,
-            "displayedRegions": [
-              {
-                "refName": "chr1",
-                "assemblyName": "grape",
-                "start": 0,
-                "end": 100000000
-              }
-            ],
-            "tracks": [
-              {
-                "type": "FeatureTrack",
-                "configuration": "grape_genes",
-                "displays": [
-                  {
-                    "configuration": "grape_genes_linear",
-                    "height": 100,
-                    "type": "LinearBasicDisplay"
-                  }
-                ]
-              }
-            ],
-            "hideControls": false,
-            "hideHeader": true,
-            "hideCloseButton": true,
-            "trackSelectorType": "hierarchical"
-          }
-        ]
-      }
-    ],
-    "widgets": {},
-    "activeWidgets": {},
-    "connections": {}
-  },
-  "assemblies": [
-    {
-      "name": "grape",
-      "sequence": {
-        "trackId": "grape_seq",
-        "type": "ReferenceSequenceTrack",
-        "adapter": {
-          "type": "ChromSizesAdapter",
-          "chromSizesLocation": {
-            "uri": "grape.chrom.sizes",
-            "locationType": "UriLocation"
-          }
-        }
-      }
-    },
-    {
-      "name": "peach",
-      "sequence": {
-        "trackId": "peach_seq",
-        "type": "ReferenceSequenceTrack",
-        "adapter": {
-          "type": "ChromSizesAdapter",
-          "chromSizesLocation": {
-            "uri": "peach.chrom.sizes",
-            "locationType": "UriLocation"
-          }
-        }
-      }
-    }
-  ],
-  "tracks": [
-    {
-      "trackId": "grape_peach_synteny_mcscan",
-      "type": "SyntenyTrack",
-      "assemblyNames": ["peach", "grape"],
-      "trackIds": [],
-      "renderDelay": 100,
-      "adapter": {
-        "mcscanAnchorsLocation": {
-          "uri": "grape.peach.anchors",
-          "locationType": "UriLocation"
-        },
-        "subadapters": [
-          {
-            "type": "NCListAdapter",
-            "rootUrlTemplate": {
-              "uri": "https://jbrowse.org/genomes/synteny/peach_gene/{refseq}/trackData.json",
-              "locationType": "UriLocation"
-            }
-          },
-          {
-            "type": "NCListAdapter",
-            "rootUrlTemplate": {
-              "uri": "https://jbrowse.org/genomes/synteny/grape_gene/{refseq}/trackData.json",
-              "locationType": "UriLocation"
-            }
-          }
-        ],
-        "assemblyNames": ["peach", "grape"],
-        "type": "MCScanAnchorsAdapter"
-      },
-      "name": "Grape peach synteny (MCScan)",
-      "category": ["Annotation"]
-    },
-    {
-      "trackId": "peach_genes",
-      "type": "FeatureTrack",
-      "assemblyNames": ["peach"],
-      "name": "mcscan",
-      "category": ["Annotation"],
-      "adapter": {
-        "type": "NCListAdapter",
-        "rootUrlTemplate": {
-          "uri": "https://jbrowse.org/genomes/synteny/peach_gene/{refseq}/trackData.json",
-          "locationType": "UriLocation"
-        }
-      },
-      "displays": [
-        {
-          "type": "LinearBasicDisplay",
-          "displayId": "peach_genes_linear",
-          "renderer": {
-            "type": "PileupRenderer"
-          }
-        }
-      ]
-    },
-    {
-      "trackId": "peach_genes2",
-      "type": "FeatureTrack",
-      "assemblyNames": ["peach"],
-      "name": "mcscan2",
-      "category": ["Annotation"],
-      "adapter": {
-        "type": "NCListAdapter",
-        "rootUrlTemplate": {
-          "uri": "https://jbrowse.org/genomes/synteny/peach_gene/{refseq}/trackData.json",
-          "locationType": "UriLocation"
-        }
-      }
-    },
-    {
-      "trackId": "grape_genes",
-      "type": "FeatureTrack",
-      "name": "mcscan",
-      "assemblyNames": ["grape"],
-      "category": ["Annotation"],
-      "adapter": {
-        "type": "NCListAdapter",
-        "rootUrlTemplate": {
-          "uri": "https://jbrowse.org/genomes/synteny/grape_gene/{refseq}/trackData.json",
-          "locationType": "UriLocation"
-        }
-      },
-      "displays": [
-        {
-          "type": "LinearBasicDisplay",
-          "displayId": "grape_genes_linear",
-          "renderer": {
-            "type": "PileupRenderer"
-          }
-        }
-      ]
-    },
-    {
-      "trackId": "grape_genes2",
-      "type": "FeatureTrack",
-      "name": "mcscan2",
-      "category": ["Annotation"],
-      "assemblyNames": ["grape"],
-      "adapter": {
-        "type": "NCListAdapter",
-        "rootUrlTemplate": {
-          "uri": "https://jbrowse.org/genomes/synteny/grape_gene/{refseq}/trackData.json",
-          "locationType": "UriLocation"
-        }
-      }
-    }
-  ],
-  "configuration": {}
-}
-```
+It is recommended to use the LinearSyntenyView's importform or a session spec
+to initialize a dotplot view.
 
 ## Configuring the theme
 

--- a/website/release_announcement_drafts/v1.6.6.md
+++ b/website/release_announcement_drafts/v1.6.6.md
@@ -1,4 +1,10 @@
 We are pleased to release v1.6.6!
 
 This contains several improvements to synteny, including the ability to load
-.chain files and .delta files from mummer
+.chain files and .delta files from mummer, and improved ability to use MCScan
+.anchors (gene pairs) and .anchors.simple (larger synteny blocks).
+
+The configuration schema for MCScan anchors files changed also, to now load the
+.bed file at startup. This is more reliable and allows us to load
+.anchors.simple (which shows large synteny blocks). See the config guide for
+details

--- a/website/release_announcement_drafts/v1.6.6.md
+++ b/website/release_announcement_drafts/v1.6.6.md
@@ -8,3 +8,8 @@ The configuration schema for MCScan anchors files changed also, to now load the
 .bed file at startup. This is more reliable and allows us to load
 .anchors.simple (which shows large synteny blocks). See the config guide for
 details
+
+There have also been some changes to how internet accounts work. If you use one
+of the built-in accounts like Google Drive or Dropbox, there's no need to change
+anything. If you've implemented your own internet account, though, see
+[#2725](https://github.com/GMOD/jbrowse-components/pull/2725) for more details.

--- a/website/release_announcement_drafts/v1.6.6.md
+++ b/website/release_announcement_drafts/v1.6.6.md
@@ -1,13 +1,31 @@
 We are pleased to release v1.6.6!
 
-This contains several improvements to synteny, including the ability to load
-.chain files and .delta files from mummer, and improved ability to use MCScan
-.anchors (gene pairs) and .anchors.simple (larger synteny blocks).
+This contains several updated synteny features, including:
 
-The configuration schema for MCScan anchors files changed also, to now load the
-.bed file at startup. This is more reliable and allows us to load
-.anchors.simple (which shows large synteny blocks). See the config guide for
-details
+- load .chain files from UCSC
+- load .delta files from mummer
+- load .anchors and .anchors.simple files from MCScan from the GUI
+- ability to "rectangularize" the dotplot view and improved dotplot view overviews (shows total bp of selected regions)
+
+![](https://user-images.githubusercontent.com/6511937/157131973-1c8962cb-bea2-4bde-a4ee-a5a874d5f370.png)
+
+Screenshot showing updated import form with ability to load MCScan data
+
+![](https://user-images.githubusercontent.com/6511937/157134881-732f0e4b-d811-4515-8b41-6b44f0668611.png)
+
+Screenshot showing multiple tracks open at once, with the .anchors (green, gene
+pairs) and .anchors.simple (black, larger synteny blocks) files from MCScan
+shown in the dotplot view
+
+Note: MCScan functionality existed internally but was not easy to use. The
+configuration schema for MCScan anchors files changed also to load the .bed
+files at startup. See the config guide for details
+
+We also have an updated configuration editor GUI with collapsible sections
+
+![](https://user-images.githubusercontent.com/6511937/158277132-760f4c2b-8cfb-4fcf-84b8-3ad27ee76290.png)
+
+Screenshot showing new collapsible (turquoise) sections in the config editor
 
 There have also been some changes to how internet accounts work. If you use one
 of the built-in accounts like Google Drive or Dropbox, there's no need to change

--- a/website/release_announcement_drafts/v1.6.6.md
+++ b/website/release_announcement_drafts/v1.6.6.md
@@ -1,0 +1,4 @@
+We are pleased to release v1.6.6!
+
+This contains several improvements to synteny, including the ability to load
+.chain files and .delta files from mummer


### PR DESCRIPTION
about two weeks since last release, includes a fix for @bbimber and other misc stuff

```
$ lerna-changelog

## Unreleased (2022-03-15)

#### :rocket: Enhancement
* Other
  * [#2799](https://github.com/GMOD/jbrowse-components/pull/2799) Exit process after rendering to speed up jb2export ([@cmdcolin](https://github.com/cmdcolin))
  * [#2793](https://github.com/GMOD/jbrowse-components/pull/2793) Add abortcontroller polyfill to jbrowse-img to allow it to run under node 14 ([@cmdcolin](https://github.com/cmdcolin))
  * [#2761](https://github.com/GMOD/jbrowse-components/pull/2761) Add a --clean argument to `jbrowse upgrade` to clean up old files ([@cmdcolin](https://github.com/cmdcolin))
  * [#2760](https://github.com/GMOD/jbrowse-components/pull/2760) Make a configurable refNameColumn in RefNameAliasAdapter ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#2791](https://github.com/GMOD/jbrowse-components/pull/2791) Add new coloring options for dotplot and ability to "rectangularize" dotplot view ([@cmdcolin](https://github.com/cmdcolin))
  * [#2741](https://github.com/GMOD/jbrowse-components/pull/2741) Allow ability to enter a space-separated locstring to open a list of regions ([@cmdcolin](https://github.com/cmdcolin))
  * [#2725](https://github.com/GMOD/jbrowse-components/pull/2725) Refactor InternetAccounts, add standard getFetcher ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#2787](https://github.com/GMOD/jbrowse-components/pull/2787) Display the total bp viewed in the header of the dotplot view ([@cmdcolin](https://github.com/cmdcolin))
  * [#2767](https://github.com/GMOD/jbrowse-components/pull/2767) Wiggle and SNPCoverage look and feel improvements ([@cmdcolin](https://github.com/cmdcolin))
  * [#2746](https://github.com/GMOD/jbrowse-components/pull/2746) Add .delta and .chain format adapters, fix ref name aliasing in synteny/dotplot views, and optimize very long CIGAR string in synteny view ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#2798](https://github.com/GMOD/jbrowse-components/pull/2798) Fix bug where web worker would sometimes be called before it was ready ([@garrettjstevens](https://github.com/garrettjstevens))
* Other
  * [#2797](https://github.com/GMOD/jbrowse-components/pull/2797) Fix crash plotting methylation in sparse regions ([@cmdcolin](https://github.com/cmdcolin))
  * [#2782](https://github.com/GMOD/jbrowse-components/pull/2782) Fix display of cytobands when horizontally flipped ([@cmdcolin](https://github.com/cmdcolin))
  * [#2678](https://github.com/GMOD/jbrowse-components/pull/2678) Preserve double border line when using trackLabel offset and use smaller gap between snpcoverage and reads ([@cmdcolin](https://github.com/cmdcolin))
  * [#2774](https://github.com/GMOD/jbrowse-components/pull/2774) Fix overwriting broken symlink with --force in add-track CLI ([@cmdcolin](https://github.com/cmdcolin))
  * [#2773](https://github.com/GMOD/jbrowse-components/pull/2773) Fix using global stats autoscale on wiggle tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#2766](https://github.com/GMOD/jbrowse-components/pull/2766) Add a check for empty content blocks to fix rare empty stats estimation ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#2762](https://github.com/GMOD/jbrowse-components/pull/2762) Add bookmark widget docs to user guide ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 2
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 2.11s.


```