### PR TITLE
Fix for BAM file sequence calculation

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -35,7 +35,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@gmod/bam": "^1.1.13",
+    "@gmod/bam": "^1.1.14",
     "@gmod/cram": "^1.6.1",
     "@material-ui/icons": "^4.9.1",
     "abortable-promise-cache": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,10 +1443,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gmod/bam@^1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.1.13.tgz#2b55cbd1d487bc360ecb6a34448669b4b29bef35"
-  integrity sha512-5vmQJLetkX3cSxO5gn8BU6Qp6FUkBH9dJIWN/dW5ePArek/2ok+Ah1FsihP/V1/jqEhiztLdhptlIVOZbjY56w==
+"@gmod/bam@^1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@gmod/bam/-/bam-1.1.14.tgz#1f807894feea0c5c4ac5ffc93564a50de1889c67"
+  integrity sha512-vxZ4nXGi/ygbHfGhj3IqKA9AF2KrD3zo30MerhImyXm2Yk5SnKYCVAZjcNxoikAz4xcrsREs0bX2xaupe7sfrA==
   dependencies:
     "@gmod/bgzf-filehandle" "^1.3.3"
     buffer-crc32 "^0.2.13"


### PR DESCRIPTION
There was an update in @gmod/bam v1.1.13 for optimizing BAM but it had a slightly inaccurate calculation for sequence apparently. The @gmod/bam v1.1.13 was updated in this repo in #2767 but  wasn't released in a jbrowse-web/desktop release yet.

Example link

works v1.6.5
https://jbrowse.org/code/jb2/v1.6.5/?config=test_data%2Fconfig_demo.json&session=share-RrN9QmtRAN&password=k97Zv

fails main
https://jbrowse.org/code/jb2/main/?config=test_data%2Fconfig_demo.json&session=share-RrN9QmtRAN&password=k97Zv

works this branch
https://jbrowse.org/code/jb2/bam_fix/?config=test_data%2Fconfig_demo.json&session=share-RrN9QmtRAN&password=k97Zv