### PR TITLE
Add ?data= option for URL as shortcut for ?config=

### DIFF
--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -25,6 +25,7 @@ import SessionLoader, {
   SessionLoaderModel,
   loadSessionSpec,
 } from './SessionLoader'
+import { getURL } from './util'
 
 // lazy components
 const SessionWarningDialog = lazy(() => import('./SessionWarningDialog'))
@@ -116,7 +117,7 @@ export function Loader({
   const [tracks, setTracks] = useQueryParam('tracks', Str)
 
   const loader = SessionLoader.create({
-    configPath: load(config) || load(data) + '/config.json',
+    configPath: load(config) || getURL(data || '', 'config.json'),
     sessionQuery: load(session),
     password: load(password),
     adminKey: load(adminKey),
@@ -257,12 +258,10 @@ const Renderer = observer(
           // error Assuming that the query changes self.sessionError or
           // self.sessionSnapshot or self.blankSession
           const pluginManager = new PluginManager([
-            ...corePlugins.map(P => {
-              return {
-                plugin: new P(),
-                metadata: { isCore: true },
-              } as PluginLoadRecord
-            }),
+            ...corePlugins.map(P => ({
+              plugin: new P(),
+              metadata: { isCore: true },
+            })),
             ...runtimePlugins.map(({ plugin: P, definition }) => ({
               plugin: new P(),
               definition,

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -106,6 +106,7 @@ export function Loader({
   const Str = StringParam
 
   const [config] = useQueryParam('config', Str)
+  const [data] = useQueryParam('data', Str)
   const [session] = useQueryParam('session', Str)
   const [adminKey] = useQueryParam('adminKey', Str)
   const [password, setPassword] = useQueryParam('password', Str)
@@ -115,7 +116,7 @@ export function Loader({
   const [tracks, setTracks] = useQueryParam('tracks', Str)
 
   const loader = SessionLoader.create({
-    configPath: load(config),
+    configPath: load(config) || load(data) + '/config.json',
     sessionQuery: load(session),
     password: load(password),
     adminKey: load(adminKey),

--- a/products/jbrowse-web/src/util.ts
+++ b/products/jbrowse-web/src/util.ts
@@ -117,3 +117,11 @@ export function filterSessionInPlace(node: IAnyStateTreeNode, type: IAnyType) {
     })
   }
 }
+
+export function getURL(...args: string[]) {
+  let u: URL | string = window.location.href
+  for (let i = 0; i < args.length; i++) {
+    u = new URL(args[i], u)
+  }
+  return `${u}`
+}


### PR DESCRIPTION
let's you type ?data=test_data/volvox which resolves to the config at test_data/volvox/config.json

the ?data= param is similar to jbrowse 1 (where it resolves to a trackList.json) and shaves a couple characters from the url

potentially this could be considered duplication/unnecessary, but might be nice