### PR TITLE
Add abortcontroller polyfill to jbrowse-img to allow it to run under node 14

### DIFF
--- a/products/jbrowse-img/package.json
+++ b/products/jbrowse-img/package.json
@@ -5,7 +5,7 @@
   "author": "JBrowse Team",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "bin": {
     "jb2export": "./dist/bin.js"
@@ -30,6 +30,7 @@
   "dependencies": {
     "@jbrowse/plugin-linear-genome-view": "^1.6.5",
     "@jbrowse/react-linear-genome-view": "^1.6.5",
+    "abortcontroller-polyfill": "^1.7.3",
     "mobx": "^5.10.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -4,6 +4,7 @@ import yargs from 'yargs'
 import { standardizeArgv, parseArgv } from './parseArgv'
 import { renderRegion } from './renderRegion'
 import tmp from 'tmp'
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
 
 import { spawnSync } from 'child_process'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5507,7 +5507,7 @@ abortable-promise-cache@^1.0.1, abortable-promise-cache@^1.2.0, abortable-promis
   dependencies:
     abortcontroller-polyfill "^1.2.9"
 
-abortcontroller-polyfill@^1.2.4, abortcontroller-polyfill@^1.2.9:
+abortcontroller-polyfill@^1.2.4, abortcontroller-polyfill@^1.2.9, abortcontroller-polyfill@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
   integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==


### PR DESCRIPTION
this approach at polyfilling specifically targets the jbrowse/img package instead of trying to make it part of core

