### PR TITLE
Fix negative strand CIGAR renderings on linear synteny view

### DIFF
--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -11,7 +11,7 @@ export interface Mismatch {
 }
 const mdRegex = new RegExp(/(\d+|\^[a-z]+|[a-z])/gi)
 const modificationRegex = new RegExp(/([A-Z])([-+])([^,.?]+)([.?])?/)
-export function parseCigar(cigar: string = '') {
+export function parseCigar(cigar = '') {
   return cigar.split(/([MIDNSHPX=])/).slice(0, -1)
 }
 export function cigarToMismatches(

--- a/plugins/alignments/src/BamAdapter/MismatchParser.ts
+++ b/plugins/alignments/src/BamAdapter/MismatchParser.ts
@@ -11,8 +11,8 @@ export interface Mismatch {
 }
 const mdRegex = new RegExp(/(\d+|\^[a-z]+|[a-z])/gi)
 const modificationRegex = new RegExp(/([A-Z])([-+])([^,.?]+)([.?])?/)
-export function parseCigar(cigar: string) {
-  return (cigar || '').split(/([MIDNSHPX=])/)
+export function parseCigar(cigar: string = '') {
+  return cigar.split(/([MIDNSHPX=])/).slice(0, -1)
 }
 export function cigarToMismatches(
   ops: string[],

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -297,6 +297,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
                 refName,
                 strand,
                 assemblyName,
+                revCigar: true,
                 syntenyId: i,
                 ...(numMatches && blockLen
                   ? { identity: numMatches / blockLen }

--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -401,7 +401,7 @@ function LinearSyntenyRendering({
             let cx2 = x21
 
             // we have to read the CIGAR backwards when looking at negative strand features
-            const f1flipped = f1.get('strand')
+            const f1flipped = f1.get('revCigar') && f1.get('strand') === -1
 
             // flip the direction of the CIGAR drawing in horizontally flipped
             // modes

--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -326,6 +326,9 @@ function LinearSyntenyRendering({
         ctx1.fillStyle = colorMap.M
         ctx1.strokeStyle = colorMap.M
         ctx2.fillStyle = `rgb(${r},${g},${b})`
+
+        // too many click map false positives with colored stroked lines
+        // ctx2.strokeStyle = `rgb(${r},${g},${b})`
         drawMatchSimple({
           cb: ctx => ctx.fill(),
           match: m,
@@ -415,9 +418,7 @@ function LinearSyntenyRendering({
               let continuingFlag = false
               let px1 = 0
               let px2 = 0
-              const unitMultiplier2 = Math.floor(
-                MAX_COLOR_RANGE / (cigar.length / 2),
-              )
+              const unitMultiplier2 = Math.floor(MAX_COLOR_RANGE / cigar.length)
               for (
                 let j = f1flipped ? cigar.length - 2 : 0;
                 f1flipped ? j >= 0 : j < cigar.length;
@@ -663,9 +664,7 @@ function LinearSyntenyRendering({
             return
           }
           const cigar = parsedCIGARs.get(match1[0].feature.id()) || []
-          const unitMultiplier2 = Math.floor(
-            MAX_COLOR_RANGE / (cigar.length / 2),
-          )
+          const unitMultiplier2 = Math.floor(MAX_COLOR_RANGE / cigar.length)
           const cigarIdx = getId(r2, g2, b2, unitMultiplier2)
           const f1 = match1[0].feature
           const f2 = match1[1].feature


### PR DESCRIPTION
Inspection of the DNA bases found that what was being rendered as the CIGAR (e.g. yellow and blue insertions/deletions) did not match up properly, so this fixes the issue