### PR TITLE
Fix loading session shares that have a plus sign in the sessionId

### DIFF
--- a/products/jbrowse-aws-lambda-functions/saved-sessions/read-session-jbrowse.js
+++ b/products/jbrowse-aws-lambda-functions/saved-sessions/read-session-jbrowse.js
@@ -17,8 +17,12 @@ async function readSession(sessionId) {
 
 exports.handler = async event => {
   const data = event.queryStringParameters
-  const { sessionId } = data
+  let { sessionId } = data
   let tableData
+
+  // workaround for '+' character being encoded by api gateway (?) as space, xref
+  // https://github.com/GMOD/jbrowse-components/pull/3524
+  sessionId = sessionId.replace(/ /g, '+')
   try {
     tableData = await readSession(sessionId)
   } catch (e) {

--- a/products/jbrowse-web/src/sessionSharing.ts
+++ b/products/jbrowse-web/src/sessionSharing.ts
@@ -72,7 +72,7 @@ export async function readSessionFromDynamo(
   signal?: AbortSignal,
 ) {
   const sessionId = sessionQueryParam.split('share-')[1]
-  const url = `${baseUrl}?sessionId=${sessionId}`
+  const url = `${baseUrl}?sessionId=${encodeURIComponent(sessionId)}`
   const response = await fetch(url, {
     signal,
   })


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/3520

Works

https://share.jbrowse.org/api/v1/load?sessionId=Xc-hrJg1O%2B

Fails

https://share.jbrowse.org/api/v1/load?sessionId=Xc-hrJg1O+

Seems like it should be the same, could fix on the server side perhaps, but this is a client side fix

