### PR TITLE
Use canvas to draw LGV gridlines

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -72,21 +72,14 @@ const RenderedBlocks = observer(
           }
           if (block instanceof ElidedBlock) {
             return (
-              <ElidedBlockComponent
+              <div
                 key={`${model.id}-${block.key}`}
-                width={block.widthPx}
+                style={{ width: block.widthPx }}
               />
             )
           }
           if (block instanceof InterRegionPaddingBlock) {
-            return (
-              <InterRegionPaddingBlockComponent
-                key={block.key}
-                width={block.widthPx}
-                style={{ background: 'none' }}
-                boundary={block.variant === 'boundary'}
-              />
-            )
+            return <div key={block.key} style={{ width: block.widthPx }} />
           }
           throw new Error(`invalid block type ${typeof block}`)
         })}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -44,13 +44,14 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
     if (!ctx) {
       return
     }
-    const height = canvas.getBoundingClientRect().height
     const p = theme.palette
     const light = p.divider
     const dark = p.text.secondary
+    const height = canvas.height
+    const w = canvas.width
+    ctx.scale(window.devicePixelRatio, window.devicePixelRatio)
     ctx.clearRect(0, 0, w, height)
     ctx.resetTransform()
-    ctx.scale(window.devicePixelRatio, window.devicePixelRatio)
     staticBlocks.forEach(b => {
       const offset = b.offsetPx - staticBlocks.offsetPx
       if (b instanceof ContentBlock) {
@@ -61,16 +62,16 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
           }
           ctx.fillStyle =
             t.type === 'major' || t.type === 'labeledMajor' ? dark : light
-          ctx.fillRect(Math.round(x + offset), 0, 1, height * 2)
+          ctx.fillRect(Math.round(x + offset), 0, 1, height)
         })
       }
       if (b instanceof ElidedBlock) {
         ctx.fillStyle = '#999'
-        ctx.fillRect(offset, 0, b.widthPx, height * 2)
+        ctx.fillRect(Math.round(offset), 0, b.widthPx, height)
       }
       if (b instanceof InterRegionPaddingBlock) {
-        ctx.fillStyle = '#999'
-        ctx.fillRect(offset, 0, b.widthPx, height * 2)
+        ctx.fillStyle = b.key.includes('Region') ? '#999' : '#000'
+        ctx.fillRect(Math.round(offset), 0, b.widthPx, height)
       }
     })
   }, [

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -56,42 +56,29 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
       return
     }
     const height = canvas.getBoundingClientRect().height
+    const p = theme.palette
+    const light = p.divider
+    const dark = p.text.secondary
     ctx.clearRect(0, 0, w, height)
     ctx.resetTransform()
     ctx.scale(window.devicePixelRatio, window.devicePixelRatio)
     staticBlocks.forEach(b => {
+      const offset = b.offsetPx - staticBlocks.offsetPx
       if (b instanceof ContentBlock) {
         makeTicks(b.start, b.end, model.bpPerPx).forEach(t => {
           const x = (b.reversed ? b.end - t.base : t.base - b.start) / bpPerPx
           ctx.fillStyle =
-            t.type === 'major' || t.type === 'labeledMajor'
-              ? theme.palette.text.secondary
-              : theme.palette.divider
-          ctx.fillRect(
-            x + b.offsetPx - staticBlocks.offsetPx,
-            0,
-            0.7,
-            height * 2,
-          )
+            t.type === 'major' || t.type === 'labeledMajor' ? dark : light
+          ctx.fillRect(x + offset, 0, 1, height * 2)
         })
       }
       if (b instanceof ElidedBlock) {
         ctx.fillStyle = '#999'
-        ctx.fillRect(
-          b.offsetPx - staticBlocks.offsetPx,
-          0,
-          b.widthPx,
-          height * 2,
-        )
+        ctx.fillRect(offset, 0, b.widthPx, height * 2)
       }
       if (b instanceof InterRegionPaddingBlock) {
-        ctx.fillStyle = '#999'
-        ctx.fillRect(
-          b.offsetPx - staticBlocks.offsetPx,
-          0,
-          b.widthPx,
-          height * 2,
-        )
+        ctx.fillStyle = '#000'
+        ctx.fillRect(offset, 0, b.widthPx, height * 2)
       }
     })
   }, [

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -14,7 +14,7 @@ import { makeTicks } from '../util'
 
 type LGV = LinearGenomeViewModel
 
-const useStyles = makeStyles()(theme => ({
+const useStyles = makeStyles()({
   verticalGuidesZoomContainer: {
     position: 'absolute',
     height: '100%',
@@ -29,18 +29,7 @@ const useStyles = makeStyles()(theme => ({
     pointerEvents: 'none',
     display: 'flex',
   },
-  tick: {
-    position: 'absolute',
-    height: '100%',
-    width: 1,
-  },
-  majorTick: {
-    background: theme.palette.text.secondary,
-  },
-  minorTick: {
-    background: theme.palette.divider,
-  },
-}))
+})
 const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
   const { staticBlocks, bpPerPx } = model
   const theme = useTheme()
@@ -67,9 +56,12 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
       if (b instanceof ContentBlock) {
         makeTicks(b.start, b.end, model.bpPerPx).forEach(t => {
           const x = (b.reversed ? b.end - t.base : t.base - b.start) / bpPerPx
+          if (x < 0 || x > b.widthPx) {
+            return
+          }
           ctx.fillStyle =
             t.type === 'major' || t.type === 'labeledMajor' ? dark : light
-          ctx.fillRect(x + offset, 0, 1, height * 2)
+          ctx.fillRect(Math.round(x + offset), 0, 1, height * 2)
         })
       }
       if (b instanceof ElidedBlock) {
@@ -77,7 +69,7 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
         ctx.fillRect(offset, 0, b.widthPx, height * 2)
       }
       if (b instanceof InterRegionPaddingBlock) {
-        ctx.fillStyle = '#000'
+        ctx.fillStyle = '#999'
         ctx.fillRect(offset, 0, b.widthPx, height * 2)
       }
     })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.test.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.test.tsx
@@ -50,7 +50,7 @@ describe('ScaleBar genome view component', () => {
     const { getByTestId } = render(<ScaleBar model={model} />)
     const ret1 = getByTestId('refLabel-ctgA')
     const ret2 = getByTestId('refLabel-ctgB')
-    expect(ret1.style.left).toBe('-1px')
+    expect(ret1.style.left).toBe('0px')
     expect(ret2.style.left).toBe('101px')
   })
   it('renders two regions when scrolled to the left, the label is ctgA to the actual blocks', () => {
@@ -92,7 +92,7 @@ describe('ScaleBar genome view component', () => {
     const { getByTestId } = render(<ScaleBar model={model} />)
     const ret1 = getByTestId('refLabel-ctgA')
     const ret2 = getByTestId('refLabel-ctgB')
-    expect(ret1.style.left).toBe('99px')
+    expect(ret1.style.left).toBe('100px')
     expect(ret2.style.left).toBe('201px')
   })
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScaleBar.tsx
@@ -1,18 +1,9 @@
+import React from 'react'
 import { Paper, Typography } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import {
-  ContentBlock,
-  ElidedBlock,
-  InterRegionPaddingBlock,
-} from '@jbrowse/core/util/blockTypes'
+import { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { observer } from 'mobx-react'
-import React from 'react'
 import { LinearGenomeViewModel } from '..'
-import {
-  ContentBlock as ContentBlockComponent,
-  ElidedBlock as ElidedBlockComponent,
-  InterRegionPaddingBlock as InterRegionPaddingBlockComponent,
-} from '../../BaseLinearDisplay/components/Block'
 import { makeTicks } from '../util'
 import { getTickDisplayStr } from '@jbrowse/core/util'
 
@@ -96,54 +87,38 @@ const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
 
 const RenderedScaleBarLabels = observer(({ model }: { model: LGV }) => {
   const { classes } = useStyles()
-  const { bpPerPx, staticBlocks } = model
+  const { staticBlocks, bpPerPx } = model
 
   return (
     <>
-      {staticBlocks.map((block, index) => {
-        const { reversed, start, end, key, widthPx } = block
+      {staticBlocks.map(block => {
+        const { reversed, start, end } = block
         if (block instanceof ContentBlock) {
           const ticks = makeTicks(start, end, bpPerPx, true, false)
 
-          return (
-            <ContentBlockComponent key={`${key}-${index}`} block={block}>
-              {ticks.map(tick => {
-                if (tick.type === 'major') {
-                  const x =
-                    (reversed ? end - tick.base : tick.base - start) / bpPerPx
-                  const baseNumber = tick.base + 1
-                  return (
-                    <div
-                      key={tick.base}
-                      className={classes.tick}
-                      style={{ left: x }}
-                    >
-                      {baseNumber ? (
-                        <Typography className={classes.majorTickLabel}>
-                          {getTickDisplayStr(baseNumber, bpPerPx)}
-                        </Typography>
-                      ) : null}
-                    </div>
-                  )
-                }
-                return null
-              })}
-            </ContentBlockComponent>
-          )
+          return ticks
+            .filter(t => t.type === 'major')
+            .map(t => {
+              const x = (reversed ? end - t.base : t.base - start) / bpPerPx
+              const baseNumber = t.base + 1
+              return (
+                <div
+                  key={t.base}
+                  className={classes.tick}
+                  style={{
+                    left: x + block.offsetPx - model.staticBlocks.offsetPx,
+                  }}
+                >
+                  {baseNumber ? (
+                    <Typography className={classes.majorTickLabel}>
+                      {getTickDisplayStr(baseNumber, bpPerPx)}
+                    </Typography>
+                  ) : null}
+                </div>
+              )
+            })
         }
-        if (block instanceof ElidedBlock) {
-          return <ElidedBlockComponent key={key} width={widthPx} />
-        }
-        if (block instanceof InterRegionPaddingBlock) {
-          return (
-            <InterRegionPaddingBlockComponent
-              key={key}
-              width={widthPx}
-              style={{ background: 'none' }}
-              boundary={block.variant === 'boundary'}
-            />
-          )
-        }
+
         return null
       })}
     </>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -359,17 +359,12 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
           <div
             class="css-1u2dss8-scaleBar"
             style="left: -801px; width: 1700px; height: 17px; box-sizing: border-box;"
-          >
-            <div
-              class="css-1f3h2yl-tick"
-              style="left: 799px;"
-            />
-          </div>
+          />
         </div>
         <p
           class="MuiTypography-root MuiTypography-body1 css-1vlu65o-MuiTypography-root-refLabel"
           data-testid="refLabel-ctgA"
-          style="left: -1px; padding-left: 1px;"
+          style="left: 0px; padding-left: 0px;"
         >
           ctgA
         </p>
@@ -466,16 +461,14 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
               style="left: -800px;"
             >
               <div
-                class="css-a9ifge-boundaryPaddingBlock"
-                style="background: none; width: 800px;"
+                style="width: 800px;"
               />
               <div
                 class="css-1dmfa10-contentBlock"
                 style="width: 100px;"
               />
               <div
-                class="css-a9ifge-boundaryPaddingBlock"
-                style="background: none; width: 800px;"
+                style="width: 800px;"
               />
             </div>
           </div>
@@ -875,10 +868,6 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
           >
             <div
               class="css-1f3h2yl-tick"
-              style="left: 799px;"
-            />
-            <div
-              class="css-1f3h2yl-tick"
               style="left: 901px;"
             >
               <p
@@ -932,7 +921,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         <p
           class="MuiTypography-root MuiTypography-body1 css-1vlu65o-MuiTypography-root-refLabel"
           data-testid="refLabel-ctgA"
-          style="left: -1px; padding-left: 1px;"
+          style="left: 0px; padding-left: 0px;"
         >
           ctgA
         </p>
@@ -1036,8 +1025,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               style="left: -800px;"
             >
               <div
-                class="css-a9ifge-boundaryPaddingBlock"
-                style="background: none; width: 800px;"
+                style="width: 800px;"
               />
               <div
                 class="css-1dmfa10-contentBlock"
@@ -1050,8 +1038,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 />
               </div>
               <div
-                class="css-1x3apsi-interRegionPaddingBlock"
-                style="background: none; width: 2px;"
+                style="width: 2px;"
               />
               <div
                 class="css-1dmfa10-contentBlock"
@@ -1168,8 +1155,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
               style="left: -800px;"
             >
               <div
-                class="css-a9ifge-boundaryPaddingBlock"
-                style="background: none; width: 800px;"
+                style="width: 800px;"
               />
               <div
                 class="css-1dmfa10-contentBlock"
@@ -1182,8 +1168,7 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
                 />
               </div>
               <div
-                class="css-1x3apsi-interRegionPaddingBlock"
-                style="background: none; width: 2px;"
+                style="width: 2px;"
               />
               <div
                 class="css-1dmfa10-contentBlock"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -337,46 +337,9 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
         class="css-17gfnt3-verticalGuidesContainer"
         style="left: -800px; width: 1700px;"
       >
-        <div
-          class="css-a9ifge-boundaryPaddingBlock"
-          style="width: 800px;"
-        />
-        <div
-          class="css-1dmfa10-contentBlock"
-          style="width: 100px;"
-        >
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: -1px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 19px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 39px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 59px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 79px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 99px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 119px;"
-          />
-        </div>
-        <div
-          class="css-a9ifge-boundaryPaddingBlock"
-          style="width: 800px;"
+        <canvas
+          style="width: 1700px; height: 100%;"
+          width="1700"
         />
       </div>
     </div>
@@ -398,21 +361,8 @@ exports[`<LinearGenomeView /> renders one track, one region 1`] = `
             style="left: -801px; width: 1700px; height: 17px; box-sizing: border-box;"
           >
             <div
-              class="css-a9ifge-boundaryPaddingBlock"
-              style="background: none; width: 800px;"
-            />
-            <div
-              class="css-1dmfa10-contentBlock"
-              style="width: 100px;"
-            >
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: -1px;"
-              />
-            </div>
-            <div
-              class="css-a9ifge-boundaryPaddingBlock"
-              style="background: none; width: 800px;"
+              class="css-1f3h2yl-tick"
+              style="left: 799px;"
             />
           </div>
         </div>
@@ -900,220 +850,10 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
         class="css-17gfnt3-verticalGuidesContainer"
         style="left: -800px; width: 1702px;"
       >
-        <div
-          class="css-a9ifge-boundaryPaddingBlock"
-          style="width: 800px;"
+        <canvas
+          style="width: 1702px; height: 100%;"
+          width="1702"
         />
-        <div
-          class="css-1dmfa10-contentBlock"
-          style="width: 100px;"
-        >
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: -1px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 19px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 39px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 59px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 79px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 99px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 119px;"
-          />
-        </div>
-        <div
-          class="css-1x3apsi-interRegionPaddingBlock"
-          style="width: 2px;"
-        />
-        <div
-          class="css-1dmfa10-contentBlock"
-          style="width: 800px;"
-        >
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: -1px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 19px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 39px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 59px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 79px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 99px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 119px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 139px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 159px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 179px;"
-          />
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: 199px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 219px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 239px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 259px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 279px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 299px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 319px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 339px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 359px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 379px;"
-          />
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: 399px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 419px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 439px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 459px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 479px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 499px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 519px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 539px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 559px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 579px;"
-          />
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: 599px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 619px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 639px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 659px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 679px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 699px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 719px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 739px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 759px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 779px;"
-          />
-          <div
-            class="css-1nnah7t-tick-majorTick"
-            style="left: 799px;"
-          />
-          <div
-            class="css-i794sq-tick-minorTick"
-            style="left: 819px;"
-          />
-        </div>
       </div>
     </div>
     <div
@@ -1134,76 +874,58 @@ exports[`<LinearGenomeView /> renders two tracks, two regions 1`] = `
             style="left: -801px; width: 1702px; height: 17px; box-sizing: border-box;"
           >
             <div
-              class="css-a9ifge-boundaryPaddingBlock"
-              style="background: none; width: 800px;"
+              class="css-1f3h2yl-tick"
+              style="left: 799px;"
             />
             <div
-              class="css-1dmfa10-contentBlock"
-              style="width: 100px;"
+              class="css-1f3h2yl-tick"
+              style="left: 901px;"
             >
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: -1px;"
-              />
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
+              >
+                1,000
+              </p>
             </div>
             <div
-              class="css-1x3apsi-interRegionPaddingBlock"
-              style="background: none; width: 2px;"
-            />
-            <div
-              class="css-1dmfa10-contentBlock"
-              style="width: 800px;"
+              class="css-1f3h2yl-tick"
+              style="left: 1101px;"
             >
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: -1px;"
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
-                >
-                  1,000
-                </p>
-              </div>
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: 199px;"
+                1,200
+              </p>
+            </div>
+            <div
+              class="css-1f3h2yl-tick"
+              style="left: 1301px;"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
-                >
-                  1,200
-                </p>
-              </div>
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: 399px;"
+                1,400
+              </p>
+            </div>
+            <div
+              class="css-1f3h2yl-tick"
+              style="left: 1501px;"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
-                >
-                  1,400
-                </p>
-              </div>
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: 599px;"
+                1,600
+              </p>
+            </div>
+            <div
+              class="css-1f3h2yl-tick"
+              style="left: 1701px;"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
-                >
-                  1,600
-                </p>
-              </div>
-              <div
-                class="css-1f3h2yl-tick"
-                style="left: 799px;"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-p92emw-MuiTypography-root-majorTickLabel"
-                >
-                  1,800
-                </p>
-              </div>
+                1,800
+              </p>
             </div>
           </div>
         </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -227,6 +227,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
     )
     .volatile(() => ({
       volatileWidth: undefined as number | undefined,
+      volatileHeight: undefined as number | undefined,
       minimumBlockWidth: 3,
       draggingTrackId: undefined as undefined | string,
       volatileError: undefined as undefined | Error,

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -429,356 +429,10 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="css-17gfnt3-verticalGuidesContainer"
                 style="left: -800px; width: 2400px;"
               >
-                <div
-                  class="css-a9ifge-boundaryPaddingBlock"
-                  style="width: 800px;"
+                <canvas
+                  style="width: 2400px; height: 100%;"
+                  width="2400"
                 />
-                <div
-                  class="css-1dmfa10-contentBlock"
-                  style="width: 800px;"
-                >
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: -20px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 0px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 20px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 40px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 60px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 80px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 100px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 120px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 140px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 160px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 180px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 200px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 220px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 240px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 260px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 280px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 300px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 320px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 340px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 360px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 380px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 400px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 420px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 440px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 460px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 480px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 500px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 520px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 540px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 560px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 580px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 600px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 620px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 640px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 660px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 680px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 700px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 720px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 740px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 760px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 780px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 800px;"
-                  />
-                </div>
-                <div
-                  class="css-1dmfa10-contentBlock"
-                  style="width: 800px;"
-                >
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: -20px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 0px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 20px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 40px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 60px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 80px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 100px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 120px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 140px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 160px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 180px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 200px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 220px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 240px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 260px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 280px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 300px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 320px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 340px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 360px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 380px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 400px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 420px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 440px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 460px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 480px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 500px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 520px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 540px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 560px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 580px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 600px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 620px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 640px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 660px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 680px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 700px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 720px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 740px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 760px;"
-                  />
-                  <div
-                    class="css-1nnah7t-tick-majorTick"
-                    style="left: 780px;"
-                  />
-                  <div
-                    class="css-i794sq-tick-minorTick"
-                    style="left: 800px;"
-                  />
-                </div>
               </div>
             </div>
             <div
@@ -799,119 +453,101 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     style="left: -801px; width: 2400px; height: 17px; box-sizing: border-box;"
                   >
                     <div
-                      class="css-a9ifge-boundaryPaddingBlock"
-                      style="background: none; width: 800px;"
-                    />
-                    <div
-                      class="css-1dmfa10-contentBlock"
-                      style="width: 800px;"
+                      class="css-1f3h2yl-tick"
+                      style="left: 980px;"
                     >
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: -20px;"
-                      />
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 180px;"
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          10
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 380px;"
-                      >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          20
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 580px;"
-                      >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          30
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 780px;"
-                      >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          40
-                        </p>
-                      </div>
+                        10
+                      </p>
                     </div>
                     <div
-                      class="css-1dmfa10-contentBlock"
-                      style="width: 800px;"
+                      class="css-1f3h2yl-tick"
+                      style="left: 1180px;"
                     >
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: -20px;"
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          40
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 180px;"
+                        20
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 1380px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          50
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 380px;"
+                        30
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 1580px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          60
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 580px;"
+                        40
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 1580px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          70
-                        </p>
-                      </div>
-                      <div
-                        class="css-1f3h2yl-tick"
-                        style="left: 780px;"
+                        40
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 1780px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
                       >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
-                        >
-                          80
-                        </p>
-                      </div>
+                        50
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 1980px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                      >
+                        60
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 2180px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                      >
+                        70
+                      </p>
+                    </div>
+                    <div
+                      class="css-1f3h2yl-tick"
+                      style="left: 2380px;"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                      >
+                        80
+                      </p>
                     </div>
                   </div>
                 </div>
                 <p
                   class="MuiTypography-root MuiTypography-body1 css-x1763-MuiTypography-root-refLabel"
                   data-testid="refLabel-ctgA"
-                  style="left: -1px; padding-left: 1px;"
+                  style="left: 0px; padding-left: 0px;"
                 >
                   ctgA
                 </p>
@@ -1008,8 +644,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       style="left: -800px;"
                     >
                       <div
-                        class="css-a9ifge-boundaryPaddingBlock"
-                        style="background: none; width: 800px;"
+                        style="width: 800px;"
                       />
                       <div
                         class="css-1dmfa10-contentBlock"


### PR DESCRIPTION
Currently, we draw all gridlines as div's with React and it can result in some scroll stutter. I don't have exact measurements for it but I think this PR can help keep FPS up, since having less mounting/unmounting components during scroll should help