### PR TITLE
Show a descriptive error if an adapter doesn't provide a sequence

### DIFF
--- a/plugins/config/src/FromConfigAdapter/FromConfigSequenceAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigSequenceAdapter.ts
@@ -3,8 +3,12 @@ import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import { NoAssemblyRegion } from '@jbrowse/core/util/types'
 import { toArray } from 'rxjs/operators'
 import FromConfigAdapter from './FromConfigAdapter'
+import { RegionsAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
 
-export default class FromConfigSequenceAdapter extends FromConfigAdapter {
+export default class FromConfigSequenceAdapter
+  extends FromConfigAdapter
+  implements RegionsAdapter
+{
   /**
    * Fetch features for a certain region
    * @param region - Region

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceDialog.tsx
@@ -119,6 +119,9 @@ function SequenceDialog({
             regionsSelected,
             controller.signal,
           )
+          if (!chunks.length) {
+            throw new Error('Adapter does not support getting sequences')
+          }
           if (active) {
             setSequence(
               formatSeqFasta(
@@ -248,7 +251,7 @@ function SequenceDialog({
         >
           Download FASTA
         </Button>
-        <Button onClick={handleClose} color="primary" autoFocus>
+        <Button onClick={handleClose} variant="contained">
           Close
         </Button>
       </DialogActions>

--- a/plugins/sequence/src/ChromSizesAdapter/ChromSizesAdapter.ts
+++ b/plugins/sequence/src/ChromSizesAdapter/ChromSizesAdapter.ts
@@ -59,10 +59,6 @@ export default class extends BaseAdapter implements RegionsAdapter {
     }))
   }
 
-  public getFeatures() {
-    throw new Error('sequence not available')
-  }
-
   public getHeader() {
     return {}
   }


### PR DESCRIPTION
This change shows an error in the "Get sequence" dialog that says that the adapter doesn't provide a sequence for relevant adapters (e.g. ChromSizesAdapter). Previously it showed an empty sequence box. The error looks like this: 

![image](https://user-images.githubusercontent.com/25592344/178373615-b18508f6-fe69-4e06-98ca-0f8213f47382.png)

Had to remove `getFeatures` in ChromSizesAdapter so that the `isFeatureAdapter` check in `CoreGetFeatures` does the right thing.
