### PR TITLE
Fix ability to run development environment on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ cd products/jbrowse-desktop
 yarn start
 ```
 
-For running like jbrowse-react-linear-genome-view you can use
-storybook
+For running e.g. jbrowse-react-linear-genome-view you can use storybook
 
 ```sh
 cd products/jbrowse-react-linear-genome-view

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "eslint-plugin-tsdoc": "^0.2.4",
     "file-loader": "^6.2.0",
     "find-yarn-workspace-root": "^2.0.0",
-    "get-yarn-workspaces": "^1.0.2",
     "husky": "^8.0.0",
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.0.0",

--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -2,7 +2,7 @@ const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { getLoader, loaderByName } = require('@craco/craco')
 const webpack = require('webpack')
-
+const path = require('path')
 const cp = require('child_process')
 
 function getWorkspaces(fromDir) {

--- a/products/jbrowse-desktop/craco.config.js
+++ b/products/jbrowse-desktop/craco.config.js
@@ -1,9 +1,19 @@
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { getLoader, loaderByName } = require('@craco/craco')
-// eslint-disable-next-line import/no-extraneous-dependencies
-const getYarnWorkspaces = require('get-yarn-workspaces')
 const webpack = require('webpack')
+
+const cp = require('child_process')
+
+function getWorkspaces(fromDir) {
+  const cwd = fromDir || process.cwd()
+  const workspacesStr = cp
+    .execSync('yarn -s workspaces info', { cwd })
+    .toString()
+  return Object.values(JSON.parse(workspacesStr)).map(e =>
+    path.resolve(path.join('..', '..', e.location)),
+  )
+}
 
 module.exports = {
   devServer: config => {
@@ -39,7 +49,7 @@ module.exports = {
         const include = Array.isArray(match.loader.include)
           ? match.loader.include
           : [match.loader.include]
-        match.loader.include = include.concat(getYarnWorkspaces())
+        match.loader.include = include.concat(getWorkspaces())
       }
 
       // similar to our webpack 4 rescript, setting target to

--- a/products/jbrowse-web/craco.config.js
+++ b/products/jbrowse-web/craco.config.js
@@ -2,7 +2,7 @@ const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { getLoader, loaderByName } = require('@craco/craco')
 const webpack = require('webpack')
-
+const path = require('path')
 const cp = require('child_process')
 
 function getWorkspaces(fromDir) {

--- a/products/jbrowse-web/craco.config.js
+++ b/products/jbrowse-web/craco.config.js
@@ -1,9 +1,19 @@
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { getLoader, loaderByName } = require('@craco/craco')
-// eslint-disable-next-line import/no-extraneous-dependencies
-const getYarnWorkspaces = require('get-yarn-workspaces')
 const webpack = require('webpack')
+
+const cp = require('child_process')
+
+function getWorkspaces(fromDir) {
+  const cwd = fromDir || process.cwd()
+  const workspacesStr = cp
+    .execSync('yarn -s workspaces info', { cwd })
+    .toString()
+  return Object.values(JSON.parse(workspacesStr)).map(e =>
+    path.resolve(path.join('..', '..', e.location)),
+  )
+}
 
 module.exports = {
   devServer: config => {
@@ -32,7 +42,7 @@ module.exports = {
         const include = Array.isArray(match.loader.include)
           ? match.loader.include
           : [match.loader.include]
-        match.loader.include = include.concat(getYarnWorkspaces())
+        match.loader.include = include.concat(getWorkspaces())
       }
 
       config.resolve.fallback = { fs: false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10794,11 +10794,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flatten@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
-  integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
-
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -11195,15 +11190,6 @@ get-value@^3.0.1:
   integrity sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==
   dependencies:
     isobject "^3.0.1"
-
-get-yarn-workspaces@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-yarn-workspaces/-/get-yarn-workspaces-1.0.2.tgz#81591bdb392f1c6bac09cdc8491a6d275781aa44"
-  integrity sha512-Auel048Uclfgr74oNXKZWH30UgKDZXQdfUfgD9iWXdoUGJpeWg9lSuX/FZkQ6RB3KnBfAaf70xQXfwOjiE9rPw==
-  dependencies:
-    find-root "^1.1.0"
-    flatten "^1.0.2"
-    glob "^7.1.2"
 
 git-raw-commits@^2.0.8:
   version "2.0.11"


### PR DESCRIPTION
Tested on a windows vm with plain cmd.exe

Uses a code snippet found in https://github.com/viewstools/yarn-workspaces-cra-crna/issues/28 which manually runs `yarn` via a spawned process, which replaces the 'get-yarn-workspaces' dependency, which assumed forward slashes
