### PR TITLE
Add OAuth token refresh

### DIFF
--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -224,7 +224,6 @@ export const InternetAccount = types
         self.removeToken()
         throw error
       }
-      self.storeToken(validatedToken)
       return {
         internetAccountType: self.type,
         authInfo: { token: validatedToken, configuration: getConf(self) },

--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -224,6 +224,7 @@ export const InternetAccount = types
         self.removeToken()
         throw error
       }
+      self.storeToken(validatedToken);
       return {
         internetAccountType: self.type,
         authInfo: { token: validatedToken, configuration: getConf(self) },
@@ -241,6 +242,9 @@ export const InternetAccount = types
      */
     getFetcher(loc?: UriLocation) {
       return async (input: RequestInfo, init?: RequestInit) => {
+        if(!inWebWorker && loc){
+          loc.internetAccountPreAuthorization = await self.getPreAuthorizationInformation(loc);
+        }
         const authToken = await self.getToken(loc)
         const newInit = self.addAuthHeaderToInit(init, authToken)
         return fetch(input, newInit)

--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -224,7 +224,7 @@ export const InternetAccount = types
         self.removeToken()
         throw error
       }
-      self.storeToken(validatedToken);
+      self.storeToken(validatedToken)
       return {
         internetAccountType: self.type,
         authInfo: { token: validatedToken, configuration: getConf(self) },
@@ -242,8 +242,9 @@ export const InternetAccount = types
      */
     getFetcher(loc?: UriLocation) {
       return async (input: RequestInfo, init?: RequestInit) => {
-        if(!inWebWorker && loc){
-          loc.internetAccountPreAuthorization = await self.getPreAuthorizationInformation(loc);
+        if (!inWebWorker && loc) {
+          loc.internetAccountPreAuthorization =
+            await self.getPreAuthorizationInformation(loc)
         }
         const authToken = await self.getToken(loc)
         const newInit = self.addAuthHeaderToInit(init, authToken)

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -323,10 +323,16 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
             self.hasRefreshToken && self.retrieveRefreshToken()
           if (refreshToken) {
             try {
-              const token = await self.exchangeRefreshForAccessToken(refreshToken);
-              resolve(token);
+              const token = await self.exchangeRefreshForAccessToken(
+                refreshToken,
+              )
+              resolve(token)
             } catch (err) {
-              reject(new Error(`Token could not be refreshed. ${err}  Please reload the page.`));
+              reject(
+                new Error(
+                  `Token could not be refreshed. ${err}  Please reload the page.`,
+                ),
+              )
             }
           }
           this.addMessageChannel(resolve, reject)
@@ -351,10 +357,12 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
                 const newToken = await refreshTokenPromise
                 return this.validateToken(newToken, location)
               } catch (err) {
-                throw new Error(`Token could not be refreshed. ${err}`);
+                throw new Error(`Token could not be refreshed. ${err}`)
               }
             }
-            throw new Error(`Token could not be refreshed. No refresh token found`);
+            throw new Error(
+              `Token could not be refreshed. No refresh token found`,
+            )
           } else {
             refreshTokenPromise = undefined
           }

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -361,7 +361,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
               }
             }
             throw new Error(
-              `Token could not be refreshed. No refresh token found`,
+              `Token could not be refreshed. No refresh token found. Please reload the page.`,
             )
           } else {
             refreshTokenPromise = undefined

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -322,7 +322,12 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           const refreshToken =
             self.hasRefreshToken && self.retrieveRefreshToken()
           if (refreshToken) {
-            resolve(await self.exchangeRefreshForAccessToken(refreshToken))
+            try {
+              const token = await self.exchangeRefreshForAccessToken(refreshToken);
+              resolve(token);
+            } catch (err) {
+              reject(new Error(`Token could not be refreshed. ${err}  Please reload the page.`));
+            }
           }
           this.addMessageChannel(resolve, reject)
           // may want to improve handling
@@ -346,9 +351,10 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
                 const newToken = await refreshTokenPromise
                 return this.validateToken(newToken, location)
               } catch (err) {
-                throw new Error(`Token could not be refreshed. ${err}`)
+                throw new Error(`Token could not be refreshed. ${err}`);
               }
             }
+            throw new Error(`Token could not be refreshed. No refresh token found`);
           } else {
             refreshTokenPromise = undefined
           }


### PR DESCRIPTION
This PR adds workaround fix of [#3194](https://github.com/GMOD/jbrowse-components/commit/02acc70d3d3c380a820c36d0533651f203d0c1f2).
It executes `getPreAuthorizationInformation()` directly from InternetAccountModel `getFetcher()`, first checking if it's used in web worker context to prevent the web worker thread from trying to open new windows.

Also fixes the issue of multiple token exchanges by executing `storeToken()` immediately after token has been exchanged in `validateToken()`.