### PR TITLE
Improve rubberband zooming across ellided regions

### DIFF
--- a/packages/core/util/Base1DUtils.ts
+++ b/packages/core/util/Base1DUtils.ts
@@ -40,11 +40,25 @@ export function moveTo(
   if (!start || !end) {
     return
   }
-  const { width, interRegionPaddingWidth } = self
+  const {
+    width,
+    interRegionPaddingWidth,
+    displayedRegions,
+    bpPerPx,
+    minimumBlockWidth,
+  } = self
 
   const len = lengthBetween(self, start, end)
-  const numBlocks = end.index - start.index
-  const targetBpPerPx = len / (width - interRegionPaddingWidth * numBlocks)
+  let numBlocksWideEnough = 0
+  for (let i = start.index; i < end.index; i++) {
+    const r = displayedRegions[i]
+    if ((r.end - r.start) / bpPerPx > minimumBlockWidth) {
+      numBlocksWideEnough++
+    }
+  }
+
+  const targetBpPerPx =
+    len / (width - interRegionPaddingWidth * numBlocksWideEnough)
   const newBpPerPx = self.zoomTo(targetBpPerPx)
 
   // If our target bpPerPx was smaller than the allowed minBpPerPx, adjust

--- a/products/jbrowse-web/src/tests/Alignments.test.tsx
+++ b/products/jbrowse-web/src/tests/Alignments.test.tsx
@@ -45,7 +45,7 @@ test('opens an alignments track', async () => {
   fireEvent.mouseMove(track[0], { clientX: -100, clientY: -100 })
 
   // this is to confirm a alignment detail widget opened
-  await findByTestId('alignment-side-drawer')
+  await findByTestId('alignment-side-drawer', {}, delay)
 }, 20000)
 
 test('test that bam with small max height displays message', async () => {


### PR DESCRIPTION
Currently, rubberbanding selection+zoom in across ellided regions results in a inaccurate zoom

The reason comes down to assuming every region has an interRegionPaddingBlock but ellided regions do not

Can test on these links: rubberband zoom across the many ellided regions

main branch
https://jbrowse.org/code/jb2/main/?session=share-9S4NOE2u-q&password=Y1Uhn

this branch
https://jbrowse.org/code/jb2/improve_rubberband_ellided/?session=share-9S4NOE2u-q&password=Y1Uhn

Even this branch is not perfect, it seems to underestimate slightly, while main branch does overestimation