### PR TITLE
Avoid performing a text index search if input looks like a locstring

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -93,6 +93,10 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const [ref, rest] = location.split(':')
     const allRefs = assembly?.allRefNames || []
     try {
+      // instead of querying text-index, first:
+      // - check if input matches a refname directly
+      // - or looks like locstring
+      // then just navigate as if it were a locstring
       if (
         allRefs.includes(location) ||
         (allRefs.includes(ref) &&

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -93,17 +93,14 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     const ref = location.split(':')[0]
     const allRefs = assembly?.allRefNames || []
     try {
-      if (
-        allRefs.includes(location) ||
-        (location.includes(':') && allRefs.find(f => ref.startsWith(f)))
-      ) {
+      if (allRefs.includes(location) || allRefs.includes(ref)) {
         model.navToLocString(location, selectedAsm)
       } else {
-        const results = await fetchResults(input, 'exact')
-        if (results && results.length > 1) {
+        const results = (await fetchResults(input, 'exact')) || []
+        if (results.length > 1) {
           model.setSearchResults(results, input.toLowerCase())
           return
-        } else if (results?.length === 1) {
+        } else if (results.length === 1) {
           location = results[0].getLocation()
           trackId = results[0].getTrackId()
         }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -90,8 +90,13 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     }
     let trackId = option.getTrackId()
     let location = input || option.getLocation() || ''
+    const ref = location.split(':')[0]
+    const allRefs = assembly?.allRefNames || []
     try {
-      if (assembly?.allRefNames?.includes(location)) {
+      if (
+        allRefs.includes(location) ||
+        (location.includes(':') && allRefs.find(f => ref.startsWith(f)))
+      ) {
         model.navToLocString(location, selectedAsm)
       } else {
         const results = await fetchResults(input, 'exact')

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -90,13 +90,18 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     }
     let trackId = option.getTrackId()
     let location = input || option.getLocation() || ''
-    const ref = location.split(':')[0]
+    const [ref, rest] = location.split(':')
     const allRefs = assembly?.allRefNames || []
     try {
-      if (allRefs.includes(location) || allRefs.includes(ref)) {
+      if (
+        allRefs.includes(location) ||
+        (allRefs.includes(ref) &&
+          rest !== undefined &&
+          !Number.isNaN(parseInt(rest, 10)))
+      ) {
         model.navToLocString(location, selectedAsm)
       } else {
-        const results = (await fetchResults(input, 'exact')) || []
+        const results = await fetchResults(input, 'exact')
         if (results.length > 1) {
           model.setSearchResults(results, input.toLowerCase())
           return

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -62,8 +62,13 @@ function SearchBox({
     let trackId = option.getTrackId()
     let location = option.getLocation()
     const label = option.getLabel()
+    const ref = location.split(':')[0]
+    const allRefs = assembly?.allRefNames || []
     try {
-      if (assembly?.allRefNames?.includes(location)) {
+      if (
+        assembly?.allRefNames?.includes(location) ||
+        (location.includes(':') && allRefs.find(f => ref.startsWith(f)))
+      ) {
         model.navToLocString(location)
       } else {
         const results = await fetchResults(label, 'exact')

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -65,17 +65,14 @@ function SearchBox({
     const ref = location.split(':')[0]
     const allRefs = assembly?.allRefNames || []
     try {
-      if (
-        assembly?.allRefNames?.includes(location) ||
-        (location.includes(':') && allRefs.find(f => ref.startsWith(f)))
-      ) {
+      if (allRefs.includes(location) || allRefs.includes(ref)) {
         model.navToLocString(location)
       } else {
-        const results = await fetchResults(label, 'exact')
-        if (results && results.length > 1) {
+        const results = (await fetchResults(label, 'exact')) || []
+        if (results.length > 1) {
           model.setSearchResults(results, label.toLowerCase())
           return
-        } else if (results?.length === 1) {
+        } else if (results.length === 1) {
           location = results[0].getLocation()
           trackId = results[0].getTrackId()
         }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -62,13 +62,18 @@ function SearchBox({
     let trackId = option.getTrackId()
     let location = option.getLocation()
     const label = option.getLabel()
-    const ref = location.split(':')[0]
+    const [ref, rest] = location.split(':')
     const allRefs = assembly?.allRefNames || []
     try {
-      if (allRefs.includes(location) || allRefs.includes(ref)) {
+      if (
+        allRefs.includes(location) ||
+        (allRefs.includes(ref) &&
+          rest !== undefined &&
+          !Number.isNaN(parseInt(rest, 10)))
+      ) {
         model.navToLocString(location)
       } else {
-        const results = (await fetchResults(label, 'exact')) || []
+        const results = await fetchResults(label, 'exact')
         if (results.length > 1) {
           model.setSearchResults(results, label.toLowerCase())
           return

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -58,6 +58,11 @@ function SearchBox({
     )
   }
 
+  // gets a string as input, or use stored option results from previous query,
+  // then re-query and
+  // 1) if it has multiple results: pop a dialog
+  // 2) if it's a single result navigate to it
+  // 3) else assume it's a locstring and navigate to it
   async function handleSelectedRegion(option: BaseResult) {
     let trackId = option.getTrackId()
     let location = option.getLocation()
@@ -65,13 +70,17 @@ function SearchBox({
     const [ref, rest] = location.split(':')
     const allRefs = assembly?.allRefNames || []
     try {
+      // instead of querying text-index, first:
+      // - check if input matches a refName directly
+      // - or looks like locString
+      // then just navigate as if it were a locString
       if (
         allRefs.includes(location) ||
         (allRefs.includes(ref) &&
           rest !== undefined &&
           !Number.isNaN(parseInt(rest, 10)))
       ) {
-        model.navToLocString(location)
+        model.navToLocString(location, assemblyName)
       } else {
         const results = await fetchResults(label, 'exact')
         if (results.length > 1) {


### PR DESCRIPTION
Possible shortcut for refnameautocomplete

If the user input looks like a locstring then we can shortcircuit and not perform a text search

This shortcut already exists for a locstring that matches exactly a chromosome name in the assembly's refname list (or alias)

So, this just expands the shortcut to detect if it matches the a locstring with a colon, splitting on the colon and assuming the start of that is a locstring

That wouldn't perfectly apply for assembly based locstrings but the majority use case would be non-assembly-including locstrings probably