### PR TITLE
Add reference base and correct percentage calculations to tooltip on SNPCoverage display

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -39,6 +39,7 @@ export function cigarToMismatches(
               start: roffset + j,
               type: 'mismatch',
               base: seq[soffset + j],
+              altbase: ref[roffset + j],
               length: 1,
             })
           }

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -11,18 +11,23 @@ type Count = {
 }
 
 type SNPInfo = {
-  ref: Count
   cov: Count
   lowqual: Count
   noncov: Count
   delskips: Count
+
   total: number
+  ref: number
+  all: number
   '-1': number
   '0': number
   '1': number
 }
 
 const en = (n: number) => n.toLocaleString('en-US')
+
+const pct = (n: number, total: number) =>
+  `${Math.round((n / (total || 1)) * 100)}%`
 
 const TooltipContents = React.forwardRef(
   ({ feature }: { feature: Feature }, ref: any) => {
@@ -31,11 +36,10 @@ const TooltipContents = React.forwardRef(
     const refbase = feature.get('refbase')
     const name = feature.get('refName')
     const info = feature.get('snpinfo') as SNPInfo
-    const loc =
-      [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
-        .filter(f => !!f)
-        .join(':') + (refbase ? ` (${refbase})` : '')
-    const total = info?.total
+    const loc = [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
+      .filter(f => !!f)
+      .join(':')
+    const total = info?.all
 
     return (
       <div ref={ref}>
@@ -53,11 +57,12 @@ const TooltipContents = React.forwardRef(
           <tbody>
             <tr>
               <td>Total</td>
-              <td>{info.total}</td>
+              <td>{total}</td>
             </tr>
             <tr>
               <td>REF {refbase ? `(${refbase.toUpperCase()})` : ''}</td>
               <td>{info.ref}</td>
+              <td>{pct(info.ref, total)}</td>
               <td>
                 {info['-1'] ? `${info['-1']}(-)` : ''}
                 {info['1'] ? `${info['1']}(+)` : ''}
@@ -73,9 +78,7 @@ const TooltipContents = React.forwardRef(
                   <td>
                     {base === 'total' || base === 'skip'
                       ? '---'
-                      : `${Math.floor(
-                          (score.total / (total || score.total || 1)) * 100,
-                        )}%`}
+                      : pct(score.total, total)}
                   </td>
                   <td>
                     {score['-1'] ? `${score['-1']}(-)` : ''}

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -56,7 +56,7 @@ const TooltipContents = React.forwardRef(
               <td>{info.total}</td>
             </tr>
             <tr>
-              <td>REF</td>
+              <td>REF {refbase ? `(${refbase.toUpperCase()})` : ''}</td>
               <td>{info.ref}</td>
               <td>
                 {info['-1'] ? `${info['-1']}(-)` : ''}

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -7,6 +7,9 @@ import { Tooltip } from '@jbrowse/plugin-wiggle'
 type Count = {
   [key: string]: {
     total: number
+    '-1': number
+    '0': number
+    '1': number
   }
 }
 
@@ -15,7 +18,7 @@ type SNPInfo = {
   lowqual: Count
   noncov: Count
   delskips: Count
-
+  refbase: string
   total: number
   ref: number
   all: number
@@ -25,24 +28,30 @@ type SNPInfo = {
 }
 
 const en = (n: number) => n.toLocaleString('en-US')
-
-const pct = (n: number, total: number) =>
-  `${Math.round((n / (total || 1)) * 100)}%`
+const toP = (s = 0) => +(+s).toFixed(1)
+const pct = (n: number, total: number) => `${toP((n / (total || 1)) * 100)}%`
 
 const TooltipContents = React.forwardRef(
-  ({ feature }: { feature: Feature }, ref: any) => {
+  ({ feature }: { feature: Feature }, reactRef: any) => {
     const start = feature.get('start')
     const end = feature.get('end')
-    const refbase = feature.get('refbase')
     const name = feature.get('refName')
-    const info = feature.get('snpinfo') as SNPInfo
+    const {
+      refbase,
+      all,
+      total,
+      ref,
+      '-1': rn1,
+      '1': r1,
+      '0': r0,
+      ...info
+    } = feature.get('snpinfo') as SNPInfo
     const loc = [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
       .filter(f => !!f)
       .join(':')
-    const total = info?.all
 
     return (
-      <div ref={ref}>
+      <div ref={reactRef}>
         <table>
           <caption>{loc}</caption>
           <thead>
@@ -57,36 +66,37 @@ const TooltipContents = React.forwardRef(
           <tbody>
             <tr>
               <td>Total</td>
-              <td>{total}</td>
+              <td>{all}</td>
             </tr>
             <tr>
               <td>REF {refbase ? `(${refbase.toUpperCase()})` : ''}</td>
-              <td>{info.ref}</td>
-              <td>{pct(info.ref, total)}</td>
+              <td>{ref}</td>
+              <td>{pct(ref, all)}</td>
               <td>
-                {info['-1'] ? `${info['-1']}(-)` : ''}
-                {info['1'] ? `${info['1']}(+)` : ''}
+                {rn1 ? `${rn1}(-)` : ''}
+                {r1 ? `${r1}(+)` : ''}
               </td>
               <td />
             </tr>
 
-            {Object.entries(info).map(([key, entry]) =>
-              Object.entries(entry).map(([base, score]) => (
-                <tr key={base}>
-                  <td>{base.toUpperCase()}</td>
-                  <td>{score.total}</td>
-                  <td>
-                    {base === 'total' || base === 'skip'
-                      ? '---'
-                      : pct(score.total, total)}
-                  </td>
-                  <td>
-                    {score['-1'] ? `${score['-1']}(-)` : ''}
-                    {score['1'] ? `${score['1']}(+)` : ''}
-                  </td>
-                  <td>{key}</td>
-                </tr>
-              )),
+            {Object.entries(info as unknown as Record<string, Count>).map(
+              ([key, entry]) =>
+                Object.entries(entry).map(([base, score]) => (
+                  <tr key={base}>
+                    <td>{base.toUpperCase()}</td>
+                    <td>{score.total}</td>
+                    <td>
+                      {base === 'total' || base === 'skip'
+                        ? '---'
+                        : pct(score.total, all)}
+                    </td>
+                    <td>
+                      {score['-1'] ? `${score['-1']}(-)` : ''}
+                      {score['1'] ? `${score['1']}(+)` : ''}
+                    </td>
+                    <td>{key}</td>
+                  </tr>
+                )),
             )}
           </tbody>
         </table>

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -28,12 +28,13 @@ const TooltipContents = React.forwardRef(
   ({ feature }: { feature: Feature }, ref: any) => {
     const start = feature.get('start')
     const end = feature.get('end')
+    const refbase = feature.get('refbase')
     const name = feature.get('refName')
     const info = feature.get('snpinfo') as SNPInfo
-    const loc = [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
-      .filter(f => !!f)
-      .join(':')
-
+    const loc =
+      [name, start === end ? en(start) : `${en(start)}..${en(end)}`]
+        .filter(f => !!f)
+        .join(':') + (refbase ? ` (${refbase})` : '')
     const total = info?.total
 
     return (

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -88,11 +88,13 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
       )
 
       bins.forEach((bin, index) => {
+        const { refbase, ...rest } = bin
         observer.next(
           new SimpleFeature({
             id: `${this.id}-${region.start + index}`,
             data: {
               score: bin.total,
+              refbase,
               snpinfo: bin,
               start: region.start + index,
               end: region.start + index + 1,

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -88,14 +88,12 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
       )
 
       bins.forEach((bin, index) => {
-        const { refbase, ...rest } = bin
         observer.next(
           new SimpleFeature({
             id: `${this.id}-${region.start + index}`,
             data: {
               score: bin.total,
-              refbase,
-              snpinfo: rest,
+              snpinfo: bin,
               start: region.start + index,
               end: region.start + index + 1,
               refName: region.refName,

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -95,7 +95,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
             data: {
               score: bin.total,
               refbase,
-              snpinfo: bin,
+              snpinfo: rest,
               start: region.start + index,
               end: region.start + index + 1,
               refName: region.refName,
@@ -168,6 +168,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
         : undefined
 
     const bins = [] as {
+      refbase?: string
       total: number
       ref: number
       '-1': 0
@@ -320,6 +321,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
               bin.total--
             } else if (!interbase && colorSNPs) {
               inc(bin, fstrand, 'cov', base)
+              bin.refbase = mismatch.altbase
             }
           }
         }

--- a/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/SNPCoverageAdapter.ts
@@ -170,6 +170,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
     const bins = [] as {
       refbase?: string
       total: number
+      all: number
       ref: number
       '-1': 0
       '0': 0
@@ -192,6 +193,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
           if (bins[i] === undefined) {
             bins[i] = {
               total: 0,
+              all: 0,
               ref: 0,
               '-1': 0,
               '0': 0,
@@ -204,6 +206,7 @@ export default class SNPCoverageAdapter extends BaseFeatureDataAdapter {
           }
           if (j !== fend) {
             bins[i].total++
+            bins[i].all++
             bins[i].ref++
             bins[i][fstrand]++
           }


### PR DESCRIPTION
Adds the reference letter, e.g. "REF (T)", to tooltip in the SNPCoverageDisplay if you are mouse-overed on a mismatch. This is a follow up from some suggestions @gringer  made recently in #2833 

Also includes a better calculation of percents when including indels (previously used a "total" score that is subtracted against when encountering a deletion, now counts the deletion against a new variable called "all" that is not subtracted against when encountering a deletion)

Before
![Screenshot from 2022-06-03 11-39-55](https://user-images.githubusercontent.com/6511937/171917563-7e6f90e4-5854-4201-aecb-0f42efee0c4a.png)


After
![Screenshot from 2022-06-03 11-39-20](https://user-images.githubusercontent.com/6511937/171917468-a0d88c6b-2fd9-4cb3-81e8-af514d0d9b50.png)
