### PR TITLE
Add ability to minimize/collapse tracks and views and move views up/down in view stack

### DIFF
--- a/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
+++ b/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
@@ -18,7 +18,7 @@ import { ElementId } from '../../util/types/mst'
  * they should contain only UI state for the track, and have
  * a reference to a track configuration (stored under
  * session.configuration.assemblies.get(assemblyName).tracks).
- * note that multiple displayed tracks could use the same 
+ * note that multiple displayed tracks could use the same
  * configuration.
  */
 export function createBaseTrackModel(

--- a/packages/core/pluggableElementTypes/models/BaseViewModel.ts
+++ b/packages/core/pluggableElementTypes/models/BaseViewModel.ts
@@ -13,21 +13,23 @@ const BaseViewModel = types
      * #property
      */
     id: ElementId,
+
     /**
      * #property
      * displayName is displayed in the header of the view, or assembly names
      * being used if none is specified
      */
     displayName: types.maybe(types.string),
+
     /**
      * #property
      */
     minimized: false,
   })
-  .volatile((/* self */) => ({
+  .volatile(() => ({
     width: 800,
   }))
-  .views((/* self */) => ({
+  .views(() => ({
     /**
      * #getter
      */
@@ -45,15 +47,19 @@ const BaseViewModel = types
 
     /**
      * #action
-     * width is an "important" attribute of the view model, when it becomes set, it
+     * width is an important attribute of the view model, when it becomes set, it
      * often indicates when the app can start drawing to it. certain views like
      * lgv are strict about this because if it tries to draw before it knows the
      * width it should draw to, it may start fetching data for regions it doesn't
      * need to
+     *
+     * setWidth is updated by a ResizeObserver generally, the views often need
+     * to know how wide they are to properly draw genomic regions
      */
     setWidth(newWidth: number) {
       self.width = newWidth
     },
+
     /**
      * #action
      */

--- a/packages/core/pluggableElementTypes/models/BaseViewModel.ts
+++ b/packages/core/pluggableElementTypes/models/BaseViewModel.ts
@@ -19,6 +19,10 @@ const BaseViewModel = types
      * being used if none is specified
      */
     displayName: types.maybe(types.string),
+    /**
+     * #property
+     */
+    minimized: false,
   })
   .volatile((/* self */) => ({
     width: 800,
@@ -49,6 +53,12 @@ const BaseViewModel = types
      */
     setWidth(newWidth: number) {
       self.width = newWidth
+    },
+    /**
+     * #action
+     */
+    setMinimized(flag: boolean) {
+      self.minimized = flag
     },
   }))
 

--- a/packages/core/ui/App.tsx
+++ b/packages/core/ui/App.tsx
@@ -19,21 +19,23 @@ import { getEnv } from 'mobx-state-tree'
 
 // locals
 import { readConfObject, AnyConfigurationModel } from '../configuration'
-import DrawerWidget from './DrawerWidget'
-import DropDownMenu from './DropDownMenu'
-import ErrorMessage from './ErrorMessage'
-import LoadingEllipses from './LoadingEllipses'
-import EditableTypography from './EditableTypography'
-import { LogoFull } from './Logo'
-import Snackbar from './Snackbar'
-import ViewContainer from './ViewContainer'
 import {
   AbstractViewModel,
   NotificationLevel,
   SessionWithDrawerWidgets,
   SnackAction,
 } from '../util'
-import { MenuItem as JBMenuItem } from './index'
+
+// ui elements
+import DrawerWidget from './DrawerWidget'
+import DropDownMenu from './DropDownMenu'
+import ErrorMessage from './ErrorMessage'
+import LoadingEllipses from './LoadingEllipses'
+import EditableTypography from './EditableTypography'
+import Snackbar from './Snackbar'
+import ViewContainer from './ViewContainer'
+import { LogoFull } from './Logo'
+import { MenuItem as JBMenuItem } from './Menu'
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -186,9 +188,7 @@ const ViewLauncher = observer(({ session }: { session: AppSession }) => {
       </FormControl>
       <FormControl style={{ margin: 2 }}>
         <Button
-          onClick={() => {
-            session.addView(value, {})
-          }}
+          onClick={() => session.addView(value, {})}
           variant="contained"
           color="primary"
         >
@@ -208,18 +208,26 @@ const ViewPanel = observer(
     }
     const { ReactComponent } = viewType
     return (
-      <ViewContainer view={view} onClose={() => session.removeView(view)}>
-        <ErrorBoundary
-          FallbackComponent={({ error }) => <ErrorMessage error={error} />}
-        >
-          <Suspense fallback={<LoadingEllipses />}>
-            <ReactComponent
-              model={view}
-              session={session}
-              getTrackType={pluginManager.getTrackType}
-            />
-          </Suspense>
-        </ErrorBoundary>
+      <ViewContainer
+        view={view}
+        onClose={() => session.removeView(view)}
+        onMinimize={() => view.setMinimized(!view.minimized)}
+      >
+        {!view.minimized ? (
+          <ErrorBoundary
+            FallbackComponent={({ error }) => <ErrorMessage error={error} />}
+          >
+            <Suspense fallback={<LoadingEllipses />}>
+              <ReactComponent
+                model={view}
+                session={session}
+                getTrackType={pluginManager.getTrackType}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        ) : (
+          false
+        )}
       </ViewContainer>
     )
   },

--- a/packages/core/ui/EditableTypography.tsx
+++ b/packages/core/ui/EditableTypography.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-interface EditableTypographyPropTypes {
+interface EditableTypographyProps {
   value: string
   setValue: (value: string) => void
   variant: Variant
@@ -37,81 +37,79 @@ interface EditableTypographyPropTypes {
 }
 
 // using forwardRef so that MUI Tooltip can wrap this component
-const EditableTypography = React.forwardRef(
-  (props: EditableTypographyPropTypes, ref: React.Ref<HTMLDivElement>) => {
-    const { value, setValue, variant, ...other } = props
-    const [editedValue, setEditedValue] = useState<string>()
-    const [width, setWidth] = useState(0)
-    const [sizerNode, setSizerNode] = useState<HTMLSpanElement | null>(null)
-    const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null)
-    const [blur, setBlur] = useState(false)
+const EditableTypography = React.forwardRef<
+  HTMLDivElement,
+  EditableTypographyProps
+>((props, ref) => {
+  const { value, setValue, variant, ...other } = props
+  const [editedValue, setEditedValue] = useState<string>()
+  const [sizerNode, setSizerNode] = useState<HTMLSpanElement | null>(null)
+  const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null)
+  const [blur, setBlur] = useState(false)
 
-    useEffect(() => {
-      if (blur) {
-        inputNode && inputNode.blur()
-        setBlur(false)
-      }
-    }, [blur, inputNode])
-
-    // possibly tss-react does not understand the passing of props to
-    // useStyles, but it appears to work
-    // @ts-ignore
-    const { classes } = useStyles(props, { props })
-    const theme = useTheme()
-
-    const clientWidth = sizerNode?.clientWidth
-    if (clientWidth && clientWidth !== width) {
-      setWidth(clientWidth)
+  useEffect(() => {
+    if (blur) {
+      inputNode?.blur()
+      setBlur(false)
     }
+  }, [blur, inputNode])
 
-    return (
-      <div {...other} ref={ref}>
-        <div style={{ position: 'relative' }}>
-          <Typography
-            ref={(node: HTMLSpanElement) => setSizerNode(node)}
-            component="span"
-            variant={variant}
-            className={classes.typography}
-          >
-            {editedValue === undefined ? value : editedValue}
-          </Typography>
-        </div>
-        <InputBase
-          inputRef={node => setInputNode(node)}
-          className={classes.inputBase}
-          inputProps={{
-            style: {
-              width,
-              ...(variant && variant !== 'inherit'
-                ? theme.typography[variant]
-                : {}),
-            },
-          }}
-          classes={{
-            input: classes.input,
-            root: classes.inputRoot,
-            focused: classes.inputFocused,
-          }}
-          value={editedValue === undefined ? value : editedValue}
-          onChange={event => setEditedValue(event.target.value)}
-          onKeyDown={event => {
-            if (event.key === 'Enter') {
-              inputNode && inputNode.blur()
-            } else if (event.key === 'Escape') {
-              setEditedValue(undefined)
-              setBlur(true)
-            }
-          }}
-          onBlur={() => {
-            if (editedValue && editedValue !== value) {
-              setValue(editedValue)
-            }
-            setEditedValue(undefined)
-          }}
-        />
+  // possibly tss-react does not understand the passing of props to
+  // useStyles, but it appears to work
+  // @ts-ignore
+  const { classes } = useStyles(props, { props })
+  const theme = useTheme()
+
+  const clientWidth = sizerNode?.clientWidth
+  const width = clientWidth || 0
+
+  const val = editedValue === undefined ? value : editedValue
+
+  return (
+    <div {...other} ref={ref}>
+      <div style={{ position: 'relative' }}>
+        <Typography
+          ref={(node: HTMLSpanElement) => setSizerNode(node)}
+          component="span"
+          variant={variant}
+          className={classes.typography}
+        >
+          {val}
+        </Typography>
       </div>
-    )
-  },
-)
+      <InputBase
+        inputRef={node => setInputNode(node)}
+        className={classes.inputBase}
+        inputProps={{
+          style: {
+            width,
+            ...(variant && variant !== 'inherit'
+              ? theme.typography[variant]
+              : {}),
+          },
+        }}
+        classes={{
+          input: classes.input,
+          root: classes.inputRoot,
+          focused: classes.inputFocused,
+        }}
+        value={val}
+        onChange={event => setEditedValue(event.target.value)}
+        onKeyDown={event => {
+          if (event.key === 'Enter') {
+            inputNode?.blur()
+          } else if (event.key === 'Escape') {
+            setEditedValue(undefined)
+            setBlur(true)
+          }
+        }}
+        onBlur={() => {
+          setValue(editedValue || '')
+          setEditedValue(undefined)
+        }}
+      />
+    </div>
+  )
+})
 
 export default EditableTypography

--- a/packages/core/ui/EditableTypography.tsx
+++ b/packages/core/ui/EditableTypography.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-interface EditableTypographyProps {
+interface Props {
   value: string
   setValue: (value: string) => void
   variant: Variant
@@ -37,79 +37,78 @@ interface EditableTypographyProps {
 }
 
 // using forwardRef so that MUI Tooltip can wrap this component
-const EditableTypography = React.forwardRef<
-  HTMLDivElement,
-  EditableTypographyProps
->((props, ref) => {
-  const { value, setValue, variant, ...other } = props
-  const [editedValue, setEditedValue] = useState<string>()
-  const [sizerNode, setSizerNode] = useState<HTMLSpanElement | null>(null)
-  const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null)
-  const [blur, setBlur] = useState(false)
+const EditableTypography = React.forwardRef<HTMLDivElement, Props>(
+  (props, ref) => {
+    const { value, setValue, variant, ...other } = props
+    const [editedValue, setEditedValue] = useState<string>()
+    const [sizerNode, setSizerNode] = useState<HTMLSpanElement | null>(null)
+    const [inputNode, setInputNode] = useState<HTMLInputElement | null>(null)
+    const [blur, setBlur] = useState(false)
 
-  useEffect(() => {
-    if (blur) {
-      inputNode?.blur()
-      setBlur(false)
-    }
-  }, [blur, inputNode])
+    useEffect(() => {
+      if (blur) {
+        inputNode?.blur()
+        setBlur(false)
+      }
+    }, [blur, inputNode])
 
-  // possibly tss-react does not understand the passing of props to
-  // useStyles, but it appears to work
-  // @ts-ignore
-  const { classes } = useStyles(props, { props })
-  const theme = useTheme()
+    // possibly tss-react does not understand the passing of props to
+    // useStyles, but it appears to work
+    // @ts-ignore
+    const { classes } = useStyles(props, { props })
+    const theme = useTheme()
 
-  const clientWidth = sizerNode?.clientWidth
-  const width = clientWidth || 0
+    const clientWidth = sizerNode?.clientWidth
+    const width = clientWidth || 0
 
-  const val = editedValue === undefined ? value : editedValue
+    const val = editedValue === undefined ? value : editedValue
 
-  return (
-    <div {...other} ref={ref}>
-      <div style={{ position: 'relative' }}>
-        <Typography
-          ref={(node: HTMLSpanElement) => setSizerNode(node)}
-          component="span"
-          variant={variant}
-          className={classes.typography}
-        >
-          {val}
-        </Typography>
-      </div>
-      <InputBase
-        inputRef={node => setInputNode(node)}
-        className={classes.inputBase}
-        inputProps={{
-          style: {
-            width,
-            ...(variant && variant !== 'inherit'
-              ? theme.typography[variant]
-              : {}),
-          },
-        }}
-        classes={{
-          input: classes.input,
-          root: classes.inputRoot,
-          focused: classes.inputFocused,
-        }}
-        value={val}
-        onChange={event => setEditedValue(event.target.value)}
-        onKeyDown={event => {
-          if (event.key === 'Enter') {
-            inputNode?.blur()
-          } else if (event.key === 'Escape') {
+    return (
+      <div {...other} ref={ref}>
+        <div style={{ position: 'relative' }}>
+          <Typography
+            ref={(node: HTMLSpanElement) => setSizerNode(node)}
+            component="span"
+            variant={variant}
+            className={classes.typography}
+          >
+            {val}
+          </Typography>
+        </div>
+        <InputBase
+          inputRef={node => setInputNode(node)}
+          className={classes.inputBase}
+          inputProps={{
+            style: {
+              width,
+              ...(variant && variant !== 'inherit'
+                ? theme.typography[variant]
+                : {}),
+            },
+          }}
+          classes={{
+            input: classes.input,
+            root: classes.inputRoot,
+            focused: classes.inputFocused,
+          }}
+          value={val}
+          onChange={event => setEditedValue(event.target.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter') {
+              inputNode?.blur()
+            } else if (event.key === 'Escape') {
+              setEditedValue(undefined)
+              setBlur(true)
+            }
+          }}
+          onBlur={() => {
+            setValue(editedValue || '')
             setEditedValue(undefined)
-            setBlur(true)
-          }
-        }}
-        onBlur={() => {
-          setValue(editedValue || '')
-          setEditedValue(undefined)
-        }}
-      />
-    </div>
-  )
-})
+          }}
+        />
+      </div>
+    )
+  },
+)
 
 export default EditableTypography

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -17,8 +17,11 @@ import CloseIcon from '@mui/icons-material/Close'
 import MinimizeIcon from '@mui/icons-material/Minimize'
 import AddIcon from '@mui/icons-material/Add'
 import MenuIcon from '@mui/icons-material/Menu'
+import ArrowDownward from '@mui/icons-material/ArrowDownward'
+import ArrowUpward from '@mui/icons-material/ArrowUpward'
 
 // locals
+import { getSession } from '../util'
 import { IBaseViewModel } from '../pluggableElementTypes/models'
 import EditableTypography from './EditableTypography'
 import Menu from './Menu'
@@ -66,15 +69,28 @@ const ViewMenu = observer(
   }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement>()
     const { menuItems } = model
+    const session = getSession(model)
 
     // <=1.3.3 didn't use a function
-    const items = typeof menuItems === 'function' ? menuItems() : menuItems
+    const items = [
+      {
+        label: 'Move view up',
+        icon: ArrowUpward,
+        onClick: () => session.moveViewUp(model.id),
+      },
+      {
+        label: 'Move view down',
+        icon: ArrowDownward,
+        onClick: () => session.moveViewDown(model.id),
+      },
 
-    return items?.length ? (
+      ...((typeof menuItems === 'function' ? menuItems() : menuItems) || []),
+    ]
+
+    return (
       <>
         <IconButton
           {...IconButtonProps}
-          style={{ padding: 3 }}
           onClick={event => setAnchorEl(event.currentTarget)}
           data-testid="view_menu_icon"
         >
@@ -88,10 +104,10 @@ const ViewMenu = observer(
             setAnchorEl(undefined)
           }}
           onClose={() => setAnchorEl(undefined)}
-          menuItems={model.menuItems()}
+          menuItems={items}
         />
       </>
-    ) : null
+    )
   },
 )
 const ViewContainer = observer(

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -71,19 +71,23 @@ const ViewMenu = observer(
     const { menuItems } = model
     const session = getSession(model)
 
-    // <=1.3.3 didn't use a function
     const items = [
-      {
-        label: 'Move view up',
-        icon: ArrowUpward,
-        onClick: () => session.moveViewUp(model.id),
-      },
-      {
-        label: 'Move view down',
-        icon: ArrowDownward,
-        onClick: () => session.moveViewDown(model.id),
-      },
+      ...(session.views.length > 1
+        ? [
+            {
+              label: 'Move view up',
+              icon: ArrowUpward,
+              onClick: () => session.moveViewUp(model.id),
+            },
+            {
+              label: 'Move view down',
+              icon: ArrowDownward,
+              onClick: () => session.moveViewDown(model.id),
+            },
+          ]
+        : []),
 
+      // <=1.3.3 didn't use a function, so check as value also
       ...((typeof menuItems === 'function' ? menuItems() : menuItems) || []),
     ]
 

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -8,13 +8,14 @@ import {
   useTheme,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import { alpha } from '@mui/material/styles'
 import { observer } from 'mobx-react'
 import { isAlive } from 'mobx-state-tree'
 import useMeasure from 'react-use-measure'
 
 // icons
 import CloseIcon from '@mui/icons-material/Close'
+import MinimizeIcon from '@mui/icons-material/Minimize'
+import AddIcon from '@mui/icons-material/Add'
 import MenuIcon from '@mui/icons-material/Menu'
 
 // locals
@@ -33,17 +34,6 @@ const useStyles = makeStyles()(theme => ({
   },
   grow: {
     flexGrow: 1,
-  },
-  iconRoot: {
-    '&:hover': {
-      backgroundColor: alpha(
-        theme.palette.secondary.contrastText,
-        theme.palette.action.hoverOpacity,
-      ),
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
-      },
-    },
   },
 
   input: {
@@ -71,7 +61,7 @@ const ViewMenu = observer(
     IconProps,
   }: {
     model: IBaseViewModel
-    IconButtonProps: IconButtonPropsType
+    IconButtonProps?: IconButtonPropsType
     IconProps: SvgIconProps
   }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement>()
@@ -87,7 +77,6 @@ const ViewMenu = observer(
           style={{ padding: 3 }}
           onClick={event => setAnchorEl(event.currentTarget)}
           data-testid="view_menu_icon"
-          size="small"
         >
           <MenuIcon {...IconProps} fontSize="small" />
         </IconButton>
@@ -109,11 +98,13 @@ const ViewContainer = observer(
   ({
     view,
     onClose,
+    onMinimize,
     style,
     children,
   }: {
     view: IBaseViewModel
     onClose: () => void
+    onMinimize: () => void
     style?: React.CSSProperties
     children: React.ReactNode
   }) => {
@@ -145,22 +136,15 @@ const ViewContainer = observer(
         style={{ ...style, padding: `0px ${padWidth} ${padWidth}` }}
       >
         <div ref={scrollRef} style={{ display: 'flex' }}>
-          <ViewMenu
-            model={view}
-            IconButtonProps={{
-              classes: { root: classes.iconRoot },
-              edge: 'start',
-            }}
-            IconProps={{ className: classes.icon }}
-          />
+          <ViewMenu model={view} IconProps={{ className: classes.icon }} />
           <div className={classes.grow} />
           <Tooltip title="Rename view" arrow>
             <EditableTypography
               value={
-                view.displayName ||
-                // @ts-ignore
-                view.assemblyNames?.join(',') ||
-                'Untitled view'
+                (view.displayName ||
+                  // @ts-ignore
+                  view.assemblyNames?.join(',') ||
+                  'Untitled view') + (view.minimized ? ' (minimized)' : '')
               }
               setValue={val => view.setDisplayName(val)}
               variant="body2"
@@ -173,13 +157,14 @@ const ViewContainer = observer(
             />
           </Tooltip>
           <div className={classes.grow} />
-          <IconButton
-            data-testid="close_view"
-            classes={{ root: classes.iconRoot }}
-            edge="end"
-            size="small"
-            onClick={onClose}
-          >
+          <IconButton data-testid="minimize_view" onClick={onMinimize}>
+            {view.minimized ? (
+              <AddIcon className={classes.icon} fontSize="small" />
+            ) : (
+              <MinimizeIcon className={classes.icon} fontSize="small" />
+            )}
+          </IconButton>
+          <IconButton data-testid="close_view" onClick={onClose}>
             <CloseIcon className={classes.icon} fontSize="small" />
           </IconButton>
         </div>

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -234,7 +234,9 @@ export interface AbstractViewModel {
   id: string
   type: string
   width: number
+  minimized: boolean
   setWidth(width: number): void
+  setMinimized(flag: boolean): void
   displayName: string | undefined
   setDisplayName: (arg: string) => void
   menuItems: () => MenuItem[]

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -93,6 +93,7 @@ function TrackContainer({
   const trackId = getConf(track, 'trackId')
   const ref = useRef(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
+  const minimized = track.minimized
   const debouncedOnDragEnter = useDebouncedCallback(() => {
     if (isAlive(display) && dimmed) {
       moveTrack(draggingTrackId, track.id)
@@ -123,27 +124,31 @@ function TrackContainer({
           onDragEnter={debouncedOnDragEnter}
           data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
         >
-          <div
-            ref={ref}
-            className={classes.renderingComponentContainer}
-            style={{ transform: `scaleX(${model.scaleFactor})` }}
-          >
-            <RenderingComponent
-              model={display}
-              onHorizontalScroll={horizontalScroll}
-            />
-          </div>
+          {!minimized ? (
+            <>
+              <div
+                ref={ref}
+                className={classes.renderingComponentContainer}
+                style={{ transform: `scaleX(${model.scaleFactor})` }}
+              >
+                <RenderingComponent
+                  model={display}
+                  onHorizontalScroll={horizontalScroll}
+                />
+              </div>
 
-          {DisplayBlurb ? (
-            <div
-              style={{
-                position: 'absolute',
-                left: 0,
-                top: display.height - 20,
-              }}
-            >
-              <DisplayBlurb model={display} />
-            </div>
+              {DisplayBlurb ? (
+                <div
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: display.height - 20,
+                  }}
+                >
+                  <DisplayBlurb model={display} />
+                </div>
+              ) : null}
+            </>
           ) : null}
         </div>
       </ErrorBoundary>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -117,10 +117,8 @@ function TrackContainer({
       >
         <div
           className={classes.trackRenderingContainer}
-          style={{ height }}
-          onScroll={event =>
-            display.setScrollTop(event.currentTarget.scrollTop)
-          }
+          style={{ height: minimized ? 20 : height }}
+          onScroll={evt => display.setScrollTop(evt.currentTarget.scrollTop)}
           onDragEnter={debouncedOnDragEnter}
           data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
         >

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -18,6 +18,8 @@ import {
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import DragIcon from '@mui/icons-material/DragIndicator'
 import CloseIcon from '@mui/icons-material/Close'
+import MinimizeIcon from '@mui/icons-material/Minimize'
+import AddIcon from '@mui/icons-material/Add'
 
 import { LinearGenomeViewModel } from '..'
 
@@ -64,6 +66,7 @@ const TrackLabel = React.forwardRef<HTMLDivElement, Props>(
     const view = getContainingView(track) as LGV
     const session = getSession(track)
     const trackConf = track.configuration
+    const minimized = track.minimized
     const trackId = getConf(track, 'trackId')
     const trackName = getTrackName(trackConf, session)
 
@@ -103,12 +106,25 @@ const TrackLabel = React.forwardRef<HTMLDivElement, Props>(
         >
           <CloseIcon fontSize="small" />
         </IconButton>
+        <IconButton
+          onClick={() => track.setMinimized(!minimized)}
+          className={classes.iconButton}
+          title={minimized ? 'restore this track' : 'minimize this track'}
+          color="secondary"
+        >
+          {minimized ? (
+            <AddIcon fontSize="small" />
+          ) : (
+            <MinimizeIcon fontSize="small" />
+          )}
+        </IconButton>
+
         <Typography
           variant="body1"
           component="span"
           className={classes.trackName}
         >
-          {trackName}
+          {trackName + (minimized ? ' (minimized)' : '')}
         </Typography>
         <IconButton
           {...bindTrigger(popupState)}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -76,6 +76,11 @@ const TrackLabel = React.forwardRef<HTMLDivElement, Props>(
     })
 
     const items = [
+      {
+        label: minimized ? 'Restore track' : 'Minimize track',
+        icon: minimized ? AddIcon : MinimizeIcon,
+        onClick: () => track.setMinimized(!minimized),
+      },
       ...(session.getTrackActionMenuItems?.(trackConf) || []),
       ...track.trackMenuItems(),
     ].sort((a, b) => (b.priority || 0) - (a.priority || 0))
@@ -105,18 +110,6 @@ const TrackLabel = React.forwardRef<HTMLDivElement, Props>(
           color="secondary"
         >
           <CloseIcon fontSize="small" />
-        </IconButton>
-        <IconButton
-          onClick={() => track.setMinimized(!minimized)}
-          className={classes.iconButton}
-          title={minimized ? 'restore this track' : 'minimize this track'}
-          color="secondary"
-        >
-          {minimized ? (
-            <AddIcon fontSize="small" />
-          ) : (
-            <MinimizeIcon fontSize="small" />
-          )}
         </IconButton>
 
         <Typography

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.tsx
@@ -1061,59 +1061,57 @@ export function stateModelFactory(pluginManager: PluginManager) {
             icon: SyncAltIcon,
             onClick: self.horizontallyFlip,
           },
-          { type: 'divider' },
           {
-            label: 'Show all regions in assembly',
+            label: 'Show...',
             icon: VisibilityIcon,
-            onClick: self.showAllRegionsInAssembly,
+            subMenu: [
+              {
+                label: 'Show all regions in assembly',
+                onClick: self.showAllRegionsInAssembly,
+              },
+              {
+                label: 'Show center line',
+                type: 'checkbox',
+                checked: self.showCenterLine,
+                onClick: self.toggleCenterLine,
+              },
+              {
+                label: 'Show header',
+                type: 'checkbox',
+                checked: !self.hideHeader,
+                onClick: self.toggleHeader,
+              },
+              {
+                label: 'Show header overview',
+                type: 'checkbox',
+                checked: !self.hideHeaderOverview,
+                onClick: self.toggleHeaderOverview,
+                disabled: self.hideHeader,
+              },
+              {
+                label: 'Show no tracks active button',
+                type: 'checkbox',
+                checked: !self.hideNoTracksActive,
+                onClick: self.toggleNoTracksActive,
+              },
+              {
+                label: 'Show guidelines',
+                type: 'checkbox',
+                checked: self.showGridlines,
+                onClick: self.toggleShowGridlines,
+              },
+              ...(canShowCytobands
+                ? [
+                    {
+                      label: 'Show ideogram',
+                      type: 'checkbox' as const,
+                      checked: self.showCytobands,
+                      onClick: () => self.setShowCytobands(!showCytobands),
+                    },
+                  ]
+                : []),
+            ],
           },
-          {
-            label: 'Show center line',
-            icon: VisibilityIcon,
-            type: 'checkbox',
-            checked: self.showCenterLine,
-            onClick: self.toggleCenterLine,
-          },
-          {
-            label: 'Show header',
-            icon: VisibilityIcon,
-            type: 'checkbox',
-            checked: !self.hideHeader,
-            onClick: self.toggleHeader,
-          },
-          {
-            label: 'Show header overview',
-            icon: VisibilityIcon,
-            type: 'checkbox',
-            checked: !self.hideHeaderOverview,
-            onClick: self.toggleHeaderOverview,
-            disabled: self.hideHeader,
-          },
-          {
-            label: 'Show no tracks active button',
-            icon: VisibilityIcon,
-            type: 'checkbox',
-            checked: !self.hideNoTracksActive,
-            onClick: self.toggleNoTracksActive,
-          },
-          {
-            label: 'Show guidelines',
-            icon: VisibilityIcon,
-            type: 'checkbox',
-            checked: self.showGridlines,
-            onClick: self.toggleShowGridlines,
-          },
-          ...(canShowCytobands
-            ? [
-                {
-                  label: 'Show ideogram',
-                  icon: VisibilityIcon,
-                  type: 'checkbox' as const,
-                  checked: self.showCytobands,
-                  onClick: () => self.setShowCytobands(!showCytobands),
-                },
-              ]
-            : []),
           {
             label: 'Track labels',
             icon: LabelIcon,

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -189,6 +189,33 @@ export default function sessionModelFactory(
       },
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
+      moveViewUp(id: string) {
+        const idx = self.views.findIndex(v => v.id === id)
+
+        if (idx === -1) {
+          return
+        }
+        if (idx > 0) {
+          self.views.splice(idx - 1, 2, self.views[idx], self.views[idx - 1])
+        }
+      },
+      /**
+       * #action
+       */
+      moveViewDown(id: string) {
+        const idx = self.views.findIndex(v => v.id === id)
+
+        if (idx === -1) {
+          return
+        }
+
+        if (idx < self.views.length - 1) {
+          self.views.splice(idx, 2, self.views[idx + 1], self.views[idx])
+        }
+      },
       setDrawerPosition(arg: string) {
         self.drawerPosition = arg
         localStorage.setItem('drawerPosition', arg)

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -95,7 +95,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
             "displayId": "volvox_refseq-LinearReferenceSequenceDisplay",
             "type": "LinearReferenceSequenceDisplay",
           },
-          Object {
+          {
             "displayId": "volvox_refseq-LinearGCContentDisplay",
             "type": "LinearGCContentDisplay",
           },
@@ -134,7 +134,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
             "displayId": "volvox_refseq2-LinearReferenceSequenceDisplay",
             "type": "LinearReferenceSequenceDisplay",
           },
-          Object {
+          {
             "displayId": "volvox_refseq2-LinearGCContentDisplay",
             "type": "LinearGCContentDisplay",
           },
@@ -166,7 +166,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
             "displayId": "volvox_refseq404-LinearReferenceSequenceDisplay",
             "type": "LinearReferenceSequenceDisplay",
           },
-          Object {
+          {
             "displayId": "volvox_refseq404-LinearGCContentDisplay",
             "type": "LinearGCContentDisplay",
           },
@@ -204,7 +204,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
             "displayId": "volvox_del-ReferenceSequenceTrack-LinearReferenceSequenceDisplay",
             "type": "LinearReferenceSequenceDisplay",
           },
-          Object {
+          {
             "displayId": "volvox_del-ReferenceSequenceTrack-LinearGCContentDisplay",
             "type": "LinearGCContentDisplay",
           },
@@ -242,7 +242,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
             "displayId": "volvox_ins-ReferenceSequenceTrack-LinearReferenceSequenceDisplay",
             "type": "LinearReferenceSequenceDisplay",
           },
-          Object {
+          {
             "displayId": "volvox_ins-ReferenceSequenceTrack-LinearGCContentDisplay",
             "type": "LinearGCContentDisplay",
           },

--- a/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/rootModel.test.js.snap
@@ -389,7 +389,7 @@ exports[`Root MST model adds track and connection configs to an assembly 1`] = `
         "displayId": "sequenceConfigId-LinearReferenceSequenceDisplay",
         "type": "LinearReferenceSequenceDisplay",
       },
-      Object {
+      {
         "displayId": "sequenceConfigId-LinearGCContentDisplay",
         "type": "LinearGCContentDisplay",
       },

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -343,6 +343,27 @@ export default function sessionModelFactory(
       },
     }))
     .actions(self => ({
+      moveViewUp(id: string) {
+        const idx = self.views.findIndex(v => v.id === id)
+
+        if (idx === -1) {
+          return
+        }
+        if (idx > 0) {
+          self.views.splice(idx - 1, 2, self.views[idx], self.views[idx - 1])
+        }
+      },
+      moveViewDown(id: string) {
+        const idx = self.views.findIndex(v => v.id === id)
+
+        if (idx === -1) {
+          return
+        }
+
+        if (idx < self.views.length - 1) {
+          self.views.splice(idx, 2, self.views[idx + 1], self.views[idx])
+        }
+      },
       /**
        * #action
        */

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -343,6 +343,9 @@ export default function sessionModelFactory(
       },
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
       moveViewUp(id: string) {
         const idx = self.views.findIndex(v => v.id === id)
 
@@ -353,6 +356,9 @@ export default function sessionModelFactory(
           self.views.splice(idx - 1, 2, self.views[idx], self.views[idx - 1])
         }
       },
+      /**
+       * #action
+       */
       moveViewDown(id: string) {
         const idx = self.views.findIndex(v => v.id === id)
 

--- a/website/docs/config/BamAdapter.md
+++ b/website/docs/config/BamAdapter.md
@@ -50,7 +50,7 @@ location: {
 fetchSizeLimit: {
       type: 'number',
       description:
-        'used to determine when to display a warning to the user that too much data will be fetched',
+        'size to fetch in bytes over which to display a warning to the user that too much data will be fetched',
       defaultValue: 5_000_000,
     }
 ```

--- a/website/docs/config/CramAdapter.md
+++ b/website/docs/config/CramAdapter.md
@@ -19,7 +19,7 @@ used to configure CRAM adapter
 fetchSizeLimit: {
       type: 'number',
       description:
-        'used to determine when to display a warning to the user that too much data will be fetched',
+        'size in bytes over which to display a warning to the user that too much data will be fetched',
       defaultValue: 3_000_000,
     }
 ```
@@ -56,8 +56,7 @@ currently needs to be manually added
 ```js
 sequenceAdapter: {
       type: 'frozen',
-      description:
-        'sequence data adapter, used to calculate SNPs when BAM reads lacking MD tags',
+      description: 'sequence data adapter',
       defaultValue: null,
     }
 ```

--- a/website/docs/config/LinearGCContentDisplay.md
+++ b/website/docs/config/LinearGCContentDisplay.md
@@ -1,6 +1,6 @@
 ---
-id: lgvsyntenydisplay
-title: LGVSyntenyDisplay
+id: lineargccontentdisplay
+title: LinearGCContentDisplay
 toplevel: true
 ---
 
@@ -8,9 +8,3 @@ Note: this document is automatically generated from configuration objects in
 our source code. See [Config guide](/docs/config_guide) for more info
 
 ## Docs
-
-## LGVSyntenyDisplay - Derives from
-
-```js
-baseConfiguration: linearPileupDisplayConfigSchemaFactory(pluginManager)
-```

--- a/website/docs/config/OAuthInternetAccount.md
+++ b/website/docs/config/OAuthInternetAccount.md
@@ -71,6 +71,16 @@ scopes: {
     }
 ```
 
+#### slot: state
+
+```js
+state: {
+      description: 'optional state for the authorization call',
+      type: 'string',
+      defaultValue: '',
+    }
+```
+
 #### slot: responseType
 
 ```js

--- a/website/docs/config/SNPCoverageAdapter.md
+++ b/website/docs/config/SNPCoverageAdapter.md
@@ -16,5 +16,8 @@ our source code. See [Config guide](/docs/config_guide) for more info
 normally refers to a BAM or CRAM adapter
 
 ```js
-subadapter: pluginManager.pluggableConfigSchemaType('adapter')
+subadapter: {
+      type: 'frozen',
+      defaultValue: null,
+    }
 ```

--- a/website/docs/models/Base1DView.md
+++ b/website/docs/models/Base1DView.md
@@ -10,6 +10,9 @@ elements](/docs/developer_guide/) for more info
 
 ## Docs
 
+used in non-lgv view representations of a 1d view e.g. the two axes of the
+dotplot use this
+
 ### Base1DView - Properties
 
 #### property: id

--- a/website/docs/models/BaseTrackModel.md
+++ b/website/docs/models/BaseTrackModel.md
@@ -1,0 +1,157 @@
+---
+id: basetrackmodel
+title: BaseTrackModel
+toplevel: true
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See [Core concepts and intro to pluggable
+elements](/docs/developer_guide/) for more info
+
+## Docs
+
+these MST models only exist for tracks that are _shown_.
+they should contain only UI state for the track, and have
+a reference to a track configuration (stored under
+session.configuration.assemblies.get(assemblyName).tracks).
+note that multiple displayed tracks could use the same
+configuration.
+
+### BaseTrackModel - Properties
+
+#### property: id
+
+```js
+// type signature
+IOptionalIType<ISimpleType<string>, [undefined]>
+// code
+id: ElementId
+```
+
+#### property: type
+
+```js
+// type signature
+ISimpleType<string>
+// code
+type: types.literal(trackType)
+```
+
+#### property: configuration
+
+```js
+// type signature
+ITypeUnion<any, any, any>
+// code
+configuration: ConfigurationReference(baseTrackConfig)
+```
+
+#### property: minimized
+
+```js
+// type signature
+false
+// code
+minimized: false
+```
+
+#### property: displays
+
+```js
+// type signature
+IArrayType<IAnyType>
+// code
+displays: types.array(pm.pluggableMstType('display', 'stateModel'))
+```
+
+### BaseTrackModel - Getters
+
+#### getter: rpcSessionId
+
+determines which webworker to send the track to, currently based on trackId
+
+```js
+// type
+any
+```
+
+#### getter: name
+
+```js
+// type
+any
+```
+
+#### getter: textSearchAdapter
+
+```js
+// type
+any
+```
+
+#### getter: adapterType
+
+```js
+// type
+AdapterType
+```
+
+#### getter: viewMenuActions
+
+```js
+// type
+MenuItem[]
+```
+
+#### getter: canConfigure
+
+```js
+// type
+any
+```
+
+### BaseTrackModel - Methods
+
+#### method: trackMenuItems
+
+```js
+// type signature
+trackMenuItems: () => MenuItem[]
+```
+
+### BaseTrackModel - Actions
+
+#### action: setMinimized
+
+```js
+// type signature
+setMinimized: (flag: boolean) => void
+```
+
+#### action: activateConfigurationUI
+
+```js
+// type signature
+activateConfigurationUI: () => void
+```
+
+#### action: showDisplay
+
+```js
+// type signature
+showDisplay: (displayId: string, initialSnapshot?: {}) => void
+```
+
+#### action: hideDisplay
+
+```js
+// type signature
+hideDisplay: (displayId: string) => number
+```
+
+#### action: replaceDisplay
+
+```js
+// type signature
+replaceDisplay: (oldId: string, newId: string, initialSnapshot?: {}) => void
+```

--- a/website/docs/models/BaseViewModel.md
+++ b/website/docs/models/BaseViewModel.md
@@ -21,114 +21,64 @@ IOptionalIType<ISimpleType<string>, [undefined]>
 id: ElementId
 ```
 
-#### property: type
+#### property: displayName
+
+displayName is displayed in the header of the view, or assembly names
+being used if none is specified
 
 ```js
 // type signature
-ISimpleType<string>
+IMaybe<ISimpleType<string>>
 // code
-type: types.literal(trackType)
+displayName: types.maybe(types.string)
 ```
 
-#### property: configuration
+#### property: minimized
 
 ```js
 // type signature
-ITypeUnion<any, any, any>
+false
 // code
-configuration: ConfigurationReference(baseTrackConfig)
-```
-
-#### property: displays
-
-```js
-// type signature
-IArrayType<IAnyType>
-// code
-displays: types.array(pm.pluggableMstType('display', 'stateModel'))
+minimized: false
 ```
 
 ### BaseViewModel - Getters
 
-#### getter: rpcSessionId
-
-decides how to assign tracks to rpc, by default uses the trackId
+#### getter: menuItems
 
 ```js
 // type
-any
-```
-
-#### getter: name
-
-```js
-// type
-any
-```
-
-#### getter: textSearchAdapter
-
-```js
-// type
-any
-```
-
-#### getter: adapterType
-
-```js
-// type
-AdapterType
-```
-
-#### getter: viewMenuActions
-
-```js
-// type
-MenuItem[]
-```
-
-#### getter: canConfigure
-
-```js
-// type
-any
-```
-
-### BaseViewModel - Methods
-
-#### method: trackMenuItems
-
-```js
-// type signature
-trackMenuItems: () => MenuItem[]
+() => MenuItem[]
 ```
 
 ### BaseViewModel - Actions
 
-#### action: s
+#### action: setDisplayName
 
 ```js
 // type signature
-s: () => void
+setDisplayName: (name: string) => void
 ```
 
-#### action: s
+#### action: setWidth
+
+width is an important attribute of the view model, when it becomes set, it
+often indicates when the app can start drawing to it. certain views like
+lgv are strict about this because if it tries to draw before it knows the
+width it should draw to, it may start fetching data for regions it doesn't
+need to
+
+setWidth is updated by a ResizeObserver generally, the views often need
+to know how wide they are to properly draw genomic regions
 
 ```js
 // type signature
-s: (displayId: string, initialSnapshot?: {}) => void
+setWidth: (newWidth: number) => void
 ```
 
-#### action: s
+#### action: setMinimized
 
 ```js
 // type signature
-s: (displayId: string) => number
-```
-
-#### action: s
-
-```js
-// type signature
-s: (oldId: string, newId: string, initialSnapshot?: {}) => void
+setMinimized: (flag: boolean) => void
 ```

--- a/website/docs/models/DotplotView.md
+++ b/website/docs/models/DotplotView.md
@@ -142,7 +142,7 @@ cursorMode: 'crosshair'
 
 ```js
 // type signature
-IArrayType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<string>; configuration: ITypeUnion<any, any, any>; displays: IArrayType<...>; }, { ...; } & ... 1 more ... & { ...; }, _NotCustomized, _NotCustomized>>
+IArrayType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; type: ISimpleType<string>; configuration: ITypeUnion<any, any, any>; minimized: IType<...>; displays: IArrayType<...>; }, { ...; } & ... 1 more ... & { ...; }, _NotCustomized, _NotCustomized>>
 // code
 tracks: types.array(
           pm.pluggableMstType('track', 'stateModel') as BaseTrackStateModel,

--- a/website/docs/models/JBrowseWebSessionModel.md
+++ b/website/docs/models/JBrowseWebSessionModel.md
@@ -329,6 +329,20 @@ getTrackActionMenuItems: (config: { [x: string]: any; } & NonEmptyObject & { set
 
 ### JBrowseWebSessionModel - Actions
 
+#### action: moveViewUp
+
+```js
+// type signature
+moveViewUp: (id: string) => void
+```
+
+#### action: moveViewDown
+
+```js
+// type signature
+moveViewDown: (id: string) => void
+```
+
 #### action: setDrawerPosition
 
 ```js

--- a/website/docs/models/LGVSyntenyDisplay.md
+++ b/website/docs/models/LGVSyntenyDisplay.md
@@ -10,7 +10,7 @@ elements](/docs/developer_guide/) for more info
 
 ## Docs
 
-extends `LinearBasicDisplay`, displays location of "synteny" features in a
+extends `LinearBasicDisplay`, displays location of "synteny" featur in a
 plain LGV, allowing linking out to external synteny views
 
 ### LGVSyntenyDisplay - Properties

--- a/website/docs/models/LinearComparativeDisplay.md
+++ b/website/docs/models/LinearComparativeDisplay.md
@@ -81,7 +81,7 @@ controlled by a reaction
 
 ```js
 // type signature
-setRendered: (args: { data: any; reactElement: React.ReactElement; renderingComponent: React.Component; }) => void
+setRendered: (args?: { data: unknown; reactElement: React.ReactElement; renderingComponent: React.Component; }) => void
 ```
 
 #### action: setError

--- a/website/docs/models/LinearComparativeView.md
+++ b/website/docs/models/LinearComparativeView.md
@@ -101,7 +101,7 @@ currently this is limited to an array of two
 
 ```js
 // type signature
-IArrayType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; } & { id: IOptionalIType<ISimpleType<string>, [...]>; ... 12 more ...; showGridlines: IType<...>; }, { ...; } & ... 14 more ... & { ...; }, _NotCustomized, _NotCustomized>>
+IArrayType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; minimized: IType<boolean, boolean, boolean>; } & { ...; }, { ...; } & ... 14 more ... & { ...; }, _NotCustomized, _NotCustomized>>
 // code
 views: types.array(
           pluginManager.getViewType('LinearGenomeView')
@@ -190,14 +190,14 @@ setHeight: (newHeight: number) => void
 
 ```js
 // type signature
-setViews: (views: ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; } & { id: IOptionalIType<ISimpleType<string>, [...]>; ... 12 more ...; showGridlines: IType<...>; }>>[]) => void
+setViews: (views: ModelCreationType<ExtractCFromProps<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; minimized: IType<boolean, boolean, boolean>; } & { ...; }>>[]) => void
 ```
 
 #### action: removeView
 
 ```js
 // type signature
-removeView: (view: { id: string; displayName: string; type: "LinearGenomeView"; offsetPx: number; bpPerPx: number; displayedRegions: IMSTArray<IModelType<{ refName: ISimpleType<string>; start: ISimpleType<number>; end: ISimpleType<...>; reversed: IOptionalIType<...>; } & { ...; }, { ...; }, _NotCustomized, _NotCustomized>> & IS...
+removeView: (view: { id: string; displayName: string; minimized: boolean; type: string; offsetPx: number; bpPerPx: number; displayedRegions: IMSTArray<IModelType<{ refName: ISimpleType<string>; start: ISimpleType<number>; end: ISimpleType<...>; reversed: IOptionalIType<...>; } & { ...; }, { ...; }, _NotCustomized, _NotCustomize...
 ```
 
 #### action: closeView

--- a/website/docs/models/LinearGenomeView.md
+++ b/website/docs/models/LinearGenomeView.md
@@ -23,11 +23,15 @@ id: ElementId
 
 #### property: type
 
+this is a string instead of the const literal 'LinearGenomeView' to reduce some
+typescripting strictness, but you should pass the string 'LinearGenomeView' to
+the model explicitly
+
 ```js
 // type signature
-ISimpleType<"LinearGenomeView">
+string
 // code
-type: types.literal('LinearGenomeView')
+type: types.literal('LinearGenomeView') as unknown as string
 ```
 
 #### property: offsetPx

--- a/website/docs/models/LinearPileupDisplay.md
+++ b/website/docs/models/LinearPileupDisplay.md
@@ -10,6 +10,8 @@ elements](/docs/developer_guide/) for more info
 
 ## Docs
 
+extends `BaseLinearDisplay`
+
 ### LinearPileupDisplay - Properties
 
 #### property: type
@@ -116,6 +118,25 @@ colorBy: types.maybe(
         )
 ```
 
+#### property: filterBy
+
+```js
+// type signature
+IOptionalIType<IModelType<{ flagInclude: IOptionalIType<ISimpleType<number>, [undefined]>; flagExclude: IOptionalIType<ISimpleType<number>, [undefined]>; readName: IMaybe<...>; tagFilter: IMaybe<...>; }, {}, _NotCustomized, _NotCustomized>, [...]>
+// code
+filterBy: types.optional(
+          types.model({
+            flagInclude: types.optional(types.number, 0),
+            flagExclude: types.optional(types.number, 1540),
+            readName: types.maybe(types.string),
+            tagFilter: types.maybe(
+              types.model({ tag: types.string, value: types.string }),
+            ),
+          }),
+          {},
+        )
+```
+
 ### LinearPileupDisplay - Getters
 
 #### getter: maxHeight
@@ -197,6 +218,13 @@ trackMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMe
 ```js
 // type signature
 setReady: (flag: boolean) => void
+```
+
+#### action: setCurrSortBpPerPx
+
+```js
+// type signature
+setCurrSortBpPerPx: (n: number) => void
 ```
 
 #### action: setMaxHeight

--- a/website/docs/models/LinearSyntenyDisplay.md
+++ b/website/docs/models/LinearSyntenyDisplay.md
@@ -63,5 +63,5 @@ string[]
 
 ```js
 // type signature
-renderProps: () => { rpcDriverName: string; displayModel: { id: string; type: never; rpcDriverName: string; configuration: any; height: number; } & NonEmptyObject & { rendererTypeName: string; error: unknown; } & ... 5 more ... & IStateTreeNode<...>; config: any; width: number; height: number; }
+renderProps: () => { rpcDriverName: string; displayModel: { id: string; type: never; rpcDriverName: string; configuration: any; height: number; } & NonEmptyObject & { rendererTypeName: string; error: unknown; } & ... 6 more ... & IStateTreeNode<...>; config: any; width: number; height: number; }
 ```


### PR DESCRIPTION
This adds the ability to toggle a "minimize" a track. The track is then not visible. This can be useful because closing a track or view loses it's state entirely, while minimizing will keep it the track state available

The text "(minimized)" is appended to track labels when this state is enabled


Fixes https://github.com/GMOD/jbrowse-components/issues/2531
Fixes https://github.com/GMOD/jbrowse-components/issues/2107
Fixes #535

![Screenshot from 2022-11-15 09-12-54](https://user-images.githubusercontent.com/6511937/201969774-5fd3297d-ba94-4164-82b3-8896275e66a7.png)
