### PR TITLE
Optimization for SNPCoverageAdapter and CRAM parsing

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -494,6 +494,10 @@ export function clamp(num: number, min: number, max: number): number {
   return num
 }
 
+function roundToNearestPointOne(num: number): number {
+  return Math.round(num * 10) / 10
+}
+
 /**
  * @param bp -
  * @param region -
@@ -508,7 +512,7 @@ export function bpToPx(
   }: { start?: number; end?: number; reversed?: boolean },
   bpPerPx: number,
 ) {
-  return (reversed ? end - bp : bp - start) / bpPerPx
+  return roundToNearestPointOne((reversed ? end - bp : bp - start) / bpPerPx)
 }
 
 const oneEightyOverPi = 180.0 / Math.PI

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -494,10 +494,6 @@ export function clamp(num: number, min: number, max: number): number {
   return num
 }
 
-function roundToNearestPointOne(num: number): number {
-  return Math.round(num * 10) / 10
-}
-
 /**
  * @param bp -
  * @param region -
@@ -512,7 +508,7 @@ export function bpToPx(
   }: { start?: number; end?: number; reversed?: boolean },
   bpPerPx: number,
 ) {
-  return roundToNearestPointOne((reversed ? end - bp : bp - start) / bpPerPx)
+  return (reversed ? end - bp : bp - start) / bpPerPx
 }
 
 const oneEightyOverPi = 180.0 / Math.PI

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@gmod/bam": "^1.1.15",
-    "@gmod/cram": "^1.6.1",
+    "@gmod/cram": "^1.6.3",
     "@material-ui/icons": "^4.9.1",
     "color": "^3.1.2",
     "copy-to-clipboard": "^3.3.1",

--- a/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
@@ -131,7 +131,8 @@ export default class CramSlightlyLazyFeature implements Feature {
     let sublen = 0
     if (typeof this.record.readFeatures !== 'undefined') {
       // @ts-ignore
-      this.record.readFeatures.forEach(({ code, refPos, sub, data }) => {
+      for (let i = 0; i < this.record.readFeatures.length; i++) {
+        const { code, refPos, sub, data } = this.record.readFeatures[i]
         sublen = refPos - last_pos
         seq += ref.substring(last_pos - refStart, refPos - refStart)
         last_pos = refPos
@@ -200,7 +201,7 @@ export default class CramSlightlyLazyFeature implements Feature {
           cigar += `${data}H`
           oplen = 0
         } // else q or Q
-      })
+      }
     } else {
       sublen = this.record.readLength - seq.length
     }
@@ -303,95 +304,87 @@ export default class CramSlightlyLazyFeature implements Feature {
       return []
     }
     const start = this.get('start')
-    const mismatches: Mismatch[] = []
-    readFeatures.forEach(
-      (args: {
-        code: string
-        refPos: number
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        data: any
-        pos: number
-        sub: string
-        ref: string
-      }) => {
-        const { code, pos, data, sub, ref } = args
-        const refPos = args.refPos - 1 - start
-        if (code === 'X') {
-          // substitution
-          mismatches.push({
-            start: refPos,
-            length: 1,
-            base: sub,
-            qual: qual?.[pos],
-            altbase: ref,
-            type: 'mismatch',
-          })
-        } else if (code === 'I') {
-          // insertion
-          mismatches.push({
-            start: refPos,
-            type: 'insertion',
-            base: `${data.length}`,
-            length: 0,
-          })
-        } else if (code === 'N') {
-          // reference skip
-          mismatches.push({
-            type: 'skip',
-            length: data,
-            start: refPos,
-            base: 'N',
-          })
-        } else if (code === 'S') {
-          // soft clip
-          const len = data.length
-          mismatches.push({
-            start: refPos,
-            type: 'softclip',
-            base: `S${len}`,
-            cliplen: len,
-            length: 1,
-          })
-        } else if (code === 'P') {
-          // padding
-        } else if (code === 'H') {
-          // hard clip
-          const len = data
-          mismatches.push({
-            start: refPos,
-            type: 'hardclip',
-            base: `H${len}`,
-            cliplen: len,
-            length: 1,
-          })
-        } else if (code === 'D') {
-          // deletion
-          mismatches.push({
-            type: 'deletion',
-            length: data,
-            start: refPos,
-            base: '*',
-          })
-        } else if (code === 'b') {
-          // stretch of bases
-        } else if (code === 'q') {
-          // stretch of qual scores
-        } else if (code === 'B') {
-          // a pair of [base, qual]
-        } else if (code === 'i') {
-          // single-base insertion
-          // insertion
-          mismatches.push({
-            start: refPos,
-            type: 'insertion',
-            base: data,
-            length: 1,
-          })
-        } else if (code === 'Q') {
-          // single quality value
+    const mismatches: Mismatch[] = new Array(readFeatures.length)
+    let j = 0
+    for (let i = 0; i < readFeatures.length; i++) {
+      const f = readFeatures[i]
+      const { code, pos, data, sub, ref } = f
+      const refPos = f.refPos - 1 - start
+      if (code === 'X') {
+        // substitution
+        mismatches[j++] = {
+          start: refPos,
+          length: 1,
+          base: sub,
+          qual: qual?.[pos],
+          altbase: ref,
+          type: 'mismatch',
         }
-      },
-    )
+      } else if (code === 'I') {
+        // insertion
+        mismatches[j++] = {
+          start: refPos,
+          type: 'insertion',
+          base: `${data.length}`,
+          length: 0,
+        }
+      } else if (code === 'N') {
+        // reference skip
+        mismatches[j++] = {
+          type: 'skip',
+          length: data,
+          start: refPos,
+          base: 'N',
+        }
+      } else if (code === 'S') {
+        // soft clip
+        const len = data.length
+        mismatches[j++] = {
+          start: refPos,
+          type: 'softclip',
+          base: `S${len}`,
+          cliplen: len,
+          length: 1,
+        }
+      } else if (code === 'P') {
+        // padding
+      } else if (code === 'H') {
+        // hard clip
+        const len = data
+        mismatches[j++] = {
+          start: refPos,
+          type: 'hardclip',
+          base: `H${len}`,
+          cliplen: len,
+          length: 1,
+        }
+      } else if (code === 'D') {
+        // deletion
+        mismatches[j++] = {
+          type: 'deletion',
+          length: data,
+          start: refPos,
+          base: '*',
+        }
+      } else if (code === 'b') {
+        // stretch of bases
+      } else if (code === 'q') {
+        // stretch of qual scores
+      } else if (code === 'B') {
+        // a pair of [base, qual]
+      } else if (code === 'i') {
+        // single-base insertion
+        // insertion
+        mismatches[j++] = {
+          start: refPos,
+          type: 'insertion',
+          base: data,
+          length: 1,
+        }
+      } else if (code === 'Q') {
+        // single quality value
+      }
+    }
     return mismatches
   }
 }

--- a/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
@@ -385,6 +385,6 @@ export default class CramSlightlyLazyFeature implements Feature {
         // single quality value
       }
     }
-    return mismatches
+    return mismatches.slice(0, j)
   }
 }

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -53,6 +53,10 @@ const TooltipContents = React.forwardRef(
             <tr>
               <td>Total</td>
               <td>{info.total}</td>
+            </tr>
+            <tr>
+              <td>REF</td>
+              <td>{info.ref}</td>
               <td>
                 {info['-1'] ? `${info['-1']}(-)` : ''}
                 {info['1'] ? `${info['1']}(+)` : ''}

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -7,7 +7,6 @@ import { Tooltip } from '@jbrowse/plugin-wiggle'
 type Count = {
   [key: string]: {
     total: number
-    strands: { [key: string]: number }
   }
 }
 
@@ -18,6 +17,9 @@ type SNPInfo = {
   noncov: Count
   delskips: Count
   total: number
+  '-1': number
+  '0': number
+  '1': number
 }
 
 const en = (n: number) => n.toLocaleString('en-US')
@@ -50,33 +52,34 @@ const TooltipContents = React.forwardRef(
           <tbody>
             <tr>
               <td>Total</td>
-              <td>{total}</td>
+              <td>{info.total}</td>
+              <td>
+                {info['-1'] ? `${info['-1']}(-)` : ''}
+                {info['1'] ? `${info['1']}(+)` : ''}
+              </td>
               <td />
             </tr>
 
-            {Object.entries(info).map(([key, entry]) => {
-              return Object.entries(entry).map(([base, score]) => {
-                const { strands } = score
-                return (
-                  <tr key={base}>
-                    <td>{base.toUpperCase()}</td>
-                    <td>{score.total}</td>
-                    <td>
-                      {base === 'total' || base === 'skip'
-                        ? '---'
-                        : `${Math.floor(
-                            (score.total / (total || score.total || 1)) * 100,
-                          )}%`}
-                    </td>
-                    <td>
-                      {strands['-1'] ? `${strands['-1']}(-)` : ''}
-                      {strands['1'] ? `${strands['1']}(+)` : ''}
-                    </td>
-                    <td>{key}</td>
-                  </tr>
-                )
-              })
-            })}
+            {Object.entries(info).map(([key, entry]) =>
+              Object.entries(entry).map(([base, score]) => (
+                <tr key={base}>
+                  <td>{base.toUpperCase()}</td>
+                  <td>{score.total}</td>
+                  <td>
+                    {base === 'total' || base === 'skip'
+                      ? '---'
+                      : `${Math.floor(
+                          (score.total / (total || score.total || 1)) * 100,
+                        )}%`}
+                  </td>
+                  <td>
+                    {score['-1'] ? `${score['-1']}(-)` : ''}
+                    {score['1'] ? `${score['1']}(+)` : ''}
+                  </td>
+                  <td>{key}</td>
+                </tr>
+              )),
+            )}
           </tbody>
         </table>
       </div>

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -872,17 +872,17 @@ export default class PileupRenderer extends BoxRendererType {
             ctx.fillStyle = 'purple'
             ctx.fillRect(leftPx - 1, topPx, 2, heightPx)
           } else if (heightPx > charHeight) {
-            const rect = measureText(txt)
+            const rwidth = measureText(txt)
             const padding = 5
             ctx.fillStyle = 'purple'
             ctx.fillRect(
-              leftPx - rect.width / 2 - padding,
+              leftPx - rwidth / 2 - padding,
               topPx,
-              rect.width + 2 * padding,
+              rwidth + 2 * padding,
               heightPx,
             )
             ctx.fillStyle = 'white'
-            ctx.fillText(txt, leftPx - rect.width / 2, topPx + heightPx)
+            ctx.fillText(txt, leftPx - rwidth / 2, topPx + heightPx)
           } else {
             const padding = 2
             ctx.fillStyle = 'purple'

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -754,17 +754,6 @@ export default class PileupRenderer extends BoxRendererType {
     const mismatches: Mismatch[] = feature.get('mismatches')
     const heightLim = charHeight - 2
 
-    function getAlphaColor(baseColor: string, mismatch: { qual?: number }) {
-      let color = baseColor
-      if (mismatchAlpha && mismatch.qual !== undefined) {
-        color = Color(baseColor)
-          .alpha(Math.min(1, mismatch.qual / 50))
-          .hsl()
-          .string()
-      }
-      return color
-    }
-
     // extraHorizontallyFlippedOffset is used to draw interbase items, which
     // are located to the left when forward and right when reversed
     const extraHorizontallyFlippedOffset = region.reversed
@@ -783,14 +772,28 @@ export default class PileupRenderer extends BoxRendererType {
       if (mismatch.type === 'mismatch' && drawSNPs) {
         const baseColor = colorForBase[mismatch.base] || '#888'
 
-        ctx.fillStyle = getAlphaColor(baseColor, mismatch)
+        ctx.fillStyle = !mismatchAlpha
+          ? baseColor
+          : mismatch.qual !== undefined
+          ? Color(baseColor)
+              .alpha(Math.min(1, mismatch.qual / 50))
+              .hsl()
+              .string()
+          : baseColor
 
         ctx.fillRect(leftPx, topPx, widthPx, heightPx)
 
         if (widthPx >= charWidth && heightPx >= heightLim) {
           // normal SNP coloring
-          const contrast = contrastForBase[mismatch.base] || 'black'
-          ctx.fillStyle = getAlphaColor(contrast, mismatch)
+          const contrastColor = contrastForBase[mismatch.base] || 'black'
+          ctx.fillStyle = !mismatchAlpha
+            ? contrastColor
+            : mismatch.qual !== undefined
+            ? Color(contrastColor)
+                .alpha(Math.min(1, mismatch.qual / 50))
+                .hsl()
+                .string()
+            : contrastColor
           ctx.fillText(
             mbase,
             leftPx + (widthPx - charWidth) / 2 + 1,
@@ -869,7 +872,7 @@ export default class PileupRenderer extends BoxRendererType {
             ctx.fillStyle = 'purple'
             ctx.fillRect(leftPx - 1, topPx, 2, heightPx)
           } else if (heightPx > charHeight) {
-            const rect = ctx.measureText(txt)
+            const rect = measureText(txt)
             const padding = 5
             ctx.fillStyle = 'purple'
             ctx.fillRect(
@@ -961,7 +964,7 @@ export default class PileupRenderer extends BoxRendererType {
     }
   }
 
-  async makeImageData(
+  makeImageData(
     ctx: CanvasRenderingContext2D,
     layoutRecords: (LayoutFeature | null)[],
     props: RenderArgsDeserializedWithFeaturesAndLayout,
@@ -984,9 +987,11 @@ export default class PileupRenderer extends BoxRendererType {
     ctx.font = 'bold 10px Courier New,monospace'
 
     const { charWidth, charHeight } = this.getCharWidthHeight(ctx)
-    layoutRecords.forEach(feat => {
+    const drawMismatches = shouldDrawMismatches(colorBy?.type)
+    for (let i = 0; i < layoutRecords.length; i++) {
+      const feat = layoutRecords[i]
       if (feat === null) {
-        return
+        continue
       }
 
       this.drawAlignmentRect(ctx, feat, {
@@ -999,8 +1004,8 @@ export default class PileupRenderer extends BoxRendererType {
       })
       this.drawMismatches(ctx, feat, props, {
         mismatchAlpha,
-        drawSNPs: shouldDrawMismatches(colorBy?.type),
-        drawIndels: shouldDrawMismatches(colorBy?.type),
+        drawSNPs: drawMismatches,
+        drawIndels: drawMismatches,
         largeInsertionIndicatorScale: insertScale,
         minSubfeatureWidth,
         charWidth,
@@ -1008,10 +1013,16 @@ export default class PileupRenderer extends BoxRendererType {
         colorForBase,
         contrastForBase,
       })
-      if (showSoftClip) {
+    }
+    if (showSoftClip) {
+      for (let i = 0; i < layoutRecords.length; i++) {
+        const feat = layoutRecords[i]
+        if (feat === null) {
+          continue
+        }
         this.drawSoftClipping(ctx, feat, props, config, theme)
       }
-    })
+    }
   }
 
   // we perform a full layout before render as a separate method because the
@@ -1041,7 +1052,7 @@ export default class PileupRenderer extends BoxRendererType {
 
     const heightPx = readConfObject(config, 'height')
     const displayMode = readConfObject(config, 'displayMode')
-    const layoutRecords = iterMap(
+    return iterMap(
       featureMap.values(),
       feature =>
         this.layoutFeature({
@@ -1055,7 +1066,6 @@ export default class PileupRenderer extends BoxRendererType {
         }),
       featureMap.size,
     )
-    return layoutRecords
   }
 
   async fetchSequence(renderProps: RenderArgsDeserialized) {

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -45,7 +45,7 @@ function inc(bin: any, strand: number, type: string, field: string) {
 function dec(bin: any, strand: number, type: string, field: string) {
   let thisBin = bin[type][field]
   if (thisBin === undefined) {
-    thisBin = { total: 0, strands: { '-1': 0, '0': 0, '1': 0 } }
+    thisBin = bin[type][field] = { total: 0, '-1': 0, '0': 0, '1': 0 }
   }
   thisBin.total--
   thisBin[strand]--
@@ -176,6 +176,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
 
     const bins = [] as {
       total: number
+      ref: number
       '-1': 0
       '0': 0
       '1': 0
@@ -199,6 +200,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
           if (bins[i] === undefined) {
             bins[i] = {
               total: 0,
+              ref: 0,
               '-1': 0,
               '0': 0,
               '1': 0,
@@ -206,11 +208,11 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
               cov: {} as BinType,
               delskips: {} as BinType,
               noncov: {} as BinType,
-              ref: {} as BinType,
             }
           }
           if (j !== fend) {
             bins[i].total++
+            bins[i].ref++
             bins[i][fstrand]++
           }
         }
@@ -273,16 +275,16 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
               if (methBins[i] || methBins[i + 1]) {
                 inc(bin, fstrand, 'cov', 'meth')
                 inc(bin1, fstrand, 'cov', 'meth')
-                bins[i].total--
+                bins[i].ref--
                 bins[i][fstrand]--
-                bins[i + 1].total--
+                bins[i + 1].ref--
                 bins[i + 1][fstrand]--
               } else {
                 inc(bin, fstrand, 'cov', 'unmeth')
                 inc(bin1, fstrand, 'cov', 'unmeth')
-                bins[i].total--
+                bins[i].ref--
                 bins[i][fstrand]--
-                bins[i + 1].total--
+                bins[i + 1].ref--
                 bins[i + 1][fstrand]--
               }
             }
@@ -305,8 +307,8 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
                 const { base, type } = mismatch
                 const interbase = isInterbase(type)
                 if (!interbase) {
-                  bins[i + 1].total--
-                  bins[i + 1][fstrand]--
+                  bin.ref--
+                  bin[fstrand]--
                 } else {
                   inc(bin, fstrand, 'noncov', type)
                 }

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -44,7 +44,7 @@ function inc(bin: any, strand: number, type: string, field: string) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function dec(bin: any, strand: number, type: string, field: string) {
   let thisBin = bin[type][field]
-  if (thisBin == undefined) {
+  if (thisBin === undefined) {
     thisBin = { total: 0, strands: { '-1': 0, '0': 0, '1': 0 } }
   }
   thisBin.total--
@@ -273,13 +273,17 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
               if (methBins[i] || methBins[i + 1]) {
                 inc(bin, fstrand, 'cov', 'meth')
                 inc(bin1, fstrand, 'cov', 'meth')
-                // decRef(bin, fstrand)
-                // decRef(bin1, fstrand)
+                bins[i].total--
+                bins[i][fstrand]--
+                bins[i + 1].total--
+                bins[i + 1][fstrand]--
               } else {
                 inc(bin, fstrand, 'cov', 'unmeth')
                 inc(bin1, fstrand, 'cov', 'unmeth')
-                // decRef(bin, fstrand)
-                // decRef(bin1, fstrand)
+                bins[i].total--
+                bins[i][fstrand]--
+                bins[i + 1].total--
+                bins[i + 1][fstrand]--
               }
             }
           }
@@ -301,7 +305,8 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
                 const { base, type } = mismatch
                 const interbase = isInterbase(type)
                 if (!interbase) {
-                  // decRef(bin, fstrand)
+                  bins[i + 1].total--
+                  bins[i + 1][fstrand]--
                 } else {
                   inc(bin, fstrand, 'noncov', type)
                 }

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -165,35 +165,17 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
         ? await this.fetchSequence(region)
         : undefined
 
-    const rlen = region.end - region.start
-    // pre-allocate array if region not too large
-    const bins =
-      rlen < 50_000
-        ? Array.from({ length: rlen }, () => ({
-            total: 0,
-            ref: 0,
-            '-1': 0,
-            '0': 0,
-            '1': 0,
-            lowqual: {} as BinType,
-            cov: {} as BinType,
-            delskips: {} as BinType,
-            noncov: {} as BinType,
-          }))
-        : ([] as {
-            total: number
-            ref: number
-            '-1': 0
-            '0': 0
-            '1': 0
-            lowqual: BinType
-            cov: BinType
-            delskips: BinType
-            noncov: BinType
-          }[])
-
-    let min = Infinity
-    let max = -Infinity
+    const bins = [] as {
+      total: number
+      ref: number
+      '-1': 0
+      '0': 0
+      '1': 0
+      lowqual: BinType
+      cov: BinType
+      delskips: BinType
+      noncov: BinType
+    }[]
 
     for (let i = 0; i < features.length; i++) {
       const feature = features[i]

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -41,15 +41,6 @@ function inc(bin: any, strand: number, type: string, field: string) {
   thisBin.total++
   thisBin[strand]++
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function dec(bin: any, strand: number, type: string, field: string) {
-  let thisBin = bin[type][field]
-  if (thisBin === undefined) {
-    thisBin = bin[type][field] = { total: 0, '-1': 0, '0': 0, '1': 0 }
-  }
-  thisBin.total--
-  thisBin[strand]--
-}
 
 export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
   protected async configure() {
@@ -184,7 +175,6 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
       cov: BinType
       delskips: BinType
       noncov: BinType
-      ref: BinType
     }[]
 
     for (let i = 0; i < features.length; i++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,10 +1504,10 @@
   dependencies:
     long "^4.0.0"
 
-"@gmod/cram@^1.6.1":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.6.2.tgz#58153b305398f98c813cd3826b9f58898b950d89"
-  integrity sha512-hlMrvuiyYJgpiQBB/BZBeqIHI38VTDHNKTT/UJPDJgWroYHG3q9RLy6RQfKvqde7flRL1lnlHPtOGoHqx4inPg==
+"@gmod/cram@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.6.3.tgz#250775a681904477cb06988a10ad0253d4dc69aa"
+  integrity sha512-fuKmrFbhpiQLkUnMj64kujKjF0ZC8ZF2EvL479ilwRq9vsMdlxpWdcC/pmEYdM+OgyHy8aZNBRmkt/rKrDJzrw==
   dependencies:
     "@gmod/binary-parser" "^1.3.5"
     "@jkbonfield/htscodecs" "^0.5.1"


### PR DESCRIPTION
This can save about ~1second in generateCoverageBins calls on a 20kb region

Allocates less nested objects


On 200x coverage shortreads from jb2profile

Time spent in generateCoverageBins specifically:

This branch 2.82s
Main branch 3.6s

Possibly we could also bin multiple bp into a single bin (jb1 does this) and or use skips_and_dels (another jb1-ism) to optimize further, but we would need to be careful about binning multiple bp into a single bin with snps/modifications as those should probably not be aggregated
