### PR TITLE
Slightly faster CIGAR parsing and MD parsing

### DIFF
--- a/plugins/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/BamAdapter/BamSlightlyLazyFeature.ts
@@ -5,7 +5,6 @@ import {
 } from '@jbrowse/core/util/simpleFeature'
 import { BamRecord } from '@gmod/bam'
 import {
-  parseCigar,
   generateMD,
   cigarToMismatches,
   mdToMismatches,
@@ -163,14 +162,12 @@ export default class BamSlightlyLazyFeature implements Feature {
   ) {
     const { cigarAttributeName } = opts
     let mismatches: Mismatch[] = []
-    let cigarOps: string[] = []
 
     // parse the CIGAR tag if it has one
     const cigarString = this.get(cigarAttributeName)
     if (cigarString) {
-      cigarOps = parseCigar(cigarString)
       mismatches = mismatches.concat(
-        cigarToMismatches(cigarOps, this.get('seq'), this.qualRaw()),
+        cigarToMismatches(cigarString, this.get('seq'), this.qualRaw()),
       )
     }
     return mismatches
@@ -184,22 +181,20 @@ export default class BamSlightlyLazyFeature implements Feature {
     mdAttributeName?: string
   } = {}) {
     let mismatches: Mismatch[] = []
-    let cigarOps: string[] = []
 
     // parse the CIGAR tag if it has one
-    const cigarString = this.get(cigarAttributeName)
+    const cigar = this.get(cigarAttributeName)
     const seq = this.get('seq')
     const qual = this.qualRaw()
-    if (cigarString) {
-      cigarOps = parseCigar(cigarString)
-      mismatches = mismatches.concat(cigarToMismatches(cigarOps, seq, qual))
+    if (cigar) {
+      mismatches = mismatches.concat(cigarToMismatches(cigar, seq, qual))
     }
 
     // now let's look for CRAM or MD mismatches
     const mdString = this.get(mdAttributeName)
     if (mdString) {
       mismatches = mismatches.concat(
-        mdToMismatches(mdString, cigarOps, mismatches, seq, qual),
+        mdToMismatches(mdString, cigar, mismatches, seq, qual),
       )
     }
 

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -171,11 +171,7 @@ export function mdToMismatches(
     if (!Number.isNaN(num)) {
       curr.start += num
     } else if (token.startsWith('^')) {
-      curr.length = token.length - 1
-      curr.base = '*'
-      curr.type = 'deletion'
-      curr.seq = token.substring(1)
-      nextRecord()
+      curr.start += token.length - 1
     } else {
       // mismatch
       for (let j = 0; j < token.length; j += 1) {
@@ -224,14 +220,7 @@ export function getMismatches(
     )
   }
 
-  // uniqify the mismatches
-  const seen: { [index: string]: boolean } = {}
-  return mismatches.filter(m => {
-    const key = `${m.type},${m.start},${m.length}`
-    const s = seen[key]
-    seen[key] = true
-    return !s
-  })
+  return mismatches
 }
 
 // adapted from minimap2 code static void write_MD_core function

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -349,7 +349,7 @@ export default class PileupRenderer extends BoxRendererType {
       const { type, positions } = modifications[i]
       const col = modificationTagMap[type] || 'black'
       const base = Color(col)
-      for (const readPos of getNextRefPos(cigarOps, positions)) {
+      for (const readPos of getNextRefPos(cigar, positions)) {
         if (readPos >= 0 && start + readPos < end) {
           const [leftPx, rightPx] = bpSpanPx(
             start + readPos,
@@ -396,7 +396,6 @@ export default class PileupRenderer extends BoxRendererType {
     const fend = feature.get('end')
     const seq = feature.get('seq')
     const strand = feature.get('strand')
-    const cigarOps = parseCigar(cigar)
     const { start: rstart, end: rend } = region
 
     const methBins = new Array(rend - rstart).fill(0)
@@ -404,7 +403,7 @@ export default class PileupRenderer extends BoxRendererType {
     for (let i = 0; i < modifications.length; i++) {
       const { type, positions } = modifications[i]
       if (type === 'm' && positions) {
-        for (const pos of getNextRefPos(cigarOps, positions)) {
+        for (const pos of getNextRefPos(cigar, positions)) {
           const epos = pos + fstart - rstart
           if (epos >= 0 && epos < methBins.length) {
             methBins[epos] = 1

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -236,7 +236,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
               getModificationPositions(mm, seq, fstrand).forEach(
                 ({ type, positions }) => {
                   const mod = `mod_${type}`
-                  for (const pos of getNextRefPos(cigarOps, positions)) {
+                  for (const pos of getNextRefPos(cigar, positions)) {
                     const epos = pos + fstart - region.start
                     if (
                       epos >= 0 &&
@@ -280,7 +280,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
                 ({ type, positions }) => {
                   // we are processing methylation
                   if (type === 'm') {
-                    for (const pos of getNextRefPos(cigarOps, positions)) {
+                    for (const pos of getNextRefPos(cigar, positions)) {
                       const epos = pos + fstart - region.start
                       if (epos >= 0 && epos < methBins.length) {
                         methBins[epos] = 1


### PR DESCRIPTION
This is a little microoptimization for the BAM/CRAM parsing pipeline

1) CIGAR parsing (which is also used for CRAM in some cases e.g. methylation) but mostly for BAM using a microbenchmark that I found is about 25% faster by skipping a regex https://jsbench.me/gpl0pyj08n/1
2) Skip "uniqifying" the mismatches, which is not needed if we don't add deletions from the MD string into the mismatches array (then deletions only come from CIGAR) string
