### PR TITLE
Clarify error message when adapter has no features

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
@@ -14,7 +14,7 @@ import ServerSideRendererType, {
   ResultsDeserialized as ServerSideResultsDeserialized,
   ResultsSerialized as ServerSideResultsSerialized,
 } from './ServerSideRendererType'
-import { BaseFeatureDataAdapter } from '../../data_adapters/BaseAdapter'
+import { isFeatureAdapter } from '../../data_adapters/BaseAdapter'
 import { AnyConfigurationModel } from '../../configuration/configurationSchema'
 
 export interface RenderArgs extends ServerSideRenderArgs {
@@ -145,6 +145,9 @@ export default class FeatureRendererType extends ServerSideRendererType {
       sessionId,
       adapterConfig,
     )
+    if (!isFeatureAdapter(dataAdapter)) {
+      throw new Error('Adapter does not support retrieving features')
+    }
     const features = new Map()
 
     if (!regions || regions.length === 0) {
@@ -168,16 +171,11 @@ export default class FeatureRendererType extends ServerSideRendererType {
 
     const featureObservable =
       requestRegions.length === 1
-        ? (dataAdapter as BaseFeatureDataAdapter).getFeatures(
+        ? dataAdapter.getFeatures(
             this.getExpandedRegion(region, renderArgs),
-            // @ts-ignore
             renderArgs,
           )
-        : // @ts-ignore
-          (dataAdapter as BaseFeatureDataAdapter).getFeaturesInMultipleRegions(
-            requestRegions,
-            renderArgs,
-          )
+        : dataAdapter.getFeaturesInMultipleRegions(requestRegions, renderArgs)
 
     const feats = await featureObservable.pipe(toArray()).toPromise()
     checkAbortSignal(signal)

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -11,10 +11,7 @@ import ServerSideRendererType, {
   ResultsSerialized,
 } from '../pluggableElementTypes/renderers/ServerSideRendererType'
 import { RemoteAbortSignal } from './remoteAbortSignals'
-import {
-  BaseFeatureDataAdapter,
-  isFeatureAdapter,
-} from '../data_adapters/BaseAdapter'
+import { isFeatureAdapter } from '../data_adapters/BaseAdapter'
 import {
   checkAbortSignal,
   renameRegionsIfNeeded,
@@ -45,7 +42,7 @@ export class CoreGetRefNames extends RpcMethodType {
       adapterConfig,
     )
 
-    if (dataAdapter instanceof BaseFeatureDataAdapter) {
+    if (isFeatureAdapter(dataAdapter)) {
       return dataAdapter.getRefNames(deserializedArgs)
     }
     return []
@@ -253,10 +250,10 @@ export class CoreEstimateRegionStats extends RpcMethodType {
       adapterConfig,
     )
 
-    if (dataAdapter instanceof BaseFeatureDataAdapter) {
+    if (isFeatureAdapter(dataAdapter)) {
       return dataAdapter.estimateRegionsStats(regions, deserializedArgs)
     }
-    throw new Error('Data adapter not found')
+    return {}
   }
 }
 

--- a/packages/core/rpc/coreRpcMethods.ts
+++ b/packages/core/rpc/coreRpcMethods.ts
@@ -250,10 +250,10 @@ export class CoreEstimateRegionStats extends RpcMethodType {
       adapterConfig,
     )
 
-    if (isFeatureAdapter(dataAdapter)) {
-      return dataAdapter.estimateRegionsStats(regions, deserializedArgs)
+    if (!isFeatureAdapter(dataAdapter)) {
+      throw new Error('Adapter does not support retrieving features')
     }
-    return {}
+    return dataAdapter.estimateRegionsStats(regions, deserializedArgs)
   }
 }
 


### PR DESCRIPTION
This uses some similar checks to #3084 to show a different error message when a reference sequence track that uses a ChromSizesAdapter or FromConfigRegionsAdapter is opened (mentioned [here](https://github.com/GMOD/jbrowse-components/pull/3084#issuecomment-1182147172)).

Before it said `Error: Data adapter not found`, now it says `Error: Adapter does not support retrieving features`.