### PR TITLE
Allow getting clip indicator after feature end

### DIFF
--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -183,7 +183,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
       const fend = feature.get('end')
       const fstrand = feature.get('strand') as -1 | 0 | 1
 
-      for (let j = fstart; j < fend; j++) {
+      for (let j = fstart; j < fend + 1; j++) {
         const i = j - region.start
         if (i >= 0 && i < binMax) {
           if (bins[i] === undefined) {


### PR DESCRIPTION
Small detail, but we are able to capture a clip indicator when it goes "past the feature end" (the soft clips are technically not stored interbase, so to get them, we need to go past the feature end)

demo

main
https://jbrowse.org/code/jb2/main/?config=test_data%2Fvolvox%2Fconfig.json&session=share-fBa97hv8H8&password=YL7ng

this branch
https://jbrowse.org/code/jb2/clip_indicator_cliff/?config=test_data%2Fvolvox%2Fconfig.json&session=share-fBa97hv8H8&password=YL7ng
