### PR TITLE
Use tick labels that correspond to the overview's larger zoom level

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScaleBar.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Typography, useTheme, alpha } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
-import { Instance } from 'mobx-state-tree'
 
 import Base1DView, { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 import { getSession, getTickDisplayStr } from '@jbrowse/core/util'
@@ -79,7 +78,7 @@ const Polygon = observer(
     useOffset = true,
   }: {
     model: LGV
-    overview: Instance<Base1DViewModel>
+    overview: Base1DViewModel
     useOffset?: boolean
   }) => {
     const theme = useTheme()
@@ -305,7 +304,7 @@ const OverviewBox = observer(
     overview: Base1DViewModel
   }) => {
     const { classes, cx } = useStyles()
-    const { cytobandOffset, bpPerPx, showCytobands } = model
+    const { cytobandOffset, showCytobands } = model
     const { start, end, reversed, refName, assemblyName } = block
     const { majorPitch } = chooseGridPitch(scale, 120, 15)
     const { assemblyManager } = getSession(model)
@@ -361,7 +360,7 @@ const OverviewBox = observer(
                     color: refNameColor,
                   }}
                 >
-                  {getTickDisplayStr(tickLabel, bpPerPx)}
+                  {getTickDisplayStr(tickLabel, overview.bpPerPx)}
                 </Typography>
               ))
             : null}


### PR DESCRIPTION
Currently, the tick labels on the overview scalebar can change depending on the zoom level of the zoomed in view

This changes it so that it only uses the "overview's zoom level", so the overview labels don't change depending on your zoom level

Not visible on genomes like human that have cytobands, since it doesn't show overview coords


before: can see overview scale bar labels change depending on your zoom level
![Screenshot from 2022-10-07 15-03-17](https://user-images.githubusercontent.com/6511937/194652916-4bc9b022-99c6-49fc-bb96-85fbd71dde52.png)
![Screenshot from 2022-10-07 15-03-23](https://user-images.githubusercontent.com/6511937/194652926-65b29c43-6fd1-4a81-b99a-b3e46b192527.png)
