### PR TITLE
Add "emphasis" mode for no fill/scatterplot mode in XYPlot type renderings

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -64,17 +64,13 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
       {model.seqDialogDisplayed ? (
         <SequenceDialog
           model={model}
-          handleClose={() => {
-            model.setSequenceDialogOpen(false)
-          }}
+          handleClose={() => model.setSequenceDialogOpen(false)}
         />
       ) : null}
       {model.isSearchDialogDisplayed ? (
         <SearchResultsDialog
           model={model}
-          handleClose={() => {
-            model.setSearchResults(undefined, undefined)
-          }}
+          handleClose={() => model.setSearchResults(undefined, undefined)}
         />
       ) : null}
       {!hideHeader ? (

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -57,6 +57,7 @@ const stateModelFactory = (
         selectedRendering: types.optional(types.string, ''),
         resolution: types.optional(types.number, 1),
         fill: types.maybe(types.boolean),
+        minSize: types.maybe(types.number),
         color: types.maybe(types.string),
         posColor: types.maybe(types.string),
         negColor: types.maybe(types.string),
@@ -123,8 +124,17 @@ const stateModelFactory = (
         self.resolution = res
       },
 
-      setFill(fill: boolean) {
-        self.fill = fill
+      setFill(fill: number) {
+        if (fill === 0) {
+          self.fill = true
+          self.minSize = 0
+        } else if (fill === 1) {
+          self.fill = false
+          self.minSize = 1
+        } else if (fill === 2) {
+          self.fill = false
+          self.minSize = 2
+        }
       },
 
       toggleLogScale() {
@@ -213,12 +223,13 @@ const stateModelFactory = (
 
         const {
           color,
-          posColor,
-          negColor,
-          summaryScoreMode,
-          scaleType,
           displayCrossHatches,
           fill,
+          minSize,
+          negColor,
+          posColor,
+          summaryScoreMode,
+          scaleType,
         } = self
 
         return self.rendererType.configSchema.create(
@@ -230,9 +241,10 @@ const stateModelFactory = (
               ? { displayCrossHatches }
               : {}),
             ...(summaryScoreMode !== undefined ? { summaryScoreMode } : {}),
-            ...(color !== undefined ? { color: color } : {}),
-            ...(negColor !== undefined ? { negColor: negColor } : {}),
-            ...(posColor !== undefined ? { posColor: posColor } : {}),
+            ...(color !== undefined ? { color } : {}),
+            ...(negColor !== undefined ? { negColor } : {}),
+            ...(posColor !== undefined ? { posColor } : {}),
+            ...(minSize !== undefined ? { minSize } : {}),
           },
           getEnv(self),
         )
@@ -351,6 +363,16 @@ const stateModelFactory = (
         get hasGlobalStats() {
           return self.adapterCapabilities.includes('hasGlobalStats')
         },
+
+        get fillSetting() {
+          if (self.filled) {
+            return 0
+          } else if (!self.filled && self.minSize === 1) {
+            return 1
+          } else {
+            return 2
+          }
+        },
       }
     })
     .views(self => {
@@ -379,18 +401,26 @@ const stateModelFactory = (
                     label: 'Summary score mode',
                     subMenu: ['min', 'max', 'avg', 'whiskers'].map(elt => ({
                       label: elt,
+                      type: 'radio',
+                      checked: self.summaryScoreModeSetting === elt,
                       onClick: () => self.setSummaryScoreMode(elt),
                     })),
                   },
                 ]
               : []),
+
             ...(self.canHaveFill
               ? [
                   {
-                    label: self.filled
-                      ? 'Turn off histogram fill'
-                      : 'Turn on histogram fill',
-                    onClick: () => self.setFill(!self.filled),
+                    label: 'Fill mode',
+                    subMenu: ['filled', 'no fill', 'no fill w/ emphasis'].map(
+                      (elt, idx) => ({
+                        label: elt,
+                        type: 'radio',
+                        checked: self.fillSetting === idx,
+                        onClick: () => self.setFill(idx),
+                      }),
+                    ),
                   },
                 ]
               : []),

--- a/plugins/wiggle/src/MultiLineRenderer/configSchema.ts
+++ b/plugins/wiggle/src/MultiLineRenderer/configSchema.ts
@@ -5,10 +5,12 @@ import ConfigSchema from '../configSchema'
 const configSchema = ConfigurationSchema(
   'MultiLineRenderer',
   {
-    filled: {
+    displayCrossHatches: {
       type: 'boolean',
+      description: 'choose to draw cross hatches (sideways lines)',
       defaultValue: false,
     },
+
     summaryScoreMode: {
       type: 'stringEnum',
       model: types.enumeration('Score type', ['max', 'min', 'avg', 'whiskers']),

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -101,31 +101,41 @@ const ColorLegend = observer(
     const {
       needsCustomLegend,
       needsScalebar,
+      needsFullHeightScalebar,
       rowHeightTooSmallForScalebar,
       renderColorBoxes,
       sources,
     } = model
     const svgFontSize = Math.min(rowHeight, 12)
     const canDisplayLabel = rowHeight > 11
-
+    const colorBoxWidth = renderColorBoxes ? 15 : 0
+    const legendWidth = labelWidth + colorBoxWidth + 5
+    const extraOffset = needsScalebar && !rowHeightTooSmallForScalebar ? 50 : 0
     return sources ? (
       <>
+        {
+          /* 0.25 for hanging letters like g */
+          needsFullHeightScalebar ? (
+            <RectBg
+              y={0}
+              x={extraOffset}
+              width={legendWidth}
+              height={(sources.length + 0.25) * rowHeight}
+            />
+          ) : null
+        }
         {sources.map((source, idx) => {
-          // put the subtrack labels to the right of the scalebar
-          const extraOffset =
-            needsScalebar && !rowHeightTooSmallForScalebar ? 50 : 0
-          const colorBoxWidth = renderColorBoxes ? 15 : 0
-          const legendWidth = labelWidth + colorBoxWidth + 5
           const boxHeight = Math.min(20, rowHeight)
-
           return (
             <React.Fragment key={source.name + '-' + idx}>
-              <RectBg
-                y={idx * rowHeight + 1}
-                x={extraOffset}
-                width={legendWidth}
-                height={boxHeight}
-              />
+              {!needsFullHeightScalebar ? (
+                <RectBg
+                  y={idx * rowHeight + 1}
+                  x={extraOffset}
+                  width={legendWidth}
+                  height={boxHeight}
+                />
+              ) : null}
               {source.color ? (
                 <RectBg
                   y={idx * rowHeight + 1}

--- a/plugins/wiggle/src/MultiRowLineRenderer/configSchema.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/configSchema.ts
@@ -4,11 +4,12 @@ import { ConfigurationSchema } from '@jbrowse/core/configuration'
 import ConfigSchema from '../configSchema'
 
 const configSchema = ConfigurationSchema(
-  'MultiRowXYPlotRenderer',
+  'MultiRowLineRenderer',
   {
-    filled: {
+    displayCrossHatches: {
       type: 'boolean',
-      defaultValue: true,
+      description: 'choose to draw cross hatches (sideways lines)',
+      defaultValue: false,
     },
     summaryScoreMode: {
       type: 'stringEnum',

--- a/plugins/wiggle/src/MultiRowXYPlotRenderer/configSchema.ts
+++ b/plugins/wiggle/src/MultiRowXYPlotRenderer/configSchema.ts
@@ -10,12 +10,21 @@ const configSchema = ConfigurationSchema(
       type: 'boolean',
       defaultValue: true,
     },
+    displayCrossHatches: {
+      type: 'boolean',
+      description: 'choose to draw cross hatches (sideways lines)',
+      defaultValue: false,
+    },
     summaryScoreMode: {
       type: 'stringEnum',
       model: types.enumeration('Score type', ['max', 'min', 'avg', 'whiskers']),
       description:
         'choose whether to use max/min/average or whiskers which combines all three into the same rendering',
       defaultValue: 'whiskers',
+    },
+    minSize: {
+      type: 'number',
+      defaultValue: 0,
     },
   },
   { baseConfiguration: ConfigSchema, explicitlyTyped: true },

--- a/plugins/wiggle/src/MultiXYPlotRenderer/configSchema.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/configSchema.ts
@@ -9,12 +9,21 @@ const configSchema = ConfigurationSchema(
       type: 'boolean',
       defaultValue: true,
     },
+    displayCrossHatches: {
+      type: 'boolean',
+      description: 'choose to draw cross hatches (sideways lines)',
+      defaultValue: false,
+    },
     summaryScoreMode: {
       type: 'stringEnum',
       model: types.enumeration('Score type', ['max', 'min', 'avg', 'whiskers']),
       description:
         'choose whether to use max/min/average or whiskers which combines all three into the same rendering',
       defaultValue: 'avg',
+    },
+    minSize: {
+      type: 'number',
+      defaultValue: 0,
     },
   },
   { baseConfiguration: ConfigSchema, explicitlyTyped: true },

--- a/plugins/wiggle/src/XYPlotRenderer/configSchema.ts
+++ b/plugins/wiggle/src/XYPlotRenderer/configSchema.ts
@@ -21,6 +21,10 @@ const configSchema = ConfigurationSchema(
         'choose whether to use max/min/average or whiskers which combines all three into the same rendering',
       defaultValue: 'whiskers',
     },
+    minSize: {
+      type: 'number',
+      defaultValue: 0,
+    },
   },
   { baseConfiguration: ConfigSchema, explicitlyTyped: true },
 )

--- a/plugins/wiggle/src/drawxy.ts
+++ b/plugins/wiggle/src/drawxy.ts
@@ -28,7 +28,7 @@ function fillRectCtx(
   ctx.fillRect(x, y, width, height)
 }
 
-const fudgeFactor = 0.3
+const fudgeFactor = 0.4
 const clipHeight = 2
 
 export function drawXY(
@@ -202,7 +202,7 @@ export function drawXY(
 
   if (displayCrossHatches) {
     ctx.lineWidth = 1
-    ctx.strokeStyle = 'rgba(200,200,200,0.8)'
+    ctx.strokeStyle = 'rgba(200,200,200,0.5)'
     ticks.values.forEach(tick => {
       ctx.beginPath()
       ctx.moveTo(0, Math.round(toY(tick)))
@@ -298,7 +298,7 @@ export function drawLine(
 
   if (displayCrossHatches) {
     ctx.lineWidth = 1
-    ctx.strokeStyle = 'rgba(200,200,200,0.8)'
+    ctx.strokeStyle = 'rgba(200,200,200,0.5)'
     values.forEach(tick => {
       ctx.beginPath()
       ctx.moveTo(0, Math.round(toY(tick)))

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
@@ -83,12 +83,12 @@ test(
   'click and drag to reorder tracks',
   async () => {
     const { view, findByTestId } = createView()
-    fireEvent.click(await findByTestId(hts('volvox_alignments'), {}, delay))
+    fireEvent.click(await findByTestId(hts('bigbed_genes'), {}, delay))
     fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), {}, delay))
 
     const trackId1 = view.tracks[1].id
     const dragHandle0 = await findByTestId(
-      'dragHandle-integration_test-volvox_alignments',
+      'dragHandle-integration_test-bigbed_genes',
       {},
       delay,
     )
@@ -131,9 +131,9 @@ test(
   'opens track selector',
   async () => {
     const { view, findByTestId } = createView()
-    await findByTestId(hts('volvox_alignments'), {}, delay)
+    await findByTestId(hts('bigbed_genes'), {}, delay)
     expect(view.tracks.length).toBe(0)
-    fireEvent.click(await findByTestId(hts('volvox_alignments'), {}, delay))
+    fireEvent.click(await findByTestId(hts('bigbed_genes'), {}, delay))
     expect(view.tracks.length).toBe(1)
   },
   total,
@@ -159,8 +159,7 @@ test(
   'click to display center line with correct value',
   async () => {
     const { view, findByTestId, findByText } = createView()
-    fireEvent.click(await findByTestId(hts('volvox_alignments'), {}, delay))
-    await findByTestId('display-volvox_alignments_alignments', {}, delay)
+    fireEvent.click(await findByTestId(hts('bigbed_genes'), {}, delay))
 
     // opens the view menu and selects show center line
     fireEvent.click(await findByTestId('view_menu_icon'))
@@ -186,9 +185,9 @@ test(
     expect(view.displayedRegions[0].refName).toEqual('ctgA')
     fireEvent.click(await findByText('Help'))
     // need this to complete before we can try to search
-    fireEvent.click(await findByTestId(hts('volvox_alignments'), {}, delay))
+    fireEvent.click(await findByTestId(hts('bigbed_genes'), {}, delay))
     await findByTestId(
-      'trackRenderingContainer-integration_test-volvox_alignments',
+      'trackRenderingContainer-integration_test-bigbed_genes',
       {},
       delay,
     )
@@ -202,8 +201,7 @@ test(
     autocomplete.focus()
     fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
     fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
-    const option = (await screen.findAllByText('ctgB'))[0]
-    fireEvent.click(option)
+    fireEvent.click((await screen.findAllByText('ctgB'))[0])
     fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
 
     await waitFor(


### PR DESCRIPTION
Currently we have the "no fill" mode on XYPlotRenderer type tracks

This helps draw a scatterplot style rendering

It can be useful to emphasize those scatterplot points, so this PR adds an "emphasis" setting that is toggleable

![Screenshot from 2022-07-22 12-18-57](https://user-images.githubusercontent.com/6511937/180500247-223138ea-6048-4e58-b8dd-59804f863446.png)
current main: all the no-fill points are quite tiny

![Screenshot from 2022-07-22 12-18-02](https://user-images.githubusercontent.com/6511937/180500321-8c6f16ca-6454-4d07-855b-4f16761e8f60.png)
this branch: emphasis mode makes points 2px in size
