### PR TITLE
v2.2.0 release announce

### DIFF
--- a/website/release_announcement_drafts/v2.2.0.md
+++ b/website/release_announcement_drafts/v2.2.0.md
@@ -1,0 +1,30 @@
+This release includes several important improvements including
+
+- Lazily loading assembly refNames: previously when you had multiple assemblies
+  in your config, it would load all their refNames at browser startup. Now, it
+  only fetches refNames when you request to use an assembly.
+- Simplified "synteny track selector" on the dotplot and synteny import forms
+- Improved documentation! The entire jbrowse 2 documentation has been
+  overhauled, and the monolithic user guide, config guide, and developer guide
+  pages have been split into smaller pages. We also now auto-generate
+  documentation on our config and state tree models, and have a search bar
+- Improved speed on alignments tracks: a small optimization was made for
+  alignments tracks that can improve performance on alignments tracks by 30% or
+  so especially on short reads
+
+![](https://user-images.githubusercontent.com/6511937/197289612-efc80e3c-6cfd-495b-834e-4c1da1cff0c9.png)
+Figure showing improved speed on short read alignments of the refactor (this
+release) vs main (which was v2.1.7)
+
+Note that the changes to allow lazy loading assemblies may have somewhat
+changed the "contract", so if your code is using the assemblyManager directly
+in any places, please be aware of this change. Proper usage of the
+assemblyManager API uses either
+
+1. use assemblyManager.get(assemblyName) which can return undefined initially,
+   but then this initiates the lazy load and can be caught by reactivity of
+   wrapping your components in observers
+2. use assemblyManager.waitForAssembly(assemblyName) function, which is
+   asynchronous but returns a promise. this avoids the initial return undefined
+   behavior
+3. avoid directly accessing e.g. assemblyManager.assemblies


### PR DESCRIPTION
Current changelog

```
## Unreleased (2022-11-04)

#### :rocket: Enhancement
* Other
  * [#3296](https://github.com/GMOD/jbrowse-components/pull/3296) Add option to use OAuth "state" param in internet accounts ([@garrettjstevens](https://github.com/garrettjstevens))
  * [#3285](https://github.com/GMOD/jbrowse-components/pull/3285) Use typescript version of @gmod/cram ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#3299](https://github.com/GMOD/jbrowse-components/pull/3299) Add ability to open a synteny track directly from the dotplot/linear synteny view import forms ([@cmdcolin](https://github.com/cmdcolin))
  * [#3287](https://github.com/GMOD/jbrowse-components/pull/3287) Lazy-load assemblies on demand instead of all at app startup ([@cmdcolin](https://github.com/cmdcolin))
  * [#3279](https://github.com/GMOD/jbrowse-components/pull/3279) Remove unnecessary expanded region query and small refactors ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#3309](https://github.com/GMOD/jbrowse-components/pull/3309) Fix animated "Loading..." message keyframes ([@cmdcolin](https://github.com/cmdcolin))
  * [#3306](https://github.com/GMOD/jbrowse-components/pull/3306) Fix the RefNameAutocomplete displaying a stale value for chromosome names ([@cmdcolin](https://github.com/cmdcolin))
  * [#3302](https://github.com/GMOD/jbrowse-components/pull/3302) Improve rubberband zooming across elided regions ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#3293](https://github.com/GMOD/jbrowse-components/pull/3293) Fix CRAM plotting for data files that encode insertions in uncommon way ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* `core`, `text-indexing`
  * [#3278](https://github.com/GMOD/jbrowse-components/pull/3278) Auto-generate docs ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* [#3310](https://github.com/GMOD/jbrowse-components/pull/3310) Remove CacheProvider emotion cache ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
- Scott Cain ([@scottcain](https://github.com/scottcain))
Done in 1.88s.


```