### PR TITLE
Add ability to open a synteny track directly from the dotplot/linear synteny view import forms

### DIFF
--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -3,6 +3,7 @@ import {
   AppBar,
   Button,
   Fab,
+  FormControl,
   MenuItem,
   Paper,
   Select,
@@ -173,22 +174,26 @@ const ViewLauncher = observer(({ session }: { session: AppSession }) => {
   return (
     <Paper className={classes.selectPaper}>
       <Typography>Select a view to launch</Typography>
-      <Select value={value} onChange={event => setValue(event.target.value)}>
-        {viewTypes.map(({ name }: { name: string }) => (
-          <MenuItem key={name} value={name}>
-            {name}
-          </MenuItem>
-        ))}
-      </Select>
-      <Button
-        onClick={() => {
-          session.addView(value, {})
-        }}
-        variant="contained"
-        color="primary"
-      >
-        Launch view
-      </Button>
+      <FormControl style={{ margin: 2 }}>
+        <Select value={value} onChange={event => setValue(event.target.value)}>
+          {viewTypes.map(({ name }: { name: string }) => (
+            <MenuItem key={name} value={name}>
+              {name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl style={{ margin: 2 }}>
+        <Button
+          onClick={() => {
+            session.addView(value, {})
+          }}
+          variant="contained"
+          color="primary"
+        >
+          Launch view
+        </Button>
+      </FormControl>
     </Paper>
   )
 })

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.tsx
@@ -256,7 +256,7 @@ const HierarchicalTrackSelector = observer(
     const [headerHeight, setHeaderHeight] = useState(0)
 
     const { assemblyNames } = model
-    const assemblyName = assemblyNames[assemblyIdx]
+    const assemblyName = assemblyNames.length ? assemblyNames[assemblyIdx] : ''
     return assemblyName ? (
       <>
         <Header

--- a/plugins/dotplot-view/src/DotplotView/components/Grid.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Grid.tsx
@@ -26,7 +26,7 @@ function Grid({
   const rx = Math.max(hbottom, 0)
   const ry = Math.max(viewHeight - vtop, 0)
   const w = Math.min(htop - hbottom, viewWidth)
-  const h = Math.min(vtop - vbottom, viewHeight)
+  const h = Math.min(viewHeight - vbottom - ry, viewHeight)
   return (
     <svg
       style={{ background: 'rgba(0,0,0,0.12)' }}

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -37,17 +37,9 @@ const useStyles = makeStyles()({
 
 const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
   const { classes } = useStyles()
-  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null)
-  const [cursorAnchorEl, setCursorAnchorEl] = useState<null | HTMLElement>(null)
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement>()
   return (
     <div>
-      <IconButton
-        onClick={event => setCursorAnchorEl(event.currentTarget)}
-        className={classes.iconButton}
-        color="secondary"
-      >
-        <CursorMouse />
-      </IconButton>
       <IconButton
         onClick={model.zoomOutButton}
         className={classes.iconButton}
@@ -89,7 +81,7 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
           open
           onMenuItemClick={(_event, callback) => {
             callback()
-            setMenuAnchorEl(null)
+            setMenuAnchorEl(undefined)
           }}
           menuItems={[
             {
@@ -106,20 +98,6 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
               label: 'Draw CIGAR',
               checked: model.drawCigar,
             },
-          ]}
-          onClose={() => setMenuAnchorEl(null)}
-        />
-      ) : null}
-
-      {cursorAnchorEl ? (
-        <Menu
-          anchorEl={cursorAnchorEl}
-          open
-          onMenuItemClick={(_event, callback) => {
-            callback()
-            setCursorAnchorEl(null)
-          }}
-          menuItems={[
             {
               onClick: () => model.setCursorMode('move'),
               label: 'Cursor mode - click and drag to move',
@@ -130,11 +108,12 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
             {
               onClick: () => model.setCursorMode('crosshair'),
               label: 'Cursor mode - select region',
+              icon: CursorMouse,
               type: 'radio',
               checked: model.cursorMode === 'crosshair',
             },
           ]}
-          onClose={() => setCursorAnchorEl(null)}
+          onClose={() => setMenuAnchorEl(undefined)}
         />
       ) : null}
     </div>

--- a/plugins/dotplot-view/src/DotplotView/components/ImportCustomTrack.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportCustomTrack.tsx
@@ -1,0 +1,264 @@
+import React, { useState, useEffect } from 'react'
+import { SnapshotIn } from 'mobx-state-tree'
+import path from 'path'
+import {
+  FormControlLabel,
+  Grid,
+  Paper,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material'
+import { ErrorMessage, FileSelector } from '@jbrowse/core/ui'
+import { FileLocation } from '@jbrowse/core/util/types'
+import { observer } from 'mobx-react'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
+
+function getName(
+  sessionTrackData?: { uri: string } | { localPath: string } | { name: string },
+) {
+  return sessionTrackData
+    ? // @ts-ignore
+      sessionTrackData.uri ||
+        // @ts-ignore
+        sessionTrackData.localPath ||
+        // @ts-ignore
+        sessionTrackData.name
+    : undefined
+}
+
+function stripGz(fileName: string) {
+  return fileName.endsWith('.gz')
+    ? fileName.slice(0, fileName.length - 3)
+    : fileName
+}
+
+function getAdapter({
+  radioOption,
+  assembly1,
+  assembly2,
+  fileLocation,
+  bed1Location,
+  bed2Location,
+}: {
+  radioOption: string
+  assembly1: string
+  assembly2: string
+  fileLocation?: FileLocation
+  bed1Location?: FileLocation
+  bed2Location?: FileLocation
+}) {
+  if (radioOption === '.paf') {
+    return {
+      type: 'PAFAdapter',
+      pafLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.out') {
+    return {
+      type: 'MashMapAdapter',
+      outLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.delta') {
+    return {
+      type: 'DeltaAdapter',
+      deltaLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.chain') {
+    return {
+      type: 'ChainAdapter',
+      chainLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.anchors') {
+    return {
+      type: 'MCScanAnchorsAdapter',
+      mcscanAnchorsLocation: fileLocation,
+      bed1Location,
+      bed2Location,
+      assemblyNames: [assembly1, assembly2],
+    }
+  } else if (radioOption === '.anchors.simple') {
+    return {
+      type: 'MCScanSimpleAnchorsAdapter',
+      mcscanSimpleAnchorsLocation: fileLocation,
+      bed1Location,
+      bed2Location,
+      assemblyNames: [assembly1, assembly2],
+    }
+  } else {
+    throw new Error('Unknown type')
+  }
+}
+
+type Conf = SnapshotIn<AnyConfigurationModel>
+
+const OpenTrack = observer(
+  ({
+    sessionTrackData,
+    assembly1,
+    assembly2,
+    setSessionTrackData,
+  }: {
+    sessionTrackData: Conf
+    assembly1: string
+    assembly2: string
+    setSessionTrackData: (arg: Conf) => void
+  }) => {
+    const [bed2Location, setBed2Location] = useState<FileLocation>()
+    const [bed1Location, setBed1Location] = useState<FileLocation>()
+    const [fileLocation, setFileLocation] = useState<FileLocation>()
+    const [value, setValue] = useState('')
+    const [error, setError] = useState<unknown>()
+    const fileName = getName(fileLocation)
+
+    const radioOption =
+      value || (fileName ? path.extname(stripGz(fileName)) : '')
+
+    useEffect(() => {
+      try {
+        if (fileLocation) {
+          const fn = fileName ? path.basename(fileName) : 'MyTrack'
+          const trackId = `${fn}-${Date.now()}`
+          setError(undefined)
+
+          setSessionTrackData({
+            trackId,
+            name: fn,
+            assemblyNames: [assembly2, assembly1],
+            type: 'SyntenyTrack',
+            adapter: getAdapter({
+              radioOption,
+              assembly1,
+              assembly2,
+              fileLocation,
+              bed1Location,
+              bed2Location,
+            }),
+          })
+        }
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
+    }, [
+      fileName,
+      assembly1,
+      assembly2,
+      bed1Location,
+      bed2Location,
+      fileLocation,
+      radioOption,
+      setSessionTrackData,
+    ])
+    return (
+      <Paper style={{ padding: 12 }}>
+        {error ? <ErrorMessage error={error} /> : null}
+        <Typography style={{ textAlign: 'center' }}>
+          Add a .paf, .out (MashMap), .delta (Mummer), .chain, .anchors or
+          .anchors.simple (MCScan) file to view in the dotplot. These file types
+          can also be gzipped. The first assembly should be the query sequence
+          (e.g. left column of the PAF) and the second assembly should be the
+          target sequence (e.g. right column of the PAF)
+        </Typography>
+        <RadioGroup
+          value={radioOption}
+          onChange={event => setValue(event.target.value)}
+        >
+          <Grid container justifyContent="center">
+            <Grid item>
+              <FormControlLabel value=".paf" control={<Radio />} label=".paf" />
+            </Grid>
+            <Grid item>
+              <FormControlLabel value=".out" control={<Radio />} label=".out" />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".delta"
+                control={<Radio />}
+                label=".delta"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".chain"
+                control={<Radio />}
+                label=".chain"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".anchors"
+                control={<Radio />}
+                label=".anchors"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".anchors.simple"
+                control={<Radio />}
+                label=".anchors.simple"
+              />
+            </Grid>
+          </Grid>
+        </RadioGroup>
+        <Grid container justifyContent="center">
+          <Grid item>
+            {value === '.anchors' || value === '.anchors.simple' ? (
+              <div>
+                <div style={{ margin: 20 }}>
+                  Open the {value} and .bed files for both genome assemblies
+                  from the MCScan (Python verson) pipeline{' '}
+                  <a href="https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)">
+                    (more info)
+                  </a>
+                </div>
+                <div style={{ display: 'flex' }}>
+                  <div>
+                    <FileSelector
+                      name=".anchors file"
+                      description=""
+                      location={fileLocation}
+                      setLocation={loc => setFileLocation(loc)}
+                    />
+                  </div>
+                  <div>
+                    <FileSelector
+                      name="genome 1 .bed (left column of anchors file)"
+                      description=""
+                      location={bed1Location}
+                      setLocation={loc => setBed1Location(loc)}
+                    />
+                  </div>
+                  <div>
+                    <FileSelector
+                      name="genome 2 .bed (right column of anchors file)"
+                      description=""
+                      location={bed2Location}
+                      setLocation={loc => setBed2Location(loc)}
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <FileSelector
+                name={value ? value + ' location' : ''}
+                description=""
+                location={fileLocation}
+                setLocation={loc => setFileLocation(loc)}
+              />
+            )}
+          </Grid>
+        </Grid>
+      </Paper>
+    )
+  },
+)
+
+export default OpenTrack

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react'
-import path from 'path'
 import {
   Button,
   Container,
+  FormControl,
+  FormLabel,
   FormControlLabel,
   Grid,
   Paper,
@@ -11,12 +12,15 @@ import {
   Typography,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import { FileSelector, ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
-import { FileLocation } from '@jbrowse/core/util/types'
 import { observer } from 'mobx-react'
 import { transaction } from 'mobx'
 import { getSession, isSessionWithAddTracks } from '@jbrowse/core/util'
+import { ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
+
+// locals
 import { DotplotViewModel } from '../model'
+import ImportCustomTrack from './ImportCustomTrack'
+import ImportSyntenyTrackSelector from './ImportSyntenyTrackSelector'
 
 const useStyles = makeStyles()(theme => ({
   importFormContainer: {
@@ -29,117 +33,42 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-function getName(
-  trackData?: { uri: string } | { localPath: string } | { name: string },
-) {
-  return trackData
-    ? // @ts-ignore
-      trackData.uri || trackData.localPath || trackData.name
-    : undefined
-}
-
-function stripGz(fileName: string) {
-  return fileName.endsWith('.gz')
-    ? fileName.slice(0, fileName.length - 3)
-    : fileName
-}
-
 const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
   const { classes } = useStyles()
   const session = getSession(model)
-  const { assemblyNames, assemblyManager } = session
-  const [trackData, setTrackData] = useState<FileLocation>()
-  const [bed2Location, setBed2Location] = useState<FileLocation>()
-  const [bed1Location, setBed1Location] = useState<FileLocation>()
-  const [targetAssembly, setTargetAssembly] = useState(assemblyNames[0])
-  const [queryAssembly, setQueryAssembly] = useState(assemblyNames[0])
-  const selected = [queryAssembly, targetAssembly]
+  const { assemblyNames } = session
+  const [assembly2, setAssembly2] = useState(
+    assemblyNames.length ? assemblyNames[0] : '',
+  )
+  const [assembly1, setAssembly1] = useState(
+    assemblyNames.length ? assemblyNames[0] : '',
+  )
   const [error, setError] = useState<unknown>()
-  const [value, setValue] = useState('')
-  const fileName = getName(trackData)
-  const radioOption = value || (fileName ? path.extname(stripGz(fileName)) : '')
-
-  const assemblyError = assemblyNames.length
-    ? selected
-        .map(a => assemblyManager.get(a)?.error)
-        .filter(f => !!f)
-        .join(', ')
-    : 'No configured assemblies'
-
-  function getAdapter() {
-    if (radioOption === '.paf') {
-      return {
-        type: 'PAFAdapter',
-        pafLocation: trackData,
-        queryAssembly,
-        targetAssembly,
-      }
-    } else if (radioOption === '.out') {
-      return {
-        type: 'MashMapAdapter',
-        outLocation: trackData,
-        queryAssembly,
-        targetAssembly,
-      }
-    } else if (radioOption === '.delta') {
-      return {
-        type: 'DeltaAdapter',
-        deltaLocation: trackData,
-        queryAssembly,
-        targetAssembly,
-      }
-    } else if (radioOption === '.chain') {
-      return {
-        type: 'ChainAdapter',
-        chainLocation: trackData,
-        queryAssembly,
-        targetAssembly,
-      }
-    } else if (radioOption === '.anchors') {
-      return {
-        type: 'MCScanAnchorsAdapter',
-        mcscanAnchorsLocation: trackData,
-        bed1Location,
-        bed2Location,
-        assemblyNames: [queryAssembly, targetAssembly],
-      }
-    } else if (radioOption === '.anchors.simple') {
-      return {
-        type: 'MCScanSimpleAnchorsAdapter',
-        mcscanSimpleAnchorsLocation: trackData,
-        bed1Location,
-        bed2Location,
-        assemblyNames: [queryAssembly, targetAssembly],
-      }
-    } else {
-      throw new Error('Unknown type')
-    }
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [sessionTrackData, setSessionTrackData] = useState<any>()
+  const [showTrackId, setShowTrackId] = useState<string>()
+  const [choice, setChoice] = useState('tracklist')
 
   function onOpenClick() {
     try {
       if (!isSessionWithAddTracks(session)) {
         return
       }
+      setError(undefined)
+      model.setError(undefined)
       transaction(() => {
-        if (trackData) {
-          const fileName = path.basename(getName(trackData)) || 'MyTrack'
-          const trackId = `${fileName}-${Date.now()}`
-
-          session.addTrackConf({
-            trackId: trackId,
-            name: fileName,
-            assemblyNames: [targetAssembly, queryAssembly],
-            type: 'SyntenyTrack',
-            adapter: getAdapter(),
-          })
-          model.toggleTrack(trackId)
+        if (sessionTrackData) {
+          session.addTrackConf(sessionTrackData)
+          model.toggleTrack(sessionTrackData.trackId)
+        } else if (showTrackId) {
+          model.showTrack(showTrackId)
         }
+
         model.setViews([
           { bpPerPx: 0.1, offsetPx: 0 },
           { bpPerPx: 0.1, offsetPx: 0 },
         ])
-        model.setAssemblyNames(targetAssembly, queryAssembly)
+        model.setAssemblyNames(assembly2, assembly1)
       })
     } catch (e) {
       console.error(e)
@@ -148,7 +77,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
   }
 
   // this is a combination of any displayed error message we have
-  const displayError = error || assemblyError
+  const displayError = error || model.error
   return (
     <Container className={classes.importFormContainer}>
       {displayError ? <ErrorMessage error={displayError} /> : null}
@@ -171,154 +100,74 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
               alignItems="center"
             >
               <Grid item>
-                <Typography>
-                  {value === '.anchors' || value === '.anchors.simple'
-                    ? 'Left column of anchors file'
-                    : 'Query'}
-                </Typography>
+                <Typography>X-axis</Typography>
                 <AssemblySelector
                   extra={0}
-                  selected={queryAssembly}
-                  onChange={val => setQueryAssembly(val)}
+                  selected={assembly1}
+                  onChange={val => setAssembly1(val)}
                   session={session}
                 />
               </Grid>
               <Grid item>
-                <Typography>
-                  {value === '.anchors' || value === '.anchors.simple'
-                    ? 'Right column of anchors file'
-                    : 'Target'}
-                </Typography>
+                <Typography>Y-axis</Typography>
                 <AssemblySelector
                   extra={1}
-                  selected={targetAssembly}
-                  onChange={val => setTargetAssembly(val)}
+                  selected={assembly2}
+                  onChange={val => setAssembly2(val)}
                   session={session}
                 />
               </Grid>
-            </Grid>
-          </Paper>
-
-          <Paper style={{ padding: 12 }}>
-            <Typography style={{ textAlign: 'center' }}>
-              <b>Optional</b>: Add a .paf, .out (MashMap), .delta (Mummer),
-              .chain, .anchors or .anchors.simple (MCScan) file to view in the
-              dotplot. These file types can also be gzipped. The first assembly
-              should be the query sequence (e.g. left column of the PAF) and the
-              second assembly should be the target sequence (e.g. right column
-              of the PAF)
-            </Typography>
-            <RadioGroup
-              value={radioOption}
-              onChange={event => setValue(event.target.value)}
-            >
-              <Grid container justifyContent="center">
-                <Grid item>
-                  <FormControlLabel
-                    value=".paf"
-                    control={<Radio />}
-                    label=".paf"
-                  />
-                </Grid>
-                <Grid item>
-                  <FormControlLabel
-                    value=".out"
-                    control={<Radio />}
-                    label=".out"
-                  />
-                </Grid>
-                <Grid item>
-                  <FormControlLabel
-                    value=".delta"
-                    control={<Radio />}
-                    label=".delta"
-                  />
-                </Grid>
-                <Grid item>
-                  <FormControlLabel
-                    value=".chain"
-                    control={<Radio />}
-                    label=".chain"
-                  />
-                </Grid>
-                <Grid item>
-                  <FormControlLabel
-                    value=".anchors"
-                    control={<Radio />}
-                    label=".anchors"
-                  />
-                </Grid>
-                <Grid item>
-                  <FormControlLabel
-                    value=".anchors.simple"
-                    control={<Radio />}
-                    label=".anchors.simple"
-                  />
-                </Grid>
-              </Grid>
-            </RadioGroup>
-            <Grid container justifyContent="center">
               <Grid item>
-                {value === '.anchors' || value === '.anchors.simple' ? (
-                  <div>
-                    <div style={{ margin: 20 }}>
-                      Open the {value} and .bed files for both genome assemblies
-                      from the MCScan (Python verson) pipeline{' '}
-                      <a href="https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)">
-                        (more info)
-                      </a>
-                    </div>
-                    <div style={{ display: 'flex' }}>
-                      <div>
-                        <FileSelector
-                          name=".anchors file"
-                          description=""
-                          location={trackData}
-                          setLocation={loc => setTrackData(loc)}
-                        />
-                      </div>
-                      <div>
-                        <FileSelector
-                          name="genome 1 .bed (left column of anchors file)"
-                          description=""
-                          location={bed1Location}
-                          setLocation={loc => setBed1Location(loc)}
-                        />
-                      </div>
-                      <div>
-                        <FileSelector
-                          name="genome 2 .bed (right column of anchors file)"
-                          description=""
-                          location={bed2Location}
-                          setLocation={loc => setBed2Location(loc)}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <FileSelector
-                    name={value ? value + ' location' : ''}
-                    description=""
-                    location={trackData}
-                    setLocation={loc => setTrackData(loc)}
-                  />
-                )}
+                <FormControl>
+                  <Button
+                    onClick={onOpenClick}
+                    variant="contained"
+                    color="primary"
+                  >
+                    Launch
+                  </Button>
+                </FormControl>
               </Grid>
             </Grid>
           </Paper>
-        </Grid>
-        <Grid item>
-          <Button
-            data-testid="submitDotplot"
-            onClick={onOpenClick}
-            // only disable button on assemblyError. for other types of errors
-            // in the useState can retry
-            disabled={!!assemblyError}
-            variant="contained"
-            color="primary"
-          >
-            Open
-          </Button>
+          <FormControl>
+            <FormLabel id="group-label">
+              (Optional) Select or add a syteny track
+            </FormLabel>
+            <RadioGroup
+              row
+              value={choice}
+              onChange={event => setChoice(event.target.value)}
+              aria-labelledby="group-label"
+            >
+              <FormControlLabel
+                value="tracklist"
+                control={<Radio />}
+                label="Select from tracklist"
+              />
+              <FormControlLabel
+                value="custom"
+                control={<Radio />}
+                label="Open custom file"
+              />
+            </RadioGroup>
+          </FormControl>
+          {choice === 'custom' ? (
+            <ImportCustomTrack
+              setSessionTrackData={setSessionTrackData}
+              sessionTrackData={sessionTrackData}
+              assembly2={assembly2}
+              assembly1={assembly1}
+            />
+          ) : null}
+          {choice === 'tracklist' ? (
+            <ImportSyntenyTrackSelector
+              model={model}
+              assembly1={assembly1}
+              assembly2={assembly2}
+              setShowTrackId={setShowTrackId}
+            />
+          ) : null}
         </Grid>
       </Grid>
     </Container>

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -141,12 +141,12 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
               <FormControlLabel
                 value="tracklist"
                 control={<Radio />}
-                label="Select from tracklist"
+                label="Existing track"
               />
               <FormControlLabel
                 value="custom"
                 control={<Radio />}
-                label="Open custom file"
+                label="New track"
               />
             </RadioGroup>
           </FormControl>

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm.tsx
@@ -9,7 +9,6 @@ import {
   Paper,
   Radio,
   RadioGroup,
-  Typography,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
@@ -47,7 +46,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [sessionTrackData, setSessionTrackData] = useState<any>()
   const [showTrackId, setShowTrackId] = useState<string>()
-  const [choice, setChoice] = useState('tracklist')
+  const [choice, setChoice] = useState('none')
 
   function onOpenClick() {
     try {
@@ -100,7 +99,6 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
               alignItems="center"
             >
               <Grid item>
-                <Typography>X-axis</Typography>
                 <AssemblySelector
                   extra={0}
                   selected={assembly1}
@@ -109,7 +107,6 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
                 />
               </Grid>
               <Grid item>
-                <Typography>Y-axis</Typography>
                 <AssemblySelector
                   extra={1}
                   selected={assembly2}
@@ -132,7 +129,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
           </Paper>
           <FormControl>
             <FormLabel id="group-label">
-              (Optional) Select or add a syteny track
+              (Optional) Select or add a synteny track
             </FormLabel>
             <RadioGroup
               row
@@ -140,6 +137,7 @@ const DotplotImportForm = observer(({ model }: { model: DotplotViewModel }) => {
               onChange={event => setChoice(event.target.value)}
               aria-labelledby="group-label"
             >
+              <FormControlLabel value="none" control={<Radio />} label="None" />
               <FormControlLabel
                 value="tracklist"
                 control={<Radio />}

--- a/plugins/dotplot-view/src/DotplotView/components/ImportSyntenyTrackSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportSyntenyTrackSelector.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react'
+import { Select, MenuItem, Paper, Typography } from '@mui/material'
+import { getSession } from '@jbrowse/core/util'
+
+import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+import { ErrorMessage } from '@jbrowse/core/ui'
+import {
+  AnyConfigurationModel,
+  readConfObject,
+} from '@jbrowse/core/configuration'
+
+import { observer } from 'mobx-react'
+import { DotplotViewModel } from '../model'
+import { getTrackName } from '@jbrowse/core/util/tracks'
+
+function f(track: AnyConfigurationModel, assembly1: string, assembly2: string) {
+  const assemblyNames = readConfObject(track, 'assemblyNames')
+  return (
+    assemblyNames.includes(assembly1) &&
+    assemblyNames.includes(assembly2) &&
+    track.type.includes('Synteny')
+  )
+}
+
+const Selector = observer(
+  ({
+    model,
+    assembly1,
+    assembly2,
+    setShowTrackId,
+  }: {
+    model: DotplotViewModel
+    assembly1: string
+    assembly2: string
+    setShowTrackId: (arg: string) => void
+  }) => {
+    const session = getSession(model)
+    const { tracks, sessionTracks } = session
+    const allTracks = [...tracks, ...sessionTracks] as AnyConfigurationModel[]
+    const filteredTracks = allTracks.filter(t => f(t, assembly2, assembly1))
+    const resetTrack = filteredTracks[0]?.trackId || ''
+    const [value, setValue] = useState(resetTrack)
+    useEffect(() => {
+      // if assembly1/assembly2 changes, then we will want to use this effect to change
+      // the state of the useState because it otherwise gets locked to a stale value
+      setValue(resetTrack)
+    }, [resetTrack])
+
+    useEffect(() => {
+      // sets track data in a useEffect because the initial load is needed as well as
+      // onChange's to the select box
+      setShowTrackId(value)
+    }, [value, setShowTrackId])
+    return (
+      <Paper style={{ padding: 12 }}>
+        <Typography paragraph>
+          Select a track from the select box below, the track will be shown when
+          you hit "Open".
+        </Typography>
+
+        <Typography paragraph>
+          Note: there is a track selector <i>inside</i> the DotplotView, which
+          can turn on one or more SyntenyTracks (more than one can be displayed
+          at once). Look for the track selector icon <TrackSelectorIcon />
+        </Typography>
+        {filteredTracks.length ? (
+          <Select
+            value={value}
+            onChange={event => setValue(event.target.value)}
+          >
+            {filteredTracks.map(track => (
+              <MenuItem key={track.trackId} value={track.trackId}>
+                {getTrackName(track, session)}
+              </MenuItem>
+            ))}
+          </Select>
+        ) : (
+          <ErrorMessage
+            error={`No synteny tracks found for ${assembly1},${assembly2}`}
+          />
+        )}
+      </Paper>
+    )
+  },
+)
+
+export default Selector

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
@@ -10,6 +10,7 @@ import LinkOffIcon from '@mui/icons-material/LinkOff'
 import CropFreeIcon from '@mui/icons-material/CropFree'
 
 import { LinearComparativeViewModel } from '../model'
+import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 
 type LCV = LinearComparativeViewModel
 
@@ -33,6 +34,17 @@ const useStyles = makeStyles()(() => ({
     display: 'flex',
   },
 }))
+
+const TrackSelector = observer(({ model }: { model: LCV }) => {
+  return (
+    <IconButton
+      onClick={model.activateTrackSelector}
+      title="Open track selector"
+    >
+      <TrackSelectorIcon color="secondary" />
+    </IconButton>
+  )
+})
 
 const LinkViews = observer(({ model }: { model: LCV }) => {
   return (
@@ -66,6 +78,7 @@ const Header = observer(
     const anyShowHeaders = model.views.some(view => !view.hideHeader)
     return (
       <div className={classes.headerBar}>
+        <TrackSelector model={model} />
         <LinkViews model={model} />
         <SquareView model={model} />
         {ExtraButtons}

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -318,6 +318,7 @@ function stateModelFactory(pluginManager: PluginManager) {
        */
       clearView() {
         self.views = cast([])
+        self.tracks = cast([])
       },
     }))
     .views(self => ({

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportCustomTrack.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportCustomTrack.tsx
@@ -1,0 +1,264 @@
+import React, { useState, useEffect } from 'react'
+import { SnapshotIn } from 'mobx-state-tree'
+import path from 'path'
+import {
+  FormControlLabel,
+  Grid,
+  Paper,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material'
+import { ErrorMessage, FileSelector } from '@jbrowse/core/ui'
+import { FileLocation } from '@jbrowse/core/util/types'
+import { observer } from 'mobx-react'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
+
+function getName(
+  sessionTrackData?: { uri: string } | { localPath: string } | { name: string },
+) {
+  return sessionTrackData
+    ? // @ts-ignore
+      sessionTrackData.uri ||
+        // @ts-ignore
+        sessionTrackData.localPath ||
+        // @ts-ignore
+        sessionTrackData.name
+    : undefined
+}
+
+function stripGz(fileName: string) {
+  return fileName.endsWith('.gz')
+    ? fileName.slice(0, fileName.length - 3)
+    : fileName
+}
+
+function getAdapter({
+  radioOption,
+  assembly1,
+  assembly2,
+  fileLocation,
+  bed1Location,
+  bed2Location,
+}: {
+  radioOption: string
+  assembly1: string
+  assembly2: string
+  fileLocation?: FileLocation
+  bed1Location?: FileLocation
+  bed2Location?: FileLocation
+}) {
+  if (radioOption === '.paf') {
+    return {
+      type: 'PAFAdapter',
+      pafLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.out') {
+    return {
+      type: 'MashMapAdapter',
+      outLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.delta') {
+    return {
+      type: 'DeltaAdapter',
+      deltaLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.chain') {
+    return {
+      type: 'ChainAdapter',
+      chainLocation: fileLocation,
+      queryAssembly: assembly1,
+      targetAssembly: assembly2,
+    }
+  } else if (radioOption === '.anchors') {
+    return {
+      type: 'MCScanAnchorsAdapter',
+      mcscanAnchorsLocation: fileLocation,
+      bed1Location,
+      bed2Location,
+      assemblyNames: [assembly1, assembly2],
+    }
+  } else if (radioOption === '.anchors.simple') {
+    return {
+      type: 'MCScanSimpleAnchorsAdapter',
+      mcscanSimpleAnchorsLocation: fileLocation,
+      bed1Location,
+      bed2Location,
+      assemblyNames: [assembly1, assembly2],
+    }
+  } else {
+    throw new Error('Unknown type')
+  }
+}
+
+type Conf = SnapshotIn<AnyConfigurationModel>
+
+const OpenTrack = observer(
+  ({
+    sessionTrackData,
+    assembly1,
+    assembly2,
+    setSessionTrackData,
+  }: {
+    sessionTrackData: Conf
+    assembly1: string
+    assembly2: string
+    setSessionTrackData: (arg: Conf) => void
+  }) => {
+    const [bed2Location, setBed2Location] = useState<FileLocation>()
+    const [bed1Location, setBed1Location] = useState<FileLocation>()
+    const [fileLocation, setFileLocation] = useState<FileLocation>()
+    const [value, setValue] = useState('')
+    const [error, setError] = useState<unknown>()
+    const fileName = getName(fileLocation)
+
+    const radioOption =
+      value || (fileName ? path.extname(stripGz(fileName)) : '')
+
+    useEffect(() => {
+      try {
+        if (fileLocation) {
+          const fn = fileName ? path.basename(fileName) : 'MyTrack'
+          const trackId = `${fn}-${Date.now()}`
+          setError(undefined)
+
+          setSessionTrackData({
+            trackId,
+            name: fn,
+            assemblyNames: [assembly2, assembly1],
+            type: 'SyntenyTrack',
+            adapter: getAdapter({
+              radioOption,
+              assembly1,
+              assembly2,
+              fileLocation,
+              bed1Location,
+              bed2Location,
+            }),
+          })
+        }
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
+    }, [
+      fileName,
+      assembly1,
+      assembly2,
+      bed1Location,
+      bed2Location,
+      fileLocation,
+      radioOption,
+      setSessionTrackData,
+    ])
+    return (
+      <Paper style={{ padding: 12 }}>
+        {error ? <ErrorMessage error={error} /> : null}
+        <Typography style={{ textAlign: 'center' }}>
+          Add a .paf, .out (MashMap), .delta (Mummer), .chain, .anchors or
+          .anchors.simple (MCScan) file to view in the dotplot. These file types
+          can also be gzipped. The first assembly should be the query sequence
+          (e.g. left column of the PAF) and the second assembly should be the
+          target sequence (e.g. right column of the PAF)
+        </Typography>
+        <RadioGroup
+          value={radioOption}
+          onChange={event => setValue(event.target.value)}
+        >
+          <Grid container justifyContent="center">
+            <Grid item>
+              <FormControlLabel value=".paf" control={<Radio />} label=".paf" />
+            </Grid>
+            <Grid item>
+              <FormControlLabel value=".out" control={<Radio />} label=".out" />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".delta"
+                control={<Radio />}
+                label=".delta"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".chain"
+                control={<Radio />}
+                label=".chain"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".anchors"
+                control={<Radio />}
+                label=".anchors"
+              />
+            </Grid>
+            <Grid item>
+              <FormControlLabel
+                value=".anchors.simple"
+                control={<Radio />}
+                label=".anchors.simple"
+              />
+            </Grid>
+          </Grid>
+        </RadioGroup>
+        <Grid container justifyContent="center">
+          <Grid item>
+            {value === '.anchors' || value === '.anchors.simple' ? (
+              <div>
+                <div style={{ margin: 20 }}>
+                  Open the {value} and .bed files for both genome assemblies
+                  from the MCScan (Python verson) pipeline{' '}
+                  <a href="https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)">
+                    (more info)
+                  </a>
+                </div>
+                <div style={{ display: 'flex' }}>
+                  <div>
+                    <FileSelector
+                      name=".anchors file"
+                      description=""
+                      location={fileLocation}
+                      setLocation={loc => setFileLocation(loc)}
+                    />
+                  </div>
+                  <div>
+                    <FileSelector
+                      name="genome 1 .bed (left column of anchors file)"
+                      description=""
+                      location={bed1Location}
+                      setLocation={loc => setBed1Location(loc)}
+                    />
+                  </div>
+                  <div>
+                    <FileSelector
+                      name="genome 2 .bed (right column of anchors file)"
+                      description=""
+                      location={bed2Location}
+                      setLocation={loc => setBed2Location(loc)}
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <FileSelector
+                name={value ? value + ' location' : ''}
+                description=""
+                location={fileLocation}
+                setLocation={loc => setFileLocation(loc)}
+              />
+            )}
+          </Grid>
+        </Grid>
+      </Paper>
+    )
+  },
+)
+
+export default OpenTrack

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm.tsx
@@ -1,313 +1,199 @@
-import React, { useState } from 'react'
-import path from 'path'
-import { transaction } from 'mobx'
-import { observer } from 'mobx-react'
-import { getSession, isSessionWithAddTracks } from '@jbrowse/core/util'
+import React, { useState, useEffect } from 'react'
 import {
   Button,
   Container,
+  FormControl,
+  FormLabel,
   FormControlLabel,
-  Radio,
-  RadioGroup,
   Grid,
   Paper,
-  Typography,
+  Radio,
+  RadioGroup,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import { FileLocation } from '@jbrowse/core/util/types'
-import { FileSelector, ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
+import { observer } from 'mobx-react'
+import { getSession, isSessionWithAddTracks } from '@jbrowse/core/util'
+import { ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
+
+// locals
 import { LinearSyntenyViewModel } from '../model'
+import ImportCustomTrack from './ImportCustomTrack'
+import ImportSyntenyTrackSelector from './ImportSyntenyTrackSelector'
 
 const useStyles = makeStyles()(theme => ({
   importFormContainer: {
     padding: theme.spacing(4),
-  },
-
-  formPaper: {
     margin: '0 auto',
-    padding: 12,
-    marginBottom: 10,
+  },
+  assemblySelector: {
+    width: '75%',
+    margin: '0 auto',
   },
 }))
 
-function getName(
-  trackData?: { uri: string } | { localPath: string } | { name: string },
-) {
-  return trackData
-    ? // @ts-ignore
-      trackData.uri || trackData.localPath || trackData.name
-    : undefined
-}
+const LinearSyntenyImportForm = observer(
+  ({ model }: { model: LinearSyntenyViewModel }) => {
+    const { classes } = useStyles()
+    const session = getSession(model)
+    const { assemblyNames } = session
+    const [assembly2, setAssembly2] = useState(
+      assemblyNames.length ? assemblyNames[0] : '',
+    )
+    const [assembly1, setAssembly1] = useState(
+      assemblyNames.length ? assemblyNames[0] : '',
+    )
+    const [error, setError] = useState<unknown>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [sessionTrackData, setSessionTrackData] = useState<any>()
+    const [showTrackId, setShowTrackId] = useState<string>()
+    const [choice, setChoice] = useState('none')
 
-function stripGz(fileName: string) {
-  return fileName.endsWith('.gz')
-    ? fileName.slice(0, fileName.length - 3)
-    : fileName
-}
-
-const ImportForm = observer(({ model }: { model: LinearSyntenyViewModel }) => {
-  const { classes } = useStyles()
-  const session = getSession(model)
-
-  const { assemblyNames, assemblyManager } = session
-  const [selected, setSelected] = useState([assemblyNames[0], assemblyNames[0]])
-  const [trackData, setTrackData] = useState<FileLocation>()
-  const [bed2Location, setBed2Location] = useState<FileLocation>()
-  const [bed1Location, setBed1Location] = useState<FileLocation>()
-  const [numRows] = useState(2)
-  const [error, setError] = useState<unknown>()
-
-  const [value, setValue] = useState('')
-  const fileName = getName(trackData)
-  const radioOption = value || (fileName ? path.extname(stripGz(fileName)) : '')
-
-  const assemblyError = assemblyNames.length
-    ? selected
-        .map(a => assemblyManager.get(a)?.error)
-        .filter(f => !!f)
-        .join(', ')
-    : 'No configured assemblies'
-
-  function getAdapter() {
-    if (radioOption === '.paf') {
-      return {
-        type: 'PAFAdapter',
-        pafLocation: trackData,
-        assemblyNames: selected,
+    useEffect(() => {
+      if (choice === 'none') {
+        setSessionTrackData(undefined)
+        setShowTrackId(undefined)
       }
-    } else if (radioOption === '.out') {
-      return {
-        type: 'MashMapAdapter',
-        outLocation: trackData,
-        assemblyNames: selected,
-      }
-    } else if (radioOption === '.delta') {
-      return {
-        type: 'DeltaAdapter',
-        deltaLocation: trackData,
-        assemblyNames: selected,
-      }
-    } else if (radioOption === '.chain') {
-      return {
-        type: 'ChainAdapter',
-        chainLocation: trackData,
-        assemblyNames: selected,
-      }
-    } else if (radioOption === '.anchors') {
-      return {
-        type: 'MCScanAnchorsAdapter',
-        mcscanAnchorsLocation: trackData,
-        bed1Location,
-        bed2Location,
-        assemblyNames: selected,
-      }
-    } else if (radioOption === '.anchors.simple') {
-      return {
-        type: 'MCScanSimpleAnchorsAdapter',
-        mcscanSimpleAnchorsLocation: trackData,
-        bed1Location,
-        bed2Location,
-        assemblyNames: selected,
-      }
-    } else {
-      throw new Error('Unknown type')
-    }
-  }
+    }, [choice])
 
-  async function onOpenClick() {
-    try {
-      if (!isSessionWithAddTracks(session)) {
-        return
-      }
-      model.setViews(
-        await Promise.all(
-          selected.map(async selection => {
-            const assembly = await assemblyManager.waitForAssembly(selection)
-            if (!assembly) {
-              throw new Error(`Assembly ${selection} failed to load`)
-            }
-            return {
-              type: 'LinearGenomeView' as const,
-              bpPerPx: 1,
-              offsetPx: 0,
-              hideHeader: true,
-              displayedRegions: assembly.regions,
-            }
-          }),
-        ),
-      )
-
-      model.views.forEach(view => view.setWidth(model.width))
-
-      transaction(() => {
-        if (trackData) {
-          const fileName = path.basename(getName(trackData)) || 'MyTrack'
-          const trackId = `${fileName}-${Date.now()}`
-
-          session.addTrackConf({
-            trackId: trackId,
-            name: fileName,
-            assemblyNames: selected,
-            type: 'SyntenyTrack',
-            adapter: getAdapter(),
-          })
-
-          model.toggleTrack(trackId)
+    async function onOpenClick() {
+      try {
+        if (!isSessionWithAddTracks(session)) {
+          return
         }
-      })
-    } catch (e) {
-      console.error(e)
-      setError(e)
-    }
-  }
+        setError(undefined)
 
-  // this is a combination of any displayed error message we have
-  const displayError = error || assemblyError
-  return (
-    <Container className={classes.importFormContainer}>
-      {displayError ? <ErrorMessage error={displayError} /> : null}
-      <Paper className={classes.formPaper}>
+        const { assemblyManager } = session
+        const assemblies = [assembly1, assembly2]
+        model.setViews(
+          await Promise.all(
+            assemblies.map(async sel => {
+              const asm = await assemblyManager.waitForAssembly(sel)
+              if (!asm) {
+                throw new Error(`Assembly ${sel} failed to load`)
+              }
+              return {
+                type: 'LinearGenomeView' as const,
+                bpPerPx: 1,
+                offsetPx: 0,
+                hideHeader: true,
+                displayedRegions: asm.regions,
+              }
+            }),
+          ),
+        )
+        model.views.forEach(view => view.setWidth(model.width))
+        if (sessionTrackData) {
+          session.addTrackConf(sessionTrackData)
+          model.toggleTrack(sessionTrackData.trackId)
+        } else if (showTrackId) {
+          model.showTrack(showTrackId)
+        }
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
+    }
+
+    // this is a combination of any displayed error message we have
+    const displayError = error
+    return (
+      <Container className={classes.importFormContainer}>
+        {displayError ? <ErrorMessage error={displayError} /> : null}
         <Grid
           container
-          item
+          spacing={1}
           justifyContent="center"
-          spacing={4}
           alignItems="center"
+          className={classes.assemblySelector}
         >
           <Grid item>
-            <Typography>Select assemblies for synteny view</Typography>
-            {[...new Array(numRows)].map((_, index) => (
-              <AssemblySelector
-                key={`row_${index}_${selected[index]}`}
-                selected={selected[index]}
-                extra={index}
-                onChange={val => {
-                  // splice the value into the current array
-                  const copy = selected.slice(0)
-                  copy[index] = val
-                  setSelected(copy)
-                }}
-                session={session}
+            <Paper style={{ padding: 12 }}>
+              <p style={{ textAlign: 'center' }}>
+                Select assemblies for linear synteny view
+              </p>
+              <Grid
+                container
+                spacing={1}
+                justifyContent="center"
+                alignItems="center"
+              >
+                <Grid item>
+                  <AssemblySelector
+                    extra={0}
+                    selected={assembly1}
+                    onChange={val => setAssembly1(val)}
+                    session={session}
+                  />
+                </Grid>
+                <Grid item>
+                  <AssemblySelector
+                    extra={1}
+                    selected={assembly2}
+                    onChange={val => setAssembly2(val)}
+                    session={session}
+                  />
+                </Grid>
+                <Grid item>
+                  <FormControl>
+                    <Button
+                      onClick={onOpenClick}
+                      variant="contained"
+                      color="primary"
+                    >
+                      Launch
+                    </Button>
+                  </FormControl>
+                </Grid>
+              </Grid>
+            </Paper>
+            <FormControl>
+              <FormLabel id="group-label">
+                (Optional) Select or add a synteny track
+              </FormLabel>
+              <RadioGroup
+                row
+                value={choice}
+                onChange={event => setChoice(event.target.value)}
+                aria-labelledby="group-label"
+              >
+                <FormControlLabel
+                  value="none"
+                  control={<Radio />}
+                  label="None"
+                />
+                <FormControlLabel
+                  value="tracklist"
+                  control={<Radio />}
+                  label="Existing track"
+                />
+                <FormControlLabel
+                  value="custom"
+                  control={<Radio />}
+                  label="New track"
+                />
+              </RadioGroup>
+            </FormControl>
+            {choice === 'custom' ? (
+              <ImportCustomTrack
+                setSessionTrackData={setSessionTrackData}
+                sessionTrackData={sessionTrackData}
+                assembly2={assembly2}
+                assembly1={assembly1}
               />
-            ))}
+            ) : null}
+            {choice === 'tracklist' ? (
+              <ImportSyntenyTrackSelector
+                model={model}
+                assembly1={assembly1}
+                assembly2={assembly2}
+                setShowTrackId={setShowTrackId}
+              />
+            ) : null}
           </Grid>
         </Grid>
-      </Paper>
+      </Container>
+    )
+  },
+)
 
-      <Paper className={classes.formPaper}>
-        <Typography style={{ textAlign: 'center' }}>
-          <b>Optional</b>: Add a .paf, .out (MashMap), .delta (Mummer), .chain,
-          .anchors or .anchors.simple (MCScan) file to view in the synteny view.
-          These file types can also be gzipped. The first assembly should be the
-          query sequence (e.g. left column of the PAF) and the second assembly
-          should be the target sequence (e.g. right column of the PAF)
-        </Typography>
-        <RadioGroup
-          value={radioOption}
-          onChange={event => setValue(event.target.value)}
-        >
-          <Grid container justifyContent="center">
-            <Grid item>
-              <FormControlLabel value=".paf" control={<Radio />} label=".paf" />
-            </Grid>
-            <Grid item>
-              <FormControlLabel value=".out" control={<Radio />} label=".out" />
-            </Grid>
-            <Grid item>
-              <FormControlLabel
-                value=".delta"
-                control={<Radio />}
-                label=".delta"
-              />
-            </Grid>
-            <Grid item>
-              <FormControlLabel
-                value=".chain"
-                control={<Radio />}
-                label=".chain"
-              />
-            </Grid>
-            <Grid item>
-              <FormControlLabel
-                value=".anchors"
-                control={<Radio />}
-                label=".anchors"
-              />
-            </Grid>
-            <Grid item>
-              <FormControlLabel
-                value=".anchors.simple"
-                control={<Radio />}
-                label=".anchors.simple"
-              />
-            </Grid>
-          </Grid>
-        </RadioGroup>
-        <Grid container justifyContent="center">
-          <Grid item>
-            {value === '.anchors' || value === '.anchors.simple' ? (
-              <div>
-                <div style={{ margin: 20 }}>
-                  Open the {value}, and .bed files for both genome assemblies
-                  from the MCScan (Python verson) pipeline{' '}
-                  <a href="https://github.com/tanghaibao/jcvi/wiki/MCscan-(Python-version)">
-                    (more info)
-                  </a>
-                </div>
-                <div style={{ display: 'flex' }}>
-                  <div>
-                    <FileSelector
-                      name=".anchors file"
-                      description=""
-                      location={trackData}
-                      setLocation={loc => setTrackData(loc)}
-                    />
-                  </div>
-                  <div>
-                    <FileSelector
-                      name="genome 1 .bed (left column of anchors file)"
-                      description=""
-                      location={bed1Location}
-                      setLocation={loc => setBed1Location(loc)}
-                    />
-                  </div>
-                  <div>
-                    <FileSelector
-                      name="genome 2 .bed (right column of anchors file)"
-                      description=""
-                      location={bed2Location}
-                      setLocation={loc => setBed2Location(loc)}
-                    />
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <FileSelector
-                name={value ? value + ' location' : ''}
-                description=""
-                location={trackData}
-                setLocation={loc => setTrackData(loc)}
-              />
-            )}
-          </Grid>
-        </Grid>
-      </Paper>
-      <Grid container justifyContent="center">
-        <Grid item>
-          <Button
-            // only disable button on assemblyError. for other types of errors
-            // in the useState can retry
-            disabled={!!assemblyError}
-            onClick={onOpenClick}
-            variant="contained"
-            color="primary"
-          >
-            Open
-          </Button>
-        </Grid>
-      </Grid>
-    </Container>
-  )
-})
-
-export default ImportForm
+export default LinearSyntenyImportForm

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportSyntenyTrackSelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportSyntenyTrackSelector.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { Select, MenuItem, Paper, Typography } from '@mui/material'
 import { getSession } from '@jbrowse/core/util'
-
-import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+import { getTrackName } from '@jbrowse/core/util/tracks'
 import { ErrorMessage } from '@jbrowse/core/ui'
 import {
   AnyConfigurationModel,
@@ -10,8 +9,7 @@ import {
 } from '@jbrowse/core/configuration'
 
 import { observer } from 'mobx-react'
-import { DotplotViewModel } from '../model'
-import { getTrackName } from '@jbrowse/core/util/tracks'
+import { LinearSyntenyViewModel } from '../model'
 
 function f(track: AnyConfigurationModel, assembly1: string, assembly2: string) {
   const assemblyNames = readConfObject(track, 'assemblyNames')
@@ -29,26 +27,27 @@ const Selector = observer(
     assembly2,
     setShowTrackId,
   }: {
-    model: DotplotViewModel
+    model: LinearSyntenyViewModel
     assembly1: string
     assembly2: string
     setShowTrackId: (arg: string) => void
   }) => {
     const session = getSession(model)
-    const { tracks, sessionTracks } = session
+    const { tracks = [], sessionTracks = [] } = session
     const allTracks = [...tracks, ...sessionTracks] as AnyConfigurationModel[]
     const filteredTracks = allTracks.filter(t => f(t, assembly2, assembly1))
     const resetTrack = filteredTracks[0]?.trackId || ''
     const [value, setValue] = useState(resetTrack)
     useEffect(() => {
-      // if assembly1/assembly2 changes, then we will want to use this effect to change
-      // the state of the useState because it otherwise gets locked to a stale value
+      // if assembly1/assembly2 changes, then we will want to use this effect to
+      // change the state of the useState because it otherwise gets locked to a
+      // stale value
       setValue(resetTrack)
     }, [resetTrack])
 
     useEffect(() => {
-      // sets track data in a useEffect because the initial load is needed as well as
-      // onChange's to the select box
+      // sets track data in a useEffect because the initial load is needed as well
+      // as onChange's to the select box
       setShowTrackId(value)
     }, [value, setShowTrackId])
     return (
@@ -58,11 +57,6 @@ const Selector = observer(
           you hit "Launch".
         </Typography>
 
-        <Typography paragraph>
-          Note: there is a track selector <i>inside</i> the DotplotView, which
-          can turn on one or more SyntenyTracks (more than one can be displayed
-          at once). Look for the track selector icon <TrackSelectorIcon />
-        </Typography>
         {filteredTracks.length ? (
           <Select
             value={value}

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -3127,6 +3127,40 @@ Object {
     },
     Object {
       "adapter": Object {
+        "pafLocation": Object {
+          "internetAccountId": undefined,
+          "internetAccountPreAuthorization": undefined,
+          "locationType": "UriLocation",
+          "uri": "volvox_ins.paf",
+        },
+        "queryAssembly": "volvox_ins",
+        "targetAssembly": "volvox",
+        "type": "PAFAdapter",
+      },
+      "assemblyNames": Array [
+        "volvox",
+        "volvox_ins",
+      ],
+      "displays": Array [
+        Object {
+          "displayId": "volvox_ins.paf-1658813720770-DotplotDisplay",
+          "type": "DotplotDisplay",
+        },
+        Object {
+          "displayId": "volvox_ins.paf-1658813720770-LinearComparativeDisplay",
+          "type": "LinearComparativeDisplay",
+        },
+        Object {
+          "displayId": "volvox_ins.paf-1658813720770-LinearSyntenyDisplay",
+          "type": "LinearSyntenyDisplay",
+        },
+      ],
+      "name": "volvox_ins.paf",
+      "trackId": "volvox_ins.paf-1658813720770",
+      "type": "SyntenyTrack",
+    },
+    Object {
+      "adapter": Object {
         "type": "VcfAdapter",
         "vcfLocation": Object {
           "internetAccountId": undefined,

--- a/products/jbrowse-web/src/tests/Dotplot.test.tsx
+++ b/products/jbrowse-web/src/tests/Dotplot.test.tsx
@@ -43,12 +43,13 @@ test('open a dotplot view with import form', async () => {
       value: 'peach',
     },
   })
+  fireEvent.click(await findByText('New track', {}, delay))
   fireEvent.change(await findByTestId('urlInput', {}, delay), {
     target: {
       value: 'peach_grape_small.paf.gz',
     },
   })
-  fireEvent.click(await findByText('Open'))
+  fireEvent.click(await findByText('Launch'))
 
   expectCanvasMatch(await findByTestId('prerendered_canvas_done', {}, delay))
 }, 30000)

--- a/products/jbrowse-web/src/tests/Dotplot.test.tsx
+++ b/products/jbrowse-web/src/tests/Dotplot.test.tsx
@@ -48,7 +48,7 @@ test('open a dotplot view with import form', async () => {
       value: 'peach_grape_small.paf.gz',
     },
   })
-  fireEvent.click(await findByTestId('submitDotplot'))
+  fireEvent.click(await findByText('Open'))
 
   expectCanvasMatch(await findByTestId('prerendered_canvas_done', {}, delay))
 }, 30000)

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1799,6 +1799,21 @@
       }
     },
     {
+      "type": "SyntenyTrack",
+      "trackId": "volvox_ins.paf-1658813720770",
+      "name": "volvox_ins.paf",
+      "assemblyNames": ["volvox", "volvox_ins"],
+      "adapter": {
+        "type": "PAFAdapter",
+        "targetAssembly": "volvox",
+        "queryAssembly": "volvox_ins",
+        "pafLocation": {
+          "uri": "volvox_ins.paf"
+        }
+      }
+    },
+
+    {
       "type": "VariantTrack",
       "trackId": "variant_effect_demo_data",
       "name": "Ensembl VEP example",


### PR DESCRIPTION
Possible fix for https://github.com/GMOD/jbrowse-components/issues/3079

Creates a rudimentary "tracklist" that shows session tracks and config tracks (not connection yet) at the synteny import form, helping users to more easily launch a synteny view

Will look for track types that contain the word 'Synteny' (in case another synteny track type is developed), and check that the track's assemblyNames matches **both** of the user selected assemblies

Makes it easier for the user to see that "opening their own track" is an optional step too


![Screenshot from 2022-10-28 19-05-47](https://user-images.githubusercontent.com/6511937/198754969-8bf1faf9-530c-4e1c-a4c6-9d27ed97cc4e.png)






