### PR TITLE
Fix labels being cut-off in SVG features by rendering feature labels on main thread

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
@@ -21,6 +21,7 @@ function FeatureGlyph(props: {
   shouldShowDescription: boolean
   fontHeight: number
   allowedWidthExpansion: number
+  exportSVG: unknown
   displayModel: DisplayModel
   selected?: boolean
   reversed?: boolean

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -50,14 +50,20 @@ export default observer(
 
     const viewLeft = reversed ? params.end : params.start
 
-    if (isStateTreeNode(region) && !isAlive(region)) {
-      return null
-    }
     const [labelVisible, setLabelVisible] = useState(exportSVG)
 
+    // we use an effect to set the label visible because there can be a
+    // mismatch between the server and the client after hydration due to the
+    // floating labels. if we are exporting an SVG we allow it as is though and
+    // do not use the effetct
     useEffect(() => {
       setLabelVisible(true)
     }, [])
+
+    if (isStateTreeNode(region) && !isAlive(region)) {
+      return null
+    }
+
     const rstart = region.start
     const rend = region.end
     const fstart = feature.get('start')

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { observer } from 'mobx-react'
 import { isAlive, isStateTreeNode } from 'mobx-state-tree'
 import { measureText, getViewParams, Feature, Region } from '@jbrowse/core/util'
@@ -12,6 +12,7 @@ export default observer(
     region,
     reversed,
     bpPerPx,
+    exportSVG,
     feature,
     viewParams,
     color = 'black',
@@ -32,6 +33,7 @@ export default observer(
     reversed?: boolean
     displayModel: DisplayModel
     region: Region
+    exportSVG: unknown
     viewParams: {
       start: number
       end: number
@@ -51,6 +53,11 @@ export default observer(
     if (isStateTreeNode(region) && !isAlive(region)) {
       return null
     }
+    const [labelVisible, setLabelVisible] = useState(exportSVG)
+
+    useEffect(() => {
+      setLabelVisible(true)
+    }, [])
     const rstart = region.start
     const rend = region.end
     const fstart = feature.get('start')
@@ -74,12 +81,12 @@ export default observer(
       x = params.offsetPx1
     }
 
-    return (
+    return labelVisible ? (
       <text x={x} y={y + fontHeight} fill={color} fontSize={fontHeight}>
         {measuredTextWidth > totalWidth
           ? `${text.slice(0, totalWidth / (fontHeight * 0.6))}...`
           : text}
       </text>
-    )
+    ) : null
   },
 )

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -32,6 +32,7 @@ function RenderedFeatureGlyph(props: {
   layout: BaseLayout<unknown>
   extraGlyphs: ExtraGlyphValidator[]
   displayMode: string
+  exportSVG: unknown
   displayModel: DisplayModel
   viewParams: {
     start: number
@@ -145,6 +146,7 @@ const RenderedFeatures = observer(
     displayMode: string
     displayModel: DisplayModel
     region: Region
+    exportSVG: unknown
     extraGlyphs: ExtraGlyphValidator[]
     layout: BaseLayout<unknown>
     viewParams: {


### PR DESCRIPTION
Currently, there can be a mismatch between the server and the client when hydrating feature labels since they are floated to the right position on the client side, and this can result in the labels being cut off sometimes

The server tries to float the feature labels in the right place,  but a mismatch can still occur because if the user scrolls for example during the time the request is sent to when it is hydrated, it can mismatch.

To help with this, this PR proposes using a useEffect to render the feature only on the main thread (e.g. the useEffect would only be used once hydrated)

There is a caveat for exportSVG which does use the server side to render the features labels in the requested position, there is no main thread "hydration" of the ssr component from the svg export so the useEffect would not be useful in that case