### PR TITLE
Remember assembly selector selections based on hostname/config and avoid infinite loop

### DIFF
--- a/packages/core/ui/AssemblySelector.tsx
+++ b/packages/core/ui/AssemblySelector.tsx
@@ -43,15 +43,25 @@ const AssemblySelector = observer(
     session,
     onChange,
     selected,
+    extra = 0,
   }: {
     session: AbstractSessionModel
     onChange: (arg: string) => void
     selected: string | undefined
+    extra?: unknown
   }) => {
     const classes = useStyles()
     const { assemblyNames, assemblyManager } = session
+
+    // constructs a localstorage key based on host/path/config to help
+    // remember. non-config assists usage with e.g. embedded apps
+    const config = new URLSearchParams(window.location.search).get('config')
     const [lastSelected, setLastSelected] = useLocalStorage(
-      'lastSelectedAsm',
+      `lastAssembly-${[
+        window.location.host + window.location.pathname,
+        config,
+        extra,
+      ].join('-')}`,
       selected,
     )
 
@@ -60,7 +70,7 @@ const AssemblySelector = observer(
       : selected
 
     useEffect(() => {
-      if (selection) {
+      if (selection && selection !== selected) {
         onChange(selection)
       }
     }, [selection, onChange])

--- a/packages/core/ui/AssemblySelector.tsx
+++ b/packages/core/ui/AssemblySelector.tsx
@@ -73,7 +73,7 @@ const AssemblySelector = observer(
       if (selection && selection !== selected) {
         onChange(selection)
       }
-    }, [selection, onChange])
+    }, [selection, onChange, selected])
 
     const error = assemblyNames.length ? '' : 'No configured assemblies'
     return (

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -177,6 +177,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
                     : 'Query'}
                 </Typography>
                 <AssemblySelector
+                  extra={0}
                   selected={queryAssembly}
                   onChange={val => setQueryAssembly(val)}
                   session={session}
@@ -189,6 +190,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
                     : 'Target'}
                 </Typography>
                 <AssemblySelector
+                  extra={1}
                   selected={targetAssembly}
                   onChange={val => setTargetAssembly(val)}
                   session={session}

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -180,6 +180,7 @@ const ImportForm = observer(({ model }: { model: LinearSyntenyViewModel }) => {
               <AssemblySelector
                 key={`row_${index}_${selected[index]}`}
                 selected={selected[index]}
+                extra={index}
                 onChange={val => {
                   // splice the value into the current array
                   const copy = selected.slice(0)


### PR DESCRIPTION
The import form for e.g. linearsyntenyview had an infinite loop with the new AssemblySelector feature that remembers your last selection.

This fixes by only calling a callback if it is different from what you passed in. It also improves ergonomics of the AssemblySelector's remember feature by associating the last selection with specific URL paths and config files


