### PR TITLE
Fix "dead state tree node" error by creating snapshots of parent region for block calculations

### DIFF
--- a/packages/core/util/calculateDynamicBlocks.ts
+++ b/packages/core/util/calculateDynamicBlocks.ts
@@ -1,3 +1,4 @@
+import { isStateTreeNode, getSnapshot } from 'mobx-state-tree'
 import { intersection2 } from './range'
 import { assembleLocString } from '.'
 import {
@@ -60,6 +61,7 @@ export default function calculateDynamicBlocks(
       displayedRegionLeftPx + (regionEnd - regionStart) / bpPerPx
 
     const regionWidthPx = (regionEnd - regionStart) / bpPerPx
+    const parentRegion = isStateTreeNode(region) ? getSnapshot(region) : region
 
     if (
       displayedRegionLeftPx < windowRightPx &&
@@ -104,7 +106,7 @@ export default function calculateDynamicBlocks(
         end,
         reversed,
         offsetPx: blockOffsetPx,
-        parentRegion: region,
+        parentRegion,
         regionNumber,
         widthPx,
         isLeftEndOfDisplayedRegion,

--- a/packages/core/util/calculateStaticBlocks.ts
+++ b/packages/core/util/calculateStaticBlocks.ts
@@ -1,3 +1,4 @@
+import { isStateTreeNode, getSnapshot, Instance } from 'mobx-state-tree'
 import { assembleLocString } from '.'
 import {
   BlockSet,
@@ -6,11 +7,12 @@ import {
   InterRegionPaddingBlock,
 } from './blockTypes'
 import { Region } from './types'
+import { Region as RegionModel } from './types/mst'
 
 export interface Base1DViewModel {
   offsetPx: number
   width: number
-  displayedRegions: Region[]
+  displayedRegions: (Region | Instance<typeof RegionModel>)[]
   bpPerPx: number
   minimumBlockWidth: number
   interRegionPaddingWidth: number
@@ -54,6 +56,7 @@ export default function calculateStaticBlocks(
       reversed,
     } = region
     const regionBlockCount = Math.ceil((regionEnd - regionStart) / blockSizeBp)
+    const parentRegion = isStateTreeNode(region) ? getSnapshot(region) : region
 
     let windowRightBlockNum =
       Math.floor((windowRightBp - regionBpOffset) / blockSizeBp) + extra
@@ -97,7 +100,7 @@ export default function calculateStaticBlocks(
         end,
         reversed,
         offsetPx: (regionBpOffset + blockNum * blockSizeBp) / bpPerPx,
-        parentRegion: region,
+        parentRegion,
         regionNumber,
         widthPx,
         isLeftEndOfDisplayedRegion,


### PR DESCRIPTION
I found a relatively reproducible procedure to create the dead state tree node error, and a probable fix for this particular case


- Go to LGV import form
- Enter EDEN
- Select EDEN from the dropdown
- Hit open


A good portion of the time, this produces the error in #3181 

I found that the "parentRegion" attribute in the static/dynamic blocks were not snapshots and were instead proxies for the state tree node, creating this error

Note that this change could mildly slow down the block calculations. Note also that parentRegion is not even used anywhere in our codebase, but have some hypothetical use cases


Fixes #3181 
