### PR TITLE
Fix floating feature label showing fragments of itself with smaller blocks

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -83,7 +83,12 @@ export default observer(
       viewLeft + featureWidthBp < fend
     ) {
       x = params.offsetPx
-    } else if (fstart < viewLeft && viewLeft + featureWidthBp < fend) {
+    } else if (
+      fstart < viewLeft &&
+      viewLeft + featureWidthBp < fend &&
+      viewLeft + featureWidthBp > rstart &&
+      viewLeft + featureWidthBp < rend
+    ) {
       x = params.offsetPx1
     }
 


### PR DESCRIPTION
Fixes #3236

Makes sure that the floating label being drawn is within an "appropriate closeness" to the left side of the screen. Can elaborate more with a teardown if there is interest (the logic for floating labels is a bit tricky) but this appeared to fix the issue seen in #3236 

Compare

https://jbrowse.org/code/jb2/main/?config=test_data%2Fvolvox%2Fconfig.json&session=share-j4NQOSjQXJ&password=QyIov
https://jbrowse.org/code/jb2/fix_block_label2/?config=test_data%2Fvolvox%2Fconfig.json&session=share-j4NQOSjQXJ&password=QyIov