### PR TITLE
Add track workflow that allows pasting JSON config

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
@@ -7,6 +7,7 @@ import { getEnv, useLocalStorage } from '@jbrowse/core/util'
 // locals
 import { AddTrackModel } from '../model'
 import DefaultAddTrackWorkflow from './DefaultAddTrackWorkflow'
+import PasteConfigWorkflow from './PasteConfigWorkflow'
 
 function AddTrackSelector({ model }: { model: AddTrackModel }) {
   const [val, setVal] = useLocalStorage('trackSelector-choice', 'Default')
@@ -16,6 +17,7 @@ function AddTrackSelector({ model }: { model: AddTrackModel }) {
   ) as AddTrackWorkflowType[]
   const ComponentMap = {
     Default: DefaultAddTrackWorkflow,
+    'Add track JSON': PasteConfigWorkflow,
     ...Object.fromEntries(widgets.map(w => [w.name, w.ReactComponent])),
   } as { [key: string]: React.FC<{ model: AddTrackModel }> }
 

--- a/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react'
+import { Button, TextField } from '@mui/material'
+import { ErrorMessage } from '@jbrowse/core/ui'
+import { makeStyles } from 'tss-react/mui'
+import { getSession } from '@jbrowse/core/util'
+import { observer } from 'mobx-react'
+
+// locals
+import { AddTrackModel } from '../model'
+
+const useStyles = makeStyles()({
+  textbox: {
+    width: '100%',
+  },
+  submit: {
+    marginTop: 25,
+    marginBottom: 100,
+    display: 'block',
+  },
+})
+
+function AddTrackWorkflow({ model }: { model: AddTrackModel }) {
+  const { classes } = useStyles()
+  const [val, setVal] = useState('')
+  const [error, setError] = useState<unknown>()
+
+  return (
+    <div>
+      {error ? <ErrorMessage error={error} /> : null}
+      <TextField
+        multiline
+        rows={10}
+        value={val}
+        onChange={event => setVal(event.target.value)}
+        placeholder={
+          'Paste track config or array of track configs in JSON format'
+        }
+        variant="outlined"
+        className={classes.textbox}
+      />
+      <Button
+        variant="contained"
+        className={classes.submit}
+        onClick={() => {
+          try {
+            setError(undefined)
+            const session = getSession(model)
+            const conf = JSON.parse(val)
+            const confs = Array.isArray(conf) ? conf : [conf]
+            confs.forEach(c => session.addTrackConf(c))
+            confs.forEach(c => c.trackId)
+            model.clearData()
+            session.hideWidget(model)
+          } catch (e) {
+            setError(e)
+          }
+        }}
+      >
+        Submit
+      </Button>
+    </div>
+  )
+}
+export default observer(AddTrackWorkflow)

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -5,8 +5,8 @@ import { FileLocation } from '@jbrowse/core/util/types'
 import {
   guessAdapter,
   guessTrackType,
-  UNSUPPORTED,
   getFileName,
+  UNSUPPORTED,
 } from '@jbrowse/core/util/tracks'
 
 function isAbsoluteUrl(url = '') {


### PR DESCRIPTION
This is a very simple component that let's users paste a config in plain JSON format

This would be an escape hatch for expert users or perhaps users getting instruction. sometimes I imagine it being helpful in a workshop for users to paste a particular thing rather than click and edit the GUI a bunch after adding the basic instance of a track

![Screenshot from 2022-10-17 18-08-54](https://user-images.githubusercontent.com/6511937/196306198-0f35ea7c-6593-4c9b-86f5-0c6d92f88b87.png)

sort of the GUI version of the add-track-json CLI