### PR TITLE
Optimize filtering on alignments tracks

### DIFF
--- a/plugins/alignments/src/BamAdapter/BamAdapter.ts
+++ b/plugins/alignments/src/BamAdapter/BamAdapter.ts
@@ -4,11 +4,7 @@ import {
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { Region } from '@jbrowse/core/util/types'
-import {
-  checkAbortSignal,
-  bytesForRegions,
-  updateStatus,
-} from '@jbrowse/core/util'
+import { bytesForRegions, updateStatus } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
@@ -204,19 +200,21 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
           )
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const flags = record.get('flags')
-        if ((flags & flagInclude) === flagInclude && !(flags & flagExclude)) {
+        const flags = record.flags
+        if (
+          !((flags & flagInclude) === flagInclude && !(flags & flagExclude))
+        ) {
           continue
         }
 
         if (tagFilter) {
           const val = record.get(tagFilter.tag)
-          if (val === '*' ? val !== undefined : val === tagFilter.value)
+          if (!(val === '*' ? val !== undefined : val === tagFilter.value)) {
             continue
+          }
         }
 
-        if (name && record.get('name') === name) {
+        if (name && record.get('name') !== name) {
           continue
         }
 

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -253,11 +253,10 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
 
         if (name) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          filtered = filtered.filter((record: any) => {
-            record.name === name
-          })
+          filtered = filtered.filter((record: any) => record.name === name)
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         filtered.forEach((record: any) => {
           observer.next(this.cramRecordToFeature(record))
         })

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -27,7 +27,6 @@ import FilterListIcon from '@material-ui/icons/ClearAll'
 
 import { autorun, observable } from 'mobx'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
 import { LinearPileupDisplayConfigModel } from './configSchema'
 import LinearPileupDisplayBlurb from './components/LinearPileupDisplayBlurb'
 

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -377,26 +377,6 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
           return LinearPileupDisplayBlurb
         },
 
-        get filters() {
-          let filters: string[] = []
-          const { flagInclude, flagExclude, tagFilter, readName } =
-            self.filterBy
-
-          filters = [
-            `jexl:((get(feature,'flags')&${flagInclude})==${flagInclude}) && !(get(feature,'flags')&${flagExclude})`,
-          ]
-          if (tagFilter) {
-            const { tag, value } = tagFilter
-            filters.push(
-              `jexl:"${value}" =='*' ? getTag(feature,"${tag}") != undefined : getTag(feature,"${tag}") == "${value}"`,
-            )
-          }
-          if (readName) {
-            filters.push(`jexl:get(feature,'name') == "${readName}"`)
-          }
-          return new SerializableFilterChain({ filters })
-        },
-
         renderProps() {
           const view = getContainingView(self) as LGV
           const {
@@ -404,6 +384,7 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
             modificationTagMap,
             sortedBy,
             colorBy,
+            filterBy,
             rpcDriverName,
           } = self
 
@@ -419,9 +400,9 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
             displayModel: self,
             sortedBy,
             colorBy,
+            filterBy,
             colorTagMap: JSON.parse(JSON.stringify(colorTagMap)),
             modificationTagMap: JSON.parse(JSON.stringify(modificationTagMap)),
-            filters: this.filters,
             showSoftClip: self.showSoftClipping,
             config: self.rendererConfig,
           }

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -135,7 +135,6 @@ const stateModelFactory = (
           return {
             ...superProps,
             notReady: superProps.notReady || !this.modificationsReady,
-            filters: self.filters,
             modificationTagMap: JSON.parse(
               JSON.stringify(self.modificationTagMap),
             ),
@@ -143,6 +142,7 @@ const stateModelFactory = (
             // must use getSnapshot because otherwise changes to e.g. just the
             // colorBy.type are not read
             colorBy: self.colorBy ? getSnapshot(self.colorBy) : undefined,
+            filterBy: self.filterBy,
           }
         },
       }
@@ -240,37 +240,6 @@ const stateModelFactory = (
               },
             },
           ]
-        },
-        // The SNPCoverage filters are called twice because the BAM/CRAM
-        // features pass filters and then the SNPCoverage score features pass
-        // through here, and are already have 'snpinfo' are passed through
-        get filters() {
-          let filters: string[] = []
-          if (self.filterBy) {
-            const { flagInclude, flagExclude, tagFilter, readName } =
-              self.filterBy
-            filters = [
-              `jexl:get(feature,'snpinfo') != undefined ? true : ` +
-                `((get(feature,'flags')&${flagInclude})==${flagInclude}) && ` +
-                `!((get(feature,'flags')&${flagExclude}))`,
-            ]
-
-            if (tagFilter) {
-              const { tag, value } = tagFilter
-              filters.push(
-                `jexl:get(feature,'snpinfo') != undefined ? true : ` +
-                  `"${value}" =='*' ? getTag(feature,"${tag}") != undefined : ` +
-                  `getTag(feature,"${tag}") == "${value}"`,
-              )
-            }
-            if (readName) {
-              filters.push(
-                `jexl:get(feature,'snpinfo') != undefined ? true : ` +
-                  `get(feature,'name') == "${readName}"`,
-              )
-            }
-          }
-          return new SerializableFilterChain({ filters })
         },
       }
     })

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -1,13 +1,14 @@
 import { addDisposer, types, cast, getEnv, getSnapshot } from 'mobx-state-tree'
 import { observable, autorun } from 'mobx'
-import { getConf, readConfObject } from '@jbrowse/core/configuration'
-import { linearWiggleDisplayModelFactory } from '@jbrowse/plugin-wiggle'
 import {
+  getConf,
+  readConfObject,
   AnyConfigurationSchemaType,
   AnyConfigurationModel,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
+import { linearWiggleDisplayModelFactory } from '@jbrowse/plugin-wiggle'
+
 import PluginManager from '@jbrowse/core/PluginManager'
-import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
 import { getContainingView } from '@jbrowse/core/util'
 import Tooltip from '../components/Tooltip'
 import { getUniqueModificationValues } from '../../shared'

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -82,7 +82,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
   getFeatures(region: Region, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       const { subadapter } = await this.configure()
-      let feats = await subadapter
+      const feats = await subadapter
         .getFeatures(region, opts)
         .pipe(toArray())
         .toPromise()

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -558,7 +558,7 @@ const stateModelFactory = (
           try {
             stats = await getStats({
               signal: aborter.signal,
-              filters: self.filters,
+              ...self.renderProps(),
             })
             if (isAlive(self)) {
               self.updateStats(stats)
@@ -591,7 +591,7 @@ const stateModelFactory = (
 
                   const wiggleStats = await getStats({
                     signal: aborter.signal,
-                    filters: self.filters,
+                    ...self.renderProps(),
                   })
 
                   if (isAlive(self)) {


### PR DESCRIPTION
Fixes #2886

Directly passes the filterBy object to the adapter, which performs filtering

This is in contrast to passing jexl filtering expressions that are evaluated by the renderer code https://github.com/GMOD/jbrowse-components/blob/4be115ed00adb0bda3f951141e840ede90d8d2a0/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts#L185-L200

