### PR TITLE
Hide add track and connection menu items when using embedded component

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -411,10 +411,6 @@ const HierarchicalTrackSelectorHeader = observer(
         label: 'Turn on/off connections...',
         onClick: () => setConnectionToggleOpen(true),
       },
-      {
-        label: 'Delete connections...',
-        onClick: () => setConnectionManagerOpen(true),
-      },
     ]
 
     if (session.addConnectionConf) {
@@ -425,6 +421,11 @@ const HierarchicalTrackSelectorHeader = observer(
             session.addWidget('AddConnectionWidget', 'addConnectionWidget'),
           )
         },
+      })
+
+      connectionMenuItems.push({
+        label: 'Delete connections...',
+        onClick: () => setConnectionManagerOpen(true),
       })
     }
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -316,52 +316,57 @@ const HierarchicalTrackSelectorContainer = observer(
           toolbarHeight={toolbarHeight}
           overrideDimensions={overrideDimensions}
         />
-        {session.addTrackConf && (
-          <div>
-            <Fab
-              color="secondary"
-              className={classes.fab}
-              onClick={event => {
-                setAnchorEl(event.currentTarget)
-              }}
-            >
-              <AddIcon />
-            </Fab>
-            <Menu
-              anchorEl={anchorEl}
-              open={Boolean(anchorEl)}
-              onClose={() => setAnchorEl(null)}
-            >
-              <MenuItem
-                onClick={() => {
-                  handleFabClose()
-                  const widget = session.addWidget(
-                    'AddConnectionWidget',
-                    'addConnectionWidget',
-                  )
-                  session.showWidget(widget)
+        {session.addTrackConf ||
+          (session.addConnectionConf && (
+            <div>
+              <Fab
+                color="secondary"
+                className={classes.fab}
+                onClick={event => {
+                  setAnchorEl(event.currentTarget)
                 }}
               >
-                Add connection
-              </MenuItem>
-              <MenuItem
-                onClick={() => {
-                  handleFabClose()
-                  const widget = session.addWidget(
-                    'AddTrackWidget',
-                    'addTrackWidget',
-                    {
-                      view: model.view.id,
-                    },
-                  )
-                  session.showWidget(widget)
-                }}
+                <AddIcon />
+              </Fab>
+              <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={() => setAnchorEl(null)}
               >
-                Add track
-              </MenuItem>
-            </Menu>
-          </div>
-        )}
+                {session.addConnectionConf && (
+                  <MenuItem
+                    onClick={() => {
+                      handleFabClose()
+                      const widget = session.addWidget(
+                        'AddConnectionWidget',
+                        'addConnectionWidget',
+                      )
+                      session.showWidget(widget)
+                    }}
+                  >
+                    Add connection
+                  </MenuItem>
+                )}
+                {session.addTrackConf && (
+                  <MenuItem
+                    onClick={() => {
+                      handleFabClose()
+                      const widget = session.addWidget(
+                        'AddTrackWidget',
+                        'addTrackWidget',
+                        {
+                          view: model.view.id,
+                        },
+                      )
+                      session.showWidget(widget)
+                    }}
+                  >
+                    Add track
+                  </MenuItem>
+                )}
+              </Menu>
+            </div>
+          ))}
       </Wrapper>
     )
   },

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -316,7 +316,7 @@ const HierarchicalTrackSelectorContainer = observer(
           toolbarHeight={toolbarHeight}
           overrideDimensions={overrideDimensions}
         />
-        {!overrideDimensions && (
+        {session.addTrackConf && (
           <div>
             <Fab
               color="secondary"
@@ -368,13 +368,7 @@ const HierarchicalTrackSelectorContainer = observer(
 )
 
 const HierarchicalTrackSelectorHeader = observer(
-  ({
-    model,
-    setHeaderHeight,
-    setAssemblyIdx,
-    assemblyIdx,
-    overrideDimensions,
-  }) => {
+  ({ model, setHeaderHeight, setAssemblyIdx, assemblyIdx }) => {
     const classes = useStyles()
     const session = getSession(model)
     const [connectionAnchorEl, setConnectionAnchorEl] = useState()
@@ -453,7 +447,7 @@ const HierarchicalTrackSelectorHeader = observer(
         data-testid="hierarchical_track_selector"
       >
         <div style={{ display: 'flex' }}>
-          {!overrideDimensions && (
+          {session.addTrackConf && (
             <div style={{ display: 'flex' }}>
               <IconButton
                 className={classes.menuIcon}
@@ -492,7 +486,7 @@ const HierarchicalTrackSelectorHeader = observer(
           />
         </div>
 
-        {!overrideDimensions && (
+        {session.addTrackConf && (
           <div>
             <JBrowseMenu
               anchorEl={connectionAnchorEl}
@@ -569,30 +563,27 @@ const HierarchicalTrackSelectorHeader = observer(
     )
   },
 )
-const HierarchicalTrackSelector = observer(
-  ({ model, toolbarHeight = 0, overrideDimensions }) => {
-    const [assemblyIdx, setAssemblyIdx] = useState(0)
-    const [headerHeight, setHeaderHeight] = useState(0)
+const HierarchicalTrackSelector = observer(({ model, toolbarHeight = 0 }) => {
+  const [assemblyIdx, setAssemblyIdx] = useState(0)
+  const [headerHeight, setHeaderHeight] = useState(0)
 
-    const { assemblyNames } = model
-    const assemblyName = assemblyNames[assemblyIdx]
-    return assemblyName ? (
-      <>
-        <HierarchicalTrackSelectorHeader
-          model={model}
-          setHeaderHeight={setHeaderHeight}
-          setAssemblyIdx={setAssemblyIdx}
-          assemblyIdx={assemblyIdx}
-          overrideDimensions={overrideDimensions}
-        />
-        <AutoSizedHierarchicalTree
-          tree={model.hierarchy(assemblyName)}
-          model={model}
-          offset={toolbarHeight + headerHeight}
-        />
-      </>
-    ) : null
-  },
-)
+  const { assemblyNames } = model
+  const assemblyName = assemblyNames[assemblyIdx]
+  return assemblyName ? (
+    <>
+      <HierarchicalTrackSelectorHeader
+        model={model}
+        setHeaderHeight={setHeaderHeight}
+        setAssemblyIdx={setAssemblyIdx}
+        assemblyIdx={assemblyIdx}
+      />
+      <AutoSizedHierarchicalTree
+        tree={model.hierarchy(assemblyName)}
+        model={model}
+        offset={toolbarHeight + headerHeight}
+      />
+    </>
+  ) : null
+})
 
 export default HierarchicalTrackSelectorContainer

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -411,6 +411,18 @@ const HierarchicalTrackSelectorHeader = observer(
         onClick: () => setConnectionManagerOpen(true),
       },
     ]
+
+    if (session.addConnectionConf) {
+      connectionMenuItems.unshift({
+        label: 'Add connection',
+        onClick: () => {
+          session.showWidget(
+            session.addWidget('AddConnectionWidget', 'addConnectionWidget'),
+          )
+        },
+      })
+    }
+
     const assemblyMenuItems =
       assemblyNames.length > 1
         ? [
@@ -447,8 +459,8 @@ const HierarchicalTrackSelectorHeader = observer(
         data-testid="hierarchical_track_selector"
       >
         <div style={{ display: 'flex' }}>
-          {session.addTrackConf && (
-            <div style={{ display: 'flex' }}>
+          <div style={{ display: 'flex' }}>
+            {session.addTrackConf && (
               <IconButton
                 className={classes.menuIcon}
                 onClick={event => {
@@ -457,6 +469,9 @@ const HierarchicalTrackSelectorHeader = observer(
               >
                 <MenuIcon />
               </IconButton>
+            )}
+
+            {session.makeConnection && (
               <IconButton
                 className={classes.menuIcon}
                 onClick={event => {
@@ -465,8 +480,8 @@ const HierarchicalTrackSelectorHeader = observer(
               >
                 <PowerOutlinedIcon />
               </IconButton>
-            </div>
-          )}
+            )}
+          </div>
 
           <TextField
             className={classes.searchBox}
@@ -485,80 +500,62 @@ const HierarchicalTrackSelectorHeader = observer(
             }}
           />
         </div>
-
-        {session.addTrackConf && (
-          <div>
-            <JBrowseMenu
-              anchorEl={connectionAnchorEl}
-              open={Boolean(connectionAnchorEl)}
-              onMenuItemClick={(_, callback) => {
-                callback()
-                setConnectionAnchorEl(undefined)
-              }}
-              onClose={() => {
-                setConnectionAnchorEl(undefined)
-              }}
-              menuItems={[
-                {
-                  label: 'Add connection',
-                  onClick: () => {
-                    session.showWidget(
-                      session.addWidget(
-                        'AddConnectionWidget',
-                        'addConnectionWidget',
-                      ),
-                    )
-                  },
-                },
-                ...connectionMenuItems,
-              ]}
+        <JBrowseMenu
+          anchorEl={connectionAnchorEl}
+          open={Boolean(connectionAnchorEl)}
+          onMenuItemClick={(_, callback) => {
+            callback()
+            setConnectionAnchorEl(undefined)
+          }}
+          onClose={() => {
+            setConnectionAnchorEl(undefined)
+          }}
+          menuItems={[...connectionMenuItems]}
+        />
+        <JBrowseMenu
+          anchorEl={menuAnchorEl}
+          open={Boolean(menuAnchorEl)}
+          onMenuItemClick={(_, callback) => {
+            callback()
+            setMenuAnchorEl(undefined)
+          }}
+          onClose={() => {
+            setMenuAnchorEl(undefined)
+          }}
+          menuItems={menuItems}
+        />
+        <Suspense fallback={<div />}>
+          {modalInfo ? (
+            <CloseConnectionDialog
+              modalInfo={modalInfo}
+              setModalInfo={setModalInfo}
+              session={session}
             />
-            <JBrowseMenu
-              anchorEl={menuAnchorEl}
-              open={Boolean(menuAnchorEl)}
-              onMenuItemClick={(_, callback) => {
-                callback()
-                setMenuAnchorEl(undefined)
+          ) : deleteDialogDetails ? (
+            <DeleteConnectionDialog
+              handleClose={() => {
+                setDeleteDialogDetails(undefined)
               }}
-              onClose={() => {
-                setMenuAnchorEl(undefined)
-              }}
-              menuItems={menuItems}
+              deleteDialogDetails={deleteDialogDetails}
+              session={session}
             />
-            <Suspense fallback={<div />}>
-              {modalInfo ? (
-                <CloseConnectionDialog
-                  modalInfo={modalInfo}
-                  setModalInfo={setModalInfo}
-                  session={session}
-                />
-              ) : deleteDialogDetails ? (
-                <DeleteConnectionDialog
-                  handleClose={() => {
-                    setDeleteDialogDetails(undefined)
-                  }}
-                  deleteDialogDetails={deleteDialogDetails}
-                  session={session}
-                />
-              ) : null}
-              {connectionManagerOpen ? (
-                <ManageConnectionsDialog
-                  handleClose={() => setConnectionManagerOpen(false)}
-                  breakConnection={breakConnection}
-                  session={session}
-                />
-              ) : null}
-              {connectionToggleOpen ? (
-                <ToggleConnectionsDialog
-                  handleClose={() => setConnectionToggleOpen(false)}
-                  session={session}
-                  breakConnection={breakConnection}
-                  assemblyName={assemblyName}
-                />
-              ) : null}
-            </Suspense>
-          </div>
-        )}
+          ) : null}
+          {connectionManagerOpen ? (
+            <ManageConnectionsDialog
+              handleClose={() => setConnectionManagerOpen(false)}
+              breakConnection={breakConnection}
+              session={session}
+            />
+          ) : null}
+          {connectionToggleOpen ? (
+            <ToggleConnectionsDialog
+              handleClose={() => setConnectionToggleOpen(false)}
+              session={session}
+              breakConnection={breakConnection}
+              assemblyName={assemblyName}
+            />
+          ) : null}
+        </Suspense>
       </div>
     )
   },

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -46,7 +46,7 @@ const ToggleConnectionsDialog = lazy(() => import('./ToggleConnectionsDialog'))
 
 const useStyles = makeStyles(theme => ({
   searchBox: {
-    marginBottom: theme.spacing(2),
+    margin: theme.spacing(2),
   },
   menuIcon: {
     marginRight: theme.spacing(1),
@@ -316,55 +316,65 @@ const HierarchicalTrackSelectorContainer = observer(
           toolbarHeight={toolbarHeight}
           overrideDimensions={overrideDimensions}
         />
-        <Fab
-          color="secondary"
-          className={classes.fab}
-          onClick={event => {
-            setAnchorEl(event.currentTarget)
-          }}
-        >
-          <AddIcon />
-        </Fab>
-        <Menu
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={() => setAnchorEl(null)}
-        >
-          <MenuItem
-            onClick={() => {
-              handleFabClose()
-              const widget = session.addWidget(
-                'AddConnectionWidget',
-                'addConnectionWidget',
-              )
-              session.showWidget(widget)
-            }}
-          >
-            Add connection
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              handleFabClose()
-              const widget = session.addWidget(
-                'AddTrackWidget',
-                'addTrackWidget',
-                {
-                  view: model.view.id,
-                },
-              )
-              session.showWidget(widget)
-            }}
-          >
-            Add track
-          </MenuItem>
-        </Menu>
+        {!overrideDimensions && (
+          <div>
+            <Fab
+              color="secondary"
+              className={classes.fab}
+              onClick={event => {
+                setAnchorEl(event.currentTarget)
+              }}
+            >
+              <AddIcon />
+            </Fab>
+            <Menu
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={() => setAnchorEl(null)}
+            >
+              <MenuItem
+                onClick={() => {
+                  handleFabClose()
+                  const widget = session.addWidget(
+                    'AddConnectionWidget',
+                    'addConnectionWidget',
+                  )
+                  session.showWidget(widget)
+                }}
+              >
+                Add connection
+              </MenuItem>
+              <MenuItem
+                onClick={() => {
+                  handleFabClose()
+                  const widget = session.addWidget(
+                    'AddTrackWidget',
+                    'addTrackWidget',
+                    {
+                      view: model.view.id,
+                    },
+                  )
+                  session.showWidget(widget)
+                }}
+              >
+                Add track
+              </MenuItem>
+            </Menu>
+          </div>
+        )}
       </Wrapper>
     )
   },
 )
 
 const HierarchicalTrackSelectorHeader = observer(
-  ({ model, setHeaderHeight, setAssemblyIdx, assemblyIdx }) => {
+  ({
+    model,
+    setHeaderHeight,
+    setAssemblyIdx,
+    assemblyIdx,
+    overrideDimensions,
+  }) => {
     const classes = useStyles()
     const session = getSession(model)
     const [connectionAnchorEl, setConnectionAnchorEl] = useState()
@@ -443,22 +453,27 @@ const HierarchicalTrackSelectorHeader = observer(
         data-testid="hierarchical_track_selector"
       >
         <div style={{ display: 'flex' }}>
-          <IconButton
-            className={classes.menuIcon}
-            onClick={event => {
-              setMenuAnchorEl(event.currentTarget)
-            }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <IconButton
-            className={classes.menuIcon}
-            onClick={event => {
-              setConnectionAnchorEl(event.currentTarget)
-            }}
-          >
-            <PowerOutlinedIcon />
-          </IconButton>
+          {!overrideDimensions && (
+            <div style={{ display: 'flex' }}>
+              <IconButton
+                className={classes.menuIcon}
+                onClick={event => {
+                  setMenuAnchorEl(event.currentTarget)
+                }}
+              >
+                <MenuIcon />
+              </IconButton>
+              <IconButton
+                className={classes.menuIcon}
+                onClick={event => {
+                  setConnectionAnchorEl(event.currentTarget)
+                }}
+              >
+                <PowerOutlinedIcon />
+              </IconButton>
+            </div>
+          )}
+
           <TextField
             className={classes.searchBox}
             label="Filter tracks"
@@ -477,102 +492,107 @@ const HierarchicalTrackSelectorHeader = observer(
           />
         </div>
 
-        <JBrowseMenu
-          anchorEl={connectionAnchorEl}
-          open={Boolean(connectionAnchorEl)}
-          onMenuItemClick={(_, callback) => {
-            callback()
-            setConnectionAnchorEl(undefined)
-          }}
-          onClose={() => {
-            setConnectionAnchorEl(undefined)
-          }}
-          menuItems={[
-            {
-              label: 'Add connection',
-              onClick: () => {
-                session.showWidget(
-                  session.addWidget(
-                    'AddConnectionWidget',
-                    'addConnectionWidget',
-                  ),
-                )
-              },
-            },
-            ...connectionMenuItems,
-          ]}
-        />
-
-        <JBrowseMenu
-          anchorEl={menuAnchorEl}
-          open={Boolean(menuAnchorEl)}
-          onMenuItemClick={(_, callback) => {
-            callback()
-            setMenuAnchorEl(undefined)
-          }}
-          onClose={() => {
-            setMenuAnchorEl(undefined)
-          }}
-          menuItems={menuItems}
-        />
-
-        <Suspense fallback={<div />}>
-          {modalInfo ? (
-            <CloseConnectionDialog
-              modalInfo={modalInfo}
-              setModalInfo={setModalInfo}
-              session={session}
-            />
-          ) : deleteDialogDetails ? (
-            <DeleteConnectionDialog
-              handleClose={() => {
-                setDeleteDialogDetails(undefined)
+        {!overrideDimensions && (
+          <div>
+            <JBrowseMenu
+              anchorEl={connectionAnchorEl}
+              open={Boolean(connectionAnchorEl)}
+              onMenuItemClick={(_, callback) => {
+                callback()
+                setConnectionAnchorEl(undefined)
               }}
-              deleteDialogDetails={deleteDialogDetails}
-              session={session}
+              onClose={() => {
+                setConnectionAnchorEl(undefined)
+              }}
+              menuItems={[
+                {
+                  label: 'Add connection',
+                  onClick: () => {
+                    session.showWidget(
+                      session.addWidget(
+                        'AddConnectionWidget',
+                        'addConnectionWidget',
+                      ),
+                    )
+                  },
+                },
+                ...connectionMenuItems,
+              ]}
             />
-          ) : null}
-          {connectionManagerOpen ? (
-            <ManageConnectionsDialog
-              handleClose={() => setConnectionManagerOpen(false)}
-              breakConnection={breakConnection}
-              session={session}
+            <JBrowseMenu
+              anchorEl={menuAnchorEl}
+              open={Boolean(menuAnchorEl)}
+              onMenuItemClick={(_, callback) => {
+                callback()
+                setMenuAnchorEl(undefined)
+              }}
+              onClose={() => {
+                setMenuAnchorEl(undefined)
+              }}
+              menuItems={menuItems}
             />
-          ) : null}
-          {connectionToggleOpen ? (
-            <ToggleConnectionsDialog
-              handleClose={() => setConnectionToggleOpen(false)}
-              session={session}
-              breakConnection={breakConnection}
-              assemblyName={assemblyName}
-            />
-          ) : null}
-        </Suspense>
+            <Suspense fallback={<div />}>
+              {modalInfo ? (
+                <CloseConnectionDialog
+                  modalInfo={modalInfo}
+                  setModalInfo={setModalInfo}
+                  session={session}
+                />
+              ) : deleteDialogDetails ? (
+                <DeleteConnectionDialog
+                  handleClose={() => {
+                    setDeleteDialogDetails(undefined)
+                  }}
+                  deleteDialogDetails={deleteDialogDetails}
+                  session={session}
+                />
+              ) : null}
+              {connectionManagerOpen ? (
+                <ManageConnectionsDialog
+                  handleClose={() => setConnectionManagerOpen(false)}
+                  breakConnection={breakConnection}
+                  session={session}
+                />
+              ) : null}
+              {connectionToggleOpen ? (
+                <ToggleConnectionsDialog
+                  handleClose={() => setConnectionToggleOpen(false)}
+                  session={session}
+                  breakConnection={breakConnection}
+                  assemblyName={assemblyName}
+                />
+              ) : null}
+            </Suspense>
+          </div>
+        )}
       </div>
     )
   },
 )
-const HierarchicalTrackSelector = observer(({ model, toolbarHeight = 0 }) => {
-  const [assemblyIdx, setAssemblyIdx] = useState(0)
-  const [headerHeight, setHeaderHeight] = useState(0)
+const HierarchicalTrackSelector = observer(
+  ({ model, toolbarHeight = 0, overrideDimensions }) => {
+    const [assemblyIdx, setAssemblyIdx] = useState(0)
+    const [headerHeight, setHeaderHeight] = useState(0)
 
-  const { assemblyNames } = model
-  const assemblyName = assemblyNames[assemblyIdx]
-  return assemblyName ? (
-    <>
-      <HierarchicalTrackSelectorHeader
-        model={model}
-        setHeaderHeight={setHeaderHeight}
-        setAssemblyIdx={setAssemblyIdx}
-        assemblyIdx={assemblyIdx}
-      />
-      <AutoSizedHierarchicalTree
-        tree={model.hierarchy(assemblyName)}
-        model={model}
-        offset={toolbarHeight + headerHeight}
-      />
-    </>
-  ) : null
-})
+    const { assemblyNames } = model
+    const assemblyName = assemblyNames[assemblyIdx]
+    return assemblyName ? (
+      <>
+        <HierarchicalTrackSelectorHeader
+          model={model}
+          setHeaderHeight={setHeaderHeight}
+          setAssemblyIdx={setAssemblyIdx}
+          assemblyIdx={assemblyIdx}
+          overrideDimensions={overrideDimensions}
+        />
+        <AutoSizedHierarchicalTree
+          tree={model.hierarchy(assemblyName)}
+          model={model}
+          offset={toolbarHeight + headerHeight}
+        />
+      </>
+    ) : null
+  },
+)
 
 export default HierarchicalTrackSelectorContainer

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -133,7 +133,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;
 
@@ -242,6 +241,5 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -1,29 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HierarchicalTrackSelector widget renders nothing with no assembly 1`] = `
-<button
-  class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
-  tabindex="0"
-  type="button"
->
-  <span
-    class="MuiFab-label"
+<div>
+  <button
+    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
+    tabindex="0"
+    type="button"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root"
-      focusable="false"
-      viewBox="0 0 24 24"
+    <span
+      class="MuiFab-label"
     >
-      <path
-        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-      />
-    </svg>
-  </span>
-  <span
-    class="MuiTouchRipple-root"
-  />
-</button>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        />
+      </svg>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+</div>
 `;
 
 exports[`HierarchicalTrackSelector widget renders with a couple of categorized tracks 1`] = `
@@ -33,52 +35,56 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
   <div
     style="display: flex;"
   >
-    <button
-      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-      tabindex="0"
-      type="button"
+    <div
+      style="display: flex;"
     >
-      <span
-        class="MuiIconButton-label"
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          class="MuiIconButton-label"
         >
-          <path
-            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-          />
-        </svg>
-      </span>
-      <span
-        class="MuiTouchRipple-root"
-      />
-    </button>
-    <button
-      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="MuiIconButton-label"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          class="MuiIconButton-label"
         >
-          <path
-            d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
-          />
-        </svg>
-      </span>
-      <span
-        class="MuiTouchRipple-root"
-      />
-    </button>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
     <div
       class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
     >
@@ -127,6 +133,7 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
       </div>
     </div>
   </div>
+  <div />
 </div>
 `;
 
@@ -137,52 +144,56 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
   <div
     style="display: flex;"
   >
-    <button
-      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-      tabindex="0"
-      type="button"
+    <div
+      style="display: flex;"
     >
-      <span
-        class="MuiIconButton-label"
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          class="MuiIconButton-label"
         >
-          <path
-            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-          />
-        </svg>
-      </span>
-      <span
-        class="MuiTouchRipple-root"
-      />
-    </button>
-    <button
-      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="MuiIconButton-label"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          class="MuiIconButton-label"
         >
-          <path
-            d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
-          />
-        </svg>
-      </span>
-      <span
-        class="MuiTouchRipple-root"
-      />
-    </button>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
     <div
       class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
     >
@@ -231,5 +242,6 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
       </div>
     </div>
   </div>
+  <div />
 </div>
 `;

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -1,32 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HierarchicalTrackSelector widget renders nothing with no assembly 1`] = `
-<div>
-  <button
-    class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiFab-label"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-        />
-      </svg>
-    </span>
-    <span
-      class="MuiTouchRipple-root"
-    />
-  </button>
-</div>
-`;
+exports[`HierarchicalTrackSelector widget renders nothing with no assembly 1`] = `null`;
 
 exports[`HierarchicalTrackSelector widget renders with a couple of categorized tracks 1`] = `
 <div


### PR DESCRIPTION
Removes the ability to attempt to add a track or connection when using an embedded component. The UI is hidden based on the existence of the session.addTrackConf property.

resolves https://github.com/GMOD/jbrowse-components/issues/1634 and part of https://github.com/GMOD/jbrowse-components/issues/2516