### PR TITLE
Larger margins to add track workflow to visually clarify next button behavior

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
@@ -32,14 +32,11 @@ const useStyles = makeStyles()(theme => ({
     backgroundColor: theme.palette.background.default,
   },
   button: {
-    marginTop: theme.spacing(1),
     marginRight: theme.spacing(1),
   },
   actionsContainer: {
+    marginTop: theme.spacing(10),
     marginBottom: theme.spacing(2),
-  },
-  stepContent: {
-    margin: theme.spacing(1),
   },
   alertContainer: {
     padding: `${theme.spacing(2)}px 0px ${theme.spacing(2)}px 0px`,

--- a/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FileSelector } from '@jbrowse/core/ui'
+import { AbstractRootModel } from '@jbrowse/core/util'
 import { Paper } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { getRoot } from 'mobx-state-tree'
@@ -10,9 +11,7 @@ import { AddTrackModel } from '../model'
 
 const useStyles = makeStyles()(theme => ({
   paper: {
-    display: 'flex',
-    flexDirection: 'column',
-    padding: theme.spacing(1),
+    padding: theme.spacing(2),
   },
   spacer: {
     height: theme.spacing(8),
@@ -21,8 +20,7 @@ const useStyles = makeStyles()(theme => ({
 
 function TrackSourceSelect({ model }: { model: AddTrackModel }) {
   const { classes } = useStyles()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rootModel = getRoot<any>(model)
+  const rootModel = getRoot<AbstractRootModel>(model)
 
   return (
     <Paper className={classes.paper}>


### PR DESCRIPTION
Screenshots

before
![Screenshot from 2023-01-25 13-34-54](https://user-images.githubusercontent.com/6511937/214684327-3a767815-280c-48bc-8388-b1879c5500a5.png)

after
![Screenshot from 2023-01-25 13-34-46](https://user-images.githubusercontent.com/6511937/214684344-4d8f4753-c6fe-44a2-9b60-e2a00dc7bce3.png)
