### PR TITLE
Improve TypeScript for queueDialog

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -114,10 +114,9 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   DialogComponent?: DialogComponentType
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DialogProps: any
-  queueDialog: (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (doneCallback: Function) => [DialogComponentType, any],
-  ) => void
+  queueDialog<T extends DialogComponentType>(
+    callback: (doneCallback: () => void) => [T, React.ComponentProps<T>],
+  ): void
   name: string
   id?: string
   tracks: AnyConfigurationModel[]

--- a/plugins/alignments/src/LinearPileupDisplay/components/SetFeatureHeight.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/SetFeatureHeight.tsx
@@ -26,14 +26,10 @@ const useStyles = makeStyles()(theme => ({
 
 function SetFeatureHeightDlg(props: {
   model: {
-    minScore: number
-    maxScore: number
-    setMinScore: Function
-    setMaxScore: Function
     setFeatureHeight: Function
     setNoSpacing: Function
     featureHeightSetting: number
-    noSpacing: boolean
+    noSpacing?: boolean
   }
   handleClose: () => void
 }) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { ErrorMessage } from '@jbrowse/core/ui'
 import CloseIcon from '@mui/icons-material/Close'
-import { LinearGenomeViewModel as LGV } from '..'
+import { ExportSvgOptions } from '..'
 
 const useStyles = makeStyles()(theme => ({
   closeButton: {
@@ -39,7 +39,7 @@ export default function ExportSvgDlg({
   model,
   handleClose,
 }: {
-  model: LGV
+  model: { exportSvg(opts: ExportSvgOptions): void }
   handleClose: () => void
 }) {
   // @ts-ignore

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceSearchDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceSearchDialog.tsx
@@ -21,9 +21,6 @@ import { getSession } from '@jbrowse/core/util'
 // icons
 import CloseIcon from '@mui/icons-material/Close'
 
-// locals
-import { LinearGenomeViewModel } from '..'
-
 const useStyles = makeStyles()(theme => ({
   closeButton: {
     position: 'absolute',
@@ -40,7 +37,7 @@ function SequenceDialog({
   model,
   handleClose,
 }: {
-  model: LinearGenomeViewModel
+  model: { assemblyNames: string[]; toggleTrack(trackId: string): void }
   handleClose: () => void
 }) {
   const { classes } = useStyles()

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -651,6 +651,22 @@ export function stateModelFactory(pluginManager: PluginManager) {
       setScaleFactor(factor: number) {
         self.scaleFactor = factor
       },
+      // this "clears the view" and makes the view return to the import form
+      clearView() {
+        this.setDisplayedRegions([])
+        self.tracks.clear()
+        // it is necessary to run these after setting displayed regions empty
+        // or else model.offsetPx gets set to Infinity and breaks
+        // mobx-state-tree snapshot
+        self.scrollTo(0)
+        self.zoomTo(10)
+      },
+      async exportSvg(opts: ExportSvgOptions = {}) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const html = await renderToSvg(self as any, opts)
+        const blob = new Blob([html], { type: 'image/svg+xml' })
+        saveAs(blob, opts.filename || 'image.svg')
+      },
     }))
     .actions(self => {
       let cancelLastAnimation = () => {}
@@ -899,16 +915,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
       }
     })
     .actions(self => ({
-      // this "clears the view" and makes the view return to the import form
-      clearView() {
-        self.setDisplayedRegions([])
-        self.tracks.clear()
-        // it is necessary to run these after setting displayed regions empty
-        // or else model.offsetPx gets set to Infinity and breaks
-        // mobx-state-tree snapshot
-        self.scrollTo(0)
-        self.zoomTo(10)
-      },
       setCoarseDynamicBlocks(blocks: BlockSet) {
         self.coarseDynamicBlocks = blocks.contentBlocks
         self.coarseTotalBp = blocks.totalBp
@@ -928,12 +934,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions(self => ({
-      async exportSvg(opts: ExportSvgOptions = {}) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
-        const blob = new Blob([html], { type: 'image/svg+xml' })
-        saveAs(blob, opts.filename || 'image.svg')
-      },
       /**
        * offset is the base-pair-offset in the displayed region, index is the index of the
        * displayed region in the linear genome view

--- a/plugins/wiggle/src/CreateMultiWiggleExtension/index.ts
+++ b/plugins/wiggle/src/CreateMultiWiggleExtension/index.ts
@@ -50,8 +50,8 @@ export default function (pm: PluginManager) {
                     ConfirmDialog,
                     {
                       tracks,
-                      onClose: (arg: boolean, arg1: { name: string }) => {
-                        if (arg) {
+                      onClose: (arg: boolean, arg1?: { name: string }) => {
+                        if (arg && arg1) {
                           makeTrack(arg1)
                         }
                         handleClose()

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.tsx
@@ -93,13 +93,13 @@ const stateModelFactory = (
           self.statsReady = true
         }
       },
-      setColor(color: string) {
+      setColor(color?: string) {
         self.color = color
       },
-      setPosColor(color: string) {
+      setPosColor(color?: string) {
         self.posColor = color
       },
-      setNegColor(color: string) {
+      setNegColor(color?: string) {
         self.negColor = color
       },
 

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
@@ -61,7 +61,7 @@ export default function SetColorDialog({
   handleClose,
 }: {
   model: {
-    sources: Source[]
+    sources?: Source[]
     setLayout: (s: Source[]) => void
     clearLayout: () => void
   }
@@ -132,7 +132,7 @@ export default function SetColorDialog({
           color="inherit"
           onClick={() => {
             model.clearLayout()
-            setCurrLayout(model.sources)
+            setCurrLayout(model.sources || [])
           }}
         >
           Clear custom settings
@@ -142,7 +142,7 @@ export default function SetColorDialog({
           color="secondary"
           onClick={() => {
             handleClose()
-            setCurrLayout([...model.sources])
+            setCurrLayout([...(model.sources || [])])
           }}
         >
           Cancel


### PR DESCRIPTION
This makes it so the `queueDialog` method type on the AbstractSessionModel checks that the props passed to it match the component passed to it, instead of being `any`. The other changes in this PR fix the type errors revealed by this change.