### PR TITLE
Support the "name" field on multi-wiggle adapter subadapters instead of source

### DIFF
--- a/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
+++ b/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
@@ -110,7 +110,6 @@ export default class MultiWiggleAdapter extends BaseFeatureDataAdapter {
   // something, but it is static for this particular multi-wiggle adapter type
   async getSources() {
     const adapters = await this.getAdapters()
-    console.log({ adapters })
     return adapters.map(({ dataAdapter, source, name, ...rest }) => ({
       name: source,
       __name: name,

--- a/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
+++ b/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
@@ -52,7 +52,7 @@ export default class MultiWiggleAdapter extends BaseFeatureDataAdapter {
         const dataAdapter = (await getSubAdapter(conf))
           .dataAdapter as BaseFeatureDataAdapter
         return {
-          source: dataAdapter.id,
+          source: conf.name || dataAdapter.id,
           ...conf,
           dataAdapter,
         }

--- a/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
+++ b/plugins/wiggle/src/MultiWiggleAdapter/MultiWiggleAdapter.ts
@@ -110,8 +110,10 @@ export default class MultiWiggleAdapter extends BaseFeatureDataAdapter {
   // something, but it is static for this particular multi-wiggle adapter type
   async getSources() {
     const adapters = await this.getAdapters()
-    return adapters.map(({ dataAdapter, source, ...rest }) => ({
+    console.log({ adapters })
+    return adapters.map(({ dataAdapter, source, name, ...rest }) => ({
       name: source,
+      __name: name,
       ...rest,
     }))
   }

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -1141,28 +1141,30 @@ Object {
             "bigWigLocation": Object {
               "uri": "v1.cram.bw",
             },
-            "source": "k1",
+            "name": "k1",
+            "source": "j1",
             "type": "BigWigAdapter",
           },
           Object {
             "bigWigLocation": Object {
               "uri": "v2.cram.bw",
             },
-            "source": "k2",
+            "name": "k2",
+            "source": "j2",
             "type": "BigWigAdapter",
           },
           Object {
             "bigWigLocation": Object {
               "uri": "v3.cram.bw",
             },
-            "source": "k3",
+            "name": "k3",
             "type": "BigWigAdapter",
           },
           Object {
             "bigWigLocation": Object {
               "uri": "v4.cram.bw",
             },
-            "source": "k4",
+            "name": "k4",
             "type": "BigWigAdapter",
           },
         ],

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -607,28 +607,30 @@
         "type": "MultiWiggleAdapter",
         "subadapters": [
           {
-            "source": "k1",
+            "name": "k1",
+            "source": "j1",
             "type": "BigWigAdapter",
             "bigWigLocation": {
               "uri": "v1.cram.bw"
             }
           },
           {
-            "source": "k2",
+            "name": "k2",
+            "source": "j2",
             "type": "BigWigAdapter",
             "bigWigLocation": {
               "uri": "v2.cram.bw"
             }
           },
           {
-            "source": "k3",
+            "name": "k3",
             "type": "BigWigAdapter",
             "bigWigLocation": {
               "uri": "v3.cram.bw"
             }
           },
           {
-            "source": "k4",
+            "name": "k4",
             "type": "BigWigAdapter",
             "bigWigLocation": {
               "uri": "v4.cram.bw"

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -670,6 +670,7 @@ Example with group field
     "subadapters": [
       {
         "type": "BigWigAdapter",
+        "name": "k1",
         "bigWigLocation": {
           "uri": "https://www.encodeproject.org/files/ENCFF055ZII/@@download/ENCFF055ZII.bigWig"
         },
@@ -677,6 +678,7 @@ Example with group field
       },
       {
         "type": "BigWigAdapter",
+        "name": "k2",
         "bigWigLocation": {
           "uri": "https://www.encodeproject.org/files/ENCFF826HEW/@@download/ENCFF826HEW.bigWig"
         },
@@ -686,6 +688,8 @@ Example with group field
   }
 }
 ```
+
+The "name" or "source" field on the subadapters will be used as the subtrack label
 
 ### QuantitativeTrack config
 

--- a/website/docs/config_guide.md
+++ b/website/docs/config_guide.md
@@ -689,7 +689,8 @@ Example with group field
 }
 ```
 
-The "name" or "source" field on the subadapters will be used as the subtrack label
+The "name" or "source" field on the subadapters will be used as the subtrack
+label (where, "source" will be given priority over "name" if specified)
 
 ### QuantitativeTrack config
 


### PR DESCRIPTION
Fixes #3122

"name" may be a fairly intuitive key to specify on the subadapter, so if "name" is specified without a "source" field, it is used. If both "source" and "name" are specified, "source" is given priority