### PR TITLE
Use the name "Read Sequence" for the read vs ref view

### DIFF
--- a/plugins/linear-comparative-view/src/ReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/ReadVsRef.tsx
@@ -341,6 +341,7 @@ export function WindowSizeDlg(props: {
         name: `${readAssembly}`,
         sequence: {
           type: 'ReferenceSequenceTrack',
+          name: `Read sequence`,
           trackId: seqTrackId,
           assemblyNames: [readAssembly],
           adapter: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -89,12 +89,12 @@ const TrackLabel = React.forwardRef(
 
     let trackName = getConf(track, 'name')
     if (getConf(track, 'type') === 'ReferenceSequenceTrack') {
-      trackName = 'Reference Sequence'
-      session.assemblies.forEach(assembly => {
-        if (assembly.sequence === trackConf) {
-          trackName = `Reference Sequence (${readConfObject(assembly, 'name')})`
-        }
-      })
+      const r = session.assemblies.find(a => a.sequence === trackConf)
+      trackName =
+        readConfObject(trackConf, 'name') ||
+        (r
+          ? `Reference Sequence (${readConfObject(r, 'name')})`
+          : 'Reference Sequence')
     }
 
     function handleMenuItemClick(_: unknown, callback: Function) {

--- a/plugins/sequence/src/referenceSeqTrackConfig.ts
+++ b/plugins/sequence/src/referenceSeqTrackConfig.ts
@@ -14,6 +14,11 @@ export function createReferenceSeqTrackConfig(pluginManager: PluginManager) {
     {
       adapter: pluginManager.pluggableConfigSchemaType('adapter'),
       displays: types.array(pluginManager.pluggableConfigSchemaType('display')),
+      name: {
+        type: 'string',
+        description: 'optional track name',
+        defaultValue: '',
+      },
       metadata: {
         type: 'frozen',
         description: 'anything to add about this track',


### PR DESCRIPTION
Adds a config slot called "name" to the Reference sequence track config, which is optional, and is otherwise filled in by "Reference Sequence (assembly name)" like it is currently on master