### PR TITLE
Fix tracklabels positioning not updating in UI after user selection

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -54,25 +54,21 @@ const useStyles = makeStyles(theme => ({
 
 type LGV = LinearGenomeViewModel
 
-function TrackContainerLabel({
-  model,
-  view,
-}: {
-  model: BaseTrackModel
-  view: LGV
-}) {
-  const classes = useStyles()
-  const labelStyle =
-    view.trackLabels === 'overlapping'
-      ? classes.trackLabelOverlap
-      : classes.trackLabelInline
-  return view.trackLabels !== 'hidden' ? (
-    <TrackLabel
-      track={model}
-      className={clsx(classes.trackLabel, labelStyle)}
-    />
-  ) : null
-}
+const TrackContainerLabel = observer(
+  ({ model, view }: { model: BaseTrackModel; view: LGV }) => {
+    const classes = useStyles()
+    const labelStyle =
+      view.trackLabels === 'overlapping'
+        ? classes.trackLabelOverlap
+        : classes.trackLabelInline
+    return view.trackLabels !== 'hidden' ? (
+      <TrackLabel
+        track={model}
+        className={clsx(classes.trackLabel, labelStyle)}
+      />
+    ) : null
+  },
+)
 
 function TrackContainer({
   model,


### PR DESCRIPTION
There is a UI bug where selecting the tracklabels "offset" option doesn't update the UI in 1.6.7, a knock on effect of fixing a bug from 1.6.6

