### PR TITLE
Fix synteny view after horizontal flip

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/stateModelFactory.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/stateModelFactory.ts
@@ -199,7 +199,12 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
               const view = getContainingView(self) as LSV
               return {
                 bpPerPx: view.views.map(v => v.bpPerPx),
-                displayedRegions: view.views.map(v => v.displayedRegions),
+
+                // stringifying 'deeply' accesses the displayed regions, see
+                // issue #3456
+                displayedRegions: JSON.stringify(
+                  view.views.map(v => v.displayedRegions),
+                ),
                 features: self.features,
                 initialized: view.initialized,
               }


### PR DESCRIPTION
There was a bug caused by use of the 'reaction' type for the new synteny rendering in v2.3.3

I thought that displayedRegions would be somewhat deeply observed, or at least shallowly observed so that if displayedRegions is assigned to, it would produce a rerendering, but the reaction data function needs to deeply access the variables to truly observe them. So, this PR JSON.stringifies the displayedRegions to fix

Fixes #3456