### PR TITLE
Fix configuration initialization on the internet accounts models

### DIFF
--- a/products/jbrowse-desktop/src/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel.ts
@@ -133,18 +133,21 @@ export default function rootModelFactory(pluginManager: PluginManager) {
         const schema = pluginManager.pluggableConfigSchemaType(
           'internet account',
         ) as IAnyModelType
-        const config = resolveIdentifier(schema, self, id)
+        const configuration = resolveIdentifier(schema, self, id)
 
-        const accountType = pluginManager.getInternetAccountType(config.type)
+        const accountType = pluginManager.getInternetAccountType(
+          configuration.type,
+        )
         if (!accountType) {
-          throw new Error(`unknown internet account type ${config.type}`)
+          throw new Error(`unknown internet account type ${configuration.type}`)
         }
 
         const internetAccount = accountType.stateModel.create({
           ...initialSnapshot,
-          type: config.type,
-          config,
+          type: configuration.type,
+          configuration,
         })
+
         self.internetAccounts.push(internetAccount)
         return internetAccount
       },


### PR DESCRIPTION
This passes a "configuration" object instead of a "config" object. I am actually a bit confused on how the internet account code worked without this fix, but this PR would fix https://github.com/GMOD/jbrowse-components/issues/3201