### PR TITLE
Fix ability to use GC content display on sequence track in Apollo

### DIFF
--- a/plugins/gccontent/src/GCContentAdapter/configSchema.ts
+++ b/plugins/gccontent/src/GCContentAdapter/configSchema.ts
@@ -13,7 +13,10 @@ const GCContentAdapterF = (pluginManager: PluginManager) => {
       /**
        * #slot
        */
-      sequenceAdapter: pluginManager.pluggableConfigSchemaType('adapter'),
+      sequenceAdapter: {
+        type: 'frozen',
+        defaultValue: null,
+      },
     },
     { explicitlyTyped: true },
   )


### PR DESCRIPTION
Possible fix for issue noted here https://github.com/GMOD/Apollo3/issues/174#issuecomment-1350924715

Referring to e.g. adapter pluggable elements from within an adapter is problematic, as it likely is just the adapters registered up until that point. Since Apollo is added after GCContent, this makes it fail validation

Similar things came up in
- The creation of "sub-displays" with the alignments display recently. It is somewhat problematic to do this generically
- Using sequenceAdapter in BAM/CRAM, these were converted to types.frozens. types.late did not work when applied to both BAM and CRAM xref https://github.com/GMOD/jbrowse-components/issues/1165
