### PR TITLE
Retain feature labels in compact display mode for SVG features, and allow turning off keeping feature description without feature label

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -60,7 +60,7 @@ function RenderedFeatureGlyph(props: {
   const { reversed } = region
   const start = feature.get(reversed ? 'end' : 'start')
   const startPx = bpToPx(start, region, bpPerPx)
-  const labelsAllowed = displayMode !== 'compact' && displayMode !== 'collapsed'
+  const labelAllowed = displayMode !== 'collapsed'
 
   const rootLayout = new SceneGraph('root', 0, 0, 0, 0)
   const GlyphComponent = chooseGlyphComponent(feature, extraGlyphs)
@@ -78,7 +78,7 @@ function RenderedFeatureGlyph(props: {
   let description = ''
   let fontHeight = 0
   let expansion = 0
-  if (labelsAllowed) {
+  if (labelAllowed) {
     const showLabels = readConfObject(config, 'showLabels')
     const showDescriptions = readConfObject(config, 'showDescriptions')
     fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature })
@@ -95,8 +95,7 @@ function RenderedFeatureGlyph(props: {
     description = String(
       readConfObject(config, ['labels', 'description'], { feature }) || '',
     )
-    shouldShowDescription =
-      /\S/.test(description) && showLabels && showDescriptions
+    shouldShowDescription = /\S/.test(description) && showDescriptions
 
     if (shouldShowName) {
       rootLayout.addChild(

--- a/plugins/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.tsx.snap
+++ b/plugins/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`no features 1`] = `
 exports[`one feature (compact mode) 1`] = `
 <svg
   data-testid="svgfeatures"
-  height="105"
+  height="120"
   width="333.3333333333333"
 >
   <g>
@@ -202,6 +202,14 @@ exports[`one feature (compact mode) 1`] = `
       points="3251.5333333333333,0,3251.5333333333333,5,3255.0333333333333,2.5"
       stroke="black"
     />
+    <text
+      fill="black"
+      font-size="13"
+      x="1991.7"
+      y="20"
+    >
+      au9.g1002.t1
+    </text>
   </g>
 </svg>
 `;


### PR DESCRIPTION
Example, with our "Gencode" gene track:

by default the gene "label" is it's ENCODE ID, and the description is it's "gene symbol". if I was an end user and it was configured this way, it would be difficult on current main to make it so that it just displays the gene symbol. Also, displaying in a compact mode, with the gene labels still displayed, I think is useful. This PR accomplishes both changes

Example screenshot, which is fairly easy to setup after this change

![Screenshot from 2022-11-23 11-44-58](https://user-images.githubusercontent.com/6511937/203602342-d3510115-55f9-464b-968e-433305258527.png)
