### PR TITLE
Respect --indexFile option when adding VCF and BED tracks

### DIFF
--- a/products/jbrowse-cli/src/commands/add-track.ts
+++ b/products/jbrowse-cli/src/commands/add-track.ts
@@ -547,7 +547,7 @@ export default class AddTrack extends JBrowseCommand {
         type: 'VcfTabixAdapter',
         vcfGzLocation: makeLocation(fileName),
         index: {
-          location: makeLocation(`${fileName}.tbi`),
+          location: makeLocation(index || `${fileName}.tbi`),
           indexType:
             index && index.toUpperCase().endsWith('CSI') ? 'CSI' : 'TBI',
         },
@@ -571,7 +571,7 @@ export default class AddTrack extends JBrowseCommand {
         type: 'BedTabixAdapter',
         bedGzLocation: makeLocation(fileName),
         index: {
-          location: makeLocation(`${fileName}.tbi`),
+          location: makeLocation(index || `${fileName}.tbi`),
           indexType:
             index && index.toUpperCase().endsWith('CSI') ? 'CSI' : 'TBI',
         },


### PR DESCRIPTION
In the current version, the following command results in a `config.json` with an index location `feature.bed.gz.tbi` ignoring the `--indexFile` value.
```
jbrowse add-track --indexFile feature.bed.gz.csi feature.bed.gz
```

GFF and BAM/CRAM are fine already.