### PR TITLE
Add OAuthModel InternetAccount token refresh

### DIFF
--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -36,6 +36,9 @@
     "build:es5": "tsc --build tsconfig.build.es5.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
+  "dependencies": {
+    "jwt-decode": "^3.1.2"
+  },
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",
     "@mui/material": "^5.0.0",

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -2,7 +2,7 @@ import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { InternetAccount } from '@jbrowse/core/pluggableElementTypes/models'
 import { isElectron, UriLocation } from '@jbrowse/core/util'
 import { Instance, types } from 'mobx-state-tree'
-import jwtDecode, { JwtPayload } from 'jwt-decode';
+import jwtDecode, { JwtPayload } from 'jwt-decode'
 
 // locals
 import { OAuthInternetAccountConfigModel } from './configSchema'
@@ -153,16 +153,17 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
 
         if (!response.ok) {
           self.removeToken()
-          const contentType = response.headers.get('Content-Type');
-          let errorMessage, errorJson;
+          const contentType = response.headers.get('Content-Type')
+          let errorMessage, errorJson
           try {
-            if (contentType && contentType.indexOf("application/json") !== -1) {
-              errorJson = await response.json();
-              if (errorJson.error && errorJson.error === "invalid_grant") {
-                this.removeRefreshToken();
+            if (contentType && contentType.indexOf('application/json') !== -1) {
+              errorJson = await response.json()
+              if (errorJson.error && errorJson.error === 'invalid_grant') {
+                this.removeRefreshToken()
               }
             }
-            errorMessage = errorJson?.error_description ?? await response.text()
+            errorMessage =
+              errorJson?.error_description ?? (await response.text())
           } catch (error) {
             errorMessage = ''
           }
@@ -175,14 +176,14 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
 
         const accessToken = await response.json()
         if (accessToken.refresh_token) {
-          this.storeRefreshToken(accessToken.refresh_token);
+          this.storeRefreshToken(accessToken.refresh_token)
         }
         return accessToken.access_token
       },
     }))
     .actions(self => {
-      let listener: (event: MessageEvent) => void;
-      let refreshTokenPromise: Promise<string> | undefined = undefined;
+      let listener: (event: MessageEvent) => void
+      let refreshTokenPromise: Promise<string> | undefined = undefined
       return {
         // used to listen to child window for auth code/token
         addMessageChannel(
@@ -321,25 +322,24 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           token: string,
           location: UriLocation,
         ): Promise<string> {
-          const decoded = jwtDecode<JwtPayload>(token);
-          if (decoded.exp && decoded.exp < (new Date()).getTime() / 1000) {
+          const decoded = jwtDecode<JwtPayload>(token)
+          if (decoded.exp && decoded.exp < new Date().getTime() / 1000) {
             const refreshToken =
               self.hasRefreshToken && self.retrieveRefreshToken()
             if (refreshToken) {
               try {
                 if (!refreshTokenPromise) {
-                  refreshTokenPromise = self.exchangeRefreshForAccessToken(
-                    refreshToken,
-                  );
+                  refreshTokenPromise =
+                    self.exchangeRefreshForAccessToken(refreshToken)
                 }
-                const newToken = await refreshTokenPromise;
+                const newToken = await refreshTokenPromise
                 return this.validateToken(newToken, location)
               } catch (err) {
                 throw new Error(`Token could not be refreshed. ${err}`)
               }
             }
           } else {
-            refreshTokenPromise = undefined;
+            refreshTokenPromise = undefined
           }
           return token
         },

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -248,30 +248,6 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           }
           this.deleteMessageChannel()
         },
-        /**
-         * Get a fetch method that will add any needed authentication headers to
-         * the request before sending it. If location is provided, it will be
-         * checked to see if it includes a token in it pre-auth information.
-         * @param location - UriLocation of the resource
-         * @returns A function that can be used to fetch
-         */
-        getFetcher(
-          location?: UriLocation,
-        ): (input: RequestInfo, init?: RequestInit) => Promise<Response> {
-          return async (
-            input: RequestInfo,
-            init?: RequestInit,
-          ): Promise<Response> => {
-            // if(location) {
-            console.log("NONRPC - oAuthModel => getFetcher() => getPreAuthorizationInformation() from:" + (typeof sessionStorage === 'undefined' ? "webworker" : "not web worker"));
-            //   location.internetAccountPreAuthorization =
-            //     await self.getPreAuthorizationInformation(location)
-            // }
-            const authToken = await self.getToken(location)
-            const newInit = self.addAuthHeaderToInit(init, authToken)
-            return fetch(input, newInit)
-          }
-        },
         // opens external OAuth flow, popup for web and new browser window for desktop
         async useEndpointForAuthorization(
           resolve: (token: string) => void,


### PR DESCRIPTION
OAuthModel is supporting refresh tokens, but because of how [getToken()](https://github.com/GMOD/jbrowse-components/blob/7ed81c2b1e1554279c0b70767ef8fcb46a68df9d/packages/core/pluggableElementTypes/models/InternetAccountModel.ts#L135) is implemented it exchanges refresh token only once and does not pull new one when currently used one expires.

This change adds a validator that checks the currently used auth token for expiration and tries to use refresh token to get a new one. If that fails it removes refresh token to force full re-authorization.

There still might be a problem if a user will re-start a previous (authorized) session exactly on the assembly selection page because assemblies do not use the same data loading flow and thus do not use [getPreAuthorizationInformation()](https://github.com/GMOD/jbrowse-components/blob/main/packages/core/pluggableElementTypes/models/InternetAccountModel.ts#L170), but this is a very specific example and I didn't encounter it last week I was testing this change since local file caching seems to bypass this problem. 
