### PR TITLE
Fix link on yeast synteny demo and fix CIGAR rendering on dotplot

### DIFF
--- a/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
+++ b/plugins/dotplot-view/src/DotplotRenderer/DotplotRenderer.ts
@@ -200,8 +200,8 @@ export default class DotplotRenderer extends ComparativeServerSideRendererType {
               } else if (op === 'I') {
                 currY += val / vBpPerPx
               }
+              ctx.lineTo(currX, height - currY)
             }
-            ctx.lineTo(currX, height - currY)
             ctx.stroke()
           } else {
             ctx.beginPath()

--- a/test_data/yeast_synteny/config.json
+++ b/test_data/yeast_synteny/config.json
@@ -49,7 +49,7 @@
       "adapter": {
         "type": "PAFAdapter",
         "pafLocation": {
-          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64_vs_yjm1447.chains.paf.gz",
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/yeast/r64_vs_yjm1447/r64_vs_yjm1447.cigar.paf.gz",
           "locationType": "UriLocation"
         },
         "assemblyNames": ["YJM1447", "R64"]


### PR DESCRIPTION
The CIGAR rendering on dotplot was not working after refactoring made awhile back, this restores it though!

It uses a path with multiple lineTo inside the loop, and a single stroke for all the segments of the line