### PR TITLE
Make assembly selector remember your last selected assembly

### DIFF
--- a/packages/core/ui/AssemblySelector.tsx
+++ b/packages/core/ui/AssemblySelector.tsx
@@ -19,7 +19,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
       const item = window.localStorage.getItem(key)
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
-      console.log(error)
+      console.error(error)
       return initialValue
     }
   })
@@ -32,7 +32,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
         window.localStorage.setItem(key, JSON.stringify(valueToStore))
       }
     } catch (error) {
-      console.log(error)
+      console.error(error)
     }
   }
   return [storedValue, setValue] as const
@@ -59,7 +59,7 @@ const AssemblySelector = observer(
       if (lastSelected) {
         onChange(lastSelected)
       }
-    }, [lastSelected])
+    }, [lastSelected, onChange])
 
     const error = assemblyNames.length ? '' : 'No configured assemblies'
     return (

--- a/packages/core/ui/AssemblySelector.tsx
+++ b/packages/core/ui/AssemblySelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { observer } from 'mobx-react'
 import { getConf } from '../configuration'
 import { makeStyles, TextField, MenuItem } from '@material-ui/core'
@@ -8,6 +8,35 @@ const useStyles = makeStyles(() => ({
     minWidth: 180,
   },
 }))
+
+// Hook from https://usehooks.com/useLocalStorage/
+function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue
+    }
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.log(error)
+      return initialValue
+    }
+  })
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+  return [storedValue, setValue] as const
+}
 
 const AssemblySelector = observer(
   ({
@@ -21,6 +50,17 @@ const AssemblySelector = observer(
   }) => {
     const classes = useStyles()
     const { assemblyNames, assemblyManager } = session
+    const [lastSelected, setLastSelected] = useLocalStorage(
+      'lastSelectedAsm',
+      selected,
+    )
+
+    useEffect(() => {
+      if (lastSelected) {
+        onChange(lastSelected)
+      }
+    }, [lastSelected])
+
     const error = assemblyNames.length ? '' : 'No configured assemblies'
     return (
       <TextField
@@ -29,9 +69,9 @@ const AssemblySelector = observer(
         variant="outlined"
         margin="normal"
         helperText={error || 'Select assembly to view'}
-        value={error ? '' : selected}
+        value={error ? '' : lastSelected}
         inputProps={{ 'data-testid': 'assembly-selector' }}
-        onChange={event => onChange(event.target.value)}
+        onChange={event => setLastSelected(event.target.value)}
         error={!!error}
         disabled={!!error}
         className={classes.importFormEntry}


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/2745

Uses a "local storage" hook. It also uses a useEffect to update the parent component onChange, becuase the component acts like a controlled component (https://reactjs.org/docs/forms.html#controlled-components) so needs to immediately (onLoad) update the parent component with a new value with the useEffect if the AssemblySelector finds a value in the localStorage entry. The alternative to this is propagating useLocalStorage to all usages of AssemblySelector but this doesn't seem like a bad approach here