### PR TITLE
Add plugin-legacy-jbrowse to React LGV core plugins

### DIFF
--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -44,6 +44,7 @@
     "@jbrowse/plugin-config": "^1.7.7",
     "@jbrowse/plugin-data-management": "^1.7.7",
     "@jbrowse/plugin-gff3": "^1.7.7",
+    "@jbrowse/plugin-legacy-jbrowse": "^1.7.7",
     "@jbrowse/plugin-linear-genome-view": "^1.7.7",
     "@jbrowse/plugin-sequence": "^1.7.7",
     "@jbrowse/plugin-svg": "^1.7.7",

--- a/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
@@ -3,6 +3,7 @@ import BED from '@jbrowse/plugin-bed'
 import Config from '@jbrowse/plugin-config'
 import DataManagement from '@jbrowse/plugin-data-management'
 import GFF3 from '@jbrowse/plugin-gff3'
+import LegacyJBrowse from '@jbrowse/plugin-legacy-jbrowse'
 import LinearGenomeView from '@jbrowse/plugin-linear-genome-view'
 import Sequence from '@jbrowse/plugin-sequence'
 import SVG from '@jbrowse/plugin-svg'
@@ -17,6 +18,7 @@ const corePlugins = [
   Config,
   DataManagement,
   GFF3,
+  LegacyJBrowse,
   LinearGenomeView,
   Sequence,
   Variants,


### PR DESCRIPTION
Prompted by @scottcain's use of the embedded LGV, this PR proposes adding the legacy JBrowse plugin (which has the NCList adapter) to the embedded LGV and React component. I'm not sure if this is a good idea or not, but I thought it would be good to have a place to discuss it. Here is the size difference of the UMD builds:

```
$ du -k without_legacy_plugin/*
14088   dist/react-linear-genome-view.umd.development.js
12908   dist/react-linear-genome-view.umd.development.js.map
2704    dist/react-linear-genome-view.umd.production.min.js
$ du -k with_legacy_plugin/*
14260   with_legacy_plugin/react-linear-genome-view.umd.development.js
13064   with_legacy_plugin/react-linear-genome-view.umd.development.js.map
2748    with_legacy_plugin/react-linear-genome-view.umd.production.min.js
```

So there's a 172K increase in the dev build and a 44K increase in the prod build.

Another alternative would be to figure out how to publish a UMD build for our internal plugins that we could publish so users could the legacy JBrowse plugin as a runtime plugin instead.