### PR TITLE
Fix crash displaying modifications called on softclipped regions of reads

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
@@ -233,17 +233,17 @@ test('clipping', () => {
   ])
 })
 
-test('getNextRefPos basic', () => {
+test('getNextRefPos test 1', () => {
   const cigar = parseCigar('10S10M1I4M1D15M')
+  console.log({ cigar })
   const iter = getNextRefPos(cigar, [5, 10, 15, 20, 25, 30, 35])
-  const [...vals] = iter
-  expect(vals).toEqual([-5, 0, 5, 10, 14, 20, 25])
+  expect([...iter]).toEqual([0, 5, 15, 20, 25])
 })
-test('getNextRefPos with many indels', () => {
-  const cigar = parseCigar('10S4M1D1IM10')
+test('getNextRefPos test 2', () => {
+  const cigar = parseCigar('10S15M')
+  console.log({ cigar })
   const iter = getNextRefPos(cigar, [5, 10, 15])
-  const [...vals] = iter
-  expect(vals).toEqual([-5, 0, 5])
+  expect([...iter]).toEqual([0, 5])
 })
 
 test('getModificationPositions', () => {

--- a/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.test.ts
@@ -235,13 +235,11 @@ test('clipping', () => {
 
 test('getNextRefPos test 1', () => {
   const cigar = parseCigar('10S10M1I4M1D15M')
-  console.log({ cigar })
   const iter = getNextRefPos(cigar, [5, 10, 15, 20, 25, 30, 35])
   expect([...iter]).toEqual([0, 5, 15, 20, 25])
 })
 test('getNextRefPos test 2', () => {
   const cigar = parseCigar('10S15M')
-  console.log({ cigar })
   const iter = getNextRefPos(cigar, [5, 10, 15])
   expect([...iter]).toEqual([0, 5])
 })

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -296,7 +296,7 @@ export function getModificationPositions(
     for (let j = 0; j < types.length; j++) {
       const type = types[j]
       let i = 0
-      let positions = []
+      const positions = []
       for (let k = 0; k < skips.length; k++) {
         let delta = +skips[k]
         do {
@@ -305,7 +305,7 @@ export function getModificationPositions(
           }
           i++
         } while (delta >= 0 && i < seq.length)
-        if (i >= seq.length) console.log('ran out of sequence')
+
         const temp = i - 1
         positions.push(fstrand === -1 ? seq.length - 1 - temp : temp)
       }

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -400,7 +400,7 @@ export default class PileupRenderer extends BoxRendererType {
     props: RenderArgsDeserializedWithFeaturesAndLayout,
   ) {
     const { feature, topPx, heightPx } = layoutFeature
-    const { regionSequence, modificationTagMap = {} } = props
+    const { modificationTagMap = {} } = props
 
     const mm = (getTagAlt(feature, 'MM', 'Mm') as string) || ''
 

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -400,7 +400,8 @@ export default class PileupRenderer extends BoxRendererType {
     props: RenderArgsDeserializedWithFeaturesAndLayout,
   ) {
     const { feature, topPx, heightPx } = layoutFeature
-    const { modificationTagMap = {} } = props
+    const { regionSequence, modificationTagMap = {} } = props
+    console.log({ regionSequence })
 
     const mm = (getTagAlt(feature, 'MM', 'Mm') as string) || ''
 
@@ -423,6 +424,7 @@ export default class PileupRenderer extends BoxRendererType {
     const cigarOps = parseCigar(cigar)
 
     const modifications = getModificationPositions(mm, seq, strand)
+    console.log({ modifications })
 
     // probIndex applies across multiple modifications e.g.
     let probIndex = 0
@@ -431,20 +433,20 @@ export default class PileupRenderer extends BoxRendererType {
       const col = modificationTagMap[type] || 'black'
       const base = Color(col)
       for (const readPos of getNextRefPos(cigarOps, positions)) {
-        if (readPos >= 0 && start + readPos < end) {
-          const [leftPx, rightPx] = bpSpanPx(
-            start + readPos,
-            start + readPos + 1,
-            region,
-            bpPerPx,
-          )
+        const r = start + readPos
+        if (readPos >= 0 && r < end) {
+          const [leftPx, rightPx] = bpSpanPx(r, r + 1, region, bpPerPx)
 
           // give it a little boost of 0.1 to not make them fully
           // invisible to avoid confusion
-          ctx.fillStyle = base
-            .alpha(probabilities[probIndex] + 0.1)
-            .hsl()
-            .string()
+          const prob = probabilities[probIndex]
+          ctx.fillStyle =
+            prob && prob !== 1
+              ? base
+                  .alpha(prob + 0.1)
+                  .hsl()
+                  .string()
+              : col
           ctx.fillRect(leftPx, topPx, rightPx - leftPx + 0.5, heightPx)
         }
         probIndex++

--- a/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
+++ b/plugins/alignments/src/PileupRenderer/PileupRenderer.tsx
@@ -401,7 +401,6 @@ export default class PileupRenderer extends BoxRendererType {
   ) {
     const { feature, topPx, heightPx } = layoutFeature
     const { regionSequence, modificationTagMap = {} } = props
-    console.log({ regionSequence })
 
     const mm = (getTagAlt(feature, 'MM', 'Mm') as string) || ''
 
@@ -418,13 +417,11 @@ export default class PileupRenderer extends BoxRendererType {
 
     const cigar = feature.get('CIGAR')
     const start = feature.get('start')
-    const end = feature.get('end')
     const seq = feature.get('seq')
     const strand = feature.get('strand')
     const cigarOps = parseCigar(cigar)
 
     const modifications = getModificationPositions(mm, seq, strand)
-    console.log({ modifications })
 
     // probIndex applies across multiple modifications e.g.
     let probIndex = 0
@@ -434,21 +431,19 @@ export default class PileupRenderer extends BoxRendererType {
       const base = Color(col)
       for (const readPos of getNextRefPos(cigarOps, positions)) {
         const r = start + readPos
-        if (readPos >= 0 && r < end) {
-          const [leftPx, rightPx] = bpSpanPx(r, r + 1, region, bpPerPx)
+        const [leftPx, rightPx] = bpSpanPx(r, r + 1, region, bpPerPx)
 
-          // give it a little boost of 0.1 to not make them fully
-          // invisible to avoid confusion
-          const prob = probabilities[probIndex]
-          ctx.fillStyle =
-            prob && prob !== 1
-              ? base
-                  .alpha(prob + 0.1)
-                  .hsl()
-                  .string()
-              : col
-          ctx.fillRect(leftPx, topPx, rightPx - leftPx + 0.5, heightPx)
-        }
+        // give it a little boost of 0.1 to not make them fully
+        // invisible to avoid confusion
+        const prob = probabilities[probIndex]
+        ctx.fillStyle =
+          prob && prob !== 1
+            ? base
+                .alpha(prob + 0.1)
+                .hsl()
+                .string()
+            : col
+        ctx.fillRect(leftPx, topPx, rightPx - leftPx + 0.5, heightPx)
         probIndex++
       }
     }

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -211,15 +211,25 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
         const seq = feature.get('seq') as string
         const mm = (getTagAlt(feature, 'MM', 'Mm') as string) || ''
         const ops = parseCigar(feature.get('CIGAR'))
+        const fend = feature.get('end')
 
         getModificationPositions(mm, seq, fstrand).forEach(
           ({ type, positions }) => {
             const mod = `mod_${type}`
             for (const pos of getNextRefPos(ops, positions)) {
+              if (pos < 0 || pos > fend) {
+                continue
+              }
               const epos = pos + fstart - region.start
               if (epos >= 0 && epos < bins.length && pos + fstart < fend) {
                 const bin = bins[epos]
-                inc(bin, fstrand, 'cov', mod)
+                if (bin) {
+                  inc(bin, fstrand, 'cov', mod)
+                } else {
+                  console.warn(
+                    'Undefined position in modifications snpcoverage encountered',
+                  )
+                }
               }
             }
           },

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -217,9 +217,6 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
           ({ type, positions }) => {
             const mod = `mod_${type}`
             for (const pos of getNextRefPos(ops, positions)) {
-              if (pos < 0 || pos > fend) {
-                continue
-              }
               const epos = pos + fstart - region.start
               if (epos >= 0 && epos < bins.length && pos + fstart < fend) {
                 const bin = bins[epos]

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -99,5 +99,5 @@ export async function fetchSequence(
 
 // has to check underlying C-G (aka CpG) on the reference sequence
 export function shouldFetchReferenceSequence(type?: string) {
-  return type === 'methylation' || type === 'modifications'
+  return type === 'methylation'
 }

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -99,5 +99,5 @@ export async function fetchSequence(
 
 // has to check underlying C-G (aka CpG) on the reference sequence
 export function shouldFetchReferenceSequence(type?: string) {
-  return type === 'methylation'
+  return type === 'methylation' || type === 'modifications'
 }


### PR DESCRIPTION
Found a crash displaying modifications, example share link
https://jbrowse.org/code/jb2/v1.7.0/?config=test_data%2Fconfig_demo.json&session=share-Jfg7Adjvai&password=ZCjW1

This is probably due to displaying a modifications that was called on a soft clipped area of a read (e.g. a part of the read that did not properly map to the reference genome)

Instead of trying to display these (and currently, causing a crash) this PR proposes to filter them out
