### PR TITLE
Collapsible accordion sections in configuration editor

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail.tsx
@@ -8,14 +8,16 @@ import {
   Typography,
   Divider,
   Tooltip,
+  makeStyles,
 } from '@material-ui/core'
 import ExpandMore from '@material-ui/icons/ExpandMore'
-import { makeStyles } from '@material-ui/core/styles'
 import { DataGrid } from '@mui/x-data-grid'
 import { observer } from 'mobx-react'
 import clsx from 'clsx'
 import isObject from 'is-object'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
+
+// locals
 import { getConf } from '../configuration'
 import { measureText, getSession } from '../util'
 import SanitizedHTML from '../ui/SanitizedHTML'

--- a/packages/core/ui/theme.test.ts
+++ b/packages/core/ui/theme.test.ts
@@ -42,7 +42,7 @@ describe('theme utils', () => {
       overrides: { MuiPaper: muiPaperStyle },
     })
     expect(theme.overrides?.MuiPaper).toEqual(muiPaperStyle)
-    expect(Object.keys(theme.overrides || {}).length).toBe(9)
+    expect(Object.keys(theme.overrides || {}).length).toBe(10)
   })
   it('allows modifying a default override', () => {
     const muiButtonStyle = { textSecondary: { color: 'orange' } }
@@ -50,7 +50,7 @@ describe('theme utils', () => {
       overrides: { MuiButton: muiButtonStyle },
     })
     expect(theme.overrides?.MuiButton).toEqual(muiButtonStyle)
-    expect(Object.keys(theme.overrides || {}).length).toBe(8)
+    expect(Object.keys(theme.overrides || {}).length).toBe(9)
   })
   it('allows adding a custom prop', () => {
     const muiPaperProps = { variant: 'outlined' as 'outlined' }

--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -143,6 +143,15 @@ export function createJBrowseDefaultOverrides(palette: PaletteOptions = {}) {
         color: generatedPalette.tertiary.main,
       },
     },
+    MuiAccordion: {
+      root: {
+        // avoid extra padding around accordion element
+        margin: 0,
+        '&$expanded': {
+          margin: 0,
+        },
+      },
+    },
     MuiAccordionSummary: {
       root: {
         // !important needed to combat the MuiButton being applied to

--- a/plugins/config/src/ConfigurationEditorWidget/components/CallbackEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/CallbackEditor.js
@@ -47,7 +47,7 @@ function CallbackEditor({ slot }) {
         jexlDebouncedCode,
         getEnv(slot).pluginManager?.jexl,
       )
-      slot.set(jexlDebouncedCode) // slot.set `jexl:${debouncedCode}`
+      slot.set(jexlDebouncedCode)
       setCodeError(null)
     } catch (e) {
       console.error({ e })
@@ -66,9 +66,7 @@ function CallbackEditor({ slot }) {
         <Editor
           className={classes.callbackEditor}
           value={code.startsWith('jexl:') ? code.split('jexl:')[1] : code}
-          onValueChange={newCode => {
-            setCode(newCode)
-          }}
+          onValueChange={newCode => setCode(newCode)}
           highlight={newCode => newCode}
           padding={10}
           style={{ background: error ? '#fdd' : undefined }}

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -84,7 +84,7 @@ const Member = observer(props => {
         <AccordionSummary
           expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
         >
-          <Typography>{[...path, slotName].join('→')}</Typography>
+          <Typography>{[...path, slotName].join('🡒')}</Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.expansionPanelDetails}>
           {typeSelector}

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -43,7 +43,13 @@ const useStyles = makeStyles(theme => ({
 
 const Member = observer(props => {
   const classes = useStyles()
-  const { slotName, slotSchema, schema, slot = schema[slotName] } = props
+  const {
+    slotName,
+    slotSchema,
+    schema,
+    slot = schema[slotName],
+    path = [],
+  } = props
   let typeSelector
   if (isConfigurationSchemaType(slotSchema)) {
     if (slot.length) {
@@ -70,25 +76,23 @@ const Member = observer(props => {
       )
     }
     return (
-      <>
-        <Accordion
-          defaultExpanded
-          className={classes.accordion}
-          TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+      <Accordion
+        defaultExpanded
+        className={classes.accordion}
+        TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
         >
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
-          >
-            <Typography>Config {slotName}</Typography>
-          </AccordionSummary>
-          <AccordionDetails className={classes.expansionPanelDetails}>
-            {typeSelector}
-            <FormGroup>
-              <Schema schema={slot} />
-            </FormGroup>
-          </AccordionDetails>
-        </Accordion>
-      </>
+          <Typography>{[...path, slotName].join('→')}</Typography>
+        </AccordionSummary>
+        <AccordionDetails className={classes.expansionPanelDetails}>
+          {typeSelector}
+          <FormGroup>
+            <Schema schema={slot} path={[...path, slotName]} />
+          </FormGroup>
+        </AccordionDetails>
+      </Accordion>
     )
   }
 
@@ -100,13 +104,14 @@ const Member = observer(props => {
   return null
 })
 
-const Schema = observer(({ schema }) => {
+const Schema = observer(({ schema, path = [] }) => {
   const properties = getMembers(schema).properties
   return Object.entries(properties).map(([slotName, slotSchema]) => (
     <Member
       key={slotName}
       slotName={slotName}
       slotSchema={slotSchema}
+      path={path}
       schema={schema}
     />
   ))
@@ -129,12 +134,13 @@ const ConfigurationEditor = observer(({ model }) => {
       <AccordionSummary
         expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
       >
-        <Typography>Configuration{name ? ' - ' + name : ''}</Typography>
+        <Typography>{name ? name : 'Configuration'}</Typography>
       </AccordionSummary>
-      <AccordionDetails className={classes.expansionPanelDetails}>
-        <div data-testid="configEditor">
-          {!model.target ? 'no target set' : <Schema schema={model.target} />}
-        </div>
+      <AccordionDetails
+        className={classes.expansionPanelDetails}
+        data-testid="configEditor"
+      >
+        {!model.target ? 'no target set' : <Schema schema={model.target} />}
       </AccordionDetails>
     </Accordion>
   )

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -79,7 +79,7 @@ const Member = observer(props => {
       <Accordion
         defaultExpanded
         className={classes.accordion}
-        TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+        TransitionProps={{ unmountOnExit: true, timeout: 150 }}
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
@@ -129,7 +129,7 @@ const ConfigurationEditor = observer(({ model }) => {
       key={key}
       defaultExpanded
       className={classes.accordion}
-      TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+      TransitionProps={{ unmountOnExit: true, timeout: 150 }}
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -35,6 +35,10 @@ const useStyles = makeStyles(theme => ({
     display: 'block',
     padding: theme.spacing(1),
   },
+
+  accordion: {
+    border: '1px solid #444',
+  },
 }))
 
 const Member = observer(props => {

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -1,32 +1,45 @@
+import React from 'react'
 import {
   readConfObject,
   getTypeNamesFromExplicitlyTypedUnion,
   isConfigurationSchemaType,
   isConfigurationSlotType,
 } from '@jbrowse/core/configuration'
-
-import { iterMap } from '@jbrowse/core/util'
-import FormGroup from '@material-ui/core/FormGroup'
-import FormLabel from '@material-ui/core/FormLabel'
-import { makeStyles } from '@material-ui/core/styles'
+import {
+  FormGroup,
+  FormLabel,
+  Accordion,
+  AccordionSummary,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
 import { observer } from 'mobx-react'
 import { getMembers } from 'mobx-state-tree'
 import { singular } from 'pluralize'
-import React from 'react'
+
+//icons
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+
+//locals
 import SlotEditor from './SlotEditor'
 import TypeSelector from './TypeSelector'
 
 const useStyles = makeStyles(theme => ({
   subSchemaContainer: {
-    marginLeft: theme.spacing(1),
-    borderLeft: `1px solid ${theme.palette.secondary.main}`,
-    paddingLeft: theme.spacing(1),
-    marginBottom: theme.spacing(1),
+    margin: theme.spacing(1),
+    padding: theme.spacing(1),
+  },
+  expandIcon: {
+    color: '#fff',
   },
   root: {
     padding: theme.spacing(1, 3, 1, 1),
-    background: theme.palette.background.default,
-    overflowX: 'hidden',
+    width: '100%',
+  },
+  accordion: {
+    maxWidth: '100%',
+    display: 'grid',
+    gridTemplateColumn: '100%',
   },
 }))
 
@@ -36,14 +49,10 @@ const Member = observer(props => {
   let typeSelector
   if (isConfigurationSchemaType(slotSchema)) {
     if (slot.length) {
-      return (
-        <>
-          {slot.map((subslot, slotIndex) => {
-            const key = `${singular(slotName)} ${slotIndex + 1}`
-            return <Member {...props} key={key} slot={subslot} slotName={key} />
-          })}
-        </>
-      )
+      return slot.map((subslot, slotIndex) => {
+        const key = `${singular(slotName)} ${slotIndex + 1}`
+        return <Member {...props} key={key} slot={subslot} slotName={key} />
+      })
     }
     // if this is an explicitly typed schema, make a type-selecting dropdown
     // that can be used to change its type
@@ -64,13 +73,23 @@ const Member = observer(props => {
     }
     return (
       <>
-        <FormLabel>{slotName}</FormLabel>
-        <div className={classes.subSchemaContainer}>
-          {typeSelector}
-          <FormGroup>
-            <Schema schema={slot} />
-          </FormGroup>
-        </div>
+        <Accordion
+          defaultExpanded
+          TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+          >
+            <Typography>Config {slotName}</Typography>
+          </AccordionSummary>
+          <FormLabel>{slotName}</FormLabel>
+          <div className={classes.subSchemaContainer}>
+            {typeSelector}
+            <FormGroup>
+              <Schema schema={slot} />
+            </FormGroup>
+          </div>
+        </Accordion>
       </>
     )
   }
@@ -84,12 +103,15 @@ const Member = observer(props => {
 })
 
 const Schema = observer(({ schema }) => {
-  return iterMap(
-    Object.entries(getMembers(schema).properties),
-    ([slotName, slotSchema]) => (
-      <Member key={slotName} {...{ slotName, slotSchema, schema }} />
-    ),
-  )
+  const properties = getMembers(schema).properties
+  return Object.entries(properties).map(([slotName, slotSchema]) => (
+    <Member
+      key={slotName}
+      slotName={slotName}
+      slotSchema={slotSchema}
+      schema={schema}
+    />
+  ))
 })
 
 const ConfigurationEditor = observer(({ model }) => {
@@ -98,10 +120,22 @@ const ConfigurationEditor = observer(({ model }) => {
   // for different tracks since only the backing model changes for example
   // see pr #804
   const key = model.target && readConfObject(model.target, 'trackId')
+  const name = model.target && readConfObject(model.target, 'name')
   return (
-    <div className={classes.root} key={key} data-testid="configEditor">
-      {!model.target ? 'no target set' : <Schema schema={model.target} />}
-    </div>
+    <Accordion
+      defaultExpanded
+      className={classes.accordion}
+      TransitionProps={{ unmountOnExit: true, timeout: 0 }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+      >
+        <Typography>Configuration{name ? ' - ' + name : ''}</Typography>
+      </AccordionSummary>
+      <div className={classes.root} key={key} data-testid="configEditor">
+        {!model.target ? 'no target set' : <Schema schema={model.target} />}
+      </div>
+    </Accordion>
   )
 })
 

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -7,8 +7,8 @@ import {
 } from '@jbrowse/core/configuration'
 import {
   FormGroup,
-  FormLabel,
   Accordion,
+  AccordionDetails,
   AccordionSummary,
   Typography,
   makeStyles,
@@ -17,29 +17,23 @@ import { observer } from 'mobx-react'
 import { getMembers } from 'mobx-state-tree'
 import { singular } from 'pluralize'
 
-//icons
+// icons
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 
-//locals
+// locals
 import SlotEditor from './SlotEditor'
 import TypeSelector from './TypeSelector'
 
 const useStyles = makeStyles(theme => ({
-  subSchemaContainer: {
-    margin: theme.spacing(1),
-    padding: theme.spacing(1),
-  },
   expandIcon: {
     color: '#fff',
   },
   root: {
     padding: theme.spacing(1, 3, 1, 1),
-    width: '100%',
   },
-  accordion: {
-    maxWidth: '100%',
-    display: 'grid',
-    gridTemplateColumn: '100%',
+  expansionPanelDetails: {
+    display: 'block',
+    padding: theme.spacing(1),
   },
 }))
 
@@ -75,6 +69,7 @@ const Member = observer(props => {
       <>
         <Accordion
           defaultExpanded
+          className={classes.accordion}
           TransitionProps={{ unmountOnExit: true, timeout: 0 }}
         >
           <AccordionSummary
@@ -82,13 +77,12 @@ const Member = observer(props => {
           >
             <Typography>Config {slotName}</Typography>
           </AccordionSummary>
-          <FormLabel>{slotName}</FormLabel>
-          <div className={classes.subSchemaContainer}>
+          <AccordionDetails className={classes.expansionPanelDetails}>
             {typeSelector}
             <FormGroup>
               <Schema schema={slot} />
             </FormGroup>
-          </div>
+          </AccordionDetails>
         </Accordion>
       </>
     )
@@ -123,6 +117,7 @@ const ConfigurationEditor = observer(({ model }) => {
   const name = model.target && readConfObject(model.target, 'name')
   return (
     <Accordion
+      key={key}
       defaultExpanded
       className={classes.accordion}
       TransitionProps={{ unmountOnExit: true, timeout: 0 }}
@@ -132,9 +127,9 @@ const ConfigurationEditor = observer(({ model }) => {
       >
         <Typography>Configuration{name ? ' - ' + name : ''}</Typography>
       </AccordionSummary>
-      <div className={classes.root} key={key} data-testid="configEditor">
+      <AccordionDetails className={classes.expansionPanelDetails}>
         {!model.target ? 'no target set' : <Schema schema={model.target} />}
-      </div>
+      </AccordionDetails>
     </Accordion>
   )
 })

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
   },
 
   accordion: {
-    border: '1px solid #444',
+    border: `1px solid ${theme.palette.text.primary}`,
   },
 }))
 

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -128,7 +128,9 @@ const ConfigurationEditor = observer(({ model }) => {
         <Typography>Configuration{name ? ' - ' + name : ''}</Typography>
       </AccordionSummary>
       <AccordionDetails className={classes.expansionPanelDetails}>
-        {!model.target ? 'no target set' : <Schema schema={model.target} />}
+        <div data-testid="configEditor">
+          {!model.target ? 'no target set' : <Schema schema={model.target} />}
+        </div>
       </AccordionDetails>
     </Accordion>
   )

--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.js
@@ -370,12 +370,9 @@ export const useSlotEditorStyles = makeStyles(theme => ({
     display: 'flex',
     marginBottom: theme.spacing(2),
     position: 'relative',
-    overflow: 'visible',
   },
   paperContent: {
-    flex: 'auto',
-    padding: theme.spacing(1),
-    overflow: 'auto',
+    width: '100%',
   },
   slotModeSwitch: {
     width: 24,

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ConfigurationEditor widget renders all the different types of built-in slots 1`] = `
 <div
-  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+  class="MuiPaper-root MuiAccordion-root makeStyles-accordion MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
     aria-disabled="false"
@@ -18,7 +18,6 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
         class="MuiTypography-root MuiTypography-body1"
       >
         Configuration
-        
       </p>
     </div>
     <div
@@ -60,530 +59,469 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
         >
           <div
             class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+            data-testid="configEditor"
           >
             <div
-              data-testid="configEditor"
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
             >
               <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                class="makeStyles-paperContent"
               >
                 <div
-                  class="makeStyles-paperContent"
+                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                 >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      stringTest
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="text"
-                        value="string1"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      stringTest
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
+                    stringTest
+                  </label>
                   <div
-                    class="MuiBox-root MuiBox-root"
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
-                      data-shrink="true"
-                    >
-                      fileLocationTest
-                    </label>
-                  </div>
-                  <div
-                    class="MuiBox-root MuiBox-root"
-                  >
-                    <div
-                      class="MuiBox-root MuiBox-root"
-                    >
-                      <div
-                        aria-label="file, url, or account picker"
-                        class="MuiToggleButtonGroup-root"
-                        role="group"
-                      >
-                        <button
-                          aria-label="local file"
-                          aria-pressed="false"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
-                          tabindex="0"
-                          type="button"
-                          value="file"
-                        >
-                          <span
-                            class="MuiToggleButton-label"
-                          >
-                            File
-                          </span>
-                          <span
-                            class="MuiTouchRipple-root"
-                          />
-                        </button>
-                        <button
-                          aria-label="url"
-                          aria-pressed="true"
-                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
-                          tabindex="0"
-                          type="button"
-                          value="url"
-                        >
-                          <span
-                            class="MuiToggleButton-label"
-                          >
-                            URL
-                          </span>
-                          <span
-                            class="MuiTouchRipple-root"
-                          />
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-                  >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      Enter URL
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiOutlinedInput-input"
-                        data-testid="urlInput"
-                        type="text"
-                        value="/path/to/my.file"
-                      />
-                      <fieldset
-                        aria-hidden="true"
-                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-                      >
-                        <legend
-                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
-                        >
-                          <span>
-                            Enter URL
-                          </span>
-                        </legend>
-                      </fieldset>
-                    </div>
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="text"
+                      value="string1"
+                    />
                   </div>
                   <p
-                    class="MuiFormHelperText-root"
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    stringTest
+                  </p>
+                </div>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <div
+                  class="MuiBox-root MuiBox-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
+                    data-shrink="true"
                   >
                     fileLocationTest
-                  </p>
+                  </label>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
+                  class="MuiBox-root MuiBox-root"
                 >
-                  <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
-                  >
-                    stringArrayTest
-                  </label>
-                  <ul
-                    class="MuiList-root"
-                  >
-                    <li
-                      class="MuiListItem-root"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                        >
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                            type="text"
-                            value="string1"
-                          />
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                          >
-                            <button
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                              tabindex="0"
-                              type="button"
-                            >
-                              <span
-                                class="MuiIconButton-label"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                  />
-                                </svg>
-                              </span>
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                    <li
-                      class="MuiListItem-root"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                        >
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                            type="text"
-                            value="string2"
-                          />
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                          >
-                            <button
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                              tabindex="0"
-                              type="button"
-                            >
-                              <span
-                                class="MuiIconButton-label"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                  />
-                                </svg>
-                              </span>
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                    <li
-                      class="MuiListItem-root"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                        >
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                            placeholder="add new"
-                            type="text"
-                            value=""
-                          />
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                          >
-                            <button
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-                              data-testid="stringArrayAdd-stringArrayTest"
-                              disabled=""
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <span
-                                class="MuiIconButton-label"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                  />
-                                </svg>
-                              </span>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
-                  <p
-                    class="MuiFormHelperText-root"
-                  >
-                    stringArrayTest
-                  </p>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
-                  >
-                    stringArrayMapTest
-                  </label>
                   <div
-                    class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                    class="MuiBox-root MuiBox-root"
                   >
                     <div
-                      class="MuiCardHeader-root"
+                      aria-label="file, url, or account picker"
+                      class="MuiToggleButtonGroup-root"
+                      role="group"
                     >
-                      <div
-                        class="MuiCardHeader-content"
+                      <button
+                        aria-label="local file"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
+                        tabindex="0"
+                        type="button"
+                        value="file"
                       >
                         <span
-                          class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
+                          class="MuiToggleButton-label"
                         >
-                          key1
+                          File
                         </span>
-                      </div>
-                      <div
-                        class="MuiCardHeader-action"
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="url"
+                        aria-pressed="true"
+                        class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
+                        tabindex="0"
+                        type="button"
+                        value="url"
                       >
-                        <button
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                          tabindex="0"
-                          type="button"
+                        <span
+                          class="MuiToggleButton-label"
                         >
-                          <span
-                            class="MuiIconButton-label"
+                          URL
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                    data-shrink="true"
+                  >
+                    Enter URL
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input"
+                      data-testid="urlInput"
+                      type="text"
+                      value="/path/to/my.file"
+                    />
+                    <fieldset
+                      aria-hidden="true"
+                      class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                      >
+                        <span>
+                          Enter URL
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-root"
+                >
+                  fileLocationTest
+                </p>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
+                >
+                  stringArrayTest
+                </label>
+                <ul
+                  class="MuiList-root"
+                >
+                  <li
+                    class="MuiListItem-root"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiTextField-root"
+                    >
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                      >
+                        <input
+                          aria-invalid="false"
+                          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                          type="text"
+                          value="string1"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                            tabindex="0"
+                            type="button"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root"
-                              focusable="false"
-                              viewBox="0 0 24 24"
+                            <span
+                              class="MuiIconButton-label"
                             >
-                              <path
-                                d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                              />
-                            </svg>
-                          </span>
-                          <span
-                            class="MuiTouchRipple-root"
-                          />
-                        </button>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
                       </div>
                     </div>
+                  </li>
+                  <li
+                    class="MuiListItem-root"
+                  >
                     <div
-                      class="MuiCardContent-root"
+                      class="MuiFormControl-root MuiTextField-root"
                     >
-                      <ul
-                        class="MuiList-root"
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
                       >
-                        <li
-                          class="MuiListItem-root"
+                        <input
+                          aria-invalid="false"
+                          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                          type="text"
+                          value="string2"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
                         >
-                          <div
-                            class="MuiFormControl-root MuiTextField-root"
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                            tabindex="0"
+                            type="button"
                           >
-                            <div
-                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                            <span
+                              class="MuiIconButton-label"
                             >
-                              <input
-                                aria-invalid="false"
-                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                                type="text"
-                                value="string1"
-                              />
-                              <div
-                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
                               >
-                                <button
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                                  tabindex="0"
-                                  type="button"
-                                >
-                                  <span
-                                    class="MuiIconButton-label"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="MuiTouchRipple-root"
-                                  />
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiListItem-root"
-                        >
-                          <div
-                            class="MuiFormControl-root MuiTextField-root"
-                          >
-                            <div
-                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                            >
-                              <input
-                                aria-invalid="false"
-                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                                type="text"
-                                value="string2"
-                              />
-                              <div
-                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                              >
-                                <button
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                                  tabindex="0"
-                                  type="button"
-                                >
-                                  <span
-                                    class="MuiIconButton-label"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="MuiTouchRipple-root"
-                                  />
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiListItem-root"
-                        >
-                          <div
-                            class="MuiFormControl-root MuiTextField-root"
-                          >
-                            <div
-                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                            >
-                              <input
-                                aria-invalid="false"
-                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                                placeholder="add new"
-                                type="text"
-                                value=""
-                              />
-                              <div
-                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                              >
-                                <button
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-                                  data-testid="stringArrayAdd-undefined"
-                                  disabled=""
-                                  tabindex="-1"
-                                  type="button"
-                                >
-                                  <span
-                                    class="MuiIconButton-label"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
-                      <p
-                        class="MuiFormHelperText-root"
+                                <path
+                                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li
+                    class="MuiListItem-root"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiTextField-root"
+                    >
+                      <div
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
                       >
-                        Values associated with entry key1
-                      </p>
+                        <input
+                          aria-invalid="false"
+                          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                          placeholder="add new"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                            data-testid="stringArrayAdd-stringArrayTest"
+                            disabled=""
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <span
+                              class="MuiIconButton-label"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+                <p
+                  class="MuiFormHelperText-root"
+                >
+                  stringArrayTest
+                </p>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
+                >
+                  stringArrayMapTest
+                </label>
+                <div
+                  class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                >
+                  <div
+                    class="MuiCardHeader-root"
+                  >
+                    <div
+                      class="MuiCardHeader-content"
+                    >
+                      <span
+                        class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
+                      >
+                        key1
+                      </span>
+                    </div>
+                    <div
+                      class="MuiCardHeader-action"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
                     </div>
                   </div>
                   <div
-                    class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                    class="MuiCardContent-root"
                   >
-                    <div
-                      class="MuiCardHeader-root"
+                    <ul
+                      class="MuiList-root"
                     >
-                      <div
-                        class="MuiCardHeader-content"
+                      <li
+                        class="MuiListItem-root"
                       >
                         <div
-                          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                          class="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                          >
+                            <input
+                              aria-invalid="false"
+                              class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                              type="text"
+                              value="string1"
+                            />
+                            <div
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                            >
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                tabindex="0"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                      <li
+                        class="MuiListItem-root"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiTextField-root"
+                        >
+                          <div
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                          >
+                            <input
+                              aria-invalid="false"
+                              class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                              type="text"
+                              value="string2"
+                            />
+                            <div
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                            >
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                tabindex="0"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                      <li
+                        class="MuiListItem-root"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiTextField-root"
+                        >
+                          <div
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
                           >
                             <input
                               aria-invalid="false"
@@ -597,6 +535,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
                             >
                               <button
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                                data-testid="stringArrayAdd-undefined"
                                 disabled=""
                                 tabindex="-1"
                                 type="button"
@@ -619,186 +558,243 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </div>
-                  </div>
-                  <p
-                    class="MuiFormHelperText-root"
-                  >
-                    stringArrayMapTest
-                  </p>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root"
-                  >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      numberTest
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="number"
-                        value="88.5"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      numberTest
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root"
-                  >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      integerTest
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="number"
-                        value="42"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      integerTest
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-                  >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      colorTest
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                      style="color: rgb(57, 100, 148); border-right-width: 25px; border-right-style: solid; border-right-color: #396494;"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="text"
-                        value="#396494"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      colorTest
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
-              </div>
-              <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <div
-                  class="makeStyles-paperContent"
-                >
-                  <div
-                    class="MuiFormControl-root"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root"
-                    >
-                      <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
-                      >
-                        <span
-                          class="MuiIconButton-label"
-                        >
-                          <input
-                            checked=""
-                            class="PrivateSwitchBase-input"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value=""
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="MuiTouchRipple-root"
-                        />
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        booleanTest
-                      </span>
-                    </label>
+                      </li>
+                    </ul>
                     <p
                       class="MuiFormHelperText-root"
                     >
-                      booleanTest
+                      Values associated with entry key1
                     </p>
                   </div>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch"
-                />
+                  class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                >
+                  <div
+                    class="MuiCardHeader-root"
+                  >
+                    <div
+                      class="MuiCardHeader-content"
+                    >
+                      <div
+                        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                      >
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                            placeholder="add new"
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                              disabled=""
+                              tabindex="-1"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                  />
+                                </svg>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-root"
+                >
+                  stringArrayMapTest
+                </p>
               </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <div
+                  class="MuiFormControl-root MuiTextField-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
+                  >
+                    numberTest
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="number"
+                      value="88.5"
+                    />
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    numberTest
+                  </p>
+                </div>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <div
+                  class="MuiFormControl-root MuiTextField-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
+                  >
+                    integerTest
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="number"
+                      value="42"
+                    />
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    integerTest
+                  </p>
+                </div>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <div
+                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
+                  >
+                    colorTest
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                    style="color: rgb(57, 100, 148); border-right-width: 25px; border-right-style: solid; border-right-color: #396494;"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="text"
+                      value="#396494"
+                    />
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    colorTest
+                  </p>
+                </div>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
+              >
+                <div
+                  class="MuiFormControl-root"
+                >
+                  <label
+                    class="MuiFormControlLabel-root"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          checked=""
+                          class="PrivateSwitchBase-input"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value=""
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      booleanTest
+                    </span>
+                  </label>
+                  <p
+                    class="MuiFormHelperText-root"
+                  >
+                    booleanTest
+                  </p>
+                </div>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
             </div>
           </div>
         </div>
@@ -810,7 +806,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
 
 exports[`ConfigurationEditor widget renders with defaults of the PileupTrack schema 1`] = `
 <div
-  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+  class="MuiPaper-root MuiAccordion-root makeStyles-accordion MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
     aria-disabled="false"
@@ -826,7 +822,6 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
         class="MuiTypography-root MuiTypography-body1"
       >
         Configuration
-        
       </p>
     </div>
     <div
@@ -868,124 +863,122 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
         >
           <div
             class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+            data-testid="configEditor"
           >
             <div
-              data-testid="configEditor"
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
             >
               <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                class="makeStyles-paperContent"
               >
                 <div
-                  class="makeStyles-paperContent"
+                  class="MuiFormControl-root MuiTextField-root"
                 >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      maxFeatureScreenDensity
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="number"
-                        value="0.3"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      maximum features per pixel that is displayed in the view, used if byte size estimates not available
-                    </p>
+                    maxFeatureScreenDensity
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="number"
+                      value="0.3"
+                    />
                   </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    maximum features per pixel that is displayed in the view, used if byte size estimates not available
+                  </p>
                 </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
               </div>
               <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
               >
                 <div
-                  class="makeStyles-paperContent"
+                  class="MuiFormControl-root MuiTextField-root"
                 >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      fetchSizeLimit
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="number"
-                        value="1000000"
-                      />
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root MuiFormHelperText-filled"
-                    >
-                      maximum data to attempt to download for a given track, used if adapter doesn't specify one
-                    </p>
+                    fetchSizeLimit
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="number"
+                      value="1000000"
+                    />
                   </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                  >
+                    maximum data to attempt to download for a given track, used if adapter doesn't specify one
+                  </p>
                 </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
               </div>
               <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                class="makeStyles-slotModeSwitch"
+              />
+            </div>
+            <div
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                class="makeStyles-paperContent"
               >
                 <div
-                  class="makeStyles-paperContent"
+                  class="MuiFormControl-root"
                 >
-                  <div
-                    class="MuiFormControl-root"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+                    data-shrink="true"
+                    for="callback-editor"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-                      data-shrink="true"
-                      for="callback-editor"
+                    mouseover
+                  </label>
+                  <div
+                    class="makeStyles-callbackEditor"
+                    style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
+                  >
+                    <textarea
+                      autocapitalize="off"
+                      autocomplete="off"
+                      autocorrect="off"
+                      class="npm__react-simple-code-editor__textarea"
+                      data-gramm="false"
+                      spellcheck="false"
+                      style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
                     >
-                      mouseover
-                    </label>
-                    <div
-                      class="makeStyles-callbackEditor"
-                      style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
+                      get(feature,'name')
+                    </textarea>
+                    <pre
+                      aria-hidden="true"
+                      style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: relative; pointer-events: none; padding: 10px 10px 10px 10px;"
                     >
-                      <textarea
-                        autocapitalize="off"
-                        autocomplete="off"
-                        autocorrect="off"
-                        class="npm__react-simple-code-editor__textarea"
-                        data-gramm="false"
-                        spellcheck="false"
-                        style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
-                      >
-                        get(feature,'name')
-                      </textarea>
-                      <pre
-                        aria-hidden="true"
-                        style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: relative; pointer-events: none; padding: 10px 10px 10px 10px;"
-                      >
-                        get(feature,'name')
-                        <br />
-                      </pre>
-                      <style
-                        type="text/css"
-                      >
-                        
+                      get(feature,'name')
+                      <br />
+                    </pre>
+                    <style
+                      type="text/css"
+                    >
+                      
 /**
  * Reset the text fill color so that placeholder is visible
  */
@@ -1012,127 +1005,179 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
   }
 }
 
-                      </style>
-                    </div>
-                    <p
-                      class="MuiFormHelperText-root"
-                    >
-                      what to display in a given mouseover
-                       
-                      <button
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <span
-                          class="MuiIconButton-label"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="MuiTouchRipple-root"
-                        />
-                      </button>
-                    </p>
+                    </style>
                   </div>
+                  <p
+                    class="MuiFormHelperText-root"
+                  >
+                    what to display in a given mouseover
+                  </p>
+                </div>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                  tabindex="0"
+                  title="convert to regular value"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20.41,3C21.8,5.71 22.35,8.84 22,12C21.8,15.16 20.7,18.29 18.83,21L17.3,20C18.91,17.57 19.85,14.8 20,12C20.34,9.2 19.89,6.43 18.7,4L20.41,3M5.17,3L6.7,4C5.09,6.43 4.15,9.2 4,12C3.66,14.8 4.12,17.57 5.3,20L3.61,21C2.21,18.29 1.65,15.17 2,12C2.2,8.84 3.3,5.71 5.17,3M12.08,10.68L14.4,7.45H16.93L13.15,12.45L15.35,17.37H13.09L11.71,14L9.28,17.33H6.76L10.66,12.21L8.53,7.45H10.8L12.08,10.68Z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="MuiPaper-root MuiAccordion-root makeStyles-accordion MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+            >
+              <div
+                aria-disabled="false"
+                aria-expanded="true"
+                class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1"
+                  >
+                    renderer
+                  </p>
                 </div>
                 <div
-                  class="makeStyles-slotModeSwitch"
+                  aria-disabled="false"
+                  aria-hidden="true"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
                 >
-                  <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                    tabindex="0"
-                    title="convert to regular value"
-                    type="button"
+                  <span
+                    class="MuiIconButton-label"
                   >
-                    <span
-                      class="MuiIconButton-label"
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root makeStyles-expandIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M20.41,3C21.8,5.71 22.35,8.84 22,12C21.8,15.16 20.7,18.29 18.83,21L17.3,20C18.91,17.57 19.85,14.8 20,12C20.34,9.2 19.89,6.43 18.7,4L20.41,3M5.17,3L6.7,4C5.09,6.43 4.15,9.2 4,12C3.66,14.8 4.12,17.57 5.3,20L3.61,21C2.21,18.29 1.65,15.17 2,12C2.2,8.84 3.3,5.71 5.17,3M12.08,10.68L14.4,7.45H16.93L13.15,12.45L15.35,17.37H13.09L11.71,14L9.28,17.33H6.76L10.66,12.21L8.53,7.45H10.8L12.08,10.68Z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
+                      <path
+                        d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+                class="MuiCollapse-root MuiCollapse-entered"
+                style="min-height: 0px;"
               >
                 <div
-                  aria-disabled="false"
-                  aria-expanded="true"
-                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
-                  role="button"
-                  tabindex="0"
+                  class="MuiCollapse-wrapper"
                 >
                   <div
-                    class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                    >
-                      Config 
-                      renderer
-                    </p>
-                  </div>
-                  <div
-                    aria-disabled="false"
-                    aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root makeStyles-expandIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="MuiCollapse-root MuiCollapse-entered"
-                  style="min-height: 0px;"
-                >
-                  <div
-                    class="MuiCollapse-wrapper"
+                    class="MuiCollapse-wrapperInner"
                   >
                     <div
-                      class="MuiCollapse-wrapperInner"
+                      role="region"
                     >
                       <div
-                        role="region"
+                        class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
                       >
                         <div
-                          class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+                          class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                        >
+                          <div
+                            class="makeStyles-paperContent"
+                          >
+                            <div
+                              class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                            >
+                              <label
+                                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                data-shrink="true"
+                              >
+                                Type
+                              </label>
+                              <div
+                                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                              >
+                                <div
+                                  aria-haspopup="listbox"
+                                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                  role="button"
+                                  tabindex="0"
+                                >
+                                  PileupRenderer
+                                </div>
+                                <input
+                                  aria-hidden="true"
+                                  class="MuiSelect-nativeInput"
+                                  tabindex="-1"
+                                  value="PileupRenderer"
+                                />
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSelect-icon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </div>
+                              <p
+                                class="MuiFormHelperText-root MuiFormHelperText-filled"
+                              >
+                                Type of renderer to use
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiFormGroup-root"
                         >
                           <div
                             class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
@@ -1147,7 +1192,69 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
                                   data-shrink="true"
                                 >
-                                  Type
+                                  color
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                  style="color: rgb(255, 0, 255); border-right-width: 25px; border-right-style: solid; border-right-color: #f0f;"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="text"
+                                    value="#f0f"
+                                  />
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  the color of each feature in a pileup alignment
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            >
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                tabindex="0"
+                                title="convert to callback"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  orientationType
                                 </label>
                                 <div
                                   class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
@@ -1158,13 +1265,13 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                                     role="button"
                                     tabindex="0"
                                   >
-                                    PileupRenderer
+                                    fr
                                   </div>
                                   <input
                                     aria-hidden="true"
                                     class="MuiSelect-nativeInput"
                                     tabindex="-1"
-                                    value="PileupRenderer"
+                                    value="fr"
                                   />
                                   <svg
                                     aria-hidden="true"
@@ -1180,503 +1287,386 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                                 <p
                                   class="MuiFormHelperText-root MuiFormHelperText-filled"
                                 >
-                                  Type of renderer to use
+                                  read sequencer orienation. fr is normal "reads pointing at each other ---&gt; &lt;--- while some other sequencers can use other options
                                 </p>
                               </div>
                             </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
                           </div>
                           <div
-                            class="MuiFormGroup-root"
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
                           >
                             <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                              class="makeStyles-paperContent"
                             >
                               <div
-                                class="makeStyles-paperContent"
+                                class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                               >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
                                 >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    color
-                                  </label>
+                                  displayMode
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                >
                                   <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                                    style="color: rgb(255, 0, 255); border-right-width: 25px; border-right-style: solid; border-right-color: #f0f;"
+                                    aria-haspopup="listbox"
+                                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                    role="button"
+                                    tabindex="0"
                                   >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="text"
-                                      value="#f0f"
-                                    />
+                                    normal
                                   </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  <input
+                                    aria-hidden="true"
+                                    class="MuiSelect-nativeInput"
+                                    tabindex="-1"
+                                    value="normal"
+                                  />
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSelect-icon"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
                                   >
-                                    the color of each feature in a pileup alignment
-                                  </p>
+                                    <path
+                                      d="M7 10l5 5 5-5z"
+                                    />
+                                  </svg>
                                 </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  Alternative display modes
+                                </p>
                               </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
                               <div
-                                class="makeStyles-slotModeSwitch"
+                                class="MuiFormControl-root MuiTextField-root"
                               >
-                                <button
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                                  tabindex="0"
-                                  title="convert to callback"
-                                  type="button"
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  minSubfeatureWidth
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="number"
+                                    value="0"
+                                  />
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  the minimum width in px for a pileup mismatch feature. use for increasing mismatch marker widths when zoomed out to e.g. 1px or 0.5px
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  maxHeight
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="number"
+                                    value="1200"
+                                  />
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  the maximum height to be used in a pileup rendering
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  maxClippingSize
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="number"
+                                    value="10000"
+                                  />
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  the max clip size to be used in a pileup rendering
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  height
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="number"
+                                    value="7"
+                                  />
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  the height of each feature in a pileup alignment
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            >
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                tabindex="0"
+                                title="convert to callback"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root"
+                              >
+                                <label
+                                  class="MuiFormControlLabel-root"
                                 >
                                   <span
-                                    class="MuiIconButton-label"
+                                    aria-disabled="false"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
+                                    <span
+                                      class="MuiIconButton-label"
                                     >
-                                      <path
-                                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                      <input
+                                        class="PrivateSwitchBase-input"
+                                        data-indeterminate="false"
+                                        type="checkbox"
+                                        value=""
                                       />
-                                    </svg>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
                                   </span>
                                   <span
-                                    class="MuiTouchRipple-root"
+                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                  >
+                                    noSpacing
+                                  </span>
+                                </label>
+                                <p
+                                  class="MuiFormHelperText-root"
+                                >
+                                  remove spacing between features
+                                </p>
+                              </div>
+                            </div>
+                            <div
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  largeInsertionIndicatorScale
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <input
+                                    aria-invalid="false"
+                                    class="MuiInputBase-input MuiInput-input"
+                                    type="number"
+                                    value="10"
                                   />
-                                </button>
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  scale at which to draw the large insertion indicators (bp/pixel)
+                                </p>
                               </div>
                             </div>
                             <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    orientationType
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <div
-                                      aria-haspopup="listbox"
-                                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      fr
-                                    </div>
-                                    <input
-                                      aria-hidden="true"
-                                      class="MuiSelect-nativeInput"
-                                      tabindex="-1"
-                                      value="fr"
-                                    />
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root MuiSelect-icon"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M7 10l5 5 5-5z"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    read sequencer orienation. fr is normal "reads pointing at each other ---&gt; &lt;--- while some other sequencers can use other options
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
+                              class="makeStyles-slotModeSwitch"
+                            />
+                          </div>
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
                             <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                              class="makeStyles-paperContent"
                             >
                               <div
-                                class="makeStyles-paperContent"
+                                class="MuiFormControl-root"
                               >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    displayMode
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <div
-                                      aria-haspopup="listbox"
-                                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      normal
-                                    </div>
-                                    <input
-                                      aria-hidden="true"
-                                      class="MuiSelect-nativeInput"
-                                      tabindex="-1"
-                                      value="normal"
-                                    />
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root MuiSelect-icon"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M7 10l5 5 5-5z"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    Alternative display modes
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    minSubfeatureWidth
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="number"
-                                      value="0"
-                                    />
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    the minimum width in px for a pileup mismatch feature. use for increasing mismatch marker widths when zoomed out to e.g. 1px or 0.5px
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    maxHeight
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="number"
-                                      value="1200"
-                                    />
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    the maximum height to be used in a pileup rendering
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    maxClippingSize
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="number"
-                                      value="10000"
-                                    />
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    the max clip size to be used in a pileup rendering
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    height
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="number"
-                                      value="7"
-                                    />
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    the height of each feature in a pileup alignment
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              >
-                                <button
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                                  tabindex="0"
-                                  title="convert to callback"
-                                  type="button"
+                                <label
+                                  class="MuiFormControlLabel-root"
                                 >
                                   <span
-                                    class="MuiIconButton-label"
+                                    aria-disabled="false"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
+                                    <span
+                                      class="MuiIconButton-label"
                                     >
-                                      <path
-                                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                      <input
+                                        class="PrivateSwitchBase-input"
+                                        data-indeterminate="false"
+                                        type="checkbox"
+                                        value=""
                                       />
-                                    </svg>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="MuiTouchRipple-root"
+                                    />
                                   </span>
                                   <span
-                                    class="MuiTouchRipple-root"
-                                  />
-                                </button>
+                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                  >
+                                    mismatchAlpha
+                                  </span>
+                                </label>
+                                <p
+                                  class="MuiFormHelperText-root"
+                                >
+                                  Fade low quality mismatches
+                                </p>
                               </div>
                             </div>
                             <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root"
-                                >
-                                  <label
-                                    class="MuiFormControlLabel-root"
-                                  >
-                                    <span
-                                      aria-disabled="false"
-                                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                    >
-                                      <span
-                                        class="MuiIconButton-label"
-                                      >
-                                        <input
-                                          class="PrivateSwitchBase-input"
-                                          data-indeterminate="false"
-                                          type="checkbox"
-                                          value=""
-                                        />
-                                        <svg
-                                          aria-hidden="true"
-                                          class="MuiSvgIcon-root"
-                                          focusable="false"
-                                          viewBox="0 0 24 24"
-                                        >
-                                          <path
-                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="MuiTouchRipple-root"
-                                      />
-                                    </span>
-                                    <span
-                                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                    >
-                                      noSpacing
-                                    </span>
-                                  </label>
-                                  <p
-                                    class="MuiFormHelperText-root"
-                                  >
-                                    remove spacing between features
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root MuiTextField-root"
-                                >
-                                  <label
-                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                                    data-shrink="true"
-                                  >
-                                    largeInsertionIndicatorScale
-                                  </label>
-                                  <div
-                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      class="MuiInputBase-input MuiInput-input"
-                                      type="number"
-                                      value="10"
-                                    />
-                                  </div>
-                                  <p
-                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
-                                  >
-                                    scale at which to draw the large insertion indicators (bp/pixel)
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
-                            <div
-                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-                            >
-                              <div
-                                class="makeStyles-paperContent"
-                              >
-                                <div
-                                  class="MuiFormControl-root"
-                                >
-                                  <label
-                                    class="MuiFormControlLabel-root"
-                                  >
-                                    <span
-                                      aria-disabled="false"
-                                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                    >
-                                      <span
-                                        class="MuiIconButton-label"
-                                      >
-                                        <input
-                                          class="PrivateSwitchBase-input"
-                                          data-indeterminate="false"
-                                          type="checkbox"
-                                          value=""
-                                        />
-                                        <svg
-                                          aria-hidden="true"
-                                          class="MuiSvgIcon-root"
-                                          focusable="false"
-                                          viewBox="0 0 24 24"
-                                        >
-                                          <path
-                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                                          />
-                                        </svg>
-                                      </span>
-                                      <span
-                                        class="MuiTouchRipple-root"
-                                      />
-                                    </span>
-                                    <span
-                                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                    >
-                                      mismatchAlpha
-                                    </span>
-                                  </label>
-                                  <p
-                                    class="MuiFormHelperText-root"
-                                  >
-                                    Fade low quality mismatches
-                                  </p>
-                                </div>
-                              </div>
-                              <div
-                                class="makeStyles-slotModeSwitch"
-                              />
-                            </div>
+                              class="makeStyles-slotModeSwitch"
+                            />
                           </div>
                         </div>
                       </div>
@@ -1695,7 +1685,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
 
 exports[`ConfigurationEditor widget renders with just the required model elements 1`] = `
 <div
-  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+  class="MuiPaper-root MuiAccordion-root makeStyles-accordion MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
     aria-disabled="false"
@@ -1711,7 +1701,6 @@ exports[`ConfigurationEditor widget renders with just the required model element
         class="MuiTypography-root MuiTypography-body1"
       >
         Configuration
-        
       </p>
     </div>
     <div
@@ -1753,42 +1742,39 @@ exports[`ConfigurationEditor widget renders with just the required model element
         >
           <div
             class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+            data-testid="configEditor"
           >
             <div
-              data-testid="configEditor"
+              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
             >
               <div
-                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                class="makeStyles-paperContent"
               >
                 <div
-                  class="makeStyles-paperContent"
+                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
                 >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                    data-shrink="true"
                   >
-                    <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-                      data-shrink="true"
-                    >
-                      foo
-                    </label>
-                    <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="MuiInputBase-input MuiInput-input"
-                        type="text"
-                        value="bar"
-                      />
-                    </div>
-                    
+                    foo
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiInput-input"
+                      type="text"
+                      value="bar"
+                    />
                   </div>
+                  
                 </div>
-                <div
-                  class="makeStyles-slotModeSwitch"
-                />
               </div>
+              <div
+                class="makeStyles-slotModeSwitch"
+              />
             </div>
           </div>
         </div>

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.js.snap
@@ -2,866 +2,990 @@
 
 exports[`ConfigurationEditor widget renders all the different types of built-in slots 1`] = `
 <div
-  class="makeStyles-root"
-  data-testid="configEditor"
+  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+    aria-disabled="false"
+    aria-expanded="true"
+    class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
+    role="button"
+    tabindex="0"
   >
     <div
-      class="makeStyles-paperContent"
+      class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
     >
-      <div
-        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          stringTest
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="text"
-            value="string1"
-          />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          stringTest
-        </p>
-      </div>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
-    >
-      <div
-        class="MuiBox-root MuiBox-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink="true"
-        >
-          fileLocationTest
-        </label>
-      </div>
-      <div
-        class="MuiBox-root MuiBox-root"
-      >
-        <div
-          class="MuiBox-root MuiBox-root"
-        >
-          <div
-            aria-label="file, url, or account picker"
-            class="MuiToggleButtonGroup-root"
-            role="group"
-          >
-            <button
-              aria-label="local file"
-              aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
-              tabindex="0"
-              type="button"
-              value="file"
-            >
-              <span
-                class="MuiToggleButton-label"
-              >
-                File
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-            <button
-              aria-label="url"
-              aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
-              tabindex="0"
-              type="button"
-              value="url"
-            >
-              <span
-                class="MuiToggleButton-label"
-              >
-                URL
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          Enter URL
-        </label>
-        <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input"
-            data-testid="urlInput"
-            type="text"
-            value="/path/to/my.file"
-          />
-          <fieldset
-            aria-hidden="true"
-            class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
-            >
-              <span>
-                Enter URL
-              </span>
-            </legend>
-          </fieldset>
-        </div>
-      </div>
       <p
-        class="MuiFormHelperText-root"
+        class="MuiTypography-root MuiTypography-body1"
       >
-        fileLocationTest
+        Configuration
+        
       </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
+      aria-disabled="false"
+      aria-hidden="true"
+      class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
+      <span
+        class="MuiIconButton-label"
       >
-        stringArrayTest
-      </label>
-      <ul
-        class="MuiList-root"
-      >
-        <li
-          class="MuiListItem-root"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root makeStyles-expandIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                type="text"
-                value="string1"
-              />
-              <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-              >
-                <button
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
-            </div>
-          </div>
-        </li>
-        <li
-          class="MuiListItem-root"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                type="text"
-                value="string2"
-              />
-              <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-              >
-                <button
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
-            </div>
-          </div>
-        </li>
-        <li
-          class="MuiListItem-root"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                placeholder="add new"
-                type="text"
-                value=""
-              />
-              <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-              >
-                <button
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-                  data-testid="stringArrayAdd-stringArrayTest"
-                  disabled=""
-                  tabindex="-1"
-                  type="button"
-                >
-                  <span
-                    class="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </li>
-      </ul>
-      <p
-        class="MuiFormHelperText-root"
-      >
-        stringArrayTest
-      </p>
+          <path
+            d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
     </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
   </div>
   <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+    class="MuiCollapse-root MuiCollapse-entered"
+    style="min-height: 0px;"
   >
     <div
-      class="makeStyles-paperContent"
+      class="MuiCollapse-wrapper"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
-      >
-        stringArrayMapTest
-      </label>
       <div
-        class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+        class="MuiCollapse-wrapperInner"
       >
         <div
-          class="MuiCardHeader-root"
+          role="region"
         >
           <div
-            class="MuiCardHeader-content"
-          >
-            <span
-              class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
-            >
-              key1
-            </span>
-          </div>
-          <div
-            class="MuiCardHeader-action"
-          >
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
-        </div>
-        <div
-          class="MuiCardContent-root"
-        >
-          <ul
-            class="MuiList-root"
-          >
-            <li
-              class="MuiListItem-root"
-            >
-              <div
-                class="MuiFormControl-root MuiTextField-root"
-              >
-                <div
-                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                >
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                    type="text"
-                    value="string1"
-                  />
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              class="MuiListItem-root"
-            >
-              <div
-                class="MuiFormControl-root MuiTextField-root"
-              >
-                <div
-                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                >
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                    type="text"
-                    value="string2"
-                  />
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              class="MuiListItem-root"
-            >
-              <div
-                class="MuiFormControl-root MuiTextField-root"
-              >
-                <div
-                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
-                >
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                    placeholder="add new"
-                    type="text"
-                    value=""
-                  />
-                  <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-                      data-testid="stringArrayAdd-undefined"
-                      disabled=""
-                      tabindex="-1"
-                      type="button"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                          />
-                        </svg>
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </li>
-          </ul>
-          <p
-            class="MuiFormHelperText-root"
-          >
-            Values associated with entry key1
-          </p>
-        </div>
-      </div>
-      <div
-        class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
-      >
-        <div
-          class="MuiCardHeader-root"
-        >
-          <div
-            class="MuiCardHeader-content"
+            class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
           >
             <div
-              class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+              data-testid="configEditor"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
               >
-                <input
-                  aria-invalid="false"
-                  class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
-                  placeholder="add new"
-                  type="text"
-                  value=""
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      stringTest
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="text"
+                        value="string1"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      stringTest
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
                 />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                  class="makeStyles-paperContent"
                 >
-                  <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
-                    disabled=""
-                    tabindex="-1"
-                    type="button"
+                  <div
+                    class="MuiBox-root MuiBox-root"
                   >
-                    <span
-                      class="MuiIconButton-label"
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
+                      data-shrink="true"
                     >
-                      <svg
+                      fileLocationTest
+                    </label>
+                  </div>
+                  <div
+                    class="MuiBox-root MuiBox-root"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root"
+                    >
+                      <div
+                        aria-label="file, url, or account picker"
+                        class="MuiToggleButtonGroup-root"
+                        role="group"
+                      >
+                        <button
+                          aria-label="local file"
+                          aria-pressed="false"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal"
+                          tabindex="0"
+                          type="button"
+                          value="file"
+                        >
+                          <span
+                            class="MuiToggleButton-label"
+                          >
+                            File
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                        <button
+                          aria-label="url"
+                          aria-pressed="true"
+                          class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-selected"
+                          tabindex="0"
+                          type="button"
+                          value="url"
+                        >
+                          <span
+                            class="MuiToggleButton-label"
+                          >
+                            URL
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      Enter URL
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiOutlinedInput-input"
+                        data-testid="urlInput"
+                        type="text"
+                        value="/path/to/my.file"
+                      />
+                      <fieldset
                         aria-hidden="true"
-                        class="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                        class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
                       >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                        <legend
+                          class="PrivateNotchedOutline-legendLabelled PrivateNotchedOutline-legendNotched"
+                        >
+                          <span>
+                            Enter URL
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root"
+                  >
+                    fileLocationTest
+                  </p>
                 </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
+                  >
+                    stringArrayTest
+                  </label>
+                  <ul
+                    class="MuiList-root"
+                  >
+                    <li
+                      class="MuiListItem-root"
+                    >
+                      <div
+                        class="MuiFormControl-root MuiTextField-root"
+                      >
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                            type="text"
+                            value="string1"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiListItem-root"
+                    >
+                      <div
+                        class="MuiFormControl-root MuiTextField-root"
+                      >
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                            type="text"
+                            value="string2"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiListItem-root"
+                    >
+                      <div
+                        class="MuiFormControl-root MuiTextField-root"
+                      >
+                        <div
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                            placeholder="add new"
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                              data-testid="stringArrayAdd-stringArrayTest"
+                              disabled=""
+                              tabindex="-1"
+                              type="button"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                  />
+                                </svg>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <p
+                    class="MuiFormHelperText-root"
+                  >
+                    stringArrayTest
+                  </p>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated"
+                  >
+                    stringArrayMapTest
+                  </label>
+                  <div
+                    class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                  >
+                    <div
+                      class="MuiCardHeader-root"
+                    >
+                      <div
+                        class="MuiCardHeader-content"
+                      >
+                        <span
+                          class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
+                        >
+                          key1
+                        </span>
+                      </div>
+                      <div
+                        class="MuiCardHeader-action"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiIconButton-label"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCardContent-root"
+                    >
+                      <ul
+                        class="MuiList-root"
+                      >
+                        <li
+                          class="MuiListItem-root"
+                        >
+                          <div
+                            class="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                            >
+                              <input
+                                aria-invalid="false"
+                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                                type="text"
+                                value="string1"
+                              />
+                              <div
+                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                              >
+                                <button
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiListItem-root"
+                        >
+                          <div
+                            class="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                            >
+                              <input
+                                aria-invalid="false"
+                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                                type="text"
+                                value="string2"
+                              />
+                              <div
+                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                              >
+                                <button
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiListItem-root"
+                        >
+                          <div
+                            class="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                            >
+                              <input
+                                aria-invalid="false"
+                                class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                                placeholder="add new"
+                                type="text"
+                                value=""
+                              />
+                              <div
+                                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                              >
+                                <button
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                                  data-testid="stringArrayAdd-undefined"
+                                  disabled=""
+                                  tabindex="-1"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                      <p
+                        class="MuiFormHelperText-root"
+                      >
+                        Values associated with entry key1
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiPaper-root MuiCard-root makeStyles-card MuiPaper-elevation8 MuiPaper-rounded"
+                  >
+                    <div
+                      class="MuiCardHeader-root"
+                    >
+                      <div
+                        class="MuiCardHeader-content"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                        >
+                          <div
+                            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+                          >
+                            <input
+                              aria-invalid="false"
+                              class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                              placeholder="add new"
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+                            >
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-disabled MuiButtonBase-disabled"
+                                disabled=""
+                                tabindex="-1"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                    />
+                                  </svg>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root"
+                  >
+                    stringArrayMapTest
+                  </p>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      numberTest
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="number"
+                        value="88.5"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      numberTest
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      integerTest
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="number"
+                        value="42"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      integerTest
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      colorTest
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                      style="color: rgb(57, 100, 148); border-right-width: 25px; border-right-style: solid; border-right-color: #396494;"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="text"
+                        value="#396494"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      colorTest
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root"
+                  >
+                    <label
+                      class="MuiFormControlLabel-root"
+                    >
+                      <span
+                        aria-disabled="false"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <input
+                            checked=""
+                            class="PrivateSwitchBase-input"
+                            data-indeterminate="false"
+                            type="checkbox"
+                            value=""
+                          />
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                      >
+                        booleanTest
+                      </span>
+                    </label>
+                    <p
+                      class="MuiFormHelperText-root"
+                    >
+                      booleanTest
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
               </div>
             </div>
           </div>
         </div>
       </div>
-      <p
-        class="MuiFormHelperText-root"
-      >
-        stringArrayMapTest
-      </p>
     </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
-    >
-      <div
-        class="MuiFormControl-root MuiTextField-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          numberTest
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="number"
-            value="88.5"
-          />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          numberTest
-        </p>
-      </div>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
-    >
-      <div
-        class="MuiFormControl-root MuiTextField-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          integerTest
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="number"
-            value="42"
-          />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          integerTest
-        </p>
-      </div>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
-    >
-      <div
-        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          colorTest
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-          style="color: rgb(57, 100, 148); border-right-width: 25px; border-right-style: solid; border-right-color: #396494;"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="text"
-            value="#396494"
-          />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          colorTest
-        </p>
-      </div>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
-    >
-      <div
-        class="MuiFormControl-root"
-      >
-        <label
-          class="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled="false"
-            class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-checked MuiCheckbox-checked MuiIconButton-colorSecondary"
-          >
-            <span
-              class="MuiIconButton-label"
-            >
-              <input
-                checked=""
-                class="PrivateSwitchBase-input"
-                data-indeterminate="false"
-                type="checkbox"
-                value=""
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            booleanTest
-          </span>
-        </label>
-        <p
-          class="MuiFormHelperText-root"
-        >
-          booleanTest
-        </p>
-      </div>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
   </div>
 </div>
 `;
 
 exports[`ConfigurationEditor widget renders with defaults of the PileupTrack schema 1`] = `
 <div
-  class="makeStyles-root"
-  data-testid="configEditor"
+  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+    aria-disabled="false"
+    aria-expanded="true"
+    class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
+    role="button"
+    tabindex="0"
   >
     <div
-      class="makeStyles-paperContent"
+      class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
     >
-      <div
-        class="MuiFormControl-root MuiTextField-root"
+      <p
+        class="MuiTypography-root MuiTypography-body1"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          maxFeatureScreenDensity
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="number"
-            value="0.3"
-          />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          maximum features per pixel that is displayed in the view, used if byte size estimates not available
-        </p>
-      </div>
+        Configuration
+        
+      </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch"
-    />
-  </div>
-  <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-  >
-    <div
-      class="makeStyles-paperContent"
+      aria-disabled="false"
+      aria-hidden="true"
+      class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
     >
-      <div
-        class="MuiFormControl-root MuiTextField-root"
+      <span
+        class="MuiIconButton-label"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root makeStyles-expandIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          fetchSizeLimit
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="number"
-            value="1000000"
+          <path
+            d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
           />
-        </div>
-        <p
-          class="MuiFormHelperText-root MuiFormHelperText-filled"
-        >
-          maximum data to attempt to download for a given track, used if adapter doesn't specify one
-        </p>
-      </div>
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
     </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    />
   </div>
   <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+    class="MuiCollapse-root MuiCollapse-entered"
+    style="min-height: 0px;"
   >
     <div
-      class="makeStyles-paperContent"
+      class="MuiCollapse-wrapper"
     >
       <div
-        class="MuiFormControl-root"
+        class="MuiCollapse-wrapperInner"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink="true"
-          for="callback-editor"
-        >
-          mouseover
-        </label>
         <div
-          class="makeStyles-callbackEditor"
-          style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
+          role="region"
         >
-          <textarea
-            autocapitalize="off"
-            autocomplete="off"
-            autocorrect="off"
-            class="npm__react-simple-code-editor__textarea"
-            data-gramm="false"
-            spellcheck="false"
-            style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
+          <div
+            class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
           >
-            get(feature,'name')
-          </textarea>
-          <pre
-            aria-hidden="true"
-            style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: relative; pointer-events: none; padding: 10px 10px 10px 10px;"
-          >
-            get(feature,'name')
-            <br />
-          </pre>
-          <style
-            type="text/css"
-          >
-            
+            <div
+              data-testid="configEditor"
+            >
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      maxFeatureScreenDensity
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="number"
+                        value="0.3"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      maximum features per pixel that is displayed in the view, used if byte size estimates not available
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      fetchSizeLimit
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="number"
+                        value="1000000"
+                      />
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root MuiFormHelperText-filled"
+                    >
+                      maximum data to attempt to download for a given track, used if adapter doesn't specify one
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+                      data-shrink="true"
+                      for="callback-editor"
+                    >
+                      mouseover
+                    </label>
+                    <div
+                      class="makeStyles-callbackEditor"
+                      style="position: relative; text-align: left; white-space: pre-wrap; word-break: keep-all; box-sizing: border-box; padding: 0px; overflow: hidden;"
+                    >
+                      <textarea
+                        autocapitalize="off"
+                        autocomplete="off"
+                        autocorrect="off"
+                        class="npm__react-simple-code-editor__textarea"
+                        data-gramm="false"
+                        spellcheck="false"
+                        style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; resize: none; overflow: hidden; padding: 10px 10px 10px 10px;"
+                      >
+                        get(feature,'name')
+                      </textarea>
+                      <pre
+                        aria-hidden="true"
+                        style="margin: 0px; border: 0px; background: none; box-sizing: inherit; display: inherit; font-family: inherit; font-style: inherit; font-variant-ligatures: inherit; font-weight: inherit; letter-spacing: inherit; line-height: inherit; tab-size: inherit; text-indent: inherit; text-rendering: inherit; text-transform: inherit; white-space: inherit; word-break: inherit; position: relative; pointer-events: none; padding: 10px 10px 10px 10px;"
+                      >
+                        get(feature,'name')
+                        <br />
+                      </pre>
+                      <style
+                        type="text/css"
+                      >
+                        
 /**
  * Reset the text fill color so that placeholder is visible
  */
@@ -888,617 +1012,681 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
   }
 }
 
-          </style>
-        </div>
-        <p
-          class="MuiFormHelperText-root"
-        >
-          what to display in a given mouseover
-        </p>
-      </div>
-      <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="makeStyles-slotModeSwitch"
-    >
-      <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-        tabindex="0"
-        title="convert to regular value"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M20.41,3C21.8,5.71 22.35,8.84 22,12C21.8,15.16 20.7,18.29 18.83,21L17.3,20C18.91,17.57 19.85,14.8 20,12C20.34,9.2 19.89,6.43 18.7,4L20.41,3M5.17,3L6.7,4C5.09,6.43 4.15,9.2 4,12C3.66,14.8 4.12,17.57 5.3,20L3.61,21C2.21,18.29 1.65,15.17 2,12C2.2,8.84 3.3,5.71 5.17,3M12.08,10.68L14.4,7.45H16.93L13.15,12.45L15.35,17.37H13.09L11.71,14L9.28,17.33H6.76L10.66,12.21L8.53,7.45H10.8L12.08,10.68Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-  </div>
-  <label
-    class="MuiFormLabel-root"
-  >
-    renderer
-  </label>
-  <div
-    class="makeStyles-subSchemaContainer"
-  >
-    <div
-      class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-    >
-      <div
-        class="makeStyles-paperContent"
-      >
-        <div
-          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-        >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-            data-shrink="true"
-          >
-            Type
-          </label>
-          <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-          >
-            <div
-              aria-haspopup="listbox"
-              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-              role="button"
-              tabindex="0"
-            >
-              PileupRenderer
-            </div>
-            <input
-              aria-hidden="true"
-              class="MuiSelect-nativeInput"
-              tabindex="-1"
-              value="PileupRenderer"
-            />
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSelect-icon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7 10l5 5 5-5z"
-              />
-            </svg>
-          </div>
-          <p
-            class="MuiFormHelperText-root MuiFormHelperText-filled"
-          >
-            Type of renderer to use
-          </p>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiFormGroup-root"
-    >
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              color
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-              style="color: rgb(255, 0, 255); border-right-width: 25px; border-right-style: solid; border-right-color: #f0f;"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="text"
-                value="#f0f"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              the color of each feature in a pileup alignment
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        >
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-            tabindex="0"
-            title="convert to callback"
-            type="button"
-          >
-            <span
-              class="MuiIconButton-label"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              orientationType
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-            >
-              <div
-                aria-haspopup="listbox"
-                class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                role="button"
-                tabindex="0"
-              >
-                fr
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput"
-                tabindex="-1"
-                value="fr"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSelect-icon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7 10l5 5 5-5z"
-                />
-              </svg>
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              read sequencer orienation. fr is normal "reads pointing at each other ---&gt; &lt;--- while some other sequencers can use other options
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              displayMode
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-            >
-              <div
-                aria-haspopup="listbox"
-                class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                role="button"
-                tabindex="0"
-              >
-                normal
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput"
-                tabindex="-1"
-                value="normal"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSelect-icon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7 10l5 5 5-5z"
-                />
-              </svg>
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              Alternative display modes
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              minSubfeatureWidth
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="number"
-                value="0"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              the minimum width in px for a pileup mismatch feature. use for increasing mismatch marker widths when zoomed out to e.g. 1px or 0.5px
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              maxHeight
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="number"
-                value="1200"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              the maximum height to be used in a pileup rendering
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              maxClippingSize
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="number"
-                value="10000"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              the max clip size to be used in a pileup rendering
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              height
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="number"
-                value="7"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              the height of each feature in a pileup alignment
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        >
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
-            tabindex="0"
-            title="convert to callback"
-            type="button"
-          >
-            <span
-              class="MuiIconButton-label"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root"
-          >
-            <label
-              class="MuiFormControlLabel-root"
-            >
-              <span
-                aria-disabled="false"
-                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-              >
-                <span
-                  class="MuiIconButton-label"
+                      </style>
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root"
+                    >
+                      what to display in a given mouseover
+                       
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
                 >
-                  <input
-                    class="PrivateSwitchBase-input"
-                    data-indeterminate="false"
-                    type="checkbox"
-                    value=""
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                    tabindex="0"
+                    title="convert to regular value"
+                    type="button"
                   >
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20.41,3C21.8,5.71 22.35,8.84 22,12C21.8,15.16 20.7,18.29 18.83,21L17.3,20C18.91,17.57 19.85,14.8 20,12C20.34,9.2 19.89,6.43 18.7,4L20.41,3M5.17,3L6.7,4C5.09,6.43 4.15,9.2 4,12C3.66,14.8 4.12,17.57 5.3,20L3.61,21C2.21,18.29 1.65,15.17 2,12C2.2,8.84 3.3,5.71 5.17,3M12.08,10.68L14.4,7.45H16.93L13.15,12.45L15.35,17.37H13.09L11.71,14L9.28,17.33H6.76L10.66,12.21L8.53,7.45H10.8L12.08,10.68Z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
                     />
-                  </svg>
-                </span>
-                <span
-                  class="MuiTouchRipple-root"
-                />
-              </span>
-              <span
-                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                  </button>
+                </div>
+              </div>
+              <div
+                class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
               >
-                noSpacing
-              </span>
-            </label>
-            <p
-              class="MuiFormHelperText-root"
-            >
-              remove spacing between features
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-              data-shrink="true"
-            >
-              largeInsertionIndicatorScale
-            </label>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input"
-                type="number"
-                value="10"
-              />
-            </div>
-            <p
-              class="MuiFormHelperText-root MuiFormHelperText-filled"
-            >
-              scale at which to draw the large insertion indicators (bp/pixel)
-            </p>
-          </div>
-        </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
-      </div>
-      <div
-        class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
-      >
-        <div
-          class="makeStyles-paperContent"
-        >
-          <div
-            class="MuiFormControl-root"
-          >
-            <label
-              class="MuiFormControlLabel-root"
-            >
-              <span
-                aria-disabled="false"
-                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-              >
-                <span
-                  class="MuiIconButton-label"
+                <div
+                  aria-disabled="false"
+                  aria-expanded="true"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
+                  role="button"
+                  tabindex="0"
                 >
-                  <input
-                    class="PrivateSwitchBase-input"
-                    data-indeterminate="false"
-                    type="checkbox"
-                    value=""
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <div
+                    class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
                   >
-                    <path
-                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                    >
+                      Config 
+                      renderer
+                    </p>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-hidden="true"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
+                  >
+                    <span
+                      class="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root makeStyles-expandIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
                     />
-                  </svg>
-                </span>
-                <span
-                  class="MuiTouchRipple-root"
-                />
-              </span>
-              <span
-                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-              >
-                mismatchAlpha
-              </span>
-            </label>
-            <p
-              class="MuiFormHelperText-root"
-            >
-              Fade low quality mismatches
-            </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiCollapse-root MuiCollapse-entered"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        role="region"
+                      >
+                        <div
+                          class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+                        >
+                          <div
+                            class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                          >
+                            <div
+                              class="makeStyles-paperContent"
+                            >
+                              <div
+                                class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                              >
+                                <label
+                                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                  data-shrink="true"
+                                >
+                                  Type
+                                </label>
+                                <div
+                                  class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                >
+                                  <div
+                                    aria-haspopup="listbox"
+                                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                    role="button"
+                                    tabindex="0"
+                                  >
+                                    PileupRenderer
+                                  </div>
+                                  <input
+                                    aria-hidden="true"
+                                    class="MuiSelect-nativeInput"
+                                    tabindex="-1"
+                                    value="PileupRenderer"
+                                  />
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSelect-icon"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M7 10l5 5 5-5z"
+                                    />
+                                  </svg>
+                                </div>
+                                <p
+                                  class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                >
+                                  Type of renderer to use
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="MuiFormGroup-root"
+                          >
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    color
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                    style="color: rgb(255, 0, 255); border-right-width: 25px; border-right-style: solid; border-right-color: #f0f;"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="text"
+                                      value="#f0f"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    the color of each feature in a pileup alignment
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              >
+                                <button
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                  tabindex="0"
+                                  title="convert to callback"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    orientationType
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <div
+                                      aria-haspopup="listbox"
+                                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      fr
+                                    </div>
+                                    <input
+                                      aria-hidden="true"
+                                      class="MuiSelect-nativeInput"
+                                      tabindex="-1"
+                                      value="fr"
+                                    />
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSelect-icon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M7 10l5 5 5-5z"
+                                      />
+                                    </svg>
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    read sequencer orienation. fr is normal "reads pointing at each other ---&gt; &lt;--- while some other sequencers can use other options
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    displayMode
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <div
+                                      aria-haspopup="listbox"
+                                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      normal
+                                    </div>
+                                    <input
+                                      aria-hidden="true"
+                                      class="MuiSelect-nativeInput"
+                                      tabindex="-1"
+                                      value="normal"
+                                    />
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSelect-icon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M7 10l5 5 5-5z"
+                                      />
+                                    </svg>
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    Alternative display modes
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    minSubfeatureWidth
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="number"
+                                      value="0"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    the minimum width in px for a pileup mismatch feature. use for increasing mismatch marker widths when zoomed out to e.g. 1px or 0.5px
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    maxHeight
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="number"
+                                      value="1200"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    the maximum height to be used in a pileup rendering
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    maxClippingSize
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="number"
+                                      value="10000"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    the max clip size to be used in a pileup rendering
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    height
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="number"
+                                      value="7"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    the height of each feature in a pileup alignment
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              >
+                                <button
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+                                  tabindex="0"
+                                  title="convert to callback"
+                                  type="button"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root"
+                                >
+                                  <label
+                                    class="MuiFormControlLabel-root"
+                                  >
+                                    <span
+                                      aria-disabled="false"
+                                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                    >
+                                      <span
+                                        class="MuiIconButton-label"
+                                      >
+                                        <input
+                                          class="PrivateSwitchBase-input"
+                                          data-indeterminate="false"
+                                          type="checkbox"
+                                          value=""
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="MuiTouchRipple-root"
+                                      />
+                                    </span>
+                                    <span
+                                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                    >
+                                      noSpacing
+                                    </span>
+                                  </label>
+                                  <p
+                                    class="MuiFormHelperText-root"
+                                  >
+                                    remove spacing between features
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root MuiTextField-root"
+                                >
+                                  <label
+                                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                                    data-shrink="true"
+                                  >
+                                    largeInsertionIndicatorScale
+                                  </label>
+                                  <div
+                                    class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      class="MuiInputBase-input MuiInput-input"
+                                      type="number"
+                                      value="10"
+                                    />
+                                  </div>
+                                  <p
+                                    class="MuiFormHelperText-root MuiFormHelperText-filled"
+                                  >
+                                    scale at which to draw the large insertion indicators (bp/pixel)
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                            <div
+                              class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+                            >
+                              <div
+                                class="makeStyles-paperContent"
+                              >
+                                <div
+                                  class="MuiFormControl-root"
+                                >
+                                  <label
+                                    class="MuiFormControlLabel-root"
+                                  >
+                                    <span
+                                      aria-disabled="false"
+                                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                    >
+                                      <span
+                                        class="MuiIconButton-label"
+                                      >
+                                        <input
+                                          class="PrivateSwitchBase-input"
+                                          data-indeterminate="false"
+                                          type="checkbox"
+                                          value=""
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="MuiTouchRipple-root"
+                                      />
+                                    </span>
+                                    <span
+                                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                    >
+                                      mismatchAlpha
+                                    </span>
+                                  </label>
+                                  <p
+                                    class="MuiFormHelperText-root"
+                                  >
+                                    Fade low quality mismatches
+                                  </p>
+                                </div>
+                              </div>
+                              <div
+                                class="makeStyles-slotModeSwitch"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        <div
-          class="makeStyles-slotModeSwitch"
-        />
       </div>
     </div>
   </div>
@@ -1507,40 +1695,105 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
 
 exports[`ConfigurationEditor widget renders with just the required model elements 1`] = `
 <div
-  class="makeStyles-root"
-  data-testid="configEditor"
+  class="MuiPaper-root MuiAccordion-root MuiAccordion-expanded MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
 >
   <div
-    class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+    aria-disabled="false"
+    aria-expanded="true"
+    class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-expanded"
+    role="button"
+    tabindex="0"
   >
     <div
-      class="makeStyles-paperContent"
+      class="MuiAccordionSummary-content MuiAccordionSummary-expanded"
     >
-      <div
-        class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+      <p
+        class="MuiTypography-root MuiTypography-body1"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
-          data-shrink="true"
-        >
-          foo
-        </label>
-        <div
-          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiInput-input"
-            type="text"
-            value="bar"
-          />
-        </div>
+        Configuration
         
-      </div>
+      </p>
     </div>
     <div
-      class="makeStyles-slotModeSwitch"
-    />
+      aria-disabled="false"
+      aria-hidden="true"
+      class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon MuiAccordionSummary-expanded MuiIconButton-edgeEnd"
+    >
+      <span
+        class="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root makeStyles-expandIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </div>
+  </div>
+  <div
+    class="MuiCollapse-root MuiCollapse-entered"
+    style="min-height: 0px;"
+  >
+    <div
+      class="MuiCollapse-wrapper"
+    >
+      <div
+        class="MuiCollapse-wrapperInner"
+      >
+        <div
+          role="region"
+        >
+          <div
+            class="MuiAccordionDetails-root makeStyles-expansionPanelDetails"
+          >
+            <div
+              data-testid="configEditor"
+            >
+              <div
+                class="MuiPaper-root makeStyles-paper MuiPaper-elevation1 MuiPaper-rounded"
+              >
+                <div
+                  class="makeStyles-paperContent"
+                >
+                  <div
+                    class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+                      data-shrink="true"
+                    >
+                      foo
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+                    >
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input MuiInput-input"
+                        type="text"
+                        value="bar"
+                      />
+                    </div>
+                    
+                  </div>
+                </div>
+                <div
+                  class="makeStyles-slotModeSwitch"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
This is a possible helper for #1402

Adds collapsible sections to the config editor. All sections are expanded by default, but they can be collapsed. The animation on collapsing is disabled so it happens quickly.

I wasn't able to make the configuration editor for the long callback strings get smaller (be contained in the width of the drawer) but you can sidescroll now (overflow:none is removed)



live link
https://jbrowse.org/code/jb2/accordion_config_editor/?config=test_data%2Fvolvox%2Fconfig.json&session=share-BfuDrTSD5P&password=LFGyt