### PR TITLE
Add padding at the bottom of the configuration editor to help color editing popup being cutoff

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.js
@@ -125,24 +125,29 @@ const ConfigurationEditor = observer(({ model }) => {
   const key = model.target && readConfObject(model.target, 'trackId')
   const name = model.target && readConfObject(model.target, 'name')
   return (
-    <Accordion
-      key={key}
-      defaultExpanded
-      className={classes.accordion}
-      TransitionProps={{ unmountOnExit: true, timeout: 150 }}
-    >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+    <>
+      <Accordion
+        key={key}
+        defaultExpanded
+        className={classes.accordion}
+        TransitionProps={{ unmountOnExit: true, timeout: 150 }}
       >
-        <Typography>{name ? name : 'Configuration'}</Typography>
-      </AccordionSummary>
-      <AccordionDetails
-        className={classes.expansionPanelDetails}
-        data-testid="configEditor"
-      >
-        {!model.target ? 'no target set' : <Schema schema={model.target} />}
-      </AccordionDetails>
-    </Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+        >
+          <Typography>{name ? name : 'Configuration'}</Typography>
+        </AccordionSummary>
+        <AccordionDetails
+          className={classes.expansionPanelDetails}
+          data-testid="configEditor"
+        >
+          {!model.target ? 'no target set' : <Schema schema={model.target} />}
+        </AccordionDetails>
+      </Accordion>
+
+      {/* blank space at the bottom of screen allows scroll */}
+      <div style={{ height: 300 }} />
+    </>
   )
 })
 


### PR DESCRIPTION
Without this PR, the color editor popup can get cutoff by the page

This PR adds some padding

Similar thing exists in the ViewContainer/App to add padding to the bottom of the stack of views



before
![Screenshot from 2022-04-06 19-35-24](https://user-images.githubusercontent.com/6511937/162102823-14900dc5-55f1-472d-aa34-8b9e55ab2572.png)



after
![Screenshot from 2022-04-06 19-34-59](https://user-images.githubusercontent.com/6511937/162102777-c863b941-4d7f-4768-8926-97844274f423.png)

