### PR TITLE
Allow user to specify number of workers

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.test.ts
+++ b/packages/core/rpc/BaseRpcDriver.test.ts
@@ -121,7 +121,7 @@ class MockRpcDriver extends BaseRpcDriver {
 
   workerCheckFrequency = 500
 
-  async makeWorker(_pluginManager: PluginManager) {
+  async makeWorker() {
     return new MockWorkerHandle()
   }
 }

--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -3,6 +3,7 @@ import { objectFromEntries } from '../util'
 import { serializeAbortSignal } from './remoteAbortSignals'
 import PluginManager from '../PluginManager'
 import { AnyConfigurationModel } from '../configuration/configurationSchema'
+import { readConfObject } from '../configuration'
 
 export interface WorkerHandle {
   status?: string
@@ -105,8 +106,6 @@ export default abstract class BaseRpcDriver {
 
   private workerAssignments = new Map<string, number>() // sessionId -> worker number
 
-  private workerCount = 0
-
   abstract makeWorker(): Promise<WorkerHandle>
 
   private workerPool?: LazyWorker[]
@@ -169,7 +168,8 @@ export default abstract class BaseRpcDriver {
     const hardwareConcurrency = detectHardwareConcurrency()
 
     const workerCount =
-      this.workerCount || Math.max(1, Math.ceil((hardwareConcurrency - 2) / 3))
+      readConfObject(this.config, 'workerCount') ||
+      Math.max(1, Math.ceil((hardwareConcurrency - 2) / 3))
 
     return [...new Array(workerCount)].map(() => new LazyWorker(this))
   }

--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -70,30 +70,31 @@ function detectHardwareConcurrency() {
   return 1
 }
 class LazyWorker {
-  worker?: WorkerHandle
+  workerP?: Promise<WorkerHandle> | undefined
 
   constructor(public driver: BaseRpcDriver) {}
 
-  async getWorker(pluginManager: PluginManager, rpcDriverClassName: string) {
-    if (!this.worker) {
-      const worker = await this.driver.makeWorker(pluginManager)
-      watchWorker(worker, this.driver.maxPingTime, rpcDriverClassName).catch(
-        error => {
-          if (this.worker) {
-            console.error(
-              'worker did not respond, killing and generating new one',
-            )
-            console.error(error)
-            this.worker.destroy()
-            this.worker.status = 'killed'
-            this.worker.error = error
-            this.worker = undefined
-          }
-        },
-      )
-      this.worker = worker
+  async getWorker() {
+    if (!this.workerP) {
+      this.workerP = this.driver.makeWorker().then(worker => {
+        watchWorker(worker, this.driver.maxPingTime, this.driver.name).catch(
+          error => {
+            if (worker) {
+              console.error(
+                'worker did not respond, killing and generating new one',
+              )
+              console.error(error)
+              worker.destroy()
+              worker.status = 'killed'
+              worker.error = error
+              this.workerP = undefined
+            }
+          },
+        )
+        return worker
+      })
     }
-    return this.worker
+    return this.workerP
   }
 }
 
@@ -106,7 +107,7 @@ export default abstract class BaseRpcDriver {
 
   private workerCount = 0
 
-  abstract makeWorker(pluginManager: PluginManager): Promise<WorkerHandle>
+  abstract makeWorker(): Promise<WorkerHandle>
 
   private workerPool?: LazyWorker[]
 
@@ -121,24 +122,18 @@ export default abstract class BaseRpcDriver {
   }
 
   // filter the given object and just remove any non-clonable things from it
-  filterArgs<THING_TYPE>(
-    thing: THING_TYPE,
-    pluginManager: PluginManager,
-    sessionId: string,
-  ): THING_TYPE {
+  filterArgs<THING_TYPE>(thing: THING_TYPE, sessionId: string): THING_TYPE {
     if (Array.isArray(thing)) {
       return thing
         .filter(isClonable)
-        .map(t =>
-          this.filterArgs(t, pluginManager, sessionId),
-        ) as unknown as THING_TYPE
+        .map(t => this.filterArgs(t, sessionId)) as unknown as THING_TYPE
     }
     if (typeof thing === 'object' && thing !== null) {
       // AbortSignals are specially handled
       if (thing instanceof AbortSignal) {
         return serializeAbortSignal(
           thing,
-          this.remoteAbort.bind(this, pluginManager, sessionId),
+          this.remoteAbort.bind(this, sessionId),
         ) as unknown as THING_TYPE
       }
 
@@ -155,19 +150,14 @@ export default abstract class BaseRpcDriver {
       return objectFromEntries(
         Object.entries(thing)
           .filter(e => isClonable(e[1]))
-          .map(([k, v]) => [k, this.filterArgs(v, pluginManager, sessionId)]),
+          .map(([k, v]) => [k, this.filterArgs(v, sessionId)]),
       ) as THING_TYPE
     }
     return thing
   }
 
-  async remoteAbort(
-    pluginManager: PluginManager,
-    sessionId: string,
-    functionName: string,
-    signalId: number,
-  ) {
-    const worker = await this.getWorker(sessionId, pluginManager)
+  async remoteAbort(sessionId: string, functionName: string, signalId: number) {
+    const worker = await this.getWorker(sessionId)
     worker.call(
       functionName,
       { signalId },
@@ -193,10 +183,7 @@ export default abstract class BaseRpcDriver {
     return this.workerPool
   }
 
-  async getWorker(
-    sessionId: string,
-    pluginManager: PluginManager,
-  ): Promise<WorkerHandle> {
+  async getWorker(sessionId: string): Promise<WorkerHandle> {
     const workers = this.getWorkerPool()
     let workerNumber = this.workerAssignments.get(sessionId)
     if (workerNumber === undefined) {
@@ -207,7 +194,7 @@ export default abstract class BaseRpcDriver {
     }
 
     // console.log(`${sessionId} -> worker ${workerNumber}`)
-    const worker = workers[workerNumber].getWorker(pluginManager, this.name)
+    const worker = workers[workerNumber].getWorker()
     if (!worker) {
       throw new Error('no web workers registered for RPC')
     }
@@ -225,14 +212,10 @@ export default abstract class BaseRpcDriver {
       throw new TypeError('sessionId is required')
     }
     let done = false
-    const worker = await this.getWorker(sessionId, pluginManager)
+    const worker = await this.getWorker(sessionId)
     const rpcMethod = pluginManager.getRpcMethodType(functionName)
     const serializedArgs = await rpcMethod.serializeArguments(args, this.name)
-    const filteredAndSerializedArgs = this.filterArgs(
-      serializedArgs,
-      pluginManager,
-      sessionId,
-    )
+    const filteredAndSerializedArgs = this.filterArgs(serializedArgs, sessionId)
 
     // now actually call the worker
     const callP = worker

--- a/packages/core/rpc/configSchema.ts
+++ b/packages/core/rpc/configSchema.ts
@@ -1,20 +1,27 @@
 import { types } from 'mobx-state-tree'
 import { ConfigurationSchema } from '../configuration'
 
+const BaseRpcDriverConfigSchema = ConfigurationSchema(
+  'MainThreadRpcDriver',
+  {
+    workerCount: {
+      type: 'number',
+      description:
+        'The number of workers to use. If 0 (the default) JBrowse will decide how many workers to use.',
+      defaultValue: 0,
+    },
+  },
+  { explicitlyTyped: true },
+)
 const MainThreadRpcDriverConfigSchema = ConfigurationSchema(
   'MainThreadRpcDriver',
   {},
-  { explicitlyTyped: true },
+  { explicitlyTyped: true, baseConfiguration: BaseRpcDriverConfigSchema },
 )
 const WebWorkerRpcDriverConfigSchema = ConfigurationSchema(
   'WebWorkerRpcDriver',
   {},
-  { explicitlyTyped: true },
-)
-const ElectronRpcDriverConfigSchema = ConfigurationSchema(
-  'ElectronRpcDriver',
-  {},
-  { explicitlyTyped: true },
+  { explicitlyTyped: true, baseConfiguration: BaseRpcDriverConfigSchema },
 )
 
 export default ConfigurationSchema(
@@ -31,7 +38,6 @@ export default ConfigurationSchema(
         types.union(
           MainThreadRpcDriverConfigSchema,
           WebWorkerRpcDriverConfigSchema,
-          ElectronRpcDriverConfigSchema,
         ),
       ),
       { MainThreadRpcDriver: { type: 'MainThreadRpcDriver' } },

--- a/packages/core/rpc/configSchema.ts
+++ b/packages/core/rpc/configSchema.ts
@@ -2,7 +2,7 @@ import { types } from 'mobx-state-tree'
 import { ConfigurationSchema } from '../configuration'
 
 const BaseRpcDriverConfigSchema = ConfigurationSchema(
-  'MainThreadRpcDriver',
+  'BaseRpcDriver',
   {
     workerCount: {
       type: 'number',

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -293,10 +293,16 @@ const Renderer = observer(
               },
               { pluginManager },
             )
-            rootModel.jbrowse.configuration.rpc.addDriverConfig(
-              'WebWorkerRpcDriver',
-              { type: 'WebWorkerRpcDriver' },
-            )
+            if (
+              !rootModel.jbrowse.configuration.rpc.drivers.get(
+                'WebWorkerRpcDriver',
+              )
+            ) {
+              rootModel.jbrowse.configuration.rpc.addDriverConfig(
+                'WebWorkerRpcDriver',
+                { type: 'WebWorkerRpcDriver' },
+              )
+            }
             if (!loader.configSnapshot?.configuration?.rpc?.defaultDriver) {
               rootModel.jbrowse.configuration.rpc.defaultDriver.set(
                 'WebWorkerRpcDriver',


### PR DESCRIPTION
As discovered with @cmdcolin yesterday, there was a `workerCount` property in `BaseRpcDriver` that was set to 0 and had no way to change it, meaning the worker count was always auto-calculated. We also realized that the config for the worker was not getting passed to the worker driver. This fixes that by passing the worker configs to the drivers and then reading `workerCount` out of the config. You can specify a certain number of workers like this:

```json
{
  "configuration": {
   "rpc": {
     "drivers": {
       "WebWorkerRpcDriver": {
         "type": "WebWorkerRpcDriver",
         "workerCount": 2
        }
      }
    }
  }
}
```

This also contains a bug fix related to #2798. As a consequence of that change, if you had a lot of tracks open when the page loaded, it would sometimes create some unused workers, but this PR fixes that.