### PR TITLE
Fix zoom to behavior being inaccurate with many displayed regions visible

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -296,7 +296,7 @@ test('can navToMultiple', () => {
     { refName: 'ctgA', start: 5000, end: 10000 },
     { refName: 'ctgC', start: 0, end: 5000 },
   ])
-  expect(model.offsetPx).toBe(2799)
+  expect(model.offsetPx).toBe(2793)
   expect(model.bpPerPx).toBeCloseTo(12.531)
 })
 
@@ -423,7 +423,8 @@ describe('Zoom to selected displayed regions', () => {
       },
     )
     // offsetPx is still 0 since we are starting from the first coord
-    expect(model.offsetPx).toBe(0)
+    // needed Math.abs since it was giving negative-zero (-0)
+    expect(Math.abs(model.offsetPx)).toEqual(0)
     // endOffset 19000 - (-1) = 19001 /  800 = zoomTo(23.75)
     expect(model.bpPerPx).toBeCloseTo(23.75)
     expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
@@ -533,7 +534,7 @@ test('can instantiate a model that >2 regions', () => {
     { refName: 'ctgB', index: 1, offset: 0, start: 0, end: 10000 },
     { refName: 'ctgC', index: 2, offset: 0, start: 0, end: 10000 },
   )
-  expect(model.offsetPx).toEqual(10000 / model.bpPerPx + 2)
+  expect(model.offsetPx).toEqual(10000 / model.bpPerPx)
   expect(model.displayedRegionsTotalPx).toEqual(30000 / model.bpPerPx)
   model.showAllRegions()
   expect(model.offsetPx).toEqual(-40)

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -1009,10 +1009,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             bpToStart += region.end - region.start
           }
         }
-        self.scrollTo(
-          Math.round(bpToStart / self.bpPerPx) +
-            self.interRegionPaddingWidth * start.index,
-        )
+        self.offsetPx = Math.round(bpToStart / self.bpPerPx)
       },
 
       horizontalScroll(distance: number) {


### PR DESCRIPTION
Fixes #3083 

This is a one-liner fix in the LGV model with a couple of fixed tests

Intuitively using the app gives reasonable values for rubberband selections (which are the primary user of the moveTo function that we fix here) even with many displayed regions visible (which commonly occurs with show all regions and synteny views)

https://jbrowse.org/code/jb2/fix_zoomto/?config=test_data%2Fconfig_dotplot.json&session=share-qZrNF9OGYz&password=MMo0X can be tested and appear to work ok
