### PR TITLE
Allow choosing trackId when using text-index with --file with --fileId

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -465,6 +465,8 @@ OPTIONS
   --file=file                  File or files to index (can be used to create trix indexes for embedded component use
                                cases not using a config.json for example)
 
+  --fileId=fileId              Set the trackId used for the indexes generated with the --file argument
+
   --force                      Overwrite previously existing indexes
 
   --out=out                    Synonym for target

--- a/products/jbrowse-cli/src/commands/text-index.ts
+++ b/products/jbrowse-cli/src/commands/text-index.ts
@@ -97,6 +97,11 @@ export default class TextIndex extends JBrowseCommand {
         'File or files to index (can be used to create trix indexes for embedded component use cases not using a config.json for example)',
       multiple: true,
     }),
+    fileId: flags.string({
+      description:
+        'Set the trackId used for the indexes generated with the --file argument',
+      multiple: true,
+    }),
     dryrun: flags.boolean({
       description:
         'Just print out tracks that will be indexed by the process, without doing any indexing',
@@ -320,7 +325,16 @@ export default class TextIndex extends JBrowseCommand {
 
   async indexFileList() {
     const { flags } = this.parse(TextIndex)
-    const { out, target, file, attributes, quiet, exclude, prefixSize } = flags
+    const {
+      out,
+      target,
+      fileId,
+      file,
+      attributes,
+      quiet,
+      exclude,
+      prefixSize,
+    } = flags
     const outFlag = target || out || '.'
     const trixDir = path.join(outFlag, 'trix')
     if (!fs.existsSync(trixDir)) {
@@ -330,6 +344,12 @@ export default class TextIndex extends JBrowseCommand {
     const configs = file
       .map(file => guessAdapterFromFileName(file))
       .filter(fileConfig => supported(fileConfig.adapter.type))
+
+    if (fileId?.length) {
+      for (let i = 0; i < fileId.length; i++) {
+        configs[i].trackId = fileId[i]
+      }
+    }
 
     await this.indexDriver({
       configs,


### PR DESCRIPTION
Fixes #2959 

Let's you run a command like

```
jbrowse text-index --file t1.vcf.gz --fileId t1
```

By default, without `--fileId`, then the output assumes the trackId will be t1.vcf.gz  (equal to the filename) but is overridden by `--fileId`