### PR TITLE
Add extendSession extension point to web and desktop

### DIFF
--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -628,7 +628,12 @@ export default function sessionModelFactory(
       },
     }))
 
-  return types.snapshotProcessor(addSnackbarToModel(sessionModel), {
+  const extendedSessionModel = pluginManager.evaluateExtensionPoint(
+    'Core-extendSession',
+    sessionModel,
+  ) as typeof sessionModel
+
+  return types.snapshotProcessor(addSnackbarToModel(extendedSessionModel), {
     // @ts-ignore
     preProcessor(snapshot) {
       if (snapshot) {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -717,7 +717,12 @@ export default function sessionModelFactory(
       },
     }))
 
-  return types.snapshotProcessor(addSnackbarToModel(sessionModel), {
+  const extendedSessionModel = pluginManager.evaluateExtensionPoint(
+    'Core-extendSession',
+    sessionModel,
+  ) as typeof sessionModel
+
+  return types.snapshotProcessor(addSnackbarToModel(extendedSessionModel), {
     // @ts-ignore
     preProcessor(snapshot) {
       if (snapshot) {


### PR DESCRIPTION
This adds an extension point to web and desktop that allows the session to be extended. You can use this to add more—or override exisiting—state, views, or actions to the session. I can be used from plugins like this:

```ts
pluginManager.addToExtensionPoint(
  'Core-extendSession',
  (sessionModel: IAnyModelType) =>
    sessionModel
      .props({
        // additional model state here
      })
      .views((self) => ({
        // additional views here
      }))
      .actions((self) => ({
        // additional actions here
      })),
)
```