### PR TITLE
Fix possible flaky issue with embedded cgv test

### DIFF
--- a/component_tests/cgv/cypress/integration/basic.spec.ts
+++ b/component_tests/cgv/cypress/integration/basic.spec.ts
@@ -3,6 +3,6 @@ describe('JBrowse embedded circular view', () => {
     cy.visit('/')
 
     // eslint-disable-next-line testing-library/await-async-query,testing-library/prefer-screen-queries
-    cy.findByTestId('chord-1240051623-vcf-6924368', { timeout: 30000 })
+    cy.findByTestId('chord-1148282975-vcf-63100', { timeout: 30000 })
   })
 })

--- a/component_tests/cgv/package.json
+++ b/component_tests/cgv/package.json
@@ -5,9 +5,10 @@
   "dependencies": {
     "@craco/craco": "^6.4.3",
     "@fontsource/roboto": "^4.5.5",
+    "@jbrowse/plugin-linear-genome-view": "^2.3.3",
     "@jbrowse/react-circular-genome-view": "^2.0.0",
-    "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/cypress": "^8.0.2",
+    "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.1",
@@ -23,25 +24,6 @@
     "start-server-and-test": "^1.14.0",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4"
-  },
-  "resolutions": {
-    "@jbrowse/core": "file:./packed/jbrowse-core.tgz",
-    "@jbrowse/plugin-alignments": "file:./packed/jbrowse-plugin-alignments.tgz",
-    "@jbrowse/plugin-authentication": "file:./packed/jbrowse-plugin-authentication.tgz",
-    "@jbrowse/plugin-bed": "file:./packed/jbrowse-plugin-bed.tgz",
-    "@jbrowse/plugin-circular-view": "file:./packed/jbrowse-plugin-circular-view.tgz",
-    "@jbrowse/plugin-config": "file:./packed/jbrowse-plugin-config.tgz",
-    "@jbrowse/plugin-data-management": "file:./packed/jbrowse-plugin-data-management.tgz",
-    "@jbrowse/plugin-gccontent": "file:./packed/jbrowse-plugin-gccontent.tgz",
-    "@jbrowse/plugin-gff3": "file:./packed/jbrowse-plugin-gff3.tgz",
-    "@jbrowse/plugin-linear-genome-view": "file:./packed/jbrowse-plugin-linear-genome-view.tgz",
-    "@jbrowse/plugin-sequence": "file:./packed/jbrowse-plugin-sequence.tgz",
-    "@jbrowse/plugin-svg": "file:./packed/jbrowse-plugin-svg.tgz",
-    "@jbrowse/plugin-trix": "file:./packed/jbrowse-plugin-trix.tgz",
-    "@jbrowse/plugin-variants": "file:./packed/jbrowse-plugin-variants.tgz",
-    "@jbrowse/plugin-wiggle": "file:./packed/jbrowse-plugin-wiggle.tgz",
-    "@jbrowse/react-linear-genome-view": "file:./packed/jbrowse-react-linear-genome-view.tgz",
-    "@jbrowse/react-circular-genome-view": "file:./packed/jbrowse-react-circular-genome-view.tgz"
   },
   "scripts": {
     "start": "craco start",

--- a/component_tests/cgv/public/test_data
+++ b/component_tests/cgv/public/test_data
@@ -1,0 +1,1 @@
+../../../test_data/volvox

--- a/component_tests/cgv/src/App.tsx
+++ b/component_tests/cgv/src/App.tsx
@@ -8,29 +8,6 @@ import {
 import assembly from './assembly'
 import tracks from './tracks'
 
-const defaultSession = {
-  name: 'My session',
-  view: {
-    id: 'circularView',
-    type: 'CircularView',
-    bpPerPx: 5000000,
-    tracks: [
-      {
-        id: 'uPdLKHik1',
-        type: 'VariantTrack',
-        configuration: 'pacbio_sv_vcf',
-        displays: [
-          {
-            id: 'v9QVAR3oaB',
-            type: 'ChordVariantDisplay',
-            configuration: 'pacbio_sv_vcf-ChordVariantDisplay',
-          },
-        ],
-      },
-    ],
-  },
-}
-
 function View() {
   const [viewState, setViewState] =
     useState<ReturnType<typeof createViewState>>()
@@ -44,8 +21,8 @@ function View() {
       onChange: (patch: any) => {
         setPatches(previous => previous + JSON.stringify(patch) + '\n')
       },
-      defaultSession,
     })
+    state.session.view.showTrack('volvox_sv_test_renamed')
     setViewState(state)
   }, [])
 

--- a/component_tests/cgv/src/assembly.ts
+++ b/component_tests/cgv/src/assembly.ts
@@ -1,32 +1,40 @@
 const assembly = {
-  name: 'hg19',
-  aliases: ['GRCh37'],
+  name: 'volvox',
+  aliases: ['vvx'],
   sequence: {
     type: 'ReferenceSequenceTrack',
-    trackId: 'Pd8Wh30ei9R',
+    trackId: 'volvox_refseq',
+    metadata: {
+      date: '2020-08-20',
+    },
+    formatAbout: {
+      hideUris: true,
+      config: "jexl:{extraField:'important data'}",
+    },
     adapter: {
-      type: 'BgzipFastaAdapter',
-      fastaLocation: {
-        uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz',
-        locationType: 'UriLocation',
-      },
-      faiLocation: {
-        uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai',
-        locationType: 'UriLocation',
-      },
-      gziLocation: {
-        uri: 'https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi',
+      type: 'TwoBitAdapter',
+      twoBitLocation: {
+        uri: 'test_data/volvox.2bit',
         locationType: 'UriLocation',
       },
     },
   },
   refNameAliases: {
     adapter: {
-      type: 'RefNameAliasAdapter',
-      location: {
-        uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt',
-        locationType: 'UriLocation',
-      },
+      type: 'FromConfigAdapter',
+      adapterId: 'W6DyPGJ0UU',
+      features: [
+        {
+          refName: 'ctgA',
+          uniqueId: 'alias1',
+          aliases: ['A', 'contigA'],
+        },
+        {
+          refName: 'ctgB',
+          uniqueId: 'alias2',
+          aliases: ['B', 'contigB'],
+        },
+      ],
     },
   },
 }

--- a/component_tests/cgv/src/tracks.ts
+++ b/component_tests/cgv/src/tracks.ts
@@ -1,19 +1,19 @@
 const tracks = [
   {
     type: 'VariantTrack',
-    trackId: 'pacbio_sv_vcf',
-    name: 'HG002 Pacbio SV (VCF)',
-    assemblyNames: ['hg19'],
-    category: ['GIAB'],
+    trackId: 'volvox_sv_test_renamed',
+    name: 'volvox structural variant test w/renamed refs',
+    category: ['VCF'],
+    assemblyNames: ['volvox'],
     adapter: {
       type: 'VcfTabixAdapter',
       vcfGzLocation: {
-        uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/hs37d5.HG002-SequelII-CCS.bnd-only.sv.vcf.gz',
+        uri: 'test_data/volvox.dup.renamed.vcf.gz',
         locationType: 'UriLocation',
       },
       index: {
         location: {
-          uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/hg19/pacbio/hs37d5.HG002-SequelII-CCS.bnd-only.sv.vcf.gz.tbi',
+          uri: 'test_data/volvox.dup.renamed.vcf.gz.tbi',
           locationType: 'UriLocation',
         },
       },


### PR DESCRIPTION
The circular embedded test I believe was loading a largish pacbio VCF, and had a 30s timeout but was seen to fail here on CI https://github.com/GMOD/jbrowse-components/actions/runs/4058747404/jobs/6986041056

This is related to https://github.com/GMOD/jbrowse-components/issues/3492 where it was actually going to our s3 bucket for the file also, which should be fast, but also, could be a source of flakyness (more likely, it was due to rendering a pretty large file in this case)

This changes the code to test a small volvox file in the embedded cgv test suite