### PR TITLE
Make pluginManager param to getFetcher optional

### DIFF
--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -89,14 +89,16 @@ export function openLocation(
 
 export function getFetcher(
   location: FileLocation,
-  pluginManager: PluginManager,
+  pluginManager?: PluginManager,
 ): Fetcher {
   if (!isUriLocation(location)) {
     throw new Error(`Not a valid UriLocation: ${JSON.stringify(location)}`)
   }
-  const internetAccount = getInternetAccount(location, pluginManager)
-  if (internetAccount) {
-    return internetAccount.getFetcher(location)
+  if (pluginManager) {
+    const internetAccount = getInternetAccount(location, pluginManager)
+    if (internetAccount) {
+      return internetAccount.getFetcher(location)
+    }
   }
   return checkAuthNeededFetch
 }


### PR DESCRIPTION
`getFetcher` is supposed to be an alternative to `openLocation` for things like adapters that need to e.g. call a REST API instead of reading a file. This makes the `pluginManager` param for `getFetcher` optional so that its function signature and logic matches `openLocation`.

I found this while trying to use `getFetcher` in an adapter that retrieves sequences from the new Apollo server.