### PR TITLE
Fix bug where web worker would sometimes be called before it was ready

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.test.ts
+++ b/packages/core/rpc/BaseRpcDriver.test.ts
@@ -121,7 +121,7 @@ class MockRpcDriver extends BaseRpcDriver {
 
   workerCheckFrequency = 500
 
-  makeWorker(_pluginManager: PluginManager) {
+  async makeWorker(_pluginManager: PluginManager) {
     return new MockWorkerHandle()
   }
 }

--- a/packages/core/rpc/MainThreadRpcDriver.ts
+++ b/packages/core/rpc/MainThreadRpcDriver.ts
@@ -21,11 +21,11 @@ class DummyHandle {
 export default class MainThreadRpcDriver extends BaseRpcDriver {
   name = 'MainThreadRpcDriver'
 
-  makeWorker: () => DummyHandle
+  makeWorker: () => Promise<DummyHandle>
 
   constructor(args: RpcDriverConstructorArgs) {
     super(args)
-    this.makeWorker = (): DummyHandle => new DummyHandle()
+    this.makeWorker = async (): Promise<DummyHandle> => new DummyHandle()
   }
 
   async call(

--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -56,7 +56,7 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
     this.WorkerClass = args.WorkerClass
   }
 
-  makeWorker() {
+  async makeWorker() {
     // note that we are making a Rpc.Client connection with a worker pool of
     // one for each worker, because we want to do our own state-group-aware
     // load balancing rather than using librpc's builtin round-robin

--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -63,8 +63,18 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
     const worker = new WebWorkerHandle({ workers: [new this.WorkerClass()] })
 
     // send the worker its boot configuration using info from the pluginManager
-    worker.workers[0].postMessage(this.workerBootConfiguration)
+    const p = new Promise((resolve: (w: WebWorkerHandle) => void, reject) => {
+      worker.workers[0].onmessage = e => {
+        if (e.data === 'ready') {
+          resolve(worker)
+        } else if (e.data === 'readyForConfig') {
+          worker.workers[0].postMessage(this.workerBootConfiguration)
+        } else {
+          reject()
+        }
+      }
+    })
 
-    return worker
+    return p
   }
 }

--- a/products/jbrowse-desktop/src/rpc.worker.ts
+++ b/products/jbrowse-desktop/src/rpc.worker.ts
@@ -25,13 +25,15 @@ let jbPluginManager: PluginManager | undefined
 // waits for a message from the main thread containing our configuration,
 // which must be sent on boot
 function receiveConfiguration(): Promise<WorkerConfiguration> {
-  return new Promise(resolve => {
+  const configurationP: Promise<WorkerConfiguration> = new Promise(resolve => {
     // listen for the configuration
     self.onmessage = (event: MessageEvent) => {
       resolve(event.data as WorkerConfiguration)
       self.onmessage = () => {}
     }
   })
+  postMessage('ready')
+  return configurationP
 }
 
 async function getPluginManager() {

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -25,13 +25,15 @@ let jbPluginManager: PluginManager | undefined
 // waits for a message from the main thread containing our configuration, which
 // must be sent on boot
 function receiveConfiguration(): Promise<WorkerConfiguration> {
-  return new Promise(resolve => {
+  const configurationP: Promise<WorkerConfiguration> = new Promise(resolve => {
     // listen for the configuration
     self.onmessage = (event: MessageEvent) => {
       resolve(event.data as WorkerConfiguration)
       self.onmessage = () => {}
     }
   })
+  postMessage('readyForConfig')
+  return configurationP
 }
 
 async function getPluginManager() {
@@ -90,6 +92,7 @@ getPluginManager()
       ...remoteAbortRpcHandler(),
       ping: () => {}, // < the ping method is required by the worker driver for checking the health of the worker
     })
+    postMessage('ready')
   })
   .catch(error => {
     // @ts-ignore


### PR DESCRIPTION
I first noticed a problem when I tried using an ESM plugin, and it seemed to make the web worker get stuck. It turned out that the little bit of additional time to load the plugin made it so that the RPC driver tried to call the first RPC method before the RPC client on the worker was ready. I also noticed when testing that sometimes the worker tried to get the message that had the worker boot configuration after it had already been sent, resulting in the RPC setup getting stuck.

The first step to fixing this was to make `makeWorker` on the RPC drivers be asynchronous. This required changing other functions in the drivers to be async as well, but it's not part of the code that is accessible to plugins, so I don't think it will break anything.

After making `makeWorker` async, I was able to set it up so that the worker signals that the RPC client is ready with a `postMessage`, and `makeWorker` waits for that happen to resolve. I also made it so that the main thread doesn't sent the worker boot configuration until it gets a signal from the worker that it's ready.