### PR TITLE
Render gene with CDS subfeatures properly

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
+import { observer } from 'mobx-react'
 import {
   AnyConfigurationModel,
   readConfObject,
 } from '@jbrowse/core/configuration'
-import { Region } from '@jbrowse/core/util/types'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
-import { observer } from 'mobx-react'
-import { isUTR } from './util'
-import Arrow from './Arrow'
+import { Region, Feature } from '@jbrowse/core/util'
 import { SceneGraph } from '@jbrowse/core/util/layouts'
 
-const utrHeightFraction = 0.65
+// locals
+import { isUTR } from './util'
+import Arrow from './Arrow'
 
+const utrHeightFraction = 0.65
 function Box(props: {
   feature: Feature
   region: Region
@@ -25,7 +25,8 @@ function Box(props: {
   const { feature, region, config, featureLayout, bpPerPx, topLevel } = props
   const { start, end } = region
   const screenWidth = (end - start) / bpPerPx
-  const { left = 0, width = 0 } = featureLayout.absolute
+  const width = (feature.get('end') - feature.get('start')) / bpPerPx
+  const { left = 0 } = featureLayout.absolute
   let { top = 0, height = 0 } = featureLayout.absolute
 
   if (left + width < 0) {

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -36,15 +36,16 @@ export function chooseGlyphComponent(
   const type = feature.get('type')
   const subfeatures = feature.get('subfeatures')
 
-  if (subfeatures) {
+  if (subfeatures && type !== 'CDS') {
     const hasSubSub = subfeatures.find(sub => !!sub.get('subfeatures'))
-    if (hasSubSub) {
-      return Subfeatures
-    } else if (
-      ['mRNA', 'transcript'].includes(type) &&
+    if (
+      ['mRNA', 'transcript', 'primary_transcript'].includes(type) &&
       subfeatures.find(f => f.get('type') === 'CDS')
     ) {
       return ProcessedTranscript
+    } else if (!feature.parent() && hasSubSub) {
+      // only do sub-sub on parent level features like gene
+      return Subfeatures
     } else {
       return Segments
     }


### PR DESCRIPTION
Possible fix for #1887

before
![Screenshot from 2022-03-29 17-28-12](https://user-images.githubusercontent.com/6511937/160722728-a7e6b7bf-a6a1-4e85-a8a4-16a9761503ec.png)

after
![Screenshot from 2022-03-29 17-27-54](https://user-images.githubusercontent.com/6511937/160722747-366a0550-1c2b-45f3-9cab-b7816ab86339.png)

this feature has CDS subfeature so triggers "hasSubSub" in the util

There are a number of weird workarounds here, but it does solve the proximate problem

Sort of unrelated but I think it may be worth making the layout part of a pre-processing routine. The way the code makes the layout as a side product of rendering might not be ideal