### PR TITLE
Add Dockerfile for JBrowse Web, upload new images on publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules/**

--- a/.github/workflows/docker_build_jbrowse_web.yml
+++ b/.github/workflows/docker_build_jbrowse_web.yml
@@ -1,0 +1,29 @@
+name: Docker build - JBrowse Web
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build and push JBrowse Web Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./jbrowse-web.Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/jbrowse-web:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/jbrowse-web:${{env.RELEASE_VERSION}}

--- a/jbrowse-web.Dockerfile
+++ b/jbrowse-web.Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage build dockerfile: https://docs.docker.com/build/building/multi-stage/
+
+# Based on the layer caching example in the Docker docs:
+# https://docs.docker.com/get-started/09_image_best/#layer-caching
+# Basically, by running `yarn install` with just the package.json and
+# yarn.lock files present, you can used cached layers to speed up builds that
+# don't need to re-run `yarn install`. Because we have a monorepo and Docker's
+# COPY doesn't handle complicated globs, though, we have to do two stages
+# ("setup" and "build") to get the layer caching to work correctly.
+FROM node:16 AS setup
+WORKDIR /app
+COPY ["package.json", "yarn.lock", "./"]
+COPY packages packages
+COPY products products
+COPY plugins plugins
+RUN find . -type f \! \( -name "package.json" -o -name "yarn.lock" \) -delete
+RUN find . -type d -empty -delete
+
+FROM node:16 AS build
+WORKDIR /app
+COPY --from=setup /app .
+RUN yarn install --frozen-lockfile
+COPY . .
+WORKDIR /app/products/jbrowse-web
+RUN yarn build
+
+# Once we've built the app, we don't need the Node environment, just the built
+# files and a static server. Based on the example in the Docker docs:
+# https://docs.docker.com/get-started/09_image_best/#react-example
+FROM httpd:alpine
+COPY --from=build /app/products/jbrowse-web/build /usr/local/apache2/htdocs


### PR DESCRIPTION
This is a proposal to add a Dockerfile for JBrowse Web and publish an image to Docker Hub with each new release.

The final Docker image is a static Apache server and the built files, with no Node environment or anything like that. It's pretty basic, and by itself probably isn't the most useful, but the ability to use it as a base image to make other Docker images is where it has some nice utility. For example, if you had a JBrowse plugin that depended on some complicated server-side setup, you could use this as a base image and publish the server-side and client-side code together in a Docker image.

There is the question of how much utility this provides vs. the maintenance of another piece of code, but I think the maintenance level will be low, and the publishing should happen automatically each time a new version is released.

Apollo will use this (or something similar if we decide not to include this in this repo) for its Docker deployment scenario.