### PR TITLE
Use transitionDuration 0 as defaultProp in theme for both popovers and menus

### DIFF
--- a/packages/core/ui/DropDownMenu.tsx
+++ b/packages/core/ui/DropDownMenu.tsx
@@ -7,9 +7,6 @@ import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
 import Menu, { MenuItem } from './Menu'
 
 const useStyles = makeStyles()(theme => ({
-  root: {
-    display: 'flex',
-  },
   buttonRoot: {
     '&:hover': {
       backgroundColor: alpha(
@@ -51,7 +48,7 @@ function DropDownMenu({
   }
 
   return (
-    <div className={classes.root}>
+    <>
       <Button
         ref={anchorEl}
         onClick={handleToggle}
@@ -70,7 +67,7 @@ function DropDownMenu({
         onClose={handleClose}
         menuItems={menuItems}
       />
-    </div>
+    </>
   )
 }
 

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -405,7 +405,6 @@ function Menu(props: MenuProps) {
 
   return (
     <Popover
-      transitionDuration={0}
       open={open}
       onClose={onClose}
       BackdropProps={{ invisible: true }}

--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -128,6 +128,16 @@ export function createJBrowseDefaultProps(/* palette: PaletteOptions = {} */) {
           size: 'small' as const,
         },
       },
+      MuiPopover: {
+        defaultProps: {
+          transitionDuration: 0,
+        },
+      },
+      MuiMenu: {
+        defaultProps: {
+          transitionDuration: 0,
+        },
+      },
       MuiMenuList: {
         defaultProps: {
           dense: true,


### PR DESCRIPTION
Currently, there is a single transitionDuration 0 on the @jbrowse/core/ui/Menu component which makes it popup fast without animation. This PR goes a bit further and applies it to all popovers and menus via defaultProps in the theme. I noticed this because the CascadingMenu (a special type of menu only used on trackMenus right now) had the slowish animation, so I made it faster here.