### PR TITLE
Polyfill window.crypto.getRandomValues in tests

### DIFF
--- a/config/jest/crypto.js
+++ b/config/jest/crypto.js
@@ -1,0 +1,5 @@
+var nodeCrypto = require('crypto')
+
+global.crypto = {
+  getRandomValues: buffer => nodeCrypto.randomFillSync(buffer),
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
     '<rootDir>/config/jest/createRange.js',
     '<rootDir>/config/jest/fetchMock.js',
     '<rootDir>/config/jest/console.js',
+    '<rootDir>/config/jest/crypto.js',
     'jest-localstorage-mock',
   ],
   testURL: 'http://localhost',


### PR DESCRIPTION
fixes #2794 

The polyfills `window.crypto.getRandomValues` in the tests since it isn't implemented in JSDOM.