### PR TITLE
Add sequenceAdapter to CramAdapter example

### DIFF
--- a/website/docs/config_guides/alignments_track.md
+++ b/website/docs/config_guides/alignments_track.md
@@ -53,6 +53,7 @@ Example `BamAdapter` config:
 
 - `cramLocation` - a 'file location' for the CRAM
 - `craiLocation` - a 'file location' for the CRAI
+- `sequenceAdapter` - a subadapter describing the location of the reference assembly (*e.g.* an [IndexedFastaAdapter](/docs/config_guides/assemblies/#IndexedFastaAdapter))
 
 Example `CramAdapter` config:
 
@@ -64,6 +65,17 @@ Example `CramAdapter` config:
   },
   "craiLocation": {
     "uri": "http://yourhost/file.cram.crai"
+  },
+  "sequenceAdapter" : {
+    "type": "IndexedFastaAdapter",
+    "fastaLocation": {
+      "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa",
+      "locationType": "UriLocation"
+    },
+    "faiLocation": {
+      "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.fai",
+      "locationType": "UriLocation"
+    }
   }
 }
 ```


### PR DESCRIPTION
Following the CRAM example as given caused our JBrowse component to fail with: "could not determine adapter type from adapter config snapshot". Page 61 of [the JB2 config spec](https://jbrowse.org/jb2/jbrowse2.pdf) has the following guidance:

> CramAdapter- This adapter uses the @gmod/cram NPM module. Note that CramAdapter also takes a sequenceAdapter as a subadapter configuration, and uses getSubAdapter to instantiate it

This PR updates the example to include a sequenceAdapter.