### PR TITLE
Fix subfeature detail formatter not being applied

### DIFF
--- a/packages/__mocks__/@jbrowse/core/util/useMeasure.ts
+++ b/packages/__mocks__/@jbrowse/core/util/useMeasure.ts
@@ -1,6 +1,3 @@
-import { useRef } from 'react'
-
 export default function useMeasure() {
-  const ref = useRef<HTMLDivElement>(null)
-  return [ref, { width: 808 }] as const
+  return [undefined, { width: 808 }] as const
 }

--- a/packages/__mocks__/react-use-measure.ts
+++ b/packages/__mocks__/react-use-measure.ts
@@ -1,2 +1,0 @@
-// 800+padding*2 = 808 from viewcontainer
-export default () => [undefined, { width: 808 }]

--- a/packages/core/BaseFeatureWidget/index.ts
+++ b/packages/core/BaseFeatureWidget/index.ts
@@ -9,13 +9,16 @@ import {
   ConfigurationSchema,
   AnyConfigurationModel,
 } from '../configuration'
-import { getSession } from '../util'
+import { Feature, getSession } from '../util'
 import { ElementId } from '../util/types/mst'
 
 const configSchema = ConfigurationSchema('BaseFeatureWidget', {})
 
 interface Feat {
   subfeatures?: Record<string, unknown>[]
+}
+interface WithConf {
+  configuration: AnyConfigurationModel
 }
 
 function formatSubfeatures(
@@ -78,24 +81,21 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             if (unformattedFeatureData) {
               const feature = clone(unformattedFeatureData)
 
-              const f = (
-                obj: { configuration: AnyConfigurationModel },
+              const combine = (
                 arg2: string,
-              ) => getConf(obj, ['formatDetails', arg2], { feature })
+                feature: Record<string, unknown>,
+              ) => ({
+                ...getConf(session, ['formatDetails', arg2], { feature }),
+                ...getConf(track, ['formatDetails', arg2], { feature }),
+              })
 
               if (track) {
                 // eslint-disable-next-line no-underscore-dangle
-                feature.__jbrowsefmt = {
-                  ...f(session, 'feature'),
-                  ...f(track, 'feature'),
-                }
+                feature.__jbrowsefmt = combine('feature', feature)
                 const depth = getConf(track, ['formatDetails', 'depth'])
                 formatSubfeatures(feature, depth, sub => {
                   // eslint-disable-next-line no-underscore-dangle
-                  sub.__jbrowsefmt = {
-                    ...f(session, 'subfeature'),
-                    ...f(track, 'subfeature'),
-                  }
+                  sub.__jbrowsefmt = combine('subfeatures', sub)
                 })
               }
 

--- a/packages/core/BaseFeatureWidget/index.ts
+++ b/packages/core/BaseFeatureWidget/index.ts
@@ -4,21 +4,14 @@ import clone from 'clone'
 
 // locals
 import PluginManager from '../PluginManager'
-import {
-  getConf,
-  ConfigurationSchema,
-  AnyConfigurationModel,
-} from '../configuration'
-import { Feature, getSession } from '../util'
+import { getConf, ConfigurationSchema } from '../configuration'
+import { getSession } from '../util'
 import { ElementId } from '../util/types/mst'
 
 const configSchema = ConfigurationSchema('BaseFeatureWidget', {})
 
 interface Feat {
   subfeatures?: Record<string, unknown>[]
-}
-interface WithConf {
-  configuration: AnyConfigurationModel
 }
 
 function formatSubfeatures(

--- a/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
+++ b/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
@@ -172,7 +172,7 @@ export function createBaseTrackConfig(pluginManager: PluginManager) {
             throw new Error(`unknown display type ${type}`)
           }
           const display = self.displays.find(
-            (d: any) => d && d.displayId === conf.displayId,
+            (d: any) => d?.displayId === conf.displayId,
           )
           if (display) {
             return display

--- a/packages/core/ui/ViewContainer.tsx
+++ b/packages/core/ui/ViewContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { IconButton, Paper, Tooltip, useTheme } from '@mui/material'
+import { IconButton, Paper, useTheme } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 
@@ -10,9 +10,9 @@ import AddIcon from '@mui/icons-material/Add'
 
 // locals
 import { IBaseViewModel } from '../pluggableElementTypes/models'
-import EditableTypography from './EditableTypography'
 import ViewMenu from './ViewMenu'
 import { useWidthSetter } from '../util'
+import ViewContainerTitle from './ViewContainerTitle'
 
 const useStyles = makeStyles()(theme => ({
   viewContainer: {
@@ -26,23 +26,6 @@ const useStyles = makeStyles()(theme => ({
   },
   grow: {
     flexGrow: 1,
-  },
-
-  input: {
-    paddingBottom: 0,
-    paddingTop: 2,
-  },
-  inputBase: {
-    color: theme.palette.secondary.contrastText,
-  },
-  inputRoot: {
-    '&:hover': {
-      backgroundColor: theme.palette.secondary.light,
-    },
-  },
-  inputFocused: {
-    borderColor: theme.palette.primary.main,
-    backgroundColor: theme.palette.secondary.light,
   },
 }))
 
@@ -74,25 +57,8 @@ export default observer(function ({
       <div ref={scrollRef} style={{ display: 'flex' }}>
         <ViewMenu model={view} IconProps={{ className: classes.icon }} />
         <div className={classes.grow} />
-        <Tooltip title="Rename view" arrow>
-          <EditableTypography
-            value={
-              view.displayName ||
-              // @ts-expect-error
-              `${view.assemblyNames?.join(',') || 'Untitled view'}${
-                view.minimized ? ' (minimized)' : ''
-              }`
-            }
-            setValue={val => view.setDisplayName(val)}
-            variant="body2"
-            classes={{
-              input: classes.input,
-              inputBase: classes.inputBase,
-              inputRoot: classes.inputRoot,
-              inputFocused: classes.inputFocused,
-            }}
-          />
-        </Tooltip>
+
+        <ViewContainerTitle view={view} />
         <div className={classes.grow} />
         <IconButton data-testid="minimize_view" onClick={onMinimize}>
           {view.minimized ? (

--- a/packages/core/ui/ViewContainerTitle.tsx
+++ b/packages/core/ui/ViewContainerTitle.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Tooltip } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+import { observer } from 'mobx-react'
+
+// locals
+import EditableTypography from './EditableTypography'
+import { IBaseViewModel } from '../pluggableElementTypes'
+
+const useStyles = makeStyles()(theme => ({
+  input: {
+    paddingBottom: 0,
+    paddingTop: 2,
+  },
+  inputBase: {
+    color: theme.palette.secondary.contrastText,
+  },
+  inputRoot: {
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.light,
+    },
+  },
+  inputFocused: {
+    borderColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.secondary.light,
+  },
+}))
+export default observer(function ViewContainerTitle({
+  view,
+}: {
+  view: IBaseViewModel
+}) {
+  const { classes } = useStyles()
+  return (
+    <Tooltip title="Rename view" arrow>
+      <EditableTypography
+        value={
+          view.displayName ||
+          // @ts-expect-error
+          `${view.assemblyNames?.join(',') || 'Untitled view'}${
+            view.minimized ? ' (minimized)' : ''
+          }`
+        }
+        setValue={val => view.setDisplayName(val)}
+        variant="body2"
+        classes={{
+          input: classes.input,
+          inputBase: classes.inputBase,
+          inputRoot: classes.inputRoot,
+          inputFocused: classes.inputFocused,
+        }}
+      />
+    </Tooltip>
+  )
+})

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -27,7 +27,7 @@ import {
 import { isAbortException, checkAbortSignal } from './aborting'
 import { BaseBlock } from './blockTypes'
 import { isUriLocation } from './types'
-import useMeasure from './useMeasure'
+import useMeasure from '@jbrowse/core/util/useMeasure'
 
 export * from './types'
 export * from './aborting'
@@ -200,15 +200,12 @@ export function springAnimate(
   ]
 }
 
-/** find the first node in the hierarchy that matches the given 'is' typescript type guard predicate */
-export function findParentThatIs<
-  PREDICATE extends (thing: IAnyStateTreeNode) => boolean,
->(
+// find the first node in the hierarchy that matches the given 'is' typescript type guard predicate
+export function findParentThatIs<T extends (a: IAnyStateTreeNode) => boolean>(
   node: IAnyStateTreeNode,
-  predicate: PREDICATE,
-): TypeTestedByPredicate<PREDICATE> & IAnyStateTreeNode {
-  return findParentThat(node, predicate) as TypeTestedByPredicate<PREDICATE> &
-    IAnyStateTreeNode
+  predicate: T,
+): TypeTestedByPredicate<T> & IAnyStateTreeNode {
+  return findParentThat(node, predicate)
 }
 
 /** get the current JBrowse session model, starting at any node in the state tree */

--- a/packages/core/util/useMeasure.ts
+++ b/packages/core/util/useMeasure.ts
@@ -1,10 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
 
-const RS =
-  typeof window !== 'undefined' && 'ResizeObserver' in window
-    ? window.ResizeObserver
-    : undefined
-
 export default function useMeasure() {
   const ref = useRef<HTMLDivElement>(null)
   const [dims, setDims] = useState<{ width?: number; height?: number }>({
@@ -15,6 +10,11 @@ export default function useMeasure() {
     if (!ref.current) {
       return
     }
+    const RS =
+      typeof window !== 'undefined' && 'ResizeObserver' in window
+        ? window.ResizeObserver
+        : undefined
+
     if (!RS) {
       return
     }

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
@@ -8,8 +8,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
     class="MuiScopedCssBaseline-root css-1pa2gw3-MuiScopedCssBaseline-root"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-11n9l57-MuiPaper-root-viewContainer"
-      style="padding: 0px 4px 4px;"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-tgvt3g-MuiPaper-root-viewContainer"
     >
       <div
         style="display: flex;"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -9,8 +9,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
       class="MuiScopedCssBaseline-root css-1pa2gw3-MuiScopedCssBaseline-root"
     >
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-11n9l57-MuiPaper-root-viewContainer"
-        style="padding: 0px 4px 4px;"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-tgvt3g-MuiPaper-root-viewContainer"
       >
         <div
           style="display: flex;"

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -2181,6 +2181,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
       ],
       "formatDetails": {
         "feature": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>',extrafield:'Field added with custom callback:' + feature.name,phase:undefined,type:undefined}",
+        "subfeatures": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>Subfeature: '+(!feature.name?'No name':feature.name)+'</a>'}",
       },
       "name": "GFF3Tabix genes",
       "trackId": "gff3tabix_genes",

--- a/products/jbrowse-web/src/tests/Alignments.test.tsx
+++ b/products/jbrowse-web/src/tests/Alignments.test.tsx
@@ -20,7 +20,7 @@ const delay = { timeout: 20000 }
 const opts = [{}, delay]
 
 test('opens an alignments track', async () => {
-  const { view, findByTestId, findByText, findAllByTestId } = createView()
+  const { view, findByTestId, findByText, findAllByTestId } = await createView()
   await findByText('Help')
   view.setNewView(5, 100)
   fireEvent.click(
@@ -45,7 +45,7 @@ test('opens an alignments track', async () => {
 }, 20000)
 
 test('test that bam with small max height displays message', async () => {
-  const { findByTestId, findAllByText } = createView()
+  const { findByTestId, findAllByText } = await createView()
   fireEvent.click(
     await findByTestId(hts('volvox_bam_small_max_height'), ...opts),
   )
@@ -54,7 +54,7 @@ test('test that bam with small max height displays message', async () => {
 }, 30000)
 
 test('test snpcoverage doesnt count snpcoverage', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.03932, 67884.16536402702)
   fireEvent.click(await findByTestId(hts('volvox-long-reads-sv-cram'), ...opts))

--- a/products/jbrowse-web/src/tests/AlignmentsFeatures.test.tsx
+++ b/products/jbrowse-web/src/tests/AlignmentsFeatures.test.tsx
@@ -21,7 +21,7 @@ const delay = { timeout: 20000 }
 const opts = [{}, delay]
 
 test('opens the track menu and enables soft clipping', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.02, 142956)
 
@@ -43,7 +43,7 @@ test('opens the track menu and enables soft clipping', async () => {
 }, 30000)
 
 test('selects a sort, sort by base pair', async () => {
-  const { view, findByTestId, findByText, findAllByTestId } = createView()
+  const { view, findByTestId, findByText, findAllByTestId } = await createView()
   await findByText('Help')
   view.setNewView(0.043688891869634636, 301762)
   const track = 'volvox_cram_alignments_ctga'
@@ -68,7 +68,7 @@ test('selects a sort, sort by base pair', async () => {
 }, 35000)
 
 test('color by tag', async () => {
-  const { view, findByTestId, findByText, findAllByTestId } = createView()
+  const { view, findByTestId, findByText, findAllByTestId } = await createView()
   await findByText('Help')
   view.setNewView(0.465, 85055)
 
@@ -90,7 +90,7 @@ test('color by tag', async () => {
 }, 30000)
 
 test('toggle short-read arc display', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:1-50000')
   fireEvent.click(await findByTestId(hts('volvox_sv_cram'), ...opts))
@@ -101,7 +101,7 @@ test('toggle short-read arc display', async () => {
 }, 30000)
 
 test('toggle short-read cloud display', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:1-50000')
   fireEvent.click(await findByTestId(hts('volvox_sv_cram'), ...opts))
@@ -112,7 +112,7 @@ test('toggle short-read cloud display', async () => {
 }, 30000)
 
 test('toggle long-read cloud display', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:19,101..32,027')
   fireEvent.click(await findByTestId(hts('volvox-simple-inv.bam'), ...opts))
@@ -123,7 +123,7 @@ test('toggle long-read cloud display', async () => {
 }, 30000)
 
 test('toggle long-read arc display', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:19,101..32,027')
   fireEvent.click(await findByTestId(hts('volvox-simple-inv.bam'), ...opts))
@@ -134,7 +134,7 @@ test('toggle long-read arc display', async () => {
 }, 30000)
 
 test('toggle long-read arc display, use out of view pairing', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:478..6,191')
   fireEvent.click(await findByTestId(hts('volvox-long-reads-sv-cram'), ...opts))
@@ -145,7 +145,7 @@ test('toggle long-read arc display, use out of view pairing', async () => {
 }, 30000)
 
 test('toggle short-read arc display, use out of view pairing', async () => {
-  const { view, findByTestId, findAllByText, findByText } = createView()
+  const { view, findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
   await view.navToLocString('ctgA:478..6,191')
   fireEvent.click(await findByTestId(hts('volvox_sv_cram'), ...opts))

--- a/products/jbrowse-web/src/tests/Authentication.test.tsx
+++ b/products/jbrowse-web/src/tests/Authentication.test.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
 const delay = { timeout: 20000 }
 
 test('open a bigwig track that needs oauth authentication and has existing token', async () => {
-  const { rootModel, view, findByTestId, findByText } = createView({
+  const { rootModel, view, findByTestId, findByText } = await createView({
     ...config,
     tracks: [
       {
@@ -63,7 +63,7 @@ test('open a bigwig track that needs oauth authentication and has existing token
 }, 25000)
 
 test('opens a bigwig track that needs external token authentication', async () => {
-  const { view, findByTestId } = createView({
+  const { view, findByTestId } = await createView({
     ...config,
     internetAccounts: [
       {
@@ -109,7 +109,7 @@ test('opens a bigwig track that needs external token authentication', async () =
 }, 25000)
 
 test('opens a bigwig track that needs httpbasic authentication', async () => {
-  const { findByTestId, findByText, view } = createView({
+  const { findByTestId, findByText, view } = await createView({
     ...config,
     tracks: [
       {

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
@@ -10,7 +10,7 @@ const delay = { timeout: 20000 }
 const opts = [{}, delay]
 
 test('access about menu', async () => {
-  const { findByText, findAllByText } = createView()
+  const { findByText, findAllByText } = await createView()
 
   fireEvent.click(await findByText('Help'))
   fireEvent.click(await findByText('About'))
@@ -23,7 +23,7 @@ test('access about menu', async () => {
 }, 30000)
 
 test('click and drag to move sideways', async () => {
-  const { view, findByTestId, findAllByText } = createView()
+  const { view, findByTestId, findAllByText } = await createView()
   await findAllByText('ctgA', ...opts)
   const start = view.offsetPx
   const track = await findByTestId('trackContainer', ...opts)
@@ -34,7 +34,7 @@ test('click and drag to move sideways', async () => {
 }, 30000)
 
 test('click and drag to rubberband', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   const track = await findByTestId('rubberband_controls', ...opts)
   expect(view.bpPerPx).toEqual(0.05)
   fireEvent.mouseDown(track, { clientX: 100, clientY: 0 })
@@ -45,7 +45,7 @@ test('click and drag to rubberband', async () => {
 }, 30000)
 
 test('click and drag rubberband, click get sequence to open sequenceDialog', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   const rubberband = await findByTestId('rubberband_controls', ...opts)
   expect(view.bpPerPx).toEqual(0.05)
   fireEvent.mouseDown(rubberband, { clientX: 100, clientY: 0 })
@@ -57,7 +57,7 @@ test('click and drag rubberband, click get sequence to open sequenceDialog', asy
 }, 30000)
 
 test('click and drag to reorder tracks', async () => {
-  const { view, findByTestId } = createView()
+  const { view, findByTestId } = await createView()
   fireEvent.click(await findByTestId(hts('bigbed_genes'), ...opts))
   fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), ...opts))
 
@@ -87,7 +87,7 @@ test('click and drag to reorder tracks', async () => {
 }, 30000)
 
 test('click and zoom in and back out', async () => {
-  const { view, findByTestId, findAllByText } = createView()
+  const { view, findByTestId, findAllByText } = await createView()
   await findAllByText('ctgA', ...opts)
   const before = view.bpPerPx
   fireEvent.click(await findByTestId('zoom_in'))
@@ -97,7 +97,7 @@ test('click and zoom in and back out', async () => {
 }, 30000)
 
 test('opens track selector', async () => {
-  const { view, findByTestId, findAllByText } = createView()
+  const { view, findByTestId, findAllByText } = await createView()
   await findAllByText('ctgA', ...opts)
   await findByTestId(hts('bigbed_genes'), ...opts)
   expect(view.tracks.length).toBe(0)
@@ -106,7 +106,7 @@ test('opens track selector', async () => {
 }, 30000)
 
 test('opens reference sequence track and expects zoom in message', async () => {
-  const { view, findByTestId, findAllByText } = createView()
+  const { view, findByTestId, findAllByText } = await createView()
   fireEvent.click(await findByTestId(hts('volvox_refseq'), ...opts))
   view.setNewView(20, 0)
   await findByTestId(
@@ -118,7 +118,7 @@ test('opens reference sequence track and expects zoom in message', async () => {
 }, 30000)
 
 test('click to display center line with correct value', async () => {
-  const { view, findAllByText, findByTestId, findByText } = createView()
+  const { view, findAllByText, findByTestId, findByText } = await createView()
   await findAllByText('ctgA', ...opts)
   fireEvent.click(await findByTestId(hts('bigbed_genes'), ...opts))
 
@@ -137,7 +137,7 @@ test('test choose option from dropdown refName autocomplete', async () => {
     findAllByText,
     findByPlaceholderText,
     getByPlaceholderText,
-  } = createView()
+  } = await createView()
 
   await findAllByText('ctgA', ...opts)
   fireEvent.click(await findByText('Help'))

--- a/products/jbrowse-web/src/tests/BigWig.test.tsx
+++ b/products/jbrowse-web/src/tests/BigWig.test.tsx
@@ -19,14 +19,14 @@ const delay = { timeout: 20000 }
 const opts = [{}, delay]
 
 test('open a bigwig track', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(5, 0)
   fireEvent.click(await findByTestId(hts('volvox_microarray'), ...opts))
   expectCanvasMatch(await findByTestId(pv('1..4000-0'), ...opts))
 }, 25000)
 test('open a bigwig line track 2', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
 
   await findByText('Help')
   view.setNewView(10, 0)
@@ -34,7 +34,7 @@ test('open a bigwig line track 2', async () => {
   expectCanvasMatch(await findByTestId(pv('1..8000-0'), ...opts))
 }, 25000)
 test('open a bigwig density track', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
 
   await findByText('Help')
   view.setNewView(5, 0)

--- a/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
+++ b/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
@@ -11,7 +11,7 @@ beforeEach(() => {
 const delay = { timeout: 15000 }
 
 test('click and drag rubberband, bookmarks region', async () => {
-  const { session, view, findByTestId, findByText } = createView()
+  const { session, view, findByTestId, findByText } = await createView()
   const rubberband = await findByTestId('rubberband_controls', {}, delay)
 
   expect(view.bpPerPx).toEqual(0.05)
@@ -27,7 +27,7 @@ test('click and drag rubberband, bookmarks region', async () => {
 }, 20000)
 
 test('bookmarks current region', async () => {
-  const { session, findByTestId, findByText } = createView()
+  const { session, findByTestId, findByText } = await createView()
 
   fireEvent.click(await findByTestId('view_menu_icon'))
   fireEvent.click(await findByText('Bookmark current region'))
@@ -40,7 +40,7 @@ test('bookmarks current region', async () => {
 }, 20000)
 
 test('navigates to bookmarked region from widget', async () => {
-  const { view, session, findByTestId, findByText } = createView()
+  const { view, session, findByTestId, findByText } = await createView()
 
   // need this to complete before we can try to navigate
   fireEvent.click(await findByTestId(hts('volvox_alignments'), {}, delay))

--- a/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
+++ b/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
@@ -16,7 +16,7 @@ test(
   'breakpoint split view',
   async () =>
     mockConsoleWarn(async () => {
-      const { findByTestId, queryAllByTestId } = createView(breakpointConfig)
+      const { findByTestId, queryAllByTestId } = await createView(breakpointConfig)
 
       // the breakpoint could be partially loaded so explicitly wait for two items
       await waitFor(() => expect(queryAllByTestId('r1').length).toBe(2), delay)

--- a/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
+++ b/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
@@ -16,7 +16,9 @@ test(
   'breakpoint split view',
   async () =>
     mockConsoleWarn(async () => {
-      const { findByTestId, queryAllByTestId } = await createView(breakpointConfig)
+      const { findByTestId, queryAllByTestId } = await createView(
+        breakpointConfig,
+      )
 
       // the breakpoint could be partially loaded so explicitly wait for two items
       await waitFor(() => expect(queryAllByTestId('r1').length).toBe(2), delay)

--- a/products/jbrowse-web/src/tests/CircularView.test.tsx
+++ b/products/jbrowse-web/src/tests/CircularView.test.tsx
@@ -14,7 +14,7 @@ const delay = { timeout: 10000 }
 const opts = [{}, delay]
 
 test('open a circular view', async () => {
-  const { findByTestId, findByText, queryByTestId } = createView({
+  const { findByTestId, findByText, queryByTestId } = await createView({
     ...configSnapshot,
     defaultSession: {
       name: 'Integration Test Circular',

--- a/products/jbrowse-web/src/tests/ConfigurationEditor.test.tsx
+++ b/products/jbrowse-web/src/tests/ConfigurationEditor.test.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 test('change color on track', async () => {
   const { view, getByTestId, findByTestId, findByText, findByDisplayValue } =
-    createView(undefined, true)
+    await createView(undefined, true)
 
   await findByText('Help')
   view.setNewView(0.05, 5000)

--- a/products/jbrowse-web/src/tests/Connection.test.tsx
+++ b/products/jbrowse-web/src/tests/Connection.test.tsx
@@ -32,7 +32,7 @@ test('Open up a UCSC trackhub connection', async () => {
     return readBuffer(request)
   })
 
-  const { findByTestId, findByText } = createView()
+  const { findByTestId, findByText } = await createView()
 
   fireEvent.click(await findByText('File'))
   fireEvent.click(await findByText(/Open connection/))

--- a/products/jbrowse-web/src/tests/CopyAndDelete.test.tsx
+++ b/products/jbrowse-web/src/tests/CopyAndDelete.test.tsx
@@ -20,7 +20,7 @@ const delay = { timeout: 40000 }
 
 test('copy and delete track in admin mode', async () => {
   const { view, findByTestId, queryByText, findAllByTestId, findByText } =
-    createView(undefined, true)
+    await createView(undefined, true)
 
   await findByText('Help')
   view.setNewView(0.05, 5000)
@@ -39,7 +39,7 @@ test('copy and delete track in admin mode', async () => {
 
 test('copy and delete reference sequence track disabled', async () => {
   const { view, rootModel, session, queryByText, findByTestId, findByText } =
-    createView(undefined, true)
+    await createView(undefined, true)
 
   // @ts-expect-error
   const { assemblyManager } = rootModel
@@ -64,7 +64,7 @@ test('copy and delete reference sequence track disabled', async () => {
 }, 40000)
 
 test('copy and delete track to session tracks', async () => {
-  const { view, findByTestId, findAllByTestId, findByText } = createView(
+  const { view, findByTestId, findAllByTestId, findByText } = await createView(
     undefined,
     false,
   )

--- a/products/jbrowse-web/src/tests/Dotplot.test.tsx
+++ b/products/jbrowse-web/src/tests/Dotplot.test.tsx
@@ -17,12 +17,12 @@ beforeEach(() => {
 })
 
 test('open a dotplot view', async () => {
-  const { findByTestId } = createView(config)
+  const { findByTestId } = await createView(config)
   expectCanvasMatch(await findByTestId('prerendered_canvas_done', ...opts))
 }, 30000)
 
 test('open a dotplot view with import form', async () => {
-  const { findByTestId, findAllByTestId, findByText } = createView(config)
+  const { findByTestId, findAllByTestId, findByText } = await createView(config)
 
   fireEvent.click(await findByTestId('close_view'))
   fireEvent.click(await findByText('File'))
@@ -46,7 +46,7 @@ test('open a dotplot view with import form', async () => {
 }, 30000)
 
 test('inverted dotplot', async () => {
-  const { findByTestId } = createView({
+  const { findByTestId } = await createView({
     ...config,
     defaultSession: dotplotSession.session,
   })
@@ -54,7 +54,7 @@ test('inverted dotplot', async () => {
 }, 30000)
 
 test('inverted dotplot flip axes', async () => {
-  const { findByTestId } = createView({
+  const { findByTestId } = await createView({
     ...config,
     defaultSession: dotplotSessionFlipAxes.session,
   })

--- a/products/jbrowse-web/src/tests/DrawerWidget.test.tsx
+++ b/products/jbrowse-web/src/tests/DrawerWidget.test.tsx
@@ -10,7 +10,7 @@ beforeEach(() => {
 })
 
 test('opens feature detail from left click', async () => {
-  const { view, findByTestId, findAllByTestId, findByText } = createView()
+  const { view, findByTestId, findAllByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.05, 5000)
   fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), {}, delay))
@@ -23,7 +23,7 @@ test('opens feature detail from left click', async () => {
 }, 20000)
 
 test('open feature detail from right click', async () => {
-  const { view, findByTestId, findAllByTestId, findByText } = createView()
+  const { view, findByTestId, findAllByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.05, 5000)
   fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), {}, delay))
@@ -39,7 +39,7 @@ test('open feature detail from right click', async () => {
 }, 20000)
 
 test('widget drawer navigation', async () => {
-  const { view, session, findByTestId, findByText } = createView()
+  const { view, session, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.05, 5000)
   // opens a config editor widget

--- a/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
+++ b/products/jbrowse-web/src/tests/ErrorConditions.test.tsx
@@ -1,4 +1,4 @@
-import { createView, doBeforeEach, mockConsole } from './util'
+import { createViewNoWait, doBeforeEach, mockConsole } from './util'
 import chromeSizesConfig from '../../test_data/config_chrom_sizes_test.json'
 import wrongAssemblyTest from '../../test_data/wrong_assembly.json'
 
@@ -10,14 +10,14 @@ beforeEach(() => {
 
 test('404 sequence file', async () => {
   await mockConsole(async () => {
-    const { findAllByText } = createView(chromeSizesConfig)
+    const { findAllByText } = createViewNoWait(chromeSizesConfig)
     await findAllByText(/HTTP 404 fetching grape.chrom.sizes.nonexist/)
   })
 })
 
 test('wrong assembly', async () => {
   await mockConsole(async () => {
-    const { view, findAllByText } = createView(wrongAssemblyTest)
+    const { view, findAllByText } = createViewNoWait(wrongAssemblyTest)
     view.showTrack('volvox_wrong_assembly')
     await findAllByText(/does not match/, {}, delay)
   })

--- a/products/jbrowse-web/src/tests/ExportSvg.test.tsx
+++ b/products/jbrowse-web/src/tests/ExportSvg.test.tsx
@@ -24,7 +24,7 @@ const delay = { timeout: 40000 }
 const opts = [{}, delay]
 
 test('export svg of lgv', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
 
   await findByText('Help')
   view.setNewView(0.1, 1)
@@ -47,7 +47,7 @@ test('export svg of lgv', async () => {
 
 test('export svg of synteny', async () => {
   console.warn = jest.fn()
-  const { findByTestId, findAllByText, findByText } = createView({
+  const { findByTestId, findAllByText, findByText } = await createView({
     ...volvoxConfig,
     defaultSession: {
       id: 'session_testing',
@@ -204,7 +204,7 @@ test('export svg of synteny', async () => {
 }, 45000)
 
 test('export svg of circular', async () => {
-  const { findByTestId, findByText } = createView({
+  const { findByTestId, findByText } = await createView({
     ...volvoxConfig,
     defaultSession: {
       name: 'Integration Test Circular',
@@ -237,7 +237,7 @@ test('export svg of circular', async () => {
 }, 45000)
 
 test('export svg of dotplot', async () => {
-  const { findByTestId, findByText } = createView({
+  const { findByTestId, findByText } = await createView({
     ...volvoxConfig,
     defaultSession: {
       id: 'yvVuWHcq2',

--- a/products/jbrowse-web/src/tests/ExportSvgBreakpointSplitView.test.tsx
+++ b/products/jbrowse-web/src/tests/ExportSvgBreakpointSplitView.test.tsx
@@ -21,7 +21,7 @@ test('export svg of breakpoint split view', async () => {
   doBeforeEach(url => require.resolve(`../../test_data/breakpoint/${url}`))
   console.warn = jest.fn()
   const { findByTestId, findAllByText, findByText } =
-    createView(breakpointConfig)
+    await createView(breakpointConfig)
 
   await findByText('Help')
 

--- a/products/jbrowse-web/src/tests/ExportSvgBreakpointSplitView.test.tsx
+++ b/products/jbrowse-web/src/tests/ExportSvgBreakpointSplitView.test.tsx
@@ -20,8 +20,9 @@ const delay = { timeout: 40000 }
 test('export svg of breakpoint split view', async () => {
   doBeforeEach(url => require.resolve(`../../test_data/breakpoint/${url}`))
   console.warn = jest.fn()
-  const { findByTestId, findAllByText, findByText } =
-    await createView(breakpointConfig)
+  const { findByTestId, findAllByText, findByText } = await createView(
+    breakpointConfig,
+  )
 
   await findByText('Help')
 

--- a/products/jbrowse-web/src/tests/Hic.test.tsx
+++ b/products/jbrowse-web/src/tests/Hic.test.tsx
@@ -21,7 +21,7 @@ setup()
 const delay = { timeout: 20000 }
 
 test('hic', async () => {
-  const { view, findByTestId } = createView(hicConfig)
+  const { view, findByTestId } = await createView(hicConfig)
 
   view.setNewView(5000, 0)
   fireEvent.click(await findByTestId(hts('hic_test'), {}, delay))

--- a/products/jbrowse-web/src/tests/JBrowse.test.tsx
+++ b/products/jbrowse-web/src/tests/JBrowse.test.tsx
@@ -23,16 +23,16 @@ beforeEach(() => {
 })
 
 test('renders with an empty config', async () => {
-  const { findByText } = createView()
+  const { findByText } = await createView()
   await findByText('Help')
 })
 test('renders with an initialState', async () => {
-  const { findByText } = createView()
+  const { findByText } = await createView()
   await findByText('Help')
 })
 
 test('lollipop track test', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(1, 150)
   fireEvent.click(await findByTestId(hts('lollipop_track'), {}, delay))
@@ -63,7 +63,7 @@ test('toplevel configuration', () => {
 })
 
 test('assembly aliases', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(0.05, 5000)
   fireEvent.click(
@@ -73,7 +73,7 @@ test('assembly aliases', async () => {
 }, 15000)
 
 test('nclist track test with long name', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(6.2, -301)
   fireEvent.click(await findByTestId(hts('nclist_long_names'), {}, delay))
@@ -94,7 +94,7 @@ test('test sharing', async () => {
     },
     password: '123',
   })
-  const { findByLabelText, findByText } = createView()
+  const { findByLabelText, findByText } = await createView()
   fireEvent.click(await findByText('Share'))
   expect(((await findByLabelText('URL')) as HTMLInputElement).value).toBe(
     'http://localhost/?session=share-abc&password=123',
@@ -102,7 +102,7 @@ test('test sharing', async () => {
 }, 15000)
 
 test('looks at about this track dialog', async () => {
-  const { findByTestId, findAllByText, findByText } = createView()
+  const { findByTestId, findAllByText, findByText } = await createView()
   await findByText('Help')
 
   // load track

--- a/products/jbrowse-web/src/tests/JBrowse.test.tsx
+++ b/products/jbrowse-web/src/tests/JBrowse.test.tsx
@@ -24,12 +24,13 @@ beforeEach(() => {
 
 test('renders with an empty config', async () => {
   const { findByText } = await createView()
-  await findByText('Help')
-})
+  await findByText('Help', {}, delay)
+}, 20000)
+
 test('renders with an initialState', async () => {
   const { findByText } = await createView()
-  await findByText('Help')
-})
+  await findByText('Help', {}, delay)
+}, 20000)
 
 test('lollipop track test', async () => {
   const { view, findByTestId, findByText } = await createView()

--- a/products/jbrowse-web/src/tests/MultiBigWig.test.tsx
+++ b/products/jbrowse-web/src/tests/MultiBigWig.test.tsx
@@ -19,7 +19,7 @@ const delay = { timeout: 20000 }
 const opts = [{}, delay]
 
 test('open a multibigwig track', async () => {
-  const { view, findByTestId, findByText } = createView()
+  const { view, findByTestId, findByText } = await createView()
   await findByText('Help')
   view.setNewView(5, 0)
   fireEvent.click(await findByTestId(hts('volvox_microarray_multi'), ...opts))

--- a/products/jbrowse-web/src/tests/ReadVsRef.test.tsx
+++ b/products/jbrowse-web/src/tests/ReadVsRef.test.tsx
@@ -15,7 +15,7 @@ const delay = { timeout: 20000 }
 
 test('launch read vs ref panel', async () => {
   const consoleMock = jest.spyOn(console, 'warn').mockImplementation()
-  const { view, findByTestId, findByText, findAllByTestId } = createView()
+  const { view, findByTestId, findByText, findAllByTestId } = await createView()
 
   await findByText('Help')
   view.setNewView(5, 100)
@@ -39,7 +39,7 @@ test('launch read vs ref panel', async () => {
 }, 40000)
 
 test('launch read vs ref dotplot', async () => {
-  const { view, findByTestId, findByText, findAllByTestId } = createView()
+  const { view, findByTestId, findByText, findAllByTestId } = await createView()
 
   await findByText('Help')
   view.setNewView(5, 100)

--- a/products/jbrowse-web/src/tests/ReloadBam.test.tsx
+++ b/products/jbrowse-web/src/tests/ReloadBam.test.tsx
@@ -35,7 +35,7 @@ test('reloads alignments track (BAI 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.5, 0)
     fireEvent.click(await findByTestId(hts('volvox_bam_snpcoverage'), ...opts))
@@ -58,7 +58,7 @@ test('reloads alignments track (BAM 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.5, 0)
     fireEvent.click(await findByTestId(hts('volvox_bam_pileup'), ...opts))

--- a/products/jbrowse-web/src/tests/ReloadBigWig.test.tsx
+++ b/products/jbrowse-web/src/tests/ReloadBigWig.test.tsx
@@ -35,7 +35,7 @@ test('reloads bigwig (BW 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(10, 0)
     fireEvent.click(await findByTestId(hts('volvox_microarray'), ...opts))

--- a/products/jbrowse-web/src/tests/ReloadCram.test.tsx
+++ b/products/jbrowse-web/src/tests/ReloadCram.test.tsx
@@ -39,7 +39,7 @@ test('reloads alignments track (CRAI 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.5, 0)
     fireEvent.click(await findByTestId(hts('volvox_cram_pileup'), ...opts))
@@ -65,7 +65,7 @@ test('reloads alignments track (CRAM 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.5, 0)
     fireEvent.click(await findByTestId(hts('volvox_cram_snpcoverage'), ...opts))

--- a/products/jbrowse-web/src/tests/ReloadVcf.test.tsx
+++ b/products/jbrowse-web/src/tests/ReloadVcf.test.tsx
@@ -33,7 +33,7 @@ test('reloads vcf (VCF.GZ 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.05, 5000)
     fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), ...opts))
@@ -59,7 +59,7 @@ test('reloads vcf (VCF.GZ.TBI 404)', async () => {
     })
 
     const { view, findByTestId, findByText, findAllByTestId, findAllByText } =
-      createView()
+      await createView()
     await findByText('Help')
     view.setNewView(0.05, 5000)
     fireEvent.click(await findByTestId(hts('volvox_filtered_vcf'), ...opts))

--- a/products/jbrowse-web/src/tests/SVInspector.test.tsx
+++ b/products/jbrowse-web/src/tests/SVInspector.test.tsx
@@ -12,7 +12,7 @@ const delay = { timeout: 20000 }
 
 test('opens a vcf.gz file in the sv inspector view', async () => {
   const consoleMock = jest.spyOn(console, 'warn').mockImplementation()
-  const { session, findByTestId, getByTestId, findByText } = createView()
+  const { session, findByTestId, getByTestId, findByText } = await createView()
 
   fireEvent.click(await findByText('File'))
   fireEvent.click(await findByText('Add'))

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.tsx
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.tsx
@@ -12,7 +12,7 @@ beforeEach(() => {
 const delay = { timeout: 10000 }
 
 test('opens a vcf.gz file in the spreadsheet view', async () => {
-  const { session, findByTestId, getByTestId, findByText } = createView()
+  const { session, findByTestId, getByTestId, findByText } = await createView()
 
   fireEvent.click(await findByText('File'))
   fireEvent.click(await findByText('Add'))
@@ -32,7 +32,7 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
 }, 15000)
 
 test('opens a bed.gz file in the spreadsheet view', async () => {
-  const { session, findByTestId, getByTestId, findByText } = createView()
+  const { session, findByTestId, getByTestId, findByText } = await createView()
   fireEvent.click(await findByText('File'))
   fireEvent.click(await findByText('Add'))
   fireEvent.click(await findByText('Spreadsheet view'))

--- a/products/jbrowse-web/src/tests/StatsEstimation.test.tsx
+++ b/products/jbrowse-web/src/tests/StatsEstimation.test.tsx
@@ -22,7 +22,7 @@ const delay = { timeout: 20000 }
 const o = [{}, delay]
 
 test('test stats estimation pileup, zoom in to see', async () => {
-  const { view, findByText, findAllByText, findByTestId } = createView()
+  const { view, findByText, findAllByText, findByTestId } = await createView()
   await findByText('Help')
   view.setNewView(30, 183)
   fireEvent.click(await findByTestId(hts('volvox_cram_pileup'), ...o))
@@ -36,7 +36,7 @@ test('test stats estimation pileup, zoom in to see', async () => {
 }, 30000)
 
 test('test stats estimation pileup, force load to see', async () => {
-  const { view, findByText, findAllByText, findByTestId } = createView()
+  const { view, findByText, findAllByText, findByTestId } = await createView()
   await findByText('Help')
   view.setNewView(25.07852564102564, 283)
 
@@ -51,7 +51,7 @@ test('test stats estimation pileup, force load to see', async () => {
 
 test('test stats estimation on vcf track, zoom in to see', async () => {
   const { view, findByText, findAllByText, findAllByTestId, findByTestId } =
-    createView()
+    await createView()
   await findByText('Help')
   view.setNewView(34, 5)
   fireEvent.click(await findByTestId('htsTrackEntry-variant_colors', ...o))
@@ -66,7 +66,7 @@ test('test stats estimation on vcf track, zoom in to see', async () => {
 
 test('test stats estimation on vcf track, force load to see', async () => {
   const { view, findByText, findAllByText, findAllByTestId, findByTestId } =
-    createView()
+    await createView()
   await findByText('Help')
   view.setNewView(34, 5)
   await findAllByText('ctgA', ...o)

--- a/products/jbrowse-web/src/tests/TextSearching.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearching.test.tsx
@@ -14,7 +14,7 @@ const delay = { timeout: 10000 }
 const opts = [{}, delay]
 
 async function doSetup(val?: unknown) {
-  const args = createView(val)
+  const args = await createView(val)
   const { findByTestId, findByPlaceholderText } = args
 
   const autocomplete = await findByTestId('autocomplete', ...opts)

--- a/products/jbrowse-web/src/tests/util.tsx
+++ b/products/jbrowse-web/src/tests/util.tsx
@@ -86,11 +86,6 @@ export function generateReadBuffer(getFile: (s: string) => GenericFilehandle) {
 }
 
 export function setup() {
-  window.requestIdleCallback = (cb: Function) => cb()
-  window.cancelIdleCallback = () => {}
-  window.requestAnimationFrame = (cb: Function) => setTimeout(cb)
-  window.cancelAnimationFrame = () => {}
-
   Storage.prototype.getItem = jest.fn(() => null)
   Storage.prototype.setItem = jest.fn()
   Storage.prototype.removeItem = jest.fn()

--- a/products/jbrowse-web/src/tests/util.tsx
+++ b/products/jbrowse-web/src/tests/util.tsx
@@ -100,7 +100,7 @@ export function setup() {
 }
 
 // eslint-disable-next-line no-global-assign
-window = Object.assign(window, { innerWidth: 800 })
+// window = Object.assign(window, { innerWidth: 800 })
 
 export function canvasToBuffer(canvas: HTMLCanvasElement) {
   return Buffer.from(

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -1091,7 +1091,8 @@
       "assemblyNames": ["volvox"],
       "name": "GFF3Tabix genes",
       "formatDetails": {
-        "feature": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>',extrafield:'Field added with custom callback:' + feature.name,phase:undefined,type:undefined}"
+        "feature": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>',extrafield:'Field added with custom callback:' + feature.name,phase:undefined,type:undefined}",
+        "subfeatures": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>Subfeature: '+(!feature.name?'No name':feature.name)+'</a>'}"
       },
       "category": ["Miscellaneous"],
       "adapter": {


### PR DESCRIPTION
The subfeatures feature detail formatter was not working, due to referring to a 'formatDetails.subfeature' instead of the plural 'formatDetails.subfeatures' and also was referring to the parent feature instead (wrongly closed over the feature) so i added it as a parameter to the formatter function instead of relying on the closure

This PR then also adds an example of the subfeature formatter to the volvox config