### PR TITLE
Add error boundary on view, track, and drawer widget

### DIFF
--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import LaunchIcon from '@mui/icons-material/Launch'
+import { ErrorBoundary } from 'react-error-boundary'
 import { observer } from 'mobx-react'
 import { getEnv } from 'mobx-state-tree'
 
@@ -19,11 +20,13 @@ import { getEnv } from 'mobx-state-tree'
 import { readConfObject, AnyConfigurationModel } from '../configuration'
 import DrawerWidget from './DrawerWidget'
 import DropDownMenu from './DropDownMenu'
+import ErrorMessage from './ErrorMessage'
 import EditableTypography from './EditableTypography'
 import { LogoFull } from './Logo'
 import Snackbar from './Snackbar'
 import ViewContainer from './ViewContainer'
 import {
+  AbstractViewModel,
   NotificationLevel,
   SessionWithDrawerWidgets,
   SnackAction,
@@ -100,11 +103,118 @@ const Logo = observer(
 
 type SnackbarMessage = [string, NotificationLevel, SnackAction]
 
+type AppSession = SessionWithDrawerWidgets & {
+  savedSessionNames: string[]
+  menus: { label: string; menuItems: JBMenuItem[] }[]
+  renameCurrentSession: (arg: string) => void
+  snackbarMessages: SnackbarMessage[]
+  popSnackbarMessage: () => unknown
+}
+
+const AppToolbar = ({
+  session,
+  HeaderButtons = <div />,
+}: {
+  HeaderButtons?: React.ReactElement
+  session: AppSession
+}) => {
+  const { classes } = useStyles()
+  const { savedSessionNames, name, menus } = session
+
+  function handleNameChange(newName: string) {
+    if (savedSessionNames?.includes(newName)) {
+      session.notify(
+        `Cannot rename session to "${newName}", a saved session with that name already exists`,
+        'warning',
+      )
+    } else {
+      session.renameCurrentSession(newName)
+    }
+  }
+  return (
+    <Toolbar>
+      {menus.map(menu => (
+        <DropDownMenu
+          key={menu.label}
+          menuTitle={menu.label}
+          menuItems={menu.menuItems}
+          session={session}
+        />
+      ))}
+      <div className={classes.grow} />
+      <Tooltip title="Rename Session" arrow>
+        <EditableTypography
+          value={name}
+          setValue={handleNameChange}
+          variant="body1"
+          classes={{
+            inputBase: classes.inputBase,
+            inputRoot: classes.inputRoot,
+            inputFocused: classes.inputFocused,
+          }}
+        />
+      </Tooltip>
+      {HeaderButtons}
+      <div className={classes.grow} />
+      <div style={{ width: 150, maxHeight: 48 }}>
+        <Logo session={session} />
+      </div>
+    </Toolbar>
+  )
+}
+
+const ViewLauncher = observer(({ session }: { session: AppSession }) => {
+  const { classes } = useStyles()
+  const { pluginManager } = getEnv(session)
+  const viewTypes = pluginManager.getElementTypeRecord('view').all()
+  const [value, setValue] = useState(viewTypes[0]?.name)
+  return (
+    <Paper className={classes.selectPaper}>
+      <Typography>Select a view to launch</Typography>
+      <Select value={value} onChange={event => setValue(event.target.value)}>
+        {viewTypes.map(({ name }: { name: string }) => (
+          <MenuItem key={name} value={name}>
+            {name}
+          </MenuItem>
+        ))}
+      </Select>
+      <Button
+        onClick={() => {
+          session.addView(value, {})
+        }}
+        variant="contained"
+        color="primary"
+      >
+        Launch view
+      </Button>
+    </Paper>
+  )
+})
+
+const ViewPanel = observer(
+  ({ view, session }: { view: AbstractViewModel; session: AppSession }) => {
+    const { pluginManager } = getEnv(session)
+    const viewType = pluginManager.getViewType(view.type)
+    if (!viewType) {
+      throw new Error(`unknown view type ${view.type}`)
+    }
+    const { ReactComponent } = viewType
+    return (
+      <ViewContainer view={view} onClose={() => session.removeView(view)}>
+        <Suspense fallback={<div>Loading...</div>}>
+          <ReactComponent
+            model={view}
+            session={session}
+            getTrackType={pluginManager.getTrackType}
+          />
+        </Suspense>
+      </ViewContainer>
+    )
+  },
+)
+
 const App = observer(
-  ({
-    session,
-    HeaderButtons = <div />,
-  }: {
+  (props: {
     HeaderButtons?: React.ReactElement
     session: SessionWithDrawerWidgets & {
       savedSessionNames: string[]
@@ -114,32 +224,17 @@ const App = observer(
       popSnackbarMessage: () => unknown
     }
   }) => {
+    const { session } = props
     const { classes } = useStyles()
-    const { pluginManager } = getEnv(session)
-    const viewTypes = pluginManager.getElementTypeRecord('view').all()
-    const [value, setValue] = useState(viewTypes[0]?.name)
+
     const {
+      minimized,
       visibleWidget,
       drawerWidth,
-      minimized,
       activeWidgets,
-      savedSessionNames,
-      name,
-      menus,
       views,
       drawerPosition,
     } = session
-
-    function handleNameChange(newName: string) {
-      if (savedSessionNames?.includes(newName)) {
-        session.notify(
-          `Cannot rename session to "${newName}", a saved session with that name already exists`,
-          'warning',
-        )
-      } else {
-        session.renameCurrentSession(newName)
-      }
-    }
 
     const drawerVisible = visibleWidget && !minimized
 
@@ -174,91 +269,26 @@ const App = observer(
         <div className={classes.menuBarAndComponents}>
           <div className={classes.menuBar}>
             <AppBar className={classes.appBar} position="static">
-              <Toolbar>
-                {menus.map(menu => (
-                  <DropDownMenu
-                    key={menu.label}
-                    menuTitle={menu.label}
-                    menuItems={menu.menuItems}
-                    session={session}
-                  />
-                ))}
-                <div className={classes.grow} />
-                <Tooltip title="Rename Session" arrow>
-                  <EditableTypography
-                    value={name}
-                    setValue={handleNameChange}
-                    variant="body1"
-                    classes={{
-                      inputBase: classes.inputBase,
-                      inputRoot: classes.inputRoot,
-                      inputFocused: classes.inputFocused,
-                    }}
-                  />
-                </Tooltip>
-                {HeaderButtons}
-                <div className={classes.grow} />
-                <div style={{ width: 150, maxHeight: 48 }}>
-                  <Logo session={session} />
-                </div>
-              </Toolbar>
+              <AppToolbar {...props} />
             </AppBar>
           </div>
           <div className={classes.components}>
             {views.length ? (
-              views.map(view => {
-                const viewType = pluginManager.getViewType(view.type)
-                if (!viewType) {
-                  throw new Error(`unknown view type ${view.type}`)
-                }
-                const { ReactComponent } = viewType
-                return (
-                  <ViewContainer
+              views.map(view => (
+                <ErrorBoundary
+                  FallbackComponent={({ error }) => (
+                    <ErrorMessage error={error} />
+                  )}
+                >
+                  <ViewPanel
                     key={`view-${view.id}`}
                     view={view}
-                    onClose={() => {
-                      session.removeView(view)
-                      session.notify(`A view has been closed`, 'info', {
-                        name: 'undo',
-                        onClick: () => {
-                          pluginManager.rootModel.history.undo()
-                        },
-                      })
-                    }}
-                  >
-                    <Suspense fallback={<div>Loading...</div>}>
-                      <ReactComponent
-                        model={view}
-                        session={session}
-                        getTrackType={pluginManager.getTrackType}
-                      />
-                    </Suspense>
-                  </ViewContainer>
-                )
-              })
+                    session={session}
+                  />
+                </ErrorBoundary>
+              ))
             ) : (
-              <Paper className={classes.selectPaper}>
-                <Typography>Select a view to launch</Typography>
-                <Select
-                  value={value}
-                  onChange={event => setValue(event.target.value)}
-                >
-                  {viewTypes.map(({ name }: { name: string }) => (
-                    <MenuItem key={name} value={name}>
-                      {name}
-                    </MenuItem>
-                  ))}
-                </Select>
-                <Button
-                  onClick={() => {
-                    session.addView(value, {})
-                  }}
-                  variant="contained"
-                  color="primary"
-                >
-                  Launch view
-                </Button>
-              </Paper>
+              <ViewLauncher {...props} />
             )}
 
             {/* blank space at the bottom of screen allows scroll */}

--- a/packages/core/ui/DrawerWidget.tsx
+++ b/packages/core/ui/DrawerWidget.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useState } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 import {
   AppBar,
   FormControl,
@@ -23,6 +24,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 
 // locals
 import Drawer from './Drawer'
+import ErrorMessage from './ErrorMessage'
 
 const useStyles = makeStyles()(theme => ({
   formControl: {
@@ -206,11 +208,15 @@ const DrawerWidget = observer(
       <Drawer session={session}>
         <DrawerHeader session={session} setToolbarHeight={setToolbarHeight} />
         <Suspense fallback={<div>Loading...</div>}>
-          <DrawerComponent
-            model={visibleWidget}
-            session={session}
-            toolbarHeight={toolbarHeight}
-          />
+          <ErrorBoundary
+            FallbackComponent={({ error }) => <ErrorMessage error={error} />}
+          >
+            <DrawerComponent
+              model={visibleWidget}
+              session={session}
+              toolbarHeight={toolbarHeight}
+            />
+          </ErrorBoundary>
         </Suspense>
       </Drawer>
     )

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -58,6 +58,7 @@
     "prop-types": "^15.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
+    "react-error-boundary": "^3.0.0",
     "tss-react": "^3.0.0"
   },
   "publishConfig": {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -196,7 +196,7 @@ export type BlockModel = Instance<BlockStateModel>
 // calls the render worker to render the block content not using a flow for
 // this, because the flow doesn't work with autorun
 export function renderBlockData(
-  self: Instance<BlockStateModel>,
+  self: BlockModel,
   optDisplay?: AbstractDisplayModel,
 ) {
   try {
@@ -269,7 +269,7 @@ interface ErrorProps {
 async function renderBlockEffect(
   props: RenderProps | ErrorProps,
   signal: AbortSignal,
-  self: Instance<BlockStateModel>,
+  self: BlockModel,
 ) {
   const {
     rendererType,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Button, Paper, Typography } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
+import { ErrorBoundary } from 'react-error-boundary'
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+import { ErrorMessage } from '@jbrowse/core/ui'
 import { observer } from 'mobx-react'
 
 // locals
@@ -108,7 +110,11 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
           </Paper>
         ) : (
           tracks.map(track => (
-            <TrackContainer key={track.id} model={model} track={track} />
+            <ErrorBoundary
+              FallbackComponent={({ error }) => <ErrorMessage error={error} />}
+            >
+              <TrackContainer key={track.id} model={model} track={track} />
+            </ErrorBoundary>
           ))
         )}
       </TracksContainer>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
-import { Instance } from 'mobx-state-tree'
 import normalizeWheel from 'normalize-wheel'
 
-import { LinearGenomeViewStateModel, SCALE_BAR_HEIGHT } from '..'
+// locals
+import { LinearGenomeViewModel, SCALE_BAR_HEIGHT } from '..'
 import RubberBand from './RubberBand'
 import ScaleBar from './ScaleBar'
 import Gridlines from './Gridlines'
@@ -21,7 +21,7 @@ const useStyles = makeStyles()({
   },
 })
 
-type LGV = Instance<LinearGenomeViewStateModel>
+type LGV = LinearGenomeViewModel
 type Timer = ReturnType<typeof setTimeout>
 
 function TracksContainer({


### PR DESCRIPTION
Example with the trackhub registry error

![Screenshot from 2022-09-23 14-41-14](https://user-images.githubusercontent.com/6511937/192053269-0c0114b2-8b13-4b87-a34a-8adeaf5a09e9.png)
