### PR TITLE
Don't load theme from session snapshot, only from local storage

### DIFF
--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -125,16 +125,9 @@ export default function sessionModelFactory(
         types.string,
         () => localStorageGetItem('drawerPosition') || 'right',
       ),
-
-      /**
-       * #property
-       */
-      sessionThemeName: types.optional(
-        types.string,
-        () => localStorageGetItem('themeName') || 'default',
-      ),
     })
     .volatile((/* self */) => ({
+      sessionThemeName: localStorageGetItem('themeName') || 'default',
       /**
        * this is the globally "selected" object. can be anything.
        * code that wants to deal with this should examine it to see what

--- a/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
+++ b/products/jbrowse-web/src/__snapshots__/sessionModelFactory.test.js.snap
@@ -12,7 +12,6 @@ exports[`JBrowseWebSessionModel creates with no parent and just a name 1`] = `
   "sessionAssemblies": [],
   "sessionConnections": [],
   "sessionPlugins": [],
-  "sessionThemeName": "default",
   "sessionTracks": [],
   "temporaryAssemblies": [],
   "views": [],

--- a/products/jbrowse-web/src/sessionModelFactory.ts
+++ b/products/jbrowse-web/src/sessionModelFactory.ts
@@ -160,16 +160,12 @@ export default function sessionModelFactory(
         types.string,
         () => localStorageGetItem('drawerPosition') || 'right',
       ),
-
-      /**
-       * #property
-       */
-      sessionThemeName: types.optional(
-        types.string,
-        () => localStorageGetItem('themeName') || 'default',
-      ),
     })
     .volatile((/* self */) => ({
+      /**
+       * #volatile
+       */
+      sessionThemeName: localStorageGetItem('themeName') || 'default',
       /**
        * #volatile
        * this is the globally "selected" object. can be anything.


### PR DESCRIPTION
Currently, the theme name is stored in the session snapshot. This makes the themes somewhat "viral" and would be applied when someone shared their session with someone else. The person receiving the snapshot, could, in a bad case, think there is a bug suddenly being thrown into a dark theme.

This PR makes it so we load the users current theme from local storage only