### PR TITLE
Use react-use-measure instead of react-use-dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@types/react": "^17.0.0",
     "@types/react-color": "^3.0.4",
     "@types/react-dom": "^17.0.0",
-    "@types/react-measure": "^2.0.6",
     "@types/react-virtualized-auto-sizer": "^1.0.0",
     "@types/rimraf": "^3.0.2",
     "@types/rollup-plugin-node-builtins": "^2.1.2",

--- a/packages/__mocks__/react-use-measure.ts
+++ b/packages/__mocks__/react-use-measure.ts
@@ -1,1 +1,2 @@
+// 800+padding*2 = 808 from viewcontainer
 export default () => [undefined, { width: 808 }]

--- a/packages/__mocks__/react-use-measure.ts
+++ b/packages/__mocks__/react-use-measure.ts
@@ -1,0 +1,1 @@
+export default () => [undefined, { width: 808 }]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "rbush": "^3.0.1",
     "react-error-boundary": "^3.0.0",
     "react-intersection-observer": "^8.32.5",
-    "react-measure": "^2.3.0",
+    "react-use-measure": "^2.1.1",
     "sanitize-filename": "^1.6.3",
     "shortid": "^2.2.13",
     "svg-path-generator": "^1.1.0",

--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -230,7 +230,6 @@ const App = observer(
                 }
                 const { ReactComponent } = viewType
                 return (
-                  // @ts-ignore
                   <ViewContainer
                     key={`view-${view.id}`}
                     view={view}

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -120,7 +120,7 @@ const ViewContainer = observer(
   }: {
     view: IBaseViewModel
     onClose: () => void
-    style: React.CSSProperties
+    style?: React.CSSProperties
     children: React.ReactNode
   }) => {
     const classes = useStyles()

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -130,9 +130,7 @@ const ViewContainer = observer(
     const [ref, { width }] = useMeasure()
 
     useEffect(() => {
-      if (typeof jest !== 'undefined') {
-        view.setWidth(800)
-      } else if (width && isAlive(view)) {
+      if (width && isAlive(view)) {
         view.setWidth(width - padWidth * 2)
       }
     }, [padWidth, view, width])

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -12,7 +12,7 @@ import {
 
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
-import { withContentRect } from 'react-measure'
+import useMeasure from 'react-use-measure'
 
 // icons
 import CloseIcon from '@material-ui/icons/Close'
@@ -117,20 +117,17 @@ const ViewContainer = observer(
     onClose,
     style,
     children,
-    contentRect,
-    measureRef,
   }: {
     view: IBaseViewModel
     onClose: () => void
     style: React.CSSProperties
     children: React.ReactNode
-    contentRect: { bounds: { width: number } }
-    measureRef: any // eslint-disable-line @typescript-eslint/no-explicit-any
   }) => {
-    const width = contentRect.bounds.width
     const classes = useStyles()
     const theme = useTheme()
     const padWidth = theme.spacing(1)
+
+    const [ref, { width }] = useMeasure()
 
     useEffect(() => {
       if (typeof jest !== 'undefined') {
@@ -150,7 +147,7 @@ const ViewContainer = observer(
 
     return (
       <Paper
-        ref={measureRef}
+        ref={ref}
         elevation={12}
         className={classes.viewContainer}
         style={{ ...style, padding: `0px ${padWidth}px ${padWidth}px` }}
@@ -203,4 +200,4 @@ const ViewContainer = observer(
   },
 )
 
-export default withContentRect('bounds')(ViewContainer)
+export default ViewContainer

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -36,7 +36,6 @@
     "@material-ui/icons": "^4.9.1",
     "clsx": "^1.0.4",
     "is-object": "^1.0.1",
-    "react-sizeme": "^3.0.2",
     "svg-path-generator": "^1.1.0"
   },
   "peerDependencies": {

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -37,8 +37,7 @@
     "clone": "^2.1.2",
     "clsx": "^1.1.0",
     "generic-filehandle": "^2.2.2",
-    "json-stable-stringify": "^1.0.1",
-    "react-sizeme": "^3.0.2"
+    "json-stable-stringify": "^1.0.1"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -41,8 +41,7 @@
     "is-object": "^1.0.1",
     "json-stable-stringify": "^1.0.1",
     "normalize-wheel": "^1.0.1",
-    "react-popper": "^2.0.0",
-    "react-sizeme": "^3.0.2"
+    "react-popper": "^2.0.0"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -50,7 +50,7 @@
     "mobx-react": "^6.0.3",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
-    "react-measure": "^2.3.0",
+    "react-use-measure": "^2.1.1",
     "rxjs": "^6.0.0"
   },
   "peerDependencies": {

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -50,7 +50,7 @@
     "mobx-react": "^6.0.3",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
-    "react-use-dimensions": "^1.2.1",
+    "react-measure": "^2.3.0",
     "rxjs": "^6.0.0"
   },
   "peerDependencies": {

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
@@ -7,12 +7,12 @@ import {
   Typography,
   makeStyles,
   useTheme,
+  alpha,
 } from '@material-ui/core'
-import { alpha } from '@material-ui/core/styles'
 import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
-import useDimensions from 'react-use-dimensions'
+import { withContentRect } from 'react-measure'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
@@ -94,11 +94,21 @@ const ViewMenu = observer(
 )
 
 const ViewContainer = observer(
-  ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
+  ({
+    view,
+    children,
+    contentRect,
+    measureRef,
+  }: {
+    view: IBaseViewModel
+    children: React.ReactNode
+    contentRect: { bounds: { width: number } }
+    measureRef: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  }) => {
     const classes = useStyles()
     const theme = useTheme()
     const session = getSession(view)
-    const [measureRef, { width }] = useDimensions()
+    const width = contentRect.bounds.width
 
     const padWidth = theme.spacing(1)
 
@@ -148,4 +158,4 @@ const ViewContainer = observer(
   },
 )
 
-export default ViewContainer
+export default withContentRect('bounds')(ViewContainer)

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
@@ -12,7 +12,7 @@ import {
 import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
-import { withContentRect } from 'react-measure'
+import useMeasure from 'react-use-measure'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
@@ -94,22 +94,11 @@ const ViewMenu = observer(
 )
 
 const ViewContainer = observer(
-  ({
-    view,
-    children,
-    contentRect,
-    measureRef,
-  }: {
-    view: IBaseViewModel
-    children: React.ReactNode
-    contentRect: { bounds: { width: number } }
-    measureRef: any // eslint-disable-line @typescript-eslint/no-explicit-any
-  }) => {
+  ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
     const classes = useStyles()
     const theme = useTheme()
     const session = getSession(view)
-    const width = contentRect.bounds.width
-
+    const [ref, { width }] = useMeasure()
     const padWidth = theme.spacing(1)
 
     useEffect(() => {
@@ -123,7 +112,7 @@ const ViewContainer = observer(
     return (
       <Paper
         elevation={12}
-        ref={measureRef}
+        ref={ref}
         className={classes.viewContainer}
         style={{ padding: `0px ${padWidth}px ${padWidth}px` }}
       >
@@ -158,4 +147,4 @@ const ViewContainer = observer(
   },
 )
 
-export default withContentRect('bounds')(ViewContainer)
+export default ViewContainer

--- a/products/jbrowse-react-circular-genome-view/src/declare.d.ts
+++ b/products/jbrowse-react-circular-genome-view/src/declare.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-use-dimensions'

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -55,7 +55,7 @@
     "mobx-react": "^6.0.3",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
-    "react-use-dimensions": "^1.2.1",
+    "react-measure": "^2.3.0",
     "rxjs": "^6.0.0"
   },
   "peerDependencies": {

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -55,7 +55,7 @@
     "mobx-react": "^6.0.3",
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
-    "react-measure": "^2.3.0",
+    "react-use-measure": "^2.1.1",
     "rxjs": "^6.0.0"
   },
   "peerDependencies": {

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
@@ -7,12 +7,12 @@ import {
   Typography,
   makeStyles,
   useTheme,
+  alpha,
 } from '@material-ui/core'
-import { alpha } from '@material-ui/core/styles'
 import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
-import useDimensions from 'react-use-dimensions'
+import { withContentRect } from 'react-measure'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
@@ -94,11 +94,21 @@ const ViewMenu = observer(
 )
 
 const ViewContainer = observer(
-  ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
+  ({
+    view,
+    children,
+    contentRect,
+    measureRef,
+  }: {
+    view: IBaseViewModel
+    children: React.ReactNode
+    contentRect: { bounds: { width: number } }
+    measureRef: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  }) => {
     const classes = useStyles()
     const theme = useTheme()
     const session = getSession(view)
-    const [measureRef, { width }] = useDimensions()
+    const width = contentRect.bounds.width
 
     const padWidth = theme.spacing(1)
 
@@ -148,4 +158,4 @@ const ViewContainer = observer(
   },
 )
 
-export default ViewContainer
+export default withContentRect('bounds')(ViewContainer)

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/ViewContainer.tsx
@@ -12,7 +12,7 @@ import {
 import MenuIcon from '@material-ui/icons/Menu'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
-import { withContentRect } from 'react-measure'
+import useMeasure from 'react-use-measure'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
@@ -94,22 +94,11 @@ const ViewMenu = observer(
 )
 
 const ViewContainer = observer(
-  ({
-    view,
-    children,
-    contentRect,
-    measureRef,
-  }: {
-    view: IBaseViewModel
-    children: React.ReactNode
-    contentRect: { bounds: { width: number } }
-    measureRef: any // eslint-disable-line @typescript-eslint/no-explicit-any
-  }) => {
+  ({ view, children }: { view: IBaseViewModel; children: React.ReactNode }) => {
+    const [ref, { width }] = useMeasure()
     const classes = useStyles()
     const theme = useTheme()
     const session = getSession(view)
-    const width = contentRect.bounds.width
-
     const padWidth = theme.spacing(1)
 
     useEffect(() => {
@@ -123,7 +112,7 @@ const ViewContainer = observer(
     return (
       <Paper
         elevation={12}
-        ref={measureRef}
+        ref={ref}
         className={classes.viewContainer}
         style={{ padding: `0px ${padWidth}px ${padWidth}px` }}
       >
@@ -158,4 +147,4 @@ const ViewContainer = observer(
   },
 )
 
-export default withContentRect('bounds')(ViewContainer)
+export default ViewContainer

--- a/products/jbrowse-react-linear-genome-view/src/declare.d.ts
+++ b/products/jbrowse-react-linear-genome-view/src/declare.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-use-dimensions'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,7 +1131,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -4790,13 +4790,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-measure@^2.0.6":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react-measure/-/react-measure-2.0.8.tgz#3615956c685e6d9fed8380aac53590b333fae34f"
-  integrity sha512-Pu4/hQ/1AKVN6efoawtcM+l376WYOI8e1fiM6ir4pdLkHilDCkJLjUGvAm0mWKJ0GE6hzu55yCrcJ/xNyEdFwA==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -8382,6 +8375,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10567,11 +10565,6 @@ get-monorepo-packages@^1.1.0:
   dependencies:
     globby "^7.1.1"
     load-json-file "^4.0.0"
-
-get-node-dimensions@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz#fb7b4bb57060fb4247dd51c9d690dfbec56b0823"
-  integrity sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -16683,16 +16676,6 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-measure@^2.3.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.5.2.tgz#4ffc410e8b9cb836d9455a9ff18fc1f0fca67f89"
-  integrity sha512-M+rpbTLWJ3FD6FXvYV6YEGvQ5tMayQ3fGrZhRPHrE9bVlBYfDCLuDcgNttYfk8IqfOI03jz6cbpqMRTUclQnaA==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    get-node-dimensions "^1.2.1"
-    prop-types "^15.6.2"
-    resize-observer-polyfill "^1.5.0"
-
 react-merge-refs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
@@ -16850,6 +16833,13 @@ react-transition-group@^4.4.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-use-measure@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.1.tgz#5824537f4ee01c9469c45d5f7a8446177c6cc4ba"
+  integrity sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==
+  dependencies:
+    debounce "^1.2.1"
 
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.6"
@@ -17334,11 +17324,6 @@ reselect@^4.0.0:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
   integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
-
-resize-observer-polyfill@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16795,7 +16795,7 @@ react-simple-code-editor@0.9.3:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.3.tgz#12af0f85455eb1be1a86f15e325ec7861bc0db75"
   integrity sha512-JexTKcpcOjArsXUDCWNoXgIdshoacJVSuf3LbdKG0tHw5ISREoh7wvNZlRRk2gncFRSixkkTI5E18svC966rYQ==
 
-react-sizeme@^3.0.1, react-sizeme@^3.0.2:
+react-sizeme@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.2.tgz#4a2f167905ba8f8b8d932a9e35164e459f9020e4"
   integrity sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==
@@ -16850,11 +16850,6 @@ react-transition-group@^4.4.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-use-dimensions@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-use-dimensions/-/react-use-dimensions-1.2.1.tgz#eb1561db7b06c393209d2bffa449931dd93f7870"
-  integrity sha512-XL+Rup9Hosxx3Ap9xpyQMbVwuUa4BSqiOjfBb2zDuGs4uv2FesFV+m8Z/huRx2BNptMd9ARPqFuSNA62zhCozg==
 
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.6"


### PR DESCRIPTION
Changes embedded components to use react-measure instead of react-use-dimensions

We at one point had react-sizeme, react-measure, and react-use-dimensions

After this PR, just react-measure :)

Even react-measure could be considered old with the HOC pattern (use-dimensions is nice as a hook) but it does not use ResizeObserver which means it could miss some resize too e.g. if elements shift around on the page (only listens to window.resize for changes)