### PR TITLE
Use a user-supplied fetchCJS callback to import CJS plugins

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -1,4 +1,3 @@
-/* global __non_webpack_require__ */
 import domLoadScript from 'load-script2'
 
 import { PluginConstructor } from './Plugin'
@@ -135,25 +134,24 @@ export default class PluginLoader {
     )
   }
 
-  async loadCJSPlugin(
-    pluginDefinition: CJSPluginDefinition,
-  ): Promise<LoadedPlugin | undefined> {
+  async loadCJSPlugin({ cjsUrl }: CJSPluginDefinition): Promise<LoadedPlugin> {
     let parsedUrl: URL
     try {
-      parsedUrl = new URL(
-        pluginDefinition.cjsUrl,
-        getGlobalObject().location.href,
-      )
+      parsedUrl = new URL(cjsUrl, getGlobalObject().location.href)
     } catch (error) {
       console.error(error)
-      throw new Error(`Error parsing URL: ${pluginDefinition.cjsUrl}`)
+      throw new Error(`Error parsing URL: ${cjsUrl}`)
     }
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error(
-        `cannot load plugins using protocol "${parsedUrl.protocol}"`,
+        `Cannot load plugins using protocol "${parsedUrl.protocol}"`,
       )
     }
-    return this.fetchCJS?.(parsedUrl.href)
+    if (!this.fetchCJS) {
+      throw new Error('No fetchCJS callback provided')
+    }
+
+    return this.fetchCJS(parsedUrl.href)
   }
 
   async loadESMPlugin(pluginDefinition: ESMPluginDefinition) {

--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -1,6 +1,5 @@
 /* global __non_webpack_require__ */
 import domLoadScript from 'load-script2'
-import sanitize from 'sanitize-filename'
 
 import { PluginConstructor } from './Plugin'
 import { ConfigurationSchema } from './configuration'
@@ -98,12 +97,17 @@ export default class PluginLoader {
   definitions: PluginDefinition[] = []
 
   fetchESM?: (url: string) => Promise<unknown>
+  fetchCJS?: (url: string) => Promise<LoadedPlugin>
 
   constructor(
     pluginDefinitions: PluginDefinition[] = [],
-    args?: { fetchESM: (url: string) => Promise<unknown> },
+    args?: {
+      fetchESM?: (url: string) => Promise<unknown>
+      fetchCJS?: (url: string) => Promise<LoadedPlugin>
+    },
   ) {
     this.fetchESM = args?.fetchESM
+    this.fetchCJS = args?.fetchCJS
     this.definitions = JSON.parse(JSON.stringify(pluginDefinitions))
   }
 
@@ -133,7 +137,7 @@ export default class PluginLoader {
 
   async loadCJSPlugin(
     pluginDefinition: CJSPluginDefinition,
-  ): Promise<LoadedPlugin> {
+  ): Promise<LoadedPlugin | undefined> {
     let parsedUrl: URL
     try {
       parsedUrl = new URL(
@@ -149,48 +153,7 @@ export default class PluginLoader {
         `cannot load plugins using protocol "${parsedUrl.protocol}"`,
       )
     }
-    const fs: typeof import('fs') = require('fs')
-    const path: typeof import('path') = require('path')
-    const os: typeof import('os') = require('os')
-    const http: typeof import('http') = require('http')
-    const fsPromises = fs.promises
-    // On macOS `os.tmpdir()` returns the path to a symlink, see:
-    // https://github.com/nodejs/node/issues/11422
-    const systemTmp = await fsPromises.realpath(os.tmpdir())
-    const tmpDir = await fsPromises.mkdtemp(
-      path.join(systemTmp, 'jbrowse-plugin-'),
-    )
-    let plugin: LoadedPlugin | undefined = undefined
-    try {
-      const pluginLocation = path.join(tmpDir, sanitize(parsedUrl.href))
-      const pluginLocationRelative = path.relative('.', pluginLocation)
-
-      const pluginDownload = new Promise<void>((resolve, reject) => {
-        const file = fs.createWriteStream(pluginLocation)
-        http
-          .get(parsedUrl.href, response => {
-            response.pipe(file)
-            file.on('finish', () => {
-              resolve()
-            })
-          })
-          .on('error', err => {
-            fs.unlinkSync(pluginLocation)
-            reject(err)
-          })
-      })
-      await pluginDownload
-      plugin = __non_webpack_require__(pluginLocationRelative) as
-        | LoadedPlugin
-        | undefined
-    } finally {
-      fsPromises.rmdir(tmpDir, { recursive: true })
-    }
-
-    if (!plugin) {
-      throw new Error(`Could not load CJS plugin: ${parsedUrl}`)
-    }
-    return plugin
+    return this.fetchCJS?.(parsedUrl.href)
   }
 
   async loadESMPlugin(pluginDefinition: ESMPluginDefinition) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,6 @@
     "react-error-boundary": "^3.0.0",
     "react-intersection-observer": "^8.32.5",
     "react-use-measure": "^2.1.1",
-    "sanitize-filename": "^1.6.3",
     "shortid": "^2.2.13",
     "svg-path-generator": "^1.1.0",
     "tenacious-fetch": "^2.1.0",

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -96,6 +96,7 @@
     "react-dom": "^17.0.0",
     "react-error-boundary": "^3.0.0",
     "rxjs": "^6.5.2",
+    "sanitize-filename": "^1.6.3",
     "split2": "^4.1.0",
     "timeago.js": "^4.0.2",
     "use-query-params": "1.2.3",

--- a/products/jbrowse-desktop/src/StartScreen/util.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/util.tsx
@@ -3,6 +3,11 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import PluginLoader from '@jbrowse/core/PluginLoader'
 import { readConfObject } from '@jbrowse/core/configuration'
 import deepmerge from 'deepmerge'
+import sanitize from 'sanitize-filename'
+
+export interface LoadedPlugin {
+  default: PluginConstructor
+}
 
 import {
   writeAWSAnalytics,
@@ -57,6 +62,48 @@ export async function createPluginManager(
 ) {
   const pluginLoader = new PluginLoader(configSnapshot.plugins, {
     fetchESM: url => import(/* webpackIgnore:true */ url),
+    fetchCJS: async url => {
+      const fs: typeof import('fs') = require('fs')
+      const path: typeof import('path') = require('path')
+      const os: typeof import('os') = require('os')
+      const http: typeof import('http') = require('http')
+      const fsPromises = fs.promises
+      // On macOS `os.tmpdir()` returns the path to a symlink, see:
+      // https://github.com/nodejs/node/issues/11422
+      const tmpDir = await fsPromises.mkdtemp(
+        path.join(await fsPromises.realpath(os.tmpdir()), 'jbrowse-plugin-'),
+      )
+      let plugin: LoadedPlugin | undefined = undefined
+      try {
+        const pluginLocation = path.join(tmpDir, sanitize(url))
+        const pluginLocationRelative = path.relative('.', pluginLocation)
+
+        await new Promise<void>((resolve, reject) => {
+          const file = fs.createWriteStream(pluginLocation)
+          http
+            .get(url, response => {
+              response.pipe(file)
+              file.on('finish', () => {
+                resolve()
+              })
+            })
+            .on('error', err => {
+              fs.unlinkSync(pluginLocation)
+              reject(err)
+            })
+        })
+        plugin = __non_webpack_require__(pluginLocationRelative) as
+          | LoadedPlugin
+          | undefined
+      } finally {
+        fsPromises.rmdir(tmpDir, { recursive: true })
+      }
+
+      if (!plugin) {
+        throw new Error(`Could not load CJS plugin: ${url}`)
+      }
+      return plugin
+    },
   })
   pluginLoader.installGlobalReExports(window)
   const runtimePlugins = await pluginLoader.load()

--- a/products/jbrowse-desktop/src/StartScreen/util.tsx
+++ b/products/jbrowse-desktop/src/StartScreen/util.tsx
@@ -1,13 +1,9 @@
 import { useState, useEffect } from 'react'
 import PluginManager from '@jbrowse/core/PluginManager'
-import PluginLoader from '@jbrowse/core/PluginLoader'
+import PluginLoader, { LoadedPlugin } from '@jbrowse/core/PluginLoader'
 import { readConfObject } from '@jbrowse/core/configuration'
 import deepmerge from 'deepmerge'
 import sanitize from 'sanitize-filename'
-
-export interface LoadedPlugin {
-  default: PluginConstructor
-}
 
 import {
   writeAWSAnalytics,
@@ -63,10 +59,10 @@ export async function createPluginManager(
   const pluginLoader = new PluginLoader(configSnapshot.plugins, {
     fetchESM: url => import(/* webpackIgnore:true */ url),
     fetchCJS: async url => {
-      const fs: typeof import('fs') = require('fs')
-      const path: typeof import('path') = require('path')
-      const os: typeof import('os') = require('os')
-      const http: typeof import('http') = require('http')
+      const fs: typeof import('fs') = window.require('fs')
+      const path: typeof import('path') = window.require('path')
+      const os: typeof import('os') = window.require('os')
+      const http: typeof import('http') = window.require('http')
       const fsPromises = fs.promises
       // On macOS `os.tmpdir()` returns the path to a symlink, see:
       // https://github.com/nodejs/node/issues/11422
@@ -92,7 +88,7 @@ export async function createPluginManager(
               reject(err)
             })
         })
-        plugin = __non_webpack_require__(pluginLocationRelative) as
+        plugin = window.require(pluginLocationRelative) as
           | LoadedPlugin
           | undefined
       } finally {


### PR DESCRIPTION
This PR is similar to https://github.com/GMOD/jbrowse-components/pull/2891 but for jbrowse-desktop, which can import CJS modules

Without this PR, a 'http' module polyfill (stream-http) is bundled in jbrowse-web

screenshots with `npx source-map-explorer build/static/js/*.js` in jbrowse-web

before (see stream-http)
![Screenshot from 2022-04-14 06-39-32](https://user-images.githubusercontent.com/6511937/163392317-4acd3b88-0287-483b-8069-66078d778cce.png)

after (stream-http removed)
![Screenshot from 2022-04-14 06-39-37](https://user-images.githubusercontent.com/6511937/163392335-dafa97b3-14be-4344-bae3-53f872759dac.png)


Also uses `window.require` instead of `__non_webpack_require__` which sort of ensures that the electron require machinery is used instead of bundled