### PR TITLE
Fix issue where snackbar would not show up when same error message is triggered multiple times

### DIFF
--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Alert, Button, IconButton, Snackbar } from '@mui/material'
-import CloseIcon from '@mui/icons-material/Close'
 import { observer } from 'mobx-react'
 import { IAnyStateTreeNode } from 'mobx-state-tree'
+
+// icons
+import CloseIcon from '@mui/icons-material/Close'
+
+// locals
 import { AbstractSessionModel, NotificationLevel, SnackAction } from '../util'
 
 type SnackbarMessage = [string, NotificationLevel, SnackAction]
@@ -17,49 +21,23 @@ function MessageSnackbar({
 }: {
   session: SnackbarSession & IAnyStateTreeNode
 }) {
-  const [open, setOpen] = useState(false)
-  const [snackbarMessage, setSnackbarMessage] = useState<SnackbarMessage>()
-
   const { popSnackbarMessage, snackbarMessages } = session
 
   const latestMessage = snackbarMessages.length
     ? snackbarMessages[snackbarMessages.length - 1]
     : null
 
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>
-
-    if (snackbarMessage) {
-      if (!latestMessage) {
-        setSnackbarMessage(undefined)
-      } else if (snackbarMessage[0] !== latestMessage[0]) {
-        setOpen(false)
-        timeoutId = setTimeout(() => {
-          setSnackbarMessage(latestMessage)
-          setOpen(true)
-        }, 100)
-      }
-    } else if (latestMessage) {
-      setSnackbarMessage(latestMessage)
-      setOpen(true)
-    }
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [latestMessage, snackbarMessage])
-
   const handleClose = (_event: unknown, reason?: string) => {
     if (reason === 'clickaway') {
       return
     }
     popSnackbarMessage()
-    setOpen(false)
   }
-  const [message, level, action] = snackbarMessage || []
+  const open = !!latestMessage
+  const [message, level, action] = latestMessage || []
   return (
     <Snackbar
-      open={open && !!message}
+      open={open}
       onClose={handleClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     >
@@ -77,11 +55,7 @@ function MessageSnackbar({
               >
                 {action.name}
               </Button>
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                onClick={handleClose}
-              >
+              <IconButton color="inherit" onClick={handleClose}>
                 <CloseIcon />
               </IconButton>
             </>


### PR DESCRIPTION
I found that if you trigger the same snackbar error e.g. two times, then close the snackbar, then trigger it again a third time, the snackbar will not show up.

Found debugging #3388 

This fixes the issue by always showing the last message on the snackbar stack. It avoids tricky React state+mobx-state-tree state conflicts by removing all react hooks from method

