### PR TITLE
Back to babel for core build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,7 @@
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
     "prepack": "yarn build",
-    "build": "tsc && cp package.json README.md ../../LICENSE dist/",
-    "build:only": "tsc"
+    "build": "babel . --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx' && cp package.json README.md ../../LICENSE dist/ && tsc"
   },
   "dependencies": {
     "@material-ui/icons": "^4.0.1",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "declaration": true,
+    "emitDeclarationOnly": true,
     "outDir": "dist/"
   }
 }


### PR DESCRIPTION
This goes back to using babel for the core build since tsc that was there was outputting ESM which could have trouble with e.g. jbrowse-img

Need better testing on that, and possibly it would be good to have a "dual package" with both ESM/CJS (similar to many of our parsers) but might have to be careful with the ESM in particular since PluginLoader has the import from variablename which bundlers hate