### PR TITLE
Fix renderDelay not being applied to dynamicBlocks

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -63,19 +63,21 @@ const blockState = types
       },
       afterAttach() {
         const display = getContainingDisplay(self)
-        makeAbortableReaction(
-          self as any,
-          renderBlockData,
-          renderBlockEffect, // reaction doesn't expect async here
-          {
-            name: `${display.id}/${assembleLocString(self.region)} rendering`,
-            delay: display.renderDelay,
-            fireImmediately: true,
-          },
-          this.setLoading,
-          this.setRendered,
-          this.setError,
-        )
+        setTimeout(() => {
+          makeAbortableReaction(
+            self as any,
+            renderBlockData,
+            renderBlockEffect, // reaction doesn't expect async here
+            {
+              name: `${display.id}/${assembleLocString(self.region)} rendering`,
+              delay: display.renderDelay,
+              fireImmediately: true,
+            },
+            this.setLoading,
+            this.setRendered,
+            this.setError,
+          )
+        }, display.renderDelay)
       },
       setStatus(message: string) {
         self.status = message


### PR DESCRIPTION
This is a more minimal PR to address same issue as https://github.com/GMOD/jbrowse-components/pull/3595 

That PR tried to introduce many refactorings to the block based system including how we hydrate content from our web worker, but I ran into many odd errors with this. 

This PR just adds a delay before creating the makeAbortableReaction on the serverSideRenderedBlock afterAttach

Fixes #887 

