### PR TITLE
Create codeVerifierPKCE only when needed

### DIFF
--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -44,12 +44,20 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
         configuration: ConfigurationReference(configSchema),
       }),
     )
-    .volatile(() => {
-      const global = getGlobalObject()
-      const array = new Uint8Array(32)
-      global.crypto.getRandomValues(array)
-      const codeVerifierPKCE = fixup(Buffer.from(array).toString('base64'))
-      return { codeVerifierPKCE }
+    .views(() => {
+      let codeVerifier: string | undefined = undefined
+      return {
+        get codeVerifierPKCE() {
+          if (codeVerifier) {
+            return codeVerifier
+          }
+          const global = getGlobalObject()
+          const array = new Uint8Array(32)
+          global.crypto.getRandomValues(array)
+          codeVerifier = fixup(Buffer.from(array).toString('base64'))
+          return codeVerifier
+        },
+      }
     })
     .views(self => ({
       get authEndpoint(): string {


### PR DESCRIPTION
Prompted by [this comment](https://github.com/GMOD/jbrowse-components/pull/2808#issuecomment-1067390189), this makes it so the `codeVerifierPKCE` is created only if an OAuth flow is started, where before it created it any time an OAuth account model was created (which is any time an OAuth account exists in the config).