### PR TITLE
Avoid drawing intron subfeatures for gene glyphs

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
@@ -40,7 +40,10 @@ function Box(props: {
   const diff = leftWithinBlock - left
   const widthWithinBlock = Math.max(1, Math.min(width - diff, screenWidth))
 
-  return (
+  // if feature has parent and type is intron, then don't render the intron
+  // subfeature (if it doesn't have a parent, then maybe the introns are
+  // separately displayed features that should be displayed)
+  return feature.parent() && feature.get('type') === 'intron' ? null : (
     <>
       {topLevel ? <Arrow {...props} /> : null}
       <rect


### PR DESCRIPTION
Fixes #2735 

Uses a heuristic that doesn't draw introns only if the feature is a subfeature