### PR TITLE
Fix use of "show all regions with data" feature in SV inspector with TRA entries (fetch CHR2 from INFO)

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/index.test.ts
@@ -311,7 +311,6 @@ test('can navToMultiple', () => {
 describe('Zoom to selected displayed regions', () => {
   const { Session, LinearGenomeModel } = initialize()
   let model: LGV
-  let largestBpPerPx: number
   beforeEach(() => {
     const session = Session.create({
       configuration: {},
@@ -357,7 +356,6 @@ describe('Zoom to selected displayed regions', () => {
       },
     )
 
-    largestBpPerPx = model.bpPerPx
     expect(model.offsetPx).toEqual(0)
     expect(model.bpPerPx).toBeCloseTo(31.408)
   })
@@ -384,7 +382,6 @@ describe('Zoom to selected displayed regions', () => {
     expect(model.offsetPx).toEqual(0)
     // 10000 - 5000 = 5000 / 800 = 6.25
     expect(model.bpPerPx).toEqual(6.25)
-    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })
 
   it('can select one region with start or end outside of displayed region', () => {
@@ -411,7 +408,6 @@ describe('Zoom to selected displayed regions', () => {
     expect(Math.abs(model.offsetPx)).toEqual(0)
     // endOffset 19000 - (-1) = 19001 /  800 = zoomTo(23.75)
     expect(model.bpPerPx).toBeCloseTo(23.75)
-    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })
 
   it('can select over two regions in the same reference sequence', () => {
@@ -439,7 +435,6 @@ describe('Zoom to selected displayed regions', () => {
     expect(model.bpPerPx).toBeCloseTo(27.78, 0)
     // offset 5000 / bpPerPx (because that is the starting) = 180.5
     expect(model.offsetPx).toBe(181)
-    expect(model.bpPerPx).toBeLessThan(largestBpPerPx)
   })
 
   it('can navigate to overlapping regions with a region between', () => {

--- a/plugins/sv-inspector/src/SvInspectorView/index.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/index.ts
@@ -3,10 +3,34 @@ import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
 
 import ReactComponent from './components/SvInspectorView'
 import stateModelFactory from './models/SvInspectorView'
+import { Feature, getContainingView, getSession } from '@jbrowse/core/util'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
+
+function defaultOnChordClick(
+  feature: Feature,
+  chordTrack: IAnyStateTreeNode,
+  pluginManager: PluginManager,
+) {
+  const session = getSession(chordTrack)
+  session.setSelection(feature)
+  const view = getContainingView(chordTrack)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const viewType = pluginManager.getViewType('BreakpointSplitView') as any
+  const viewSnapshot = viewType.snapshotFromBreakendFeature(feature, view)
+
+  // try to center the offsetPx
+  viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
+  viewSnapshot.views[1].offsetPx -= view.width / 2 + 100
+  viewSnapshot.featureData = feature.toJSON()
+
+  session.addView('BreakpointSplitView', viewSnapshot)
+}
 
 export default (pluginManager: PluginManager) => {
+  pluginManager.jexl.addFunction('defaultOnChordClick', defaultOnChordClick)
+
   pluginManager.addViewType(() => {
-    const { stateModel } = stateModelFactory(pluginManager)
+    const stateModel = stateModelFactory(pluginManager)
     return new ViewType({
       name: 'SvInspectorView',
       displayName: 'SV inspector',

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -1,49 +1,29 @@
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import clone from 'clone'
-import {
-  getContainingView,
-  getSession,
-  Feature,
-  Region,
-} from '@jbrowse/core/util'
-
 import { autorun, reaction } from 'mobx'
-import { readConfObject } from '@jbrowse/core/configuration'
 import { types, getParent, addDisposer, Instance } from 'mobx-state-tree'
+
+import PluginManager from '@jbrowse/core/PluginManager'
+import { getSession, Region } from '@jbrowse/core/util'
+import { readConfObject } from '@jbrowse/core/configuration'
 import { ElementId } from '@jbrowse/core/util/types/mst'
 import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
+import { SpreadsheetViewStateModel } from '@jbrowse/plugin-spreadsheet-view'
+import { CircularViewStateModel } from '@jbrowse/plugin-circular-view'
+
+// icons
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 // locals
 import {
   canOpenBreakpointSplitViewFromTableRow,
   openBreakpointSplitViewFromTableRow,
-  getSerializedFeatureForRow,
+  getFeatureForRow,
 } from './breakpointSplitViewFromTableRow'
-import PluginManager from '@jbrowse/core/PluginManager'
-import { SpreadsheetViewStateModel } from '@jbrowse/plugin-spreadsheet-view'
-import { CircularViewStateModel } from '@jbrowse/plugin-circular-view'
 
-function defaultOnChordClick(
-  feature: Feature,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  chordTrack: any,
-  pluginManager: PluginManager,
-) {
-  const session = getSession(chordTrack)
-  session.setSelection(feature)
-  const view = getContainingView(chordTrack)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const viewType = pluginManager.getViewType('BreakpointSplitView') as any
-  const viewSnapshot = viewType.snapshotFromBreakendFeature(feature, view)
-
-  // try to center the offsetPx
-  viewSnapshot.views[0].offsetPx -= view.width / 2 + 100
-  viewSnapshot.views[1].offsetPx -= view.width / 2 + 100
-  viewSnapshot.featureData = feature.toJSON()
-
-  session.addView('BreakpointSplitView', viewSnapshot)
-}
-
+/**
+ * #stateModel SvInspectorView
+ * combination of a spreadsheetview and a circularview
+ */
 const SvInspectorViewF = (pluginManager: PluginManager) => {
   const SpreadsheetViewType = pluginManager.getViewType('SpreadsheetView')
   const CircularViewType = pluginManager.getViewType('CircularView')
@@ -56,92 +36,121 @@ const SvInspectorViewF = (pluginManager: PluginManager) => {
   const defaultHeight = 550
   const headerHeight = 52
   const circularViewOptionsBarHeight = 52
-  const model = types
-    .model('SvInspectorView', {
-      id: ElementId,
-      type: types.literal('SvInspectorView'),
-      dragHandleHeight: 4,
-      height: types.optional(
-        types.refinement(
-          'SvInspectorViewHeight',
-          types.number,
-          n => n >= minHeight,
+  return types
+    .compose(
+      BaseViewModel,
+      types.model('SvInspectorView', {
+        /**
+         * #property
+         */
+        id: ElementId,
+        /**
+         * #property
+         */
+        type: types.literal('SvInspectorView'),
+
+        /**
+         * #property
+         */
+        height: types.optional(
+          types.refinement(
+            'SvInspectorViewHeight',
+            types.number,
+            n => n >= minHeight,
+          ),
+          defaultHeight,
         ),
-        defaultHeight,
-      ),
-
-      onlyDisplayRelevantRegionsInCircularView: false,
-
-      // switch specifying whether we are showing the import wizard or the
-      // spreadsheet in our viewing area
-      mode: types.optional(
-        types.enumeration('SvInspectorViewMode', ['import', 'display']),
-        'import',
-      ),
-
-      spreadsheetView: types.optional(SpreadsheetModel, () =>
-        SpreadsheetModel.create({
-          type: 'SpreadsheetView',
-          hideViewControls: true,
-          hideVerticalResizeHandle: true,
-        }),
-      ),
-
-      circularView: types.optional(CircularModel, () =>
-        CircularModel.create({
-          type: 'CircularView',
-          hideVerticalResizeHandle: true,
-          hideTrackSelectorButton: true,
-          disableImportForm: true,
-        }),
-      ),
-    })
+        /**
+         * #property
+         */
+        onlyDisplayRelevantRegionsInCircularView: false,
+        /**
+         * #property
+         * switch specifying whether we are showing the import wizard or the
+         * spreadsheet in our viewing area
+         */
+        mode: types.optional(
+          types.enumeration('SvInspectorViewMode', ['import', 'display']),
+          'import',
+        ),
+        /**
+         * #property
+         */
+        spreadsheetView: types.optional(SpreadsheetModel, () =>
+          SpreadsheetModel.create({
+            type: 'SpreadsheetView',
+            hideViewControls: true,
+            hideVerticalResizeHandle: true,
+          }),
+        ),
+        /**
+         * #property
+         */
+        circularView: types.optional(CircularModel, () =>
+          CircularModel.create({
+            type: 'CircularView',
+            hideVerticalResizeHandle: true,
+            hideTrackSelectorButton: true,
+            disableImportForm: true,
+          }),
+        ),
+      }),
+    )
     .volatile(() => ({
       width: 800,
+      dragHandleHeight: 4,
     }))
     .views(self => ({
+      /**
+       * #getter
+       */
       get selectedRows() {
         // @ts-expect-error
         return self.spreadsheetView.rowSet.selectedRows
       },
-
+      /**
+       * #getter
+       */
       get assemblyName() {
         const { assembly } = self.spreadsheetView
         return assembly ? readConfObject(assembly, 'name') : undefined
       },
-
+      /**
+       * #getter
+       */
       get showCircularView() {
         return self.spreadsheetView.mode === 'display'
       },
 
-      get featuresAdapterConfigSnapshot() {
+      get features() {
         const session = getSession(self)
         const { spreadsheetView } = self
         const { outputRows = [] } = spreadsheetView
+        return outputRows
+          .map((r, i) => getFeatureForRow(session, spreadsheetView, r, i))
+          .filter(f => !!f)
+      },
+      /**
+       * #getter
+       */
+      get featuresAdapterConfigSnapshot() {
         return {
           type: 'FromConfigAdapter',
-          features: outputRows
-            .map((r, i) =>
-              getSerializedFeatureForRow(session, spreadsheetView, r, i),
-            )
-            .filter(f => !!f),
+          features: this.features,
         }
       },
-
-      // Promise<string[]> of refnames
-      get featuresRefNamesP(): Promise<string[]> {
-        const { getAdapterClass } =
-          pluginManager.getAdapterType('FromConfigAdapter')
-        return getAdapterClass().then(Adapter =>
-          // @ts-expect-error
-          new Adapter(self.featuresAdapterConfigSnapshot).getRefNames(),
-        )
+      /**
+       * #getter
+       */
+      get featureRefNames() {
+        const refs = this.features.map(r => r.refName)
+        const CHR2 = this.features.flatMap(r => r.INFO?.CHR2).filter(f => !!f)
+        return [...refs, ...CHR2]
       },
+      /**
+       * #getter
+       */
       get featuresCircularTrackConfiguration() {
-        pluginManager.jexl.addFunction(
-          'defaultOnChordClick',
-          defaultOnChordClick,
-        )
         return {
           type: 'VariantTrack',
           trackId: `sv-inspector-variant-track-${self.id}`,
@@ -165,36 +174,55 @@ const SvInspectorViewF = (pluginManager: PluginManager) => {
       circularViewOptionsBarHeight,
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
       setWidth(newWidth: number) {
         self.width = newWidth
       },
+      /**
+       * #action
+       */
       setHeight(newHeight: number) {
         self.height = newHeight > minHeight ? newHeight : minHeight
         return self.height
       },
-
+      /**
+       * #action
+       */
       setImportMode() {
         self.spreadsheetView.setImportMode()
       },
-
+      /**
+       * #action
+       */
       setDisplayMode() {
         self.spreadsheetView.setDisplayMode()
       },
-
+      /**
+       * #action
+       */
       closeView() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getParent<any>(self, 2).removeView(self)
       },
-
+      /**
+       * #action
+       */
       setDisplayedRegions(regions: Region[]) {
         self.circularView.setDisplayedRegions(regions)
       },
-
+      /**
+       * #action
+       */
       setOnlyDisplayRelevantRegionsInCircularView(val: boolean) {
         self.onlyDisplayRelevantRegionsInCircularView = Boolean(val)
       },
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
       resizeHeight(distance: number) {
         const oldHeight = self.height
         const newHeight = self.setHeight(self.height + distance)
@@ -242,28 +270,27 @@ const SvInspectorViewF = (pluginManager: PluginManager) => {
                 assemblyName,
                 onlyDisplayRelevantRegionsInCircularView,
                 circularView,
-                featuresRefNamesP,
+                featureRefNames,
               } = self
               const { tracks } = circularView
-              const session = getSession(self)
+              const { assemblyManager } = getSession(self)
               if (!assemblyName) {
                 return
               }
-              const { assemblyManager } = session
               const asm = await assemblyManager.waitForAssembly(assemblyName)
               if (!asm) {
-                circularView.setDisplayedRegions([])
                 return
               }
+
               const { getCanonicalRefName, regions = [] } = asm
               if (onlyDisplayRelevantRegionsInCircularView) {
                 if (tracks.length === 1) {
                   try {
-                    const refNames = await featuresRefNamesP
                     // canonicalize the store's ref names if necessary
                     const refSet = new Set(
-                      refNames.map(r => getCanonicalRefName(r) || r),
+                      featureRefNames.map(r => getCanonicalRefName(r) || r),
                     )
+
                     circularView.setDisplayedRegions(
                       clone(regions.filter(r => refSet.has(r.refName))),
                     )
@@ -292,15 +319,16 @@ const SvInspectorViewF = (pluginManager: PluginManager) => {
                 return
               }
               const { assemblyName, generatedTrackConf } = data
+              const { circularView } = self
               // hide any visible tracks
-              self.circularView.tracks.forEach(track => {
-                self.circularView.hideTrack(track.configuration.trackId)
-              })
+              circularView.tracks.forEach(t =>
+                circularView.hideTrack(t.configuration.trackId),
+              )
 
               // put our track in as the only track
               if (assemblyName && generatedTrackConf) {
                 // @ts-expect-error
-                self.circularView.addTrackConf(generatedTrackConf, {
+                circularView.addTrackConf(generatedTrackConf, {
                   assemblyName,
                 })
               }
@@ -352,13 +380,9 @@ const SvInspectorViewF = (pluginManager: PluginManager) => {
         )
       },
     }))
-
-  return { stateModel: types.compose(BaseViewModel, model) }
 }
 
-export type SvInspectorViewStateModel = ReturnType<
-  typeof SvInspectorViewF
->['stateModel']
+export type SvInspectorViewStateModel = ReturnType<typeof SvInspectorViewF>
 export type SvInspectorViewModel = Instance<SvInspectorViewStateModel>
 
 export default SvInspectorViewF

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -24,7 +24,7 @@ import {
  * #stateModel SvInspectorView
  * combination of a spreadsheetview and a circularview
  */
-const SvInspectorViewF = (pluginManager: PluginManager) => {
+function SvInspectorViewF(pluginManager: PluginManager) {
   const SpreadsheetViewType = pluginManager.getViewType('SpreadsheetView')
   const CircularViewType = pluginManager.getViewType('CircularView')
 

--- a/website/docs/models/Base1DView.md
+++ b/website/docs/models/Base1DView.md
@@ -231,7 +231,7 @@ zoomIn: () => void
 
 ```js
 // type signature
-zoomTo: (newBpPerPx: number, offset?: number) => number
+zoomTo: (bpPerPx: number, offset?: number) => number
 ```
 
 #### action: scrollTo

--- a/website/docs/models/BaseLinearDisplay.md
+++ b/website/docs/models/BaseLinearDisplay.md
@@ -299,7 +299,7 @@ clearRegionStats: () => void
 
 ```js
 // type signature
-setHeight: (displayHeight: number) => any
+setHeight: (displayHeight: number) => number
 ```
 
 #### action: resizeHeight

--- a/website/docs/models/Dotplot1DView.md
+++ b/website/docs/models/Dotplot1DView.md
@@ -43,6 +43,27 @@ number
 number
 ```
 
+#### getter: minBpPerPx
+
+```js
+// type
+number
+```
+
+#### getter: maxOffset
+
+```js
+// type
+number
+```
+
+#### getter: minOffset
+
+```js
+// type
+number
+```
+
 ### Dotplot1DView - Actions
 
 #### action: setScaleFactor

--- a/website/docs/models/DotplotView.md
+++ b/website/docs/models/DotplotView.md
@@ -138,9 +138,37 @@ vview: types.optional(DotplotVView, {})
 
 ```js
 // type signature
-string
+IOptionalIType<ISimpleType<string>, [undefined]>
 // code
-cursorMode: 'crosshair'
+cursorMode: types.optional(
+          types.string,
+          () => localStorageGetItem('dotplot-cursorMode') || 'crosshair',
+        )
+```
+
+#### property: wheelMode
+
+```js
+// type signature
+IOptionalIType<ISimpleType<string>, [undefined]>
+// code
+wheelMode: types.optional(
+          types.string,
+          () => localStorageGetItem('dotplot-wheelMode') || 'zoom',
+        )
+```
+
+#### property: showPanButtons
+
+```js
+// type signature
+IOptionalIType<ISimpleType<boolean>, [undefined]>
+// code
+showPanButtons: types.optional(types.boolean, () =>
+          Boolean(
+            JSON.parse(localStorageGetItem('dotplot-showPanbuttons') || 'true'),
+          ),
+        )
 ```
 
 #### property: tracks
@@ -262,6 +290,20 @@ menuItems: () => ({ label: string; onClick: () => void; icon: OverridableCompone
 ```
 
 ### DotplotView - Actions
+
+#### action: setShowPanButtons
+
+```js
+// type signature
+setShowPanButtons: (flag: boolean) => void
+```
+
+#### action: setWheelMode
+
+```js
+// type signature
+setWheelMode: (str: string) => void
+```
 
 #### action: setCursorMode
 

--- a/website/docs/models/JBrowseDesktopSessionModel.md
+++ b/website/docs/models/JBrowseDesktopSessionModel.md
@@ -180,28 +180,28 @@ any
 
 ```js
 // type
-any
+{ [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>
 ```
 
 #### getter: assemblies
 
 ```js
 // type
-any
+({ [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>)[]
 ```
 
 #### getter: assemblyNames
 
 ```js
 // type
-any
+string[]
 ```
 
 #### getter: tracks
 
 ```js
 // type
-any
+({ [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>)[]
 ```
 
 #### getter: textSearchManager
@@ -520,12 +520,8 @@ addViewFromAnotherView: (
 
 ```js
 // type signature
-addWidget: (
-  typeName: string,
-  id: string,
-  initialState?: {},
-  configuration?: { type: string },
-) => any
+addWidget: (typeName: string, id: string, initialState?: {}, conf?: unknown) =>
+  any
 ```
 
 #### action: showWidget

--- a/website/docs/models/JBrowseReactCGVSessionModel.md
+++ b/website/docs/models/JBrowseReactCGVSessionModel.md
@@ -268,12 +268,8 @@ removeView: () => void
 
 ```js
 // type signature
-addWidget: (
-  typeName: string,
-  id: string,
-  initialState?: {},
-  configuration?: { type: string },
-) => any
+addWidget: (typeName: string, id: string, initialState?: {}, conf?: unknown) =>
+  any
 ```
 
 #### action: showWidget

--- a/website/docs/models/JBrowseReactLGVSessionModel.md
+++ b/website/docs/models/JBrowseReactLGVSessionModel.md
@@ -305,12 +305,8 @@ addView: (typeName: string, initialState?: {}) => { id: string; displayName: str
 
 ```js
 // type signature
-addWidget: (
-  typeName: string,
-  id: string,
-  initialState?: {},
-  configuration?: { type: string },
-) => any
+addWidget: (typeName: string, id: string, initialState?: {}, conf?: unknown) =>
+  any
 ```
 
 #### action: showWidget

--- a/website/docs/models/JBrowseWebSessionModel.md
+++ b/website/docs/models/JBrowseWebSessionModel.md
@@ -584,12 +584,8 @@ addViewFromAnotherView: (
 
 ```js
 // type signature
-addWidget: (
-  typeName: string,
-  id: string,
-  initialState?: {},
-  configuration?: { type: string },
-) => any
+addWidget: (typeName: string, id: string, initialState?: {}, conf?: unknown) =>
+  any
 ```
 
 #### action: showWidget

--- a/website/docs/models/LinearGenomeView.md
+++ b/website/docs/models/LinearGenomeView.md
@@ -259,7 +259,7 @@ number
 
 ```js
 // type
-any
+number
 ```
 
 #### getter: trackHeightsWithResizeHandles
@@ -616,7 +616,7 @@ scrollTo: (offsetPx: number) => number
 
 ```js
 // type signature
-zoomTo: (bpPerPx: number) => number
+zoomTo: (bpPerPx: number, offset?: number, centerAtOffset?: boolean) => number
 ```
 
 #### action: setOffsets

--- a/website/docs/models/SvInspectorView.md
+++ b/website/docs/models/SvInspectorView.md
@@ -1,0 +1,214 @@
+---
+id: svinspectorview
+title: SvInspectorView
+toplevel: true
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+## Source file
+
+[plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts)
+
+## Docs
+
+combination of a spreadsheetview and a circularview
+
+### SvInspectorView - Properties
+
+#### property: id
+
+```js
+// type signature
+IOptionalIType<ISimpleType<string>, [undefined]>
+// code
+id: ElementId
+```
+
+#### property: type
+
+```js
+// type signature
+ISimpleType<"SvInspectorView">
+// code
+type: types.literal('SvInspectorView')
+```
+
+#### property: height
+
+```js
+// type signature
+IOptionalIType<ISimpleType<number>, [undefined]>
+// code
+height: types.optional(
+          types.refinement(
+            'SvInspectorViewHeight',
+            types.number,
+            n => n >= minHeight,
+          ),
+          defaultHeight,
+        )
+```
+
+#### property: onlyDisplayRelevantRegionsInCircularView
+
+```js
+// type signature
+false
+// code
+onlyDisplayRelevantRegionsInCircularView: false
+```
+
+#### property: mode
+
+switch specifying whether we are showing the import wizard or the spreadsheet in
+our viewing area
+
+```js
+// type signature
+IOptionalIType<ISimpleType<string>, [undefined]>
+// code
+mode: types.optional(
+          types.enumeration('SvInspectorViewMode', ['import', 'display']),
+          'import',
+        )
+```
+
+#### property: spreadsheetView
+
+```js
+// type signature
+IOptionalIType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; minimized: IType<boolean, boolean, boolean>; } & { ...; }, { ...; } & ... 4 more ... & { ...; }, _NotCustomized, _NotCustomized>, [...]>
+// code
+spreadsheetView: types.optional(SpreadsheetModel, () =>
+          SpreadsheetModel.create({
+            type: 'SpreadsheetView',
+            hideViewControls: true,
+            hideVerticalResizeHandle: true,
+          }),
+        )
+```
+
+#### property: circularView
+
+```js
+// type signature
+IOptionalIType<IModelType<{ id: IOptionalIType<ISimpleType<string>, [undefined]>; displayName: IMaybe<ISimpleType<string>>; minimized: IType<boolean, boolean, boolean>; } & { ...; }, { ...; } & ... 7 more ... & { ...; }, _NotCustomized, _NotCustomized>, [...]>
+// code
+circularView: types.optional(CircularModel, () =>
+          CircularModel.create({
+            type: 'CircularView',
+            hideVerticalResizeHandle: true,
+            hideTrackSelectorButton: true,
+            disableImportForm: true,
+          }),
+        )
+```
+
+### SvInspectorView - Getters
+
+#### getter: selectedRows
+
+```js
+// type
+any
+```
+
+#### getter: assemblyName
+
+```js
+// type
+any
+```
+
+#### getter: showCircularView
+
+```js
+// type
+boolean
+```
+
+#### getter: featuresAdapterConfigSnapshot
+
+```js
+// type
+{
+  type: string
+  features: any
+}
+```
+
+#### getter: featureRefNames
+
+```js
+// type
+any[]
+```
+
+#### getter: featuresCircularTrackConfiguration
+
+```js
+// type
+{ type: string; trackId: string; name: string; adapter: any; assemblyNames: any[]; displays: { type: string; displayId: string; onChordClick: string; renderer: { type: string; }; }[]; }
+```
+
+### SvInspectorView - Actions
+
+#### action: setWidth
+
+```js
+// type signature
+setWidth: (newWidth: number) => void
+```
+
+#### action: setHeight
+
+```js
+// type signature
+setHeight: (newHeight: number) => number
+```
+
+#### action: setImportMode
+
+```js
+// type signature
+setImportMode: () => void
+```
+
+#### action: setDisplayMode
+
+```js
+// type signature
+setDisplayMode: () => void
+```
+
+#### action: closeView
+
+```js
+// type signature
+closeView: () => void
+```
+
+#### action: setDisplayedRegions
+
+```js
+// type signature
+setDisplayedRegions: (regions: Region[]) => void
+```
+
+#### action: setOnlyDisplayRelevantRegionsInCircularView
+
+```js
+// type signature
+setOnlyDisplayRelevantRegionsInCircularView: (val: boolean) => void
+```
+
+#### action: resizeHeight
+
+```js
+// type signature
+resizeHeight: (distance: number) => number
+```


### PR DESCRIPTION
Changes featuresRefNamesP (which asynchronously initializes a FromConfigAdapter) to a simpler function that looks at the set of feature refNames and combines it with feature.INFO?.CHR2. 

also fixes a couple other small things including

- moving a jexl addFunction to plugin installation
- add javadoc style contents

this bug was I think noted by a user at PAG2023