### PR TITLE
Allow selecting session assemblies, improve session adding

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -179,6 +179,10 @@ export default function assemblyFactory(
         return getConf(self, 'aliases')
       },
 
+      get displayName(): string | undefined {
+        return getConf(self, 'displayName')
+      },
+
       hasName(name: string) {
         return this.allAliases.includes(name)
       },

--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -72,14 +72,22 @@ export default function assemblyManagerFactory(
         if (!assemblyName) {
           throw new Error('no assembly name supplied to waitForAssembly')
         }
-        const assembly = self.get(assemblyName)
+        let assembly = self.get(assemblyName)
+        if (!assembly) {
+          try {
+            await when(() => Boolean(self.get(assemblyName)), { timeout: 1000 })
+            assembly = self.get(assemblyName)
+          } catch (e) {
+            // ignore
+          }
+        }
         if (!assembly) {
           return undefined
         }
         await when(
           () =>
-            Boolean(assembly.regions && assembly.refNameAliases) ||
-            !!assembly.error,
+            Boolean(assembly?.regions && assembly.refNameAliases) ||
+            !!assembly?.error,
         )
         if (assembly.error) {
           throw assembly.error

--- a/packages/core/ui/AboutDialog.tsx
+++ b/packages/core/ui/AboutDialog.tsx
@@ -78,7 +78,9 @@ export default function AboutDialog({
     )
 
     trackName = asm
-      ? `Reference Sequence (${readConfObject(asm, 'name')})`
+      ? `Reference Sequence (${
+          readConfObject(asm, 'displayName') || readConfObject(asm, 'name')
+        })`
       : 'Reference Sequence'
   }
 

--- a/packages/core/util/when.ts
+++ b/packages/core/util/when.ts
@@ -1,10 +1,8 @@
-import { when as mobxWhen } from 'mobx'
+import { when as mobxWhen, IWhenOptions } from 'mobx'
 import { makeAbortError } from './aborting'
 
-interface WhenOpts {
-  timeout?: number
+interface WhenOpts extends IWhenOptions {
   signal?: AbortSignal
-  name?: string
 }
 
 /**

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
@@ -27,7 +27,10 @@ function getTrackName(config: AnyConfigurationModel): string {
   }
   return (
     readConfObject(config, 'name') ||
-    `Reference sequence (${readConfObject(getParent(config), 'name')})`
+    `Reference sequence (${
+      readConfObject(getParent(config), 'displayName') ||
+      readConfObject(getParent(config), 'name')
+    })`
   )
 }
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewSvg.tsx
@@ -235,10 +235,10 @@ function SVGTracks({
         const current = offset
         const trackName =
           getConf(track, 'name') ||
-          `Reference sequence (${readConfObject(
-            getParent(track.configuration),
-            'name',
-          )})`
+          `Reference sequence (${
+            readConfObject(getParent(track.configuration), 'displayName') ||
+            readConfObject(getParent(track.configuration), 'name')
+          })`
         const display = track.displays[0]
         offset += display.height + paddingHeight + textHeight
         return (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -72,7 +72,9 @@ function getTrackName(
     return (
       trackName ||
       (asm
-        ? `Reference Sequence (${readConfObject(asm, 'name')})`
+        ? `Reference Sequence (${
+            readConfObject(asm, 'displayName') || readConfObject(asm, 'name')
+          })`
         : 'Reference Sequence')
     )
   }

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -248,7 +248,8 @@ export default function sessionModelFactory(
           console.warn(`Assembly ${assemblyConfig.name} was already existing`)
           return asm
         }
-        self.sessionAssemblies.push(assemblyConfig)
+        const length = self.sessionAssemblies.push(assemblyConfig)
+        return self.sessionAssemblies[length - 1]
       },
       addSessionPlugin(plugin: JBrowsePlugin) {
         if (self.sessionPlugins.find(p => p.name === plugin.name)) {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -142,7 +142,11 @@ export default function sessionModelFactory(
         return getParent<any>(self).jbrowse.assemblies
       },
       get assemblyNames() {
-        return getParent<any>(self).jbrowse.assemblyNames
+        const { assemblyNames } = getParent<any>(self).jbrowse
+        const sessionAssemblyNames = self.sessionAssemblies.map(assembly =>
+          readConfObject(assembly, 'name'),
+        )
+        return [...assemblyNames, ...sessionAssemblyNames]
       },
       get tracks() {
         return [...self.sessionTracks, ...getParent<any>(self).jbrowse.tracks]


### PR DESCRIPTION
This has a few different changes related to assemblies:

- In the session view `assemblyNames`, this now includes the session assemblies' names as well. This has the effect of being able to choose session assemblies from the assembly selector in e.g. the LGV setup screen.
- Uses the assembly's `displayName` instead of `name` in more user-facing places.
- Improves `waitForAssembly` on the assembly manager. Before, if you added an assembly and then immediately called `waitForAssembly`, it wouldn't work because the reaction that adds the new assembly hadn't fired yet. Now, if it can't find the assembly it waits for a second and tries again to give the reaction time to run.
- (minor) returns the assembly config when it's added via the session action