### PR TITLE
Remove y-scalebar rendering placeholder values in blank and loading states

### DIFF
--- a/plugins/wiggle/src/BigWigAdapter/__snapshots__/BigWigAdapter.test.ts.snap
+++ b/plugins/wiggle/src/BigWigAdapter/__snapshots__/BigWigAdapter.test.ts.snap
@@ -15,12 +15,12 @@ exports[`adapter can fetch features from volvox.bw adapter can fetch stats from 
 
 exports[`adapter can fetch features from volvox.bw get local stats 1`] = `
 {
-  "basesCovered": 30100,
+  "basesCovered": 30000,
   "featureCount": 30000,
-  "featureDensity": 0.9966777408637874,
+  "featureDensity": 1,
   "scoreMax": 38,
   "scoreMean": 19.297233333333335,
-  "scoreMin": 5,
+  "scoreMin": 0,
   "scoreStdDev": 4.380942680236127,
   "scoreSum": 578917,
   "scoreSumSquares": 11747257,

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { observer } from 'mobx-react'
 import {
   measureText,
   getContainingView,
@@ -9,7 +10,8 @@ import {
   BaseLinearDisplayComponent,
   LinearGenomeViewModel,
 } from '@jbrowse/plugin-linear-genome-view'
-import { observer } from 'mobx-react'
+
+// locals
 import { WiggleDisplayModel } from '../models/model'
 import YScaleBar from './YScaleBar'
 

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -76,7 +76,7 @@ const ScoreLegend = observer(({ model }: { model: WiggleDisplayModel }) => {
   const { ticks, scaleType } = model
   const { width } = getContainingView(model) as LGV
   const legend =
-    `[${ticks.values[0]}-${ticks.values[1]}]` +
+    `[${ticks?.values[0]}-${ticks?.values[1]}]` +
     (scaleType === 'log' ? ' (log scale)' : '')
   const len = measureText(legend, 14)
   const padding = 25

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.tsx
@@ -97,9 +97,8 @@ const stateModelFactory = (
       }),
     )
     .volatile(() => ({
-      statsReady: false,
       message: undefined as undefined | string,
-      stats: { scoreMin: 0, scoreMax: 50 },
+      stats: undefined as { scoreMin: number; scoreMax: number } | undefined,
       statsRegion: undefined as string | undefined,
       statsFetchInProgress: undefined as undefined | AbortController,
       featureUnderMouseVolatile: undefined as Feature | undefined,
@@ -115,12 +114,13 @@ const stateModelFactory = (
       updateStats(stats: { scoreMin: number; scoreMax: number }) {
         const { scoreMin, scoreMax } = stats
         const EPSILON = 0.000001
-        if (
+        if (!self.stats) {
+          self.stats = { scoreMin, scoreMax }
+        } else if (
           Math.abs(self.stats.scoreMax - scoreMax) > EPSILON ||
           Math.abs(self.stats.scoreMin - scoreMin) > EPSILON
         ) {
           self.stats = { scoreMin, scoreMax }
-          self.statsReady = true
         }
       },
       setSources(sources: Source[]) {
@@ -376,6 +376,9 @@ const stateModelFactory = (
         },
         get domain() {
           const { stats, scaleType, minScore, maxScore } = self
+          if (!stats) {
+            return undefined
+          }
           const { scoreMin, scoreMax } = stats
 
           const ret = getNiceDomain({
@@ -440,6 +443,10 @@ const stateModelFactory = (
         const { scaleType, domain, isMultiRow, rowHeight, useMinimalTicks } =
           self
 
+        if (!domain) {
+          return undefined
+        }
+
         const offset = isMultiRow ? 0 : YSCALEBAR_LABEL_OFFSET
         const ticks = axisPropsFromTickScale(
           getScale({
@@ -485,14 +492,14 @@ const stateModelFactory = (
             resolution,
             rpcDriverName,
             scaleOpts,
+            stats,
             sources,
-            statsReady,
             ticks,
             rendererConfig: config,
           } = self
           return {
             ...superProps,
-            notReady: superProps.notReady || !sources || !statsReady,
+            notReady: superProps.notReady || !sources || !stats,
             displayModel: self,
             config,
             displayCrossHatches,
@@ -702,7 +709,7 @@ const stateModelFactory = (
           )
         },
         async renderSvg(opts: ExportSvgOpts) {
-          await when(() => self.statsReady && !!self.regionCannotBeRenderedText)
+          await when(() => !!self.stats && !!self.regionCannotBeRenderedText)
           const { offsetPx } = getContainingView(self) as LGV
           return (
             <>


### PR DESCRIPTION
allows stats to exist in an undefined state, avoids the display of 5e-234 after blank region is viewed and [0-50] when loading https://github.com/GMOD/jbrowse-components/issues/3399

fixes https://github.com/GMOD/jbrowse-components/issues/3399