### PR TITLE
typescript checking for config slot names

### DIFF
--- a/packages/core/Plugin.ts
+++ b/packages/core/Plugin.ts
@@ -1,5 +1,5 @@
 import PluginManager from './PluginManager'
-import { AnyConfigurationSchemaType } from './configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from './configuration'
 
 /**
  * base class for a JBrowse plugin

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -381,9 +381,9 @@ export default function assemblyFactory(
        */
       async loadPre() {
         const conf = self.configuration
-        const refNameAliasesAdapterConf = conf.refNameAliases?.adapter
-        const cytobandAdapterConf = conf.cytobands?.adapter
-        const sequenceAdapterConf = conf.sequence.adapter
+        const refNameAliasesAdapterConf = conf?.refNameAliases?.adapter
+        const cytobandAdapterConf = conf?.cytobands?.adapter
+        const sequenceAdapterConf = conf?.sequence.adapter
         const assemblyName = self.name
 
         const regions = await getAssemblyRegions(sequenceAdapterConf, pm)

--- a/packages/core/configuration/configurationSchema.test.ts
+++ b/packages/core/configuration/configurationSchema.test.ts
@@ -2,6 +2,7 @@ import { types, getSnapshot } from 'mobx-state-tree'
 import { ConfigurationSchema } from './configurationSchema'
 import { isConfigurationModel } from './util'
 import { getConf, readConfObject } from '.'
+// import { ConfigurationSchemaForModel, GetOptions, GetBase, ConfigurationSlotName } from './types'
 
 describe('configuration schemas', () => {
   test('can make a schema with a color', () => {
@@ -21,6 +22,7 @@ describe('configuration schemas', () => {
     })
 
     const model = container.create()
+
     expect(isConfigurationModel(model.configuration)).toBe(true)
     expect(getConf(model, 'backgroundColor')).toBe('#eee')
     expect(getConf(model, 'someInteger')).toBe(12)
@@ -35,6 +37,13 @@ describe('configuration schemas', () => {
     expect(getConf(model, 'someInteger', { a: 5 })).toBe(10)
     model.configuration.someInteger.set(42)
     expect(getConf(model, 'someInteger', { a: 5 })).toBe(42)
+
+    // typescript tests
+    // const conf = model.configuration
+    // let schema: ConfigurationSchemaForModel<typeof conf>
+    // let options: GetOptions<typeof schema>
+    // let base: GetBase<typeof schema>
+    // let slot: ConfigurationSlotName<typeof schema>
   })
 
   test('can nest an array of configuration schemas', () => {
@@ -84,6 +93,47 @@ describe('configuration schemas', () => {
     expect(isConfigurationModel(model.configuration)).toBe(true)
     expect(getConf(model, 'someInteger')).toBe(12)
     // expect(getConf(model, 'mySubConfiguration.someNumber')).toBe(4.3)
+  })
+
+  test('a schema can inherit from another base schema', () => {
+    const base = ConfigurationSchema('Foo', {
+      someInteger: {
+        description: 'an integer slot',
+        type: 'integer',
+        defaultValue: 12,
+      },
+      mySubConfiguration: ConfigurationSchema('SubObject', {
+        someNumber: {
+          description: 'some number in a subconfiguration',
+          type: 'number',
+          defaultValue: 4.3,
+        },
+      }),
+    })
+
+    const child = ConfigurationSchema(
+      'Bar',
+      {
+        anotherInteger: {
+          type: 'integer',
+          defaultValue: 4,
+        },
+      },
+      {
+        baseConfiguration: base,
+      },
+    )
+
+    const model = child.create()
+    expect(isConfigurationModel(model)).toBe(true)
+    expect(readConfObject(model, 'someInteger')).toBe(12)
+
+    // typescript tests
+    // const conf = model
+    // let schema: ConfigurationSchemaForModel<typeof conf>
+    // let options: GetOptions<typeof schema>
+    // let baseConf: GetBase<typeof schema>
+    // let slot: ConfigurationSlotName<typeof schema>
   })
 
   test('can snapshot a simple schema', () => {

--- a/packages/core/configuration/index.ts
+++ b/packages/core/configuration/index.ts
@@ -4,8 +4,10 @@ export {
 } from './configurationSchema'
 
 export type {
-  AnyConfigurationModel,
   AnyConfigurationSchemaType,
-} from './configurationSchema'
+  AnyConfigurationModel,
+  AnyConfigurationSlot,
+  AnyConfigurationSlotType,
+} from './types'
 
 export * from './util'

--- a/packages/core/configuration/types.ts
+++ b/packages/core/configuration/types.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { IStateTreeNode, Instance } from 'mobx-state-tree'
+import type {
+  ConfigurationSchemaType,
+  ConfigurationSchemaOptions,
+} from './configurationSchema'
+import type ConfigSlot from './configurationSlot'
+
+export type GetOptions<SCHEMA> = SCHEMA extends ConfigurationSchemaType<
+  any,
+  infer OPTIONS
+>
+  ? OPTIONS
+  : never
+
+// type GetDefinition<SCHEMA> = SCHEMA extends ConfigurationSchemaType<
+//   infer D,
+//   any
+// >
+//   ? D
+//   : never
+
+export type GetBase<SCHEMA> = SCHEMA extends undefined
+  ? never
+  : GetOptions<SCHEMA> extends ConfigurationSchemaOptions<undefined, any>
+  ? undefined
+  : GetOptions<SCHEMA> extends ConfigurationSchemaOptions<
+      infer BASE extends AnyConfigurationSchemaType,
+      any
+    >
+  ? BASE
+  : never
+
+export type GetExplicitIdentifier<SCHEMA> =
+  GetOptions<SCHEMA> extends ConfigurationSchemaOptions<
+    any,
+    infer EXPLICIT_IDENTIFIER extends string
+  >
+    ? EXPLICIT_IDENTIFIER
+    : never
+
+export type ConfigurationSchemaForModel<MODEL> = MODEL extends IStateTreeNode<
+  infer SCHEMA extends AnyConfigurationSchemaType
+>
+  ? SCHEMA
+  : never
+
+export type ConfigurationSlotName<SCHEMA> = SCHEMA extends undefined
+  ? never
+  : SCHEMA extends ConfigurationSchemaType<infer D, any>
+  ?
+      | (keyof D & string)
+      | GetExplicitIdentifier<SCHEMA>
+      | (GetBase<SCHEMA> extends ConfigurationSchemaType<any, any>
+          ? ConfigurationSlotName<GetBase<SCHEMA>>
+          : never)
+  : never
+
+export type AnyConfigurationSchemaType = ConfigurationSchemaType<any, any>
+export type AnyConfigurationModel = Instance<AnyConfigurationSchemaType>
+export type AnyConfigurationSlotType = ReturnType<typeof ConfigSlot>
+export type AnyConfigurationSlot = Instance<AnyConfigurationSlotType>
+
+export type ConfigurationModel<SCHEMA extends AnyConfigurationSchemaType> =
+  Instance<SCHEMA>

--- a/packages/core/data_adapters/BaseAdapter/BaseAdapter.ts
+++ b/packages/core/data_adapters/BaseAdapter/BaseAdapter.ts
@@ -30,6 +30,10 @@ export abstract class BaseAdapter {
     }
   }
 
+  /**
+   * Same as `readConfObject(this.config, arg)`.
+   * @deprecated Does not offer the same TS type checking as `readConfObject`, consider using that instead.
+   */
   getConf(arg: string | string[]) {
     return readConfObject(this.config, arg)
   }

--- a/packages/core/pluggableElementTypes/AdapterType.ts
+++ b/packages/core/pluggableElementTypes/AdapterType.ts
@@ -1,5 +1,5 @@
 import PluggableElementBase from './PluggableElementBase'
-import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../configuration'
 import { AnyAdapter } from '../data_adapters/BaseAdapter'
 
 export type AdapterMetadata = {

--- a/packages/core/pluggableElementTypes/ConnectionType.ts
+++ b/packages/core/pluggableElementTypes/ConnectionType.ts
@@ -1,6 +1,6 @@
 import { IAnyModelType } from 'mobx-state-tree'
 import PluggableElementBase from './PluggableElementBase'
-import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../configuration'
 import { AnyReactComponentType } from '../util'
 
 export default class ConnectionType extends PluggableElementBase {

--- a/packages/core/pluggableElementTypes/DisplayType.ts
+++ b/packages/core/pluggableElementTypes/DisplayType.ts
@@ -2,7 +2,7 @@ import { IAnyModelType } from 'mobx-state-tree'
 import PluggableElementBase from './PluggableElementBase'
 import { AnyReactComponentType } from '../util'
 import { getDefaultValue } from '../util/mst-reflection'
-import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../configuration'
 
 export default class DisplayType extends PluggableElementBase {
   stateModel: IAnyModelType

--- a/packages/core/pluggableElementTypes/InternetAccountType.ts
+++ b/packages/core/pluggableElementTypes/InternetAccountType.ts
@@ -1,7 +1,7 @@
 import { IAnyModelType } from 'mobx-state-tree'
 import PluggableElementBase from './PluggableElementBase'
 import { getDefaultValue } from '../util/mst-reflection'
-import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../configuration/types'
 
 export default class InternetAccountType extends PluggableElementBase {
   stateModel: IAnyModelType

--- a/packages/core/pluggableElementTypes/TextSearchAdapterType.ts
+++ b/packages/core/pluggableElementTypes/TextSearchAdapterType.ts
@@ -1,5 +1,5 @@
 import PluggableElementBase from './PluggableElementBase'
-import { AnyConfigurationSchemaType } from '../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../configuration'
 import { AnyAdapter } from '../data_adapters/BaseAdapter'
 
 export default class TextSearchAdapterType extends PluggableElementBase {

--- a/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
+++ b/packages/core/pluggableElementTypes/models/BaseTrackModel.ts
@@ -69,7 +69,7 @@ export function createBaseTrackModel(
        * determines which webworker to send the track to, currently based on trackId
        */
       get rpcSessionId() {
-        return self.configuration.trackId
+        return self.configuration?.trackId
       },
       /**
        * #getter
@@ -117,7 +117,7 @@ export function createBaseTrackModel(
           (adminMode ||
             sessionTracks.find(
               (track: { trackId: string }) =>
-                track.trackId === self.configuration.trackId,
+                track.trackId === self.configuration?.trackId,
             ))
         )
       },

--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -1,17 +1,16 @@
 import React from 'react'
 import { Instance, types } from 'mobx-state-tree'
-import { getConf } from '../../configuration'
+import { ConfigurationReference, getConf } from '../../configuration'
 import { RemoteFileWithRangeCache } from '../../util/io'
 import { ElementId } from '../../util/types/mst'
 import { UriLocation, AnyReactComponentType } from '../../util/types'
+import { BaseInternetAccountConfig } from './baseInternetAccountConfig'
 
 const inWebWorker = typeof sessionStorage === 'undefined'
 
 /**
  * #stateModel BaseInternetAccountModel
  */
-function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
-
 export const InternetAccount = types
   .model('InternetAccount', {
     /**
@@ -22,6 +21,10 @@ export const InternetAccount = types
      * #property
      */
     type: types.string,
+    /**
+     * #property
+     */
+    configuration: ConfigurationReference(BaseInternetAccountConfig),
   })
   .views(self => ({
     /**
@@ -40,7 +43,7 @@ export const InternetAccount = types
      * #getter
      */
     get internetAccountId(): string {
-      return getConf(self, 'internetAccountId')
+      return getConf(self, 'internetAccountId') // NOTE: this is the explicitIdentifier of the config schema
     },
     /**
      * #getter

--- a/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/FeatureRendererType.ts
@@ -19,7 +19,7 @@ import ServerSideRendererType, {
   ResultsSerialized as ServerSideResultsSerialized,
 } from './ServerSideRendererType'
 import { isFeatureAdapter } from '../../data_adapters/BaseAdapter'
-import { AnyConfigurationModel } from '../../configuration/configurationSchema'
+import { AnyConfigurationModel } from '../../configuration'
 
 export interface RenderArgs extends ServerSideRenderArgs {
   displayModel: { id: string; selectedFeatureId?: string }

--- a/packages/core/pluggableElementTypes/renderers/RendererType.ts
+++ b/packages/core/pluggableElementTypes/renderers/RendererType.ts
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import { getDefaultValue } from '../../util/mst-reflection'
 import PluggableElementBase from '../PluggableElementBase'
-import { AnyConfigurationSchemaType } from '../../configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '../../configuration'
 import { AnyReactComponentType } from '../../util'
 import PluginManager from '../../PluginManager'
 

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.tsx
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.tsx
@@ -14,7 +14,7 @@ import { checkAbortSignal, getSerializedSvg, updateStatus } from '../../util'
 import SerializableFilterChain, {
   SerializedFilterChain,
 } from './util/serializableFilterChain'
-import { AnyConfigurationModel } from '../../configuration/configurationSchema'
+import { AnyConfigurationModel } from '../../configuration'
 import RpcManager from '../../rpc/RpcManager'
 import { createJBrowseTheme } from '../../ui'
 

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -7,7 +7,7 @@ import {
   IStateTreeNode,
   IType,
 } from 'mobx-state-tree'
-import { AnyConfigurationModel } from '../../configuration/configurationSchema'
+import { AnyConfigurationModel } from '../../configuration'
 
 import assemblyManager from '../../assemblyManager'
 import TextSearchManager from '../../TextSearch/TextSearchManager'
@@ -105,6 +105,7 @@ export interface AbstractSessionModel extends AbstractViewContainer {
     name: string
     connectionId: string
     tracks: AnyConfigurationModel[]
+    configuration: AnyConfigurationModel
   }[]
   makeConnection?: Function
   adminMode?: boolean
@@ -252,6 +253,7 @@ export function isViewModel(thing: unknown): thing is AbstractViewModel {
 
 export interface AbstractTrackModel {
   displays: AbstractDisplayModel[]
+  configuration: AnyConfigurationModel
 }
 
 export function isTrackModel(thing: unknown): thing is AbstractTrackModel {

--- a/plugins/alignments/src/CramAdapter/CramTestAdapters.ts
+++ b/plugins/alignments/src/CramAdapter/CramTestAdapters.ts
@@ -2,7 +2,7 @@ import { GenericFilehandle } from 'generic-filehandle'
 import { Observable } from 'rxjs'
 import SimpleFeature from '@jbrowse/core/util/simpleFeature'
 import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { ConfigurationSchema } from '@jbrowse/core/configuration/configurationSchema'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
 
 // setup for Cram Adapter Testing
 export function parseSmallFasta(text: string) {

--- a/plugins/alignments/src/LinearReadCloudDisplay/drawFeats.ts
+++ b/plugins/alignments/src/LinearReadCloudDisplay/drawFeats.ts
@@ -1,4 +1,4 @@
-import { getConf } from '@jbrowse/core/configuration'
+import { AnyConfigurationModel, getConf } from '@jbrowse/core/configuration'
 import { getContainingView, getSession } from '@jbrowse/core/util'
 
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
@@ -53,6 +53,7 @@ export default async function drawFeats(
     colorBy?: { type: string }
     height: number
     chainData?: ChainData
+    configuration: AnyConfigurationModel
   },
   ctx: CanvasRenderingContext2D,
 ) {

--- a/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
+++ b/plugins/alignments/src/PileupRenderer/PileupLayoutSession.ts
@@ -1,6 +1,6 @@
 import deepEqual from 'fast-deep-equal'
 import { LayoutSession } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
 import GranularRectLayout from '@jbrowse/core/util/layouts/GranularRectLayout'
 import MultiLayout from '@jbrowse/core/util/layouts/MultiLayout'

--- a/plugins/arc/src/LinearArcDisplay/model.ts
+++ b/plugins/arc/src/LinearArcDisplay/model.ts
@@ -1,7 +1,7 @@
 import {
   AnyConfigurationSchemaType,
   ConfigurationReference,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
 import { types } from 'mobx-state-tree'
 import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
 

--- a/plugins/circular-view/src/BaseChordDisplay/models/model.tsx
+++ b/plugins/circular-view/src/BaseChordDisplay/models/model.tsx
@@ -3,7 +3,7 @@ import clone from 'clone'
 import { getParent, isAlive, types } from 'mobx-state-tree'
 
 // jbrowse
-import { getConf } from '@jbrowse/core/configuration'
+import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes/models'
 import CircularChordRendererType from '@jbrowse/core/pluggableElementTypes/renderers/CircularChordRendererType'
 import RendererType from '@jbrowse/core/pluggableElementTypes/renderers/RendererType'
@@ -30,6 +30,7 @@ import {
   ExportSvgOptions,
 } from '../../CircularView/models/CircularView'
 import { ThemeOptions } from '@mui/material'
+import { baseChordDisplayConfig } from './configSchema'
 
 /**
  * #stateModel BaseChordDisplay
@@ -50,6 +51,10 @@ export const BaseChordDisplayModel = types
        * #property
        */
       assemblyName: types.maybe(types.string),
+      /**
+       * #property
+       */
+      configuration: ConfigurationReference(baseChordDisplayConfig),
     }),
   )
   .volatile(() => ({

--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.tsx
@@ -27,7 +27,7 @@ import BooleanEditor from './BooleanEditor'
 import {
   AnyConfigurationSlot,
   AnyConfigurationSlotType,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
 
 const StringEditor = observer(
   ({

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
@@ -1127,7 +1127,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                     </div>
                   </div>
                   <p>
-                    what to display in a given mouseover
+                    text to display when the cursor hovers over a feature
                   </p>
                   <button
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"

--- a/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
@@ -87,7 +87,7 @@ function AddTrackWorkflow({ model }: { model: AddTrackModel }) {
 
     const assemblyInstance = session.assemblyManager.get(assembly)
 
-    if (trackAdapter && trackAdapter.type !== 'UNKNOWN') {
+    if (assemblyInstance && trackAdapter && trackAdapter.type !== 'UNKNOWN') {
       session.addTrackConf({
         trackId,
         type: trackType,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/DeleteConnectionDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/DeleteConnectionDialog.tsx
@@ -8,7 +8,7 @@ import {
   Button,
 } from '@mui/material'
 import { observer } from 'mobx-react'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { AbstractSessionModel } from '@jbrowse/core/util'
 
 function DeleteConnectionDialog({

--- a/plugins/data-management/src/ucsc-trackhub/model.ts
+++ b/plugins/data-management/src/ucsc-trackhub/model.ts
@@ -31,7 +31,7 @@ export default function UCSCTrackHubConnection(pluginManager: PluginManager) {
       async connect() {
         const session = getSession(self)
         try {
-          const connectionName = getConf(self, 'name')
+          const connectionName = getConf(self, 'name') // NOTE: name comes from the base configuration
           const hubFileLocation = getConf(self, 'hubTxtLocation')
           const hubFile = await fetchHubFile(hubFileLocation)
           const genomeFile = hubFile.get('genomesFile')

--- a/plugins/hic/src/HicRenderer/HicRenderer.tsx
+++ b/plugins/hic/src/HicRenderer/HicRenderer.tsx
@@ -11,7 +11,7 @@ import { toArray } from 'rxjs/operators'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { getAdapter } from '@jbrowse/core/data_adapters/dataAdapterCache'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
 interface HicFeature {
   bin1: number

--- a/plugins/hic/src/LinearHicDisplay/model.ts
+++ b/plugins/hic/src/LinearHicDisplay/model.ts
@@ -1,7 +1,7 @@
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
 import { types, getEnv } from 'mobx-state-tree'
-import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration'
 
 export default (configSchema: AnyConfigurationSchemaType) =>
   types

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeView.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeView.tsx
@@ -140,7 +140,9 @@ export default observer(function (props: {
   const { model } = props
 
   const middle = model.tracks.some(({ displays }) =>
-    displays.some((d: AnyConfigurationModel) => getConf(d, 'middle')),
+    displays.some((d: { configuration: AnyConfigurationModel }) =>
+      getConf(d, 'middle'),
+    ),
   )
   return middle ? (
     <MiddleComparativeView {...props} />

--- a/plugins/linear-comparative-view/src/LinearReadVsRef/LinearReadVsRef.tsx
+++ b/plugins/linear-comparative-view/src/LinearReadVsRef/LinearReadVsRef.tsx
@@ -159,6 +159,9 @@ export default function ReadVsRefDialog({
       // tracks can be opened on the top panel of the linear read vs ref
       const { assemblyManager } = session
       const assembly = assemblyManager.get(trackAssembly)
+      if (!assembly) {
+        throw new Error('assembly not found')
+      }
 
       const suppAlns = featurizeSA(SA, feature.id(), origStrand, readName, true)
 

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { ThemeOptions } from '@mui/material'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes/models'
-import { getConf } from '@jbrowse/core/configuration'
+import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import { MenuItem } from '@jbrowse/core/ui'
 import {
   isAbortException,
@@ -33,6 +33,7 @@ import { Tooltip } from '../components/BaseLinearDisplay'
 import TooLargeMessage from '../components/TooLargeMessage'
 import BlockState, { renderBlockData } from './serverSideRenderedBlock'
 import { getId, getDisplayStr, getFeatureDensityStatsPre } from './util'
+import configSchema from './configSchema'
 
 type LGV = LinearGenomeViewModel
 
@@ -81,6 +82,10 @@ function stateModelFactory() {
          * #property
          */
         userByteSizeLimit: types.maybe(types.number),
+        /**
+         * #property
+         */
+        configuration: ConfigurationReference(configSchema),
       }),
     )
     .volatile(() => ({

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/configSchema.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/configSchema.ts
@@ -37,6 +37,16 @@ const baseLinearDisplayConfigSchema = ConfigurationSchema(
       defaultValue: 100,
       description: 'default height for the track',
     },
+    /**
+     * #slot
+     */
+    mouseover: {
+      type: 'string',
+      description: 'text to display when the cursor hovers over a feature',
+      defaultValue: `jexl:get(feature,'name')`,
+
+      contextVariable: ['feature'],
+    },
   },
   {
     /**

--- a/plugins/linear-genome-view/src/LinearBareDisplay/model.ts
+++ b/plugins/linear-genome-view/src/LinearBareDisplay/model.ts
@@ -1,7 +1,7 @@
 import {
   AnyConfigurationSchemaType,
   ConfigurationReference,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 import { types } from 'mobx-state-tree'
 import { BaseLinearDisplay } from '../BaseLinearDisplay'

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/configSchema.ts
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/configSchema.ts
@@ -12,16 +12,6 @@ function configSchemaFactory(pluginManager: PluginManager) {
       /**
        * #slot
        */
-      mouseover: {
-        type: 'string',
-        description: 'what to display in a given mouseover',
-        defaultValue: `jexl:get(feature,'name')`,
-
-        contextVariable: ['feature'],
-      },
-      /**
-       * #slot
-       */
       renderer: pluginManager.pluggableConfigSchemaType('renderer'),
     },
     {

--- a/plugins/lollipop/src/LinearLollipopDisplay/model.ts
+++ b/plugins/lollipop/src/LinearLollipopDisplay/model.ts
@@ -1,7 +1,7 @@
 import {
   AnyConfigurationSchemaType,
   ConfigurationReference,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
 import { types } from 'mobx-state-tree'
 import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
 

--- a/plugins/lollipop/src/LollipopRenderer/Layout.ts
+++ b/plugins/lollipop/src/LollipopRenderer/Layout.ts
@@ -1,6 +1,6 @@
 import { readConfObject } from '@jbrowse/core/configuration'
 import { doesIntersect2 } from '@jbrowse/core/util/range'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
 interface LayoutItem {
   uniqueId: string

--- a/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
+++ b/plugins/sequence/src/TwoBitAdapter/TwoBitAdapter.ts
@@ -5,7 +5,7 @@ import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { TwoBitFile } from '@gmod/twobit'
 import { readConfObject } from '@jbrowse/core/configuration'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
 

--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -179,6 +179,7 @@ export function groupBy<T>(array: T[], predicate: (v: T) => string) {
 export async function getQuantitativeStats(
   self: {
     adapterConfig: AnyConfigurationModel
+    configuration: AnyConfigurationModel
     autoscaleType: string
     setMessage: (str: string) => void
   },
@@ -273,6 +274,7 @@ export function quantitativeStatsAutorun(self: {
     statsRegion: string,
   ) => void
   renderProps: () => Record<string, unknown>
+  configuration: AnyConfigurationModel
   adapterConfig: AnyConfigurationModel
   autoscaleType: string
   setMessage: (str: string) => void

--- a/products/jbrowse-desktop/src/jbrowseModel.ts
+++ b/products/jbrowse-desktop/src/jbrowseModel.ts
@@ -5,7 +5,7 @@ import {
 import {
   AnyConfigurationModel,
   AnyConfigurationSchemaType,
-} from '@jbrowse/core/configuration/configurationSchema'
+} from '@jbrowse/core/configuration'
 import { PluginDefinition } from '@jbrowse/core/PluginLoader'
 import PluginManager from '@jbrowse/core/PluginManager'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'

--- a/products/jbrowse-desktop/src/sessionModelFactory.ts
+++ b/products/jbrowse-desktop/src/sessionModelFactory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { lazy } from 'react'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import {
   readConfObject,
   isConfigurationModel,

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createConfigModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createConfigModel.ts
@@ -1,14 +1,15 @@
 import {
+  AnyConfigurationSchemaType,
   ConfigurationSchema,
   readConfObject,
 } from '@jbrowse/core/configuration'
 import PluginManager from '@jbrowse/core/PluginManager'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'
-import { getParent, IAnyType, types } from 'mobx-state-tree'
+import { getParent, types } from 'mobx-state-tree'
 
 export default function createConfigModel(
   pluginManager: PluginManager,
-  assemblyConfigSchemasType: IAnyType,
+  assemblyConfigSchemasType: AnyConfigurationSchemaType,
 ) {
   return types
     .model('Configuration', {

--- a/products/jbrowse-react-circular-genome-view/src/createViewState.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createViewState.ts
@@ -77,11 +77,11 @@ export default function createViewState(opts: ViewStateOptions) {
     if (!session.view.initialized) {
       return
     }
-    const asm = assemblyManager.get(assembly.name)
-    if (!asm?.regions) {
+    const regions = assemblyManager.get(assembly?.name)?.regions
+    if (!regions) {
       return
     }
-    session.view.setDisplayedRegions(asm.regions)
+    session.view.setDisplayedRegions(regions)
     reaction.dispose()
   })
   if (onChange) {

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -11,7 +11,7 @@ import PluginLoader, {
 import { fromUrlSafeB64 } from './util'
 import { readSessionFromDynamo } from './sessionSharing'
 import { openLocation } from '@jbrowse/core/util/io'
-import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import shortid from 'shortid'
 
 type Config = SnapshotOut<AnyConfigurationModel>


### PR DESCRIPTION
This PR adds type checking of config slot names to the configuration system TS. It can figure out the specific config schema surprisingly often.

Other things in this PR:

* fixes some type errors found by the new checking
* changes a lot of imports to import from '@jbrowse/core/configuration' at the top level instead of '/configurationSchema' under it for better forward compatibility. The old import location still works though.
