### PR TITLE
Add more docs about color callbacks

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -4,15 +4,15 @@ title: FAQ
 toplevel: true
 ---
 
-### Developers
+## Developers
 
-#### How can I start the JBrowse 2 app as a developer
+### How can I start the JBrowse 2 app as a developer
 
 We recommend that you have the following:
 
 - A stable and recent version of [node](https://nodejs.org/en/)
 - Git
-- [Yarn](https://classic.yarnpkg.com/en/docs/install/#debian-stable)
+- [Yarn](https://classic.yarnpkg.com/en/docs/install/debian-stable)
 
 Then you can follow steps from our
 [README](https://github.com/gmod/jbrowse-components).
@@ -39,9 +39,9 @@ use `yarn storybook` instead of `yarn start`.
 
 For a more extensive tutorial, see [Developing with JBrowse web and desktop](../tutorials/develop_web_and_desktop_tutorial).
 
-### General
+## General
 
-#### What is special about JBrowse 2
+### What is special about JBrowse 2
 
 One thing that makes JBrowse 2 special is that we can create new view types via
 our plugin system, e.g. circular, dotplot, etc.. Anything you want can be added
@@ -50,13 +50,13 @@ as a view, and can be shown alongside our other views.
 This makes JBrowse 2 more than just a genome browser: it is really a platform
 that can be built upon.
 
-#### What are new features in JBrowse 2
+### What are new features in JBrowse 2
 
 See the https://jbrowse.org/jb2/features page for an overview of features
 
-### Setup
+## Setup
 
-#### What web server do I need to run JBrowse 2
+### What web server do I need to run JBrowse 2
 
 JBrowse 2 by itself is just a set of JS, CSS, and HTML files that can be
 statically hosted on a webserver without any backend services running.
@@ -72,7 +72,7 @@ Note that the server that you use should support byte-range requests (e.g. the
 header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range) so
 that JBrowse can get small slices of large binary data files.
 
-#### BAM files do not work on my server
+### BAM files do not work on my server
 
 If you are using Apache then you will probably want to disable mime_magic. If
 mime_magic is enabled, you may see that your server responds with the HTTP
@@ -80,7 +80,7 @@ header Content-Encoding: gzip which JBrowse does NOT want, because this
 instructs the browser to unzip the data but JBrowse should be in charge of
 this.
 
-#### How can I setup JBrowse 2 on my web server
+### How can I setup JBrowse 2 on my web server
 
 We recommend following the steps in the [quickstart web via CLI](../quickstart_cli/) guide.
 
@@ -90,7 +90,7 @@ will download the latest version of jbrowse to your web folder e.g. in
 
 You can also use `jbrowse upgrade /var/www/html/jb2` to get the latest version.
 
-#### How do I install or update the @jbrowse/cli tool
+### How do I install or update the @jbrowse/cli tool
 
 To install the @jbrowse/cli tool, you can use `npm install -g @jbrowse/cli`
 
@@ -103,7 +103,7 @@ using nodesource or nvm to get your nodejs for this.
 Also note that the @jbrowse/cli tool is just made for preparing your
 config.json, it is **not used to run any server-side code**.
 
-#### How do I update my instance of jbrowse-web
+### How do I update my instance of jbrowse-web
 
 You can use the command, after installing:
 
@@ -116,7 +116,7 @@ jbrowse-web instance.
 
 If you've manually downloaded jbrowse-web, the newest releases can be found [here](https://github.com/GMOD/jbrowse-components/releases).
 
-#### How can I setup JBrowse 2 without the CLI tools
+### How can I setup JBrowse 2 without the CLI tools
 
 The jbrowse CLI tools are basically a convenience, and are not strictly required.
 
@@ -133,14 +133,14 @@ For other things, like add-assembly and add-track, you can manually edit the
 
 To configure JBrowse using the GUI, checkout our [tutorial](../tutorials/config_gui).
 
-Understanding the [config basics](../config_guide/#intro-to-the-configjson) will
+Understanding the [config basics](../config_guide/intro-to-the-configjson) will
 come in handy also because you can manually edit in advanced configs after your
 tracks are loaded; however be careful:s corrupt configs can produce hard
 to understand errors, because our config system is strongly typed.
 
 Reach out to the team [on gitter](https://gitter.im/GMOD/jbrowse2) or in the [discussions](https://github.com/GMOD/jbrowse-components/discussions) if you have any complex configuration issues.
 
-#### How do I load a track into JBrowse 2
+### How do I load a track into JBrowse 2
 
 With the JBrowse CLI tools, you can easily add tracks with the `add-track` command, e.g.:
 
@@ -160,71 +160,91 @@ The add-track command will do as much as possible to infer from the file
 extension how to configure this track, and automatically infer the index to be
 myfile.bam.bai.
 
-As mentioned [above](#how-can-i-setup-jbrowse-2-without-the-cli-tools) you can also manually edit your config file, or use the GUI.
+As mentioned [above](how-can-i-setup-jbrowse-2-without-the-cli-tools) you can also manually edit your config file, or use the GUI.
 
-#### How do I customize the color of the features displayed on my track
+### How do I customize the color of the features displayed on my track
 
 We use [Jexl](https://github.com/TomFrost/Jexl) for defining configuration
 callbacks, including feature coloration.
 
 An example of a Jexl configuration callback might look like this:
 
+```json
     "color": "jexl:get(feature,'strand')==-1?'red':'blue'"
+```
 
-See our [configuration callbacks guide](../config_guide/#configuration-callbacks) for more information.
+See our [configuration callbacks guide](../config_guide/configuration-callbacks) for more information.
 
-##### Adding color callbacks in the GUI
+### My jexl is too complicated, how can I simplify it?
 
-In brief, to add a configuration callback to a track using the GUI, perform the following steps:
+You can create a small plugin that adds a new function to the jexl language.
 
-1. On the track you're meaning to color, click on the three vertical dots '...' on the right side of the track label
-2. Click "Settings" (if this option is greyed out, copy the track with "Copy Track", then open up the track under "Session Tracks" and repeat steps 1-2)
-3. Scroll down to the "display 1 renderer" heading (this is typically the display you want to edit, if not scroll to display 2)
+See [here](../config_guide/#making-sophisticated-color-callbacks) for an example
+of making a color callback.
+
+### Adding color callbacks in the GUI
+
+In brief, to add a configuration callback to a track using the GUI, perform the
+following steps:
+
+1. On the track you're meaning to color, click on the three vertical dots '...'
+   on the right side of the track label
+2. Click "Settings" (if this option is greyed out, copy the track with "Copy
+   Track", then open up the track under "Session Tracks" and repeat steps 1-2)
+3. Scroll down to the "display 1 renderer" heading (this is typically the
+   display you want to edit, if not scroll to display 2)
 4. Click on the circle to the right of the color you'd like to change
-5. In this text box, enter in the [Jexl](https://github.com/TomFrost/Jexl) callback for the feature colouration, e.g. "get(feature,'strand') == -1 ? 'red' : 'blue'"
+5. In this text box, enter in the [Jexl](https://github.com/TomFrost/Jexl)
+   callback for the feature colouration, e.g. "get(feature,'strand') == -1 ?
+   'red' : 'blue'"
 
-##### Adding color callbacks via the command line
+### Adding color callbacks via the command line
 
-Adding color callbacks via the command line can be a little tricky because the coloration property exists within the renderer.
+Adding color callbacks via the command line can be a little tricky because the
+coloration property exists within the renderer.
 
-In brief, to add a configuration callback to a track using the CLI, your `add-track` is going to look something like this:
+In brief, to add a configuration callback to a track using the CLI, your
+`add-track` is going to look something like this:
 
 ```bash
 jbrowse add-track somevariants.vcf --load copy --config '{"displays": [{"displayId": "my_BasicDisplay", "type": "LinearBasicDisplay", "renderer": {"color1": "jexl:get(feature, 'strand') == -1 ? 'red' : 'blue'" }}]}'
 ```
 
-While adding the track to the `config.json`, you're adding additional configurations using the --config option. This additional configuration is a "renderer" on the display that your track will be using. In this case, this .vcf will be using the LinearBasicDisplay
+While adding the track to the `config.json`, you're adding additional
+configurations using the --config option. This additional configuration is a
+"renderer" on the display that your track will be using. In this case, this
+.vcf will be using the `LinearBasicDisplay`.
 
-### Curiosities
+## Curiosities
 
-#### Why do all the tracks need an assembly specified
+### Why do all the tracks need an assembly specified
 
 We require that all tracks have a specific genome assembly specified in their
 config. This is because JBrowse 2 is a multi-genome-assembly browser (and can
 compare genomes given the data). This may be different to using, say, JBrowse 1
 where it knows which genome assembly you are working with at any given time.
 
-#### How are the menus structured in the app
+### How are the menus structured in the app
 
 In JBrowse 1, the app level menu operated on the single linear genome view, but
 with JBrowse 2, the top level menu only performs global operations and the
 linear genome view has its own hamburger menu. Note that each track also has
 its own track level menu.
 
-#### Why do some of my reads not display soft clipping
+### Why do some of my reads not display soft clipping
 
 Some reads, such as secondary reads, do not have a SEQ field on their records,
 so they will not display softclipping.
 
 The soft clipping indicators on these reads will appear black.
 
-#### Do you have any tips for learning React and mobx-state-tree
+### Do you have any tips for learning React and mobx-state-tree
 
 Here is a short guide to React and mobx-state-tree that could help get you oriented:
 
 https://gist.github.com/cmdcolin/94d1cbc285e6319cc3af4b9a8556f03f
 
-#### What technologies does JBrowse 2 use
+### What technologies does JBrowse 2 use
 
 We build on a lot of great open source technology, some main ones include:
 
@@ -234,7 +254,7 @@ We build on a lot of great open source technology, some main ones include:
 - Typescript
 - Electron (for desktop specifically)
 
-#### Should I configure gzip on my web server
+### Should I configure gzip on my web server
 
 Yes! JBrowse 2 may load ~5MB of JS resources (2.5MB for main thread bundle,
 2.5MB for worker bundle). If you have gzip enabled, the amount of data the user
@@ -244,7 +264,7 @@ small with lazy loading and other methods but adding gzip will help your users.
 It will depend on your particular server setup e.g. apache, nginx, cloudfront,
 etc. how this may be done, but it is recommended to look into this.
 
-#### How does JBrowse know when to display the "Zoom in to see more features" message
+### How does JBrowse know when to display the "Zoom in to see more features" message
 
 The rules that JBrowse uses to determine when to display the "Zoom in to see more features" message are called stats estimation rules
 
@@ -320,16 +340,16 @@ Example config for a CRAM file with a small fetchSizeLimit configured:
 }
 ```
 
-### Text searching
+## Text searching
 
-#### Why I am running out of disk space while trix is running
+### Why I am running out of disk space while trix is running
 
 The `jbrowse text-index` program will output data to a TMP directory while
 indexing. If your filesystem has low diskspace for /tmp you can set an
 alternative temporary directory using the environment variable
 `TMPDIR=~/alt_tmp_dir/ jbrowse text-index`.
 
-#### How does the jbrowse text-index trix format work
+### How does the jbrowse text-index trix format work
 
 The `jbrowse text-index` command creates text searching indexes using trix. The
 trix indexes are based on the format described by UCSC here
@@ -364,9 +384,9 @@ Note that JBrowse creates a specialized trix index also. Instead of creating a
 ix file with just the gene names, it also provides their name and location in
 an encoded format.
 
-### URL params
+## URL params
 
-#### Why can't I copy and paste my URL bar to share it with another user
+### Why can't I copy and paste my URL bar to share it with another user
 
 In JBrowse Web, the current session can become too long to store in the URL
 bar, so instead, we store it in localStorage and only keep the key to the
@@ -383,7 +403,7 @@ Note 2: You can copy and paste your URL bar and put it in another tab on your
 own computer, and JBrowse will restore the session using BroadcastChannel
 (supported on Firefox and Chrome).
 
-#### How does the session sharing work with shortened URLs work in JBrowse Web
+### How does the session sharing work with shortened URLs work in JBrowse Web
 
 We have a central database hosted as a AWS dynamoDB that stores encrypted
 session snapshots that users create when they use the "Share" button. The
@@ -402,7 +422,7 @@ entry, and decodes it with the DECODEKEY from the URL that you provide
 With this system, the contents of the dynamoDB are safe and unable to be read,
 even by JBrowse administrators.
 
-### Troubleshooting
+## Troubleshooting
 
 Doing things like:
 
@@ -413,7 +433,7 @@ Can make user's saved sessions fail to load. If part of a session is
 inconsistent, currently, the entire session will fail to load. Therefore, make
 decisions to delete or change IDs carefully.
 
-#### What should I do if the Share system isn't working?
+### What should I do if the Share system isn't working?
 
 If for any reason the session sharing system isn't working, e.g. you are behind
 a firewall or you are not able to connect to the central share server, you can


### PR DESCRIPTION
Makes a note about how a custom function for jexl color callbacks is a little different from the jexl function for feature details, and adds a link to FAQ

Also makes the indentation a little less on FAQ, so the sidebar/TOC works better