### PR TITLE
Handle alternate line endings

### DIFF
--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails.test.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails.test.tsx
@@ -35,7 +35,7 @@ test('test using the sequence feature panel', () => {
 const readFasta = (filename: string) => {
   return fs
     .readFileSync(require.resolve(filename), 'utf8')
-    .split('\n')
+    .split(/\n|\r\n|\r/)
     .slice(1)
     .join('')
 }

--- a/packages/core/data_adapters/CytobandAdapter.ts
+++ b/packages/core/data_adapters/CytobandAdapter.ts
@@ -22,7 +22,7 @@ class CytobandAdapter extends BaseAdapter {
     }
     const data = await openLocation(loc).readFile('utf8')
     return data
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(f => !!f.trim())
       .map(line => {
         const [refName, start, end, name, type] = line.split('\t')

--- a/plugins/alignments/src/CramAdapter/CramTestAdapters.ts
+++ b/plugins/alignments/src/CramAdapter/CramTestAdapters.ts
@@ -10,7 +10,7 @@ export function parseSmallFasta(text: string) {
     .split('>')
     .filter(t => /\S/.test(t))
     .map(entryText => {
-      const [defLine, ...seqLines] = entryText.split('\n')
+      const [defLine, ...seqLines] = entryText.split(/\n|\r\n|\r/)
       const [id, ...descriptionLines] = defLine.split(' ')
       const description = descriptionLines.join(' ')
       const sequence = seqLines.join('').replace(/\s/g, '')

--- a/plugins/bed/src/BedAdapter/BedAdapter.ts
+++ b/plugins/bed/src/BedAdapter/BedAdapter.ts
@@ -42,7 +42,7 @@ export default class BedAdapter extends BaseFeatureDataAdapter {
       throw new Error('Data exceeds maximum string length (512MB)')
     }
     const data = new TextDecoder('utf8', { fatal: true }).decode(buffer)
-    const lines = data.split('\n').filter(f => !!f)
+    const lines = data.split(/\n|\r\n|\r/).filter(f => !!f)
     const headerLines = []
     let i = 0
     for (; i < lines.length && lines[i].startsWith('#'); i++) {
@@ -106,7 +106,7 @@ export default class BedAdapter extends BaseFeatureDataAdapter {
     if (columnNames.length) {
       return columnNames
     }
-    const defs = header.split('\n').filter(f => !!f)
+    const defs = header.split(/\n|\r\n|\r/).filter(f => !!f)
     const defline = defs[defs.length - 1]
     return defline?.includes('\t')
       ? defline

--- a/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
+++ b/plugins/bed/src/BedTabixAdapter/BedTabixAdapter.ts
@@ -59,7 +59,7 @@ export default class BedTabixAdapter extends BaseFeatureDataAdapter {
       return this.columnNames
     }
     const header = await this.bed.getHeader()
-    const defs = header.split('\n').filter(f => !!f)
+    const defs = header.split(/\n|\r\n|\r/).filter(f => !!f)
     const defline = defs[defs.length - 1]
     return defline?.includes('\t')
       ? defline

--- a/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
@@ -177,6 +177,6 @@ export default class ChainAdapter extends PAFAdapter {
       throw new Error('Data exceeds maximum string length (512MB)')
     }
     const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
-    return paf_chain2paf(text.split('\n').filter(line => !!line))
+    return paf_chain2paf(text.split(/\n|\r\n|\r/).filter(line => !!line))
   }
 }

--- a/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
@@ -151,6 +151,6 @@ export default class DeltaAdapter extends PAFAdapter {
     }
     const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
 
-    return paf_delta2paf(text.split('\n').filter(line => !!line))
+    return paf_delta2paf(text.split(/\n|\r\n|\r/).filter(line => !!line))
   }
 }

--- a/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
+++ b/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
@@ -51,7 +51,7 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
     const bed1Map = parseBed(bed1text)
     const bed2Map = parseBed(bed2text)
     const feats = mcscantext
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(f => !!f && f !== '###')
       .map((line, index) => {
         const [name1, name2, score] = line.split('\t')

--- a/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/MCScanSimpleAnchorsAdapter.ts
+++ b/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/MCScanSimpleAnchorsAdapter.ts
@@ -56,7 +56,7 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
     const bed1Map = parseBed(bed1text)
     const bed2Map = parseBed(bed2text)
     const feats = mcscantext
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(f => !!f && f !== '###')
       .map((line, index) => {
         const [n11, n12, n21, n22, score, strand] = line.split('\t')

--- a/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
@@ -20,7 +20,7 @@ export default class MashMapAdapter extends PAFAdapter {
 
     // mashmap produces PAF-like data that is space separated instead of tab
     return text
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(line => !!line)
       .map(line => {
         const fields = line.split(' ')

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -160,7 +160,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
     const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
 
     return text
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(line => !!line)
       .map(line => {
         const [

--- a/plugins/comparative-adapters/src/util.ts
+++ b/plugins/comparative-adapters/src/util.ts
@@ -9,7 +9,7 @@ export function isGzip(buf: Buffer) {
 export function parseBed(text: string) {
   return new Map(
     text
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(f => !!f || f.startsWith('#'))
       .map(line => {
         const [refName, start, end, name, score, strand] = line.split('\t')

--- a/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
+++ b/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
@@ -18,7 +18,7 @@ export default class RefNameAliasAdapter
     const refColumn = readConfObject(this.config, 'refNameColumn')
     return results
       .trim()
-      .split('\n')
+      .split(/\n|\r\n|\r/)
       .filter(f => !!f && !f.startsWith('#'))
       .map(row => {
         const aliases = row.split('\t')

--- a/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
+++ b/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
@@ -30,7 +30,7 @@ export default class extends BaseFeatureDataAdapter {
       throw new Error('Data exceeds maximum string length (512MB)')
     }
     const data = new TextDecoder('utf8', { fatal: true }).decode(buffer)
-    const lines = data.split('\n')
+    const lines = data.split(/\n|\r\n|\r/)
     const headerLines = []
     for (let i = 0; i < lines.length && lines[i].startsWith('#'); i++) {
       headerLines.push(lines[i])

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/ImportBookmarks.tsx
@@ -112,7 +112,7 @@ function ImportBookmarks({
                 }
                 const data = await openLocation(location).readFile('utf8')
                 const regions = data
-                  .split('\n')
+                  .split(/\n|\r\n|\r/)
                   .filter(f => !!f.trim())
                   .filter(
                     f =>

--- a/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
+++ b/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
@@ -34,7 +34,9 @@ export default class extends BaseFeatureDataAdapter {
     }
     const data = new TextDecoder('utf8', { fatal: true }).decode(buf)
 
-    const lines = data.split('\n').filter(f => !!f && !f.startsWith('#'))
+    const lines = data
+      .split(/\n|\r\n|\r/)
+      .filter(f => !!f && !f.startsWith('#'))
     const feats = {} as { [key: string]: string[] }
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]

--- a/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigParse.ts
+++ b/plugins/legacy-jbrowse/src/JBrowse1Connection/jb1ConfigParse.ts
@@ -99,7 +99,7 @@ function parse(text: string, url: string): Config {
     }
   }
 
-  text.split('\n').forEach((textLine, i): void => {
+  text.split(/\n|\r\n|\r/).forEach((textLine, i): void => {
     lineNumber = i + 1
     const line = textLine.replace(/^\s*#.+/, '')
 

--- a/plugins/sequence/src/ChromSizesAdapter/ChromSizesAdapter.ts
+++ b/plugins/sequence/src/ChromSizesAdapter/ChromSizesAdapter.ts
@@ -14,7 +14,7 @@ export default class extends BaseAdapter implements RegionsAdapter {
     const data = await file.readFile('utf8')
     return Object.fromEntries(
       data
-        .split('\n')
+        .split(/\n|\r\n|\r/)
         .map(f => f.trim())
         .filter(f => !!f)
         .map((line: string) => {

--- a/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
+++ b/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
@@ -26,7 +26,7 @@ export default class TwoBitAdapter extends BaseSequenceAdapter {
       const data = await file.readFile('utf8')
       return Object.fromEntries(
         data
-          ?.split('\n')
+          ?.split(/\n|\r\n|\r/)
           .filter(line => !!line.trim())
           .map(line => {
             const [name, length] = line.split('\t')

--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/VcfImport.ts
@@ -59,7 +59,7 @@ export function parseVcfBuffer(
   const rows: Row[] = []
   const vcfParser = new VCF({ header })
   header = '' // garbage collect
-  body.split('\n').forEach((line: string, lineNumber) => {
+  body.split(/\n|\r\n|\r/).forEach((line: string, lineNumber) => {
     if (/\S/.test(line)) {
       rows.push(vcfRecordToRow(vcfParser, line, lineNumber))
     }

--- a/plugins/variants/src/VcfAdapter/VcfAdapter.ts
+++ b/plugins/variants/src/VcfAdapter/VcfAdapter.ts
@@ -14,7 +14,7 @@ import VcfFeature from '../VcfTabixAdapter/VcfFeature'
 const readVcf = (f: string) => {
   const header: string[] = []
   const rest: string[] = []
-  f.split('\n')
+  f.split(/\n|\r\n|\r/)
     .map(f => f.trim())
     .filter(f => !!f)
     .forEach(line => {

--- a/plugins/wiggle/src/MultiWiggleAddTrackWidget/AddTrackWorkflow.tsx
+++ b/plugins/wiggle/src/MultiWiggleAddTrackWidget/AddTrackWorkflow.tsx
@@ -86,7 +86,7 @@ export default function MultiWiggleWidget({ model }: { model: AddTrackModel }) {
           try {
             bigWigs = JSON.parse(val)
           } catch (e) {
-            bigWigs = val.split('\n')
+            bigWigs = val.split(/\n|\r\n|\r/)
           }
           const obj =
             typeof bigWigs[0] === 'string'

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -7,7 +7,7 @@ function main(changed, version) {
     ['--silent', 'lerna-changelog', '--next-version', version],
     { encoding: 'utf8' },
   ).stdout
-  const changelogLines = lernaChangelog.split('\n')
+  const changelogLines = lernaChangelog.split(/\n|\r\n|\r/)
   const changedPackages = JSON.parse(changed)
   const updatesTable = ['| Package | Download |', '| --- | --- |']
   changedPackages.forEach(changedPackage => {


### PR DESCRIPTION
This does a global find-and-replace of `.split('\n')` with `.split(/\n|\r\n|\r/)`. This should handle unix (`\n`), dos (`\r\n`) and old-style mac (`\r`) line-endings. Hopefully it helps avoid issues especially with users creating files on Windows, like [this](https://github.com/GMOD/jbrowse-components/discussions/3249#discussioncomment-3791863).