### PR TITLE
Fix use of embedded components with vite 3.0 using tsc to compile @jbrowse/core

### DIFF
--- a/demos/jbrowse-react-linear-genome-view-vite/package.json
+++ b/demos/jbrowse-react-linear-genome-view-vite/package.json
@@ -26,6 +26,6 @@
     "@vitejs/plugin-react": "^1.0.0",
     "stream-browserify": "^3.0.0",
     "typescript": "^4.4.4",
-    "vite": "^2.0.0"
+    "vite": "^3.0.0"
   }
 }

--- a/demos/jbrowse-react-linear-genome-view-vite/yarn.lock
+++ b/demos/jbrowse-react-linear-genome-view-vite/yarn.lock
@@ -1392,7 +1392,7 @@ esbuild-windows-arm64@0.14.49:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz#d83c03ff6436caf3262347cfa7e16b0a8049fae7"
   integrity sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==
 
-esbuild@^0.14.27:
+esbuild@^0.14.47:
   version "0.14.49"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.49.tgz#b82834760eba2ddc17b44f05cfcc0aaca2bae492"
   integrity sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==
@@ -2000,7 +2000,7 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-postcss@^8.4.13:
+postcss@^8.4.14:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
@@ -2198,7 +2198,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.12.0, resolve@^1.22.0:
+resolve@^1.12.0, resolve@^1.22.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -2230,7 +2230,7 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.59.0:
+rollup@^2.75.6:
   version "2.76.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.76.0.tgz#c69fe03db530ac53fcb9523b3caa0d3c0b9491a1"
   integrity sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==
@@ -2442,15 +2442,15 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vite@^2.0.0:
-  version "2.9.14"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.14.tgz#c438324c6594afd1050df3777da981dee988bb1b"
-  integrity sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==
+vite@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.0.tgz#b4675cb9ab83ec0803b9c952ffa6519bcce033a7"
+  integrity sha512-M7phQhY3+fRZa0H+1WzI6N+/onruwPTBTMvaj7TzgZ0v2TE+N2sdLKxJOfOv9CckDWt5C4HmyQP81xB4dwRKzA==
   dependencies:
-    esbuild "^0.14.27"
-    postcss "^8.4.13"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
+    esbuild "^0.14.47"
+    postcss "^8.4.14"
+    resolve "^1.22.1"
+    rollup "^2.75.6"
   optionalDependencies:
     fsevents "~2.3.2"
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,7 @@
     "clean": "rimraf dist tsconfig.build.tsbuildinfo",
     "prebuild": "yarn clean",
     "prepack": "yarn build",
-    "build": "babel . --root-mode upward --out-dir dist --extensions '.ts,.js,.tsx,.jsx' && cp package.json README.md ../../LICENSE dist/",
-    "postbuild": "tsc -b tsconfig.build.json"
+    "build": "tsc -b tsconfig.build.json && cp package.json README.md ../../LICENSE dist/"
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",

--- a/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
@@ -211,5 +211,3 @@ export default class FeatureRendererType extends ServerSideRendererType {
     return { ...result, features }
   }
 }
-
-export class NewFeatureRendererType extends ServerSideRendererType {}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "composite": true,
-    "emitDeclarationOnly": true,
     "noEmit": false,
     "declaration": true
   }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "module": "commonjs"
   },
 
   "exclude": ["**/*.test.ts*", "**/*.test.js*", "dist"]


### PR DESCRIPTION
Fixes #3091 
Uses tsc instead of babel to compile @jbrowse/core

Outputs module type "commonjs" since it is used under node, and it is difficult to create dual esm/commonjs builds for core (becuase of the "flat" module structure/importing from subpaths)

Simple local testing showed it fixed the vite 3.0.0 build