### PR TITLE
Add v1.7.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v1.7.0.md
+++ b/website/release_announcement_drafts/v1.7.0.md
@@ -2,12 +2,31 @@ We are excited to announce the latest JBrowse release! This has many great
 features including
 
 1. Floating feature labels, so if you are zoomed into the middle of a gene, the
-   feature label hangs out alongside it on the left side of the screen
+   feature label hangs out alongside it on the left side of the screen! The
+   results may not be pixel perfect in all cases (reverse complement labels can
+   end up overallping other features for example) but we hope this helps you
+   see the labels for features that extend off the screen!
 
-2. Upgraded build system to webpack 5, resulting in smaller build sizes and
-   all-around more modern tooling
+   ![](https://user-images.githubusercontent.com/6511937/163470981-cfbd4464-bd5a-4421-8d9c-c8e6bb2d19bc.png)
 
-3. Optimizations to breakpoint split view and synteny views!
+   Figure showing the feature labels floating alongside gene even when you are
+   zoomed into the feature
 
-4. Assembly selector remembers your last selection, so you can more easily
-   return to your genome of interest
+2. Upgraded build system for jbrowse-web and jbrowse-desktop to webpack 5, and
+   added examples of using webpack 5 with embedded components. Webpack 5
+   results in smaller build sizes for jbrowse-web. For a typical session,
+   amount of .js downloaded with gzip enabled in v1.6.9 is ~1.4MB, in v1.7.0
+   ~900kb (-500kb smaller). Without gzip enabled v1.6.9 4.8MB, v1.7.0 2.5MB
+   (-2MB smaller). The result is largely due to better webworker bundling.
+
+3. Optimizations and improved visualization of paired-end reads in the
+   breakpoint split view
+
+4. Optimized linear synteny renderings with long CIGAR strings. These
+   optimizations help viewing large alignments such as the CHM13-T2T-v2.0
+   assembly vs hg38 PAF file from https://github.com/marbl/CHM13#downloads
+   (example here
+   https://jbrowse.org/code/jb2/main/?config=test_data%2Fconfig_demo.json&session=share-0qD2-d_k4K&password=GF8Sk)
+
+5. The "Assembly selector" dropdown box now remembers your last selection, so
+   you can more easily return to your genome of interest

--- a/website/release_announcement_drafts/v1.7.0.md
+++ b/website/release_announcement_drafts/v1.7.0.md
@@ -1,0 +1,13 @@
+We are excited to announce the latest JBrowse release! This has many great
+features including
+
+1. Floating feature labels, so if you are zoomed into the middle of a gene, the
+   feature label hangs out alongside it on the left side of the screen
+
+2. Upgraded build system to webpack 5, resulting in smaller build sizes and
+   all-around more modern tooling
+
+3. Optimizations to breakpoint split view and synteny views!
+
+4. Assembly selector remembers your last selection, so you can more easily
+   return to your genome of interest


### PR DESCRIPTION
Placeholder for new release :) 
```

## Unreleased (2022-04-13)

#### :rocket: Enhancement
* Other
  * [#2887](https://github.com/GMOD/jbrowse-components/pull/2887) Optimize filtering on alignments tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#2879](https://github.com/GMOD/jbrowse-components/pull/2879) Multi-level synteny rubberband ([@cmdcolin](https://github.com/cmdcolin))
  * [#2874](https://github.com/GMOD/jbrowse-components/pull/2874) Optimizations for rendering long syntenic alignments e.g. CHM13 vs GRCh38 ([@cmdcolin](https://github.com/cmdcolin))
  * [#2872](https://github.com/GMOD/jbrowse-components/pull/2872) Better connection between paired-end alignments in breakpoint split view and optimizations ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#2781](https://github.com/GMOD/jbrowse-components/pull/2781) Add floating labels to SVG features ([@cmdcolin](https://github.com/cmdcolin))
  * [#2875](https://github.com/GMOD/jbrowse-components/pull/2875) Make assembly selector remember your last selected assembly ([@cmdcolin](https://github.com/cmdcolin))
  * [#2860](https://github.com/GMOD/jbrowse-components/pull/2860) Avoid performing many peekTransferables to optimize RPC serialization ([@rbuels](https://github.com/rbuels))

#### :bug: Bug Fix
* [#2900](https://github.com/GMOD/jbrowse-components/pull/2900) Fix the 'Open assembly' menu item in jbrowse desktop ([@cmdcolin](https://github.com/cmdcolin))
* [#2882](https://github.com/GMOD/jbrowse-components/pull/2882) Add padding at the bottom of the configuration editor to help color editing popup being cutoff ([@cmdcolin](https://github.com/cmdcolin))
* [#2877](https://github.com/GMOD/jbrowse-components/pull/2877) Fix strand on arrows in horizontally flipped mode ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#2830](https://github.com/GMOD/jbrowse-components/pull/2830) Documentation comparing main app with embedded components ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))

#### :house: Internal
* `core`
  * [#2891](https://github.com/GMOD/jbrowse-components/pull/2891) Use a user-supplied fetchESM callback to import ESM plugins to fix 'Critical dependency...' errors from embedded components ([@cmdcolin](https://github.com/cmdcolin))
  * [#2857](https://github.com/GMOD/jbrowse-components/pull/2857) Refactor and improve types of OffscreenCanvas shim and ponyfill ([@rbuels](https://github.com/rbuels))
* `__mocks__`, `core`
  * [#2646](https://github.com/GMOD/jbrowse-components/pull/2646) Upgrade repository to use webpack 5/CRA 5 ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Robert Buels ([@rbuels](https://github.com/rbuels))
Done in 1.83s.


```