### PR TITLE
Adds miscellaneous fixes to Add Track workflow

### DIFF
--- a/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
+++ b/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
@@ -62,8 +62,8 @@ function parseStrand(strand: string) {
 export default class BedpeAdapter extends BaseFeatureDataAdapter {
   protected bedpeFeatures?: Promise<{
     header: string
-    feats1: Record<string, string[]>
-    feats2: Record<string, string[]>
+    feats1: Record<string, string[] | undefined>
+    feats2: Record<string, string[] | undefined>
     columnNames: string[]
   }>
 
@@ -90,8 +90,8 @@ export default class BedpeAdapter extends BaseFeatureDataAdapter {
       headerLines.push(lines[i])
     }
     const header = headerLines.join('\n')
-    const feats1 = {} as Record<string, string[]>
-    const feats2 = {} as Record<string, string[]>
+    const feats1 = {} as Record<string, string[] | undefined>
+    const feats2 = {} as Record<string, string[] | undefined>
     for (; i < lines.length; i++) {
       const line = lines[i]
       const cols = line.split('\t')
@@ -103,8 +103,10 @@ export default class BedpeAdapter extends BaseFeatureDataAdapter {
       if (!feats2[r2]) {
         feats2[r2] = []
       }
-      feats1[r1].push(line)
-      feats2[r2].push(line)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      feats1[r1]!.push(line)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      feats2[r2]!.push(line)
     }
     const columnNames = this.getConf('columnNames')
 

--- a/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
+++ b/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
@@ -168,12 +168,16 @@ export default class BedpeAdapter extends BaseFeatureDataAdapter {
       return featureData(f, uniqueId, true, names)
     })
 
-    for (const obj of ret1) {
-      intervalTree.insert([obj.get('start'), obj.get('end')], obj)
+    if (ret1) {
+      for (const obj of ret1) {
+        intervalTree.insert([obj.get('start'), obj.get('end')], obj)
+      }
     }
 
-    for (const obj of ret2) {
-      intervalTree.insert([obj.get('start'), obj.get('end')], obj)
+    if (ret2) {
+      for (const obj of ret2) {
+        intervalTree.insert([obj.get('start'), obj.get('end')], obj)
+      }
     }
 
     return intervalTree

--- a/plugins/bed/src/index.ts
+++ b/plugins/bed/src/index.ts
@@ -10,6 +10,7 @@ import {
   makeIndex,
   makeIndexType,
   AdapterGuesser,
+  TrackTypeGuesser,
 } from '@jbrowse/core/util/tracks'
 
 export default class BedPlugin extends Plugin {
@@ -113,6 +114,18 @@ export default class BedPlugin extends Plugin {
             }
           }
           return adapterGuesser(file, index, adapterHint)
+        }
+      },
+    )
+
+    pluginManager.addToExtensionPoint(
+      'Core-guessTrackTypeForLocation',
+      (trackTypeGuesser: TrackTypeGuesser) => {
+        return (adapterName: string) => {
+          if (adapterName === 'BedpeAdapter') {
+            return 'VariantTrack'
+          }
+          return trackTypeGuesser(adapterName)
         }
       },
     )

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
@@ -6,6 +6,7 @@ import JBrowseMenu from '@jbrowse/core/ui/Menu'
 import {
   getSession,
   isSessionModelWithWidgets,
+  isSessionWithAddTracks,
   isSessionModelWithConnections,
 } from '@jbrowse/core/util'
 import {
@@ -116,6 +117,22 @@ export default observer(function HamburgerMenu({
       onClick: () => setConnectionManagerOpen(true),
     })
   }
+
+  const trackMenuItems = [
+    {
+      label: 'Add track...',
+      onClick: () => {
+        if (isSessionModelWithWidgets(session)) {
+          session.showWidget(
+            session.addWidget('AddTrackWidget', 'addTrackWidget', {
+              view: model.view.id,
+            }),
+          )
+        }
+      },
+    },
+  ]
+
   return (
     <>
       <IconButton
@@ -134,18 +151,7 @@ export default observer(function HamburgerMenu({
         }}
         onClose={() => setMenuEl(undefined)}
         menuItems={[
-          {
-            label: 'Add track...',
-            onClick: () => {
-              if (isSessionModelWithWidgets(session)) {
-                session.showWidget(
-                  session.addWidget('AddTrackWidget', 'addTrackWidget', {
-                    view: model.view.id,
-                  }),
-                )
-              }
-            },
-          },
+          ...(isSessionWithAddTracks(session) ? trackMenuItems : []),
           ...(session.makeConnection ? connectionMenuItems : []),
 
           ...(assemblyNames.length > 1


### PR DESCRIPTION
- adds a track type guess to the bedpe filetype (variant track) such that if you pop it into circular view, it will work
- follows through with track population if a certain field from the bedpe file is null
- disables the add track hamburger menu item from the sidebar such that if a user has disabled addtrack it will not give them the option