### PR TITLE
Allow user to select local assembly to add tracks to for trackhub registry

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
@@ -24,6 +24,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 // locals
 import SlotEditor from './SlotEditor'
 import TypeSelector from './TypeSelector'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()(theme => ({
   expandIcon: {
@@ -139,7 +140,12 @@ const Schema = observer(
 )
 
 const ConfigurationEditor = observer(
-  ({ model }: { model: { target: AnyConfigurationModel } }) => {
+  ({
+    model,
+  }: {
+    model: { target: AnyConfigurationModel }
+    session?: AbstractSessionModel
+  }) => {
     const { classes } = useStyles()
     // key forces a re-render, otherwise the same field can end up being used
     // for different tracks since only the backing model changes for example

--- a/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.tsx
+++ b/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.tsx
@@ -75,6 +75,7 @@ function AddConnectionWidget({ model }: { model: unknown }) {
           <ConfigureConnection
             connectionType={connectionType}
             model={configModel}
+            session={session}
           />
         ) : null
 

--- a/plugins/data-management/src/AddConnectionWidget/components/ConfigureConnection.tsx
+++ b/plugins/data-management/src/AddConnectionWidget/components/ConfigureConnection.tsx
@@ -3,16 +3,21 @@ import { ConfigurationEditor } from '@jbrowse/plugin-config'
 import { observer } from 'mobx-react'
 import { ConnectionType } from '@jbrowse/core/pluggableElementTypes'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import { AbstractSessionModel } from '@jbrowse/core/util'
 
 const ConfigureConnection = observer(
-  (props: { connectionType: ConnectionType; model: AnyConfigurationModel }) => {
-    const { connectionType, model } = props
+  (props: {
+    connectionType: ConnectionType
+    model: AnyConfigurationModel
+    session: AbstractSessionModel
+  }) => {
+    const { connectionType, model, session } = props
     const ConfigEditorComponent =
       connectionType.configEditorComponent || ConfigurationEditor
 
     return (
       <Suspense fallback={<div>Loading...</div>}>
-        <ConfigEditorComponent model={{ target: model }} />
+        <ConfigEditorComponent model={{ target: model }} session={session} />
       </Suspense>
     )
   },


### PR DESCRIPTION
This allows a user to select a local assembly name to add their tracks from the trackhub registry to

It might be the case that the name of the user's local assembly does not match the remote name provided by the trackhub, so this allows the user to select the local assembly to add the trackhub tracks to.

