### PR TITLE
Fix issue with breakpoint split view using view before initialized

### DIFF
--- a/plugins/breakpoint-split-view/src/model.ts
+++ b/plugins/breakpoint-split-view/src/model.ts
@@ -239,16 +239,25 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         addDisposer(
           self,
           autorun(async () => {
-            const res = Object.fromEntries(
-              await Promise.all(
-                self.matchedTracks.map(async track => [
-                  track.configuration.trackId,
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  await getBlockFeatures(self as any, track),
-                ]),
-              ),
-            )
-            self.setMatchedTrackFeatures(res)
+            try {
+              if (!self.views.every(view => view.initialized)) {
+                return
+              }
+              self.setMatchedTrackFeatures(
+                Object.fromEntries(
+                  await Promise.all(
+                    self.matchedTracks.map(async track => [
+                      track.configuration.trackId,
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      await getBlockFeatures(self as any, track),
+                    ]),
+                  ),
+                ),
+              )
+            } catch (e) {
+              console.error(e)
+              getSession(self).notify(`${e}`, 'error')
+            }
           }),
         )
       },


### PR DESCRIPTION
Adds a check for view.initialized before performing operations with view.staticBlocks

Also catches async errors during fetching and runs `session.notify` if any errors occur


Seen in firefox, similar to recent issue caught with view.staticBlocks  here https://github.com/GMOD/jbrowse-components/pull/3256/files