### PR TITLE
Optimize gtf by only parsing lazily per-refName

### DIFF
--- a/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
+++ b/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
@@ -3,13 +3,11 @@ import {
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { NoAssemblyRegion } from '@jbrowse/core/util/types'
-import { readConfObject } from '@jbrowse/core/configuration'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import IntervalTree from '@flatten-js/interval-tree'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { unzip } from '@gmod/bgzf-filehandle'
-
 import gtf from '@gmod/gtf'
 import { FeatureLoc, featureData } from '../util'
 function isGzip(buf: Buffer) {
@@ -18,12 +16,16 @@ function isGzip(buf: Buffer) {
 
 export default class extends BaseFeatureDataAdapter {
   protected gtfFeatures?: Promise<{
-    intervalTree: Record<string, IntervalTree>
+    feats: { [key: string]: string[] }
   }>
+
+  protected intervalTrees: {
+    [key: string]: Promise<IntervalTree | undefined> | undefined
+  } = {}
 
   private async loadDataP() {
     const buffer = await openLocation(
-      readConfObject(this.config, 'gtfLocation'),
+      this.getConf('gtfLocation'),
       this.pluginManager,
     ).readFile()
 
@@ -33,31 +35,18 @@ export default class extends BaseFeatureDataAdapter {
       throw new Error('Data exceeds maximum string length (512MB)')
     }
     const data = new TextDecoder('utf8', { fatal: true }).decode(buf)
-    const feats = gtf.parseStringSync(data, {
-      parseFeatures: true,
-      parseComments: false,
-      parseDirectives: false,
-      parseSequences: false,
-    }) as FeatureLoc[][]
 
-    const intervalTree = feats
-      .flat()
-      .map(
-        (f, i) =>
-          new SimpleFeature({
-            data: featureData(f),
-            id: `${this.id}-offset-${i}`,
-          }),
-      )
-      .reduce((acc, obj) => {
-        const key = obj.get('refName')
-        if (!acc[key]) {
-          acc[key] = new IntervalTree()
-        }
-        acc[key].insert([obj.get('start'), obj.get('end')], obj)
-        return acc
-      }, {} as Record<string, IntervalTree>)
-    return { intervalTree }
+    const lines = data.split('\n').filter(f => !!f && !f.startsWith('#'))
+    const feats = {} as { [key: string]: string[] }
+    for (let i = 0; i < lines.length; i++) {
+      const refName = lines[i].split('\t')[0]
+      if (!feats[refName]) {
+        feats[refName] = []
+      }
+      feats[refName].push(lines[i])
+    }
+
+    return { feats }
   }
 
   private async loadData() {
@@ -72,18 +61,57 @@ export default class extends BaseFeatureDataAdapter {
   }
 
   public async getRefNames(opts: BaseOptions = {}) {
-    const { intervalTree } = await this.loadData()
-    return Object.keys(intervalTree)
+    const { feats } = await this.loadData()
+    return Object.keys(feats)
+  }
+
+  private async loadFeatureIntervalTreeHelper(refName: string) {
+    const { feats } = await this.loadData()
+    const lines = feats[refName]
+    if (!lines) {
+      return undefined
+    }
+    const data = gtf.parseStringSync(lines.join('\n'), {
+      parseFeatures: true,
+      parseComments: false,
+      parseDirectives: false,
+      parseSequences: false,
+    }) as FeatureLoc[][]
+
+    const intervalTree = new IntervalTree()
+    const ret = data.flat().map(
+      (f, i) =>
+        new SimpleFeature({
+          data: featureData(f),
+          id: `${this.id}-offset-${i}`,
+        }),
+    )
+
+    for (let i = 0; i < ret.length; i++) {
+      const obj = ret[i]
+      intervalTree.insert([obj.get('start'), obj.get('end')], obj)
+    }
+    return intervalTree
+  }
+
+  private async loadFeatureIntervalTree(refName: string) {
+    if (!this.intervalTrees[refName]) {
+      this.intervalTrees[refName] = this.loadFeatureIntervalTreeHelper(
+        refName,
+      ).catch(e => {
+        this.intervalTrees[refName] = undefined
+        throw e
+      })
+    }
+    return this.intervalTrees[refName]
   }
 
   public getFeatures(query: NoAssemblyRegion, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       try {
         const { start, end, refName } = query
-        const { intervalTree } = await this.loadData()
-        intervalTree[refName]
-          ?.search([start, end])
-          .forEach(f => observer.next(f))
+        const intervalTree = await this.loadFeatureIntervalTree(refName)
+        intervalTree?.search([start, end]).forEach(f => observer.next(f))
         observer.complete()
       } catch (e) {
         observer.error(e)


### PR DESCRIPTION
Possible fix for https://github.com/GMOD/jbrowse-components/issues/2681

loading a random location on chr1 for a 19MB gtf.gz file from UCSC

This branch, ~10s
Main branch, ~48s


approx tracing differences

this branch
![Screenshot from 2022-04-18 18-18-39](https://user-images.githubusercontent.com/6511937/163896508-75a9d8d0-d734-440d-b754-b7f673f1b4e9.png)

main branch
![Screenshot from 2022-04-18 18-17-28](https://user-images.githubusercontent.com/6511937/163896524-5c7e213b-7837-468d-b44a-e320132fef14.png)
