### PR TITLE
Add tsc types compilation/project references to text-indexing commands

### DIFF
--- a/packages/text-indexing/package.json
+++ b/packages/text-indexing/package.json
@@ -26,12 +26,11 @@
     "src"
   ],
   "scripts": {
+    "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest packages/text-indexing",
-    "coverage": "yarn test --coverage",
-    "lint": "tsc --noEmit && eslint --ext .js,.ts,.jsx,.tsx .",
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
-    "build": "NODE_ENV=production babel src/ --out-dir dist/ --root-mode upward ---extensions '.ts,.js,.tsx,.jsx'",
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",

--- a/packages/text-indexing/tsconfig.build.json
+++ b/packages/text-indexing/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../core/tsconfig.build.json" }]
+}

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
     "postbuild": "tsc --build tsconfig.build.json",
-    "test": "cd ../..; jest plugins/text-indexing",
+    "test": "cd ../..; jest plugins/jobs-management",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@material-ui/icons": "^4.9.1",
-    "@jbrowse/text-indexing": "^1.6.9"
+    "@jbrowse/text-indexing": "^1.7.4"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -24,12 +24,18 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions .ts,.js,.tsx,.jsx",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/text-indexing",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
     "useSrc": "node ../../scripts/useSrc.js"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@material-ui/icons": "^4.9.1",
+    "@jbrowse/text-indexing": "^1.6.9"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",
@@ -39,10 +45,6 @@
     "mobx-state-tree": "3.14.1",
     "prop-types": "^15.0.0",
     "react": ">=16.8.0"
-  },
-  "dependencies": {
-    "@material-ui/icons": "^4.9.1",
-    "@jbrowse/text-indexing": "^1.6.9"
   },
   "private": true
 }

--- a/plugins/jobs-management/tsconfig.build.json
+++ b/plugins/jobs-management/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [{ "path": "../../packages/core/tsconfig.build.json" }]
+}

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -46,6 +46,5 @@
     "prop-types": "^15.0.0",
     "react": ">=16.8.0"
   },
-  
   "private": true
 }

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -24,12 +24,18 @@
   ],
   "scripts": {
     "build": "babel src --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx'",
+    "postbuild": "tsc --build tsconfig.build.json",
     "test": "cd ../..; jest plugins/text-indexing",
     "prepublishOnly": "yarn test",
     "prepack": "yarn build; yarn useDist",
     "postpack": "yarn useSrc",
     "useDist": "node ../../scripts/useDist.js",
     "useSrc": "node ../../scripts/useSrc.js"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.17.9",
+    "@jbrowse/text-indexing": "^1.6.9",
+    "@material-ui/icons": "^4.9.1"
   },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.0",
@@ -40,9 +46,6 @@
     "prop-types": "^15.0.0",
     "react": ">=16.8.0"
   },
-  "dependencies": {
-    "@jbrowse/text-indexing": "^1.6.9",
-    "@material-ui/icons": "^4.9.1"
-  },
+  
   "private": true
 }

--- a/plugins/text-indexing/tsconfig.build.json
+++ b/plugins/text-indexing/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel. This file is based on examples from the MUI github repo
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["./src/**/*.ts*", "./src/**/*.js*"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.test.js*"],
+  "references": [
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../../packages/text-indexing/tsconfig.build.json" }
+  ]
+}


### PR DESCRIPTION
The release of webpack 5 uses typescript project references in a file called tsconfig.build.json to correctly generate types

This PR propagates those changes to the newly landed text-indexing/jobs related packages (this change will be most useful if and when the packages are published to npm, so that they include .d.ts files)