### PR TITLE
Fix loading external plugins in embedded linear-genome-view demo

### DIFF
--- a/packages/core/PluginLoader.ts
+++ b/packages/core/PluginLoader.ts
@@ -133,7 +133,7 @@ export default class PluginLoader {
     )
   }
 
-  async loadCJSPlugin(def: CJSPluginDefinition, windowHref: string) {
+  async loadCJSPlugin(def: CJSPluginDefinition, windowHref?: string) {
     const parsedUrl = new URL(def.cjsUrl, windowHref)
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error(
@@ -147,7 +147,7 @@ export default class PluginLoader {
     return this.fetchCJS(parsedUrl.href)
   }
 
-  async loadESMPlugin(def: ESMPluginDefinition, windowHref: string) {
+  async loadESMPlugin(def: ESMPluginDefinition, windowHref?: string) {
     const parsedUrl =
       'esmUrl' in def
         ? new URL(def.esmUrl, windowHref)
@@ -170,7 +170,7 @@ export default class PluginLoader {
 
   async loadUMDPlugin(
     def: UMDPluginDefinition | LegacyUMDPluginDefinition,
-    windowHref: string,
+    windowHref?: string,
   ) {
     const parsedUrl =
       'url' in def
@@ -200,7 +200,7 @@ export default class PluginLoader {
     return plugin
   }
 
-  async loadPlugin(def: PluginDefinition, windowHref: string) {
+  async loadPlugin(def: PluginDefinition, windowHref?: string) {
     let plugin: LoadedPlugin
     if (isElectron && isCJSPluginDefinition(def)) {
       plugin = await this.loadCJSPlugin(def, windowHref)
@@ -229,7 +229,7 @@ export default class PluginLoader {
     )
   }
 
-  async load(windowHref = '') {
+  async load(windowHref?: string) {
     return Promise.all(
       this.definitions.map(async definition => ({
         plugin: await this.loadPlugin(definition, windowHref),

--- a/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
@@ -7,9 +7,12 @@ interface PluginDefinition {
 
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
-  args?: { fetchESM: (url: string) => Promise<unknown> },
+  args?: {
+    fetchESM?: (url: string) => Promise<unknown>
+    baseUrl?: string
+  },
 ) {
   const pluginLoader = new PluginLoader(pluginDefinitions, args)
   pluginLoader.installGlobalReExports(window)
-  return pluginLoader.load('')
+  return pluginLoader.load(args?.baseUrl)
 }

--- a/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-circular-genome-view/src/loadPlugins.ts
@@ -1,4 +1,4 @@
-import PluginLoader from '@jbrowse/core/PluginLoader'
+import PluginLoader, { LoadedPlugin } from '@jbrowse/core/PluginLoader'
 
 interface PluginDefinition {
   name: string
@@ -8,7 +8,7 @@ interface PluginDefinition {
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
   args?: {
-    fetchESM?: (url: string) => Promise<unknown>
+    fetchESM?: (url: string) => Promise<LoadedPlugin>
     baseUrl?: string
   },
 ) {

--- a/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
@@ -7,9 +7,12 @@ interface PluginDefinition {
 
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
-  args?: { fetchESM: (url: string) => Promise<unknown> },
+  args?: {
+    fetchESM?: (url: string) => Promise<unknown>
+    baseUrl?: string
+  },
 ) {
   const pluginLoader = new PluginLoader(pluginDefinitions, args)
   pluginLoader.installGlobalReExports(window)
-  return pluginLoader.load('')
+  return pluginLoader.load(args?.baseUrl)
 }

--- a/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/loadPlugins.ts
@@ -1,4 +1,4 @@
-import PluginLoader from '@jbrowse/core/PluginLoader'
+import PluginLoader, { LoadedPlugin } from '@jbrowse/core/PluginLoader'
 
 interface PluginDefinition {
   name: string
@@ -8,7 +8,7 @@ interface PluginDefinition {
 export default async function loadPlugins(
   pluginDefinitions: PluginDefinition[],
   args?: {
-    fetchESM?: (url: string) => Promise<unknown>
+    fetchESM?: (url: string) => Promise<LoadedPlugin>
     baseUrl?: string
   },
 ) {

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import React, { useEffect, useState } from 'react'
 import { observer } from 'mobx-react'
-import { PluginRecord } from '@jbrowse/core/PluginLoader'
 import { Region } from '@jbrowse/core/util/types'
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
 import PluginManager from '@jbrowse/core/PluginManager'
@@ -596,6 +595,9 @@ export const Hg38Exome = () => {
   return <JBrowseLinearGenomeView viewState={state} />
 }
 export const WithExternalPlugins = () => {
+  const [error, setError] = useState<unknown>()
+  const [viewState, setViewState] =
+    useState<ReturnType<typeof createViewState>>()
   // usage with buildtime plugins
   // this plugins array is then passed to the createViewState constructor
   //
@@ -606,112 +608,117 @@ export const WithExternalPlugins = () => {
   // import {loadPlugins} from '@jbrowse/react-linear-genome-view'
   //
   // we manually call loadPlugins, and pass the result to the createViewState constructor
-  const [plugins, setPlugins] = useState<PluginRecord[]>()
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ;(async () => {
-      const loadedPlugins = await loadPlugins([
-        {
-          name: 'UCSC',
-          url: 'https://unpkg.com/jbrowse-plugin-ucsc@^1/dist/jbrowse-plugin-ucsc.umd.production.min.js',
-        },
-      ])
-      setPlugins(loadedPlugins)
-    })()
-  }, [setPlugins])
-
-  if (!plugins) {
-    return null
-  }
-
-  const state = createViewState({
-    assembly: {
-      name: 'hg19',
-      aliases: ['GRCh37'],
-      sequence: {
-        type: 'ReferenceSequenceTrack',
-        trackId: 'Pd8Wh30ei9R',
-        adapter: {
-          type: 'BgzipFastaAdapter',
-          fastaLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
-            locationType: 'UriLocation',
-          },
-          faiLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
-            locationType: 'UriLocation',
-          },
-          gziLocation: {
-            uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
-            locationType: 'UriLocation',
-          },
-        },
-      },
-      refNameAliases: {
-        adapter: {
-          type: 'RefNameAliasAdapter',
-          location: {
-            uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
-            locationType: 'UriLocation',
-          },
-        },
-      },
-    },
-    plugins: plugins.map(p => p.plugin),
-    tracks: [
-      {
-        type: 'FeatureTrack',
-        trackId: 'segdups_ucsc_hg19',
-        name: 'UCSC SegDups',
-        category: ['Annotation'],
-        assemblyNames: ['hg19'],
-        adapter: {
-          type: 'UCSCAdapter',
-          track: 'genomicSuperDups',
-        },
-      },
-    ],
-    location: '1:2,467,681..2,667,681',
-    defaultSession: {
-      name: 'Runtime plugins',
-      view: {
-        id: 'aU9Nqje1U',
-        type: 'LinearGenomeView',
-        offsetPx: 22654,
-        bpPerPx: 108.93300653594771,
-        displayedRegions: [
+      try {
+        const plugins = await loadPlugins([
           {
-            refName: '1',
-            start: 0,
-            end: 249250621,
-            reversed: false,
-            assemblyName: 'hg19',
+            name: 'UCSC',
+            url: 'https://unpkg.com/jbrowse-plugin-ucsc@^1/dist/jbrowse-plugin-ucsc.umd.production.min.js',
           },
-        ],
-        tracks: [
-          {
-            id: 'MbiRphmDa',
-            type: 'FeatureTrack',
-            configuration: 'segdups_ucsc_hg19',
-            displays: [
-              {
-                id: '8ovhuA5cFM',
-                type: 'LinearBasicDisplay',
-                height: 100,
-                configuration: 'segdups_ucsc_hg19-LinearBasicDisplay',
+        ])
+        const state = createViewState({
+          assembly: {
+            name: 'hg19',
+            aliases: ['GRCh37'],
+            sequence: {
+              type: 'ReferenceSequenceTrack',
+              trackId: 'Pd8Wh30ei9R',
+              adapter: {
+                type: 'BgzipFastaAdapter',
+                fastaLocation: {
+                  uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
+                  locationType: 'UriLocation',
+                },
+                faiLocation: {
+                  uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
+                  locationType: 'UriLocation',
+                },
+                gziLocation: {
+                  uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
+                  locationType: 'UriLocation',
+                },
               },
-            ],
+            },
+            refNameAliases: {
+              adapter: {
+                type: 'RefNameAliasAdapter',
+                location: {
+                  uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
+                  locationType: 'UriLocation',
+                },
+              },
+            },
           },
-        ],
-        hideHeader: false,
-        hideHeaderOverview: false,
-        trackSelectorType: 'hierarchical',
-        trackLabels: 'overlapping',
-        showCenterLine: false,
-      },
-    },
-  })
-  return <JBrowseLinearGenomeView viewState={state} />
+          plugins: plugins.map(p => p.plugin) || [],
+          tracks: [
+            {
+              type: 'FeatureTrack',
+              trackId: 'segdups_ucsc_hg19',
+              name: 'UCSC SegDups',
+              category: ['Annotation'],
+              assemblyNames: ['hg19'],
+              adapter: {
+                type: 'UCSCAdapter',
+                track: 'genomicSuperDups',
+              },
+            },
+          ],
+          location: '1:2,467,681..2,667,681',
+          defaultSession: {
+            name: 'Runtime plugins',
+            view: {
+              id: 'aU9Nqje1U',
+              type: 'LinearGenomeView',
+              offsetPx: 22654,
+              bpPerPx: 108.93300653594771,
+              displayedRegions: [
+                {
+                  refName: '1',
+                  start: 0,
+                  end: 249250621,
+                  reversed: false,
+                  assemblyName: 'hg19',
+                },
+              ],
+              tracks: [
+                {
+                  id: 'MbiRphmDa',
+                  type: 'FeatureTrack',
+                  configuration: 'segdups_ucsc_hg19',
+                  displays: [
+                    {
+                      id: '8ovhuA5cFM',
+                      type: 'LinearBasicDisplay',
+                      height: 100,
+                      configuration: 'segdups_ucsc_hg19-LinearBasicDisplay',
+                    },
+                  ],
+                },
+              ],
+              hideHeader: false,
+              hideHeaderOverview: false,
+              trackSelectorType: 'hierarchical',
+              trackLabels: 'overlapping',
+              showCenterLine: false,
+            },
+          },
+        })
+        setViewState(state)
+      } catch (e) {
+        setError(e)
+      }
+    })()
+  }, [])
+
+  return error ? (
+    <div style={{ color: 'red' }}>{`${error}`}</div>
+  ) : !viewState ? (
+    <div>Loading...</div>
+  ) : (
+    <JBrowseLinearGenomeView viewState={viewState} />
+  )
 }
 
 export const WithInternetAccounts = () => {


### PR DESCRIPTION
Since version v2.1.6 https://jbrowse.org/jb2/blog/2022/10/19/v2.1.6-release/ the 'loading external plugins in embedded lgv' demo has been broken. This is due to changes in the PluginLoader to support loading relative paths (relative to a window.location.href or baseUrl) in jbrowse-web

This came from a confusion in my case that new URL(someUrl,baseUrl='') would just ignore the baseUrl, but it actually throws an exception when baseUrl is an empty string. This updates the code to use undefined instead of empty string, and then wires the code so undefineds flow through the pluginLoader instead of empty string





