### PR TITLE
Use "code" instead of "key" for undo/redo keyboard event

### DIFF
--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -540,24 +540,25 @@ export default function rootModelFactory(pluginManager: PluginManager) {
 
       afterCreate() {
         document.addEventListener('keydown', event => {
-          if (event.shiftKey || event.key === 'y') {
+          if (self.history.canRedo) {
             if (
-              (event.shiftKey && event.ctrlKey && event.key === 'z') ||
-              (event.shiftKey && event.metaKey && event.key === 'z') ||
-              (event.ctrlKey && event.key === 'y')
+              // ctrl+shift+z or cmd+shift+z
+              ((event.ctrlKey || event.metaKey) &&
+                event.shiftKey &&
+                event.code === 'KeyZ') ||
+              // ctrl+y
+              (event.ctrlKey && !event.shiftKey && event.code === 'KeyY')
             ) {
-              if (self.history.canRedo) {
-                self.history.redo()
-              }
+              self.history.redo()
             }
-          } else {
+          } else if (self.history.canUndo) {
             if (
-              (event.ctrlKey && event.key === 'z') ||
-              (event.metaKey && event.key === 'z')
+              // ctrl+z or cmd+z
+              (event.ctrlKey || event.metaKey) &&
+              !event.shiftKey &&
+              event.code === 'KeyZ'
             ) {
-              if (self.history.canUndo) {
-                self.history.undo()
-              }
+              self.history.undo()
             }
           }
         })

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -119,24 +119,25 @@ export default function RootModel(
     .actions(self => ({
       afterCreate() {
         document.addEventListener('keydown', event => {
-          if (event.shiftKey || event.key === 'y') {
+          if (self.history.canRedo) {
             if (
-              (event.shiftKey && event.ctrlKey && event.key === 'z') ||
-              (event.shiftKey && event.metaKey && event.key === 'z') ||
-              (event.ctrlKey && event.key === 'y')
+              // ctrl+shift+z or cmd+shift+z
+              ((event.ctrlKey || event.metaKey) &&
+                event.shiftKey &&
+                event.code === 'KeyZ') ||
+              // ctrl+y
+              (event.ctrlKey && !event.shiftKey && event.code === 'KeyY')
             ) {
-              if (self.history.canRedo) {
-                self.history.redo()
-              }
+              self.history.redo()
             }
-          } else {
+          } else if (self.history.canUndo) {
             if (
-              (event.ctrlKey && event.key === 'z') ||
-              (event.metaKey && event.key === 'z')
+              // ctrl+z or cmd+z
+              (event.ctrlKey || event.metaKey) &&
+              !event.shiftKey &&
+              event.code === 'KeyZ'
             ) {
-              if (self.history.canUndo) {
-                self.history.undo()
-              }
+              self.history.undo()
             }
           }
         })

--- a/website/docs/user_guide.md
+++ b/website/docs/user_guide.md
@@ -44,8 +44,8 @@ also exist in the header of the linear genome view
 The zoom buttons exist in the header of the linear genome view, and there is
 also a slider bar to zoom in and out.
 
-Note: You can also hold the "Ctrl" key and use your mousewheel or trackpad to
-scroll and this will zoom in and out
+Note: You can also hold the <kbd>Ctrl</kbd> key and use your mousewheel or
+trackpad to scroll and this will zoom in and out
 
 #### Re-ordering tracks
 
@@ -98,8 +98,11 @@ guide](../quickstart_gui)
 ### Undo and redo
 
 You can undo the closing of a view, track, or any other action in the UI with
-the Tools->Undo/Redo buttons. The keyboard shortcut "ctrl+z"/"cmd+z"(mac) work
-for undo as well as "ctrl+y"/"cmd+shift"z"(mac)
+the <kbd><kbd><samp>Tools</samp></kbd>→<kbd><samp>Undo/Redo</samp></kbd></kbd>
+buttons. The keyboard shortcuts <kbd><kbd>Ctrl</kbd>+<kbd>Z</kbd></kbd>
+/<kbd><kbd>Cmd</kbd>+<kbd>Z</kbd></kbd> (mac) work for undo as well
+as <kbd><kbd>Ctrl</kbd>+<kbd>Y</kbd></kbd>
+/<kbd><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd></kbd> (mac) for redo.
 
 ### Sharing sessions
 


### PR DESCRIPTION
<kbd><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd></kbd> for redo wasn't working for me, since it was using the `event.key` attribute being "z", and my system detects "Z" (upper case) for that case. This changes it to use `event.code` being "KeyZ" instead, which should work on any system.

It also updates the description of the shortcuts in the docs to use `<kbd>` and `<samp>` elements as suggested in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd. For example, instead of "ctrl+z", use <kbd><kbd>Ctrl</kbd>+<kbd>Z</kbd></kbd>.