### PR TITLE
Fix visual effect from using the overview scalebar click and dragging backwards

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberband.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberband.tsx
@@ -4,6 +4,8 @@ import { makeStyles } from 'tss-react/mui'
 import { getSession, stringify } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 import { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
+
+// locals
 import { LinearGenomeViewModel } from '..'
 import RubberbandSpan from './RubberbandSpan'
 import { getRelativeX } from './util'
@@ -25,50 +27,43 @@ const useStyles = makeStyles()({
   },
 })
 
-const HoverTooltip = observer(
-  ({
-    model,
-    open,
-    guideX,
-    overview,
-  }: {
-    model: LGV
-    open: boolean
-    guideX: number
-    overview: Base1DViewModel
-  }) => {
-    const { classes } = useStyles()
-    const { cytobandOffset } = model
-    const { assemblyManager } = getSession(model)
+const HoverTooltip = observer(function ({
+  model,
+  open,
+  guideX,
+  overview,
+}: {
+  model: LGV
+  open: boolean
+  guideX: number
+  overview: Base1DViewModel
+}) {
+  const { classes } = useStyles()
+  const { cytobandOffset } = model
+  const { assemblyManager } = getSession(model)
 
-    const px = overview.pxToBp(guideX - cytobandOffset)
-    const assembly = assemblyManager.get(px.assemblyName)
-    const cytoband = assembly?.cytobands?.find(
-      f =>
-        px.coord > f.get('start') &&
-        px.coord < f.get('end') &&
-        px.refName === assembly.getCanonicalRefName(f.get('refName')),
-    )
+  const px = overview.pxToBp(guideX - cytobandOffset)
+  const assembly = assemblyManager.get(px.assemblyName)
+  const cytoband = assembly?.cytobands?.find(
+    f =>
+      px.coord > f.get('start') &&
+      px.coord < f.get('end') &&
+      px.refName === assembly.getCanonicalRefName(f.get('refName')),
+  )
 
-    return (
-      <Tooltip
-        open={open}
-        placement="top"
-        title={[stringify(px), cytoband?.get('name')].join(' ')}
-        arrow
-      >
-        <div
-          className={classes.guide}
-          style={{
-            left: guideX,
-          }}
-        />
-      </Tooltip>
-    )
-  },
-)
+  return (
+    <Tooltip
+      open={open}
+      placement="top"
+      title={[stringify(px), cytoband?.get('name')].join(' ')}
+      arrow
+    >
+      <div className={classes.guide} style={{ left: guideX }} />
+    </Tooltip>
+  )
+})
 
-function OverviewRubberband({
+export default observer(function OverviewRubberband({
   model,
   overview,
   ControlComponent = <div />,
@@ -171,7 +166,6 @@ function OverviewRubberband({
         ) : null}
         <div
           className={classes.rubberbandControl}
-          role="presentation"
           ref={controlsRef}
           onMouseDown={mouseDown}
           onMouseOut={mouseOut}
@@ -195,7 +189,7 @@ function OverviewRubberband({
   if (startX) {
     leftBpOffset = overview.pxToBp(startX - cytobandOffset)
     rightBpOffset = overview.pxToBp(startX + width - cytobandOffset)
-    if (currentX && currentX < startX) {
+    if (currentX !== undefined && currentX < startX) {
       ;[leftBpOffset, rightBpOffset] = [rightBpOffset, leftBpOffset]
     }
   }
@@ -206,14 +200,13 @@ function OverviewRubberband({
         <RubberbandSpan
           leftBpOffset={leftBpOffset}
           rightBpOffset={rightBpOffset}
-          width={width}
+          width={Math.abs(width)}
           left={left}
         />
       ) : null}
       <div
         data-testid="rubberband_controls"
         className={classes.rubberbandControl}
-        role="presentation"
         ref={controlsRef}
         onMouseDown={mouseDown}
         onMouseOut={mouseOut}
@@ -223,6 +216,4 @@ function OverviewRubberband({
       </div>
     </div>
   )
-}
-
-export default observer(OverviewRubberband)
+})

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
@@ -297,7 +297,7 @@ const Scalebar = observer(function ({
   )
 })
 
-function OverviewScalebar({
+export default observer(function OverviewScalebar({
   model,
   children,
 }: {
@@ -337,8 +337,6 @@ function OverviewScalebar({
       </div>
     </div>
   )
-}
-
-export default observer(OverviewScalebar)
+})
 
 export { Cytobands, Polygon }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandSpan.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandSpan.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react'
 import { makeStyles } from 'tss-react/mui'
-
 import { Popover, Typography, alpha } from '@mui/material'
 import { stringify, toLocale } from '@jbrowse/core/util'
 
@@ -43,7 +42,7 @@ interface Offset {
   oob?: boolean
 }
 
-function RubberbandSpan({
+export default function RubberbandSpan({
   leftBpOffset,
   rightBpOffset,
   numOfBpSelected,
@@ -67,14 +66,8 @@ function RubberbandSpan({
             classes={{ paper: classes.paper }}
             open
             anchorEl={ref.current}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'left',
-            }}
-            transformOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right',
-            }}
+            anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
             keepMounted
             disableRestoreFocus
           >
@@ -82,19 +75,11 @@ function RubberbandSpan({
           </Popover>
           <Popover
             className={classes.popover}
-            classes={{
-              paper: classes.paper,
-            }}
+            classes={{ paper: classes.paper }}
             open
             anchorEl={ref.current}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            transformOrigin={{
-              vertical: 'bottom',
-              horizontal: 'left',
-            }}
+            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             keepMounted
             disableRestoreFocus
           >
@@ -112,5 +97,3 @@ function RubberbandSpan({
     </>
   )
 }
-
-export default RubberbandSpan

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`renders one track, one region 1`] = `
       >
         <div
           class="css-dznme2-rubberbandControl"
-          role="presentation"
         >
           <div
             class="css-16vhz0m-scalebar"
@@ -570,7 +569,6 @@ exports[`renders two tracks, two regions 1`] = `
       >
         <div
           class="css-dznme2-rubberbandControl"
-          role="presentation"
         >
           <div
             class="css-16vhz0m-scalebar"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
             >
               <div
                 class="css-dznme2-rubberbandControl"
-                role="presentation"
               >
                 <div
                   class="css-16vhz0m-scalebar"


### PR DESCRIPTION
Clicking and dragging the overview scale bar and going from right to left produced the wrong visual selection (the accurate zoom would be produced though)

This was introduced in v2.2.2 with #3357 