### PR TITLE
Fix facet filtering track toggle

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
@@ -170,12 +170,18 @@ export default observer(function FacetedSelector({
       width: widthsDebounced[i + 1 + keys.length],
     })),
   ]
-  const shownTrackIds = view.tracks.map(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (t: any) => t.configuration.trackId,
-  ) as string[]
 
   const arrFilters = Object.entries(filters).filter(f => f[1].length > 0)
+  const shownRows = rows.filter(row =>
+    arrFilters.every(([key, val]) => val.includes(row[key])),
+  )
+  const shownRowTrackIds = shownRows.map(r => r.id)
+  const shownTrackIds = (
+    view.tracks as { configuration: { trackId: string } }[]
+  )
+    .map(t => t.configuration.trackId)
+    .filter(f => shownRowTrackIds.includes(f))
+
   return (
     <>
       {info ? (
@@ -222,9 +228,7 @@ export default observer(function FacetedSelector({
             scrollLeft={scrollLeft}
           />
           <DataGrid
-            rows={rows.filter(row =>
-              arrFilters.every(([key, val]) => val.includes(row[key])),
-            )}
+            rows={shownRows}
             headerHeight={35}
             checkboxSelection
             disableSelectionOnClick


### PR DESCRIPTION
Currently the faceted selector uses "MUI's native checkbox data selector" (as opposed to for example, making a custom column type with a checkbox in it to toggle tracks)

By doing so, we get MUI native checkbox multi-select, which allows shift+click to toggle multiple rows in the selector which is convenient in some cases

But, in order to handle this kind of multi-select, we perform a step to "synchronize" the MUI x-data-grid's selection model with the current view's open tracks by showing and hiding tracks  (see code here https://github.com/GMOD/jbrowse-components/blob/fix_facet_filtering_track_toggle/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx#L241-L244)

This PR makes sure to only synchronize the tracks that are currently visible, because if we perform any sort of facet filtering, the selection model changes (becomes empty for example) but we don't want to hide tracks that we previously clicked

Thanks to @carolinebridge-oicr for reporting