### PR TITLE
Change gitter link to use new element gitter app

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -152,7 +152,8 @@ also because you can manually edit in advanced configs after your tracks are
 loaded; however be careful:s corrupt configs can produce hard to understand
 errors, because our config system is strongly typed.
 
-Reach out to the team [on gitter](https://gitter.im/GMOD/jbrowse2) or in the
+Reach out to the team
+[on gitter](https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im) or in the
 [discussions](https://github.com/GMOD/jbrowse-components/discussions) if you
 have any complex configuration issues.
 

--- a/website/docs/tutorials/simple_plugin.md
+++ b/website/docs/tutorials/simple_plugin.md
@@ -858,5 +858,6 @@ thus more that you can do with plugins!) checkout our
 
 If you have further questions about plugin development, or development with
 JBrowse in general, stop by the JBrowse team
-[gitter channel](https://gitter.im/GMOD/jbrowse2), or start a discssion on the
+[gitter channel](https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im), or
+start a discssion on the
 [jbrowse-components discussions forum](https://github.com/GMOD/jbrowse-components/discussions).

--- a/website/docusaurus.config.json
+++ b/website/docusaurus.config.json
@@ -103,7 +103,7 @@
           "items": [
             {
               "label": "Gitter",
-              "href": "https://gitter.im/GMOD/jbrowse2"
+              "href": "https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im"
             },
             {
               "label": "Twitter",

--- a/website/src/pages/contact.md
+++ b/website/src/pages/contact.md
@@ -11,5 +11,6 @@ have on what we are building!
   https://github.com/GMOD/jbrowse-components/discussions
 - Report a bug or request a feature at
   https://github.com/GMOD/jbrowse-components/issues/new/choose
-- Join our developers chat at https://gitter.im/GMOD/jbrowse2
+- Join our developers chat at
+  https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im
 - Send an email to our mailing list at `gmod-ajax@lists.sourceforge.net`


### PR DESCRIPTION
When the old `gitter.im` shuts down and we have to use the new `app.gitter.im` element app, this link should work for the JBrowse 2 room.