### PR TITLE
Bypass plugins.json download if unneeded during app startup

### DIFF
--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -48,6 +48,9 @@ async function fetchPlugins() {
 }
 
 async function checkPlugins(pluginsToCheck: PluginDefinition[]) {
+  if (pluginsToCheck.length === 0) {
+    return true
+  }
   const storePlugins = await fetchPlugins()
   return pluginsToCheck.every(p => {
     if (isUMDPluginDefinition(p)) {


### PR DESCRIPTION
Currently, the app downloads the plugins.json file at app startup to see if any 'sessionPlugins' are used that may be dangerous, or if cross-domain configs are being used that use plugins also

But, even if sessionPlugins is empty and config is not cross-domain, plugins.json is still downloaded, so this skips the plugins.json DL if uneeded