### PR TITLE
Add ability to use internet accounts in embedded

### DIFF
--- a/packages/core/util/io/index.ts
+++ b/packages/core/util/io/index.ts
@@ -12,7 +12,7 @@ import {
   FileLocation,
   LocalPathLocation,
   BlobLocation,
-  isAppRootModel,
+  isRootModelWithInternetAccounts,
   isUriLocation,
   AuthNeededError,
   UriLocation,
@@ -109,7 +109,7 @@ function getInternetAccount(
 ): BaseInternetAccountModel | undefined {
   const { rootModel } = pluginManager
   // If there is an appRootModel, use it to find the internetAccount
-  if (rootModel && isAppRootModel(rootModel)) {
+  if (rootModel && isRootModelWithInternetAccounts(rootModel)) {
     return rootModel.findAppropriateInternetAccount(location)
   }
   // If there is no appRootModel, but there is pre-auth, create a temporary

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -322,6 +322,24 @@ export function isAppRootModel(thing: unknown): thing is AppRootModel {
   )
 }
 
+export interface RootModelWithInternetAccounts extends AbstractRootModel {
+  internetAccounts: BaseInternetAccountModel[]
+  findAppropriateInternetAccount(
+    location: UriLocation,
+  ): BaseInternetAccountModel | undefined
+}
+
+export function isRootModelWithInternetAccounts(
+  thing: unknown,
+): thing is RootModelWithInternetAccounts {
+  return (
+    typeof thing === 'object' &&
+    thing !== null &&
+    'internetAccounts' in thing &&
+    'findAppropriateInternetAccount' in thing
+  )
+}
+
 /** a root model that manages global menus */
 export interface AbstractMenuManager {
   appendMenu(menuName: string): void

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -44,6 +44,7 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@jbrowse/core": "^2.1.7",
+    "@jbrowse/plugin-authentication": "^2.1.7",
     "@jbrowse/plugin-circular-view": "^2.1.7",
     "@jbrowse/plugin-config": "^2.1.7",
     "@jbrowse/plugin-data-management": "^2.1.7",

--- a/products/jbrowse-react-circular-genome-view/src/corePlugins.ts
+++ b/products/jbrowse-react-circular-genome-view/src/corePlugins.ts
@@ -1,3 +1,4 @@
+import Authentication from '@jbrowse/plugin-authentication'
 import Config from '@jbrowse/plugin-config'
 import DataManagement from '@jbrowse/plugin-data-management'
 import CircularGenomeView from '@jbrowse/plugin-circular-view'
@@ -6,6 +7,7 @@ import Variants from '@jbrowse/plugin-variants'
 import Wiggle from '@jbrowse/plugin-wiggle'
 
 const corePlugins = [
+  Authentication,
   Config,
   DataManagement,
   CircularGenomeView,

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createConfigModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createConfigModel.ts
@@ -53,6 +53,9 @@ export default function createConfigModel(
       }),
       assembly: assemblyConfigSchemasType,
       tracks: types.array(pluginManager.pluggableConfigSchemaType('track')),
+      internetAccounts: types.array(
+        pluginManager.pluggableConfigSchemaType('internet account'),
+      ),
       connections: types.array(
         pluginManager.pluggableConfigSchemaType('connection'),
       ),

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createModel.ts
@@ -5,6 +5,7 @@ import { PluginConstructor } from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'
 import TextSearchManager from '@jbrowse/core/TextSearch/TextSearchManager'
+import { UriLocation } from '@jbrowse/core/util'
 import { cast, getSnapshot, Instance, SnapshotIn, types } from 'mobx-state-tree'
 import corePlugins from '../corePlugins'
 import createConfigModel from './createConfigModel'
@@ -26,6 +27,9 @@ export default function createModel(runtimePlugins: PluginConstructor[]) {
       config: createConfigModel(pluginManager, assemblyConfigSchema),
       session: Session,
       assemblyManager: assemblyManagerType,
+      internetAccounts: types.array(
+        pluginManager.pluggableMstType('internet account', 'stateModel'),
+      ),
     })
     .volatile(() => ({
       error: undefined as Error | undefined,
@@ -43,6 +47,34 @@ export default function createModel(runtimePlugins: PluginConstructor[]) {
       },
       setError(errorMessage: Error | undefined) {
         self.error = errorMessage
+      },
+      addInternetAccount(
+        internetAccount: SnapshotIn<typeof self.internetAccounts[0]>,
+      ) {
+        self.internetAccounts.push(internetAccount)
+      },
+      findAppropriateInternetAccount(location: UriLocation) {
+        // find the existing account selected from menu
+        const selectedId = location.internetAccountId
+        if (selectedId) {
+          const selectedAccount = self.internetAccounts.find(account => {
+            return account.internetAccountId === selectedId
+          })
+          if (selectedAccount) {
+            return selectedAccount
+          }
+        }
+
+        // if no existing account or not found, try to find working account
+        for (const account of self.internetAccounts) {
+          const handleResult = account.handlesLocation(location)
+          if (handleResult) {
+            return account
+          }
+        }
+
+        // no available internet accounts
+        return null
       },
     }))
     .views(self => ({

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -45,6 +45,7 @@
     "@emotion/styled": "^11.8.1",
     "@jbrowse/core": "^2.1.7",
     "@jbrowse/plugin-alignments": "^2.1.7",
+    "@jbrowse/plugin-authentication": "^2.1.7",
     "@jbrowse/plugin-bed": "^2.1.7",
     "@jbrowse/plugin-circular-view": "^2.1.7",
     "@jbrowse/plugin-config": "^2.1.7",

--- a/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
@@ -1,4 +1,5 @@
 import Alignments from '@jbrowse/plugin-alignments'
+import Authentication from '@jbrowse/plugin-authentication'
 import BED from '@jbrowse/plugin-bed'
 import Config from '@jbrowse/plugin-config'
 import DataManagement from '@jbrowse/plugin-data-management'
@@ -14,6 +15,7 @@ import Trix from '@jbrowse/plugin-trix'
 const corePlugins = [
   SVG,
   Alignments,
+  Authentication,
   BED,
   Config,
   DataManagement,

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createConfigModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createConfigModel.ts
@@ -59,6 +59,9 @@ export default function createConfigModel(
       }),
       assembly: assemblyConfigSchemasType,
       tracks: types.array(pluginManager.pluggableConfigSchemaType('track')),
+      internetAccounts: types.array(
+        pluginManager.pluggableConfigSchemaType('internet account'),
+      ),
       connections: types.array(
         pluginManager.pluggableConfigSchemaType('connection'),
       ),

--- a/products/jbrowse-react-linear-genome-view/src/createViewState.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createViewState.ts
@@ -10,6 +10,7 @@ type SessionSnapshot = SnapshotIn<ReturnType<typeof createSessionModel>>
 type ConfigSnapshot = SnapshotIn<ReturnType<typeof createConfigModel>>
 type Assembly = ConfigSnapshot['assembly']
 type Tracks = ConfigSnapshot['tracks']
+type InternetAccounts = ConfigSnapshot['internetAccounts']
 type AggregateTextSearchAdapters = ConfigSnapshot['aggregateTextSearchAdapters']
 
 interface Location {
@@ -22,6 +23,7 @@ interface Location {
 interface ViewStateOptions {
   assembly: Assembly
   tracks: Tracks
+  internetAccounts?: InternetAccounts
   aggregateTextSearchAdapters?: AggregateTextSearchAdapters
   configuration?: Record<string, unknown>
   plugins?: PluginConstructor[]
@@ -36,6 +38,7 @@ export default function createViewState(opts: ViewStateOptions) {
   const {
     assembly,
     tracks,
+    internetAccounts,
     configuration,
     aggregateTextSearchAdapters,
     plugins,
@@ -64,6 +67,7 @@ export default function createViewState(opts: ViewStateOptions) {
         configuration,
         assembly,
         tracks,
+        internetAccounts,
         aggregateTextSearchAdapters,
       },
       disableAddTracks,
@@ -71,6 +75,18 @@ export default function createViewState(opts: ViewStateOptions) {
     },
     { pluginManager },
   )
+  stateTree.config.internetAccounts.forEach(account => {
+    const internetAccountType = pluginManager.getInternetAccountType(
+      account.type,
+    )
+    if (!internetAccountType) {
+      throw new Error(`unknown internet account type ${account.type}`)
+    }
+    stateTree.addInternetAccount({
+      type: account.type,
+      configuration: account,
+    })
+  })
   pluginManager.setRootModel(stateTree)
   pluginManager.configure()
   if (location) {

--- a/products/jbrowse-web/src/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel.ts
@@ -3,11 +3,9 @@ import {
   cast,
   getSnapshot,
   getType,
-  resolveIdentifier,
   types,
   IAnyStateTreeNode,
   SnapshotIn,
-  IAnyModelType,
 } from 'mobx-state-tree'
 
 import { saveAs } from 'file-saver'
@@ -43,6 +41,7 @@ import corePlugins from './corePlugins'
 import jbrowseWebFactory from './jbrowseModel'
 import sessionModelFactory from './sessionModelFactory'
 import { filterSessionInPlace } from './util'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
 interface Menu {
   label: string
@@ -241,7 +240,7 @@ export default function RootModel(
           self,
           autorun(() => {
             self.jbrowse.internetAccounts.forEach(account => {
-              this.initializeInternetAccount(account.internetAccountId)
+              this.initializeInternetAccount(account)
             })
           }),
         )
@@ -261,28 +260,22 @@ export default function RootModel(
         }
       },
       initializeInternetAccount(
-        internetAccountId: string,
+        internetAccountConfig: AnyConfigurationModel,
         initialSnapshot = {},
       ) {
-        const internetAccountConfigSchema =
-          pluginManager.pluggableConfigSchemaType('internet account')
-        const configuration = resolveIdentifier(
-          internetAccountConfigSchema as IAnyModelType,
-          self,
-          internetAccountId,
-        )
-
         const internetAccountType = pluginManager.getInternetAccountType(
-          configuration.type,
+          internetAccountConfig.type,
         )
         if (!internetAccountType) {
-          throw new Error(`unknown internet account type ${configuration.type}`)
+          throw new Error(
+            `unknown internet account type ${internetAccountConfig.type}`,
+          )
         }
 
         const length = self.internetAccounts.push({
           ...initialSnapshot,
-          type: configuration.type,
-          configuration,
+          type: internetAccountConfig.type,
+          configuration: internetAccountConfig,
         })
         return self.internetAccounts[length - 1]
       },


### PR DESCRIPTION
This is a proposal that adds the ability to use internet accounts in the embedded React LGV and CGV. I've tested it with HTTP basic authentication.

The motivation for this is for use in `jbrowse-jupyter` (see [this comment](https://github.com/GMOD/jbrowse-jupyter/pull/66#issuecomment-1287333694)). There is a way to open local files (or at least files on the same machine as the jupyter/colab server) by taking advantage of the ability to invoke functions in the Python kernel from the notebook client. We can use that to read chunks of a file from disk instead of fetching them from a server. @teresam856 and I have been trying to think of a way to get this to work.

The proposed workflow would be to add tracks that have a UriLocation with a different protocol (`file://` might work, but maybe it would have to be custom). Then  for those tracks, `jbrowse-jupyter` would use a plugin to add an internet account with a custom `getFetcher` which would then invoke the Python kernel instead of fetching from a server.

An alternative to doing this with an internet account would be to use a custom filehandle and invoke the Python kernel there, but @rbuels and I couldn't figure out a way for a plugin to add and use a custom filehandle.