### PR TITLE
Use es2015 setting for commonjs builds of packages to fix @jbrowse/img

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/bam": "^1.1.15",
     "@gmod/cram": "^1.6.4",
     "@mui/icons-material": "^5.0.1",

--- a/plugins/alignments/tsconfig.build.es5.json
+++ b/plugins/alignments/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "./src",
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/arc/package.json
+++ b/plugins/arc/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "react-svg-tooltip": "^0.0.11"
   },
   "peerDependencies": {

--- a/plugins/arc/tsconfig.build.es5.json
+++ b/plugins/arc/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -36,9 +36,7 @@
     "build:es5": "tsc --build tsconfig.build.es5.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.17.9"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",
     "@mui/material": "^5.0.0",

--- a/plugins/authentication/tsconfig.build.es5.json
+++ b/plugins/authentication/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bbi": "^2.0.2",
     "@gmod/bed": "^2.1.2",

--- a/plugins/bed/tsconfig.build.es5.json
+++ b/plugins/bed/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/vcf": "^5.0.5",
     "@mui/icons-material": "^5.0.1",
     "svg-path-generator": "^1.1.0"

--- a/plugins/breakpoint-split-view/tsconfig.build.es5.json
+++ b/plugins/breakpoint-split-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1"
   },
   "peerDependencies": {

--- a/plugins/circular-view/tsconfig.build.es5.json
+++ b/plugins/circular-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "generic-filehandle": "^3.0.0"
   },

--- a/plugins/comparative-adapters/tsconfig.build.es5.json
+++ b/plugins/comparative-adapters/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "pluralize": "^8.0.0"
   },

--- a/plugins/config/tsconfig.build.es5.json
+++ b/plugins/config/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/ucsc-hub": "^0.1.3",
     "@mui/icons-material": "^5.0.1",
     "clsx": "^1.1.0",

--- a/plugins/data-management/tsconfig.build.es5.json
+++ b/plugins/data-management/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "@mui/x-data-grid": "^5.0.1",
     "clone": "^2.1.2",

--- a/plugins/dotplot-view/tsconfig.build.es5.json
+++ b/plugins/dotplot-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "@gmod/gff": "^1.2.0",

--- a/plugins/gff3/tsconfig.build.es5.json
+++ b/plugins/gff3/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/grid-bookmark/package.json
+++ b/plugins/grid-bookmark/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "file-saver": "^2.0.0"
   },

--- a/plugins/grid-bookmark/tsconfig.build.es5.json
+++ b/plugins/grid-bookmark/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "@gmod/gtf": "^0.0.6"

--- a/plugins/gtf/tsconfig.build.es5.json
+++ b/plugins/gtf/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "color": "^3.1.3",
     "hic-straw": "^2.0.3"
   },

--- a/plugins/hic/tsconfig.build.es5.json
+++ b/plugins/hic/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@jbrowse/text-indexing": "^2.1.0",
     "@mui/icons-material": "^5.0.0"
   },

--- a/plugins/jobs-management/tsconfig.build.es5.json
+++ b/plugins/jobs-management/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/legacy-jbrowse/package.json
+++ b/plugins/legacy-jbrowse/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/nclist": "^0.2.1",
     "buffer-crc32": "^0.2.13",
     "generic-filehandle": "^3.0.0",

--- a/plugins/legacy-jbrowse/tsconfig.build.es5.json
+++ b/plugins/legacy-jbrowse/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "clone": "^2.1.2",
     "copy-to-clipboard": "^3.3.1",

--- a/plugins/linear-comparative-view/tsconfig.build.es5.json
+++ b/plugins/linear-comparative-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -39,7 +39,6 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "@popperjs/core": "^2.11.0",
     "clone": "^2.1.2",

--- a/plugins/linear-genome-view/tsconfig.build.es5.json
+++ b/plugins/linear-genome-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -36,9 +36,7 @@
     "build:es5": "tsc --build tsconfig.build.es5.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.17.9"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",
     "@jbrowse/plugin-linear-genome-view": "^2.0.0",

--- a/plugins/lollipop/tsconfig.build.es5.json
+++ b/plugins/lollipop/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/menus/package.json
+++ b/plugins/menus/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "pluralize": "^8.0.0",
     "react-dropzone": "^14.2.1"

--- a/plugins/menus/tsconfig.build.es5.json
+++ b/plugins/menus/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/protein/package.json
+++ b/plugins/protein/package.json
@@ -36,9 +36,7 @@
     "build:es5": "tsc --build tsconfig.build.es5.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.17.9"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",
     "mobx": "^6.0.0",

--- a/plugins/protein/tsconfig.build.es5.json
+++ b/plugins/protein/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "string-template": "^1.0.0"
   },
   "peerDependencies": {

--- a/plugins/rdf/tsconfig.build.es5.json
+++ b/plugins/rdf/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/indexedfasta": "^2.0.2",
     "@gmod/twobit": "^1.1.12",
     "abortable-promise-cache": "^1.5.0"

--- a/plugins/sequence/tsconfig.build.es5.json
+++ b/plugins/sequence/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "@gmod/vcf": "^5.0.5",
     "@jbrowse/plugin-variants": "^2.1.0",

--- a/plugins/spreadsheet-view/tsconfig.build.es5.json
+++ b/plugins/spreadsheet-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@mui/icons-material": "^5.0.1",
     "clone": "^2.1.2"
   },

--- a/plugins/sv-inspector/tsconfig.build.es5.json
+++ b/plugins/sv-inspector/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/svg/package.json
+++ b/plugins/svg/package.json
@@ -36,9 +36,7 @@
     "build:es5": "tsc --build tsconfig.build.es5.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.17.9"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",
     "mobx": "^6.0.0",

--- a/plugins/svg/tsconfig.build.es5.json
+++ b/plugins/svg/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@jbrowse/text-indexing": "^2.1.0"
   },
   "peerDependencies": {

--- a/plugins/text-indexing/tsconfig.build.es5.json
+++ b/plugins/text-indexing/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/trackhub-registry/package.json
+++ b/plugins/trackhub-registry/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/ucsc-hub": "^0.1.3",
     "@mui/icons-material": "^5.0.1"
   },

--- a/plugins/trackhub-registry/tsconfig.build.es5.json
+++ b/plugins/trackhub-registry/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/trix/package.json
+++ b/plugins/trix/package.json
@@ -46,7 +46,6 @@
     "react": ">=16.8.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/trix": "^2.0.4"
   },
   "publishConfig": {

--- a/plugins/trix/tsconfig.build.es5.json
+++ b/plugins/trix/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "@gmod/tabix": "^1.5.2",

--- a/plugins/variants/tsconfig.build.es5.json
+++ b/plugins/variants/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -37,7 +37,6 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
     "@gmod/bbi": "^2.0.2",
     "@mui/icons-material": "^5.0.2",
     "@popperjs/core": "^2.11.0",

--- a/plugins/wiggle/tsconfig.build.es5.json
+++ b/plugins/wiggle/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "rootDir": "./src",
     "composite": true,
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs"
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/products/jbrowse-react-circular-genome-view/tsconfig.build.es5.json
+++ b/products/jbrowse-react-circular-genome-view/tsconfig.build.es5.json
@@ -6,7 +6,7 @@
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "./src",
-    "target": "es5",
+    "target": "es2015",
     "composite": true
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/products/jbrowse-react-linear-genome-view/tsconfig.build.es5.json
+++ b/products/jbrowse-react-linear-genome-view/tsconfig.build.es5.json
@@ -7,7 +7,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "./src",
-    "target": "es5",
+    "target": "es2015",
     "composite": true
   },
   "include": ["./src/**/*.ts*", "./src/**/*.js*"],

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -847,7 +847,7 @@ Slots
 - queryAssembly - alternative to assemblyNames: just the assemblyName of the
   query
 - targetAssembly - alternative to assemblyNames: just the assemblyName of the
-  query
+  target
 
 ### ChainAdapter config
 
@@ -874,7 +874,7 @@ Slots
 - queryAssembly - alternative to assemblyNames: just the assemblyName of the
   query
 - targetAssembly - alternative to assemblyNames: just the assemblyName of the
-  query
+  target
 
 ### MCScanAnchorsAdapter
 

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -820,7 +820,7 @@ Slots
 - queryAssembly - alternative to assemblyNames: just the assemblyName of the
   query
 - targetAssembly - alternative to assemblyNames: just the assemblyName of the
-  query
+  target
 
 ### DeltaAdapter config
 


### PR DESCRIPTION
The current @jbrowse/img fails to run due to the packages/core being updated to a newer-than-es5 build as well

Error message

```
TypeError: Class constructor Plugin cannot be invoked without 'new'
```
This is due to trying to subclass a true ES6 class (in core) from a ES5 function-like-class (in the plugins)

Only affects nodejs/commonjs usages of the code currently

This updates the target from es5->es2015 and also removes @babel/runtime (should be unneeded since it's compiled by tsc instead of babel now)