### PR TITLE
Proposal: modified configuration format for display types

### DIFF
--- a/packages/core/pluggableElementTypes/DisplayType.ts
+++ b/packages/core/pluggableElementTypes/DisplayType.ts
@@ -13,12 +13,18 @@ export default class DisplayType extends PluggableElementBase {
 
   trackType: string
 
+  // priority allows a given display to be "higher priority" for being the
+  // default when you turn on a track for the first time. higher number ==
+  // higher priority
+  priority: number
+
   viewType: string
 
   constructor(stuff: {
     name: string
     stateModel: IAnyModelType
     trackType: string
+    priority?: number
     viewType: string
     configSchema: AnyConfigurationSchemaType
     ReactComponent: AnyReactComponentType
@@ -29,6 +35,7 @@ export default class DisplayType extends PluggableElementBase {
     this.ReactComponent = stuff.ReactComponent
     this.trackType = stuff.trackType
     this.viewType = stuff.viewType
+    this.priority = stuff.priority || 0
     if (!this.stateModel) {
       throw new Error(`no stateModel defined for display ${this.name}`)
     }

--- a/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
+++ b/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
@@ -89,15 +89,22 @@ export function createBaseTrackConfig(pluginManager: PluginManager) {
           const trackType = pluginManager.getTrackType(snap.type)
           trackType.displayTypes.forEach(d => {
             displays[d.name] = displays[d.name] || {
-              displayId: `${snap.trackId}-${d.name}`,
               type: d.name,
               priority: -1,
             }
           })
         }
+        console.log({ displays }, snap.trackId)
         return {
           ...snap,
-          displays,
+          displays: Object.fromEntries(
+            Object.entries(displays).map(([key, val]) => [
+              key,
+              // synthesizes display id if none availble
+              // @ts-ignore
+              { displayId: `${snap.trackId}-${key}`, ...val },
+            ]),
+          ),
         }
       },
       explicitIdentifier: 'trackId',

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1220,7 +1220,7 @@ export function getCompatibleDisplays(
     .map(d => d.name)
 
   const trackDisplays = [...config.displays.entries()]
-    .sort((a, b) => b[1].priority.value - a[1].priority.value)
+    .sort((a, b) => (b[1].priority?.value || 0) - (a[1].priority?.value || 0))
     .map(ent => ent[0])
 
   // note: order of params to intersect matter here: this prioritizes

--- a/plugins/alignments/src/LinearAlignmentsDisplay/index.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/index.ts
@@ -14,6 +14,7 @@ export default function (pluginManager: PluginManager) {
       stateModel: modelFactory(pluginManager, configSchema),
       trackType: 'AlignmentsTrack',
       viewType: 'LinearGenomeView',
+      priority: 1,
       ReactComponent,
     })
   })

--- a/plugins/alignments/src/LinearPileupDisplay/index.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/index.ts
@@ -13,6 +13,7 @@ export default function register(pluginManager: PluginManager) {
       stateModel: modelFactory(configSchema),
       trackType: 'AlignmentsTrack',
       viewType: 'LinearGenomeView',
+      priority: 0,
       ReactComponent: BaseLinearDisplayComponent,
     })
   })

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/index.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/index.ts
@@ -13,6 +13,7 @@ export default function register(pluginManager: PluginManager) {
       stateModel: modelFactory(pluginManager, configSchema),
       trackType: 'AlignmentsTrack',
       viewType: 'LinearGenomeView',
+      priority: 0,
       ReactComponent: LinearWiggleDisplayReactComponent,
     })
   })

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -224,6 +224,7 @@ const HierarchicalTree = observer(({ height, tree, model }) => {
         try {
           view.toggleTrack(trackId)
         } catch (e) {
+          console.error(e)
           session.notify(`${e}`, 'error')
         }
       },

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.js
@@ -220,7 +220,13 @@ const HierarchicalTree = observer(({ height, tree, model }) => {
 
   const extra = useMemo(
     () => ({
-      onChange: trackId => view.toggleTrack(trackId),
+      onChange: trackId => {
+        try {
+          view.toggleTrack(trackId)
+        } catch (e) {
+          session.notify(`${e}`, 'error')
+        }
+      },
       toggleCollapse: pathName => model.toggleCategory(pathName),
       onMoreInfo: setMoreInfo,
       drawerPosition,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.js
@@ -147,10 +147,8 @@ export default pluginManager =>
             })
             .filter(conf => {
               const { displayTypes } = pluginManager.getViewType(self.view.type)
-              const compatibleDisplays = displayTypes.map(
-                display => display.name,
-              )
-              const trackDisplays = conf.displays.map(display => display.type)
+              const compatibleDisplays = displayTypes.map(d => d.name)
+              const trackDisplays = [...conf.displays.keys()]
               return hasAnyOverlap(compatibleDisplays, trackDisplays)
             }),
         ])

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/baseLinearDisplayConfigSchema.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/baseLinearDisplayConfigSchema.ts
@@ -3,6 +3,11 @@ import { ConfigurationSchema } from '@jbrowse/core/configuration'
 export const baseLinearDisplayConfigSchema = ConfigurationSchema(
   'BaseLinearDisplay',
   {
+    priority: {
+      type: 'number',
+      description: 'The priority to give to this display type in your config',
+      defaultValue: 0,
+    },
     maxFeatureScreenDensity: {
       type: 'number',
       description:

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -85,7 +85,7 @@ function TrackContainer({
   track: BaseTrackModel
 }) {
   const classes = useStyles()
-  const display = track.displays[0]
+  const display = track.display
   const { horizontalScroll, draggingTrackId, moveTrack } = model
   const { height } = display
   const trackId = getConf(track, 'trackId')

--- a/plugins/sequence/src/referenceSeqTrackConfig.ts
+++ b/plugins/sequence/src/referenceSeqTrackConfig.ts
@@ -30,21 +30,21 @@ export function createReferenceSeqTrackConfig(pluginManager: PluginManager) {
         const snap = JSON.parse(JSON.stringify(s))
         const displayTypes = new Set()
         const { displays = [] } = snap
-        if (snap.trackId !== 'placeholderId') {
-          // Gets the displays on the track snapshot and the possible displays
-          // from the track type and adds any missing possible displays to the
-          // snapshot
-          displays.forEach((d: any) => d && displayTypes.add(d.type))
-          const trackType = pluginManager.getTrackType(snap.type)
-          trackType.displayTypes.forEach(displayType => {
-            if (!displayTypes.has(displayType.name)) {
-              displays.push({
-                displayId: `${snap.trackId}-${displayType.name}`,
-                type: displayType.name,
-              })
-            }
-          })
-        }
+        // if (snap.trackId !== 'placeholderId') {
+        //   // Gets the displays on the track snapshot and the possible displays
+        //   // from the track type and adds any missing possible displays to the
+        //   // snapshot
+        //   displays.forEach((d: any) => d && displayTypes.add(d.type))
+        //   const trackType = pluginManager.getTrackType(snap.type)
+        //   trackType.displayTypes.forEach(displayType => {
+        //     if (!displayTypes.has(displayType.name)) {
+        //       displays.push({
+        //         displayId: `${snap.trackId}-${displayType.name}`,
+        //         type: displayType.name,
+        //       })
+        //     }
+        //   })
+        // }
         return { ...snap, displays }
       },
       explicitIdentifier: 'trackId',

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1671,6 +1671,35 @@
           }
         }
       }
+    },
+
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "volvox_cram_snpcoverage_new_display_config",
+      "name": "volvox-sorted.cram (new display config type)",
+      "category": ["Integration test"],
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "volvox-sorted-altname.cram",
+          "locationType": "UriLocation"
+        },
+        "craiLocation": {
+          "uri": "volvox-sorted-altname.cram.crai",
+          "locationType": "UriLocation"
+        },
+        "sequenceAdapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "volvox.2bit",
+            "locationType": "UriLocation"
+          }
+        }
+      },
+      "displays": {
+        "LinearSNPCoverageDisplay": {}
+      }
     }
   ],
   "defaultSession": {


### PR DESCRIPTION
This is a somewhat experimental proposal that makes a change to the config file to use a key-value map instead of array for the displays config slot in the config file. To see an example:

The current way that we configure e.g. display and renderer slots on the a variant track

```
{
  "type": "VariantTrack",
  "trackId": "mytrack",
  "name": "mytrack",
  "assemblyNames": ["volvox"],
  "adapter": /* stuff here */,
  "displays": [
    {
      "type": "LinearVariantDisplay",
      "maxFeatureScreenDensity": 0.0006,
      "displayId": "volvox_filtered_vcf_color-LinearVariantDisplay",
      "renderer": {
        "type": "SvgFeatureRenderer",
        "color1": "jexl:get(feature,'type')=='SNV'?'green':'purple'"
      }
    }
  ]
}

```

This PR changes it to allow something more like this

```
{
  "type": "VariantTrack",
  "trackId": "mytrack",
  "name": "mytrack",
  "assemblyNames": ["volvox"],
  "adapter": /* stuff here */,
  "displays": {
    "LinearVariantDisplay": {
      "maxFeatureScreenDensity": 0.0006,
      "renderer": {
        "type": "SvgFeatureRenderer",
        "color1": "jexl:get(feature,'type')=='SNV'?'green':'purple'"
      }
    }
  }
}

```

This PR includes a snapshot preprocessor that is able to load the older config slot, keeping some backwards compatibility for the older config style, but internally, code that refers to displays would need to update to refer to the hashmap.

Another feature of this PR: this PR codifies the concept of "priority" that the user (via config) and plugin developers (by adding priority to their display type) can choose to make sure their track is displayed in a given config by default on first click from the track selector



