### PR TITLE
Disable cache for webpack builds

### DIFF
--- a/products/jbrowse-web/craco.config.js
+++ b/products/jbrowse-web/craco.config.js
@@ -43,6 +43,8 @@ module.exports = {
       // worker chunks xref
       // https://github.com/webpack/webpack/issues/13791#issuecomment-897579223
       config.output.publicPath = 'auto'
+
+      config.cache = false
       return config
     },
   },


### PR DESCRIPTION
This helps fix a fairly confusing situation with webpack where the cache was not allowing changes to node_modules to get picked up, including `yarn link`, manually copying files into node_modules folder, etc. it was very difficult to get the cache to pick up changes for under development external modules like yarn link @gmod/trix, etc.

Possibly we could look into this more and find a way to keep the cache but disabling it helped me to develop modules that rely on changing node_modules