### PR TITLE
Limit peekTransferables

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "is-object": "^1.0.1",
     "jexl": "^2.3.0",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.2.0",
+    "librpc-web-mod": "^1.1.5",
     "load-script2": "^2.0.5",
     "object.fromentries": "^2.0.0",
     "rbush": "^3.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "is-object": "^1.0.1",
     "jexl": "^2.3.0",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.1.4",
+    "librpc-web-mod": "^1.2.0",
     "load-script2": "^2.0.5",
     "object.fromentries": "^2.0.0",
     "rbush": "^3.0.1",

--- a/packages/core/util/layouts/BaseLayout.ts
+++ b/packages/core/util/layouts/BaseLayout.ts
@@ -2,6 +2,7 @@ export type RectTuple = [number, number, number, number]
 export interface SerializedLayout {
   rectangles: Record<string, RectTuple>
   totalHeight: number
+  containsNoTransferables: true
   maxHeightReached: boolean
 }
 export interface Rectangle<T> {

--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -567,6 +567,7 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     }
     return {
       rectangles: regionRectangles,
+      containsNoTransferables: true,
       totalHeight: this.getTotalHeight(),
       maxHeightReached,
     }
@@ -576,6 +577,7 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     const rectangles = objectFromEntries(this.getRectangles())
     return {
       rectangles,
+      containsNoTransferables: true,
       totalHeight: this.getTotalHeight(),
       maxHeightReached: this.maxHeightReached,
     }

--- a/packages/core/util/layouts/PrecomputedLayout.ts
+++ b/packages/core/util/layouts/PrecomputedLayout.ts
@@ -93,6 +93,7 @@ export default class PrecomputedLayout<T> implements BaseLayout<T> {
       rectangles: objectFromEntries(this.rectangles),
       totalHeight: this.totalHeight,
       maxHeightReached: false,
+      containsNoTransferables: true,
     }
   }
 }

--- a/packages/core/util/offscreenCanvas/ponyfill.ts
+++ b/packages/core/util/offscreenCanvas/ponyfill.ts
@@ -76,11 +76,13 @@ if (weHave.realOffscreenCanvas) {
   }
   createImageBitmap = async canvas => {
     const ctx = (canvas as OffscreenCanvasShim).getContext('2d')
-    return {
+    const d: CanvasImageDataShim = {
       height: ctx.height,
       width: ctx.width,
       serializedCommands: ctx.getSerializedCommands(),
-    } as CanvasImageDataShim
+      containsNoTransferables: true,
+    }
+    return d
   }
   ImageBitmapType = String
 }

--- a/packages/core/util/offscreenCanvas/types.ts
+++ b/packages/core/util/offscreenCanvas/types.ts
@@ -18,6 +18,7 @@ export type AbstractImageBitmap = Pick<ImageBitmap, 'height' | 'width'>
 /** a plain-object (JSON) serialization of a OffscreenCanvasRenderingContext2DShim */
 export interface CanvasImageDataShim {
   serializedCommands: Command[]
+  containsNoTransferables: true
   height: number
   width: number
 }

--- a/plugins/wiggle/src/WiggleBaseRenderer.tsx
+++ b/plugins/wiggle/src/WiggleBaseRenderer.tsx
@@ -69,6 +69,7 @@ export default abstract class WiggleBaseRenderer extends FeatureRendererType {
       ...results,
       ...res,
       features,
+      containsNoTransferables: true,
       height,
       width,
     }

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -83,7 +83,7 @@
     "electron-updater": "^4.6.1",
     "electron-window-state": "^5.0.3",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.1.4",
+    "librpc-web-mod": "^1.2.0",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -83,7 +83,7 @@
     "electron-updater": "^4.6.1",
     "electron-window-state": "^5.0.3",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.2.0",
+    "librpc-web-mod": "^1.1.5",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -59,7 +59,7 @@
     "crypto-js": "^3.0.0",
     "file-saver": "^2.0.0",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.1.4",
+    "librpc-web-mod": "^1.2.0",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -59,7 +59,7 @@
     "crypto-js": "^3.0.0",
     "file-saver": "^2.0.0",
     "json-stable-stringify": "^1.0.1",
-    "librpc-web-mod": "^1.2.0",
+    "librpc-web-mod": "^1.1.5",
     "merge-deep": "^3.0.2",
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14647,10 +14647,10 @@ libnpmpublish@^4.0.0:
     semver "^7.1.3"
     ssri "^8.0.1"
 
-librpc-web-mod@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/librpc-web-mod/-/librpc-web-mod-1.1.4.tgz#23cf9d7b65c837871a64915281cb235c18085f8e"
-  integrity sha512-3MioyXsDrDR6YSQ6FNo5i8dyPIhEzDTlUiOKBAM9apVV15Inez+p85n30le3IfKIvgtCdLEgSf03TtkfJR0xcw==
+librpc-web-mod@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/librpc-web-mod/-/librpc-web-mod-1.1.5.tgz#b3bccc6a078d95bef1fe06bcaa768d8b3b2cfd0c"
+  integrity sha512-gB4QWhlTJtlD5C5Rp9aNUrERdFv9kWSp6Ybb73oiKA5Vl1EBhwQnGKFp5OZh5JlqYn2bSz+J/xUf1tHNfkLIFw==
   dependencies:
     "@librpc/ee" "1.0.4"
     serialize-error "^8.1.0"


### PR DESCRIPTION
Marks serialized layouts, wiggle-type render results, and shimmed offscreen canvas serializations as containing no transferables.

Gets a good performance boost, but I haven't measured exactly how much.

depends on https://github.com/cmdcolin/librpc-web/pull/1 being merged and released as 1.2.0