### PR TITLE
Fix layout of small features without labels for SvgFeatureRenderer

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
@@ -45,7 +45,6 @@ function FeatureGlyph(props: {
   return (
     <g>
       <GlyphComponent
-        key={`glyph-${feature.id()}`}
         featureLayout={featureLayout}
         selected={selected}
         {...props}

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -123,7 +123,7 @@ export function layOutFeature(args: FeatureLayOutArgs): SceneGraph {
     String(feature.id()),
     x,
     displayMode === 'collapse' ? 0 : top,
-    width,
+    Math.max(width, 1), // has to be at least one to register in the layout
     displayMode === 'compact' ? height / 2 : height,
     { GlyphComponent },
   )


### PR DESCRIPTION
Before, can see feature is overlapping another (arrow in middle of feature)
![localhost_3000__config=test_data%2Fconfig_demo json session=local-WGdOoxfGs (1)](https://user-images.githubusercontent.com/6511937/159632775-03b5ba9e-f32f-4634-8729-111fa61810fa.png)

After, no overlapping features
![localhost_3000__config=test_data%2Fconfig_demo json session=local-WGdOoxfGs](https://user-images.githubusercontent.com/6511937/159632789-52001cda-5a69-483f-bd1e-473cf5b904ba.png)

Fixes #1204
