### PR TITLE
Create tsconfig.build.json to add types to plugins/embedded components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yalc.lock
 lerna-debug.log
 .yarn
 .yarnrc
+*.tsbuildinfo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,3 +264,12 @@ jbrowse text-index --tracks ncbi_refseq_109_hg38_latest  --out config_demo.json 
 jbrowse text-index -a hg19 --tracks ncbi_gff_hg19 --out config_demo.json --force --attributes Name,ID,Note,description,gene_synonym
 
 ```
+
+
+## Notes about monorepo setup
+
+Our setup for the monorepo takes notes from the material-ui repository. Some particular notes include
+
+1. The use of the "flat" packages/core package, where you can import from nested subpaths like '@jbrowse/core/util'
+2. The use of tsconfig.build.json to generate types in the final release
+3. The use of referring to the src directory at development time

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,6 @@ jbrowse text-index -a hg19 --tracks ncbi_gff_hg19 --out config_demo.json --force
 
 ```
 
-
 ## Notes about monorepo setup
 
 Our setup for the monorepo takes notes from the material-ui repository. Some particular notes include

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
     "prepack": "yarn build",
-    "build": "babel . --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx' && cp package.json README.md ../../LICENSE dist/ && tsc"
+    "build": "babel . --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx' && cp package.json README.md ../../LICENSE dist/",
+    "postbuild": "tsc -b tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "test": "cd ../..; jest packages/core",
     "coverage": "yarn test --coverage",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.build.tsbuildinfo",
     "prebuild": "yarn clean",
     "prepack": "yarn build",
     "build": "babel . --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx' && cp package.json README.md ../../LICENSE dist/",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "declaration": true
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true,
     "outDir": "dist/"
-  }
+  },
+
+  "exclude": ["**/*.test.ts*", "**/*.test.js*", "dist"]
 }

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/alignments",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",

--- a/plugins/alignments/tsconfig.build.json
+++ b/plugins/alignments/tsconfig.build.json
@@ -8,8 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "rootDir": "./src",
-    "composite": true
+    "rootDir": "./src"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],
   "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],

--- a/plugins/alignments/tsconfig.build.json
+++ b/plugins/alignments/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../wiggle/tsconfig.build.json" },
+    { "path": "../linear-genome-view/tsconfig.build.json" }
+  ]
+}

--- a/plugins/alignments/tsconfig.build.json
+++ b/plugins/alignments/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/arc/package.json
+++ b/plugins/arc/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/arc",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",

--- a/plugins/arc/tsconfig.build.json
+++ b/plugins/arc/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/arc/tsconfig.build.json
+++ b/plugins/arc/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/arc/tsconfig.build.json
+++ b/plugins/arc/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/arc/tsconfig.build.json
+++ b/plugins/arc/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@jbrowse/plugin-variants": "^1.7.0",

--- a/plugins/authentication/tsconfig.build.json
+++ b/plugins/authentication/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/authentication/tsconfig.build.json
+++ b/plugins/authentication/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/authentication/tsconfig.build.json
+++ b/plugins/authentication/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/authentication/tsconfig.build.json
+++ b/plugins/authentication/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/bbi": "^1.0.32",

--- a/plugins/bed/tsconfig.build.json
+++ b/plugins/bed/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/bed/tsconfig.build.json
+++ b/plugins/bed/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/bed/tsconfig.build.json
+++ b/plugins/bed/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/bed/tsconfig.build.json
+++ b/plugins/bed/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/vcf": "^5.0.5",

--- a/plugins/breakpoint-split-view/tsconfig.build.json
+++ b/plugins/breakpoint-split-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/breakpoint-split-view/tsconfig.build.json
+++ b/plugins/breakpoint-split-view/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/breakpoint-split-view/tsconfig.build.json
+++ b/plugins/breakpoint-split-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/breakpoint-split-view/tsconfig.build.json
+++ b/plugins/breakpoint-split-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1"

--- a/plugins/circular-view/tsconfig.build.json
+++ b/plugins/circular-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/circular-view/tsconfig.build.json
+++ b/plugins/circular-view/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/circular-view/tsconfig.build.json
+++ b/plugins/circular-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/circular-view/tsconfig.build.json
+++ b/plugins/circular-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.4.3",

--- a/plugins/comparative-adapters/tsconfig.build.json
+++ b/plugins/comparative-adapters/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/comparative-adapters/tsconfig.build.json
+++ b/plugins/comparative-adapters/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/comparative-adapters/tsconfig.build.json
+++ b/plugins/comparative-adapters/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/comparative-adapters/tsconfig.build.json
+++ b/plugins/comparative-adapters/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/config/tsconfig.build.json
+++ b/plugins/config/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/config/tsconfig.build.json
+++ b/plugins/config/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/config/tsconfig.build.json
+++ b/plugins/config/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/config/tsconfig.build.json
+++ b/plugins/config/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/ucsc-hub": "^0.1.3",

--- a/plugins/data-management/tsconfig.build.json
+++ b/plugins/data-management/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/data-management/tsconfig.build.json
+++ b/plugins/data-management/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/data-management/tsconfig.build.json
+++ b/plugins/data-management/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/data-management/tsconfig.build.json
+++ b/plugins/data-management/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.4.3",

--- a/plugins/dotplot-view/tsconfig.build.json
+++ b/plugins/dotplot-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/dotplot-view/tsconfig.build.json
+++ b/plugins/dotplot-view/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../wiggle/tsconfig.build.json" },
+    { "path": "../alignments/tsconfig.build.json" }
+  ]
+}

--- a/plugins/dotplot-view/tsconfig.build.json
+++ b/plugins/dotplot-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/dotplot-view/tsconfig.build.json
+++ b/plugins/dotplot-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/gff3 --passWithNoTests",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",

--- a/plugins/gff3/tsconfig.build.json
+++ b/plugins/gff3/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/gff3/tsconfig.build.json
+++ b/plugins/gff3/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/gff3/tsconfig.build.json
+++ b/plugins/gff3/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/gff3/tsconfig.build.json
+++ b/plugins/gff3/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/grid-bookmark/package.json
+++ b/plugins/grid-bookmark/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/grid-bookmark/tsconfig.build.json
+++ b/plugins/grid-bookmark/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/grid-bookmark/tsconfig.build.json
+++ b/plugins/grid-bookmark/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/grid-bookmark/tsconfig.build.json
+++ b/plugins/grid-bookmark/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/grid-bookmark/tsconfig.build.json
+++ b/plugins/grid-bookmark/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.15",

--- a/plugins/gtf/tsconfig.build.json
+++ b/plugins/gtf/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/gtf/tsconfig.build.json
+++ b/plugins/gtf/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/gtf/tsconfig.build.json
+++ b/plugins/gtf/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/gtf/tsconfig.build.json
+++ b/plugins/gtf/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "abortable-promise-cache": "^1.5.0",

--- a/plugins/hic/tsconfig.build.json
+++ b/plugins/hic/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/hic/tsconfig.build.json
+++ b/plugins/hic/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/hic/tsconfig.build.json
+++ b/plugins/hic/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/hic/tsconfig.build.json
+++ b/plugins/hic/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/legacy-jbrowse/package.json
+++ b/plugins/legacy-jbrowse/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/nclist": "^0.2.1",

--- a/plugins/legacy-jbrowse/tsconfig.build.json
+++ b/plugins/legacy-jbrowse/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/legacy-jbrowse/tsconfig.build.json
+++ b/plugins/legacy-jbrowse/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/legacy-jbrowse/tsconfig.build.json
+++ b/plugins/legacy-jbrowse/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/legacy-jbrowse/tsconfig.build.json
+++ b/plugins/legacy-jbrowse/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/linear-comparative-view/tsconfig.build.json
+++ b/plugins/linear-comparative-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/linear-comparative-view/tsconfig.build.json
+++ b/plugins/linear-comparative-view/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../wiggle/tsconfig.build.json" },
+    { "path": "../alignments/tsconfig.build.json" }
+  ]
+}

--- a/plugins/linear-comparative-view/tsconfig.build.json
+++ b/plugins/linear-comparative-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/linear-comparative-view/tsconfig.build.json
+++ b/plugins/linear-comparative-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/linear-genome-view/tsconfig.build.json
+++ b/plugins/linear-genome-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/linear-genome-view/tsconfig.build.json
+++ b/plugins/linear-genome-view/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/linear-genome-view/tsconfig.build.json
+++ b/plugins/linear-genome-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/linear-genome-view/tsconfig.build.json
+++ b/plugins/linear-genome-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/lollipop/tsconfig.build.json
+++ b/plugins/lollipop/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/lollipop/tsconfig.build.json
+++ b/plugins/lollipop/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/lollipop/tsconfig.build.json
+++ b/plugins/lollipop/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/lollipop/tsconfig.build.json
+++ b/plugins/lollipop/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/menus/package.json
+++ b/plugins/menus/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/menus/tsconfig.build.json
+++ b/plugins/menus/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/menus/tsconfig.build.json
+++ b/plugins/menus/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/menus/tsconfig.build.json
+++ b/plugins/menus/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/menus/tsconfig.build.json
+++ b/plugins/menus/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/protein/package.json
+++ b/plugins/protein/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/protein/tsconfig.build.json
+++ b/plugins/protein/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/protein/tsconfig.build.json
+++ b/plugins/protein/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/protein/tsconfig.build.json
+++ b/plugins/protein/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/protein/tsconfig.build.json
+++ b/plugins/protein/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "string-template": "^1.0.0"

--- a/plugins/rdf/tsconfig.build.json
+++ b/plugins/rdf/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/rdf/tsconfig.build.json
+++ b/plugins/rdf/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/rdf/tsconfig.build.json
+++ b/plugins/rdf/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/rdf/tsconfig.build.json
+++ b/plugins/rdf/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/indexedfasta": "^2.0.2",

--- a/plugins/sequence/tsconfig.build.json
+++ b/plugins/sequence/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/sequence/tsconfig.build.json
+++ b/plugins/sequence/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/sequence/tsconfig.build.json
+++ b/plugins/sequence/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/sequence/tsconfig.build.json
+++ b/plugins/sequence/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.4.3",

--- a/plugins/spreadsheet-view/tsconfig.build.json
+++ b/plugins/spreadsheet-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/spreadsheet-view/tsconfig.build.json
+++ b/plugins/spreadsheet-view/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/spreadsheet-view/tsconfig.build.json
+++ b/plugins/spreadsheet-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/spreadsheet-view/tsconfig.build.json
+++ b/plugins/spreadsheet-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",

--- a/plugins/sv-inspector/tsconfig.build.json
+++ b/plugins/sv-inspector/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/sv-inspector/tsconfig.build.json
+++ b/plugins/sv-inspector/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/sv-inspector/tsconfig.build.json
+++ b/plugins/sv-inspector/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/sv-inspector/tsconfig.build.json
+++ b/plugins/sv-inspector/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/svg/package.json
+++ b/plugins/svg/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/svg/tsconfig.build.json
+++ b/plugins/svg/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/svg/tsconfig.build.json
+++ b/plugins/svg/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/svg/tsconfig.build.json
+++ b/plugins/svg/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/svg/tsconfig.build.json
+++ b/plugins/svg/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/trackhub-registry/package.json
+++ b/plugins/trackhub-registry/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@gmod/ucsc-hub": "^0.1.3",

--- a/plugins/trackhub-registry/tsconfig.build.json
+++ b/plugins/trackhub-registry/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/trackhub-registry/tsconfig.build.json
+++ b/plugins/trackhub-registry/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/trackhub-registry/tsconfig.build.json
+++ b/plugins/trackhub-registry/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/trackhub-registry/tsconfig.build.json
+++ b/plugins/trackhub-registry/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/trix/package.json
+++ b/plugins/trix/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/trix/tsconfig.build.json
+++ b/plugins/trix/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/trix/tsconfig.build.json
+++ b/plugins/trix/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/trix/tsconfig.build.json
+++ b/plugins/trix/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/trix/tsconfig.build.json
+++ b/plugins/trix/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -29,7 +29,8 @@
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
-    "useSrc": "node ../../scripts/useSrc.js"
+    "useSrc": "node ../../scripts/useSrc.js",
+    "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.15",

--- a/plugins/variants/tsconfig.build.json
+++ b/plugins/variants/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/variants/tsconfig.build.json
+++ b/plugins/variants/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/variants/tsconfig.build.json
+++ b/plugins/variants/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/variants/tsconfig.build.json
+++ b/plugins/variants/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/wiggle",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",

--- a/plugins/wiggle/tsconfig.build.json
+++ b/plugins/wiggle/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/wiggle/tsconfig.build.json
+++ b/plugins/wiggle/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../linear-genome-view/tsconfig.build.json" }
+  ]
+}

--- a/plugins/wiggle/tsconfig.build.json
+++ b/plugins/wiggle/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/plugins/wiggle/tsconfig.build.json
+++ b/plugins/wiggle/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -26,6 +26,7 @@
     "start:umd": "cross-env NODE_ENV=development webpack-dev-server",
     "prebuild": "npm run clean",
     "build": "npm-run-all build:*",
+    "postbuild": "tsc -b tsconfig.build.json",
     "build:babel": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
     "build:webpack": "npm-run-all build:webpack:*",
     "build:webpack:dev": "cross-env NODE_ENV=development webpack",

--- a/products/jbrowse-react-circular-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-circular-genome-view/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../../plugins/circular-view/tsconfig.build.json" },
+    { "path": "../../plugins/config/tsconfig.build.json" },
+    { "path": "../../plugins/data-management/tsconfig.build.json" },
+    { "path": "../../plugins/sequence/tsconfig.build.json" },
+    { "path": "../../plugins/variants/tsconfig.build.json" },
+    { "path": "../../plugins/wiggle/tsconfig.build.json" }
+  ]
+}

--- a/products/jbrowse-react-circular-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-circular-genome-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/products/jbrowse-react-circular-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-circular-genome-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/products/jbrowse-react-circular-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-circular-genome-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "start:umd": "cross-env NODE_ENV=development webpack-dev-server",
     "prebuild": "npm run clean",
+    "postbuild": "tsc -b tsconfig.build.json",
     "build": "npm-run-all build:*",
     "build:babel": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
     "build:webpack": "npm-run-all build:webpack:*",
@@ -38,7 +39,6 @@
     "@jbrowse/core": "^1.7.0",
     "@jbrowse/plugin-alignments": "^1.7.0",
     "@jbrowse/plugin-bed": "^1.7.0",
-    "@jbrowse/plugin-circular-view": "^1.7.0",
     "@jbrowse/plugin-config": "^1.7.0",
     "@jbrowse/plugin-data-management": "^1.7.0",
     "@jbrowse/plugin-gff3": "^1.7.0",

--- a/products/jbrowse-react-linear-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-linear-genome-view/tsconfig.build.json
@@ -3,7 +3,6 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/products/jbrowse-react-linear-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-linear-genome-view/tsconfig.build.json
@@ -1,0 +1,30 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../../plugins/alignments/tsconfig.build.json" },
+    { "path": "../../plugins/bed/tsconfig.build.json" },
+    { "path": "../../plugins/config/tsconfig.build.json" },
+    { "path": "../../plugins/data-management/tsconfig.build.json" },
+    { "path": "../../plugins/gff3/tsconfig.build.json" },
+    { "path": "../../plugins/linear-genome-view/tsconfig.build.json" },
+    { "path": "../../plugins/sequence/tsconfig.build.json" },
+    { "path": "../../plugins/svg/tsconfig.build.json" },
+    { "path": "../../plugins/trix/tsconfig.build.json" },
+    { "path": "../../plugins/variants/tsconfig.build.json" },
+    { "path": "../../plugins/wiggle/tsconfig.build.json" }
+  ]
+}

--- a/products/jbrowse-react-linear-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-linear-genome-view/tsconfig.build.json
@@ -3,7 +3,7 @@
   // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
-    "composite": true,
+    
     "declaration": true,
     "noEmit": false,
     "emitDeclarationOnly": true,

--- a/products/jbrowse-react-linear-genome-view/tsconfig.build.json
+++ b/products/jbrowse-react-linear-genome-view/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   // This config is for emitting declarations (.d.ts) only
-  // Actual .ts source files are transpiled via babel
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
This is a template that starts to add types back to try to fix #2915 as that issue is not a great dev experience (no types!)

This is based off of looking at the MUI repo https://github.com/mui/material-ui/blob/master/packages/mui-material/package.json

It uses a specialized tsconfig for build time that they call tsconfig.build.json

It also uses project references, which were briefly looked at for the webpack 5 upgrade but didn't fully fit the bill, but I think in this case they may work. Draft PR just being hopeful it will work