### PR TITLE
Make ideogram menu item similar to others

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -774,12 +774,25 @@ export function stateModelFactory(pluginManager: PluginManager) {
             onClick: self.toggleNoTracksActive,
           },
           {
-            label: 'Show gridlines',
+            label: 'Show guidelines',
             icon: VisibilityIcon,
             type: 'checkbox',
             checked: self.showGridlines,
             onClick: self.toggleShowGridlines,
           },
+          ...(canShowCytobands
+            ? [
+                {
+                  label: 'Show ideogram',
+                  icon: VisibilityIcon,
+                  type: 'checkbox' as const,
+                  checked: self.showCytobands,
+                  onClick: () => {
+                    self.setShowCytobands(!showCytobands)
+                  },
+                },
+              ]
+            : []),
           {
             label: 'Track labels',
             icon: LabelIcon,
@@ -807,16 +820,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
               },
             ],
           },
-          ...(canShowCytobands
-            ? [
-                {
-                  label: showCytobands ? 'Hide ideogram' : 'Show ideograms',
-                  onClick: () => {
-                    self.setShowCytobands(!showCytobands)
-                  },
-                },
-              ]
-            : []),
         ]
 
         // add track's view level menu options


### PR DESCRIPTION
This standardizes the ideogram LGV menu item so that it is more like the others.

**Before:**
![](https://files.gitter.im/600b35cbd73408ce4ff97fd2/K8I5/image.png)

**After:**
![](https://files.gitter.im/600b35cbd73408ce4ff97fd2/LnXr/image.png)

It also changes "Show gridlines" to "Show guidelines". Since there are no horizontal lines, only vertical ones, that are hidden/shown, it isn't a grid, so I think "guidelines" is more clear. It could also be "Show vertical guidelines" to be more explicit, or something else entirely if anyone has suggestions.