### PR TITLE
Callback to import ESM from PluginLoader

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -101,9 +101,9 @@ export default class PluginLoader {
 
   constructor(
     pluginDefinitions: PluginDefinition[] = [],
-    { fetchESM }: { fetchESM: (url: string) => Promise<unknown> },
+    args?: { fetchESM: (url: string) => Promise<unknown> },
   ) {
-    this.fetchESM = fetchESM
+    this.fetchESM = args?.fetchESM
     this.definitions = JSON.parse(JSON.stringify(pluginDefinitions))
   }
 

--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -97,7 +97,13 @@ function isInWebWorker(globalObject: ReturnType<typeof getGlobalObject>) {
 export default class PluginLoader {
   definitions: PluginDefinition[] = []
 
-  constructor(pluginDefinitions: PluginDefinition[] = []) {
+  fetchESM?: (url: string) => Promise<unknown>
+
+  constructor(
+    pluginDefinitions: PluginDefinition[] = [],
+    { fetchESM }: { fetchESM: (url: string) => Promise<unknown> },
+  ) {
+    this.fetchESM = fetchESM
     this.definitions = JSON.parse(JSON.stringify(pluginDefinitions))
   }
 
@@ -203,7 +209,7 @@ export default class PluginLoader {
         `cannot load plugins using protocol "${parsedUrl.protocol}"`,
       )
     }
-    const plugin = (await import(/* webpackIgnore: true */ parsedUrl.href)) as
+    const plugin = (await this.fetchESM?.(parsedUrl.href)) as
       | LoadedPlugin
       | undefined
     if (!plugin) {
@@ -278,13 +284,10 @@ export default class PluginLoader {
 
   async load() {
     return Promise.all(
-      this.definitions.map(
-        async definition =>
-          ({
-            plugin: await this.loadPlugin(definition),
-            definition,
-          } as PluginRecord),
-      ),
+      this.definitions.map(async definition => ({
+        plugin: await this.loadPlugin(definition),
+        definition,
+      })),
     )
   }
 }

--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -55,10 +55,7 @@ class PhasedScheduler<PhaseName extends string> {
 
   run() {
     this.phaseOrder.forEach(phaseName => {
-      const phaseCallbacks = this.phaseCallbacks.get(phaseName)
-      if (phaseCallbacks) {
-        phaseCallbacks.forEach(callback => callback())
-      }
+      this.phaseCallbacks.get(phaseName)?.forEach(callback => callback())
     })
   }
 }

--- a/products/jbrowse-desktop/src/StartScreen/util.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/util.tsx
@@ -56,7 +56,7 @@ export async function createPluginManager(
   initialTimestamp = +Date.now(),
 ) {
   const pluginLoader = new PluginLoader(configSnapshot.plugins, {
-    fetchESM: url => import(url),
+    fetchESM: url => import(/* webpackIgnore:true */ url),
   })
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()

--- a/products/jbrowse-desktop/src/StartScreen/util.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/util.tsx
@@ -55,7 +55,9 @@ export async function createPluginManager(
   configSnapshot: any,
   initialTimestamp = +Date.now(),
 ) {
-  const pluginLoader = new PluginLoader(configSnapshot.plugins)
+  const pluginLoader = new PluginLoader(configSnapshot.plugins, {
+    fetchESM: url => import(url),
+  })
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()
   const pm = new PluginManager([

--- a/products/jbrowse-desktop/src/rpc.worker.ts
+++ b/products/jbrowse-desktop/src/rpc.worker.ts
@@ -43,7 +43,7 @@ async function getPluginManager() {
   // Load runtime plugins
   const config = await receiveConfiguration()
   const pluginLoader = new PluginLoader(config.plugins, {
-    fetchESM: url => import(url),
+    fetchESM: url => import(/* webpackIgnore:true */ url),
   })
   pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()

--- a/products/jbrowse-desktop/src/rpc.worker.ts
+++ b/products/jbrowse-desktop/src/rpc.worker.ts
@@ -42,7 +42,9 @@ async function getPluginManager() {
   }
   // Load runtime plugins
   const config = await receiveConfiguration()
-  const pluginLoader = new PluginLoader(config.plugins)
+  const pluginLoader = new PluginLoader(config.plugins, {
+    fetchESM: url => import(url),
+  })
   pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()
   const plugins = [...corePlugins.map(p => ({ plugin: p })), ...runtimePlugins]

--- a/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
@@ -7,8 +7,9 @@ interface PluginDefinition {
 
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
+  args?: { fetchESM: (url: string) => Promise<unknown> },
 ) {
-  const pluginLoader = new PluginLoader(pluginDefinitions)
+  const pluginLoader = new PluginLoader(pluginDefinitions, args)
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()
   return runtimePlugins

--- a/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
@@ -7,8 +7,9 @@ interface PluginDefinition {
 
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
+  args?: { fetchESM: (url: string) => Promise<unknown> },
 ) {
-  const pluginLoader = new PluginLoader(pluginDefinitions)
+  const pluginLoader = new PluginLoader(pluginDefinitions, args)
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()
   return runtimePlugins

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -279,9 +279,7 @@ const Renderer = observer(
             })),
           ])
           pluginManager.createPluggableElements()
-          const isAdmin = !!adminKey
-
-          const RootModel = JBrowseRootModelFactory(pluginManager, isAdmin)
+          const RootModel = JBrowseRootModelFactory(pluginManager, !!adminKey)
 
           if (configSnapshot) {
             const rootModel = RootModel.create(

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -209,7 +209,9 @@ const SessionLoader = types
   .actions(self => ({
     async fetchPlugins(config: { plugins: PluginDefinition[] }) {
       try {
-        const pluginLoader = new PluginLoader(config.plugins)
+        const pluginLoader = new PluginLoader(config.plugins, {
+          fetchESM: url => import(url),
+        })
         pluginLoader.installGlobalReExports(window)
         const runtimePlugins = await pluginLoader.load()
         self.setRuntimePlugins([...runtimePlugins])
@@ -220,7 +222,9 @@ const SessionLoader = types
     },
     async fetchSessionPlugins(snap: { sessionPlugins?: PluginDefinition[] }) {
       try {
-        const pluginLoader = new PluginLoader(snap.sessionPlugins || [])
+        const pluginLoader = new PluginLoader(snap.sessionPlugins || [], {
+          fetchESM: url => import(url),
+        })
         pluginLoader.installGlobalReExports(window)
         const plugins = await pluginLoader.load()
         self.setSessionPlugins([...plugins])

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -210,7 +210,7 @@ const SessionLoader = types
     async fetchPlugins(config: { plugins: PluginDefinition[] }) {
       try {
         const pluginLoader = new PluginLoader(config.plugins, {
-          fetchESM: url => import(url),
+          fetchESM: url => import(/* webpackIgnore:true */ url),
         })
         pluginLoader.installGlobalReExports(window)
         const runtimePlugins = await pluginLoader.load()
@@ -223,7 +223,7 @@ const SessionLoader = types
     async fetchSessionPlugins(snap: { sessionPlugins?: PluginDefinition[] }) {
       try {
         const pluginLoader = new PluginLoader(snap.sessionPlugins || [], {
-          fetchESM: url => import(url),
+          fetchESM: url => import(/* webpackIgnore:true */ url),
         })
         pluginLoader.installGlobalReExports(window)
         const plugins = await pluginLoader.load()

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -43,7 +43,7 @@ async function getPluginManager() {
   // Load runtime plugins
   const config = await receiveConfiguration()
   const pluginLoader = new PluginLoader(config.plugins, {
-    fetchESM: url => import(url),
+    fetchESM: url => import(/* webpackIgnore:true */ url),
   })
   pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()

--- a/products/jbrowse-web/src/rpc.worker.ts
+++ b/products/jbrowse-web/src/rpc.worker.ts
@@ -42,7 +42,9 @@ async function getPluginManager() {
   }
   // Load runtime plugins
   const config = await receiveConfiguration()
-  const pluginLoader = new PluginLoader(config.plugins)
+  const pluginLoader = new PluginLoader(config.plugins, {
+    fetchESM: url => import(url),
+  })
   pluginLoader.installGlobalReExports(self)
   const runtimePlugins = await pluginLoader.load()
   const plugins = [...corePlugins.map(p => ({ plugin: p })), ...runtimePlugins]


### PR DESCRIPTION
This is a concept that can help import ESM using a callback, which avoids bundler specific behavior of `/*webpackIgnore:true */` being embedded in core (helps avoid embedded users getting the Critical dependency of an expression also, and embedded users could pass their own fetchESM callback if they want)


Possible fix for https://github.com/GMOD/jbrowse-components/issues/2638 