### PR TITLE
Fix loading CRAM, TwoBit, and other modules that use @gmod/binary-parser on jbrowse desktop

### DIFF
--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -15,6 +15,13 @@ module.exports = {
       new NodePolyfillPlugin({
         excludeAliases: ['console'],
       }),
+
+      // this is needed to properly polyfill buffer in desktop, after the CRA5
+      // conversion it was observed cram, twobit, etc that use
+      // @gmod/binary-parser complained of buffers not being real buffers
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+      }),
       new webpack.ContextReplacementPlugin(/any-promise/),
       new webpack.DefinePlugin({
         // Global mobx-state-tree configuration.
@@ -36,9 +43,10 @@ module.exports = {
         match.loader.include = include.concat(getYarnWorkspaces())
       }
 
-      // similar to our webpack 4 rescript, helps load 'fs' module for local
-      // file access and avoid browser:{} field from package.json being used
-      // (which sometimes kicks out fs access e.g. in generic-filehandle)
+      // similar to our webpack 4 rescript, setting target to
+      // 'electron-renderer' helps load 'fs' module for local file access and
+      // avoid browser:{} field from package.json being used (which sometimes
+      // kicks out fs access e.g. in generic-filehandle)
       config.target = 'electron-renderer'
       config.resolve.aliasFields = []
       config.resolve.mainFields = ['module', 'main']
@@ -46,6 +54,7 @@ module.exports = {
       // worker chunks xref
       // https://github.com/webpack/webpack/issues/13791#issuecomment-897579223
       config.output.publicPath = 'auto'
+      config.cache = false
       return config
     },
   },


### PR DESCRIPTION
Without this change to craco.config.js, on jbrowse-desktop, we get an error with usage of anything that uses CRAM, TwoBit, etc (which have a particularly strict Buffer.isBuffer from @gmod/binary-parser)


https://stackoverflow.com/questions/68707553/uncaught-referenceerror-buffer-is-not-defined

The error is "argument buffer is not a Buffer object"

![Screenshot from 2022-04-25 19-26-25](https://user-images.githubusercontent.com/6511937/165200599-07949597-3788-4e02-a3e3-ea5be44a1cf8.png)
