### PR TITLE
Dotplot UI improvements

### DIFF
--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -196,17 +196,26 @@ const Base1DView = types
     /**
      * #action
      */
-    zoomTo(newBpPerPx: number, offset = self.width / 2) {
-      const bpPerPx = newBpPerPx
-      if (bpPerPx === self.bpPerPx) {
-        return self.bpPerPx
-      }
-      const oldBpPerPx = self.bpPerPx
-      self.bpPerPx = bpPerPx
+    zoomTo(bpPerPx: number, offset = self.width / 2) {
+      const newBpPerPx = clamp(
+        bpPerPx,
+        'minBpPerPx' in self ? (self.minBpPerPx as number) : 0,
+        'maxBpPerPx' in self ? (self.maxBpPerPx as number) : Infinity,
+      )
 
-      // tweak the offset so that the center of the view remains at the same coordinate
+      const oldBpPerPx = self.bpPerPx
+      if (Math.abs(oldBpPerPx - newBpPerPx) < 0.000001) {
+        return oldBpPerPx
+      }
+
+      self.bpPerPx = newBpPerPx
+
+      // tweak the offset so that the center of the view remains at the same
+      // coordinate
       self.offsetPx = clamp(
-        Math.round(((self.offsetPx + offset) * oldBpPerPx) / bpPerPx - offset),
+        Math.round(
+          ((self.offsetPx + offset) * oldBpPerPx) / newBpPerPx - offset,
+        ),
         self.minOffset,
         self.maxOffset,
       )

--- a/plugins/dotplot-view/src/DotplotView/1dview.ts
+++ b/plugins/dotplot-view/src/DotplotView/1dview.ts
@@ -34,6 +34,13 @@ const Dotplot1DView = Base1DView.extend(self => {
       get maxBpPerPx() {
         return self.totalBp / (self.width - 50)
       },
+
+      /**
+       * #getter
+       */
+      get minBpPerPx() {
+        return 1 / 50
+      },
     },
     actions: {
       /**

--- a/plugins/dotplot-view/src/DotplotView/1dview.ts
+++ b/plugins/dotplot-view/src/DotplotView/1dview.ts
@@ -41,6 +41,20 @@ const Dotplot1DView = Base1DView.extend(self => {
       get minBpPerPx() {
         return 1 / 50
       },
+
+      /**
+       * #getter
+       */
+      get maxOffset() {
+        return self.displayedRegionsTotalPx - self.width * 0.95
+      },
+
+      /**
+       * #getter
+       */
+      get minOffset() {
+        return -self.width * 0.05
+      },
     },
     actions: {
       /**

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -102,7 +102,7 @@ const DotplotViewInternal = observer(function ({
   const mouserect = mouseup || mousecurr
   const xdistance = mousedown && mouserect ? mouserect[0] - mousedown[0] : 0
   const ydistance = mousedown && mouserect ? mouserect[1] - mousedown[1] : 0
-  const { hview, vview } = model
+  const { hview, vview, wheelMode } = model
 
   // use non-React wheel handler to properly prevent body scrolling
   useEffect(() => {
@@ -117,8 +117,14 @@ const DotplotViewInternal = observer(function ({
 
         window.requestAnimationFrame(() => {
           transaction(() => {
-            hview.scroll(distanceX.current)
-            vview.scroll(distanceY.current)
+            if (wheelMode === 'pan') {
+              hview.scroll(distanceX.current / 3)
+              vview.scroll(distanceY.current / 10)
+            } else if (wheelMode === 'zoom') {
+              const val = distanceY.current < 0 ? 1.1 : 0.9
+              hview.zoomTo(hview.bpPerPx * val)
+              vview.zoomTo(vview.bpPerPx * val)
+            }
           })
           scheduled.current = false
           distanceX.current = 0
@@ -132,7 +138,7 @@ const DotplotViewInternal = observer(function ({
       return () => curr.removeEventListener('wheel', onWheel)
     }
     return () => {}
-  }, [hview, vview])
+  }, [hview, vview, wheelMode])
 
   useEffect(() => {
     function globalMouseMove(event: MouseEvent) {

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotWarnings.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotWarnings.tsx
@@ -1,0 +1,26 @@
+import React, { lazy, useState } from 'react'
+import { Alert, Button } from '@mui/material'
+import { observer } from 'mobx-react'
+
+// locals
+import { DotplotViewModel } from '../model'
+
+// lazy components
+const WarningDialog = lazy(() => import('./WarningDialog'))
+
+export default observer(function ({ model }: { model: DotplotViewModel }) {
+  const trackWarnings = model.tracks.filter(t => t.displays[0].warnings?.length)
+  const [shown, setShown] = useState(false)
+  return trackWarnings.length ? (
+    <Alert severity="warning">
+      Warnings during render{' '}
+      <Button onClick={() => setShown(true)}>More info</Button>
+      {shown ? (
+        <WarningDialog
+          trackWarnings={trackWarnings}
+          handleClose={() => setShown(false)}
+        />
+      ) : null}
+    </Alert>
+  ) : null
+})

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -98,18 +98,18 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
               checked: model.showPanButtons,
             },
             {
-              label: 'Cursor mode',
+              label: 'Click and drag mode',
               subMenu: [
                 {
                   onClick: () => model.setCursorMode('move'),
-                  label: 'Click and drag to move',
+                  label: 'Pan by default, select region when ctrl key is held',
                   icon: CursorMove,
                   type: 'radio',
                   checked: model.cursorMode === 'move',
                 },
                 {
                   onClick: () => model.setCursorMode('crosshair'),
-                  label: 'Select region',
+                  label: 'Select region by default, pan when ctrl key is held',
                   icon: CursorMouse,
                   type: 'radio',
                   checked: model.cursorMode === 'crosshair',

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -79,7 +79,7 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
             },
             {
               onClick: () => model.squareViewProportional(),
-              label: 'Rectanglular view - same total bp',
+              label: 'Rectanglularize view - same total bp',
             },
             {
               onClick: () => model.showAllRegions(),
@@ -98,18 +98,46 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
               checked: model.showPanButtons,
             },
             {
-              onClick: () => model.setCursorMode('move'),
-              label: 'Cursor mode - click and drag to move',
-              icon: CursorMove,
-              type: 'radio',
-              checked: model.cursorMode === 'move',
+              label: 'Cursor mode',
+              subMenu: [
+                {
+                  onClick: () => model.setCursorMode('move'),
+                  label: 'Click and drag to move',
+                  icon: CursorMove,
+                  type: 'radio',
+                  checked: model.cursorMode === 'move',
+                },
+                {
+                  onClick: () => model.setCursorMode('crosshair'),
+                  label: 'Select region',
+                  icon: CursorMouse,
+                  type: 'radio',
+                  checked: model.cursorMode === 'crosshair',
+                },
+              ],
             },
             {
-              onClick: () => model.setCursorMode('crosshair'),
-              label: 'Cursor mode - select region',
-              icon: CursorMouse,
-              type: 'radio',
-              checked: model.cursorMode === 'crosshair',
+              label: 'Wheel scroll mode',
+              subMenu: [
+                {
+                  onClick: () => model.setWheelMode('pan'),
+                  label: 'Pans view',
+                  type: 'radio',
+                  checked: model.wheelMode === 'pan',
+                },
+                {
+                  onClick: () => model.setWheelMode('zoom'),
+                  label: 'Zooms view',
+                  type: 'radio',
+                  checked: model.wheelMode === 'zoom',
+                },
+                {
+                  onClick: () => model.setWheelMode('none'),
+                  label: 'Disable',
+                  type: 'radio',
+                  checked: model.wheelMode === 'none',
+                },
+              ],
             },
           ]}
           onClose={() => setMenuAnchorEl(undefined)}

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -1,5 +1,5 @@
-import React, { lazy, useState } from 'react'
-import { Alert, Button, IconButton, Typography } from '@mui/material'
+import React, { useState } from 'react'
+import { IconButton, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 import { getBpDisplayStr } from '@jbrowse/core/util'
@@ -14,9 +14,8 @@ import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 
 // locals
 import { DotplotViewModel } from '../model'
-
-// lazy components
-const WarningDialog = lazy(() => import('./WarningDialog'))
+import DotplotWarnings from './DotplotWarnings'
+import PanButtons from './PanButtons'
 
 const useStyles = makeStyles()({
   iconButton: {
@@ -32,6 +31,7 @@ const useStyles = makeStyles()({
   },
   headerBar: {
     display: 'flex',
+    position: 'relative',
   },
 })
 
@@ -44,16 +44,12 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
         <ZoomOut />
       </IconButton>
 
-      <IconButton
-        onClick={model.zoomInButton}
-        className={classes.iconButton}
-        title="zoom in"
-      >
+      <IconButton onClick={model.zoomInButton} className={classes.iconButton}>
         <ZoomIn />
       </IconButton>
 
       <IconButton
-        onClick={model.activateTrackSelector}
+        onClick={() => model.activateTrackSelector()}
         className={classes.iconButton}
         title="Open track selector"
         data-testid="circular_track_select"
@@ -96,6 +92,12 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
               checked: model.drawCigar,
             },
             {
+              onClick: () => model.setShowPanButtons(!model.showPanButtons),
+              label: 'Show pan buttons',
+              type: 'checkbox',
+              checked: model.showPanButtons,
+            },
+            {
               onClick: () => model.setCursorMode('move'),
               label: 'Cursor mode - click and drag to move',
               icon: CursorMove,
@@ -116,61 +118,37 @@ const DotplotControls = observer(({ model }: { model: DotplotViewModel }) => {
     </div>
   )
 })
-const Warnings = observer(({ model }: { model: DotplotViewModel }) => {
-  const tracksWithWarnings = model.tracks.filter(
-    t => t.displays[0].warnings?.length,
-  )
-  const [shown, setShown] = useState(false)
-  return tracksWithWarnings.length ? (
-    <Alert severity="warning">
-      Warnings during render{' '}
-      <Button onClick={() => setShown(true)}>More info</Button>
-      {shown ? (
-        <WarningDialog
-          tracksWithWarnings={tracksWithWarnings}
-          handleClose={() => setShown(false)}
-        />
-      ) : null}
-    </Alert>
-  ) : null
-})
 
-const Header = observer(
-  ({
-    model,
-    selection,
-  }: {
-    model: DotplotViewModel
-    selection?: { width: number; height: number }
-  }) => {
-    const { classes } = useStyles()
-    const { hview, vview } = model
-    return (
-      <div className={classes.headerBar}>
-        <DotplotControls model={model} />
+export default observer(function Header({
+  model,
+  selection,
+}: {
+  model: DotplotViewModel
+  selection?: { width: number; height: number }
+}) {
+  const { classes } = useStyles()
+  const { hview, vview, showPanButtons } = model
+  return (
+    <div className={classes.headerBar}>
+      <DotplotControls model={model} />
+      <Typography className={classes.bp} variant="body2" color="textSecondary">
+        x: {hview.assemblyNames.join(',')} {getBpDisplayStr(hview.currBp)}
+        <br />
+        y: {vview.assemblyNames.join(',')} {getBpDisplayStr(vview.currBp)}
+      </Typography>
+      {selection ? (
         <Typography
           className={classes.bp}
           variant="body2"
           color="textSecondary"
         >
-          x: {hview.assemblyNames.join(',')} {getBpDisplayStr(hview.currBp)}
-          <br />
-          y: {vview.assemblyNames.join(',')} {getBpDisplayStr(vview.currBp)}
+          {`width:${getBpDisplayStr(hview.bpPerPx * selection.width)}`} <br />
+          {`height:${getBpDisplayStr(vview.bpPerPx * selection.height)}`}
         </Typography>
-        {selection ? (
-          <Typography
-            className={classes.bp}
-            variant="body2"
-            color="textSecondary"
-          >
-            {`width:${getBpDisplayStr(hview.bpPerPx * selection.width)}`} <br />
-            {`height:${getBpDisplayStr(vview.bpPerPx * selection.height)}`}
-          </Typography>
-        ) : null}
-        <div className={classes.spacer} />
-        <Warnings model={model} />
-      </div>
-    )
-  },
-)
-export default Header
+      ) : null}
+      <div className={classes.spacer} />
+      <DotplotWarnings model={model} />
+      {showPanButtons ? <PanButtons model={model} /> : null}
+    </div>
+  )
+})

--- a/plugins/dotplot-view/src/DotplotView/components/PanButtons.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/PanButtons.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { IconButton, Paper } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+
+// icons
+import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
+import ArrowDropUp from '@mui/icons-material/ArrowDropUp'
+import ArrowLeft from '@mui/icons-material/ArrowLeft'
+import ArrowRight from '@mui/icons-material/ArrowRight'
+import { DotplotViewModel } from '../model'
+import { observer } from 'mobx-react'
+
+const useStyles = makeStyles()(theme => ({
+  dpad: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    margin: 0,
+    position: 'absolute',
+    right: 50,
+    zIndex: 1000,
+    top: 50,
+  },
+  icon: {
+    padding: 0,
+    margin: 0,
+  },
+}))
+
+export default observer(function PanButtons({
+  model,
+}: {
+  model: DotplotViewModel
+}) {
+  const { classes } = useStyles()
+  return (
+    <Paper className={classes.dpad} elevation={6}>
+      <div />
+      <IconButton
+        className={classes.icon}
+        onClick={() => model.vview.scroll(100)}
+      >
+        <ArrowDropUp />
+      </IconButton>
+      <div />
+
+      <IconButton
+        className={classes.icon}
+        onClick={() => model.hview.scroll(100)}
+      >
+        <ArrowLeft />
+      </IconButton>
+      <div />
+      <IconButton
+        className={classes.icon}
+        onClick={() => model.hview.scroll(-100)}
+      >
+        <ArrowRight />
+      </IconButton>
+
+      <div />
+      <IconButton
+        className={classes.icon}
+        onClick={() => model.vview.scroll(-100)}
+      >
+        <ArrowDropDown />
+      </IconButton>
+      <div />
+    </Paper>
+  )
+})

--- a/plugins/dotplot-view/src/DotplotView/components/WarningDialog.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/WarningDialog.tsx
@@ -13,15 +13,17 @@ const useStyles = makeStyles()({
   },
 })
 
-function WarningDialog({
-  tracksWithWarnings,
+interface TrackWarning {
+  configuration: AnyConfigurationModel
+  displays: { warnings: { message: string; effect: string }[] }[]
+}
+
+export default observer(function WarningDialog({
+  trackWarnings,
   handleClose,
 }: {
   handleClose: () => void
-  tracksWithWarnings: {
-    configuration: AnyConfigurationModel
-    displays: { warnings: { message: string; effect: string }[] }[]
-  }[]
+  trackWarnings: TrackWarning[]
 }) {
   const { classes } = useStyles()
   const rows = [] as {
@@ -30,8 +32,8 @@ function WarningDialog({
     effect: string
     id: string
   }[]
-  for (let i = 0; i < tracksWithWarnings.length; i++) {
-    const track = tracksWithWarnings[i]
+  for (let i = 0; i < trackWarnings.length; i++) {
+    const track = trackWarnings[i]
     const name = getConf(track, 'name')
     for (let j = 0; j < track.displays[0].warnings.length; j++) {
       const warning = track.displays[0].warnings[j]
@@ -69,6 +71,4 @@ function WarningDialog({
       </DialogContent>
     </Dialog>
   )
-}
-
-export default observer(WarningDialog)
+})

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -129,7 +129,7 @@ export default function stateModelFactory(pm: PluginManager) {
          */
         wheelMode: types.optional(
           types.string,
-          () => localStorageGetItem('dotplot-wheelMode') || 'pan',
+          () => localStorageGetItem('dotplot-wheelMode') || 'zoom',
         ),
 
         /**

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -119,7 +119,18 @@ export default function stateModelFactory(pm: PluginManager) {
         /**
          * #property
          */
-        cursorMode: 'crosshair',
+        cursorMode: types.optional(
+          types.string,
+          () => localStorageGetItem('dotplot-cursorMode') || 'crosshair',
+        ),
+
+        /**
+         * #property
+         */
+        wheelMode: types.optional(
+          types.string,
+          () => localStorageGetItem('dotplot-wheelMode') || 'pan',
+        ),
 
         /**
          * #property
@@ -259,6 +270,12 @@ export default function stateModelFactory(pm: PluginManager) {
        */
       setShowPanButtons(flag: boolean) {
         self.showPanButtons = flag
+      },
+      /**
+       * #action
+       */
+      setWheelMode(str: string) {
+        self.wheelMode = str
       },
       /**
        * #action

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -24,6 +24,7 @@ import {
   minmax,
   measureText,
   max,
+  localStorageGetItem,
 } from '@jbrowse/core/util'
 import { getConf, AnyConfigurationModel } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
@@ -119,6 +120,15 @@ export default function stateModelFactory(pm: PluginManager) {
          * #property
          */
         cursorMode: 'crosshair',
+
+        /**
+         * #property
+         */
+        showPanButtons: types.optional(types.boolean, () =>
+          Boolean(
+            JSON.parse(localStorageGetItem('dotplot-showPanbuttons') || 'true'),
+          ),
+        ),
 
         /**
          * #property
@@ -247,6 +257,12 @@ export default function stateModelFactory(pm: PluginManager) {
       /**
        * #action
        */
+      setShowPanButtons(flag: boolean) {
+        self.showPanButtons = flag
+      },
+      /**
+       * #action
+       */
       setCursorMode(str: string) {
         self.cursorMode = str
       },
@@ -302,7 +318,8 @@ export default function stateModelFactory(pm: PluginManager) {
 
       /**
        * #action
-       * removes the view itself from the state tree entirely by calling the parent removeView
+       * removes the view itself from the state tree entirely by calling the
+       * parent removeView
        */
       closeView() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -531,6 +548,16 @@ export default function stateModelFactory(pm: PluginManager) {
         self.assemblyNames.forEach(asm => session.removeTemporaryAssembly(asm))
       },
       afterAttach() {
+        addDisposer(
+          self,
+          autorun(() => {
+            const s = (s: unknown) => JSON.stringify(s)
+            const { showPanButtons } = self
+            if (typeof localStorage !== 'undefined') {
+              localStorage.setItem('dotplot-showPanbuttons', s(showPanButtons))
+            }
+          }),
+        )
         addDisposer(
           self,
           autorun(

--- a/plugins/linear-genome-view/src/LinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.ts
@@ -4,15 +4,14 @@ import { ViewType } from '@jbrowse/core/pluggableElementTypes'
 import { stateModelFactory } from './model'
 
 export default (pluginManager: PluginManager) => {
-  pluginManager.addViewType(
-    () =>
-      new ViewType({
-        name: 'LinearGenomeView',
-        displayName: 'Linear genome view',
-        stateModel: stateModelFactory(pluginManager),
-        ReactComponent: lazy(() => import('./components/LinearGenomeView')),
-      }),
-  )
+  pluginManager.addViewType(() => {
+    return new ViewType({
+      name: 'LinearGenomeView',
+      displayName: 'Linear genome view',
+      stateModel: stateModelFactory(pluginManager),
+      ReactComponent: lazy(() => import('./components/LinearGenomeView')),
+    })
+  })
 }
 
 export * from './model'

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -583,25 +583,24 @@ export function stateModelFactory(pluginManager: PluginManager) {
       /**
        * #action
        */
-      zoomTo(bpPerPx: number) {
+      zoomTo(bpPerPx: number, offset = self.width / 2) {
         const newBpPerPx = clamp(bpPerPx, self.minBpPerPx, self.maxBpPerPx)
         if (newBpPerPx === self.bpPerPx) {
           return newBpPerPx
         }
         const oldBpPerPx = self.bpPerPx
-        self.bpPerPx = newBpPerPx
 
         if (Math.abs(oldBpPerPx - newBpPerPx) < 0.000001) {
           console.warn('zoomTo bpPerPx rounding error')
           return oldBpPerPx
         }
+        self.bpPerPx = newBpPerPx
 
-        // tweak the offset so that the center of the view remains at the same coordinate
-        const viewWidth = self.width
+        // tweak the offset so that the center of the view remains at the same
+        // coordinate
         this.scrollTo(
           Math.round(
-            ((self.offsetPx + viewWidth / 2) * oldBpPerPx) / newBpPerPx -
-              viewWidth / 2,
+            ((self.offsetPx + offset) * oldBpPerPx) / newBpPerPx - offset,
           ),
         )
         return newBpPerPx


### PR DESCRIPTION
1) Adds a d-pad pan buttons
2) Makes wheel scroll perform a zoom instead of a pan (user can change if they want, but wheel scroll to zoom is a more common UI interaction: think google map)
3) Reduces the action of wheel scroll by dividing by a reduction factor, this makes movements less dramatic
4) Adds holding ctrl+click-and-drag to pan view. Can also switch around so pan view is the default click-and-drag, and holding control performs region select. The latter is almost more user intuitive, but it reduces discoverability of "Open in linear synteny view" and the precise zooms, so the default is still click-and-drag to select region
5) Stricter zoom and scroll boundaries for the dotplot, to avoid scrolling out of view

Fixes #3554


