### PR TITLE
Fix circular embedded view failing to load in v2.1.3 and v2.1.4

### DIFF
--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/ViewContainer.tsx
@@ -18,7 +18,6 @@ import { Menu, Logomark } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
 
 const AboutDialog = lazy(() => import('./AboutDialog'))
-
 const useStyles = makeStyles()(theme => ({
   viewContainer: {
     overflow: 'hidden',
@@ -141,7 +140,11 @@ const ViewContainer = observer(
           </IconButton>
         </div>
         <Paper>{children}</Paper>
-        <AboutDialog open={dlgOpen} onClose={() => setDlgOpen(false)} />
+        {dlgOpen ? (
+          <Suspense fallback={<div />}>
+            <AboutDialog open onClose={() => setDlgOpen(false)} />
+          </Suspense>
+        ) : null}
       </Paper>
     )
   },

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
 <div
   class="tss-jn2cxo-avoidParentStyle"
-  style=""
 >
   <div
     class="MuiScopedCssBaseline-root mui-1pa2gw3-MuiScopedCssBaseline-root"


### PR DESCRIPTION
The addition of the version number in a little dialog box in 2.1.3 made circular view fail to load

Can be seen to fail currently here https://jbrowse.org/demos/cgv and elsewhere

The reason was a oversight keeping the "ViewContainer" between the linear and circular embedded components synced up. Adding app-core, and maybe a simple embedded test for circular, could help avoid future issues

