### PR TITLE
Fix the display of deletions vs insertions being backwards in synteny view with CIGAR strings

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -249,11 +249,11 @@ function LinearSyntenyRendering({
                 cx1 += d1 * rev1
                 cx2 += d2 * rev2
               } else if (op === 'D') {
-                cx1 += d1 * rev1
-              } else if (op === 'N') {
-                cx1 += d1 * rev1
-              } else if (op === 'I') {
                 cx2 += d2 * rev2
+              } else if (op === 'N') {
+                cx2 += d2 * rev2
+              } else if (op === 'I') {
+                cx1 += d1 * rev1
               }
 
               // check that we are even drawing in view here, e.g. that all


### PR DESCRIPTION
Was seen because the mouseover, worked on in #3071 does not incorporate CIGARs, just using feature.start and feature.end but it did not match up with what the CIGAR renderings were showing. Flipping the orientation of insertions and deletions fixes the issue
