### PR TITLE
Remove errors related to test coverage in CI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
     // most packages have their src in src/, except for jbrowse-core
     'packages/core/**/*.{js,jsx,ts,tsx}',
   ],
+  coveragePathIgnorePatterns: ['!*.d.ts'],
   setupFiles: [
     '<rootDir>/config/jest/createRange.js',
     '<rootDir>/config/jest/fetchMock.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     // most packages have their src in src/, except for jbrowse-core
     'packages/core/**/*.{js,jsx,ts,tsx}',
   ],
-  coveragePathIgnorePatterns: ['!*.d.ts'],
+  coveragePathIgnorePatterns: ['!*.d.ts', 'makeWorkerInstance.ts'],
   setupFiles: [
     '<rootDir>/config/jest/createRange.js',
     '<rootDir>/config/jest/fetchMock.js',

--- a/products/jbrowse-web/src/tests/Authentication.test.js
+++ b/products/jbrowse-web/src/tests/Authentication.test.js
@@ -108,7 +108,7 @@ test('opens a bigwig track that needs external token authentication', async () =
     await findByTestId('htsTrackEntry-volvox_microarray_externaltoken'),
   )
   const { findByText: findByTextWithin } = within(
-    await findByTestId('externalToken-form'),
+    await findByTestId('externalToken-form', {}, delay),
   )
   fireEvent.change(await findByTestId('entry-externalToken'), {
     target: { value: 'testentry' },


### PR DESCRIPTION
This ignores .d.ts and the specific makeWorkerInstance file (since it uses a new Worker syntax, which jest has trouble with, and indeed, we mock this module out when doing our actual tests)