### PR TITLE
Small fix to rankSearchResults logic

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -177,11 +177,18 @@ export function stateModelFactory(pluginManager: PluginManager) {
       get interRegionPaddingWidth() {
         return INTER_REGION_PADDING_WIDTH
       },
+
+      get assemblyNames() {
+        return [
+          ...new Set(self.displayedRegions.map(region => region.assemblyName)),
+        ]
+      },
     }))
     .views(self => ({
       get assemblyErrors() {
         const { assemblyManager } = getSession(self)
-        return this.assemblyNames
+        const { assemblyNames } = self
+        return assemblyNames
           .map(a => assemblyManager.get(a)?.error)
           .filter(f => !!f)
           .join(', ')
@@ -189,9 +196,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       get assembliesInitialized() {
         const { assemblyManager } = getSession(self)
-        return this.assemblyNames.every(
-          a => assemblyManager.get(a)?.initialized,
-        )
+        const { assemblyNames } = self
+        return assemblyNames.every(a => assemblyManager.get(a)?.initialized)
       },
       get initialized() {
         return self.volatileWidth !== undefined && this.assembliesInitialized
@@ -273,11 +279,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
         }
       },
 
-      get assemblyNames() {
-        return [
-          ...new Set(self.displayedRegions.map(region => region.assemblyName)),
-        ]
-      },
       searchScope(assemblyName: string) {
         return {
           assemblyName,
@@ -286,13 +287,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
         }
       },
 
-      /**
-       * @param refName - refName of the displayedRegion
-       * @param coord - coordinate at the displayed Region
-       * @param regionNumber - optional param used as identifier when
-       * there are multiple displayedRegions with the same refName
-       * @returns offsetPx of the displayed region that it lands in
-       */
       bpToPx({
         refName,
         coord,
@@ -396,10 +390,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
           track => track.configuration.trackId,
         )
         results.forEach(result => {
-          if (openTrackIds !== []) {
-            if (openTrackIds.includes(result.trackId)) {
-              result.updateScore(result.getScore() + 1)
-            }
+          if (openTrackIds.includes(result.trackId)) {
+            result.updateScore(result.getScore() + 1)
           }
         })
         return results
@@ -407,7 +399,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       // modifies view menu action onClick to apply to all tracks of same type
       rewriteOnClicks(trackType: string, viewMenuActions: MenuItem[]) {
-        viewMenuActions.forEach((action: MenuItem) => {
+        viewMenuActions.forEach(action => {
           // go to lowest level menu
           if ('subMenu' in action) {
             this.rewriteOnClicks(trackType, action.subMenu)


### PR DESCRIPTION
The !== comparison to [] is not a valid operation as it would always be false

e.g. it is referential equality, whether it refers to the exact same array, so with this even []!==[] is true

Just a small fix. This may or may not actually improve search results, haven't tested