### PR TITLE
Make track selector filter text persist across refresh

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
@@ -141,10 +141,10 @@ export default function stateTreeFactory(pluginManager: PluginManager) {
       view: types.safeReference(
         pluginManager.pluggableMstType('view', 'stateModel'),
       ),
+      filterText: '',
     })
     .volatile(() => ({
       selection: [] as AnyConfigurationModel[],
-      filterText: '',
     }))
     .actions(self => ({
       setSelection(elt: AnyConfigurationModel[]) {


### PR DESCRIPTION
This is a small change that proposes the filter text in the Hierarchical Track Selector be stored in regular MST state instead of volatile state. This has the effect of being able to keep the filter in place when refreshing the page.