### PR TITLE
Add zoom to visible sequence level button

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Typography, Button } from '@mui/material'
+import { Typography, Button, Alert, Stack } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { getParent } from 'mobx-state-tree'
@@ -18,24 +18,8 @@ const useStyles = makeStyles()(theme => ({
     textAlign: 'center',
   },
   blockMessage: {
-    width: '100%',
-    background: theme.palette.action.disabledBackground,
-    padding: theme.spacing(2),
-    pointerEvents: 'none',
-    textAlign: 'center',
-  },
-  blockError: {
-    padding: theme.spacing(2),
-    width: '100%',
+    margin: theme.spacing(2),
     whiteSpace: 'normal',
-    color: theme.palette.error.main,
-    overflowY: 'auto',
-  },
-  blockReactNodeMessage: {
-    width: '100%',
-    background: theme.palette.action.disabledBackground,
-    padding: theme.spacing(2),
-    textAlign: 'center',
   },
   dots: {
     '&::after': {
@@ -61,10 +45,10 @@ const useStyles = makeStyles()(theme => ({
 
 function Repeater({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: 'flex' }}>
-      {children}
-      {children}
-    </div>
+    <Stack direction="row">
+      <div style={{ width: '50%' }}>{children}</div>
+      <div style={{ width: '50%' }}>{children}</div>
+    </Stack>
   )
 }
 
@@ -110,12 +94,14 @@ function BlockMessage({
 }) {
   const { classes } = useStyles()
 
-  return React.isValidElement(messageContent) ? (
-    <div className={classes.blockReactNodeMessage}>{messageContent}</div>
-  ) : (
-    <Typography variant="body2" className={classes.blockMessage}>
-      {messageContent}
-    </Typography>
+  return (
+    <div className={classes.blockMessage}>
+      {React.isValidElement(messageContent) ? (
+        messageContent
+      ) : (
+        <Alert severity="info">{messageContent}</Alert>
+      )}
+    </div>
   )
 }
 
@@ -130,19 +116,23 @@ function BlockError({
 }) {
   const { classes } = useStyles()
   return (
-    <div className={classes.blockError} style={{ height: displayHeight }}>
-      {reload ? (
-        <Button
-          data-testid="reload_button"
-          onClick={reload}
-          startIcon={<RefreshIcon />}
-        >
-          Reload
-        </Button>
-      ) : null}
-      <Typography color="error" variant="body2" display="inline">
-        {`${error}`}
-      </Typography>
+    <div className={classes.blockMessage}>
+      <Alert
+        severity="error"
+        action={
+          reload ? (
+            <Button
+              data-testid="reload_button"
+              onClick={reload}
+              startIcon={<RefreshIcon />}
+            >
+              Reload
+            </Button>
+          ) : null
+        }
+      >
+        {error.message}
+      </Alert>
     </div>
   )
 }

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
-import { Button, Typography } from '@mui/material'
+import { Alert, Button } from '@mui/material'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes/models'
 import { getConf } from '@jbrowse/core/configuration'
 import { MenuItem } from '@jbrowse/core/ui'
@@ -502,29 +502,27 @@ export const BaseLinearDisplay = types
 
       if (regionTooLarge) {
         return (
-          <>
-            <Typography component="span" variant="body2">
-              {regionTooLargeReason ? regionTooLargeReason + '. ' : ''}
-              Zoom in to see features or{' '}
-            </Typography>
-            <Button
-              data-testid="force_reload_button"
-              onClick={() => {
-                if (!self.estimatedRegionStats) {
-                  console.error('No global stats?')
-                } else {
-                  self.updateStatsLimit(self.estimatedRegionStats)
-                  self.reload()
-                }
-              }}
-              variant="outlined"
-            >
-              Force Load
-            </Button>
-            <Typography component="span" variant="body2">
-              (force load may be slow)
-            </Typography>
-          </>
+          <Alert
+            severity="warning"
+            action={
+              <Button
+                data-testid="force_reload_button"
+                onClick={() => {
+                  if (!self.estimatedRegionStats) {
+                    console.error('No global stats?')
+                  } else {
+                    self.updateStatsLimit(self.estimatedRegionStats)
+                    self.reload()
+                  }
+                }}
+              >
+                Force Load
+              </Button>
+            }
+          >
+            {regionTooLargeReason ? regionTooLargeReason + '. ' : ''}
+            Zoom in to see features or force load (may be slow).
+          </Alert>
         )
       }
       return undefined

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.js.snap
@@ -524,8 +524,15 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
                 style="width: 100px;"
               >
                 <div
-                  style="display: flex;"
-                />
+                  class="css-m69qwo-MuiStack-root"
+                >
+                  <div
+                    style="width: 50%;"
+                  />
+                  <div
+                    style="width: 50%;"
+                  />
+                </div>
               </div>
               <div
                 class="tss-a9ifge-boundaryPaddingBlock"

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -46,6 +46,7 @@
     "@jbrowse/plugin-linear-genome-view": "^2.0.0",
     "@jbrowse/plugin-wiggle": "^2.0.0",
     "@mui/material": "^5.0.0",
+    "@mui/icons-material": "^5.0.1",
     "mobx": "^6.0.0",
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/sequence/src/LinearReferenceSequenceDisplay/model.tsx
+++ b/plugins/sequence/src/LinearReferenceSequenceDisplay/model.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { types } from 'mobx-state-tree'
 import {
   BaseLinearDisplay,
@@ -8,6 +9,8 @@ import {
   ConfigurationReference,
 } from '@jbrowse/core/configuration'
 import { getContainingView } from '@jbrowse/core/util'
+import { Alert, Button } from '@mui/material'
+import ZoomInIcon from '@mui/icons-material/ZoomIn'
 
 export function modelFactory(configSchema: AnyConfigurationSchemaType) {
   return types
@@ -39,8 +42,23 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
         },
         regionCannotBeRendered(/* region */) {
           const view = getContainingView(self) as LinearGenomeViewModel
-          if (view && view.bpPerPx >= 1) {
-            return 'Zoom in to see sequence'
+          if (view && view.bpPerPx > 1) {
+            return (
+              <Alert
+                severity="info"
+                action={
+                  <Button
+                    data-testid="zoom_in_button"
+                    onClick={() => view.zoomTo(1)}
+                    startIcon={<ZoomInIcon />}
+                  >
+                    Zoom in
+                  </Button>
+                }
+              >
+                Zoom in to see sequence
+              </Alert>
+            )
           }
           return undefined
         },

--- a/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
+++ b/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
@@ -20,7 +20,7 @@ test('wrong assembly', async () => {
   const { view, findAllByText } = createView()
   view.showTrack('volvox_wrong_assembly')
   await findAllByText(
-    'Error: region assembly (volvox) does not match track assemblies (wombat)',
+    'region assembly (volvox) does not match track assemblies (wombat)',
     {},
     delay,
   )


### PR DESCRIPTION
This was proposed by @carolinebridge-oicr in https://github.com/GMOD/jbrowse-components/pull/3200#issuecomment-1254056802. It adds a "Zoom in" button to the "Zoom in to see sequence" message that zooms to 1 bpPerPx so that the sequence is visible.

Looks like this:

![image](https://user-images.githubusercontent.com/25592344/192364041-78c0b8e9-a5d1-408d-99bc-cf1a9d704533.png)
