### PR TITLE
Auto-adjust height of reference sequence track to current settings

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1191,3 +1191,9 @@ export function measureGridWidth(elements: string[]) {
 export function getEnv(obj: any) {
   return getEnvMST<{ pluginManager: PluginManager }>(obj)
 }
+
+export function localStorageGetItem(item: string) {
+  return typeof localStorage !== 'undefined'
+    ? localStorage.getItem(item)
+    : undefined
+}

--- a/plugins/gccontent/src/LinearGCContentDisplay/config.ts
+++ b/plugins/gccontent/src/LinearGCContentDisplay/config.ts
@@ -4,16 +4,17 @@ import PluginManager from '@jbrowse/core/PluginManager'
 /**
  * #config LinearGCContentDisplay
  */
-function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
-
 export default function WiggleConfigFactory(pluginManager: PluginManager) {
-  const baseConfiguration = pluginManager.getDisplayType(
-    'LinearWiggleDisplay',
-  ).configSchema
-
   return ConfigurationSchema(
     'LinearGCContentDisplay',
     {},
-    { baseConfiguration, explicitlyTyped: true },
+    {
+      /**
+       * #baseConfiguration
+       */
+      baseConfiguration: pluginManager.getDisplayType('LinearWiggleDisplay')
+        .configSchema,
+      explicitlyTyped: true,
+    },
   )
 }

--- a/plugins/gccontent/src/LinearGCContentDisplay/stateModel.ts
+++ b/plugins/gccontent/src/LinearGCContentDisplay/stateModel.ts
@@ -6,6 +6,10 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { linearWiggleDisplayModelFactory } from '@jbrowse/plugin-wiggle'
 import { types } from 'mobx-state-tree'
 
+/**
+ * #stateModel LinearGCContentDisplay
+ * base model BaseWiggleDisplayModel
+ */
 export default function stateModelFactory(
   pluginManager: PluginManager,
   configSchema: AnyConfigurationSchemaType,
@@ -15,12 +19,20 @@ export default function stateModelFactory(
       'LinearGCContentDisplay',
       linearWiggleDisplayModelFactory(pluginManager, configSchema),
       types.model({
+        /**
+         * #property
+         */
         type: types.literal('LinearGCContentDisplay'),
       }),
     )
     .views(self => {
       const { renderProps: superRenderProps } = self
       return {
+        /**
+         * #method
+         * retrieves the sequence adapter from parent track, and puts it as a
+         * subadapter on a GCContentAdapter
+         */
         renderProps() {
           const sequenceAdapter = getConf(self.parentTrack, 'adapter')
           return {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -149,7 +149,7 @@ function RefNameAutocomplete({
   // heuristic, text width + icon width
   // + 45 accommodates help icon and search icon
   const width = Math.min(
-    Math.max(measureText(inputBoxVal, 16) + 45, minWidth),
+    Math.max(measureText(inputBoxVal, 16) + 50, minWidth),
     550,
   )
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -718,7 +718,7 @@ exports[`renders two tracks, two regions 1`] = `
           <div
             class="MuiAutocomplete-root css-1qqsdnr-MuiAutocomplete-root"
             data-testid="autocomplete"
-            style="width: 255.27500000000003px;"
+            style="width: 260.27500000000003px;"
           >
             <div
               class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1efd6m0-MuiFormControl-root-MuiTextField-root-headerRefName"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -991,7 +991,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               <div
                 class="css-1ql7uaq-trackRenderingContainer"
                 data-testid="trackRenderingContainer-test_view-volvox_refseq"
-                style="height: 180px;"
+                style="height: 140px;"
               >
                 <div
                   class="css-v11ioz-renderingComponentContainer"
@@ -6897,7 +6897,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               </div>
               <div
                 class="css-1hk9st0-overlay"
-                style="height: 180px;"
+                style="height: 140px;"
               />
               <div
                 class="css-14zcv15-horizontalHandle-resizeHandle"

--- a/website/docs/config/LinearGCContentDisplay.md
+++ b/website/docs/config/LinearGCContentDisplay.md
@@ -8,3 +8,10 @@ Note: this document is automatically generated from configuration objects in our
 source code. See [Config guide](/docs/config_guide) for more info
 
 ## Docs
+
+## LinearGCContentDisplay - Derives from
+
+```js
+baseConfiguration: pluginManager.getDisplayType('LinearWiggleDisplay')
+  .configSchema
+```

--- a/website/docs/config/LinearReadArcsDisplay.md
+++ b/website/docs/config/LinearReadArcsDisplay.md
@@ -31,6 +31,17 @@ lineWidth: {
       }
 ```
 
+#### slot: jitter
+
+```js
+jitter: {
+        type: 'number',
+        description:
+          'jitters the x position so e.g. if many reads map to exact same x position, jittering makes it easy to see that there are many of them',
+        defaultValue: 0,
+      }
+```
+
 #### slot: colorScheme
 
 ```js

--- a/website/docs/models/CircularView.md
+++ b/website/docs/models/CircularView.md
@@ -41,7 +41,7 @@ offsetRadians: -Math.PI / 2
 // type signature
 number
 // code
-bpPerPx: 2000000
+bpPerPx: 200
 ```
 
 #### property: tracks
@@ -131,6 +131,13 @@ scrollY: 0
 ```
 
 ### CircularView - Getters
+
+#### getter: width
+
+```js
+// type
+number
+```
 
 #### getter: staticSlices
 
@@ -261,7 +268,7 @@ see reasonably
 
 ```js
 // type
-any[]
+({ elided: true; widthBp: number; regions: Region[]; } | { elided: false; widthBp: number; start: number; end: number; refName: string; })[]
 ```
 
 #### getter: assemblyNames

--- a/website/docs/models/LinearGCContentDisplay.md
+++ b/website/docs/models/LinearGCContentDisplay.md
@@ -1,0 +1,37 @@
+---
+id: lineargccontentdisplay
+title: LinearGCContentDisplay
+toplevel: true
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+## Docs
+
+base model BaseWiggleDisplayModel
+
+### LinearGCContentDisplay - Properties
+
+#### property: type
+
+```js
+// type signature
+ISimpleType<"LinearGCContentDisplay">
+// code
+type: types.literal('LinearGCContentDisplay')
+```
+
+### LinearGCContentDisplay - Methods
+
+#### method: renderProps
+
+retrieves the sequence adapter from parent track, and puts it as a subadapter on
+a GCContentAdapter
+
+```js
+// type signature
+renderProps: () => any
+```

--- a/website/docs/models/LinearGenomeView.md
+++ b/website/docs/models/LinearGenomeView.md
@@ -146,10 +146,9 @@ show the "center line"
 // type signature
 IOptionalIType<ISimpleType<boolean>, [undefined]>
 // code
-showCenterLine: types.optional(types.boolean, () => {
-          const setting = localStorageGetItem('lgv-showCenterLine')
-          return setting !== undefined && setting !== null ? !!+setting : false
-        })
+showCenterLine: types.optional(types.boolean, () =>
+          JSON.parse(localStorageGetItem('lgv-showCenterLine') || 'false'),
+        )
 ```
 
 #### property: showCytobandsSetting
@@ -160,10 +159,9 @@ show the "cytobands" in the overview scale bar
 // type signature
 IOptionalIType<ISimpleType<boolean>, [undefined]>
 // code
-showCytobandsSetting: types.optional(types.boolean, () => {
-          const setting = localStorageGetItem('lgv-showCytobands')
-          return setting !== undefined && setting !== null ? !!+setting : true
-        })
+showCytobandsSetting: types.optional(types.boolean, () =>
+          JSON.parse(localStorageGetItem('lgv-showCytobands') || 'true'),
+        )
 ```
 
 #### property: showGridlines

--- a/website/docs/models/LinearReadArcsDisplay.md
+++ b/website/docs/models/LinearReadArcsDisplay.md
@@ -51,6 +51,15 @@ IMaybe<ISimpleType<number>>
 lineWidth: types.maybe(types.number)
 ```
 
+#### property: jitter
+
+```js
+// type signature
+IMaybe<ISimpleType<number>>
+// code
+jitter: types.maybe(types.number)
+```
+
 #### property: colorBy
 
 ```js
@@ -93,6 +102,13 @@ drawLongRange: true
 any
 ```
 
+#### getter: jitterVal
+
+```js
+// type
+number
+```
+
 #### getter: ready
 
 ```js
@@ -106,7 +122,7 @@ boolean
 
 ```js
 // type signature
-trackMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; })[]
+trackMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; } | { ...; })[]
 ```
 
 #### method: renderSvg
@@ -206,4 +222,14 @@ thin, bold, extrabold, etc
 ```js
 // type signature
 setLineWidth: (n: number) => void
+```
+
+#### action: setJitter
+
+jitter val, helpful to jitter the x direction so you see better evidence when
+e.g. 100 long reads map to same x position
+
+```js
+// type signature
+setJitter: (n: number) => void
 ```

--- a/website/docs/models/LinearReferenceSequenceDisplay.md
+++ b/website/docs/models/LinearReferenceSequenceDisplay.md
@@ -1,0 +1,122 @@
+---
+id: linearreferencesequencedisplay
+title: LinearReferenceSequenceDisplay
+toplevel: true
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+## Docs
+
+base model `BaseLinearDisplay`
+
+### LinearReferenceSequenceDisplay - Properties
+
+#### property: type
+
+```js
+// type signature
+ISimpleType<"LinearReferenceSequenceDisplay">
+// code
+type: types.literal('LinearReferenceSequenceDisplay')
+```
+
+#### property: configuration
+
+```js
+// type signature
+ITypeUnion<any, any, any>
+// code
+configuration: ConfigurationReference(configSchema)
+```
+
+#### property: showForward
+
+```js
+// type signature
+IOptionalIType<ISimpleType<boolean>, [undefined]>
+// code
+showForward: types.optional(types.boolean, () =>
+          getBool('seq-showForward', true),
+        )
+```
+
+#### property: showReverse
+
+```js
+// type signature
+IOptionalIType<ISimpleType<boolean>, [undefined]>
+// code
+showReverse: types.optional(types.boolean, () =>
+          getBool('seq-showReverse', true),
+        )
+```
+
+#### property: showTranslation
+
+```js
+// type signature
+IOptionalIType<ISimpleType<boolean>, [undefined]>
+// code
+showTranslation: types.optional(types.boolean, () =>
+          getBool('seq-showTranslation', true),
+        )
+```
+
+### LinearReferenceSequenceDisplay - Getters
+
+#### getter: rendererTypeName
+
+```js
+// type
+any
+```
+
+### LinearReferenceSequenceDisplay - Methods
+
+#### method: renderProps
+
+```js
+// type signature
+renderProps: () => any
+```
+
+#### method: regionCannotBeRendered
+
+```js
+// type signature
+regionCannotBeRendered: () => 'Zoom in to see sequence'
+```
+
+#### method: trackMenuItems
+
+```js
+// type signature
+trackMenuItems: () => { label: string; type: string; checked: boolean; onClick: () => void; }[]
+```
+
+### LinearReferenceSequenceDisplay - Actions
+
+#### action: toggleShowForward
+
+```js
+// type signature
+toggleShowForward: () => void
+```
+
+#### action: toggleShowReverse
+
+```js
+// type signature
+toggleShowReverse: () => void
+```
+
+#### action: toggleShowTranslation
+
+```js
+// type signature
+toggleShowTranslation: () => void
+```


### PR DESCRIPTION
When you e.g. turn off the "show translation" on the reference sequence track, it automatically makes the height smaller. This can reduce click and drag. 

Aside: I considered making show forward/reverse/translation settings "sticky" e.g. storing in localstorage, but thought that it could be confusing if it got stuck to "show reverse" and you were expecting show forward.
