### PR TITLE
Add button to copy track config in About track dialog

### DIFF
--- a/packages/core/ui/AboutDialog.tsx
+++ b/packages/core/ui/AboutDialog.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react'
+import copy from 'copy-to-clipboard'
 import {
+  Button,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -28,11 +30,13 @@ export default function AboutDialog({
   handleClose,
 }: {
   config: AnyConfigurationModel
+
   handleClose: () => void
 }) {
   const classes = useStyles()
   const [info, setInfo] = useState<FileInfo>()
   const [error, setError] = useState<unknown>()
+  const [copied, setCopied] = useState(false)
   const session = getSession(config)
   const { rpcManager } = session
   const conf = readConfObject(config)
@@ -67,12 +71,13 @@ export default function AboutDialog({
 
   let trackName = readConfObject(config, 'name')
   if (readConfObject(config, 'type') === 'ReferenceSequenceTrack') {
-    trackName = 'Reference Sequence'
-    session.assemblies.forEach(assembly => {
-      if (assembly.sequence === config.configuration) {
-        trackName = `Reference Sequence (${readConfObject(assembly, 'name')})`
-      }
-    })
+    const asm = session.assemblies.find(
+      a => a.sequence === config.configuration,
+    )
+
+    trackName = asm
+      ? `Reference Sequence (${readConfObject(asm, 'name')})`
+      : 'Reference Sequence'
   }
 
   const details =
@@ -97,6 +102,17 @@ export default function AboutDialog({
       </DialogTitle>
       <DialogContent>
         <BaseCard title="Configuration">
+          <Button
+            variant="contained"
+            style={{ float: 'right' }}
+            onClick={() => {
+              copy(JSON.stringify(conf, null, 2))
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1000)
+            }}
+          >
+            {copied ? 'Copied to clipboard!' : 'Copy config'}
+          </Button>
           <Attributes
             attributes={conf}
             omit={['displays', 'baseUri', 'refNames']}


### PR DESCRIPTION
Allows you to copy the JSON to clipboard using a button click in the about track dialog

![image](https://user-images.githubusercontent.com/6511937/172653136-720e48f9-2e9f-494b-8dda-a1708e74d089.png)


May help with e.g. #2889

This type of feature requires otherwise going into the chrome dev console to try to copy it out. This feature can allow a little "lightweight" admin server type functionality since you can copy track configs back into your config.json manually.