### PR TITLE
Release announcement v2.1.5

### DIFF
--- a/website/release_announcement_drafts/v2.1.5.md
+++ b/website/release_announcement_drafts/v2.1.5.md
@@ -1,0 +1,6 @@
+We are happy to present v2.1.5! This release adds the ability for the embedded
+linear genome view component to have session tracks, and we added a new UI for
+alerts/errors on tracks. See the changelog for details.
+
+Other issues with the circular genome view, authentication on jbrowse-desktop,
+and the trackhub registry were also fixed. Enjoy!


### PR DESCRIPTION
```

## Unreleased (2022-09-29)

#### :rocket: Enhancement
* Other
  * [#3229](https://github.com/GMOD/jbrowse-components/pull/3229) Allow user to select local assembly to add tracks to for trackhub registry ([@cmdcolin](https://github.com/cmdcolin))
  * [#3220](https://github.com/GMOD/jbrowse-components/pull/3220) Better error display on SV inspector/spreadsheet view on import form ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#3223](https://github.com/GMOD/jbrowse-components/pull/3223) Allow adding session tracks to embedded react component along with disableAddTracks option if unwanted ([@cmdcolin](https://github.com/cmdcolin))
  * [#3227](https://github.com/GMOD/jbrowse-components/pull/3227) Add infrastructure for creating linear-genome-view sub-classes ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
  * [#3215](https://github.com/GMOD/jbrowse-components/pull/3215) Add error boundary on view, track, and drawer widget ([@cmdcolin](https://github.com/cmdcolin))
  * [#3216](https://github.com/GMOD/jbrowse-components/pull/3216) Configure number of bases to display up/down stream of feature and inside intron for feature details ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#3231](https://github.com/GMOD/jbrowse-components/pull/3231) Use provided theme in overrides, update TS types ([@garrettjstevens](https://github.com/garrettjstevens))
* Other
  * [#3217](https://github.com/GMOD/jbrowse-components/pull/3217) Fix loading tracks from connection using assembly alias ([@cmdcolin](https://github.com/cmdcolin))
  * [#3214](https://github.com/GMOD/jbrowse-components/pull/3214) Fix trackhub registry failing to load in 2.x.y versions of jbrowse ([@cmdcolin](https://github.com/cmdcolin))
  * [#3204](https://github.com/GMOD/jbrowse-components/pull/3204) Fix authentication configuration on jbrowse-desktop ([@cmdcolin](https://github.com/cmdcolin))
  * [#3198](https://github.com/GMOD/jbrowse-components/pull/3198) Better error reporting on jbrowse-web start screen when user attempts to open a broken recent session ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))

#### :memo: Documentation
* [#3193](https://github.com/GMOD/jbrowse-components/pull/3193) [update docs] add desktop specific plugin tutorial ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))

#### :house: Internal
* `core`
  * [#3228](https://github.com/GMOD/jbrowse-components/pull/3228) Improve TypeScript for queueDialog ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3224](https://github.com/GMOD/jbrowse-components/pull/3224) More typescripting of plain js files ([@cmdcolin](https://github.com/cmdcolin))
  * [#3207](https://github.com/GMOD/jbrowse-components/pull/3207) Hardcoded block width of 800px on static blocks ([@cmdcolin](https://github.com/cmdcolin))
  * [#3197](https://github.com/GMOD/jbrowse-components/pull/3197) Use "temporaryAssemblies" to store read vs ref assemblies, and allow selecting "sessionAssemblies" in dropdown ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 1.94s.


```