### PR TITLE
Fix export SVG crash on some BigWig tracks

### DIFF
--- a/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
+++ b/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
@@ -16,7 +16,7 @@ function fillRect(
   color?: string,
 ) {
   if (color) {
-    ctx.fillStyle = color
+    ctx.fillStyle = String(color)
   }
   if (width < 0) {
     x += width
@@ -123,12 +123,11 @@ export default class XYPlotRenderer extends WiggleBaseRenderer {
             filled ? toHeight(maxr) - toHeight(score) : 1,
             crossingOrigin
               ? colorCallback(feature, maxr)
-              : Color(c).lighten(0.6).toString(),
+              : Color(c).lighten(0.6),
           )
         }
 
         // normal
-
         fillRect(
           ctx,
           leftPx,
@@ -152,7 +151,7 @@ export default class XYPlotRenderer extends WiggleBaseRenderer {
             filled ? toHeight(minr) : 1,
             crossingOrigin
               ? colorCallback(feature, minr)
-              : Color(c).darken(0.6).toString(),
+              : Color(c).darken(0.6),
           )
         }
       } else {


### PR DESCRIPTION
Fixes #3046

Need to make sure to stringify the result. The HTML5 canvas API presumably automatically stringifies the fillStyle object, but canvas2svg needs to do this manually.

It is perhaps a bit surprising that typescript does not catch the Color object as not being a string in our custom fillRect helper function, but this PR should help avoid crash