### PR TITLE
Fix for flaky test

### DIFF
--- a/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
+++ b/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
@@ -1,5 +1,6 @@
 import { createView, doBeforeEach } from './util'
 import chromeSizesConfig from '../../test_data/config_chrom_sizes_test.json'
+import wrongAssemblyTest from '../../test_data/wrong_assembly.json'
 
 const delay = { timeout: 15000 }
 
@@ -10,13 +11,11 @@ beforeEach(() => {
 test('404 sequence file', async () => {
   console.error = jest.fn()
   const { findAllByText } = createView(chromeSizesConfig)
-  await findAllByText('HTTP 404 fetching grape.chrom.sizes.nonexist', {
-    exact: false,
-  })
+  await findAllByText(/HTTP 404 fetching grape.chrom.sizes.nonexist/)
 })
 
 test('wrong assembly', async () => {
-  const { view, findAllByText } = createView()
+  const { view, findAllByText } = createView(wrongAssemblyTest)
   view.showTrack('volvox_wrong_assembly')
   await findAllByText(/does not match/, {}, delay)
 }, 15000)

--- a/test_data/wrong_assembly.json
+++ b/test_data/wrong_assembly.json
@@ -1,0 +1,53 @@
+{
+  "assemblies": [
+    {
+      "name": "volvox",
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "volvox_refseq",
+        "adapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "volvox.2bit",
+            "locationType": "UriLocation"
+          }
+        }
+      }
+    }
+  ],
+  "defaultSession": {
+    "name": "Integration test example",
+    "views": [
+      {
+        "id": "integration_test",
+        "type": "LinearGenomeView",
+        "offsetPx": 2000,
+        "bpPerPx": 0.05,
+        "displayedRegions": [
+          {
+            "refName": "ctgA",
+            "start": 0,
+            "end": 50001,
+            "assemblyName": "volvox"
+          }
+        ]
+      }
+    ]
+  },
+  "tracks": [
+    {
+      "type": "QuantitativeTrack",
+      "trackId": "volvox_wrong_assembly",
+      "name": "wiggle_track (wrong assembly error)",
+      "category": ["Integration test"],
+      "assemblyNames": ["wombat"],
+      "adapter": {
+        "type": "BigWigAdapter",
+        "bigWigLocation": {
+          "uri": "volvox.bw.nonexist",
+          "locationType": "UriLocation"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Possible fix for #3260

This fix creates a small minimal config for testing the wrong assembly error

A possible alternative to this approach would be checking that the LGV is initialized before finishing test, but I think the minimal config would not try to load any refnamealiases and thus would not cause any error