### PR TITLE
Fix ability to use callbacks for the linear arc renderer

### DIFF
--- a/plugins/arc/src/ArcRenderer/configSchema.tsx
+++ b/plugins/arc/src/ArcRenderer/configSchema.tsx
@@ -7,11 +7,13 @@ export default ConfigurationSchema(
       type: 'color',
       description: 'the color of the arcs',
       defaultValue: 'darkblue',
+      contextVariable: ['feature'],
     },
     thickness: {
       type: 'number',
       description: 'the thickness of the arcs',
       defaultValue: `jexl:logThickness(feature,'score')`,
+      contextVariable: ['feature'],
     },
     label: {
       type: 'string',
@@ -23,6 +25,7 @@ export default ConfigurationSchema(
       type: 'number',
       description: 'the height of the arcs',
       defaultValue: `jexl:log10(get(feature,'end')-get(feature,'start'))*50`,
+      contextVariable: ['feature'],
     },
     caption: {
       type: 'string',


### PR DESCRIPTION
I think it is intended for all the linear arc renderer slots to be able to become callbacks, but it is not displayed this way in the user interface since they lack the "contextVariable"