### PR TITLE
Fix read vs ref on certain CRAM files

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@gmod/bam": "^1.1.15",
-    "@gmod/cram": "^1.6.3",
+    "@gmod/cram": "^1.6.4",
     "@material-ui/icons": "^4.9.1",
     "color": "^3.1.2",
     "copy-to-clipboard": "^3.3.1",

--- a/plugins/linear-comparative-view/src/ReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/ReadVsRef.tsx
@@ -196,7 +196,7 @@ export function WindowSizeDlg(props: {
           const { rpcManager } = getSession(track)
           const adapterConfig = getConf(track, 'adapter')
           const sessionId = getRpcSessionId(track)
-          const assemblyNames = getConf(track, 'assemblyNames')
+
           const feats = (await rpcManager.call(sessionId, 'CoreGetFeatures', {
             adapterConfig,
             sessionId,
@@ -204,8 +204,7 @@ export function WindowSizeDlg(props: {
               {
                 refName: saRef,
                 start: +saStart - 1,
-                end: +saStart,
-                assemblyName: assemblyNames[0],
+                end: +saStart + 1,
               },
             ],
           })) as Feature[]
@@ -496,13 +495,8 @@ export function WindowSizeDlg(props: {
   }
 
   return (
-    <Dialog
-      open
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">
+    <Dialog open onClose={handleClose}>
+      <DialogTitle>
         Set window size
         <IconButton
           aria-label="close"
@@ -513,7 +507,9 @@ export function WindowSizeDlg(props: {
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        {!primaryFeature ? (
+        {error ? (
+          <Typography color="error">{`${error}`}</Typography>
+        ) : !primaryFeature ? (
           <div>
             <Typography>
               To accurately perform comparison we are fetching the primary
@@ -527,7 +523,6 @@ export function WindowSizeDlg(props: {
               Show an extra window size around each part of the split alignment.
               Using a larger value can allow you to see more genomic context.
             </Typography>
-            {error ? <Typography color="error">{`${error}`}</Typography> : null}
 
             <TextField
               value={windowSize}

--- a/plugins/linear-comparative-view/src/ReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/ReadVsRef.tsx
@@ -204,10 +204,11 @@ export function WindowSizeDlg(props: {
               {
                 refName: saRef,
                 start: +saStart - 1,
-                end: +saStart + 1,
+                end: +saStart,
               },
             ],
           })) as Feature[]
+
           const result = feats.find(
             f =>
               f.get('name') === preFeature.get('name') &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,10 +1419,10 @@
   dependencies:
     long "^4.0.0"
 
-"@gmod/cram@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.6.3.tgz#250775a681904477cb06988a10ad0253d4dc69aa"
-  integrity sha512-fuKmrFbhpiQLkUnMj64kujKjF0ZC8ZF2EvL479ilwRq9vsMdlxpWdcC/pmEYdM+OgyHy8aZNBRmkt/rKrDJzrw==
+"@gmod/cram@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-1.6.4.tgz#4c585238ba201381f2e794785f6497b0b2c3bd1a"
+  integrity sha512-uj3BOukiQmL9JwJFMN7qqkvhfWMVVYhymrUA6+z6YMg3u107azw9Oxip6UEUHlVtrJhh2jyLDYgpewFLghJZew==
   dependencies:
     "@gmod/binary-parser" "^1.3.5"
     "@jkbonfield/htscodecs" "^0.5.1"


### PR DESCRIPTION
Currently, there is a routine to get the primary read if you start with a supplementary read for linear ReadVsRef visualization. It requests reads overlapping a single base pair where the start of the primary read is. One issue though is there is likely an off-by-one error in specifically CRAM feature fetching where if I request reads overlapping ctgA:0-1, it does not return anything. Making it request ctgA:0-2 is a workaround, but fixing the off by one would be worthwhile

Also, fixes error handling on the read vs ref dialog (previously, the error wasn't displayed)

