### PR TITLE
Use "temporaryAssemblies" to store read vs ref assemblies, and allow selecting "sessionAssemblies" in dropdown

### DIFF
--- a/packages/core/assemblyManager/assemblyManager.ts
+++ b/packages/core/assemblyManager/assemblyManager.ts
@@ -37,12 +37,13 @@ export default function assemblyManagerFactory(
         // hence the union with {name:string}
         const {
           jbrowse: { assemblies },
-          session: { sessionAssemblies = [] } = {},
+          session: { sessionAssemblies = [], temporaryAssemblies = [] } = {},
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } = getParent<any>(self)
         return [
           ...assemblies,
           ...sessionAssemblies,
+          ...temporaryAssemblies,
         ] as (AnyConfigurationModel & { name: string })[]
       },
 

--- a/plugins/dotplot-view/src/DotplotReadVsRef.ts
+++ b/plugins/dotplot-view/src/DotplotReadVsRef.ts
@@ -106,6 +106,7 @@ export function onClick(feature: Feature, self: LinearPileupDisplayModel) {
           },
         ],
       },
+
       viewTrackConfigs: [
         {
           type: 'SyntenyTrack',
@@ -116,19 +117,6 @@ export function onClick(feature: Feature, self: LinearPileupDisplayModel) {
           },
           trackId,
           name: trackName,
-        },
-      ],
-      viewAssemblyConfigs: [
-        {
-          name: readAssembly,
-          sequence: {
-            type: 'ReferenceSequenceTrack',
-            trackId: `${readName}_${Date.now()}`,
-            adapter: {
-              type: 'FromConfigSequenceAdapter',
-              features: [feature.toJSON()],
-            },
-          },
         },
       ],
       assemblyNames,
@@ -144,6 +132,7 @@ export function onClick(feature: Feature, self: LinearPileupDisplayModel) {
           ],
         },
       ],
+
       displayName: `${readName} vs ${trackAssembly}`,
     })
   } catch (e) {

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -224,6 +224,10 @@ export default function stateModelFactory(pm: PluginManager) {
       closeView() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getParent<any>(self, 2).removeView(self)
+        const session = getSession(self)
+        self.assemblyNames.forEach(asm => {
+          session.removeTemporaryAssembly(asm)
+        })
       },
 
       setHeaderHeight(height: number) {
@@ -395,6 +399,13 @@ export default function stateModelFactory(pm: PluginManager) {
       },
     }))
     .actions(self => ({
+      // if any of our assemblies are temporary assemblies
+      beforeDestroy() {
+        const session = getSession(self)
+        self.assemblyNames.forEach(asm => {
+          session.removeTemporaryAssembly(asm)
+        })
+      },
       afterAttach() {
         addDisposer(
           self,

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -82,7 +82,6 @@ export default function stateModelFactory(pm: PluginManager) {
       types.model('DotplotView', {
         id: ElementId,
         type: types.literal('DotplotView'),
-        headerHeight: 0,
         height: 600,
         borderSize: 20,
         tickSize: 5,
@@ -104,10 +103,6 @@ export default function stateModelFactory(pm: PluginManager) {
         // read vs ref dotplots where this track would not really apply
         // elsewhere
         viewTrackConfigs: types.array(pm.pluggableConfigSchemaType('track')),
-
-        // this represents assemblies in the specialized read vs ref dotplot
-        // view
-        viewAssemblyConfigs: types.array(types.frozen()),
       }),
     )
     .volatile(() => ({
@@ -224,14 +219,6 @@ export default function stateModelFactory(pm: PluginManager) {
       closeView() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getParent<any>(self, 2).removeView(self)
-        const session = getSession(self)
-        self.assemblyNames.forEach(asm => {
-          session.removeTemporaryAssembly(asm)
-        })
-      },
-
-      setHeaderHeight(height: number) {
-        self.headerHeight = height
       },
 
       zoomOutButton() {

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -56,14 +56,9 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         viewTrackConfigs: types.array(
           pluginManager.pluggableConfigSchemaType('track'),
         ),
-
-        // this represents assemblies in the specialized read vs ref dotplot
-        // view
-        viewAssemblyConfigs: types.array(types.frozen()),
       }),
     )
     .volatile(() => ({
-      headerHeight: 0,
       width: 800,
     }))
     .views(self => ({
@@ -147,10 +142,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         getParent<any>(self, 2).removeView(self)
       },
 
-      setHeaderHeight(height: number) {
-        self.headerHeight = height
-      },
-
       setMiddleComparativeHeight(n: number) {
         self.middleComparativeHeight = n
         return self.middleComparativeHeight
@@ -180,6 +171,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       toggleTrack(trackId: string) {
         // if we have any tracks with that configuration, turn them off
         const hiddenCount = this.hideTrack(trackId)
+
         // if none had that configuration, turn one on
         if (!hiddenCount) {
           this.showTrack(trackId)

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -56,6 +56,10 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         viewTrackConfigs: types.array(
           pluginManager.pluggableConfigSchemaType('track'),
         ),
+
+        // this represents assemblies in the specialized read vs ref dotplot
+        // view
+        viewAssemblyConfigs: types.array(types.frozen()),
       }),
     )
     .volatile(() => ({

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -106,10 +106,8 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       // e.g. read vs ref
       beforeDestroy() {
         const session = getSession(self)
-        self.assemblyNames.forEach(name => {
-          if (name.endsWith('-temp')) {
-            session.removeAssembly?.(name)
-          }
+        self.assemblyNames.forEach(asm => {
+          session.removeTemporaryAssembly(asm)
         })
       },
 

--- a/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
@@ -425,6 +425,41 @@ export function WindowSizeDlg(props: {
                   },
                 ],
               },
+
+              ...(qualTrack
+                ? [
+                    {
+                      id: `${Math.random()}`,
+                      type: 'QuantitativeTrack',
+                      configuration: {
+                        trackId: 'qualTrack',
+                        assemblyNames: [readAssembly],
+                        name: 'Read quality',
+                        type: 'QuantitativeTrack',
+                        adapter: {
+                          type: 'FromConfigAdapter',
+                          noAssemblyManager: true,
+                          features: qual.split(' ').map((score, index) => {
+                            return {
+                              start: index,
+                              end: index + 1,
+                              refName: readName,
+                              score: +score,
+                              uniqueId: `feat_${index}`,
+                            }
+                          }),
+                        },
+                      },
+                      displays: [
+                        {
+                          id: `${Math.random()}`,
+                          type: 'LinearWiggleDisplay',
+                          height: 100,
+                        },
+                      ],
+                    },
+                  ]
+                : []),
             ],
           },
         ],

--- a/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
@@ -345,31 +345,30 @@ export function WindowSizeDlg(props: {
         })),
       )
 
-      session.addAssembly?.({
-        name: `${readAssembly}`,
-        sequence: {
-          type: 'ReferenceSequenceTrack',
-          name: `Read sequence`,
-          trackId: seqTrackId,
-          assemblyNames: [readAssembly],
-          adapter: {
-            type: 'FromConfigSequenceAdapter',
-            noAssemblyManager: true,
-            features: [
-              {
-                start: 0,
-                end: totalLength,
-                seq: featSeq,
-                refName: readName,
-                uniqueId: `${Math.random()}`,
-              },
-            ],
-          },
-        },
-      })
-
       session.addView('LinearSyntenyView', {
         type: 'LinearSyntenyView',
+        viewAssemblyConfigs: [
+          {
+            name: `${readAssembly}`,
+            sequence: {
+              type: 'ReferenceSequenceTrack',
+              name: `Read sequence`,
+              trackId: seqTrackId,
+              adapter: {
+                type: 'FromConfigSequenceAdapter',
+                features: [
+                  {
+                    start: 0,
+                    end: totalLength,
+                    seq: featSeq,
+                    refName: readName,
+                    uniqueId: `${Math.random()}`,
+                  },
+                ],
+              },
+            },
+          },
+        ],
         views: [
           {
             type: 'LinearGenomeView',
@@ -377,24 +376,7 @@ export function WindowSizeDlg(props: {
             offsetPx: 0,
             bpPerPx: refLength / view.width,
             displayedRegions: lgvRegions,
-            tracks: [
-              {
-                id: `${Math.random()}`,
-                type: 'ReferenceSequenceTrack',
-                assemblyNames: [trackAssembly],
-                configuration: sequenceTrackConf.trackId,
-                displays: [
-                  {
-                    id: `${Math.random()}`,
-                    type: 'LinearReferenceSequenceDisplay',
-                    showReverse: true,
-                    showTranslation: false,
-                    height: 35,
-                    configuration: `${seqTrackId}-LinearReferenceSequenceDisplay`,
-                  },
-                ],
-              },
-            ],
+            tracks: [],
           },
           {
             type: 'LinearGenomeView',
@@ -413,7 +395,8 @@ export function WindowSizeDlg(props: {
               {
                 id: `${Math.random()}`,
                 type: 'ReferenceSequenceTrack',
-                configuration: seqTrackId,
+                assemblyNames: [trackAssembly],
+                configuration: sequenceTrackConf.trackId,
                 displays: [
                   {
                     id: `${Math.random()}`,
@@ -425,40 +408,6 @@ export function WindowSizeDlg(props: {
                   },
                 ],
               },
-              ...(qualTrack
-                ? [
-                    {
-                      id: `${Math.random()}`,
-                      type: 'QuantitativeTrack',
-                      configuration: {
-                        trackId: 'qualTrack',
-                        assemblyNames: [readAssembly],
-                        name: 'Read quality',
-                        type: 'QuantitativeTrack',
-                        adapter: {
-                          type: 'FromConfigAdapter',
-                          noAssemblyManager: true,
-                          features: qual.split(' ').map((score, index) => {
-                            return {
-                              start: index,
-                              end: index + 1,
-                              refName: readName,
-                              score: +score,
-                              uniqueId: `feat_${index}`,
-                            }
-                          }),
-                        },
-                      },
-                      displays: [
-                        {
-                          id: `${Math.random()}`,
-                          type: 'LinearWiggleDisplay',
-                          height: 100,
-                        },
-                      ],
-                    },
-                  ]
-                : []),
             ],
           },
         ],

--- a/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/LinearReadVsRef.tsx
@@ -345,30 +345,31 @@ export function WindowSizeDlg(props: {
         })),
       )
 
+      session.addTemporaryAssembly({
+        name: `${readAssembly}`,
+        sequence: {
+          type: 'ReferenceSequenceTrack',
+          name: `Read sequence`,
+          trackId: seqTrackId,
+          assemblyNames: [readAssembly],
+          adapter: {
+            type: 'FromConfigSequenceAdapter',
+            noAssemblyManager: true,
+            features: [
+              {
+                start: 0,
+                end: totalLength,
+                seq: featSeq,
+                refName: readName,
+                uniqueId: `${Math.random()}`,
+              },
+            ],
+          },
+        },
+      })
+
       session.addView('LinearSyntenyView', {
         type: 'LinearSyntenyView',
-        viewAssemblyConfigs: [
-          {
-            name: `${readAssembly}`,
-            sequence: {
-              type: 'ReferenceSequenceTrack',
-              name: `Read sequence`,
-              trackId: seqTrackId,
-              adapter: {
-                type: 'FromConfigSequenceAdapter',
-                features: [
-                  {
-                    start: 0,
-                    end: totalLength,
-                    seq: featSeq,
-                    refName: readName,
-                    uniqueId: `${Math.random()}`,
-                  },
-                ],
-              },
-            },
-          },
-        ],
         views: [
           {
             type: 'LinearGenomeView',
@@ -376,7 +377,24 @@ export function WindowSizeDlg(props: {
             offsetPx: 0,
             bpPerPx: refLength / view.width,
             displayedRegions: lgvRegions,
-            tracks: [],
+            tracks: [
+              {
+                id: `${Math.random()}`,
+                type: 'ReferenceSequenceTrack',
+                assemblyNames: [trackAssembly],
+                configuration: sequenceTrackConf.trackId,
+                displays: [
+                  {
+                    id: `${Math.random()}`,
+                    type: 'LinearReferenceSequenceDisplay',
+                    showReverse: true,
+                    showTranslation: false,
+                    height: 35,
+                    configuration: `${seqTrackId}-LinearReferenceSequenceDisplay`,
+                  },
+                ],
+              },
+            ],
           },
           {
             type: 'LinearGenomeView',
@@ -395,8 +413,7 @@ export function WindowSizeDlg(props: {
               {
                 id: `${Math.random()}`,
                 type: 'ReferenceSequenceTrack',
-                assemblyNames: [trackAssembly],
-                configuration: sequenceTrackConf.trackId,
+                configuration: seqTrackId,
                 displays: [
                   {
                     id: `${Math.random()}`,

--- a/plugins/linear-comparative-view/src/index.tsx
+++ b/plugins/linear-comparative-view/src/index.tsx
@@ -19,7 +19,7 @@ import LinearSyntenyViewF from './LinearSyntenyView'
 import LaunchLinearSyntenyViewF from './LaunchLinearSyntenyView'
 import SyntenyTrackF from './SyntenyTrack'
 import SyntenyFeatureWidgetF from './SyntenyFeatureDetail'
-import { WindowSizeDlg } from './ReadVsRef'
+import { WindowSizeDlg } from './LinearReadVsRef'
 
 function isDisplay(elt: { name: string }): elt is DisplayType {
   return elt.name === 'LinearPileupDisplay'

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -67,16 +67,13 @@ function getTrackName(
   session: { assemblies: AnyConfigurationModel[] },
 ) {
   const trackName = getConf(track, 'name')
-  if (getConf(track, 'type') === 'ReferenceSequenceTrack') {
+  if (!trackName && getConf(track, 'type') === 'ReferenceSequenceTrack') {
     const asm = session.assemblies.find(a => a.sequence === track.configuration)
-    return (
-      trackName ||
-      (asm
-        ? `Reference Sequence (${
-            readConfObject(asm, 'displayName') || readConfObject(asm, 'name')
-          })`
-        : 'Reference Sequence')
-    )
+    return asm
+      ? `Reference Sequence (${
+          readConfObject(asm, 'displayName') || readConfObject(asm, 'name')
+        })`
+      : 'Reference Sequence'
   }
   return trackName
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -204,10 +204,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       get assembliesInitialized() {
         const { assemblyManager } = getSession(self)
         const { assemblyNames } = self
-        return assemblyNames.every(a => {
-          let s = assemblyManager.get(a)
-          return s ? s.initialized : true
-        })
+        return assemblyNames.every(a => assemblyManager.get(a)?.initialized)
       },
       get initialized() {
         return self.volatileWidth !== undefined && this.assembliesInitialized

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -204,7 +204,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
       get assembliesInitialized() {
         const { assemblyManager } = getSession(self)
         const { assemblyNames } = self
-        return assemblyNames.every(a => assemblyManager.get(a)?.initialized)
+        return assemblyNames.every(a => {
+          let s = assemblyManager.get(a)
+          return s ? s.initialized : true
+        })
       },
       get initialized() {
         return self.volatileWidth !== undefined && this.assembliesInitialized

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -46,7 +46,7 @@ export declare interface ReferringNode {
 
 export default function sessionModelFactory(
   pluginManager: PluginManager,
-  assemblyConfigSchemasType = types.frozen(), // if not using sessionAssemblies
+  assemblyConfigSchemasType = types.frozen(),
 ) {
   const minDrawerWidth = 128
   const sessionModel = types
@@ -70,6 +70,7 @@ export default function sessionModelFactory(
         pluginManager.pluggableMstType('connection', 'stateModel'),
       ),
       sessionAssemblies: types.array(assemblyConfigSchemasType),
+      temporaryAssemblies: types.array(assemblyConfigSchemasType),
 
       minimized: types.optional(types.boolean, false),
 
@@ -300,6 +301,36 @@ export default function sessionModelFactory(
 
       addAssembly(assemblyConfig: any) {
         self.sessionAssemblies.push(assemblyConfig)
+      },
+      removeAssembly(assemblyName: string) {
+        const index = self.sessionAssemblies.findIndex(
+          asm => asm.name === assemblyName,
+        )
+        if (index !== -1) {
+          self.sessionAssemblies.splice(index, 1)
+        }
+      },
+
+      removeTemporaryAssembly(assemblyName: string) {
+        const index = self.temporaryAssemblies.findIndex(
+          asm => asm.name === assemblyName,
+        )
+        if (index !== -1) {
+          self.temporaryAssemblies.splice(index, 1)
+        }
+      },
+
+      // used for read vs ref type assemblies.
+      addTemporaryAssembly(assemblyConfig: AnyConfigurationModel) {
+        const asm = self.sessionAssemblies.find(
+          f => f.name === assemblyConfig.name,
+        )
+        if (asm) {
+          console.warn(`Assembly ${assemblyConfig.name} was already existing`)
+          return asm
+        }
+        const length = self.temporaryAssemblies.push(assemblyConfig)
+        return self.temporaryAssemblies[length - 1]
       },
 
       addAssemblyConf(assemblyConf: any) {

--- a/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
@@ -13,6 +13,7 @@ Object {
   "sessionConnections": Array [],
   "sessionPlugins": Array [],
   "sessionTracks": Array [],
+  "temporaryAssemblies": Array [],
   "views": Array [],
   "widgets": Object {},
 }

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -143,7 +143,11 @@ export default function sessionModelFactory(
         return getParent<any>(self).jbrowse.assemblies
       },
       get assemblyNames() {
-        return getParent<any>(self).jbrowse.assemblyNames
+        const { assemblyNames } = getParent<any>(self).jbrowse
+        const sessionAssemblyNames = self.sessionAssemblies.map(assembly =>
+          readConfObject(assembly, 'name'),
+        )
+        return [...assemblyNames, ...sessionAssemblyNames]
       },
       get tracks() {
         return [...self.sessionTracks, ...getParent<any>(self).jbrowse.tracks]

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -57,7 +57,7 @@ export declare interface ReactProps {
 
 export default function sessionModelFactory(
   pluginManager: PluginManager,
-  assemblyConfigSchemasType = types.frozen(), // if not using sessionAssemblies
+  assemblySchema = types.frozen(),
 ) {
   const minDrawerWidth = 128
   const sessionModel = types
@@ -87,7 +87,8 @@ export default function sessionModelFactory(
       sessionConnections: types.array(
         pluginManager.pluggableConfigSchemaType('connection'),
       ),
-      sessionAssemblies: types.array(assemblyConfigSchemasType),
+      sessionAssemblies: types.array(assemblySchema),
+      temporaryAssemblies: types.array(assemblySchema),
       sessionPlugins: types.array(types.frozen()),
       minimized: types.optional(types.boolean, false),
 
@@ -247,6 +248,19 @@ export default function sessionModelFactory(
         const length = self.sessionAssemblies.push(assemblyConfig)
         return self.sessionAssemblies[length - 1]
       },
+
+      // used for read vs ref type assemblies.
+      addTemporaryAssembly(assemblyConfig: AnyConfigurationModel) {
+        const asm = self.sessionAssemblies.find(
+          f => f.name === assemblyConfig.name,
+        )
+        if (asm) {
+          console.warn(`Assembly ${assemblyConfig.name} was already existing`)
+          return asm
+        }
+        const length = self.temporaryAssemblies.push(assemblyConfig)
+        return self.temporaryAssemblies[length - 1]
+      },
       addSessionPlugin(plugin: JBrowsePlugin) {
         if (self.sessionPlugins.find(p => p.name === plugin.name)) {
           throw new Error('session plugin cannot be installed twice')
@@ -260,6 +274,14 @@ export default function sessionModelFactory(
         )
         if (index !== -1) {
           self.sessionAssemblies.splice(index, 1)
+        }
+      },
+      removeTemporaryAssembly(assemblyName: string) {
+        const index = self.temporaryAssemblies.findIndex(
+          asm => asm.name === assemblyName,
+        )
+        if (index !== -1) {
+          self.temporaryAssemblies.splice(index, 1)
         }
       },
       removeSessionPlugin(pluginDefinition: PluginDefinition) {

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -57,7 +57,7 @@ export declare interface ReactProps {
 
 export default function sessionModelFactory(
   pluginManager: PluginManager,
-  assemblySchema = types.frozen(),
+  assemblyConfigSchemasType = types.frozen(),
 ) {
   const minDrawerWidth = 128
   const sessionModel = types
@@ -87,8 +87,8 @@ export default function sessionModelFactory(
       sessionConnections: types.array(
         pluginManager.pluggableConfigSchemaType('connection'),
       ),
-      sessionAssemblies: types.array(assemblySchema),
-      temporaryAssemblies: types.array(assemblySchema),
+      sessionAssemblies: types.array(assemblyConfigSchemasType),
+      temporaryAssemblies: types.array(assemblyConfigSchemasType),
       sessionPlugins: types.array(types.frozen()),
       minimized: types.optional(types.boolean, false),
 

--- a/products/jbrowse-web/src/tests/dotplot_inverted_flipaxes.json
+++ b/products/jbrowse-web/src/tests/dotplot_inverted_flipaxes.json
@@ -1619,8 +1619,7 @@
             ]
           }
         ],
-        "viewTrackConfigs": [],
-        "viewAssemblyConfigs": []
+        "viewTrackConfigs": []
       }
     ],
     "widgets": {

--- a/products/jbrowse-web/src/tests/dotplot_inverted_test.json
+++ b/products/jbrowse-web/src/tests/dotplot_inverted_test.json
@@ -1619,8 +1619,7 @@
             ]
           }
         ],
-        "viewTrackConfigs": [],
-        "viewAssemblyConfigs": []
+        "viewTrackConfigs": []
       }
     ],
     "widgets": {

--- a/test_data/yeast_synteny/config.json
+++ b/test_data/yeast_synteny/config.json
@@ -451,8 +451,7 @@
             ]
           }
         ],
-        "viewTrackConfigs": [],
-        "viewAssemblyConfigs": []
+        "viewTrackConfigs": []
       },
       {
         "id": "1Brqh2UJa",


### PR DESCRIPTION
This restores the ability to view session assemblies in the session selector https://github.com/GMOD/jbrowse-components/pull/3180

It stores the "read assemblies" in a new field called "temporaryAssemblies" on the sessionmodel

I considered also using the "view assembly" (store the assembly itself on the view model) but this is tricky to make work right because 

a) it has to bypass using the assembly manager, or otherwise makee the assembly manager track assemblies on the view models
b) has to make the view receive the assembly config, which it currently does not (was using a frozen for 'view assemblies'). as a frozen, it will not properly hydrate the displays such as the LinearReferenceDisplay (which is used to display the sequence track on the read assembly in the synteny view), it must be a real assembly config to do so

So instead of trying to solve (a) and (b) with view assemblies, which are sort of delicate operations in general, I created the concept of "temporary assemblies" which are session assemblies, and integrate with assembly manager and the proper assembly config schema