### PR TITLE
Update use-query-params to 2.0.0

### DIFF
--- a/packages/core/ui/FatalErrorDialog.tsx
+++ b/packages/core/ui/FatalErrorDialog.tsx
@@ -1,10 +1,11 @@
-import Button from '@mui/material/Button'
-import Dialog from '@mui/material/Dialog'
-import DialogActions from '@mui/material/DialogActions'
-import DialogContent from '@mui/material/DialogContent'
-import DialogTitle from '@mui/material/DialogTitle'
-import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material'
 import FactoryResetDialog from './FactoryResetDialog'
 
 const ResetComponent = ({
@@ -34,28 +35,25 @@ const ResetComponent = ({
     </>
   )
 }
-ResetComponent.propTypes = {
-  onFactoryReset: PropTypes.func.isRequired,
-  resetButtonText: PropTypes.string.isRequired,
-}
 
 const FatalErrorDialog = ({
   componentStack,
-  error,
+  error = 'No error message provided',
   onFactoryReset,
-  resetButtonText,
+  resetButtonText = 'Factory Reset',
 }: {
-  componentStack: string
-  error: Error
+  componentStack?: string
+  error?: unknown
   onFactoryReset: Function
-  resetButtonText: string
+  resetButtonText?: string
 }) => {
+  console.error(error)
   return (
     <Dialog open>
-      <DialogTitle style={{ backgroundColor: '#e88' }}>Fatal error</DialogTitle>
+      <DialogTitle style={{ background: '#e88' }}>Fatal error</DialogTitle>
       <DialogContent>
         <pre>
-          {error.toString()}
+          {`${error}`}
           {componentStack}
         </pre>
       </DialogContent>
@@ -74,19 +72,6 @@ const FatalErrorDialog = ({
       </DialogActions>
     </Dialog>
   )
-}
-
-FatalErrorDialog.propTypes = {
-  componentStack: PropTypes.string,
-  error: PropTypes.shape({}),
-  onFactoryReset: PropTypes.func.isRequired,
-  resetButtonText: PropTypes.string,
-}
-
-FatalErrorDialog.defaultProps = {
-  error: { message: 'No error message provided' },
-  componentStack: '',
-  resetButtonText: 'Factory Reset',
 }
 
 export default FatalErrorDialog

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -99,7 +99,7 @@
     "sanitize-filename": "^1.6.3",
     "timeago.js": "^4.0.2",
     "tss-react": "^3.7.0",
-    "use-query-params": "1.2.3",
+    "use-query-params": "^2.0.0",
     "webpack": "^5.72.0"
   },
   "devDependencies": {

--- a/products/jbrowse-desktop/src/declare.d.ts
+++ b/products/jbrowse-desktop/src/declare.d.ts
@@ -1,2 +1,1 @@
 declare module 'librpc-web-mod'
-declare module '@jbrowse/core/ui/RecentSessionCard'

--- a/products/jbrowse-desktop/src/index.tsx
+++ b/products/jbrowse-desktop/src/index.tsx
@@ -3,33 +3,29 @@ import ReactDOM from 'react-dom'
 import { FatalErrorDialog } from '@jbrowse/core/ui'
 import { ErrorBoundary } from 'react-error-boundary'
 import { QueryParamProvider } from 'use-query-params'
+import { WindowHistoryAdapter } from 'use-query-params/adapters/window'
 
 import '@fontsource/roboto'
 
 import factoryReset from './factoryReset'
 import Loader from './Loader'
 
-const initialTimestamp = Date.now()
-
-if (window && window.name.startsWith('JBrowseAuthWindow')) {
-  const parent = window.opener
-  if (parent) {
-    parent.postMessage({
-      name: window.name,
-      redirectUri: window.location.href,
-    })
-  }
+if (window?.name.startsWith('JBrowseAuthWindow')) {
+  window.opener?.postMessage({
+    name: window.name,
+    redirectUri: window.location.href,
+  })
   window.close()
 }
 
-const PlatformSpecificFatalErrorDialog = props => {
-  return <FatalErrorDialog onFactoryReset={factoryReset} {...props} />
+const PlatformSpecificFatalErrorDialog = (props: { error?: unknown }) => {
+  return <FatalErrorDialog {...props} onFactoryReset={factoryReset} />
 }
 
 ReactDOM.render(
   <ErrorBoundary FallbackComponent={PlatformSpecificFatalErrorDialog}>
-    <QueryParamProvider>
-      <Loader initialTimestamp={initialTimestamp} />
+    <QueryParamProvider adapter={WindowHistoryAdapter}>
+      <Loader />
     </QueryParamProvider>
   </ErrorBoundary>,
   document.getElementById('root'),

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -62,7 +62,6 @@
     "node-polyfill-webpack-plugin": "^1.1.4",
     "pako": "^1.0.10",
     "prop-types": "^15.7.2",
-    "query-string": "^7.0.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-error-boundary": "^3.0.0",
@@ -70,7 +69,7 @@
     "rxjs": "^6.5.2",
     "shortid": "^2.2.15",
     "tss-react": "^3.7.0",
-    "use-query-params": "1.2.3",
+    "use-query-params": "^2.0.0",
     "webpack": "^5.72.0"
   },
   "browserslist": {

--- a/products/jbrowse-web/src/Loader.tsx
+++ b/products/jbrowse-web/src/Loader.tsx
@@ -8,6 +8,7 @@ import {
   QueryParamProvider,
   useQueryParam,
 } from 'use-query-params'
+import { WindowHistoryAdapter } from 'use-query-params/adapters/window'
 import { FatalErrorDialog } from '@jbrowse/core/ui'
 import '@fontsource/roboto'
 import 'requestidlecallback-polyfill'
@@ -414,7 +415,7 @@ const LoaderWrapper = ({ initialTimestamp }: { initialTimestamp: number }) => {
   return (
     // @ts-ignore
     <ErrorBoundary FallbackComponent={PlatformSpecificFatalErrorDialog}>
-      <QueryParamProvider>
+      <QueryParamProvider adapter={WindowHistoryAdapter}>
         <Loader initialTimestamp={initialTimestamp} />
       </QueryParamProvider>
     </ErrorBoundary>

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -65,7 +65,7 @@ export default function RootModel(
       jbrowse: jbrowseWebFactory(pluginManager, Session, assemblyConfigSchema),
       configPath: types.maybe(types.string),
       session: types.maybe(Session),
-      assemblyManager: assemblyManagerType,
+      assemblyManager: types.optional(assemblyManagerType, {}),
       version: types.maybe(types.string),
       internetAccounts: types.array(
         pluginManager.pluggableMstType('internet account', 'stateModel'),

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -6,8 +6,8 @@ import { TextEncoder, TextDecoder } from 'web-encoding'
 import { LocalFile } from 'generic-filehandle'
 import rangeParser from 'range-parser'
 import { Image, createCanvas } from 'canvas'
-
 import { QueryParamProvider } from 'use-query-params'
+import { WindowHistoryAdapter } from 'use-query-params/adapters/window'
 
 import { Loader } from '../Loader'
 
@@ -27,10 +27,10 @@ if (!window.TextDecoder) {
   window.TextDecoder = TextDecoder
 }
 
-const getFile = (url: string) => {
-  url = url.replace(/http:\/\/localhost\//, '')
-  return new LocalFile(require.resolve(`../../${url}`))
-}
+const getFile = (url: string) =>
+  new LocalFile(
+    require.resolve(`../../${url.replace(/http:\/\/localhost\//, '')}`),
+  )
 
 const readBuffer = async (url: string, args: RequestInit) => {
   if (url.match('plugin-store')) {
@@ -107,232 +107,127 @@ const readBuffer = async (url: string, args: RequestInit) => {
 // @ts-ignore
 jest.spyOn(global, 'fetch').mockImplementation(readBuffer)
 
-function FallbackComponent({ error }: FallbackProps) {
-  return <div>there was an error: {String(error)}</div>
+function App({ search }: { search: string }) {
+  const location = {
+    ...window.location,
+    search,
+  }
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: location,
+  })
+  return (
+    <QueryParamProvider adapter={WindowHistoryAdapter}>
+      <Loader />
+    </QueryParamProvider>
+  )
 }
 
-describe('<Loader />', () => {
-  afterEach(() => {
-    localStorage.clear()
-    sessionStorage.clear()
-  })
-  it('errors with config in URL that does not exist', async () => {
-    console.error = jest.fn()
-    const { findByText } = render(
-      // @ts-ignore
-      <ErrorBoundary FallbackComponent={FallbackComponent}>
-        {/* @ts-ignore */}
-        <QueryParamProvider location={{ search: '?config=doesNotExist.json' }}>
-          <Loader />
-        </QueryParamProvider>
-      </ErrorBoundary>,
-    )
-    expect(
-      await findByText('HTTP 404 fetching doesNotExist.json', {
-        exact: false,
-      }),
-    ).toBeTruthy()
-  })
-
-  it('can use config from a url with session param+sessionStorage', async () => {
-    sessionStorage.setItem(
-      'current',
-      `{"id": "abcdefg", "name": "testSession"}`,
-    )
-    const { findByText } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=abcdefg',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-  }, 20000)
-
-  it('can use config from a url with shared session ', async () => {
-    const { findByText } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=share-testid&password=Z42aq',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-    await waitFor(() => expect(sessionStorage.length).toBeGreaterThan(0), delay)
-  }, 20000)
-
-  // minimal session with plugin in our plugins.json
-  // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
-  it('can warn of callbacks in json session', async () => {
-    render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-    await waitFor(() => expect(sessionStorage.length).toBeGreaterThan(0), {
-      timeout: 30000,
-    })
-  }, 30000)
-
-  // minimal session,
-  // {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
-  it('pops up a warning for evil plugin', async () => {
-    const { findByTestId } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://evil.com/evil.js"}]}}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-    await findByTestId('session-warning-modal')
-  }, 20000)
-
-  it('can use config from a url with nonexistent share param ', async () => {
-    const { findAllByText } = render(
-      // @ts-ignore
-      <ErrorBoundary FallbackComponent={({ error }) => <div>{`${error}`}</div>}>
-        <QueryParamProvider
-          // @ts-ignore
-          location={{
-            search:
-              '?config=test_data/volvox/config_main_thread.json&session=share-nonexist',
-          }}
-        >
-          <Loader />
-        </QueryParamProvider>
-      </ErrorBoundary>,
-    )
-    await findAllByText(/Error/, {}, delay)
-  }, 20000)
-
-  it('can catch error from loading a bad config', async () => {
-    const { findAllByText } = render(
-      // @ts-ignore
-      <ErrorBoundary FallbackComponent={({ error }) => <div>{`${error}`}</div>}>
-        <QueryParamProvider
-          // @ts-ignore
-          location={{
-            search:
-              '?config=test_data/bad_config_for_testing_error_catcher.json',
-          }}
-        >
-          <Loader />
-        </QueryParamProvider>
-      </ErrorBoundary>,
-    )
-    await findAllByText(/Failed to load/)
-  }, 20000)
-
-  it('can use a spec url for lgv', async () => {
-    const { findByText, findByPlaceholderText } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&loc=ctgA:6000-7000&assembly=volvox&tracks=volvox_bam_pileup',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-
-    await findByText(/volvox-sorted.bam/, {}, delay)
-    const elt = await findByPlaceholderText('Search for location', {}, delay)
-
-    // @ts-ignore
-    await waitFor(() => expect(elt.value).toBe('ctgA:5,999..6,999'), delay)
-  }, 40000)
-
-  it('can use a spec url for dotplot view', async () => {
-    const { findByText, findByTestId } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"DotplotView","views":[{"assembly":"volvox"},{"assembly":"volvox"}],"tracks":["volvox_fake_synteny"]}]}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-    await findByTestId('prerendered_canvas_done', {}, delay)
-  }, 40000)
-
-  it('can use a spec url for synteny view', async () => {
-    console.warn = jest.fn()
-    const { findByText, findByTestId } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"LinearSyntenyView","tracks":["volvox_fake_synteny"],"views":[{"loc":"ctgA:1-100","assembly":"volvox"},{"loc":"ctgA:300-400","assembly":"volvox"}]}]}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-    await findByTestId('synteny_canvas', {}, delay)
-  }, 40000)
-
-  it('can use a spec url for spreadsheet view', async () => {
-    console.warn = jest.fn()
-    const { findByText } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"SpreadsheetView","uri":"test_data/volvox/volvox.filtered.vcf.gz","assembly":"volvox"}]}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-    await findByText('ctgA:8470..8471', {}, delay)
-  }, 40000)
-
-  it('can use a spec url for sv inspector view', async () => {
-    console.warn = jest.fn()
-    const { findByText } = render(
-      <QueryParamProvider
-        // @ts-ignore
-        location={{
-          search:
-            '?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"SvInspectorView","uri":"test_data/volvox/volvox.dup.vcf.gz","assembly":"volvox"}]}',
-        }}
-      >
-        <Loader />
-      </QueryParamProvider>,
-    )
-
-    await findByText('Help', {}, delay)
-    await findByText('ctgB:1982..1983', {}, delay)
-  }, 40000)
+afterEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
 })
+test('errors with config in URL that does not exist', async () => {
+  console.error = jest.fn()
+  const { findByText } = render(<App search="?config=doesNotExist.json" />)
+  await findByText(/HTTP 404 fetching doesNotExist.json/)
+})
+
+test('can use config from a url with session param+sessionStorage', async () => {
+  sessionStorage.setItem('current', `{"id": "abcdefg", "name": "testSession"}`)
+  const { findByText } = render(
+    <App search="?config=test_data/volvox/config_main_thread.json&session=abcdefg" />,
+  )
+
+  await findByText('Help', {}, delay)
+}, 20000)
+
+test('can use config from a url with shared session ', async () => {
+  render(
+    <App search="?config=test_data/volvox/config_main_thread.json&session=share-testid&password=Z42aq" />,
+  )
+
+  await waitFor(() => expect(sessionStorage.length).toBeGreaterThan(0), delay)
+}, 20000)
+
+// minimal session with plugin in our plugins.json
+// {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
+test('can warn of callbacks in json session', async () => {
+  render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}' />,
+  )
+  await waitFor(() => expect(sessionStorage.length).toBeGreaterThan(0), {
+    timeout: 30000,
+  })
+}, 30000)
+
+// minimal session,
+// {"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://unpkg.com/jbrowse-plugin-msaview/dist/jbrowse-plugin-msaview.umd.production.min.js"}]}}
+test('pops up a warning for evil plugin', async () => {
+  const { findByTestId } = render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=json-{"session":{"id":"xSHu7qGJN","name":"test","sessionPlugins":[{"url":"https://evil.com/evil.js"}]}}' />,
+  )
+  await findByTestId('session-warning-modal')
+}, 20000)
+
+test('can use config from a url with nonexistent share param ', async () => {
+  const { findAllByText } = render(
+    <App search="?config=test_data/volvox/config_main_thread.json&session=share-nonexist" />,
+  )
+  await findAllByText(/Error/, {}, delay)
+}, 20000)
+
+test('can catch error from loading a bad config', async () => {
+  const { findAllByText } = render(
+    <App search="?config=test_data/bad_config_for_testing_error_catcher.json" />,
+  )
+  await findAllByText(/Failed to load/)
+}, 20000)
+
+test('can use a spec url for lgv', async () => {
+  const { findByText, findByPlaceholderText } = render(
+    <App search="?config=test_data/volvox/config_main_thread.json&loc=ctgA:6000-7000&assembly=volvox&tracks=volvox_bam_pileup" />,
+  )
+
+  await findByText(/volvox-sorted.bam/, {}, delay)
+  const elt = await findByPlaceholderText('Search for location', {}, delay)
+  await waitFor(
+    () => expect((elt as HTMLInputElement).value).toBe('ctgA:5,999..6,999'),
+    delay,
+  )
+}, 40000)
+
+test('can use a spec url for dotplot view', async () => {
+  const { findByTestId } = render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"DotplotView","views":[{"assembly":"volvox"},{"assembly":"volvox"}],"tracks":["volvox_fake_synteny"]}]}' />,
+  )
+
+  await findByTestId('prerendered_canvas_done', {}, delay)
+}, 40000)
+
+test('can use a spec url for synteny view', async () => {
+  console.warn = jest.fn()
+  const { findByTestId } = render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"LinearSyntenyView","tracks":["volvox_fake_synteny"],"views":[{"loc":"ctgA:1-100","assembly":"volvox"},{"loc":"ctgA:300-400","assembly":"volvox"}]}]}' />,
+  )
+
+  await findByTestId('synteny_canvas', {}, delay)
+}, 40000)
+
+test('can use a spec url for spreadsheet view', async () => {
+  console.warn = jest.fn()
+  const { findByText } = render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"SpreadsheetView","uri":"test_data/volvox/volvox.filtered.vcf.gz","assembly":"volvox"}]}' />,
+  )
+
+  await findByText('ctgA:8470..8471', {}, delay)
+}, 40000)
+
+test('can use a spec url for sv inspector view', async () => {
+  console.warn = jest.fn()
+  const { findByText } = render(
+    <App search='?config=test_data/volvox/config_main_thread.json&session=spec-{"views":[{"type":"SvInspectorView","uri":"test_data/volvox/volvox.dup.vcf.gz","assembly":"volvox"}]}' />,
+  )
+
+  await findByText('ctgB:1982..1983', {}, delay)
+}, 40000)

--- a/products/jbrowse-web/src/tests/util.tsx
+++ b/products/jbrowse-web/src/tests/util.tsx
@@ -24,6 +24,7 @@ import corePlugins from '../corePlugins'
 import { Image, createCanvas } from 'canvas'
 
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import { WindowHistoryAdapter } from 'use-query-params/adapters/window'
 
 type LGV = LinearGenomeViewModel
 
@@ -136,7 +137,7 @@ export function expectCanvasMatch(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function JBrowse(props: any) {
   return (
-    <QueryParamProvider>
+    <QueryParamProvider adapter={WindowHistoryAdapter}>
       <JBrowseWithoutQueryParamProvider {...props} />
     </QueryParamProvider>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -10665,11 +10665,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
-
 filter-obj@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-2.0.2.tgz#fff662368e505d69826abb113f0f6a98f56e9d5f"
@@ -17420,16 +17415,6 @@ qs@^6.10.0:
   dependencies:
     side-channel "^1.0.4"
 
-query-string@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -18669,6 +18654,11 @@ serialize-query-params@^1.3.5:
   resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.3.6.tgz#5dd5225db85ce747fe6fbc4897628504faafec6d"
   integrity sha512-VlH7sfWNyPVZClPkRacopn6sn5uQMXBsjPVz1+pBHX895VpcYVznfJtZ49e6jymcrz+l/vowkepCZn/7xEAEdw==
 
+serialize-query-params@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.1.tgz#f28f45a3da77ad5b578832fc8c9dc8ee08df9348"
+  integrity sha512-MCw3M1sc0N0vTxsXfInqogI7Cygsnlv4Vdy1Sc+QAN50bpteYCIQRRS3FXT/mcCKOLxCR8ohLg29WmeOEXyjmw==
+
 serve-favicon@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"
@@ -19091,11 +19081,6 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -19265,11 +19250,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -20561,6 +20541,13 @@ use-query-params@1.2.3:
   integrity sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==
   dependencies:
     serialize-query-params "^1.3.5"
+
+use-query-params@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.1.1.tgz#6b9abc9b96aed5f4476a28a91e92c4d98c283a66"
+  integrity sha512-6trNvHhbb9PjtNxIFA0l31A09WmafRrmcGtSPnqwKgoI7i+m741Oh3gjz9SkJFhE5FFruBWtXx7QyfmjGcI0jA==
+  dependencies:
+    serialize-query-params "^2.0.0"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18649,11 +18649,6 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-query-params@^1.3.5:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.3.6.tgz#5dd5225db85ce747fe6fbc4897628504faafec6d"
-  integrity sha512-VlH7sfWNyPVZClPkRacopn6sn5uQMXBsjPVz1+pBHX895VpcYVznfJtZ49e6jymcrz+l/vowkepCZn/7xEAEdw==
-
 serialize-query-params@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.1.tgz#f28f45a3da77ad5b578832fc8c9dc8ee08df9348"
@@ -20534,13 +20529,6 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-use-query-params@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.2.3.tgz#306c31a0cbc714e8a3b4bd7e91a6a9aaccaa5e22"
-  integrity sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==
-  dependencies:
-    serialize-query-params "^1.3.5"
 
 use-query-params@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
Updates the use-query-params dependency to 2.0.0, which is more lightweight (uses native URLSearchParams instead of query-string). Also includes a couple small refactors ported over from  https://github.com/GMOD/jbrowse-components/pull/3192 e.g. onSnapshot in jbrowse-web is properly disposed of in the useEffect