### PR TITLE
v2.1.3 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.1.3.md
+++ b/website/release_announcement_drafts/v2.1.3.md
@@ -1,0 +1,13 @@
+This release includes a quality-of-life improvement for users plotting synteny
+with CIGAR strings. Before this version, the x-axis in the dotplot was assumed
+to be target sequence (and similarly, the top row in the linear synteny view
+was assumed to be the target sequence). But now, target can be either x- or
+y-axis in dotplot, and top or bottom in linear synteny views, removing the need
+for the user to care as much about query-vs-target ordering.
+
+This release also includes several fixes for the the behavior of text searching
+in the linear genome view, a new button to open a .jbrowse file directly from
+the start screen on jbrowse-desktop, and an important bugfix to plotting
+inverted alignments on dotplots that affected versions v2.1.0-v2.1.2.
+
+Enjoy!


### PR DESCRIPTION
current changelog 

```

## Unreleased (2022-09-15)

#### :rocket: Enhancement
* Other
  * [#3188](https://github.com/GMOD/jbrowse-components/pull/3188) Add 'Open saved session' button to start screen on desktop ([@cmdcolin](https://github.com/cmdcolin))
  * [#3187](https://github.com/GMOD/jbrowse-components/pull/3187) Add mouseover tooltip descriptions to the header of the VariantFeatureDetails sample/genotype table ([@cmdcolin](https://github.com/cmdcolin))
  * [#3179](https://github.com/GMOD/jbrowse-components/pull/3179) Add extendSession extension point to web and desktop ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3178](https://github.com/GMOD/jbrowse-components/pull/3178) Allow X/Y assemblies of dotplot or top/bottom selection of synteny views to be either query or target ([@cmdcolin](https://github.com/cmdcolin))
  * [#3173](https://github.com/GMOD/jbrowse-components/pull/3173) Add ability for CLI to recognize plaintext BED files ([@cmdcolin](https://github.com/cmdcolin))
  * [#3162](https://github.com/GMOD/jbrowse-components/pull/3162) Add about dialog with version number for embedded components ([@cmdcolin](https://github.com/cmdcolin))
  * [#3163](https://github.com/GMOD/jbrowse-components/pull/3163) Note for user to wait before re-launching app on desktop update ([@cmdcolin](https://github.com/cmdcolin))
  * [#3179](https://github.com/GMOD/jbrowse-components/pull/3179) Add extendSession extension point to web and desktop ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3178](https://github.com/GMOD/jbrowse-components/pull/3178) Allow X/Y assemblies of dotplot or top/bottom selection of synteny views to be either query or target ([@cmdcolin](https://github.com/cmdcolin))
  * [#3173](https://github.com/GMOD/jbrowse-components/pull/3173) Add ability for CLI to recognize plaintext BED files ([@cmdcolin](https://github.com/cmdcolin))
  * [#3162](https://github.com/GMOD/jbrowse-components/pull/3162) Add about dialog with version number for embedded components ([@cmdcolin](https://github.com/cmdcolin))
  * [#3163](https://github.com/GMOD/jbrowse-components/pull/3163) Note for user to wait before re-launching app on desktop update ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#3180](https://github.com/GMOD/jbrowse-components/pull/3180) Allow selecting session assemblies, improve session adding, and use the assembly displayName in more places in the UI ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3183](https://github.com/GMOD/jbrowse-components/pull/3183) Make pluginManager param to getFetcher optional ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3183](https://github.com/GMOD/jbrowse-components/pull/3183) Make pluginManager param to getFetcher optional ([@garrettjstevens](https://github.com/garrettjstevens))

#### :bug: Bug Fix
* `core`
  * [#3168](https://github.com/GMOD/jbrowse-components/pull/3168) Fix search behavior when there are multiple matches in LGV header and when feature description matched in import form ([@cmdcolin](https://github.com/cmdcolin))
  * [#3182](https://github.com/GMOD/jbrowse-components/pull/3182) Fix "dead state tree node" error by creating snapshots of parent region for block calculations ([@cmdcolin](https://github.com/cmdcolin))
  * [#3182](https://github.com/GMOD/jbrowse-components/pull/3182) Fix "dead state tree node" error by creating snapshots of parent region for block calculations ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#3170](https://github.com/GMOD/jbrowse-components/pull/3170) Fix drawing inverted CIGAR segments on dotplot ([@cmdcolin](https://github.com/cmdcolin))
  * [#3170](https://github.com/GMOD/jbrowse-components/pull/3170) Fix drawing inverted CIGAR segments on dotplot ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#3138](https://github.com/GMOD/jbrowse-components/pull/3138) Documentation overhaul ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
* [#3138](https://github.com/GMOD/jbrowse-components/pull/3138) Documentation overhaul ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))

#### :house: Internal
* Other
  * [#3179](https://github.com/GMOD/jbrowse-components/pull/3179) Add extendSession extension point to web and desktop ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3179](https://github.com/GMOD/jbrowse-components/pull/3179) Add extendSession extension point to web and desktop ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3165](https://github.com/GMOD/jbrowse-components/pull/3165) Use more defaults in rollup plugins ([@garrettjstevens](https://github.com/garrettjstevens))
* `core`
  * [#3183](https://github.com/GMOD/jbrowse-components/pull/3183) Make pluginManager param to getFetcher optional ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3164](https://github.com/GMOD/jbrowse-components/pull/3164) Typescript the QuickLRU module in @jbrowse/core ([@cmdcolin](https://github.com/cmdcolin))
  * [#3183](https://github.com/GMOD/jbrowse-components/pull/3183) Make pluginManager param to getFetcher optional ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3164](https://github.com/GMOD/jbrowse-components/pull/3164) Typescript the QuickLRU module in @jbrowse/core ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 2.44s.


```