### PR TITLE
Add v1.7.9 announcement

### DIFF
--- a/website/release_announcement_drafts/v1.7.9.md
+++ b/website/release_announcement_drafts/v1.7.9.md
@@ -1,0 +1,4 @@
+Hello, we are happy to release v1.7.9!
+
+This features a couple great bugfixes and improvements submitted by community
+members, see release notes for details

--- a/website/release_announcement_drafts/v1.7.9.md
+++ b/website/release_announcement_drafts/v1.7.9.md
@@ -1,4 +1,15 @@
-Hello, we are happy to release v1.7.9!
+We are pleased to present v1.7.9!
 
-This features a couple great bugfixes and improvements submitted by community
-members, see release notes for details
+This release features several bugfixes and improvements submitted by community
+members, including a CLI fix when specifying --indexFile with CSI files, and a
+new feature to get FASTA metadata from an external file.
+
+Additionally, we have switched to canvas2svg for SVG exports, which can now
+handle more sophisticated operations like bezierCurves (used for sashimi-style
+arc in RNA-seq data), and circles (used by jbrowse-plugin-gwas)
+
+Before (note bad intron and lack of arcs rendered on bottom track)
+![](https://user-images.githubusercontent.com/6511937/171530567-8401e44d-4ae9-4d84-b918-3b7dec4fc3ee.png)
+
+After (fixed intron rendering and arcs)
+![](https://user-images.githubusercontent.com/6511937/171530346-8466465f-fbae-49bd-a099-1acb2baddf1d.png)


### PR DESCRIPTION


```
## Unreleased (2022-06-02)

#### :rocket: Enhancement
* `core`
  * [#2483](https://github.com/GMOD/jbrowse-components/pull/2483) Add setting to color by query score per alignment for dotplot, support HTML in config slot descriptions ([@cmdcolin](https://github.com/cmdcolin))
  * [#2983](https://github.com/GMOD/jbrowse-components/pull/2983) Set target=_blank by default in user HTML links ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#2989](https://github.com/GMOD/jbrowse-components/pull/2989) Fix bezierCurveTo ponyfill on firefox ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#2977](https://github.com/GMOD/jbrowse-components/pull/2977) Respect --indexFile option when adding VCF and BED tracks ([@heavywatal](https://github.com/heavywatal))
  * [#2974](https://github.com/GMOD/jbrowse-components/pull/2974) Fix track indexing being ignored after first add track widget usage ([@teresam856](https://github.com/teresam856))

#### :house: Internal
* [#2980](https://github.com/GMOD/jbrowse-components/pull/2980) Remove errors related to test coverage in CI ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 4
- Adam Wright ([@adamjohnwright](https://github.com/adamjohnwright))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Teresa Martinez ([@teresam856](https://github.com/teresam856))
- Watal M. Iwasaki ([@heavywatal](https://github.com/heavywatal))
Done in 1.56s.
```