### PR TITLE
Fix warnings in React for rendering functions as children

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -29,7 +29,7 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown'
 import ArrowRightIcon from '@material-ui/icons/ArrowRight'
 import MenuIcon from '@material-ui/icons/Menu'
 import MoreIcon from '@material-ui/icons/MoreHoriz'
-import PowerOutlinedIcon from '@material-ui/icons/PowerOutlined'
+import { Cable } from '@jbrowse/core/ui/Icons'
 
 // other
 import AutoSizer from 'react-virtualized-auto-sizer'
@@ -316,57 +316,55 @@ const HierarchicalTrackSelectorContainer = observer(
           toolbarHeight={toolbarHeight}
           overrideDimensions={overrideDimensions}
         />
-        {session.addTrackConf ? (
-          session.addConnectionConf ? (
-            <div>
-              <Fab
-                color="secondary"
-                className={classes.fab}
-                onClick={event => {
-                  setAnchorEl(event.currentTarget)
-                }}
-              >
-                <AddIcon />
-              </Fab>
-              <Menu
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={() => setAnchorEl(null)}
-              >
-                {session.addConnectionConf ? (
-                  <MenuItem
-                    onClick={() => {
-                      handleFabClose()
-                      const widget = session.addWidget(
-                        'AddConnectionWidget',
-                        'addConnectionWidget',
-                      )
-                      session.showWidget(widget)
-                    }}
-                  >
-                    Add connection
-                  </MenuItem>
-                ) : null}
-                {session.addTrackConf ? (
-                  <MenuItem
-                    onClick={() => {
-                      handleFabClose()
-                      const widget = session.addWidget(
-                        'AddTrackWidget',
-                        'addTrackWidget',
-                        {
-                          view: model.view.id,
-                        },
-                      )
-                      session.showWidget(widget)
-                    }}
-                  >
-                    Add track
-                  </MenuItem>
-                ) : null}
-              </Menu>
-            </div>
-          ) : null
+        {session.addConnectionConf || session.addTrackConf ? (
+          <>
+            <Fab
+              color="secondary"
+              className={classes.fab}
+              onClick={event => {
+                setAnchorEl(event.currentTarget)
+              }}
+            >
+              <AddIcon />
+            </Fab>
+            <Menu
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={() => setAnchorEl(null)}
+            >
+              {session.addConnectionConf ? (
+                <MenuItem
+                  onClick={() => {
+                    handleFabClose()
+                    const widget = session.addWidget(
+                      'AddConnectionWidget',
+                      'addConnectionWidget',
+                    )
+                    session.showWidget(widget)
+                  }}
+                >
+                  Add connection
+                </MenuItem>
+              ) : null}
+              {session.addTrackConf ? (
+                <MenuItem
+                  onClick={() => {
+                    handleFabClose()
+                    const widget = session.addWidget(
+                      'AddTrackWidget',
+                      'addTrackWidget',
+                      {
+                        view: model.view.id,
+                      },
+                    )
+                    session.showWidget(widget)
+                  }}
+                >
+                  Add track
+                </MenuItem>
+              ) : null}
+            </Menu>
+          </>
         ) : null}
       </Wrapper>
     )
@@ -466,29 +464,27 @@ const HierarchicalTrackSelectorHeader = observer(
         data-testid="hierarchical_track_selector"
       >
         <div style={{ display: 'flex' }}>
-          <div style={{ display: 'flex' }}>
-            {session.addTrackConf && (
-              <IconButton
-                className={classes.menuIcon}
-                onClick={event => {
-                  setMenuAnchorEl(event.currentTarget)
-                }}
-              >
-                <MenuIcon />
-              </IconButton>
-            )}
+          {session.addTrackConf && (
+            <IconButton
+              className={classes.menuIcon}
+              onClick={event => {
+                setMenuAnchorEl(event.currentTarget)
+              }}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
 
-            {session.makeConnection && (
-              <IconButton
-                className={classes.menuIcon}
-                onClick={event => {
-                  setConnectionAnchorEl(event.currentTarget)
-                }}
-              >
-                <PowerOutlinedIcon />
-              </IconButton>
-            )}
-          </div>
+          {session.makeConnection && (
+            <IconButton
+              className={classes.menuIcon}
+              onClick={event => {
+                setConnectionAnchorEl(event.currentTarget)
+              }}
+            >
+              <Cable />
+            </IconButton>
+          )}
 
           <TextField
             className={classes.searchBox}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -316,8 +316,8 @@ const HierarchicalTrackSelectorContainer = observer(
           toolbarHeight={toolbarHeight}
           overrideDimensions={overrideDimensions}
         />
-        {session.addTrackConf ||
-          (session.addConnectionConf && (
+        {session.addTrackConf ? (
+          session.addConnectionConf ? (
             <div>
               <Fab
                 color="secondary"
@@ -333,7 +333,7 @@ const HierarchicalTrackSelectorContainer = observer(
                 open={Boolean(anchorEl)}
                 onClose={() => setAnchorEl(null)}
               >
-                {session.addConnectionConf && (
+                {session.addConnectionConf ? (
                   <MenuItem
                     onClick={() => {
                       handleFabClose()
@@ -346,8 +346,8 @@ const HierarchicalTrackSelectorContainer = observer(
                   >
                     Add connection
                   </MenuItem>
-                )}
-                {session.addTrackConf && (
+                ) : null}
+                {session.addTrackConf ? (
                   <MenuItem
                     onClick={() => {
                       handleFabClose()
@@ -363,10 +363,11 @@ const HierarchicalTrackSelectorContainer = observer(
                   >
                     Add track
                   </MenuItem>
-                )}
+                ) : null}
               </Menu>
             </div>
-          ))}
+          ) : null
+        ) : null}
       </Wrapper>
     )
   },
@@ -513,10 +514,8 @@ const HierarchicalTrackSelectorHeader = observer(
             callback()
             setConnectionAnchorEl(undefined)
           }}
-          onClose={() => {
-            setConnectionAnchorEl(undefined)
-          }}
-          menuItems={[...connectionMenuItems]}
+          onClose={() => setConnectionAnchorEl(undefined)}
+          menuItems={connectionMenuItems}
         />
         <JBrowseMenu
           anchorEl={menuAnchorEl}
@@ -525,9 +524,7 @@ const HierarchicalTrackSelectorHeader = observer(
             callback()
             setMenuAnchorEl(undefined)
           }}
-          onClose={() => {
-            setMenuAnchorEl(undefined)
-          }}
+          onClose={() => setMenuAnchorEl(undefined)}
           menuItems={menuItems}
         />
         <Suspense fallback={<div />}>
@@ -539,9 +536,7 @@ const HierarchicalTrackSelectorHeader = observer(
             />
           ) : deleteDialogDetails ? (
             <DeleteConnectionDialog
-              handleClose={() => {
-                setDeleteDialogDetails(undefined)
-              }}
+              handleClose={() => setDeleteDialogDetails(undefined)}
               deleteDialogDetails={deleteDialogDetails}
               session={session}
             />

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.js.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HierarchicalTrackSelector widget renders nothing with no assembly 1`] = `null`;
+exports[`HierarchicalTrackSelector widget renders nothing with no assembly 1`] = `
+<button
+  class="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-secondary"
+  tabindex="0"
+  type="button"
+>
+  <span
+    class="MuiFab-label"
+  >
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+      />
+    </svg>
+  </span>
+  <span
+    class="MuiTouchRipple-root"
+  />
+</button>
+`;
 
 exports[`HierarchicalTrackSelector widget renders with a couple of categorized tracks 1`] = `
 <div
@@ -9,56 +33,52 @@ exports[`HierarchicalTrackSelector widget renders with a couple of categorized t
   <div
     style="display: flex;"
   >
-    <div
-      style="display: flex;"
+    <button
+      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+      tabindex="0"
+      type="button"
     >
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-        tabindex="0"
-        type="button"
+      <span
+        class="MuiIconButton-label"
       >
-        <span
-          class="MuiIconButton-label"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-        tabindex="0"
-        type="button"
+          <path
+            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
       >
-        <span
-          class="MuiIconButton-label"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
+          <path
+            d="M20 5V4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v1h-1v4c0 .55.45 1 1 1h1v7c0 1.1-.9 2-2 2s-2-.9-2-2V7c0-2.21-1.79-4-4-4S5 4.79 5 7v7H4c-.55 0-1 .45-1 1v4h1v1c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-1h1v-4c0-.55-.45-1-1-1H7V7c0-1.1.9-2 2-2s2 .9 2 2v10c0 2.21 1.79 4 4 4s4-1.79 4-4v-7h1c.55 0 1-.45 1-1V5h-1z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
     <div
       class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
     >
@@ -117,56 +137,52 @@ exports[`HierarchicalTrackSelector widget renders with a couple of uncategorized
   <div
     style="display: flex;"
   >
-    <div
-      style="display: flex;"
+    <button
+      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+      tabindex="0"
+      type="button"
     >
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-        tabindex="0"
-        type="button"
+      <span
+        class="MuiIconButton-label"
       >
-        <span
-          class="MuiIconButton-label"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
-        tabindex="0"
-        type="button"
+          <path
+            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+    <button
+      class="MuiButtonBase-root MuiIconButton-root makeStyles-menuIcon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
       >
-        <span
-          class="MuiIconButton-label"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16 9v4.66l-3.5 3.51V19h-1v-1.83L8 13.65V9h8m0-6h-2v4h-4V3H8v4h-.01C6.9 6.99 6 7.89 6 8.98v5.52L9.5 18v3h5v-3l3.5-3.51V9c0-1.1-.9-2-2-2V3z"
-            />
-          </svg>
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
+          <path
+            d="M20 5V4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1v1h-1v4c0 .55.45 1 1 1h1v7c0 1.1-.9 2-2 2s-2-.9-2-2V7c0-2.21-1.79-4-4-4S5 4.79 5 7v7H4c-.55 0-1 .45-1 1v4h1v1c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-1h1v-4c0-.55-.45-1-1-1H7V7c0-1.1.9-2 2-2s2 .9 2 2v10c0 2.21 1.79 4 4 4s4-1.79 4-4v-7h1c.55 0 1-.45 1-1V5h-1z"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
     <div
       class="MuiFormControl-root MuiTextField-root makeStyles-searchBox MuiFormControl-fullWidth"
     >


### PR DESCRIPTION
Currently the tests and the live webapp have warnings in dev mode saying

`Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.`

This changes the booleans (which I think eventually puts a raw session.addTrackConf as a react child) into ternaries (article with similar recommendation :) https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx )