### PR TITLE
Updating bp displayed to have units and truncate the digits where relevant and adding an option to hide the "add tracks" button that appears on the empty track when no tracks are visible

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1137,12 +1137,36 @@ export function supportedIndexingAdapters(type: string) {
 
 export function getBpDisplayStr(totalBp: number) {
   let str
-  if (Math.floor(totalBp / 1000000) > 0) {
-    str = `${parseFloat((totalBp / 1000000).toPrecision(3))}Mbp`
-  } else if (Math.floor(totalBp / 1000) > 0) {
-    str = `${parseFloat((totalBp / 1000).toPrecision(3))}Kbp`
+  if (Math.floor(totalBp / 1_000_000) > 0) {
+    str = `${parseFloat((totalBp / 1_000_000).toPrecision(3))}Mbp`
+  } else if (Math.floor(totalBp / 1_000) > 0) {
+    str = `${parseFloat((totalBp / 1_000).toPrecision(3))}Kbp`
   } else {
-    str = `${Math.floor(totalBp)}bp`
+    str = `${Math.floor(totalBp).toLocaleString('en-US')}bp`
+  }
+  return str
+}
+
+export function toLocale(n: number) {
+  return n.toLocaleString('en-US')
+}
+
+export function getTickDisplayStr(totalBp: number, bpPerPx: number) {
+  let str
+  if (Math.floor(bpPerPx / 1_000) > 0) {
+    str = `${toLocale(parseFloat((totalBp / 1_000_000).toFixed(2)))}M`
+  } else {
+    str = `${toLocale(Math.floor(totalBp))}`
+  }
+  return str
+}
+
+export function getTickDisplayStr2(totalBp: number, bpPerPx: number) {
+  let str
+  if (Math.floor(bpPerPx / 1_000) > 0) {
+    str = `${toLocale(parseFloat((totalBp / 1_000_000).toFixed(2)))}Mbp`
+  } else {
+    str = `${toLocale(Math.floor(totalBp))}bp`
   }
   return str
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -7,6 +7,7 @@ import {
   makeStyles,
   alpha,
 } from '@material-ui/core'
+import { getTickDisplayStr2 } from '@jbrowse/core/util'
 import SearchBox from './SearchBox'
 
 // icons
@@ -97,10 +98,10 @@ function PanControls({ model }: { model: LGV }) {
 
 const RegionWidth = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
-  const { coarseTotalBp } = model
+  const { coarseTotalBp, bpPerPx } = model
   return (
     <Typography variant="body2" color="textSecondary" className={classes.bp}>
-      {Math.round(coarseTotalBp).toLocaleString('en-US')} bp
+      {getTickDisplayStr2(coarseTotalBp, bpPerPx)}
     </Typography>
   )
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.test.js
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.test.js
@@ -75,13 +75,11 @@ describe('<LinearGenomeView />', () => {
     })
     const model = session.views[0]
     model.setWidth(800)
-    const { container, findByText, findAllByText } = render(
-      <LinearGenomeView model={model} />,
-    )
+    const { container, findByText } = render(<LinearGenomeView model={model} />)
     await findByText('Foo Track')
     // test needs to wait until it's updated to display 100 bp in the header to
     // make snapshot pass
-    await findAllByText('100 bp')
+    await findByText('100bp')
     expect(container.firstChild).toMatchSnapshot()
   })
   it('renders two tracks, two regions', async () => {
@@ -147,7 +145,7 @@ describe('<LinearGenomeView />', () => {
       <LinearGenomeView model={model} />,
     )
     await findByText('Foo Track')
-    await findByText('798 bp')
+    await findByText('798bp')
     await findAllByTestId('svgfeatures')
 
     expect(container.firstChild).toMatchSnapshot()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.test.js
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.test.js
@@ -75,11 +75,13 @@ describe('<LinearGenomeView />', () => {
     })
     const model = session.views[0]
     model.setWidth(800)
-    const { container, findByText } = render(<LinearGenomeView model={model} />)
+    const { container, findByText, findAllByText } = render(
+      <LinearGenomeView model={model} />,
+    )
     await findByText('Foo Track')
     // test needs to wait until it's updated to display 100 bp in the header to
     // make snapshot pass
-    await findByText('100 bp')
+    await findAllByText('100 bp')
     expect(container.firstChild).toMatchSnapshot()
   })
   it('renders two tracks, two regions', async () => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -92,16 +92,22 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
       <TracksContainer model={model}>
         {!tracks.length ? (
           <Paper variant="outlined" className={classes.note}>
-            <Typography>No tracks active.</Typography>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={model.activateTrackSelector}
-              style={{ zIndex: 1000 }}
-              startIcon={<TrackSelectorIcon />}
-            >
-              Open track selector
-            </Button>
+            {!model.hideNoTracksActive ? (
+              <>
+                <Typography>No tracks active.</Typography>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={model.activateTrackSelector}
+                  style={{ zIndex: 1000 }}
+                  startIcon={<TrackSelectorIcon />}
+                >
+                  Open track selector
+                </Button>
+              </>
+            ) : (
+              <div style={{ height: '48px' }}></div>
+            )}
           </Paper>
         ) : (
           tracks.map(track => (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -51,7 +51,6 @@ const useStyles = makeStyles(theme => {
     },
     scaleBarLabel: {
       height: HEADER_OVERVIEW_HEIGHT,
-      width: 1,
       position: 'absolute',
       display: 'flex',
       justifyContent: 'center',
@@ -354,7 +353,7 @@ const OverviewBox = observer(
                     color: refNameColor,
                   }}
                 >
-                  {tickToStringAndTruncate(tickLabel)}
+                  {tickToStringAndTruncate(tickLabel, majorPitch)}
                 </Typography>
               ))
             : null}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -5,7 +5,7 @@ import { Instance } from 'mobx-state-tree'
 import clsx from 'clsx'
 
 import Base1DView, { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
-import { getSession } from '@jbrowse/core/util'
+import { getSession, getTickDisplayStr } from '@jbrowse/core/util'
 import { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 
@@ -15,7 +15,7 @@ import {
   HEADER_BAR_HEIGHT,
   HEADER_OVERVIEW_HEIGHT,
 } from '..'
-import { chooseGridPitch, tickToStringAndTruncate } from '../util'
+import { chooseGridPitch } from '../util'
 import OverviewRubberBand from './OverviewRubberBand'
 
 const wholeSeqSpacer = 2
@@ -300,7 +300,7 @@ const OverviewBox = observer(
     overview: Base1DViewModel
   }) => {
     const classes = useStyles()
-    const { cytobandOffset, showCytobands } = model
+    const { cytobandOffset, bpPerPx, showCytobands } = model
     const { start, end, reversed, refName, assemblyName } = block
     const { majorPitch } = chooseGridPitch(scale, 120, 15)
     const { assemblyManager } = getSession(model)
@@ -353,7 +353,7 @@ const OverviewBox = observer(
                     color: refNameColor,
                   }}
                 >
-                  {tickToStringAndTruncate(tickLabel, majorPitch)}
+                  {getTickDisplayStr(tickLabel, bpPerPx)}
                 </Typography>
               ))
             : null}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -15,7 +15,7 @@ import {
   HEADER_BAR_HEIGHT,
   HEADER_OVERVIEW_HEIGHT,
 } from '..'
-import { chooseGridPitch } from '../util'
+import { chooseGridPitch, tickToStringAndTruncate } from '../util'
 import OverviewRubberBand from './OverviewRubberBand'
 
 const wholeSeqSpacer = 2
@@ -354,7 +354,7 @@ const OverviewBox = observer(
                     color: refNameColor,
                   }}
                 >
-                  {tickLabel.toLocaleString('en-US')}
+                  {tickToStringAndTruncate(tickLabel)}
                 </Typography>
               ))
             : null}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -13,7 +13,7 @@ import {
   ElidedBlock as ElidedBlockComponent,
   InterRegionPaddingBlock as InterRegionPaddingBlockComponent,
 } from '../../BaseLinearDisplay/components/Block'
-import { makeTicks } from '../util'
+import { makeTicks, tickToStringAndTruncate } from '../util'
 
 type LGV = LinearGenomeViewModel
 
@@ -116,7 +116,7 @@ const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
                     (block.reversed
                       ? block.end - tick.base
                       : tick.base - block.start) / model.bpPerPx
-                  const baseNumber = (tick.base + 1).toLocaleString('en-US')
+                  const baseNumber = tick.base + 1
                   return (
                     <div
                       key={tick.base}
@@ -125,7 +125,7 @@ const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
                     >
                       {baseNumber ? (
                         <Typography className={classes.majorTickLabel}>
-                          {baseNumber}
+                          {tickToStringAndTruncate(baseNumber)}
                         </Typography>
                       ) : null}
                     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -13,7 +13,8 @@ import {
   ElidedBlock as ElidedBlockComponent,
   InterRegionPaddingBlock as InterRegionPaddingBlockComponent,
 } from '../../BaseLinearDisplay/components/Block'
-import { makeTicks, chooseGridPitch, tickToStringAndTruncate } from '../util'
+import { makeTicks } from '../util'
+import { getTickDisplayStr } from '@jbrowse/core/util'
 
 type LGV = LinearGenomeViewModel
 
@@ -95,19 +96,14 @@ const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
 
 const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
   const classes = useStyles()
+  const { bpPerPx } = model
 
   return (
     <>
       {model.staticBlocks.map((block, index) => {
         if (block instanceof ContentBlock) {
-          const ticks = makeTicks(
-            block.start,
-            block.end,
-            model.bpPerPx,
-            true,
-            false,
-          )
-          const { majorPitch } = chooseGridPitch(model.bpPerPx, 60, 15)
+          const { start, end } = block
+          const ticks = makeTicks(start, end, bpPerPx, true, false)
 
           return (
             <ContentBlockComponent key={`${block.key}-${index}`} block={block}>
@@ -126,7 +122,7 @@ const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
                     >
                       {baseNumber ? (
                         <Typography className={classes.majorTickLabel}>
-                          {tickToStringAndTruncate(baseNumber, majorPitch)}
+                          {getTickDisplayStr(baseNumber, bpPerPx)}
                         </Typography>
                       ) : null}
                     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -13,7 +13,7 @@ import {
   ElidedBlock as ElidedBlockComponent,
   InterRegionPaddingBlock as InterRegionPaddingBlockComponent,
 } from '../../BaseLinearDisplay/components/Block'
-import { makeTicks, tickToStringAndTruncate } from '../util'
+import { makeTicks, chooseGridPitch, tickToStringAndTruncate } from '../util'
 
 type LGV = LinearGenomeViewModel
 
@@ -107,6 +107,7 @@ const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
             true,
             false,
           )
+          const { majorPitch } = chooseGridPitch(model.bpPerPx, 60, 15)
 
           return (
             <ContentBlockComponent key={`${block.key}-${index}`} block={block}>
@@ -125,7 +126,7 @@ const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
                     >
                       {baseNumber ? (
                         <Typography className={classes.majorTickLabel}>
-                          {tickToStringAndTruncate(baseNumber)}
+                          {tickToStringAndTruncate(baseNumber, majorPitch)}
                         </Typography>
                       ) : null}
                     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -626,31 +626,31 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 145.0909090909091px; pointer-events: none;"
               >
-                1,200 bp
+                1,200
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 290.1818181818182px; pointer-events: none;"
               >
-                1,400 bp
+                1,400
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 435.27272727272725px; pointer-events: none;"
               >
-                1,600 bp
+                1,600
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 580.3636363636364px; pointer-events: none;"
               >
-                1,800 bp
+                1,800
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 725.4545454545454px; pointer-events: none;"
               >
-                2,000 bp
+                2,000
               </p>
             </div>
           </div>
@@ -843,8 +843,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <p
           class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
         >
-          798
-           bp
+          798bp
         </p>
         <div
           class="makeStyles-container"
@@ -1249,7 +1248,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,000 bp
+                  1,000
                 </p>
               </div>
               <div
@@ -1259,7 +1258,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,200 bp
+                  1,200
                 </p>
               </div>
               <div
@@ -1269,7 +1268,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,400 bp
+                  1,400
                 </p>
               </div>
               <div
@@ -1279,7 +1278,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,600 bp
+                  1,600
                 </p>
               </div>
               <div
@@ -1289,7 +1288,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,800 bp
+                  1,800
                 </p>
               </div>
               <div
@@ -1299,7 +1298,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  2,000 bp
+                  2,000
                 </p>
               </div>
             </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -38,31 +38,31 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                20
+                20bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                40
+                40bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                60
+                60bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                80
+                80bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                100
+                100bp
               </p>
             </div>
           </div>
@@ -425,13 +425,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               <div
                 class="makeStyles-tick"
                 style="left: -1px;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-                >
-                  0
-                </p>
-              </div>
+              />
             </div>
             <div
               class="makeStyles-boundaryPaddingBlock"
@@ -633,31 +627,31 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 145.0909090909091px; pointer-events: none;"
               >
-                1,200
+                1.2kbp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 290.1818181818182px; pointer-events: none;"
               >
-                1,400
+                1.4kbp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 435.27272727272725px; pointer-events: none;"
               >
-                1,600
+                1.6kbp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 580.3636363636364px; pointer-events: none;"
               >
-                1,800
+                1.8kbp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 725.4545454545454px; pointer-events: none;"
               >
-                2,000
+                2kbp
               </p>
             </div>
           </div>
@@ -1239,13 +1233,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               <div
                 class="makeStyles-tick"
                 style="left: -1px;"
-              >
-                <p
-                  class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-                >
-                  0
-                </p>
-              </div>
+              />
             </div>
             <div
               class="makeStyles-interRegionPaddingBlock"
@@ -1262,7 +1250,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,000
+                  1kbp
                 </p>
               </div>
               <div
@@ -1272,7 +1260,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,200
+                  1.2kbp
                 </p>
               </div>
               <div
@@ -1282,7 +1270,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,400
+                  1.4kbp
                 </p>
               </div>
               <div
@@ -1292,7 +1280,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,600
+                  1.6kbp
                 </p>
               </div>
               <div
@@ -1302,7 +1290,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1,800
+                  1.8kbp
                 </p>
               </div>
               <div
@@ -1312,7 +1300,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  2,000
+                  2kbp
                 </p>
               </div>
             </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -38,31 +38,31 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                20bp
+                20 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                40bp
+                40 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                60bp
+                60 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                80bp
+                80 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                100bp
+                100 bp
               </p>
             </div>
           </div>
@@ -627,31 +627,31 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 145.0909090909091px; pointer-events: none;"
               >
-                1.2kbp
+                1,200 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 290.1818181818182px; pointer-events: none;"
               >
-                1.4kbp
+                1,400 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 435.27272727272725px; pointer-events: none;"
               >
-                1.6kbp
+                1,600 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 580.3636363636364px; pointer-events: none;"
               >
-                1.8kbp
+                1,800 bp
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 725.4545454545454px; pointer-events: none;"
               >
-                2kbp
+                2,000 bp
               </p>
             </div>
           </div>
@@ -1250,7 +1250,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1kbp
+                  1,000 bp
                 </p>
               </div>
               <div
@@ -1260,7 +1260,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1.2kbp
+                  1,200 bp
                 </p>
               </div>
               <div
@@ -1270,7 +1270,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1.4kbp
+                  1,400 bp
                 </p>
               </div>
               <div
@@ -1280,7 +1280,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1.6kbp
+                  1,600 bp
                 </p>
               </div>
               <div
@@ -1290,7 +1290,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  1.8kbp
+                  1,800 bp
                 </p>
               </div>
               <div
@@ -1300,7 +1300,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                 >
-                  2kbp
+                  2,000 bp
                 </p>
               </div>
             </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -38,31 +38,31 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 160px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                20 bp
+                20
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 320px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                40 bp
+                40
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 480px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                60 bp
+                60
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 640px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                80 bp
+                80
               </p>
               <p
                 class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                 style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
               >
-                100 bp
+                100
               </p>
             </div>
           </div>
@@ -255,8 +255,7 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         <p
           class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
         >
-          100
-           bp
+          100bp
         </p>
         <div
           class="makeStyles-container"

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -126,6 +126,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         ),
         hideHeader: false,
         hideHeaderOverview: false,
+        hideNoTracksActive: false,
         trackSelectorType: types.optional(
           types.enumeration(['hierarchical']),
           'hierarchical',
@@ -462,6 +463,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       toggleHeaderOverview() {
         self.hideHeaderOverview = !self.hideHeaderOverview
+      },
+      toggleNoTracksActive() {
+        self.hideNoTracksActive = !self.hideNoTracksActive
       },
 
       scrollTo(offsetPx: number) {
@@ -1205,6 +1209,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
             checked: !self.hideHeaderOverview,
             onClick: self.toggleHeaderOverview,
             disabled: self.hideHeader,
+          },
+          {
+            label: 'Show no tracks active button',
+            icon: VisibilityIcon,
+            type: 'checkbox',
+            checked: !self.hideNoTracksActive,
+            onClick: self.toggleNoTracksActive,
           },
           {
             label: 'Track labels',

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -82,3 +82,15 @@ export function makeTicks(
   }
   return ticks
 }
+
+export function tickToStringAndTruncate(label: number) {
+  if (label / 1000000 >= 1) {
+    const nval = label / 1000000
+    return `${nval}Mbp`
+  } else if (label / 1000 >= 1) {
+    const nval = label / 1000
+    return `${nval}kbp`
+  } else {
+    return `${label.toLocaleString('en-US')}bp`
+  }
+}

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -83,14 +83,15 @@ export function makeTicks(
   return ticks
 }
 
-export function tickToStringAndTruncate(label: number) {
-  if (label / 1000000 >= 1) {
+export function tickToStringAndTruncate(label: number, majorPitch: number) {
+  console.log(majorPitch)
+  if (label % 1000000 === 0 && majorPitch >= 500000) {
     const nval = label / 1000000
-    return `${nval}Mbp`
-  } else if (label / 1000 >= 1) {
+    return `${nval.toLocaleString('en-Us')} Mbp`
+  } else if (label % 1000 === 0 && majorPitch >= 500) {
     const nval = label / 1000
-    return `${nval}kbp`
+    return `${nval.toLocaleString('en-Us')} kbp`
   } else {
-    return `${label.toLocaleString('en-US')}bp`
+    return `${label.toLocaleString('en-US')} bp`
   }
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -82,15 +82,3 @@ export function makeTicks(
   }
   return ticks
 }
-
-export function tickToStringAndTruncate(label: number, majorPitch: number) {
-  if (label % 1000000 === 0 && majorPitch >= 500000) {
-    const nval = label / 1000000
-    return `${nval.toLocaleString('en-Us')} Mbp`
-  } else if (label % 1000 === 0 && majorPitch >= 500) {
-    const nval = label / 1000
-    return `${nval.toLocaleString('en-Us')} kbp`
-  } else {
-    return `${label.toLocaleString('en-US')} bp`
-  }
-}

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -84,7 +84,6 @@ export function makeTicks(
 }
 
 export function tickToStringAndTruncate(label: number, majorPitch: number) {
-  console.log(majorPitch)
   if (label % 1000000 === 0 && majorPitch >= 500000) {
     const nval = label / 1000000
     return `${nval.toLocaleString('en-Us')} Mbp`

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -116,37 +116,37 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        20 bp
+                        20
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        40 bp
+                        40
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        60 bp
+                        60
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        80 bp
+                        80
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        100 bp
+                        100
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        120 bp
+                        120
                       </p>
                     </div>
                   </div>
@@ -339,8 +339,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 <p
                   class="MuiTypography-root makeStyles-bp MuiTypography-body2 MuiTypography-colorTextSecondary"
                 >
-                  40
-                   bp
+                  40bp
                 </p>
                 <div
                   class="makeStyles-container"
@@ -703,7 +702,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          10 bp
+                          10
                         </p>
                       </div>
                       <div
@@ -713,7 +712,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          20 bp
+                          20
                         </p>
                       </div>
                       <div
@@ -723,7 +722,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          30 bp
+                          30
                         </p>
                       </div>
                       <div
@@ -733,7 +732,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          40 bp
+                          40
                         </p>
                       </div>
                       <div
@@ -743,7 +742,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          50 bp
+                          50
                         </p>
                       </div>
                     </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -116,37 +116,37 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        20
+                        20bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        40
+                        40bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        60
+                        60bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        80
+                        80bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        100
+                        100bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        120
+                        120bp
                       </p>
                     </div>
                   </div>
@@ -695,13 +695,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       <div
                         class="makeStyles-tick"
                         style="left: -20px;"
-                      >
-                        <p
-                          class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
-                        >
-                          0
-                        </p>
-                      </div>
+                      />
                       <div
                         class="makeStyles-tick"
                         style="left: 180px;"
@@ -709,7 +703,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          10
+                          10bp
                         </p>
                       </div>
                       <div
@@ -719,7 +713,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          20
+                          20bp
                         </p>
                       </div>
                       <div
@@ -729,7 +723,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          30
+                          30bp
                         </p>
                       </div>
                       <div
@@ -739,7 +733,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          40
+                          40bp
                         </p>
                       </div>
                       <div
@@ -749,7 +743,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          50
+                          50bp
                         </p>
                       </div>
                     </div>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -116,37 +116,37 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        20bp
+                        20 bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        40bp
+                        40 bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        60bp
+                        60 bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        80bp
+                        80 bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        100bp
+                        100 bp
                       </p>
                       <p
                         class="MuiTypography-root makeStyles-scaleBarLabel MuiTypography-body2"
                         style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
                       >
-                        120bp
+                        120 bp
                       </p>
                     </div>
                   </div>
@@ -703,7 +703,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          10bp
+                          10 bp
                         </p>
                       </div>
                       <div
@@ -713,7 +713,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          20bp
+                          20 bp
                         </p>
                       </div>
                       <div
@@ -723,7 +723,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          30bp
+                          30 bp
                         </p>
                       </div>
                       <div
@@ -733,7 +733,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          40bp
+                          40 bp
                         </p>
                       </div>
                       <div
@@ -743,7 +743,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         <p
                           class="MuiTypography-root makeStyles-majorTickLabel MuiTypography-body1"
                         >
-                          50bp
+                          50 bp
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
Any bp amount over 1 million will be truncated and displayed as Mbs, any bp amount under 1 million and over 1000 will be displayed as kbp and under that amount as bp.

Hide Add Track is now a toggleable option in the LGV menu

Screenshot showing tracks without the add tracks button, and with various displays of bp units:

![image](https://user-images.githubusercontent.com/83305007/171495422-4750caa8-1bb0-48ff-a68f-fd3836b880a9.png)
