### PR TITLE
Better error reporting on jbrowse-web start screen when user attempts to open a broken recent session

### DIFF
--- a/products/jbrowse-web/src/RecentSessionCard.js
+++ b/products/jbrowse-web/src/RecentSessionCard.js
@@ -20,7 +20,6 @@ const useStyles = makeStyles()({
 
 function RecentSessionCard({ sessionName, onClick, onDelete }) {
   const { classes } = useStyles()
-  const [hovered, setHovered] = useState(false)
   const [menuAnchorEl, setMenuAnchorEl] = useState(null)
 
   function onMenuClick(event) {
@@ -38,13 +37,7 @@ function RecentSessionCard({ sessionName, onClick, onDelete }) {
 
   return (
     <>
-      <ListItem
-        onMouseOver={() => setHovered(true)}
-        onMouseOut={() => setHovered(false)}
-        onClick={() => onClick(sessionName)}
-        raised={Boolean(hovered)}
-        button
-      >
+      <ListItem onClick={() => onClick(sessionName)} button>
         <Tooltip title={sessionName} enterDelay={300}>
           <Typography variant="body2" noWrap style={{ width: 250 }}>
             {sessionName}

--- a/products/jbrowse-web/src/RecentSessionCard.tsx
+++ b/products/jbrowse-web/src/RecentSessionCard.tsx
@@ -18,16 +18,24 @@ const useStyles = makeStyles()({
   },
 })
 
-function RecentSessionCard({ sessionName, onClick, onDelete }) {
+function RecentSessionCard({
+  sessionName,
+  onClick,
+  onDelete,
+}: {
+  sessionName: string
+  onClick: (arg: string) => void
+  onDelete: (arg: string) => void
+}) {
   const { classes } = useStyles()
   const [menuAnchorEl, setMenuAnchorEl] = useState(null)
 
-  function onMenuClick(event) {
+  function onMenuClick(event: any) {
     event.stopPropagation()
     setMenuAnchorEl(event.currentTarget)
   }
 
-  const handleMenuClose = action => {
+  const handleMenuClose = (action: any) => {
     setMenuAnchorEl(null)
     if (action === 'delete') {
       return onDelete(sessionName)

--- a/products/jbrowse-web/src/RecentSessionCard.tsx
+++ b/products/jbrowse-web/src/RecentSessionCard.tsx
@@ -28,14 +28,9 @@ function RecentSessionCard({
   onDelete: (arg: string) => void
 }) {
   const { classes } = useStyles()
-  const [menuAnchorEl, setMenuAnchorEl] = useState(null)
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
 
-  function onMenuClick(event: any) {
-    event.stopPropagation()
-    setMenuAnchorEl(event.currentTarget)
-  }
-
-  const handleMenuClose = (action: any) => {
+  const handleMenuClose = (action: string) => {
     setMenuAnchorEl(null)
     if (action === 'delete') {
       return onDelete(sessionName)
@@ -51,7 +46,13 @@ function RecentSessionCard({
             {sessionName}
           </Typography>
         </Tooltip>
-        <IconButton className={classes.menu} onClick={onMenuClick}>
+        <IconButton
+          className={classes.menu}
+          onClick={event => {
+            event.stopPropagation()
+            setMenuAnchorEl(event.currentTarget)
+          }}
+        >
           <MoreVertIcon color="secondary" />
         </IconButton>
       </ListItem>

--- a/products/jbrowse-web/src/StartScreen.tsx
+++ b/products/jbrowse-web/src/StartScreen.tsx
@@ -109,7 +109,7 @@ export default function StartScreen({
   const [sessions, setSessions] = useState<Record<string, any>>()
   const [sessionToDelete, setSessionToDelete] = useState<string>()
   const [sessionToLoad, setSessionToLoad] = useState<string>()
-  const [userMessage, setUserMessage] = useState<string>()
+  const [error, setError] = useState<unknown>()
   const [updateSessionsList, setUpdateSessionsList] = useState(true)
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null)
   const [reset, setReset] = useState(false)
@@ -122,9 +122,7 @@ export default function StartScreen({
           rootModel.activateSession(sessionToLoad)
         }
       } catch (e) {
-        setUserMessage(
-          'There was an issue loading the session. Please check your configuration or contact your administrator.',
-        )
+        setError(e)
       }
     })()
   }, [rootModel, sessionToLoad])
@@ -227,7 +225,7 @@ export default function StartScreen({
               />
             ))}
           </List>
-          {userMessage ? <ErrorMessage error={userMessage} /> : null}
+          {error ? <ErrorMessage error={error} /> : null}
         </div>
       </Container>
 

--- a/products/jbrowse-web/src/StartScreen.tsx
+++ b/products/jbrowse-web/src/StartScreen.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState } from 'react'
 import {
-  Alert,
   Button,
   CircularProgress,
   Container,
@@ -23,7 +22,7 @@ import { makeStyles } from 'tss-react/mui'
 import WarningIcon from '@mui/icons-material/Warning'
 import SettingsIcon from '@mui/icons-material/Settings'
 
-import { LogoFull, FactoryResetDialog } from '@jbrowse/core/ui'
+import { LogoFull, FactoryResetDialog, ErrorMessage } from '@jbrowse/core/ui'
 import {
   NewEmptySession,
   NewLinearGenomeViewSession,
@@ -228,7 +227,7 @@ export default function StartScreen({
               />
             ))}
           </List>
-          {userMessage ? <Alert severity="error">{userMessage}</Alert> : null}
+          {userMessage ? <ErrorMessage error={userMessage} /> : null}
         </div>
       </Container>
 

--- a/products/jbrowse-web/src/StartScreen.tsx
+++ b/products/jbrowse-web/src/StartScreen.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState } from 'react'
 import {
+  Alert,
   Button,
   CircularProgress,
   Container,
@@ -109,6 +110,7 @@ export default function StartScreen({
   const [sessions, setSessions] = useState<Record<string, any>>()
   const [sessionToDelete, setSessionToDelete] = useState<string>()
   const [sessionToLoad, setSessionToLoad] = useState<string>()
+  const [userMessage, setUserMessage] = useState<string>()
   const [updateSessionsList, setUpdateSessionsList] = useState(true)
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null)
   const [reset, setReset] = useState(false)
@@ -121,9 +123,9 @@ export default function StartScreen({
           rootModel.activateSession(sessionToLoad)
         }
       } catch (e) {
-        setSessions(() => {
-          throw e
-        })
+        setUserMessage(
+          'There was an issue loading the session. Please check your configuration or contact your administrator.',
+        )
       }
     })()
   }, [rootModel, sessionToLoad])
@@ -226,6 +228,7 @@ export default function StartScreen({
               />
             ))}
           </List>
+          {userMessage ? <Alert severity="error">{userMessage}</Alert> : null}
         </div>
       </Container>
 


### PR DESCRIPTION
- removes deprecated prop ("raised") on listItem to fix a console error
- sets a message for the user instead of throwing an error on the front end that was causing a crash if the user attempted to open a "Recent session" that cannot be loaded