### PR TITLE
Note for user to wait before re-launching app on desktop update

### DIFF
--- a/products/jbrowse-desktop/public/electron.ts
+++ b/products/jbrowse-desktop/public/electron.ts
@@ -611,7 +611,7 @@ autoUpdater.on('update-downloaded', () => {
     type: 'info',
     title: 'Update completed',
     message:
-      'Update downloaded, the update will take place when you restart the app',
+      'Update downloaded, the update will take place when you restart the app. Once you close the app, wait a minute or so before re-launching because it will be doing a reinstall in the background',
     buttons: ['OK'],
   })
 })


### PR DESCRIPTION
This message could help for the issue seen by @carolinebridge-oicr where it takes a minute or so to install after you close, and could otherwise be confusing if the user relaunches immediately after closing the app and not seeing the update