### PR TITLE
Add option to use OAuth "state" param

### DIFF
--- a/plugins/authentication/src/OAuthModel/configSchema.ts
+++ b/plugins/authentication/src/OAuthModel/configSchema.ts
@@ -61,6 +61,14 @@ const OAuthConfigSchema = ConfigurationSchema(
     /**
      * #slot
      */
+    state: {
+      description: 'optional state for the authorization call',
+      type: 'string',
+      defaultValue: '',
+    },
+    /**
+     * #slot
+     */
     responseType: {
       description: 'the type of response from the authorization endpoint',
       type: 'string',

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -73,9 +73,9 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
       },
       /**
        * OAuth state parameter: https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1
-       * Can override this getter if dynamic state is needed.
+       * Can override or extend if dynamic state is needed.
        */
-      get state(): string | undefined {
+      state(): string | undefined {
         return getConf(self, 'state') || undefined
       },
       get responseType(): 'token' | 'code' {
@@ -264,8 +264,8 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
             response_type: self.responseType || 'code',
           }
 
-          if (self.state) {
-            data.state = self.state
+          if (self.state()) {
+            data.state = self.state()
           }
 
           if (self.scopes) {


### PR DESCRIPTION
This adds to the option to use the [state](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1) parameter in an OAuth authorization. By default it is read from the config, but if dynamic state is needed, the `get state` getter can be overridden in an extending model.

Motivation is to use this in Apollo to keep track of some state across the OAuth flow.