### PR TITLE
Booleanize localstorage settings from older versions of LGV to avoid crash

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -205,7 +205,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
          * show the "center line"
          */
         showCenterLine: types.optional(types.boolean, () =>
-          JSON.parse(localStorageGetItem('lgv-showCenterLine') || 'false'),
+          Boolean(
+            JSON.parse(localStorageGetItem('lgv-showCenterLine') || 'false'),
+          ),
         ),
 
         /**
@@ -213,7 +215,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
          * show the "cytobands" in the overview scale bar
          */
         showCytobandsSetting: types.optional(types.boolean, () =>
-          JSON.parse(localStorageGetItem('lgv-showCytobands') || 'true'),
+          Boolean(
+            JSON.parse(localStorageGetItem('lgv-showCytobands') || 'true'),
+          ),
         ),
 
         /**


### PR DESCRIPTION
Fixes bug found by @carolinebridge-oicr when loading LGV with the localstorage populated with older "0"/"1" for settings instead of "true"/"false"

Git blame traces to here https://github.com/GMOD/jbrowse-components/commit/d509556f8d05f62e67b77a31d746a2cc799dba9a#diff-16ff04395edd82556eb8f6df4a771c9d56a968b512fba86976d5ace75344d2cbL212

Error message @carolinebridge-oicr reported

```
react-dom.production.min.js:101 Uncaught Error: [mobx-state-tree] Error while converting `0` to `boolean`:

    value `0` is not assignable to type: `boolean` (Value is not a boolean).
    at pt (mobx-state-tree.module.js:3847:12)
    at Ge (mobx-state-tree.module.js:3440:15)
    at Ze (mobx-state-tree.module.js:3426:9)
    at t.value (mobx-state-tree.module.js:7105:17)
    at t.value (mobx-state-tree.module.js:7078:54)
    at mobx-state-tree.module.js:6130:42
    at mobx-state-tree.module.js:6328:64
    at Array.forEach (<anonymous>)
    at t.value (mobx-state-tree.module.js:6328:32)
    at t.value (mobx-state-tree.module.js:6129:18)
```
