### PR TITLE
Avoid cutting off import form of spreadsheet view, fix overflowed text in table header

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataRow.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataRow.tsx
@@ -16,51 +16,47 @@ import CellData from './CellData'
 type SpreadsheetModel = Instance<typeof SpreadsheetStateModel>
 type RowModel = Instance<typeof RowStateModel>
 
-const useStyles = makeStyles()(theme => {
-  const { palette } = theme
-  return {
-    rowNumCell: {
-      textAlign: 'left',
-      border: `1px solid ${palette.action.disabledBackground}`,
-      position: 'relative',
-      padding: '0 2px 0 0',
-      whiteSpace: 'nowrap',
-      userSelect: 'none',
-    },
-    rowNumber: {
-      fontWeight: 'normal',
-      display: 'inline-block',
-      flex: 'none',
-      paddingRight: '20px',
-      margin: 0,
-      whiteSpace: 'nowrap',
-    },
-    rowMenuButton: {
-      padding: 0,
-      margin: 0,
-      position: 'absolute',
-      right: 0,
-      display: 'inline-block',
-      whiteSpace: 'nowrap',
-      flex: 'none',
-    },
-    rowMenuButtonIcon: {},
-    rowSelector: {
-      position: 'relative',
-      top: '-2px',
-      margin: 0,
-      padding: '0 0.2rem',
-    },
+const useStyles = makeStyles()(theme => ({
+  rowNumCell: {
+    textAlign: 'left',
+    border: `1px solid ${theme.palette.action.disabledBackground}`,
+    position: 'relative',
+    padding: '0 2px 0 0',
+    whiteSpace: 'nowrap',
+    userSelect: 'none',
+  },
+  rowNumber: {
+    fontWeight: 'normal',
+    display: 'inline-block',
+    flex: 'none',
+    paddingRight: '20px',
+    margin: 0,
+    whiteSpace: 'nowrap',
+  },
+  rowMenuButton: {
+    padding: 0,
+    margin: 0,
+    position: 'absolute',
+    right: 0,
+    display: 'inline-block',
+    whiteSpace: 'nowrap',
+    flex: 'none',
+  },
+  rowMenuButtonIcon: {},
+  rowSelector: {
+    position: 'relative',
+    top: '-2px',
+    margin: 0,
+    padding: '0 0.2rem',
+  },
 
-    dataRowSelected: {
+  dataRowSelected: {
+    background: indigo[100],
+    '& th': {
       background: indigo[100],
-      '& th': {
-        background: indigo[100],
-      },
     },
-    emptyMessage: { captionSide: 'bottom' },
-  }
-})
+  },
+}))
 
 const DataRow = observer(function ({
   rowModel,
@@ -86,7 +82,7 @@ const DataRow = observer(function ({
 
   return (
     <tr className={rowClass}>
-      <th className={classes.rowNumCell} onClick={labelClick}>
+      <td className={classes.rowNumCell} onClick={labelClick}>
         {hideRowSelection ? (
           <FormControlLabel
             className={classes.rowNumber}
@@ -113,7 +109,7 @@ const DataRow = observer(function ({
         >
           <ArrowDropDown className={classes.rowMenuButtonIcon} />
         </IconButton>
-      </th>
+      </td>
       {columnDisplayOrder.map(colNumber => (
         <td key={colNumber}>
           <CellData

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
@@ -97,7 +97,7 @@ const DataTableBody = observer(function ({
   )
 })
 
-const DataTable = observer(function ({
+export default observer(function ({
   model,
   page,
   rowsPerPage,
@@ -203,5 +203,3 @@ const DataTable = observer(function ({
     </>
   )
 })
-
-export default DataTable

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
@@ -16,8 +16,6 @@ type RowModel = Instance<typeof RowStateModel>
 const useStyles = makeStyles()(theme => ({
   dataTable: {
     borderCollapse: 'collapse',
-    borderSpacing: 0,
-    boxSizing: 'border-box',
     '& td': {
       border: `1px solid ${theme.palette.action.disabledBackground}`,
       padding: '0.2rem',

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles()(theme => ({
     fontWeight: 'normal',
     border: `1px solid ${theme.palette.action.disabledBackground}`,
     position: 'sticky',
-    top: '-1px',
     zIndex: 2,
     whiteSpace: 'nowrap',
   },
@@ -52,10 +51,10 @@ const useStyles = makeStyles()(theme => ({
     position: 'absolute',
     right: 0,
     top: 0,
-    background: theme.palette.action.disabled,
+    zIndex: 100,
+    background: theme.palette.action.hover,
     height: '100%',
-    boxSizing: 'border-box',
-    borderLeft: `1px solid ${theme.palette.action.disabledBackground}`,
+    borderLeft: `1px solid ${theme.palette.action.selected}`,
   },
   columnButton: {
     padding: 0,
@@ -111,15 +110,6 @@ export default observer(function ({
 
   // column menu active state
   const [currentColumnMenu, setColumnMenu] = useState<ColMenu>()
-  function columnButtonClick(
-    colNumber: number,
-    evt: React.MouseEvent<HTMLElement>,
-  ) {
-    setColumnMenu({
-      colNumber,
-      anchorEl: evt.currentTarget,
-    })
-  }
 
   // column header hover state
   const [currentHoveredColumn, setHoveredColumn] = useState<number>()
@@ -179,7 +169,12 @@ export default observer(function ({
                 >
                   <IconButton
                     className={classes.columnButton}
-                    onClick={columnButtonClick.bind(null, colNumber)}
+                    onClick={(evt: React.MouseEvent<HTMLElement>) => {
+                      setColumnMenu({
+                        colNumber,
+                        anchorEl: evt.currentTarget,
+                      })
+                    }}
                   >
                     <ArrowDropDown />
                   </IconButton>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTable.tsx
@@ -1,29 +1,17 @@
-import React, { useState } from 'react'
-import { IconButton, Tooltip } from '@mui/material'
+import React from 'react'
 import { observer } from 'mobx-react'
 import { getParent, Instance } from 'mobx-state-tree'
 import { makeStyles } from 'tss-react/mui'
 
-// icons
-import CropFreeIcon from '@mui/icons-material/CropFree'
-import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
-
 // locals
 import SpreadsheetStateModel from '../models/Spreadsheet'
 import RowStateModel from '../models/Row'
-import ColumnMenu from './ColumnMenu'
 import RowMenu from './RowMenu'
 import DataRow from './DataRow'
-import SortIndicator from './SortIndicator'
-import { numToColName } from './util'
+import DataTableHeader from './DataTableHeader'
 
 type SpreadsheetModel = Instance<typeof SpreadsheetStateModel>
 type RowModel = Instance<typeof RowStateModel>
-
-interface ColMenu {
-  colNumber: number
-  anchorEl: HTMLElement
-}
 
 const useStyles = makeStyles()(theme => ({
   dataTable: {
@@ -37,35 +25,6 @@ const useStyles = makeStyles()(theme => ({
       overflow: 'hidden',
       textOverflow: 'ellipsis',
     },
-  },
-
-  columnHead: {
-    fontWeight: 'normal',
-    background: theme.palette.mode === 'dark' ? '#333' : '#eee',
-    position: 'sticky',
-    top: 0,
-    zIndex: 2,
-    whiteSpace: 'nowrap',
-  },
-
-  columnButtonContainer: {
-    display: 'none',
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    background: theme.palette.background.paper,
-    zIndex: 100,
-    height: '100%',
-    boxSizing: 'border-box',
-  },
-
-  topLeftCorner: {
-    background: theme.palette.mode === 'dark' ? '#333' : '#eee',
-    position: 'sticky',
-    top: 0,
-    zIndex: 2,
-    minWidth: theme.spacing(2),
-    textAlign: 'left',
   },
 
   emptyMessage: {
@@ -95,77 +54,6 @@ const DataTableBody = observer(function ({
         />
       ))}
     </tbody>
-  )
-})
-
-const DataTableHeader = observer(function ({
-  model,
-}: {
-  model: SpreadsheetModel
-}) {
-  const { classes } = useStyles()
-  const { columnDisplayOrder, columns, hasColumnNames, rowSet } = model
-  const [currentColumnMenu, setColumnMenu] = useState<ColMenu>()
-  const [currentHoveredColumn, setHoveredColumn] = useState<number>()
-
-  return (
-    <>
-      <thead>
-        <tr>
-          <th className={classes.topLeftCorner}>
-            <Tooltip title="Unselect all" placement="right">
-              <span>
-                <IconButton
-                  onClick={() => model.unselectAll()}
-                  disabled={!rowSet.selectedCount}
-                >
-                  <CropFreeIcon />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </th>
-          {columnDisplayOrder.map(colNumber => (
-            <th
-              className={classes.columnHead}
-              key={colNumber}
-              onMouseOver={() => setHoveredColumn(colNumber)}
-              onMouseOut={() => setHoveredColumn(undefined)}
-            >
-              <SortIndicator model={model} columnNumber={colNumber} />
-              {(hasColumnNames && columns[colNumber]?.name) ||
-                numToColName(colNumber)}
-              <div
-                className={classes.columnButtonContainer}
-                style={{
-                  display:
-                    currentHoveredColumn === colNumber ||
-                    currentColumnMenu?.colNumber === colNumber
-                      ? 'block'
-                      : 'none',
-                }}
-              >
-                <IconButton
-                  onClick={(evt: React.MouseEvent<HTMLElement>) => {
-                    setColumnMenu({
-                      colNumber,
-                      anchorEl: evt.currentTarget,
-                    })
-                  }}
-                >
-                  <ArrowDropDown />
-                </IconButton>
-              </div>
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <ColumnMenu
-        viewModel={getParent(model)}
-        spreadsheetModel={model}
-        currentColumnMenu={currentColumnMenu}
-        setColumnMenu={setColumnMenu}
-      />
-    </>
   )
 })
 

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTableHeader.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTableHeader.tsx
@@ -37,16 +37,13 @@ const useStyles = makeStyles()(theme => ({
     right: 0,
     top: 0,
     background: theme.palette.background.paper,
-    zIndex: 100,
     height: '100%',
-    boxSizing: 'border-box',
   },
 
   topLeftCorner: {
     background: theme.palette.mode === 'dark' ? '#333' : '#eee',
     position: 'sticky',
     top: 0,
-    zIndex: 2,
     minWidth: theme.spacing(2),
     textAlign: 'left',
   },

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTableHeader.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/DataTableHeader.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react'
+import { IconButton, Tooltip } from '@mui/material'
+import { observer } from 'mobx-react'
+import { getParent, Instance } from 'mobx-state-tree'
+import { makeStyles } from 'tss-react/mui'
+
+// icons
+import CropFreeIcon from '@mui/icons-material/CropFree'
+import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
+
+// locals
+import SpreadsheetStateModel from '../models/Spreadsheet'
+import ColumnMenu from './ColumnMenu'
+import SortIndicator from './SortIndicator'
+import { numToColName } from './util'
+
+type SpreadsheetModel = Instance<typeof SpreadsheetStateModel>
+
+interface ColMenu {
+  colNumber: number
+  anchorEl: HTMLElement
+}
+
+const useStyles = makeStyles()(theme => ({
+  columnHead: {
+    fontWeight: 'normal',
+    background: theme.palette.mode === 'dark' ? '#333' : '#eee',
+    position: 'sticky',
+    top: 0,
+    zIndex: 2,
+    whiteSpace: 'nowrap',
+  },
+
+  columnButtonContainer: {
+    display: 'none',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    background: theme.palette.background.paper,
+    zIndex: 100,
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+
+  topLeftCorner: {
+    background: theme.palette.mode === 'dark' ? '#333' : '#eee',
+    position: 'sticky',
+    top: 0,
+    zIndex: 2,
+    minWidth: theme.spacing(2),
+    textAlign: 'left',
+  },
+}))
+
+const DataTableHeader = observer(function ({
+  model,
+}: {
+  model: SpreadsheetModel
+}) {
+  const { classes } = useStyles()
+  const { columnDisplayOrder, columns, hasColumnNames, rowSet } = model
+  const [currentColumnMenu, setColumnMenu] = useState<ColMenu>()
+  const [currentHoveredColumn, setHoveredColumn] = useState<number>()
+
+  return (
+    <>
+      <thead>
+        <tr>
+          <th className={classes.topLeftCorner}>
+            <Tooltip title="Unselect all" placement="right">
+              <span>
+                <IconButton
+                  onClick={() => model.unselectAll()}
+                  disabled={!rowSet.selectedCount}
+                >
+                  <CropFreeIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </th>
+          {columnDisplayOrder.map(colNumber => (
+            <th
+              className={classes.columnHead}
+              key={colNumber}
+              onMouseOver={() => setHoveredColumn(colNumber)}
+              onMouseOut={() => setHoveredColumn(undefined)}
+            >
+              <SortIndicator model={model} columnNumber={colNumber} />
+              {(hasColumnNames && columns[colNumber]?.name) ||
+                numToColName(colNumber)}
+              <div
+                className={classes.columnButtonContainer}
+                style={{
+                  display:
+                    currentHoveredColumn === colNumber ||
+                    currentColumnMenu?.colNumber === colNumber
+                      ? 'block'
+                      : 'none',
+                }}
+              >
+                <IconButton
+                  onClick={(evt: React.MouseEvent<HTMLElement>) => {
+                    setColumnMenu({
+                      colNumber,
+                      anchorEl: evt.currentTarget,
+                    })
+                  }}
+                >
+                  <ArrowDropDown />
+                </IconButton>
+              </div>
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <ColumnMenu
+        viewModel={getParent(model)}
+        spreadsheetModel={model}
+        currentColumnMenu={currentColumnMenu}
+        setColumnMenu={setColumnMenu}
+      />
+    </>
+  )
+})
+
+export default DataTableHeader

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/GlobalFilterControls.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/GlobalFilterControls.tsx
@@ -14,54 +14,52 @@ const useStyles = makeStyles()({
   },
 })
 
-const TextFilter = observer(
-  ({
-    textFilter,
-  }: {
-    textFilter: { stringToFind: string; setString: (arg: string) => void }
-  }) => {
-    const { classes } = useStyles()
-    // this paragraph is silliness to debounce the text filter input
-    const [textFilterValue, setTextFilterValue] = useState(
-      textFilter.stringToFind,
-    )
-    const debouncedTextFilter = useDebounce(textFilterValue, 500)
-    useEffect(() => {
-      textFilter.setString(debouncedTextFilter)
-    }, [debouncedTextFilter, textFilter])
+const TextFilter = observer(function ({
+  textFilter,
+}: {
+  textFilter: { stringToFind: string; setString: (arg: string) => void }
+}) {
+  const { classes } = useStyles()
+  // this paragraph is silliness to debounce the text filter input
+  const [textFilterValue, setTextFilterValue] = useState(
+    textFilter.stringToFind,
+  )
+  const debouncedTextFilter = useDebounce(textFilterValue, 500)
+  useEffect(() => {
+    textFilter.setString(debouncedTextFilter)
+  }, [debouncedTextFilter, textFilter])
 
-    return (
-      <div>
-        <TextField
-          label="text filter"
-          value={textFilterValue}
-          onChange={evt => setTextFilterValue(evt.target.value)}
-          variant="outlined"
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <FilterIcon />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <InputAdornment
-                className={classes.textFilterControlEndAdornment}
-                position="end"
+  return (
+    <div>
+      <TextField
+        label="text filter"
+        value={textFilterValue}
+        onChange={evt => setTextFilterValue(evt.target.value)}
+        variant="outlined"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <FilterIcon />
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment
+              className={classes.textFilterControlEndAdornment}
+              position="end"
+            >
+              <IconButton
+                aria-label="clear filter"
+                onClick={() => setTextFilterValue('')}
               >
-                <IconButton
-                  aria-label="clear filter"
-                  onClick={() => setTextFilterValue('')}
-                >
-                  <ClearIcon />
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
-      </div>
-    )
-  },
-)
+                <ClearIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+    </div>
+  )
+})
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const GlobalFilterControls = observer(({ model }: { model: any }) => {

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -1,29 +1,36 @@
 import React, { useState } from 'react'
-
 import {
   FormControl,
   FormGroup,
   FormLabel,
   FormControlLabel,
   Checkbox,
+  Container,
   RadioGroup,
   Radio,
-  Container,
   Button,
   Grid,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-
 import { observer } from 'mobx-react'
 import { getRoot } from 'mobx-state-tree'
 import { AbstractRootModel, getSession } from '@jbrowse/core/util'
 import { FileSelector, ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
+
+// locals
 import { ImportWizardModel } from '../models/ImportWizard'
 import NumberEditor from './NumberEditor'
 
 const useStyles = makeStyles()(theme => ({
   buttonContainer: {
     marginTop: theme.spacing(1),
+  },
+  grid: {
+    width: '25rem',
+    margin: '0 auto',
+  },
+  container: {
+    overflow: 'auto',
   },
 }))
 
@@ -46,10 +53,10 @@ const ImportWizard = observer(({ model }: { model: ImportWizardModel }) => {
   const rootModel = getRoot(model)
 
   return (
-    <Container>
+    <Container className={classes.container}>
       {err ? <ErrorMessage error={err} /> : null}
       <Grid
-        style={{ width: '25rem', margin: '0 auto' }}
+        className={classes.grid}
         container
         spacing={1}
         direction="column"
@@ -72,19 +79,17 @@ const ImportWizard = observer(({ model }: { model: ImportWizardModel }) => {
             <FormLabel component="legend">File Type</FormLabel>
             <RadioGroup aria-label="file type" name="type" value={fileType}>
               <Grid container spacing={1} direction="row">
-                {fileTypes.map(fileTypeName => {
-                  return (
-                    <Grid item key={fileTypeName}>
-                      <FormControlLabel
-                        checked={fileType === fileTypeName}
-                        value={fileTypeName}
-                        onClick={() => model.setFileType(fileTypeName)}
-                        control={<Radio />}
-                        label={fileTypeName}
-                      />
-                    </Grid>
-                  )
-                })}
+                {fileTypes.map(fileTypeName => (
+                  <Grid item key={fileTypeName}>
+                    <FormControlLabel
+                      checked={fileType === fileTypeName}
+                      value={fileTypeName}
+                      onClick={() => model.setFileType(fileTypeName)}
+                      control={<Radio />}
+                      label={fileTypeName}
+                    />
+                  </Grid>
+                ))}
               </Grid>
             </RadioGroup>
           </FormControl>

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles()(theme => ({
     margin: '0 auto',
   },
   container: {
-    overflow: 'auto',
+    margin: theme.spacing(2),
   },
 }))
 

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -5,9 +5,9 @@ import {
   FormLabel,
   FormControlLabel,
   Checkbox,
-  Container,
   RadioGroup,
   Radio,
+  Container,
   Button,
   Grid,
 } from '@mui/material'

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/NumberEditor.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/NumberEditor.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
-
 import { TextField } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
+
+// locals
 import { ImportWizardModel } from '../models/ImportWizard'
 
 const useStyles = makeStyles()({

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
@@ -11,11 +11,10 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 // locals
 import ImportWizard from './ImportWizard'
 import Spreadsheet from './Spreadsheet'
-import SpreadsheetStateModel from '../models/Spreadsheet'
-import SpreadsheetStateViewModel from '../models/SpreadsheetView'
-
 import GlobalFilterControls from './GlobalFilterControls'
 import ColumnFilterControls from './ColumnFilterControls'
+import SpreadsheetStateModel from '../models/Spreadsheet'
+import SpreadsheetStateViewModel from '../models/SpreadsheetView'
 
 type SpreadsheetModel = Instance<typeof SpreadsheetStateModel>
 type SpreadsheetViewModel = Instance<typeof SpreadsheetStateViewModel>
@@ -28,20 +27,15 @@ const useStyles = makeStyles()(theme => ({
   root: {
     position: 'relative',
     marginBottom: theme.spacing(1),
-    overflow: 'hidden',
   },
   header: {
-    overflow: 'hidden',
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     height: headerHeight,
     paddingLeft: theme.spacing(1),
   },
-  contentArea: {
-    overflow: 'auto',
-  },
+
   columnFilter: {
-    overflow: 'hidden',
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     height: headerHeight,
@@ -187,11 +181,7 @@ function StatusBar({
   )
 }
 
-const SpreadsheetView = observer(function ({
-  model,
-}: {
-  model: SpreadsheetViewModel
-}) {
+export default observer(function ({ model }: { model: SpreadsheetViewModel }) {
   const { classes } = useStyles()
   const {
     spreadsheet,
@@ -212,11 +202,7 @@ const SpreadsheetView = observer(function ({
   const hide2 = mode !== 'display' || hideFilterControls
 
   return (
-    <div
-      className={classes.root}
-      style={{ height: model.height, width: model.width }}
-      data-testid={model.id}
-    >
+    <div className={classes.root} data-testid={model.id}>
       {!hide1 || !hide2 ? (
         <Grid container direction="row" className={classes.header}>
           {hide1 ? null : (
@@ -246,10 +232,7 @@ const SpreadsheetView = observer(function ({
       {mode === 'import' ? (
         <ImportWizard model={model.importWizard} />
       ) : (
-        <div
-          className={classes.contentArea}
-          style={{ height: height - headerHeight }}
-        >
+        <div style={{ height: height - headerHeight }}>
           <div
             style={{
               position: 'relative',
@@ -288,5 +271,3 @@ const SpreadsheetView = observer(function ({
     </div>
   )
 })
-
-export default SpreadsheetView

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
@@ -27,15 +27,20 @@ const useStyles = makeStyles()(theme => ({
   root: {
     position: 'relative',
     marginBottom: theme.spacing(1),
+    overflow: 'hidden',
   },
   header: {
+    overflow: 'hidden',
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     height: headerHeight,
     paddingLeft: theme.spacing(1),
   },
-
+  contentArea: {
+    overflow: 'auto',
+  },
   columnFilter: {
+    overflow: 'hidden',
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     height: headerHeight,
@@ -232,7 +237,10 @@ export default observer(function ({ model }: { model: SpreadsheetViewModel }) {
       {mode === 'import' ? (
         <ImportWizard model={model.importWizard} />
       ) : (
-        <div style={{ height: height - headerHeight }}>
+        <div
+          className={classes.contentArea}
+          style={{ height: height - headerHeight }}
+        >
           <div
             style={{
               position: 'relative',


### PR DESCRIPTION
When you were zoomed in on the spreadsheet view, the import form's "Submit" button could be hidden because of the combination of the ViewContainer's overflow:hidden and the SpreadsheetView's strict usage of model.height

This changes the code to allow the SpreadsheetView to autosize it's contents better and does not strictly apply model.height when viewing the "ImportForm"