### PR TITLE
Fix alignments tracks loading excessive data on chromosomes where no features exist

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -24,6 +24,7 @@ import {
 } from './types'
 import { isAbortException, checkAbortSignal } from './aborting'
 
+export type { Feature }
 export * from './types'
 export * from './aborting'
 export * from './when'

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -1,5 +1,4 @@
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import { toArray } from 'rxjs/operators'
 import BoxRendererType, {
   RenderArgs,
   RenderArgsSerialized,
@@ -27,7 +26,7 @@ import {
   getNextRefPos,
 } from '../BamAdapter/MismatchParser'
 import { sortFeature } from './sortUtil'
-import { getTagAlt, orientationTypes } from '../util'
+import { getTagAlt, orientationTypes, fetchSequence } from '../util'
 import {
   PileupLayoutSession,
   PileupLayoutSessionProps,
@@ -112,9 +111,6 @@ function shouldDrawMismatches(type?: string) {
   return !['methylation', 'modifications'].includes(type || '')
 }
 
-function shouldFetchReferenceSequence(type?: string) {
-  return !['methylation', 'modifications'].includes(type || '')
-}
 
 export default class PileupRenderer extends BoxRendererType {
   supportsSVG = true
@@ -985,17 +981,7 @@ export default class PileupRenderer extends BoxRendererType {
       sequenceAdapter,
     )
     const [region] = regions
-    const { end, originalRefName, refName } = region
-
-    const feats = await (dataAdapter as BaseFeatureDataAdapter)
-      .getFeatures({
-        ...region,
-        refName: originalRefName || refName,
-        end: end + 1,
-      })
-      .pipe(toArray())
-      .toPromise()
-    return feats[0]?.get('seq')
+    return fetchSequence(region, dataAdapter)
   }
 
   async render(renderProps: RenderArgsDeserialized) {

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -112,6 +112,10 @@ function shouldDrawMismatches(type?: string) {
   return !['methylation', 'modifications'].includes(type || '')
 }
 
+function shouldFetchReferenceSequence(type?: string) {
+  return !['methylation', 'modifications'].includes(type || '')
+}
+
 export default class PileupRenderer extends BoxRendererType {
   supportsSVG = true
 
@@ -1005,9 +1009,13 @@ export default class PileupRenderer extends BoxRendererType {
       layout,
     })
     const [region] = regions
-    const regionSequence = features.size
-      ? await this.fetchSequence(renderProps)
-      : undefined
+
+    // only need reference sequence if there are features and only for some
+    // cases
+    const regionSequence =
+      features.size && shouldFetchReferenceSequence(renderProps.colorBy?.type)
+        ? await this.fetchSequence(renderProps)
+        : undefined
     const { end, start } = region
 
     const width = (end - start) / bpPerPx

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -1,4 +1,4 @@
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import Color from 'color'
 import BoxRendererType, {
   RenderArgs,
   RenderArgsSerialized,
@@ -9,14 +9,20 @@ import BoxRendererType, {
 } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 import { Theme } from '@material-ui/core'
 import { createJBrowseTheme } from '@jbrowse/core/ui'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
-import { bpSpanPx, iterMap, measureText } from '@jbrowse/core/util'
-import Color from 'color'
-import { Region } from '@jbrowse/core/util/types'
+import {
+  bpSpanPx,
+  iterMap,
+  measureText,
+  Region,
+  Feature,
+} from '@jbrowse/core/util'
 import { renderToAbstractCanvas } from '@jbrowse/core/util/offscreenCanvasUtils'
 import { BaseLayout } from '@jbrowse/core/util/layouts/BaseLayout'
 import { getAdapter } from '@jbrowse/core/data_adapters/dataAdapterCache'
-import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  readConfObject,
+  AnyConfigurationModel,
+} from '@jbrowse/core/configuration'
 
 // locals
 import {
@@ -26,7 +32,12 @@ import {
   getNextRefPos,
 } from '../BamAdapter/MismatchParser'
 import { sortFeature } from './sortUtil'
-import { getTagAlt, orientationTypes, fetchSequence } from '../util'
+import {
+  getTagAlt,
+  orientationTypes,
+  fetchSequence,
+  shouldFetchReferenceSequence,
+} from '../util'
 import {
   PileupLayoutSession,
   PileupLayoutSessionProps,
@@ -110,7 +121,6 @@ interface LayoutFeature {
 function shouldDrawMismatches(type?: string) {
   return !['methylation', 'modifications'].includes(type || '')
 }
-
 
 export default class PileupRenderer extends BoxRendererType {
   supportsSVG = true
@@ -981,7 +991,7 @@ export default class PileupRenderer extends BoxRendererType {
       sequenceAdapter,
     )
     const [region] = regions
-    return fetchSequence(region, dataAdapter)
+    return fetchSequence(region, dataAdapter as BaseFeatureDataAdapter)
   }
 
   async render(renderProps: RenderArgsDeserialized) {

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -27,6 +27,10 @@ function isInterbase(type: string) {
   return type === 'softclip' || type === 'hardclip' || type === 'insertion'
 }
 
+function shouldFetchReferenceSequence(type?: string) {
+  return !['methylation', 'modifications'].includes(type || '')
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function inc(bin: any, strand: number, type: string, field: string) {
   if (!bin[type][field]) {
@@ -178,9 +182,10 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
     // - delskips deletions or introns that don't contribute to coverage
     type BinType = { total: number; strands: { [key: string]: number } }
 
-    const regionSeq = features.length
-      ? await this.fetchSequence(region)
-      : undefined
+    const regionSeq =
+      features.length && shouldFetchReferenceSequence(opts.colorBy?.type)
+        ? await this.fetchSequence(region)
+        : undefined
 
     const bins = [] as {
       total: number

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -1,4 +1,7 @@
+import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
+import { toArray } from 'rxjs/operators'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
+import { AugmentedRegion } from '@jbrowse/core/util'
 // get tag from BAM or CRAM feature, where CRAM uses feature.get('tags') and
 // BAM does not
 export function getTag(feature: Feature, tag: string) {
@@ -75,4 +78,25 @@ export function getColorWGBS(strand: number, base: string) {
     }
   }
   return '#888'
+}
+
+export async function fetchSequence(
+  region: AugmentedRegion,
+  adapter: BaseFeatureDataAdapter,
+) {
+  const { end, originalRefName, refName } = region
+
+  const feats = await adapter
+    .getFeatures({
+      ...region,
+      refName: originalRefName || refName,
+      end: end + 1,
+    })
+    .pipe(toArray())
+    .toPromise()
+  return feats[0]?.get('seq')
+}
+
+export function shouldFetchReferenceSequence(type?: string) {
+  return !['methylation', 'modifications'].includes(type || '')
 }

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -97,6 +97,7 @@ export async function fetchSequence(
   return feats[0]?.get('seq')
 }
 
+// has to check underlying C-G (aka CpG) on the reference sequence
 export function shouldFetchReferenceSequence(type?: string) {
-  return !['methylation', 'modifications'].includes(type || '')
+  return type === 'methylation'
 }


### PR DESCRIPTION
Fixes #2832 

The sparse CRAM may be relevant in some cases but I found that for totally empty chromosomes, our color-by-methylation/modifications was trying to fetch the large sequence regions

This only fetches if features are found to draw and the methylation/modifications mode is used