### PR TITLE
Change arrow in ConfigurationEditor

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
@@ -92,7 +92,7 @@ const Member = observer(
           <AccordionSummary
             expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
           >
-            <Typography>{[...path, slotName].join('🡒')}</Typography>
+            <Typography>{[...path, slotName].join('➔')}</Typography>
           </AccordionSummary>
           <AccordionDetails className={classes.expansionPanelDetails}>
             {typeSelector}


### PR DESCRIPTION
The "level arrow" in the ConfigurationEditor is currently "🡒" (Rightwards Sans-Serif Arrow U+1F852), which does not render on my computer, so it looks like this:

![](https://files.gitter.im/600b35cbd73408ce4ff97fd2/rWJT/image.png)

Since I recently re-installed my OS, I'm guessing there are other systems that have trouble with that arrow character as well. This PR changes it to "➔" (Heavy Wide-Headed Rightwards Arrow U+2794), which I think is more common. It looks like this for me:

![](https://files.gitter.im/600b35cbd73408ce4ff97fd2/kjWm/image.png)

If someone with a Mac (@rbuels or @carolinebridge-oicr?) could double-check for me that it looks fine on there, that would be great. Session link: https://s3.amazonaws.com/jbrowse.org/code/jb2/config_editor_level_arrow/index.html?session=share-uNPMnDdnXA&password=QunGJ