### PR TITLE
Allow whitespace separated refname,start,end type locstring

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HelpDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HelpDialog.tsx
@@ -32,11 +32,8 @@ export default function HelpDialog({
         Using the search box
         {handleClose ? (
           <IconButton
-            data-testid="close-resultsDialog"
             className={classes.closeButton}
-            onClick={() => {
-              handleClose()
-            }}
+            onClick={() => handleClose()}
           >
             <CloseIcon />
           </IconButton>
@@ -80,6 +77,10 @@ export default function HelpDialog({
           <li>
             <code>chr1:1-100[rev] chr2:1-100</code> - open up the first region
             in the horizontally flipped orientation
+          </li>
+          <li>
+            <code>chr1 100 200</code> - use whitespace separated refname, start,
+            end
           </li>
         </ul>
       </DialogContent>

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -72,7 +72,7 @@ function initialize() {
     })
     .actions(self => ({
       isValidRefName(str: string) {
-        return !str.includes(':')
+        return str === 'ctgA' || str === 'ctgB'
       },
       get(str: string) {
         return self.assemblies.get(str)
@@ -989,8 +989,23 @@ test('multi region', () => {
   model.navToLocString('ctgA ctgB')
   expect(model.displayedRegions[0].refName).toBe('ctgA')
   expect(model.displayedRegions[1].refName).toBe('ctgB')
-  // [
-  //   { refName: 'ctgA', start: 0, end: 50001 },
-  //   { refName: 'ctgB', start: 0, end: 6079 },
-  // ])
+})
+
+test('space separated locstring', () => {
+  const { Session, LinearGenomeModel } = initialize()
+  const model = Session.create({
+    configuration: {},
+  }).setView(
+    LinearGenomeModel.create({
+      type: 'LinearGenomeView',
+      tracks: [{ name: 'foo track', type: 'BasicTrack' }],
+    }),
+  )
+  model.setWidth(800)
+  model.setDisplayedRegions(volvoxDisplayedRegions.slice(0, 1))
+
+  model.navToLocString('ctgA 0 100')
+
+  expect(model.offsetPx).toBe(0)
+  expect(model.bpPerPx).toBe(0.125)
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -675,13 +675,38 @@ export function stateModelFactory(pluginManager: PluginManager) {
         const { assemblyManager } = getSession(self)
         const { isValidRefName } = assemblyManager
         const assemblyName = optAssemblyName || assemblyNames[0]
+        let parsedLocStrings
+        const inputs = locString
+          .split(/(\s+)/)
+          .map(f => f.trim())
+          .filter(f => !!f)
 
-        const parsedLocStrings = locString
-          .split(' ')
-          .filter(f => !!f.trim())
-          .map(l => parseLocString(l, ref => isValidRefName(ref, assemblyName)))
+        // first try interpreting as a whitespace-separated sequence of
+        // multiple locstrings
+        try {
+          parsedLocStrings = inputs.map(l =>
+            parseLocString(l, ref => isValidRefName(ref, assemblyName)),
+          )
+        } catch (e) {
+          // if this fails, try interpreting as a whitespace-separated refname,
+          // start, end if start and end are integer inputs
+          const [refName, start, end] = inputs
+          if (
+            `${e}`.match(/Unknown reference sequence/) &&
+            Number.isInteger(+start) &&
+            Number.isInteger(+end)
+          ) {
+            parsedLocStrings = [
+              parseLocString(refName + ':' + start + '..' + end, ref =>
+                isValidRefName(ref, assemblyName),
+              ),
+            ]
+          } else {
+            throw e
+          }
+        }
 
-        const locations = parsedLocStrings.map(region => {
+        const locations = parsedLocStrings?.map(region => {
           const asmName = region.assemblyName || assemblyName
           const asm = assemblyManager.get(asmName)
           const { refName } = region


### PR DESCRIPTION
Fixes #2978

Allows you to enter e.g. ctgA 1 100 to navigate to ctgA:1-100. Can be any type of whitespace separated

The code first tries to interpret this as a sequence of locstrings first, to handle our usage of e.g. ctgA ctgB to navigate to multiple chromosomes, but if one of the inputted sequences is not a locstring it throws an exception which we catch and then retry using whitespace separated refName,start,end
