### PR TITLE
Manually polyfill fetch in @jbrowse/img

### DIFF
--- a/products/jbrowse-img/package.json
+++ b/products/jbrowse-img/package.json
@@ -32,6 +32,7 @@
     "@jbrowse/react-linear-genome-view": "^1.7.0",
     "abortcontroller-polyfill": "^1.7.3",
     "mobx": "^5.10.1",
+    "node-fetch": "^2.6.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "tmp": "^0.2.1",

--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -6,6 +6,14 @@ import { renderRegion } from './renderRegion'
 import tmp from 'tmp'
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
 import { spawnSync } from 'child_process'
+import fetch, { Headers, Response, Request } from 'node-fetch'
+
+if (!global.fetch) {
+  global.fetch = fetch
+  global.Headers = Headers
+  global.Response = Response
+  global.Request = Request
+}
 
 const err = console.error
 console.error = (...args) => {

--- a/products/jbrowse-img/src/index.js
+++ b/products/jbrowse-img/src/index.js
@@ -24,6 +24,14 @@ console.error = (...args) => {
   }
 }
 
+console.warn = (...args) => {
+  if (`${args[0]}`.match('estimation reached timeout')) {
+    return null
+  } else {
+    err(args)
+  }
+}
+
 // eslint-disable-next-line no-unused-expressions
 yargs
   .command('jb2export', 'Creates a jbrowse 2 image snapshot')


### PR DESCRIPTION
Currently @jbrowse/img fails in 1.7.0 because RemoteFileWithRangeCache uses Headers/Response objects, which are not defined in node since  we stopped using cross-fetch as a polyfill inside of http-range-fetcher

That basically means we were sort of "cryptically dependent" on http-range-fetcher polyfilling these variables

This more explicitly polyfills fetch in @jbrowse/img. Soon node will have fetch built in by default but until then...