### PR TITLE
Change calculation for number of webworkers for web/desktop

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -1,9 +1,8 @@
 import { isAlive, isStateTreeNode } from 'mobx-state-tree'
-import { objectFromEntries } from '../util'
+import { clamp, objectFromEntries } from '../util'
 import { serializeAbortSignal } from './remoteAbortSignals'
 import PluginManager from '../PluginManager'
-import { AnyConfigurationModel } from '../configuration/configurationSchema'
-import { readConfObject } from '../configuration'
+import { readConfObject, AnyConfigurationModel } from '../configuration'
 
 export interface WorkerHandle {
   status?: string
@@ -169,7 +168,7 @@ export default abstract class BaseRpcDriver {
 
     const workerCount =
       readConfObject(this.config, 'workerCount') ||
-      Math.max(1, Math.ceil((hardwareConcurrency - 2) / 3))
+      clamp(1, Math.max(1, hardwareConcurrency - 1), 5)
 
     return [...new Array(workerCount)].map(() => new LazyWorker(this))
   }


### PR DESCRIPTION
Currently the formula for getting number of web workers is a bit odd. (#cores -2) /3. probably an ad-hoc formula

On my machine it produces 5 workers (16 cores-2/3 = 4.666 Math.ceil to 5)

I think 5 on my machine with many cores is reasonable, if it used a lot more it would probably go too crazy (its a laptop...fans would take off)

But, on a 4 core AWS instance doing profiling tests, it is only getting 1 worker thread. I think maxing out hardware cores -1 for jbrowse, with a cap on 5 cpu's, could be a reasonable change to the formula
