### PR TITLE
Fix issue where clearing search box on LGV import form turns search box into loading bar

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()(theme => ({
 
 type LGV = LinearGenomeViewModel
 
-const ImportForm = observer(({ model }: { model: LGV }) => {
+export default observer(function ({ model }: { model: LGV }) {
   const { classes } = useStyles()
   const session = getSession(model)
   const { assemblyNames, assemblyManager, textSearchManager } = session
@@ -49,10 +49,11 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   const assemblyError = assemblyNames.length
     ? assembly?.error
     : 'No configured assemblies'
-  const regions = assembly?.regions || []
   const displayError = assemblyError || error
   const [value, setValue] = useState('')
-  const r0 = regions[0]?.refName
+  const regions = assembly?.regions
+  const assemblyLoaded = !!regions
+  const r0 = regions ? regions[0]?.refName : ''
 
   // useEffect resets to an "initial state" of displaying first region from
   // assembly after assembly change. needs to react to selectedAsm as well as
@@ -154,7 +155,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
               {selectedAsm ? (
                 assemblyError ? (
                   <CloseIcon style={{ color: 'red' }} />
-                ) : regions.length ? (
+                ) : assemblyLoaded ? (
                   <FormControl>
                     <RefNameAutocomplete
                       fetchResults={queryString =>
@@ -224,5 +225,3 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
     </div>
   )
 })
-
-export default ImportForm

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -4,10 +4,10 @@ import { observer } from 'mobx-react'
 import { getSession } from '@jbrowse/core/util'
 import {
   Button,
-  CircularProgress,
   FormControl,
   Container,
   Grid,
+  CircularProgress,
 } from '@mui/material'
 import { ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
 import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
@@ -19,6 +19,8 @@ import CloseIcon from '@mui/icons-material/Close'
 import RefNameAutocomplete from './RefNameAutocomplete'
 import { fetchResults, splitLast } from './util'
 import { LinearGenomeViewModel } from '..'
+
+// lazies
 const SearchResultsDialog = lazy(() => import('./SearchResultsDialog'))
 
 const useStyles = makeStyles()(theme => ({
@@ -42,9 +44,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   const { rankSearchResults, isSearchDialogDisplayed, error } = model
   const [selectedAsm, setSelectedAsm] = useState(assemblyNames[0])
   const [option, setOption] = useState<BaseResult>()
-
   const searchScope = model.searchScope(selectedAsm)
-
   const assembly = assemblyManager.get(selectedAsm)
   const assemblyError = assemblyNames.length
     ? assembly?.error
@@ -54,10 +54,11 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
   const [value, setValue] = useState('')
   const r0 = regions[0]?.refName
 
-  // useEffect resets to an "initial state" of displaying first region from assembly
-  // after assembly change. needs to react to selectedAsm as well as r0 because changing
-  // assembly will run setValue('') and then r0 may not change if assembly names are the
-  // same across assemblies, but it still needs to be reset
+  // useEffect resets to an "initial state" of displaying first region from
+  // assembly after assembly change. needs to react to selectedAsm as well as
+  // r0 because changing assembly will run setValue('') and then r0 may not
+  // change if assembly names are the same across assemblies, but it still
+  // needs to be reset
   useEffect(() => {
     setValue(r0)
   }, [r0, selectedAsm])
@@ -142,10 +143,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
             <Grid item>
               <FormControl>
                 <AssemblySelector
-                  onChange={val => {
-                    setSelectedAsm(val)
-                    setValue('')
-                  }}
+                  onChange={val => setSelectedAsm(val)}
                   localStorageKey="lgv"
                   session={session}
                   selected={selectedAsm}
@@ -156,7 +154,7 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
               {selectedAsm ? (
                 assemblyError ? (
                   <CloseIcon style={{ color: 'red' }} />
-                ) : value ? (
+                ) : regions.length ? (
                   <FormControl>
                     <RefNameAutocomplete
                       fetchResults={queryString =>
@@ -169,9 +167,8 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                         })
                       }
                       model={model}
-                      assemblyName={assemblyError ? undefined : selectedAsm}
+                      assemblyName={selectedAsm}
                       value={value}
-                      // note: minWidth 270 accommodates full width of helperText
                       minWidth={270}
                       onChange={str => setValue(str)}
                       onSelect={val => setOption(val)}
@@ -179,16 +176,11 @@ const ImportForm = observer(({ model }: { model: LGV }) => {
                         variant: 'outlined',
                         helperText:
                           'Enter sequence name, feature name, or location',
-                        style: { minWidth: '175px' },
                       }}
                     />
                   </FormControl>
                 ) : (
-                  <CircularProgress
-                    role="progressbar"
-                    size={20}
-                    disableShrink
-                  />
+                  <CircularProgress size={20} disableShrink />
                 )
               ) : null}
             </Grid>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -6,7 +6,6 @@ import BaseResult, {
 } from '@jbrowse/core/TextSearch/BaseResults'
 import {
   Autocomplete,
-  CircularProgress,
   IconButton,
   InputAdornment,
   TextField,
@@ -244,21 +243,17 @@ function RefNameAutocomplete({
 
                 endAdornment: (
                   <>
-                    {!loaded ? (
-                      <CircularProgress color="inherit" size={20} />
-                    ) : (
-                      <InputAdornment position="end" style={{ marginRight: 7 }}>
-                        <SearchIcon fontSize="small" />
-                        {showHelp ? (
-                          <IconButton
-                            onClick={() => setHelpDialogDisplayed(true)}
-                            size="small"
-                          >
-                            <HelpIcon fontSize="small" />
-                          </IconButton>
-                        ) : null}
-                      </InputAdornment>
-                    )}
+                    <InputAdornment position="end" style={{ marginRight: 7 }}>
+                      <SearchIcon fontSize="small" />
+                      {showHelp ? (
+                        <IconButton
+                          onClick={() => setHelpDialogDisplayed(true)}
+                          size="small"
+                        >
+                          <HelpIcon fontSize="small" />
+                        </IconButton>
+                      ) : null}
+                    </InputAdornment>
                     {params.InputProps.endAdornment}
                   </>
                 ),

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -103,10 +103,11 @@ function SearchBox({
         })
       }
       model={model}
+      minWidth={175}
       TextFieldProps={{
         variant: 'outlined',
         className: classes.headerRefName,
-        style: { margin: SPACING, minWidth: '175px' },
+        style: { margin: SPACING },
         InputProps: {
           style: {
             padding: 0,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -160,11 +160,11 @@ exports[`renders one track, one region 1`] = `
             <div
               class="MuiAutocomplete-root css-l3ln04-MuiAutocomplete-root"
               data-testid="autocomplete"
-              style="width: 200px;"
+              style="width: 175px;"
             >
               <div
                 class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1efd6m0-MuiFormControl-root-MuiTextField-root-headerRefName"
-                style="margin: 7px; min-width: 175px;"
+                style="margin: 7px;"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
@@ -177,7 +177,7 @@ exports[`renders one track, one region 1`] = `
                     autocapitalize="none"
                     autocomplete="off"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                    id="refNameAutocomplete-lgv"
+                    id="mui-7"
                     placeholder="Search for location"
                     role="combobox"
                     spellcheck="false"
@@ -740,7 +740,7 @@ exports[`renders two tracks, two regions 1`] = `
             >
               <div
                 class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1efd6m0-MuiFormControl-root-MuiTextField-root-headerRefName"
-                style="margin: 7px; min-width: 175px;"
+                style="margin: 7px;"
               >
                 <div
                   class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
@@ -753,7 +753,7 @@ exports[`renders two tracks, two regions 1`] = `
                     autocapitalize="none"
                     autocomplete="off"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
-                    id="refNameAutocomplete-lgv"
+                    id="mui-9"
                     placeholder="Search for location"
                     role="combobox"
                     spellcheck="false"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -249,11 +249,11 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   <div
                     class="MuiAutocomplete-root css-4xbbh5-MuiAutocomplete-root"
                     data-testid="autocomplete"
-                    style="width: 200px;"
+                    style="width: 175px;"
                   >
                     <div
                       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-19wwqcl-MuiFormControl-root-MuiTextField-root-headerRefName"
-                      style="margin: 7px; min-width: 175px;"
+                      style="margin: 7px;"
                     >
                       <div
                         class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1dityd8-MuiInputBase-root-MuiOutlinedInput-root"
@@ -266,7 +266,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="refNameAutocomplete-test_view"
+                          id="mui-3"
                           placeholder="Search for location"
                           role="combobox"
                           spellcheck="false"


### PR DESCRIPTION
This addresses a regression introduced in v2.2.0, related to #3306

The bug that is seen is if you clear the text in the searchbox in the linear genome view import form, an infinite loading spinner replaces the search box suddenly, and you can then no longer alter the search unless you change assemblies


The fix applied here is instead of showing a loading state depending on the "value" of the box being empty, show loading state if regions.length is empty which implies the assembly is loading (could try to do undefined also if it is of interest but we have a assembly?.regions||[])

Some small refactorings added also, but the main issue fixed by the above description


