### PR TITLE
Fix strand on mcscan anchors alignments

### DIFF
--- a/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
+++ b/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
@@ -10,6 +10,7 @@ import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readFile, parseBed } from '../util'
 
 interface BareFeature {
+  strand: number
   refName: string
   start: number
   end: number
@@ -100,6 +101,9 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
                 ...f1,
                 uniqueId: `${index}-${rowNum}`,
                 syntenyId: rowNum,
+                // note: strand would be -1 if the two features are on opposite strands,
+                // indicating inverted alignment
+                strand: f1.strand * f2.strand,
                 score,
                 mate: f2 as BareFeature,
               }),


### PR DESCRIPTION
With this PR, properly identifies that the gene is inverted

![Screenshot from 2022-07-07 12-44-05](https://user-images.githubusercontent.com/6511937/177846355-6606030b-593d-4849-8361-69b474544201.png)

Without this PR, thinks it is the same strand

![Screenshot from 2022-07-07 12-43-56](https://user-images.githubusercontent.com/6511937/177846369-2edf0b81-00d6-46f7-9761-04c82853e972.png)

The logic added in this PR: if the genes are on different strands (f.strand*f.strand===-1) then it is inverted
