### PR TITLE
Variant sample grid auto-size columns and resizer

### DIFF
--- a/packages/core/ui/ResizeBar.tsx
+++ b/packages/core/ui/ResizeBar.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { ResizeHandle } from '@jbrowse/core/ui'
+import { makeStyles } from 'tss-react/mui'
+
+const useStyles = makeStyles()({
+  resizeBar: {
+    background: 'lightgrey',
+    height: 12,
+    position: 'relative',
+  },
+  tick: {
+    position: 'absolute',
+    height: '100%',
+    background: 'black',
+    width: 1,
+  },
+})
+export default function ResizeBar({
+  widths,
+  setWidths,
+}: {
+  widths: number[]
+  setWidths: (arg: number[]) => void
+}) {
+  const { classes } = useStyles()
+  const offsets = [] as number[]
+  widths.reduce((a, b, i) => (offsets[i] = a + b), 52)
+
+  return (
+    <div className={classes.resizeBar}>
+      {offsets.map((left, i) => (
+        <ResizeHandle
+          key={'tick-' + i}
+          onDrag={distance => {
+            const newWidths = [...widths]
+            newWidths[i] = newWidths[i] + distance
+            setWidths(newWidths)
+          }}
+          vertical
+          className={classes.tick}
+          style={{ left }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/core/ui/ResizeBar.tsx
+++ b/packages/core/ui/ResizeBar.tsx
@@ -18,19 +18,21 @@ const useStyles = makeStyles()({
 export default function ResizeBar({
   widths,
   setWidths,
+  checkbox,
 }: {
   widths: number[]
   setWidths: (arg: number[]) => void
+  checkbox?: boolean
 }) {
   const { classes } = useStyles()
   const offsets = [] as number[]
-  widths.reduce((a, b, i) => (offsets[i] = a + b), 52)
+  widths.reduce((a, b, i) => (offsets[i] = a + b), checkbox ? 52 : 0)
 
   return (
     <div className={classes.resizeBar}>
       {offsets.map((left, i) => (
         <ResizeHandle
-          key={'tick-' + i}
+          key={'tick-' + i + '-' + left}
           onDrag={distance => {
             const newWidths = [...widths]
             newWidths[i] = newWidths[i] + distance

--- a/packages/core/ui/ResizeHandle.tsx
+++ b/packages/core/ui/ResizeHandle.tsx
@@ -27,7 +27,7 @@ function ResizeHandle({
   className: originalClassName,
   ...props
 }: {
-  onDrag: (arg: number) => number
+  onDrag: (arg: number) => number | void
   vertical?: boolean
   flexbox?: boolean
   className?: string

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react'
 
 import {
@@ -11,6 +10,7 @@ import {
 import { DataGrid } from '@mui/x-data-grid'
 import { BaseCard } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
 import { measureGridWidth, SimpleFeatureSerialized } from '@jbrowse/core/util'
+import ResizeBar from '@jbrowse/core/ui/ResizeBar'
 
 interface Entry {
   sample: string
@@ -23,16 +23,14 @@ type Filters = Record<string, string>
 
 export default function VariantSamples(props: {
   feature: SimpleFeatureSerialized
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   descriptions: any
 }) {
-  const { feature, descriptions } = props
+  const { feature, descriptions = {} } = props
   const [filter, setFilter] = useState<Filters>({})
   const [showFilters, setShowFilters] = useState(false)
   const samples = (feature.samples || {}) as Record<string, InfoFields>
   const preFilteredRows = Object.entries(samples)
-  if (!preFilteredRows.length) {
-    return null
-  }
 
   let error
   let rows = [] as Entry[]
@@ -43,16 +41,15 @@ export default function VariantSamples(props: {
   // sortable by the data-grid
   try {
     rows = preFilteredRows
-      .map(
-        row =>
-          ({
-            ...Object.fromEntries(
-              Object.entries(row[1]).map(entry => [entry[0], String(entry[1])]),
-            ),
-            sample: row[0],
-            id: row[0],
-          } as Entry),
-      )
+      .map(row => {
+        return {
+          ...Object.fromEntries(
+            Object.entries(row[1]).map(e => [e[0], `${e[1]}`]),
+          ),
+          sample: row[0],
+          id: row[0],
+        } as Entry
+      })
       .filter(row =>
         filters.length
           ? filters.every(key => {
@@ -65,17 +62,21 @@ export default function VariantSamples(props: {
   } catch (e) {
     error = e
   }
-  const infoFields = ['sample', ...Object.keys(preFilteredRows[0][1])].map(
-    field => ({
-      field,
-      description: descriptions.FORMAT?.[field]?.Description,
-      width: measureGridWidth(rows.map(r => r[field])),
-    }),
+
+  const keys = ['sample', ...Object.keys(preFilteredRows[0]?.[1] || {})]
+
+  const [widths, setWidths] = useState(
+    keys.map(e => measureGridWidth(rows.map(r => r[e]))),
   )
+  const infoFields = keys.map((field, index) => ({
+    field,
+    description: descriptions.FORMAT?.[field]?.Description,
+    width: widths[index],
+  }))
 
   // disableSelectionOnClick helps avoid
   // https://github.com/mui-org/material-ui-x/issues/1197
-  return (
+  return !preFilteredRows.length ? null : (
     <BaseCard {...props} title="Samples">
       {error ? <Typography color="error">{`${error}`}</Typography> : null}
 
@@ -108,12 +109,14 @@ export default function VariantSamples(props: {
           ))}
         </>
       ) : null}
+      <ResizeBar widths={widths} setWidths={setWidths} />
       <div style={{ height: 600, width: '100%', overflow: 'auto' }}>
         <DataGrid
           rows={rows}
           columns={infoFields}
           disableSelectionOnClick
           rowHeight={25}
+          headerHeight={35}
           disableColumnMenu
         />
       </div>

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid.tsx
@@ -10,7 +10,7 @@ import {
 
 import { DataGrid } from '@mui/x-data-grid'
 import { BaseCard } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
-import { SimpleFeatureSerialized } from '@jbrowse/core/util/simpleFeature'
+import { measureGridWidth, SimpleFeatureSerialized } from '@jbrowse/core/util'
 
 interface Entry {
   sample: string
@@ -18,28 +18,21 @@ interface Entry {
   [key: string]: string
 }
 
+type InfoFields = Record<string, unknown>
+type Filters = Record<string, string>
+
 export default function VariantSamples(props: {
   feature: SimpleFeatureSerialized
   descriptions: any
 }) {
   const { feature, descriptions } = props
-  const [filter, setFilter] = useState<Record<string, string>>({})
+  const [filter, setFilter] = useState<Filters>({})
   const [showFilters, setShowFilters] = useState(false)
-  const { samples = {} } = feature as Record<
-    string,
-    Record<string, Record<string, unknown>>
-  >
+  const samples = (feature.samples || {}) as Record<string, InfoFields>
   const preFilteredRows = Object.entries(samples)
   if (!preFilteredRows.length) {
     return null
   }
-
-  const infoFields = ['sample', ...Object.keys(preFilteredRows[0][1])].map(
-    field => ({
-      field,
-      description: descriptions.FORMAT?.[field]?.Description,
-    }),
-  )
 
   let error
   let rows = [] as Entry[]
@@ -72,6 +65,14 @@ export default function VariantSamples(props: {
   } catch (e) {
     error = e
   }
+  const infoFields = ['sample', ...Object.keys(preFilteredRows[0][1])].map(
+    field => ({
+      field,
+      description: descriptions.FORMAT?.[field]?.Description,
+      width: measureGridWidth(rows.map(r => r[field])),
+    }),
+  )
+
   // disableSelectionOnClick helps avoid
   // https://github.com/mui-org/material-ui-x/issues/1197
   return (


### PR DESCRIPTION
Ports the resizer concept from the the faceted PR and also now auto-sizes the columns using the measureGridWidth method that is used in several other data-grid usages in the codebase