### PR TITLE
v2.1.6 release announcement

### DIFF
--- a/products/jbrowse-react-linear-genome-view/stories/UsingWebWorker.stories.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/UsingWebWorker.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs'
+import { isArrayLike } from 'lodash'
+
+<Meta title="Using WebWorker RPC" />
+
+## Web Worker RPC
+
+Developers can configure their instance of @jbrowse/react-linear-genome-view to use webworkers from v2.1.6 of jbrowse forward.
+
+The code snippet looks this
+
+```
+import { makeWorkerInstance, createViewState, loadPlugins, JBrowseLinearGenomeView } from '../src'
+
+...
+function YourApp() {
+ const state = createViewState({
+    assembly,
+    tracks,
+    location: 'ctgA:1105..1221',
+    configuration: {
+      rpc: {
+        defaultDriver: 'WebWorkerRpcDriver',
+      },
+    },
+    makeWorkerInstance,
+  })
+
+  return <JBrowseLinearGenomeView viewState={state} />
+}
+
+```
+
+By importing makeWorkerInstance and adding the WebWorkerRpcDriver configuration 
+to createViewState, the app will use the WebWorker RPC
+
+Using WebWorker RPC can greatly reduce "hanging" of the main thread browsing 
+alignments datasets like BAM / CRAM
+
+
+<Canvas withSource="open">
+  <Story id="linear-view--with-web-worker" />
+</Canvas>

--- a/website/release_announcement_drafts/v2.1.6.md
+++ b/website/release_announcement_drafts/v2.1.6.md
@@ -1,0 +1,36 @@
+We are happy to release v2.1.6
+
+This has several important fixes and improvements
+
+- Tracks no longer hang in "Loading..." state under Safari and Webkit based
+  browsers, a bug with starting the webworker was fixed
+- There is now an option to use the WebWorkerRpc on the
+  @jbrowse/react-linear-genome-view. This is a great improvement because the
+  WebWorkerRpc dramatically reduces the "stalling" of the main thread when
+  large datasets like BAM/CRAM are being loaded. See
+  https://jbrowse.org/storybook/lgv/main/?path=/story/using-webworker-rpc--page
+  for more info!
+- All feature types, not just gene features, can obtain the underlying feature
+  sequence with upstream/downstream options
+- The ability to refer to plugins in a path relative to your data directory
+  has been fixed, so you can easily refer to plugins in your config file with
+  e.g. `"plugins":[{"name":"MyPlugin","umdLoc":{"uri":"myplugin.js"}}]`
+  (`umdLoc` resolves the uri relative to the config.json file that it is in
+  use). There is also `umdUrl` which can be used in place of `umdLoc` which can
+  be used like this `"plugins":[{"name":"MyPlugin","umdUrl":"myplugin.js"}]`
+  and this will resolve relative to the jbrowse root directory e.g. where the
+  index.html is. We recommend using UMD for now, as ESM modules do not have
+  full browser support e.g. in firefox yet, but this will likely be changing
+  soon and we will update tutorials when this occurs!
+
+See our volvox example for a simple no-build plugin
+https://github.com/GMOD/jbrowse-components/blob/main/test_data/volvox/umd_plugin.js
+along with it's config
+https://github.com/GMOD/jbrowse-components/blob/main/test_data/volvox/config.json
+and see our no-build plugin tutorial!
+https://jbrowse.org/jb2/docs/tutorials/no_build_plugin_tutorial/
+
+![](https://user-images.githubusercontent.com/6511937/196806717-5b94a8cd-38fa-4861-9692-393158a5b2b0.png)
+
+Screenshot of the feature sequence panel showing on a SNP, allowing you to get
+upstream and downstream sequence of the SNP


### PR DESCRIPTION
Current changelog

```
yarn run v1.22.18
$ lerna-changelog

## Unreleased (2022-10-14)

#### :rocket: Enhancement
* `core`
  * [#3250](https://github.com/GMOD/jbrowse-components/pull/3250) Handle alternate line endings ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3252](https://github.com/GMOD/jbrowse-components/pull/3252) Fix gene sequence fetching in embedded, and allow fetching genomic sequence for other feature types ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#3254](https://github.com/GMOD/jbrowse-components/pull/3254) Use tick labels that correspond to the overview's larger zoom level ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#3269](https://github.com/GMOD/jbrowse-components/pull/3269) Fix ability to rename session in web/desktop ([@cmdcolin](https://github.com/cmdcolin))
  * [#3256](https://github.com/GMOD/jbrowse-components/pull/3256) Fix tracks hanging in safari and polyfill for bigwig tracks ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#3259](https://github.com/GMOD/jbrowse-components/pull/3259) Fix issue with breakpoint split view using view before initialized ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#3255](https://github.com/GMOD/jbrowse-components/pull/3255) Add more docs about color callbacks ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* `core`
  * [#3261](https://github.com/GMOD/jbrowse-components/pull/3261) Fix for flaky test ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
- Scott Cain ([@scottcain](https://github.com/scottcain))
Done in 1.61s.

```

might be good if we can get the plugin fixes in as well e.g. https://github.com/GMOD/jbrowse-components/pull/3266