### PR TITLE
Fix mygene.info demo track

### DIFF
--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -267,7 +267,7 @@
       "assemblyNames": ["hg38"],
       "category": ["Annotation"],
       "adapter": {
-        "baseUrl": "https://mygene.info/v3/query?q=${ref}:${start}-${end}&size=1000&fields=all&size=1000&species=human",
+        "baseUrl": "https://mygene.info/v3/query?q={ref}:{start}-{end}&size=1000&fields=all&size=1000&species=human",
         "type": "MyGeneV3Adapter"
       }
     },
@@ -278,7 +278,7 @@
       "assemblyNames": ["hg19"],
       "category": ["Annotation"],
       "adapter": {
-        "baseUrl": "https://mygene.info/v3/query?q=hg19.${ref}:${start}-${end}&size=1000&fields=all&size=1000&species=human",
+        "baseUrl": "https://mygene.info/v3/query?q=hg19.{ref}:{start}-{end}&size=1000&fields=all&size=1000&species=human",
         "type": "MyGeneV3Adapter"
       }
     },


### PR DESCRIPTION
The jbrowse-plugin-biothings-api plugin was changed to use the package 'string-template' https://www.npmjs.com/package/string-template in recent versions (circa june 2022) so the "dollar signs" need to be removed to make the demo work