### PR TITLE
Fix filter functionality on pileup tracks

### DIFF
--- a/plugins/alignments/src/BamAdapter/BamAdapter.ts
+++ b/plugins/alignments/src/BamAdapter/BamAdapter.ts
@@ -171,7 +171,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
         flagInclude: number
         flagExclude: number
         tagFilter: { tag: string; value: unknown }
-        name: string
+        readName: string
       }
     },
   ) {
@@ -187,7 +187,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
         flagInclude = 0,
         flagExclude = 0,
         tagFilter,
-        name,
+        readName,
       } = filterBy || {}
 
       for (const record of records) {
@@ -214,7 +214,7 @@ export default class BamAdapter extends BaseFeatureDataAdapter {
           }
         }
 
-        if (name && record.get('name') !== name) {
+        if (readName && record.get('name') !== readName) {
           continue
         }
 

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -20,6 +20,13 @@ interface Header {
   readGroups?: number[]
 }
 
+interface FilterBy {
+  flagInclude: number
+  flagExclude: number
+  tagFilter: { tag: string; value: unknown }
+  readName: string
+}
+
 export default class CramAdapter extends BaseFeatureDataAdapter {
   samHeader: Header = {}
 
@@ -206,12 +213,7 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
   getFeatures(
     region: Region & { originalRefName?: string },
     opts?: BaseOptions & {
-      filterBy: {
-        flagInclude: number
-        flagExclude: number
-        tagFilter: { tag: string; value: unknown }
-        name: string
-      }
+      filterBy: FilterBy
     },
   ) {
     const { signal, filterBy, statusCallback = () => {} } = opts || {}
@@ -234,7 +236,7 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
           flagInclude = 0,
           flagExclude = 0,
           tagFilter,
-          name,
+          readName,
         } = filterBy || {}
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -251,9 +253,11 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
           })
         }
 
-        if (name) {
+        if (readName) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          filtered = filtered.filter((record: any) => record.name === name)
+          filtered = filtered.filter(
+            (record: any) => record.readName === readName,
+          )
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -254,8 +254,8 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
         }
 
         if (readName) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           filtered = filtered.filter(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (record: any) => record.readName === readName,
           )
         }

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -409,7 +409,7 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
             displayModel: self,
             sortedBy,
             colorBy,
-            filterBy,
+            filterBy: JSON.parse(JSON.stringify(filterBy)),
             colorTagMap: JSON.parse(JSON.stringify(colorTagMap)),
             modificationTagMap: JSON.parse(JSON.stringify(modificationTagMap)),
             showSoftClip: self.showSoftClipping,

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -143,7 +143,7 @@ const stateModelFactory = (
             // must use getSnapshot because otherwise changes to e.g. just the
             // colorBy.type are not read
             colorBy: self.colorBy ? getSnapshot(self.colorBy) : undefined,
-            filterBy: self.filterBy,
+            filterBy: self.filterBy ? getSnapshot(self.filterBy) : undefined,
           }
         },
       }

--- a/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
@@ -10,6 +10,7 @@ export interface PileupLayoutSessionProps {
   config: AnyConfigurationModel
   bpPerPx: number
   filters: SerializableFilterChain
+  filterBy: unknown
   sortedBy: unknown
   showSoftClip: unknown
 }
@@ -19,6 +20,7 @@ interface CachedPileupLayout {
   layout: MyMultiLayout
   config: AnyConfigurationModel
   filters: SerializableFilterChain
+  filterBy: unknown
   sortedBy: unknown
   showSoftClip: boolean
 }
@@ -26,6 +28,7 @@ interface CachedPileupLayout {
 // Adds extra conditions to see if cached layout is valid
 export class PileupLayoutSession extends LayoutSession {
   sortedBy: unknown
+  filterBy: unknown
 
   showSoftClip = false
 
@@ -50,6 +53,7 @@ export class PileupLayoutSession extends LayoutSession {
         layout: this.makeLayout(),
         config: readConfObject(this.config),
         filters: this.filters,
+        filterBy: this.filterBy,
         sortedBy: this.sortedBy,
         showSoftClip: this.showSoftClip,
       }

--- a/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
@@ -41,7 +41,8 @@ export class PileupLayoutSession extends LayoutSession {
     return (
       super.cachedLayoutIsValid(cachedLayout) &&
       this.showSoftClip === cachedLayout.showSoftClip &&
-      deepEqual(this.sortedBy, cachedLayout.sortedBy)
+      deepEqual(this.sortedBy, cachedLayout.sortedBy) &&
+      deepEqual(this.filterBy, cachedLayout.filterBy)
     )
   }
 


### PR DESCRIPTION
The optimization for filterBy caused the filter reads function to break in the pileup track. This restores functionality by

1) Using readName instead of name in the filter by read name function
2) Recreating the layout after a filterBy is applied
3) Serializing a clone of the filterBy object to make sure it gets recognized by observability systems when it is updated