### PR TITLE
Fix for mouseover/mouse click on wiggle/multi-wiggle causing errors in embedded mode

### DIFF
--- a/plugins/wiggle/src/WiggleBaseRenderer.tsx
+++ b/plugins/wiggle/src/WiggleBaseRenderer.tsx
@@ -73,11 +73,11 @@ export default abstract class WiggleBaseRenderer extends FeatureRendererType {
     return {
       ...results,
       ...rest,
-      // @ts-ignore
-      features: reducedFeatures || results.features,
-      containsNoTransferables: true,
+      features: (new Map(reducedFeatures?.map((r: Feature) => [r.id(), r])) ||
+        results.features) as Map<string, Feature>,
       height,
       width,
+      containsNoTransferables: true,
     }
   }
 


### PR DESCRIPTION
Fixes #3155 


This makes sure to transform reducedFeatures returned by wiggle adapters to a Map (was returning an array, which worked in some cases e.g. arrays have a .values() function but not in others with the .has() on composite map)