### PR TITLE
Add authorization(intenetAccount) support for Trix index files

### DIFF
--- a/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/TrixTextSearchAdapter.ts
@@ -56,8 +56,8 @@ export default class TrixTextSearchAdapter
       throw new Error('must provide out.ixx')
     }
     this.trixJs = new Trix(
-      openLocation(ixxFilePath),
-      openLocation(ixFilePath),
+      openLocation(ixxFilePath, pluginManager),
+      openLocation(ixFilePath, pluginManager),
       1500,
     )
   }


### PR DESCRIPTION
Trix files were the only files that ignored "intenetAccountId" and thus did not use authorization.  This commit enables existing support for them.