### PR TITLE
Fix tracks hanging in safari

### DIFF
--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -23,9 +23,7 @@ class WebWorkerHandle extends Rpc.Client {
     const { statusCallback, rpcDriverClassName } = opts
     const channel = `message-${shortid.generate()}`
     const listener = (message: string) => {
-      if (statusCallback) {
-        statusCallback(message)
-      }
+      statusCallback?.(message)
     }
     this.on(channel, listener)
     const result = await super.call(
@@ -37,6 +35,8 @@ class WebWorkerHandle extends Rpc.Client {
     return result
   }
 }
+
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
 export default class WebWorkerRpcDriver extends BaseRpcDriver {
   name = 'WebWorkerRpcDriver'
@@ -58,6 +58,13 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
     const instance = this.makeWorkerInstance()
 
     const worker = new WebWorkerHandle({ workers: [instance] })
+    if (isSafari) {
+      // eslint-disable-next-line no-console
+      console.log(
+        'console logging the webworker handle avoids the track going into an infinite loading state, this is a hacky workaround for safari',
+        instance,
+      )
+    }
 
     // send the worker its boot configuration using info from the pluginManager
     const p = new Promise((resolve: (w: WebWorkerHandle) => void, reject) => {

--- a/packages/core/rpc/WebWorkerRpcDriver.ts
+++ b/packages/core/rpc/WebWorkerRpcDriver.ts
@@ -36,8 +36,6 @@ class WebWorkerHandle extends Rpc.Client {
   }
 }
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-
 export default class WebWorkerRpcDriver extends BaseRpcDriver {
   name = 'WebWorkerRpcDriver'
 
@@ -58,6 +56,7 @@ export default class WebWorkerRpcDriver extends BaseRpcDriver {
     const instance = this.makeWorkerInstance()
 
     const worker = new WebWorkerHandle({ workers: [instance] })
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
     if (isSafari) {
       // eslint-disable-next-line no-console
       console.log(

--- a/packages/core/ui/FatalErrorDialog.tsx
+++ b/packages/core/ui/FatalErrorDialog.tsx
@@ -1,10 +1,11 @@
-import Button from '@mui/material/Button'
-import Dialog from '@mui/material/Dialog'
-import DialogActions from '@mui/material/DialogActions'
-import DialogContent from '@mui/material/DialogContent'
-import DialogTitle from '@mui/material/DialogTitle'
-import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material'
 import FactoryResetDialog from './FactoryResetDialog'
 
 const ResetComponent = ({
@@ -34,28 +35,25 @@ const ResetComponent = ({
     </>
   )
 }
-ResetComponent.propTypes = {
-  onFactoryReset: PropTypes.func.isRequired,
-  resetButtonText: PropTypes.string.isRequired,
-}
 
 const FatalErrorDialog = ({
   componentStack,
-  error,
+  error = 'No error message provided',
   onFactoryReset,
-  resetButtonText,
+  resetButtonText = 'Factory Reset',
 }: {
-  componentStack: string
-  error: Error
+  componentStack?: string
+  error?: unknown
   onFactoryReset: Function
-  resetButtonText: string
+  resetButtonText?: string
 }) => {
+  console.error(error)
   return (
     <Dialog open>
-      <DialogTitle style={{ backgroundColor: '#e88' }}>Fatal error</DialogTitle>
+      <DialogTitle style={{ background: '#e88' }}>Fatal error</DialogTitle>
       <DialogContent>
         <pre>
-          {error.toString()}
+          {`${error}`}
           {componentStack}
         </pre>
       </DialogContent>
@@ -74,19 +72,6 @@ const FatalErrorDialog = ({
       </DialogActions>
     </Dialog>
   )
-}
-
-FatalErrorDialog.propTypes = {
-  componentStack: PropTypes.string,
-  error: PropTypes.shape({}),
-  onFactoryReset: PropTypes.func.isRequired,
-  resetButtonText: PropTypes.string,
-}
-
-FatalErrorDialog.defaultProps = {
-  error: { message: 'No error message provided' },
-  componentStack: '',
-  resetButtonText: 'Factory Reset',
 }
 
 export default FatalErrorDialog

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -177,24 +177,22 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
                   adapterConfig,
                   rendererType,
                 } = self
+
+                if (
+                  !view.initialized ||
+                  !self.estimatedStatsReady ||
+                  self.regionTooLarge
+                ) {
+                  return
+                }
+
                 const { staticBlocks, bpPerPx } = view
-
-                if (!self.estimatedStatsReady) {
-                  return
-                }
-                if (self.regionTooLarge) {
-                  return
-                }
-
                 // continually generate the vc pairing, set and rerender if any
                 // new values seen
                 if (colorBy?.tag) {
-                  const uniqueTagSet = await getUniqueTagValues(
-                    self,
-                    colorBy,
-                    staticBlocks,
+                  self.updateColorTagMap(
+                    await getUniqueTagValues(self, colorBy, staticBlocks),
                   )
-                  self.updateColorTagMap(uniqueTagSet)
                 }
 
                 if (colorBy?.type === 'modifications') {
@@ -211,7 +209,6 @@ const stateModelFactory = (configSchema: LinearPileupDisplayConfigModel) =>
 
                 if (sortedBy) {
                   const { pos, refName, assemblyName } = sortedBy
-
                   // render just the sorted region first
                   await self.rendererType.renderInClient(rpcManager, {
                     assemblyName,

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -160,22 +160,26 @@ const stateModelFactory = (
             async () => {
               try {
                 const { colorBy } = self
-                const { staticBlocks } = getContainingView(self) as LGV
+                const view = getContainingView(self) as LGV
 
-                if (!self.estimatedStatsReady) {
+                if (
+                  !view.initialized ||
+                  !self.estimatedStatsReady ||
+                  self.regionTooLarge
+                ) {
                   return
                 }
-                if (self.regionTooLarge) {
-                  return
-                }
+                const { staticBlocks } = view
                 if (colorBy?.type === 'modifications') {
-                  const vals = await getUniqueModificationValues(
-                    self,
-                    getConf(self.parentTrack, 'adapter'),
-                    colorBy,
-                    staticBlocks,
+                  const adapter = getConf(self.parentTrack, 'adapter')
+                  self.updateModificationColorMap(
+                    await getUniqueModificationValues(
+                      self,
+                      adapter,
+                      colorBy,
+                      staticBlocks,
+                    ),
                   )
-                  self.updateModificationColorMap(vals)
                 }
               } catch (error) {
                 console.error(error)
@@ -222,25 +226,19 @@ const stateModelFactory = (
               label: 'Draw insertion/clipping indicators',
               type: 'checkbox',
               checked: self.drawIndicatorsSetting,
-              onClick: () => {
-                self.toggleDrawIndicators()
-              },
+              onClick: () => self.toggleDrawIndicators(),
             },
             {
               label: 'Draw insertion/clipping counts',
               type: 'checkbox',
               checked: self.drawInterbaseCountsSetting,
-              onClick: () => {
-                self.toggleDrawInterbaseCounts()
-              },
+              onClick: () => self.toggleDrawInterbaseCounts(),
             },
             {
               label: 'Draw arcs',
               type: 'checkbox',
               checked: self.drawArcsSetting,
-              onClick: () => {
-                self.toggleDrawArcs()
-              },
+              onClick: () => self.toggleDrawArcs(),
             },
           ]
         },

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.15",
-    "@gmod/bbi": "^2.0.2",
+    "@gmod/bbi": "^2.0.3",
     "@gmod/bed": "^2.1.2",
     "@gmod/bgzf-filehandle": "^1.4.3",
     "@gmod/tabix": "^1.5.2"

--- a/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
+++ b/plugins/variants/src/VcfTabixAdapter/VcfTabixAdapter.ts
@@ -85,7 +85,7 @@ export default class extends BaseFeatureDataAdapter {
       const { refName, start, end } = query
       const { vcf, parser } = await this.configure()
       await vcf.getLines(refName, start, end, {
-        lineCallback: (line: string, fileOffset: number) => {
+        lineCallback: (line, fileOffset) => {
           observer.next(
             new VcfFeature({
               variant: parser.parseLine(line),

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -37,7 +37,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@gmod/bbi": "^2.0.2",
+    "@gmod/bbi": "^2.0.3",
     "@mui/icons-material": "^5.0.2",
     "@popperjs/core": "^2.11.0",
     "clone": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,10 +1537,10 @@
     object.entries-ponyfill "^1.0.1"
     quick-lru "^2.0.0"
 
-"@gmod/bbi@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@gmod/bbi/-/bbi-2.0.2.tgz#33f343ad46cce789d3e8e1de348bf1a69d19f538"
-  integrity sha512-6sReScRL9it2jCjMFRjLOFiU4+gS8Uzx2d7rBcnb1izktAxMFvR1TPXtzP4MPvYYSiv1W/rxtOOz2iItKDkq/A==
+"@gmod/bbi@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@gmod/bbi/-/bbi-2.0.3.tgz#961a0beb0b7406289d6c4ba4977939610668a09c"
+  integrity sha512-dFZi1SHBLhVPhsaGXE9yP5gRGQyoBp6u3TthkoYYLee5p7RJI0imzlVrF1/tYSAV484Rd985s04gwjBjbWVfzA==
   dependencies:
     abortable-promise-cache "^1.4.1"
     binary-parser "^2.1.0"


### PR DESCRIPTION
I found that safari/webkitgtk, tracks can hang in  https://github.com/GMOD/jbrowse-components/issues/3245

This seems to be a safari/webkitgtk only bug

I found an odd workaround where if I console.log the value returned by makeWorkerHandle (which is a "new Worker" https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker instance) then it removes the issue with tracks hanging. This seems odd, perhaps indicative of a race condition, but I did not see issue after doing this change.

Fixes https://github.com/GMOD/jbrowse-components/issues/3245

Also found two instances where tracks (pileup and snpcoverage) were using view.staticBlocks before view.initialized was completed, which throws a hard error, so that was also fixed. These errors were not seen in other browsers but i did see it thrown in safari
