### PR TITLE
Fix strand on arrows in reverse mode

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/Arrow.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Arrow.tsx
@@ -5,24 +5,32 @@ import {
   AnyConfigurationModel,
   readConfObject,
 } from '@jbrowse/core/configuration'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { SceneGraph } from '@jbrowse/core/util/layouts'
+import { Region, Feature } from '@jbrowse/core/util'
 
 const Arrow = ({
   feature,
   featureLayout,
   config,
+  region,
 }: {
+  region: Region
   feature: Feature
   featureLayout: SceneGraph
   config: AnyConfigurationModel
 }) => {
   const strand = feature.get('strand')
   const size = 5
-  const offset = 7 * strand
+  const reverseFlip = region.reversed ? -1 : 1
+  const offset = 7 * strand * reverseFlip
   const { left = 0, top = 0, width = 0, height = 0 } = featureLayout.absolute
   const color2 = readConfObject(config, 'color2', { feature })
-  const p = strand === -1 ? left : strand === 1 ? left + width : null
+  const p =
+    strand * reverseFlip === -1
+      ? left
+      : strand * reverseFlip === 1
+      ? left + width
+      : null
   const y = top + height / 2
 
   return p ? (

--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import {
   AnyConfigurationModel,
   readConfObject,
@@ -9,9 +8,11 @@ import {
 import Segments from './Segments'
 import { ExtraGlyphValidator, layOutFeature, layOutSubfeatures } from './util'
 import { SceneGraph } from '@jbrowse/core/util/layouts'
+import { Region, Feature, SimpleFeature } from '@jbrowse/core/util'
 
 function ProcessedTranscript(props: {
   feature: Feature
+  region: Region
   config: AnyConfigurationModel
   featureLayout: SceneGraph
   selected?: boolean

--- a/plugins/svg/src/SvgFeatureRenderer/components/Segments.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Segments.tsx
@@ -4,11 +4,12 @@ import {
   readConfObject,
 } from '@jbrowse/core/configuration'
 import { observer } from 'mobx-react'
-import { Feature } from '@jbrowse/core/util/simpleFeature'
 import Arrow from './Arrow'
 import { SceneGraph } from '@jbrowse/core/util/layouts'
+import { Region, Feature } from '@jbrowse/core/util'
 
 function Segments(props: {
+  region: Region
   feature: Feature
   featureLayout: SceneGraph
   config: AnyConfigurationModel


### PR DESCRIPTION
After the new glyph style (#2775) the arrows pointed the wrong way in horizontally flipped mode, this fixes it