### PR TITLE
Fix rendering and clicking synteny features when using MainThreadRpc

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -254,7 +254,12 @@ function LinearSyntenyRendering({
     () =>
       features.map(level =>
         level
-          .map(f => new SimpleFeature(f))
+          .map(
+            f =>
+              (typeof f.id === 'function'
+                ? f
+                : new SimpleFeature(f)) as Feature,
+          )
           .sort((a, b) => a.get('syntenyId') - b.get('syntenyId')),
       ),
     [features],


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/3376

Basically it trying to pass a SimpleFeature as argument to the SimpleFeature constructor instead of a SimpleFeatureSerialized due to a confusing about hydration.

It might be that a follow up could refactor LinearSyntenyRendering to not use server side rendering, because it doesn't actually benefit from this at all (it just makes a blank react component in the web worker but all the drawing is done on the main thread). That basically means it could just use a RPC call to fetch the features instead and be conceptually simpler