### PR TITLE
Simplify RPC watchWorker

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -43,22 +43,13 @@ export async function watchWorker(
   rpcDriverClassName: string,
 ) {
   // after first ping succeeds, apply wait for timeout
-  return new Promise((_resolve, reject) => {
-    function delay() {
-      setTimeout(async () => {
-        try {
-          await worker.call('ping', [], {
-            timeout: pingTime * 2,
-            rpcDriverClassName,
-          })
-          delay()
-        } catch (e) {
-          reject(e)
-        }
-      }, pingTime)
-    }
-    delay()
-  })
+  while (true) {
+    await worker.call('ping', [], {
+      timeout: pingTime * 2,
+      rpcDriverClassName,
+    })
+    await new Promise(resolve => setTimeout(resolve, pingTime))
+  }
 }
 
 function detectHardwareConcurrency() {


### PR DESCRIPTION
Possible code simplification for the watchWorker RPC

Currently if this fails, it can produce a large stack trace due to the recursion. It's not very obscured by doing so, but seemed sort of awkward so I changed it into a while loop and the code seemed simpler anyways