### PR TITLE
Index track by default on add track widget

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -82,7 +82,7 @@ export default function f(pluginManager: PluginManager) {
         self.indexTrackData = undefined
         self.trackData = undefined
         self.textIndexingConf = undefined
-        self.textIndexTrack = false
+        self.textIndexTrack = true
       },
     }))
     .views(self => ({


### PR DESCRIPTION
* fixes https://github.com/GMOD/jbrowse-components/issues/2972
* sets textIndexTrack to true