### PR TITLE
Add v1.7.5 release announcement

### DIFF
--- a/website/release_announcement_drafts/v1.7.5.md
+++ b/website/release_announcement_drafts/v1.7.5.md
@@ -1,0 +1,10 @@
+We are pleased to present the release of v1.7.5
+
+This release includes two major improvements
+
+- Ability to index tracks for searching by gene names in JBrowse Desktop
+- Removed serialization of BAM/CRAM features for pileup tracks which brings
+  large performance benefits for jbrowse-web and jbrowse-desktop
+
+It also fixes a bug with using trix indexes created by `jbrowse text-index` in
+v1.7.0-v1.7.4 (with the adjustable prefix size)


### PR DESCRIPTION
```
## Unreleased (2022-04-25)

#### :rocket: Enhancement
* `core`
  * [#2885](https://github.com/GMOD/jbrowse-components/pull/2885) Reduce serialization overhead on alignments tracks and access feature details asynchronously ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2935](https://github.com/GMOD/jbrowse-components/pull/2935) Use the name "Read Sequence" for the read vs ref view ([@cmdcolin](https://github.com/cmdcolin))
  * [#2916](https://github.com/GMOD/jbrowse-components/pull/2916) Add vite setup to our embedded component demos ([@cmdcolin](https://github.com/cmdcolin))
  * [#2927](https://github.com/GMOD/jbrowse-components/pull/2927) Optimize gtf by only parsing lazily per-refName ([@cmdcolin](https://github.com/cmdcolin))
  * [#2928](https://github.com/GMOD/jbrowse-components/pull/2928) Add vanillajs/script tag loading embedded components demos ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `text-indexing`
  * [#2684](https://github.com/GMOD/jbrowse-components/pull/2684) Text-indexing in desktop ([@teresam856](https://github.com/teresam856))

#### :bug: Bug Fix
* [#2863](https://github.com/GMOD/jbrowse-components/pull/2863) Render gene with CDS subfeatures properly ([@cmdcolin](https://github.com/cmdcolin))
* [#2934](https://github.com/GMOD/jbrowse-components/pull/2934) Bump @gmod/trix to fix prefix size calculation and searching first word in index ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
- Teresa Martinez ([@teresam856](https://github.com/teresam856))
Done in 1.61s.

```