### PR TITLE
Update github actions workflows to newer versions

### DIFF
--- a/.github/workflows/desktop_build_linux.yml
+++ b/.github/workflows/desktop_build_linux.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build Linux desktop app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)

--- a/.github/workflows/desktop_build_mac.yml
+++ b/.github/workflows/desktop_build_mac.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build Mac desktop app
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)

--- a/.github/workflows/desktop_build_win.yml
+++ b/.github/workflows/desktop_build_win.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: docker://node:16-bullseye
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Install wine

--- a/.github/workflows/jbrowse-web.yml
+++ b/.github/workflows/jbrowse-web.yml
@@ -22,9 +22,9 @@ jobs:
           # This allows us to manually edit the release body text before publishing
           draft: true
           prerelease: false
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Set env

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,9 +7,9 @@ jobs:
     name: Lint on node 16 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps and build (with cache)
@@ -21,9 +21,9 @@ jobs:
     name: Format on node 16 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps and build (with cache)
@@ -36,6 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check spelling
         uses: crate-ci/typos@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,9 +7,9 @@ jobs:
     name: Test and typecheck on node 16.x and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)
@@ -25,9 +25,9 @@ jobs:
     name: Build website on node 16 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install website deps (with cache)
@@ -49,9 +49,9 @@ jobs:
     name: Build whole repo on node 16 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)
@@ -77,9 +77,9 @@ jobs:
     name: Build only jbrowse-web and upload to s3 on node 16 and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)
@@ -91,7 +91,7 @@ jobs:
           NODE_OPTIONS='--max-old-space-size=6500' yarn build
           cd ../../
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -105,9 +105,9 @@ jobs:
     name: Build and deploy static linear genome view Storybook site to AWS S3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)
@@ -117,7 +117,7 @@ jobs:
           yarn storybook:build
         working-directory: products/jbrowse-react-linear-genome-view
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -131,9 +131,9 @@ jobs:
     name: Build and deploy static circular genome view Storybook site to AWS S3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install deps (with cache)
@@ -143,7 +143,7 @@ jobs:
           yarn storybook:build
         working-directory: products/jbrowse-react-circular-genome-view
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, 'update docs')"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Attempting to fix warnings


```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2, aws-actions/configure-aws-credentials@v1
```

xref https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

note that our create-release may be unmaintained https://github.com/actions/create-release