### PR TITLE
v2.3.2 release announcement

### DIFF
--- a/website/release_announcement_drafts/2.3.2.md
+++ b/website/release_announcement_drafts/2.3.2.md
@@ -1,0 +1,13 @@
+This release contains important fixes for drawing base-level synteny based on
+CIGAR strings, especially in inverted regions. We also fixed refName renaming
+(e.g. your BAM file has 'chr1' but the FASTA has '1') on the new arc display
+(see v2.3.1).
+
+Additionally, it offers the ability to reverse/complement the sequence in the
+"Get sequence" dialog.
+
+![](https://user-images.githubusercontent.com/6511937/208767035-90f1fb23-0fa4-468a-8095-14dc597014b2.png)
+
+Screenshot showing how insertions from relative to one assembly exactly match up
+at a "deletion" relative to another, using the LGV synteny display and curved
+arcs. Previous versions had bugs but will now match exactly.


### PR DESCRIPTION
The fixes to the synteny rendering are pretty substantial and probably warrant a quick fix release. Details below


## Unreleased (2022-12-20)

#### :rocket: Enhancement
* [#3421](https://github.com/GMOD/jbrowse-components/pull/3421) Add ability to revcomp sequence in the "Get sequence" dialog ([@cmdcolin](https://github.com/cmdcolin))
* [#3413](https://github.com/GMOD/jbrowse-components/pull/3413) Add a "base" set of tracks and assemblies for the embedded demos ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* [#3419](https://github.com/GMOD/jbrowse-components/pull/3419) Fix rendering base-level alignments on synteny visualizations, especially in inverted regions ([@cmdcolin](https://github.com/cmdcolin))
* [#3416](https://github.com/GMOD/jbrowse-components/pull/3416) Fix rendering alignment arcs on files that need refname renaming and add jitter setting ([@cmdcolin](https://github.com/cmdcolin))
* [#3415](https://github.com/GMOD/jbrowse-components/pull/3415) Fix circular view being rendered as a blank area if tab is opened in the background ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 1
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 1.28s.
