### PR TITLE
Add optional action buttons to snackbar

### DIFF
--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -24,7 +24,11 @@ import EditableTypography from './EditableTypography'
 import { LogoFull } from './Logo'
 import Snackbar from './Snackbar'
 import ViewContainer from './ViewContainer'
-import { NotificationLevel, SessionWithDrawerWidgets } from '../util'
+import {
+  NotificationLevel,
+  SessionWithDrawerWidgets,
+  SnackAction,
+} from '../util'
 import { MenuItem as JBMenuItem } from './index'
 
 const useStyles = makeStyles(theme => ({
@@ -115,7 +119,7 @@ const Logo = observer(
   },
 )
 
-type SnackbarMessage = [string, NotificationLevel]
+type SnackbarMessage = [string, NotificationLevel, SnackAction]
 
 const App = observer(
   ({

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -57,23 +57,22 @@ function MessageSnackbar({
     popSnackbarMessage()
     setOpen(false)
   }
-  const [message, level, retry] = snackbarMessage || []
+  const [message, level, action] = snackbarMessage || []
   return (
     <Snackbar open={open && !!message} onClose={handleClose}>
       <Alert
         onClose={handleClose}
         action={
-          retry ? (
+          action ? (
             <>
               <Button
                 color="inherit"
-                variant="contained"
                 onClick={e => {
-                  retry.onClick()
+                  action.onClick()
                   handleClose(e)
                 }}
               >
-                {retry.name}
+                {action.name}
               </Button>
               <IconButton
                 aria-label="close"

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react'
-import { IconButton, Snackbar } from '@material-ui/core'
+import { Button, IconButton, Snackbar } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
 import Alert from '@material-ui/lab/Alert'
 import { observer } from 'mobx-react'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
-import { AbstractSessionModel, NotificationLevel } from '../util'
+import { AbstractSessionModel, NotificationLevel, SnackAction } from '../util'
 
-type SnackbarMessage = [string, NotificationLevel]
+type SnackbarMessage = [string, NotificationLevel, SnackAction]
 
 interface SnackbarSession extends AbstractSessionModel {
   snackbarMessages: SnackbarMessage[]
@@ -57,19 +57,36 @@ function MessageSnackbar({
     popSnackbarMessage()
     setOpen(false)
   }
-
-  const [message, level] = snackbarMessage || []
+  const [message, level, retry] = snackbarMessage || []
   return (
-    <Snackbar
-      open={open && !!message}
-      onClose={handleClose}
-      action={
-        <IconButton aria-label="close" color="inherit" onClick={handleClose}>
-          <CloseIcon />
-        </IconButton>
-      }
-    >
-      <Alert onClose={handleClose} severity={level || 'warning'}>
+    <Snackbar open={open && !!message} onClose={handleClose}>
+      <Alert
+        onClose={handleClose}
+        action={
+          retry ? (
+            <>
+              <Button
+                color="inherit"
+                variant="contained"
+                onClick={e => {
+                  retry.onClick()
+                  handleClose(e)
+                }}
+              >
+                {retry.name}
+              </Button>
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                onClick={handleClose}
+              >
+                <CloseIcon />
+              </IconButton>
+            </>
+          ) : null
+        }
+        severity={level || 'warning'}
+      >
         {message}
       </Alert>
     </Snackbar>

--- a/packages/core/ui/SnackbarModel.ts
+++ b/packages/core/ui/SnackbarModel.ts
@@ -1,6 +1,6 @@
 import { IModelType, ModelProperties } from 'mobx-state-tree'
 import { IObservableArray, observable } from 'mobx'
-import { NotificationLevel } from '../util/types'
+import { NotificationLevel, SnackAction } from '../util/types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeExtension(snackbarMessages: IObservableArray<any>) {
@@ -11,8 +11,8 @@ function makeExtension(snackbarMessages: IObservableArray<any>) {
       },
     },
     actions: {
-      notify(message: string, level?: NotificationLevel) {
-        this.pushSnackbarMessage(message, level)
+      notify(message: string, level?: NotificationLevel, retry?: SnackAction) {
+        this.pushSnackbarMessage(message, level, retry)
         if (level === 'info' || level === 'success') {
           setTimeout(() => {
             this.removeSnackbarMessage(message)
@@ -20,8 +20,12 @@ function makeExtension(snackbarMessages: IObservableArray<any>) {
         }
       },
 
-      pushSnackbarMessage(message: string, level?: NotificationLevel) {
-        return snackbarMessages.push([message, level])
+      pushSnackbarMessage(
+        message: string,
+        level?: NotificationLevel,
+        retry?: SnackAction,
+      ) {
+        return snackbarMessages.push([message, level, retry])
       },
 
       popSnackbarMessage() {

--- a/packages/core/ui/SnackbarModel.ts
+++ b/packages/core/ui/SnackbarModel.ts
@@ -11,8 +11,8 @@ function makeExtension(snackbarMessages: IObservableArray<any>) {
       },
     },
     actions: {
-      notify(message: string, level?: NotificationLevel, retry?: SnackAction) {
-        this.pushSnackbarMessage(message, level, retry)
+      notify(message: string, level?: NotificationLevel, action?: SnackAction) {
+        this.pushSnackbarMessage(message, level, action)
         if (level === 'info' || level === 'success') {
           setTimeout(() => {
             this.removeSnackbarMessage(message)
@@ -23,9 +23,9 @@ function makeExtension(snackbarMessages: IObservableArray<any>) {
       pushSnackbarMessage(
         message: string,
         level?: NotificationLevel,
-        retry?: SnackAction,
+        action?: SnackAction,
       ) {
-        return snackbarMessages.push([message, level, retry])
+        return snackbarMessages.push([message, level, action])
       },
 
       popSnackbarMessage() {

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -86,7 +86,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   assemblies: AnyConfigurationModel[]
   selection?: unknown
   duplicateCurrentSession?(): void
-  notify(message: string, level?: NotificationLevel, retry?: SnackAction): void
+  notify(message: string, level?: NotificationLevel, action?: SnackAction): void
   assemblyManager: AssemblyManager
   version: string
   getTrackActionMenuItems?: Function

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -44,6 +44,10 @@ export function isViewContainer(
 }
 
 export type NotificationLevel = 'error' | 'info' | 'warning' | 'success'
+export interface SnackAction {
+  name: string
+  onClick: () => void
+}
 
 export type AssemblyManager = Instance<ReturnType<typeof assemblyManager>>
 export type { TextSearchManager }
@@ -82,7 +86,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   assemblies: AnyConfigurationModel[]
   selection?: unknown
   duplicateCurrentSession?(): void
-  notify(message: string, level?: NotificationLevel): void
+  notify(message: string, level?: NotificationLevel, retry?: SnackAction): void
   assemblyManager: AssemblyManager
   version: string
   getTrackActionMenuItems?: Function


### PR DESCRIPTION
https://github.com/GMOD/jbrowse-components/issues/2866

https://user-images.githubusercontent.com/45598764/160950988-d97d3865-8f58-4a68-b1b5-51094424a2a5.mov
```
session.notify('SnackBar with action buttons', 'error', {
  name: 'Retry',
  onClick: () => {
    console.log('retryyyyyyyy')
  },
})
```