### PR TITLE
Fix shading on synteny features after mouseout

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
@@ -199,9 +199,7 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
             if (!view.initialized) {
               return
             }
-            if (self.mouseoverId || self.clickId) {
-              drawMouseoverSynteny(self)
-            }
+            drawMouseoverSynteny(self)
           }),
         )
 


### PR DESCRIPTION
v2.4.1 introduced a small regression after #3578 was landed where the mouseout doesn't work properly on the synteny mouseover shading

Was basically a type confusion after converting the "-1" for undefined features to true undefined