### PR TITLE
Add v1.7.8 announcement

### DIFF
--- a/website/release_announcement_drafts/v1.7.8.md
+++ b/website/release_announcement_drafts/v1.7.8.md
@@ -1,0 +1,3 @@
+We are happy to announce v1.7.8
+
+This includes a variety of small improvements, see the release notes for details

--- a/website/release_announcement_drafts/v1.7.8.md
+++ b/website/release_announcement_drafts/v1.7.8.md
@@ -1,3 +1,12 @@
 We are happy to announce v1.7.8
 
-This includes a variety of small improvements, see the release notes for details
+Some highlights include
+
+- ~20% speed improvement for CRAM data
+- bugfix for filter-by being broken on alignments tracks in v1.7.0-v1.7.7
+- bugfix for certain methylation/modifications being drawn incorrectly on alignments tracks
+- bugfix for the "Open" button not navigating to the correct location on the LGV import form
+- improved visualization of indels in methylation/modifications mode on alignments tracks
+- skip text index query if the input is a loc string, resulting in quicker navigation
+
+See the release notes for details


### PR DESCRIPTION
```
## Unreleased (2022-05-19)

#### :rocket: Enhancement
* [#2960](https://github.com/GMOD/jbrowse-components/pull/2960) Avoid performing a text index search if input looks like a locstring ([@cmdcolin](https://github.com/cmdcolin))
* [#2954](https://github.com/GMOD/jbrowse-components/pull/2954) Support in-memory GFF3 and GTF in JBrowse 1 connection ([@garrettjstevens](https://github.com/garrettjstevens))

#### :bug: Bug Fix
* [#2964](https://github.com/GMOD/jbrowse-components/pull/2964) Fix crash displaying modifications called on softclipped regions of reads ([@cmdcolin](https://github.com/cmdcolin))
* [#2965](https://github.com/GMOD/jbrowse-components/pull/2965) Fix filter functionality on pileup tracks ([@cmdcolin](https://github.com/cmdcolin))
* [#2953](https://github.com/GMOD/jbrowse-components/pull/2953) Fix "Open" button on LGV ImportForm ([@cmdcolin](https://github.com/cmdcolin))
* [#2952](https://github.com/GMOD/jbrowse-components/pull/2952) Fix read vs ref not finding primary alignment on certain CRAM files ([@cmdcolin](https://github.com/cmdcolin))
* [#2951](https://github.com/GMOD/jbrowse-components/pull/2951) Allow getting clip indicator after feature end ([@cmdcolin](https://github.com/cmdcolin))
* [#2947](https://github.com/GMOD/jbrowse-components/pull/2947) Optimization for SNPCoverageAdapter and CRAM parsing ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#2946](https://github.com/GMOD/jbrowse-components/pull/2946) Small doc updates ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* [#2955](https://github.com/GMOD/jbrowse-components/pull/2955) Re-enable eslint autofix for prettier rules ([@garrettjstevens](https://github.com/garrettjstevens))

#### Committers: 2
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 1.48s.

```