### PR TITLE
Exit process after rendering to speed up jb2export

### DIFF
--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -140,48 +140,53 @@ const args = standardizeArgv(parseArgv(process.argv.slice(2)), [
 ])
 
 time(async () => {
-  const result = await renderRegion(args)
-  const outfile = args.out || 'out.svg'
-  if (outfile.endsWith('.png')) {
-    const tmpobj = tmp.fileSync({
-      mode: 0o644,
-      prefix: 'prefix-',
-      postfix: '.svg',
-    })
-    fs.writeFileSync(tmpobj.name, result)
-    const ls = spawnSync('rsvg-convert', [
-      '-w',
-      args.pngwidth || 2048,
-      tmpobj.name,
-      '-o',
-      outfile,
-    ])
+  try {
+    const result = await renderRegion(args)
+    const outfile = args.out || 'out.svg'
+    if (outfile.endsWith('.png')) {
+      const tmpobj = tmp.fileSync({
+        mode: 0o644,
+        prefix: 'prefix-',
+        postfix: '.svg',
+      })
+      fs.writeFileSync(tmpobj.name, result)
+      const ls = spawnSync('rsvg-convert', [
+        '-w',
+        args.pngwidth || 2048,
+        tmpobj.name,
+        '-o',
+        outfile,
+      ])
 
-    console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
-    console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
-    fs.unlinkSync(tmpobj.name)
-  } else if (outfile.endsWith('.pdf')) {
-    const tmpobj = tmp.fileSync({
-      mode: 0o644,
-      prefix: 'prefix-',
-      postfix: '.svg',
-    })
-    fs.writeFileSync(tmpobj.name, result)
-    const ls = spawnSync('rsvg-convert', [
-      '-w',
-      args.pngwidth || 2048,
-      tmpobj.name,
-      '-f',
-      'pdf',
-      '-o',
-      outfile,
-    ])
+      console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
+      console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
+      fs.unlinkSync(tmpobj.name)
+    } else if (outfile.endsWith('.pdf')) {
+      const tmpobj = tmp.fileSync({
+        mode: 0o644,
+        prefix: 'prefix-',
+        postfix: '.svg',
+      })
+      fs.writeFileSync(tmpobj.name, result)
+      const ls = spawnSync('rsvg-convert', [
+        '-w',
+        args.pngwidth || 2048,
+        tmpobj.name,
+        '-f',
+        'pdf',
+        '-o',
+        outfile,
+      ])
 
-    console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
-    console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
-    fs.unlinkSync(tmpobj.name)
-  } else {
-    fs.writeFileSync(outfile, result)
+      console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
+      console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
+      fs.unlinkSync(tmpobj.name)
+    } else {
+      fs.writeFileSync(outfile, result)
+    }
+    process.exit(0)
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
   }
-  process.exit(0)
 })

--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -139,49 +139,49 @@ const args = standardizeArgv(parseArgv(process.argv.slice(2)), [
   'configtracks',
 ])
 
-time(() =>
-  renderRegion(args).then(result => {
-    const outfile = args.out || 'out.svg'
-    if (outfile.endsWith('.png')) {
-      const tmpobj = tmp.fileSync({
-        mode: 0o644,
-        prefix: 'prefix-',
-        postfix: '.svg',
-      })
-      fs.writeFileSync(tmpobj.name, result)
-      const ls = spawnSync('rsvg-convert', [
-        '-w',
-        args.pngwidth || 2048,
-        tmpobj.name,
-        '-o',
-        outfile,
-      ])
+time(async () => {
+  const result = await renderRegion(args)
+  const outfile = args.out || 'out.svg'
+  if (outfile.endsWith('.png')) {
+    const tmpobj = tmp.fileSync({
+      mode: 0o644,
+      prefix: 'prefix-',
+      postfix: '.svg',
+    })
+    fs.writeFileSync(tmpobj.name, result)
+    const ls = spawnSync('rsvg-convert', [
+      '-w',
+      args.pngwidth || 2048,
+      tmpobj.name,
+      '-o',
+      outfile,
+    ])
 
-      console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
-      console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
-      fs.unlinkSync(tmpobj.name)
-    } else if (outfile.endsWith('.pdf')) {
-      const tmpobj = tmp.fileSync({
-        mode: 0o644,
-        prefix: 'prefix-',
-        postfix: '.svg',
-      })
-      fs.writeFileSync(tmpobj.name, result)
-      const ls = spawnSync('rsvg-convert', [
-        '-w',
-        args.pngwidth || 2048,
-        tmpobj.name,
-        '-f',
-        'pdf',
-        '-o',
-        outfile,
-      ])
+    console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
+    console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
+    fs.unlinkSync(tmpobj.name)
+  } else if (outfile.endsWith('.pdf')) {
+    const tmpobj = tmp.fileSync({
+      mode: 0o644,
+      prefix: 'prefix-',
+      postfix: '.svg',
+    })
+    fs.writeFileSync(tmpobj.name, result)
+    const ls = spawnSync('rsvg-convert', [
+      '-w',
+      args.pngwidth || 2048,
+      tmpobj.name,
+      '-f',
+      'pdf',
+      '-o',
+      outfile,
+    ])
 
-      console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
-      console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
-      fs.unlinkSync(tmpobj.name)
-    } else {
-      fs.writeFileSync(outfile, result)
-    }
-  }, console.error),
-)
+    console.log(`rsvg-convert stderr: ${ls.stderr.toString()}`)
+    console.log(`rsvg-convert stdout: ${ls.stdout.toString()}`)
+    fs.unlinkSync(tmpobj.name)
+  } else {
+    fs.writeFileSync(outfile, result)
+  }
+  process.exit(0)
+})

--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -5,8 +5,11 @@ import { standardizeArgv, parseArgv } from './parseArgv'
 import { renderRegion } from './renderRegion'
 import tmp from 'tmp'
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
-
 import { spawnSync } from 'child_process'
+
+const err = console.error
+console.error = (...args) =>
+  args[0]?.match('useLayoutEffect') ? null : err(args)
 
 // eslint-disable-next-line no-unused-expressions
 yargs
@@ -184,6 +187,10 @@ time(async () => {
     } else {
       fs.writeFileSync(outfile, result)
     }
+
+    // manually exit the process after done rendering because autoruns or
+    // something similar otherwise keeps the nodejs process alive xref
+    // https://github.com/GMOD/jb2export/issues/6
     process.exit(0)
   } catch (e) {
     console.error(e)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,9 +1285,9 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@electron/get@^1.13.0":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"
-  integrity sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.0.tgz#c4004723d9ee482ba1baaec33698c60669b5464e"
+  integrity sha512-CKiXY8VsS1ZSSrkh5cd2iBgQp7XnAv31XKFRszuDM5njTxWYTmWUpy+RNa1SNeMtdyT6Hz2YH5+tRul4MKi7eQ==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
@@ -3150,13 +3150,13 @@
     "@octokit/types" "^6.0.3"
 
 "@octokit/core@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
-  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
   dependencies:
     "@octokit/auth-token" "^2.4.4"
     "@octokit/graphql" "^4.5.8"
-    "@octokit/request" "^5.6.0"
+    "@octokit/request" "^5.6.3"
     "@octokit/request-error" "^2.0.5"
     "@octokit/types" "^6.0.3"
     before-after-hook "^2.2.0"
@@ -3219,7 +3219,7 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.6.0":
+"@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
   integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
@@ -3276,9 +3276,9 @@
     source-map "^0.7.3"
 
 "@popperjs/core@^2.11.0", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
-  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.3.tgz#f327fcb4f2576bf0b0ea0e65e773495cdf40188b"
+  integrity sha512-8U7hIl7+30XbIrJ0deQMXpXESM1L4yrt6BHok5hzcR0LivivuNkk+tHU1iRVScOwCmQcrOr6kvtIr29MNbQHqQ==
 
 "@rescripts/cli@^0.0.16":
   version "0.0.16"
@@ -5738,9 +5738,9 @@ ansi-regex@^3.0.0:
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-regex@^4.0.0, ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
@@ -7250,9 +7250,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001313:
-  version "1.0.30001314"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz#65c7f9fb7e4594fca0a333bec1d8939662377596"
-  integrity sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==
+  version "1.0.30001315"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz#f1b1efd1171ee1170d52709a7252632dacbd7c77"
+  integrity sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==
 
 canvas@^2.8.0:
   version "2.9.0"
@@ -9440,9 +9440,9 @@ electron-publish@22.14.13:
     mime "^2.5.2"
 
 electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.76:
-  version "1.4.81"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz#a9ce8997232fb9fb0ec53de8931a85b18c0a7383"
-  integrity sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw==
+  version "1.4.82"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.82.tgz#51e123ca434b1eba8c434ece2b54f095b304a651"
+  integrity sha512-Ks+ANzLoIrFDUOJdjxYMH6CMKB8UQo5modAwvSZTxgF+vEs/U7G5IbWFUp6dS4klPkTDVdxbORuk8xAXXhMsWw==
 
 electron-updater@^4.6.1:
   version "4.6.5"
@@ -9674,9 +9674,9 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.57"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.57.tgz#440574256186e2bf22223d673087caae83edabd2"
-  integrity sha512-L7cCNoPwTkAp7IBHxrKLsh7NKiVFkcdxlP9vbVw9QUvb7gF0Mz9bEBN0WY9xqdTjGF907EMT/iG013vnbqwu1Q==
+  version "0.10.58"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.58.tgz#5b97d94236285fb87c8ffc782cf42eb0a25d2ae0"
+  integrity sha512-LHO+KBBaHGwjy32ibSaMY+ZzjpC4K4I5bPoijICMBL7gXEXfrEUrzssmNP+KigbQEp1dRUnGkry/vUnxOqptLQ==
   dependencies:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.3"
@@ -15267,22 +15267,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
-
-"mime-db@>= 1.43.0 < 2":
+mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12, mime-types@^2.1.16, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
-  version "2.1.34"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
-  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.51.0"
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -17817,9 +17812,9 @@ promise-inflight@^1.0.1:
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
 promise-polyfill@^8.1.3:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.1.tgz#1fa955b325bee4f6b8a4311e18148d4e5b46d254"
-  integrity sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 promise-retry@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Currently running jb2export will finish quickly and print out "Finished rendering 1.24s" for example, but the process will stay running. This may be due to an autorun or something keeping nodejs alive.

We could try to dig into why it is kept alive, but doing a process.exit after the image is generated seems reasonable also

This would fix an older issue open at https://github.com/GMOD/jb2export/issues/6 