### PR TITLE
Use notarytool for macOS desktop signing

### DIFF
--- a/.github/workflows/desktop_build_mac.yml
+++ b/.github/workflows/desktop_build_mac.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Install build deps

--- a/.github/workflows/desktop_build_win.yml
+++ b/.github/workflows/desktop_build_win.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build Windows desktop app
     runs-on: ubuntu-latest
     container:
-      image: docker://node:18-bullseye
+      image: docker://node:20-bullseye
     steps:
       - uses: actions/checkout@v3
       - name: Install deps (with cache)

--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -23,10 +23,10 @@ jobs:
           draft: true
           prerelease: false
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Install deps

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,28 +4,28 @@ on: pull_request
 
 jobs:
   lint:
-    name: Lint on node 18 and ubuntu-latest
+    name: Lint on node 20 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
       - name: Lint codebase
         run: yarn lint
 
   format:
-    name: Format on node 18 and ubuntu-latest
+    name: Format on node 20 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
       - name: Check codebase format

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,14 +4,14 @@ on: push
 
 jobs:
   test:
-    name: Test and typecheck on node 18.x and ubuntu-latest
+    name: Test and typecheck on node 20.x and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Test codebase
@@ -22,14 +22,14 @@ jobs:
         run: yarn typecheck
 
   buildwebsite:
-    name: Build website on node 18 and ubuntu-latest
+    name: Build website on node 20 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install website deps (with cache)
         uses: bahmutov/npm-install@v1
         with:
@@ -46,14 +46,14 @@ jobs:
           args: website/testing/ --check-anchors
 
   buildwholerepo:
-    name: Build whole repo on node 18 and ubuntu-latest
+    name: Build whole repo on node 20 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build codebase
@@ -80,14 +80,14 @@ jobs:
         working-directory: component_tests/react-app
 
   buildjbrowseweb:
-    name: Build only jbrowse-web and upload to s3 on node 18 and ubuntu-latest
+    name: Build only jbrowse-web and upload to s3 on node 20 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build project
@@ -112,10 +112,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build Storybook static site
@@ -139,10 +139,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build Storybook static site
@@ -167,10 +167,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Build Storybook static site

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
     "@craco/craco": "^7.0.0",
-    "@electron/notarize": "^1.2.3",
+    "@electron/notarize": "^2.0.0",
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/products/jbrowse-desktop/scripts/notarize.js
+++ b/products/jbrowse-desktop/scripts/notarize.js
@@ -10,6 +10,7 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productFilename
 
   return notarize({
+    tool: 'notarytool',
     appBundleId: 'org.jbrowse2.app',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,

--- a/products/jbrowse-desktop/scripts/notarize.js
+++ b/products/jbrowse-desktop/scripts/notarize.js
@@ -11,6 +11,7 @@ exports.default = async function notarizing(context) {
 
   return notarize({
     tool: 'notarytool',
+    teamId: process.env.APPLETEAMID,
     appBundleId: 'org.jbrowse2.app',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,6 +1655,14 @@
     debug "^4.1.1"
     fs-extra "^9.0.1"
 
+"@electron/notarize@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@electron/notarize/-/notarize-2.0.0.tgz#4df39e817264746aa9bd779e0091b6c441715b72"
+  integrity sha512-dqDpd2YCgl6PHJgXEuKGYH3+L4GIGV7ZbKYJjJv66ed+hVPxZA+GAL5JH8/hCnoyQa8WzJTzqd+qhiL5Oxr+SA==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+
 "@electron/osx-sign@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.4.tgz#8e91442846471636ca0469426a82b253b9170151"


### PR DESCRIPTION
Switches from 'legacy' (default) in @electron/notarize to 'notarytool' because the legacy says it'll be deprecated late 2023

Also suggests that the newer 'notarytool' is up to 10x faster https://github.com/electron/notarize



possibly will need to add 'teamId' also? see the readme https://github.com/electron/notarize (`teamId String - The team ID you want to notarize under.`, which is not in the legacy one)