### PR TITLE
Update and publish authentication plugin

### DIFF
--- a/packages/core/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/util/io/RemoteFileWithRangeCache.ts
@@ -9,7 +9,7 @@ type BinaryRangeFetch = (
   options?: { headers?: HeadersInit; signal?: AbortSignal },
 ) => Promise<BinaryRangeResponse>
 
-interface BinaryRangeResponse {
+export interface BinaryRangeResponse {
   headers: Record<string, string>
   requestDate: Date
   responseDate: Date

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -53,7 +53,9 @@
     "react-dom": ">=16.8.0",
     "rxjs": "^6.0.0"
   },
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",
   "module": ""

--- a/plugins/authentication/src/DropboxOAuthModel/model.tsx
+++ b/plugins/authentication/src/DropboxOAuthModel/model.tsx
@@ -59,15 +59,12 @@ async function getDescriptiveErrorMessage(response: Response) {
 const stateModelFactory = (
   configSchema: DropboxOAuthInternetAccountConfigModel,
 ) => {
-  return types
-    .compose(
-      'DropboxOAuthInternetAccount',
-      baseModel(OAuthConfigSchema),
-      types.model({
-        type: types.literal('DropboxOAuthInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return baseModel(OAuthConfigSchema)
+    .named('DropboxOAuthInternetAccount')
+    .props({
+      type: types.literal('DropboxOAuthInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views(() => ({
       get toggleContents() {
         return <DropboxIcon />

--- a/plugins/authentication/src/ExternalTokenModel/model.tsx
+++ b/plugins/authentication/src/ExternalTokenModel/model.tsx
@@ -9,15 +9,11 @@ import { ExternalTokenEntryForm } from './ExternalTokenEntryForm'
 const stateModelFactory = (
   configSchema: ExternalTokenInternetAccountConfigModel,
 ) => {
-  return types
-    .compose(
-      'ExternalTokenInternetAccount',
-      InternetAccount,
-      types.model({
-        type: types.literal('ExternalTokenInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return InternetAccount.named('ExternalTokenInternetAccount')
+    .props({
+      type: types.literal('ExternalTokenInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views(self => ({
       get validateWithHEAD(): boolean {
         return getConf(self, 'validateWithHEAD')

--- a/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
+++ b/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
@@ -95,15 +95,12 @@ async function getDescriptiveErrorMessage(response: Response) {
 const stateModelFactory = (
   configSchema: GoogleDriveOAuthInternetAccountConfigModel,
 ) => {
-  return types
-    .compose(
-      'GoogleDriveOAuthInternetAccount',
-      baseModel(OAuthConfigSchema),
-      types.model({
-        type: types.literal('GoogleDriveOAuthInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return baseModel(OAuthConfigSchema)
+    .named('GoogleDriveOAuthInternetAccount')
+    .props({
+      type: types.literal('GoogleDriveOAuthInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views(() => ({
       get toggleContents() {
         return <GoogleDriveIcon />

--- a/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
+++ b/plugins/authentication/src/GoogleDriveOAuthModel/model.tsx
@@ -15,7 +15,7 @@ import { GoogleDriveOAuthInternetAccountConfigModel } from './configSchema'
 import baseModel from '../OAuthModel/model'
 import { configSchema as OAuthConfigSchema } from '../OAuthModel'
 
-interface RequestInitWithMetadata extends RequestInit {
+export interface RequestInitWithMetadata extends RequestInit {
   metadataOnly?: boolean
 }
 
@@ -40,7 +40,7 @@ interface GoogleDriveError {
   }
 }
 
-class GoogleDriveFile extends RemoteFileWithRangeCache {
+export class GoogleDriveFile extends RemoteFileWithRangeCache {
   private statsPromise: Promise<{ size: number }>
   constructor(source: string, opts: GoogleDriveFilehandleOptions) {
     super(source, opts)

--- a/plugins/authentication/src/HTTPBasicModel/model.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/model.tsx
@@ -9,15 +9,11 @@ import { HTTPBasicLoginForm } from './HTTPBasicLoginForm'
 const stateModelFactory = (
   configSchema: HTTPBasicInternetAccountConfigModel,
 ) => {
-  return types
-    .compose(
-      'HTTPBasicInternetAccount',
-      InternetAccount,
-      types.model({
-        type: types.literal('HTTPBasicInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return InternetAccount.named('HTTPBasicInternetAccount')
+    .props({
+      type: types.literal('HTTPBasicInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views(self => ({
       get validateWithHEAD(): boolean {
         return getConf(self, 'validateWithHEAD')

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -34,15 +34,11 @@ function getGlobalObject(): Window {
 }
 
 const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
-  return types
-    .compose(
-      'OAuthInternetAccount',
-      InternetAccount,
-      types.model('OAuthModel', {
-        type: types.literal('OAuthInternetAccount'),
-        configuration: ConfigurationReference(configSchema),
-      }),
-    )
+  return InternetAccount.named('OAuthInternetAccount')
+    .props({
+      type: types.literal('OAuthInternetAccount'),
+      configuration: ConfigurationReference(configSchema),
+    })
     .views(() => {
       let codeVerifier: string | undefined = undefined
       return {

--- a/plugins/authentication/src/index.ts
+++ b/plugins/authentication/src/index.ts
@@ -25,6 +25,19 @@ import {
 export default class AuthenticationPlugin extends Plugin {
   name = 'AuthenticationPlugin'
 
+  exports = {
+    OAuthConfigSchema,
+    OAuthInternetAccountModelFactory,
+    ExternalTokenConfigSchema,
+    ExternalTokenInternetAccountModelFactory,
+    HTTPBasicConfigSchema,
+    HTTPBasicInternetAccountModelFactory,
+    DropboxOAuthConfigSchema,
+    DropboxOAuthInternetAccountModelFactory,
+    GoogleDriveOAuthConfigSchema,
+    GoogleDriveOAuthInternetAccountModelFactory,
+  }
+
   install(pluginManager: PluginManager) {
     pluginManager.addInternetAccountType(() => {
       return new InternetAccountType({
@@ -68,4 +81,17 @@ export default class AuthenticationPlugin extends Plugin {
       })
     })
   }
+}
+
+export {
+  OAuthConfigSchema,
+  OAuthInternetAccountModelFactory,
+  ExternalTokenConfigSchema,
+  ExternalTokenInternetAccountModelFactory,
+  HTTPBasicConfigSchema,
+  HTTPBasicInternetAccountModelFactory,
+  DropboxOAuthConfigSchema,
+  DropboxOAuthInternetAccountModelFactory,
+  GoogleDriveOAuthConfigSchema,
+  GoogleDriveOAuthInternetAccountModelFactory,
 }

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -249,13 +249,12 @@ export default function RootModel(
           throw new Error(`unknown internet account type ${configuration.type}`)
         }
 
-        const internetAccount = internetAccountType.stateModel.create({
+        const length = self.internetAccounts.push({
           ...initialSnapshot,
           type: configuration.type,
           configuration,
         })
-        self.internetAccounts.push(internetAccount)
-        return internetAccount
+        return self.internetAccounts[length - 1]
       },
       createEphemeralInternetAccount(
         internetAccountId: string,


### PR DESCRIPTION
This exports some things from the authentication plugin and makes the package public. The motivation is to be able to use the OAuth plugin in Apollo. A few classes and interfaces had to have `export` added to them (including one in core) so that TypeScript could make public types for the newly exported files.

Also updates the internetAccount models to use a simpler MST named/props pattern instead of using compose.