### PR TITLE
Fix AboutDialog under vite for embedded components

### DIFF
--- a/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { lazy } from 'react'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+// note: AboutDialog is imported statically instead of as a lazy component
+// due to vite failing to load it xref #2896
 import {
   AbstractSessionModel,
   TrackViewModel,
@@ -21,12 +21,14 @@ import {
   Instance,
 } from 'mobx-state-tree'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  readConfObject,
+  AnyConfigurationModel,
+} from '@jbrowse/core/configuration'
 import InfoIcon from '@material-ui/icons/Info'
-import { ReferringNode } from '../types'
+import AboutDialog from '@jbrowse/core/ui/AboutDialog'
 import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
-
-const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
+import { ReferringNode } from '../types'
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
   const model = types

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -1,14 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { lazy } from 'react'
+// note: AboutDialog is imported statically instead of as a lazy component
+// due to vite failing to load it xref #2896
 import {
   AbstractSessionModel,
   TrackViewModel,
   DialogComponentType,
 } from '@jbrowse/core/util/types'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import addSnackbarToModel from '@jbrowse/core/ui/SnackbarModel'
 import { getContainingView } from '@jbrowse/core/util'
-import { readConfObject } from '@jbrowse/core/configuration'
+import {
+  readConfObject,
+  AnyConfigurationModel,
+} from '@jbrowse/core/configuration'
 import {
   getMembers,
   getParent,
@@ -23,11 +26,10 @@ import {
   IAnyStateTreeNode,
 } from 'mobx-state-tree'
 import PluginManager from '@jbrowse/core/PluginManager'
+import AboutDialog from '@jbrowse/core/ui/AboutDialog'
 import TextSearchManager from '@jbrowse/core/TextSearch/TextSearchManager'
 import InfoIcon from '@material-ui/icons/Info'
 import { ReferringNode } from '../types'
-
-const AboutDialog = lazy(() => import('@jbrowse/core/ui/AboutDialog'))
 
 export default function sessionModelFactory(pluginManager: PluginManager) {
   const model = types


### PR DESCRIPTION
This avoids using the lazy import for AboutDialog for the embedded components.

This is a particular issue that affected vite only. xref https://github.com/GMOD/jbrowse-components/issues/2896

The issue does not affect our webpack configs

Possibly an esm build of core could help avoid this workaround, but this might be challenging with the flat/import-from-subdirectory style. Would maybe need to use exports:{} in package.json to explicitly allow legal core import paths