### PR TITLE
Add spreadsheet spec

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -29,7 +29,7 @@ export interface AbstractViewContainer extends IAnyStateTreeNode {
   removeView(view: AbstractViewModel): void
   addView(
     typeName: string,
-    initialState: Record<string, unknown>,
+    initialState?: Record<string, unknown>,
   ): void | AbstractViewModel
 }
 export function isViewContainer(

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -184,6 +184,9 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       showTrack(trackId: string, initialSnapshot = {}) {
         const schema = pluginManager.pluggableConfigSchemaType('track')
         const configuration = resolveIdentifier(schema, getRoot(self), trackId)
+        if (!configuration) {
+          throw new Error(`track not found ${trackId}`)
+        }
         const trackType = pluginManager.getTrackType(configuration.type)
         if (!trackType) {
           throw new Error(`unknown track type ${configuration.type}`)

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { autorun } from 'mobx'
 import BaseViewModel from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { MenuItem, ReturnToImportFormDialog } from '@jbrowse/core/ui'
 import { getSession, isSessionModelWithWidgets } from '@jbrowse/core/util'
@@ -124,7 +125,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
 
       setWidth(newWidth: number) {
         self.width = newWidth
-        self.views.forEach(v => v.setWidth(newWidth))
       },
       setHeight(newHeight: number) {
         self.height = newHeight
@@ -273,6 +273,18 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             },
           },
         ]
+      },
+    }))
+    .actions(self => ({
+      afterAttach() {
+        addDisposer(
+          self,
+          autorun(() => {
+            if (self.initialized) {
+              self.views.forEach(v => v.setWidth(self.width))
+            }
+          }),
+        )
       },
     }))
 }

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -137,42 +137,47 @@ export default class LinearGenomeViewPlugin extends Plugin {
         loc: string
         tracks?: string[]
       }) => {
-        const { assemblyManager } = session
-        const view = session.addView('LinearGenomeView', {}) as LGV
+        try {
+          const { assemblyManager } = session
+          const view = session.addView('LinearGenomeView', {}) as LGV
 
-        await when(() => !!view.volatileWidth)
+          await when(() => !!view.volatileWidth)
 
-        if (!assembly) {
-          throw new Error(
-            'No assembly provided when launching linear genome view',
-          )
-        }
-
-        const asm = await assemblyManager.waitForAssembly(assembly)
-        if (!asm) {
-          throw new Error(
-            `Assembly "${assembly}" not found when launching linear genome view`,
-          )
-        }
-
-        view.navToLocString(loc, assembly)
-
-        const idsNotFound = [] as string[]
-        tracks.forEach(track => {
-          try {
-            view.showTrack(track)
-          } catch (e) {
-            if (`${e}`.match('Could not resolve identifier')) {
-              idsNotFound.push(track)
-            } else {
-              throw e
-            }
+          if (!assembly) {
+            throw new Error(
+              'No assembly provided when launching linear genome view',
+            )
           }
-        })
-        if (idsNotFound.length) {
-          throw new Error(
-            `Could not resolve identifiers: ${idsNotFound.join(',')}`,
-          )
+
+          const asm = await assemblyManager.waitForAssembly(assembly)
+          if (!asm) {
+            throw new Error(
+              `Assembly "${assembly}" not found when launching linear genome view`,
+            )
+          }
+
+          view.navToLocString(loc, assembly)
+
+          const idsNotFound = [] as string[]
+          tracks.forEach(track => {
+            try {
+              view.showTrack(track)
+            } catch (e) {
+              if (`${e}`.match('Could not resolve identifier')) {
+                idsNotFound.push(track)
+              } else {
+                throw e
+              }
+            }
+          })
+          if (idsNotFound.length) {
+            throw new Error(
+              `Could not resolve identifiers: ${idsNotFound.join(',')}`,
+            )
+          }
+        } catch (e) {
+          session.notify(`${e}`, 'error')
+          throw e
         }
       },
     )

--- a/plugins/spreadsheet-view/src/index.ts
+++ b/plugins/spreadsheet-view/src/index.ts
@@ -1,10 +1,13 @@
 import { lazy } from 'react'
+import { Instance } from 'mobx-state-tree'
 import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
 import PluginManager from '@jbrowse/core/PluginManager'
 import Plugin from '@jbrowse/core/Plugin'
 import ViewComfyIcon from '@material-ui/icons/ViewComfy'
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
 import SpreadsheetViewModel from './SpreadsheetView/models/SpreadsheetView'
+
+type SpreadsheetView = Instance<typeof SpreadsheetViewModel>
 
 export default class SpreadsheetViewPlugin extends Plugin {
   name = 'SpreadsheetViewPlugin'
@@ -19,11 +22,51 @@ export default class SpreadsheetViewPlugin extends Plugin {
         ),
       })
     })
+
+    pluginManager.addToExtensionPoint(
+      'LaunchView-SpreadsheetView',
+      // @ts-ignore
+      async ({
+        session,
+        assembly,
+        uri,
+        fileType,
+      }: {
+        session: AbstractSessionModel
+        assembly: string
+        uri: string
+        fileType?: string
+      }) => {
+        // add view, make typescript happy with return type
+        const { rootModel } = pluginManager
+        const view = rootModel?.session?.addView(
+          'SpreadsheetView',
+        ) as SpreadsheetView
+
+        if (!view) {
+          throw new Error('Failed to initialize view')
+        }
+        const exts = uri.split('.')
+        let ext = exts?.pop()?.toUpperCase()
+        if (ext === 'GZ') {
+          ext = exts?.pop()?.toUpperCase()
+        }
+
+        view.importWizard.setFileType(fileType || ext || '')
+        view.importWizard.setSelectedAssemblyName(assembly)
+        view.importWizard.setFileSource({
+          uri,
+          locationType: 'UriLocation',
+        })
+        view.importWizard.import(assembly)
+      },
+    )
   }
 
   configure(pluginManager: PluginManager) {
-    if (isAbstractMenuManager(pluginManager.rootModel)) {
-      pluginManager.rootModel.appendToSubMenu(['Add'], {
+    const { rootModel } = pluginManager
+    if (isAbstractMenuManager(rootModel)) {
+      rootModel.appendToSubMenu(['Add'], {
         label: 'Spreadsheet view',
         icon: ViewComfyIcon,
         onClick: (session: AbstractSessionModel) => {

--- a/plugins/sv-inspector/src/index.ts
+++ b/plugins/sv-inspector/src/index.ts
@@ -7,12 +7,53 @@ import {
 import TableChartIcon from '@material-ui/icons/TableChart'
 import SvInspectorViewTypeFactory from './SvInspectorView/SvInspectorViewType'
 
+type SvInspectorView = ReturnType<typeof SvInspectorViewTypeFactory>
+
 export default class SvInspectorViewPlugin extends Plugin {
   name = 'SvInspectorViewPlugin'
 
   install(pluginManager: PluginManager) {
     pluginManager.addViewType(() =>
       pluginManager.jbrequire(SvInspectorViewTypeFactory),
+    )
+
+    pluginManager.addToExtensionPoint(
+      'LaunchView-SvInspectorView',
+      // @ts-ignore
+      async ({
+        session,
+        assembly,
+        uri,
+        fileType,
+      }: {
+        session: AbstractSessionModel
+        assembly: string
+        uri: string
+        fileType?: string
+      }) => {
+        // add view, make typescript happy with return type
+        const { rootModel } = pluginManager
+        const view = rootModel?.session?.addView(
+          'SvInspectorView',
+        ) as SvInspectorView
+
+        if (!view) {
+          throw new Error('Failed to initialize view')
+        }
+        const exts = uri.split('.')
+        let ext = exts?.pop()?.toUpperCase()
+        if (ext === 'GZ') {
+          ext = exts?.pop()?.toUpperCase()
+        }
+
+        view.spreadsheetView.importWizard.setFileType(fileType || ext || '')
+        view.spreadsheetView.importWizard.setSelectedAssemblyName(assembly)
+        view.spreadsheetView.importWizard.setFileSource({
+          uri,
+          locationType: 'UriLocation',
+        })
+        view.spreadsheetView.importWizard.import(assembly)
+      },
     )
   }
 

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -234,7 +234,7 @@ describe('<Loader />', () => {
     await findAllByText(/Failed to load/)
   }, 20000)
 
-  it('can use a spec url', async () => {
+  it('can use a spec url for lgv', async () => {
     const { findByText, findByPlaceholderText } = render(
       <QueryParamProvider
         // @ts-ignore
@@ -255,4 +255,28 @@ describe('<Loader />', () => {
     // @ts-ignore
     await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'), delay)
   }, 40000)
+
+  it('can use a spec url for synteny view', async () => {
+    const { findByText, findByPlaceholderText } = render(
+      <QueryParamProvider
+        // @ts-ignore
+        location={{
+          search:
+            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"LinearSyntenyView","tracks":["volvox_fake_synteny"],"views":[{"loc":"ctgA:1-100","assembly":"volvox"},{"loc":"ctgA:300-400","assembly":"volvox"}]}]}',
+        }}
+      >
+        <Loader />
+      </QueryParamProvider>,
+    )
+
+    await findByText('Help', {}, delay)
+
+    await findByText(/volvox-sorted.bam/, {}, delay)
+    const elt = await findByPlaceholderText('Search for location', {}, delay)
+
+    // @ts-ignore
+    await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'), delay)
+  }, 40000)
 })
+
+//http://localhost:3000/?config=test_data/volvox/config_main_thread.json&session=spec-{%22views%22:[{%22type%22:%22LinearSyntenyView%22,%22tracks%22:[%22volvox_fake_synteny%22],%22views%22:[{%22loc%22:%22ctgA:1-100%22,%22assembly%22:%22volvox%22},{%22loc%22:%22ctgA:300-400%22,%22assembly%22:%22volvox%22}]}]}

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -257,7 +257,8 @@ describe('<Loader />', () => {
   }, 40000)
 
   it('can use a spec url for synteny view', async () => {
-    const { findByText, findByPlaceholderText } = render(
+    console.warn = jest.fn()
+    const { findByText, findByTestId } = render(
       <QueryParamProvider
         // @ts-ignore
         location={{
@@ -270,13 +271,26 @@ describe('<Loader />', () => {
     )
 
     await findByText('Help', {}, delay)
+    await findByTestId('synteny_canvas', {}, delay)
+  }, 40000)
 
-    await findByText(/volvox-sorted.bam/, {}, delay)
-    const elt = await findByPlaceholderText('Search for location', {}, delay)
+  it('can use a spec url for spreadsheet view', async () => {
+    console.warn = jest.fn()
+    const { findByText } = render(
+      <QueryParamProvider
+        // @ts-ignore
+        location={{
+          search:
+            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"SpreadsheetView","uri":"test_data/volvox/volvox.filtered.vcf.gz","assembly":"volvox"}]}',
+        }}
+      >
+        <Loader />
+      </QueryParamProvider>,
+    )
 
-    // @ts-ignore
-    await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'), delay)
+    await findByText('Help', {}, delay)
+
+    // random row in spreadsheet
+    await findByText('ctgA:8470..8471', {}, delay)
   }, 40000)
 })
-
-//http://localhost:3000/?config=test_data/volvox/config_main_thread.json&session=spec-{%22views%22:[{%22type%22:%22LinearSyntenyView%22,%22tracks%22:[%22volvox_fake_synteny%22],%22views%22:[{%22loc%22:%22ctgA:1-100%22,%22assembly%22:%22volvox%22},{%22loc%22:%22ctgA:300-400%22,%22assembly%22:%22volvox%22}]}]}

--- a/test_data/volvox/config_main_thread.json
+++ b/test_data/volvox/config_main_thread.json
@@ -64,6 +64,21 @@
           "displayId": "volvox_bam_pileup_pileup"
         }
       ]
+    },
+
+    {
+      "type": "SyntenyTrack",
+      "trackId": "volvox_fake_synteny",
+      "name": "volvox_fake_synteny",
+      "assemblyNames": ["volvox", "volvox"],
+      "adapter": {
+        "type": "PAFAdapter",
+        "pafLocation": {
+          "uri": "volvox_fake_synteny.paf",
+          "locationType": "UriLocation"
+        },
+        "assemblyNames": ["volvox", "volvox"]
+      }
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11213,11 +11213,6 @@ ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
   integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"


### PR DESCRIPTION
Adds ability to automatically load a spreadsheet from the spec URL

http://localhost:3000/?config=test_data/volvox/config.json&session=spec-{%22views%22:[{%22type%22:%22SpreadsheetView%22,%20%22uri%22:%22test_data/volvox/volvox.filtered.vcf.gz%22,%22assembly%22:%22volvox%22}]}

prettier output for url

```
{
  views: [
    {
      type: "SpreadsheetView",
      uri: "test_data/volvox/volvox.filtered.vcf.gz",
      assembly: "volvox",
    },
  ],
};

```