### PR TITLE
Fix electron localfile

### DIFF
--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -1,7 +1,7 @@
 import {
   BlobFile,
-  LocalFile,
   GenericFilehandle,
+  LocalFile,
   Fetcher,
 } from 'generic-filehandle'
 import { RemoteFileWithRangeCache } from './RemoteFileWithRangeCache'

--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -18,6 +18,7 @@ import { BaseInternetAccountModel } from '../../pluggableElementTypes/models'
 import { getBlob } from '../tracks'
 import PluginManager from '../../PluginManager'
 import isNode from 'detect-node'
+import { isElectron } from '@jbrowse/core/util'
 
 export { RemoteFileWithRangeCache }
 
@@ -43,7 +44,7 @@ export function openLocation(
       throw new Error('No local path provided')
     }
 
-    if (isNode) {
+    if (isNode || isElectron) {
       return new LocalFile(location.localPath)
     } else {
       throw new Error("can't use local files in the browser")

--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -16,6 +16,12 @@ module.exports = {
         excludeAliases: ['console'],
       }),
       new webpack.ContextReplacementPlugin(/any-promise/),
+      new webpack.DefinePlugin({
+        // Global mobx-state-tree configuration.
+        // Force type checking in production for easier debugging:
+        // xref https://github.com/GMOD/jbrowse-components/pull/1575
+        'process.env.ENABLE_TYPE_CHECK': '"true"',
+      }),
     ],
     configure: config => {
       const { isFound, match } = getLoader(config, loaderByName('babel-loader'))

--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -20,6 +20,7 @@ module.exports = {
       new webpack.ContextReplacementPlugin(/any-promise/),
     ],
     configure: webpackConfig => {
+      webpackConfig.target = 'electron-renderer'
       const { isFound, match } = getLoader(
         webpackConfig,
         loaderByName('babel-loader'),

--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -42,6 +42,10 @@ module.exports = {
       config.target = 'electron-renderer'
       config.resolve.aliasFields = []
       config.resolve.mainFields = ['module', 'main']
+      // the 'auto' setting is important for properly resolving the loading of
+      // worker chunks xref
+      // https://github.com/webpack/webpack/issues/13791#issuecomment-897579223
+      config.output.publicPath = 'auto'
       return config
     },
   },

--- a/products/jbrowse-web/craco.config.js
+++ b/products/jbrowse-web/craco.config.js
@@ -18,6 +18,12 @@ module.exports = {
         excludeAliases: ['console'],
       }),
       new webpack.ContextReplacementPlugin(/any-promise/),
+      new webpack.DefinePlugin({
+        // Global mobx-state-tree configuration.
+        // Force type checking in production for easier debugging:
+        // xref https://github.com/GMOD/jbrowse-components/pull/1575
+        'process.env.ENABLE_TYPE_CHECK': '"true"',
+      }),
     ],
     configure: webpackConfig => {
       const { isFound, match } = getLoader(

--- a/products/jbrowse-web/craco.config.js
+++ b/products/jbrowse-web/craco.config.js
@@ -25,11 +25,8 @@ module.exports = {
         'process.env.ENABLE_TYPE_CHECK': '"true"',
       }),
     ],
-    configure: webpackConfig => {
-      const { isFound, match } = getLoader(
-        webpackConfig,
-        loaderByName('babel-loader'),
-      )
+    configure: config => {
+      const { isFound, match } = getLoader(config, loaderByName('babel-loader'))
 
       // technique here similar to
       // https://github.com/brammitch/monorepo/blob/main/packages/app-one/craco.config.js
@@ -40,19 +37,13 @@ module.exports = {
           : [match.loader.include]
         match.loader.include = include.concat(getYarnWorkspaces())
       }
-      return {
-        ...webpackConfig,
-        resolve: {
-          ...webpackConfig.resolve,
-          fallback: { fs: false },
-        },
-        output: {
-          ...webpackConfig.output,
-          // the 'auto' setting is important for properly resolving the loading
-          // of worker chunks xref https://github.com/webpack/webpack/issues/13791#issuecomment-897579223
-          publicPath: 'auto',
-        },
-      }
+
+      config.resolve.fallback = { fs: false }
+      // the 'auto' setting is important for properly resolving the loading of
+      // worker chunks xref
+      // https://github.com/webpack/webpack/issues/13791#issuecomment-897579223
+      config.output.publicPath = 'auto'
+      return config
     },
   },
 }


### PR DESCRIPTION
Fixes #2898 

Uses the "electron-renderer" target from webpack, and also requires loading the alternative localFile util class instead of generic-filehandle's because it is possible the "browser" package.json field is too strict in this case