### PR TITLE
Fix double-render of some synteny features

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/ComparativeServerSideRendererType.ts
@@ -13,6 +13,7 @@ import ServerSideRenderer, {
 import RpcManager from '../../rpc/RpcManager'
 import { getAdapter } from '../../data_adapters/dataAdapterCache'
 import { BaseFeatureDataAdapter } from '../../data_adapters/BaseAdapter'
+import { dedupe } from '../../util'
 
 export interface RenderArgs extends ServerSideRenderArgs {
   displayModel: {}
@@ -127,12 +128,15 @@ export default class ComparativeServerSideRenderer extends ServerSideRenderer {
     })
 
     // note that getFeaturesInMultipleRegions does not do glyph expansion
-    return (dataAdapter as BaseFeatureDataAdapter)
+    const res = await (dataAdapter as BaseFeatureDataAdapter)
       .getFeaturesInMultipleRegions(requestRegions, renderArgs)
       .pipe(
         filter(f => this.featurePassesFilters(renderArgs, f)),
         toArray(),
       )
       .toPromise()
+
+    // dedupe needed xref https://github.com/GMOD/jbrowse-components/pull/3404/
+    return dedupe(res, f => f.id())
   }
 }

--- a/packages/core/util/dedupe.ts
+++ b/packages/core/util/dedupe.ts
@@ -3,15 +3,15 @@ type Hasher<T> = (input: T) => string
 // from https://github.com/seriousManual/dedupe/blob/master/LICENSE
 export function dedupe<T>(list: T[], hasher: Hasher<T> = JSON.stringify) {
   const clone: T[] = []
-  const lookup: Record<string, boolean> = {}
+  const lookup = new Set<string>()
 
   for (let i = 0; i < list.length; i++) {
     const entry = list[i]
     const hashed = hasher(entry)
 
-    if (!lookup[hashed]) {
+    if (!lookup.has(hashed)) {
       clone.push(entry)
-      lookup[hashed] = true
+      lookup.add(hashed)
     }
   }
 

--- a/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyRenderer/components/LinearSyntenyRendering.tsx
@@ -50,6 +50,13 @@ function px(view: ViewSnap, arg: { refName: string; coord: number }) {
   return r
 }
 
+interface Match {
+  layout: RectTuple
+  feature: Feature
+  level: number
+  refName: string
+}
+
 function drawMatchSimple({
   match,
   ctx,
@@ -61,12 +68,7 @@ function drawMatchSimple({
   height,
   drawCurves,
 }: {
-  match: {
-    layout: RectTuple
-    feature: Feature
-    level: number
-    refName: string
-  }[]
+  match: Match[]
   ctx: CanvasRenderingContext2D
   offsets: number[]
   cb: (ctx: CanvasRenderingContext2D) => void


### PR DESCRIPTION
Fixes  #1794

The 'comparative renderer' getFeatures fetches features from all staticBlocks, and features can overlap multiple static blocks (they could overlap multiple dynamic blocks too, just less common)


xref https://github.com/GMOD/jbrowse-components/blob/fix_double_render/plugins/linear-comparative-view/src/LinearSyntenyRenderer/LinearSyntenyRenderer.ts


therefore, we uniquify by feature id before returning results