### PR TITLE
wait until mouse-up to re-render during LGV drag scroll

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -94,7 +94,8 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
 function VerticalGuides({ model }: { model: LGV }) {
   const { classes } = useStyles()
   // find the block that needs pinning to the left side for context
-  const offsetLeft = model.staticBlocks.offsetPx - model.offsetPx
+  const offsetLeft =
+    model.staticBlocks.offsetPx - model.offsetPx - model.previewScrollOffsetPx
   return (
     <div
       className={classes.verticalGuidesZoomContainer}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -62,10 +62,12 @@ const useStyles = makeStyles()(theme => ({
 const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
   const { classes } = useStyles()
 
+  const totalOffsetPx = model.offsetPx + model.previewScrollOffsetPx
+
   // find the block that needs pinning to the left side for context
   let lastLeftBlock = 0
   model.staticBlocks.forEach((block, i) => {
-    if (block.offsetPx - model.offsetPx < 0) {
+    if (block.offsetPx - totalOffsetPx < 0) {
       lastLeftBlock = i
     }
   })
@@ -79,8 +81,8 @@ const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
             style={{
               left:
                 index === lastLeftBlock
-                  ? Math.max(0, -model.offsetPx)
-                  : block.offsetPx - model.offsetPx - 1,
+                  ? Math.max(0, -totalOffsetPx)
+                  : block.offsetPx - totalOffsetPx - 1,
               paddingLeft: index === lastLeftBlock ? 0 : 1,
             }}
             className={classes.refLabel}
@@ -160,7 +162,8 @@ const Scalebar = React.forwardRef<HTMLDivElement, ScalebarProps>(
   ({ model, style, className, ...other }, ref) => {
     const { classes, cx } = useStyles()
 
-    const offsetLeft = model.staticBlocks.offsetPx - model.offsetPx
+    const offsetLeft =
+      model.staticBlocks.offsetPx - model.offsetPx - model.previewScrollOffsetPx
     return (
       <Paper
         data-resizer="true" // used to avoid click-and-drag scrolls on trackscontainer

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -129,7 +129,11 @@ function TrackContainer({
               <div
                 ref={ref}
                 className={classes.renderingComponentContainer}
-                style={{ transform: `scaleX(${model.scaleFactor})` }}
+                style={{
+                  transform: `scaleX(${
+                    model.scaleFactor
+                  }) translate(${-model.previewScrollOffsetPx}px, 0)`,
+                }}
               >
                 <RenderingComponent
                   model={display}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -512,7 +512,7 @@ exports[`renders one track, one region 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
+            style="transform: scaleX(1) translate(0px, 0);"
           >
             <div
               class="css-1y9lrrz-display"
@@ -1331,7 +1331,7 @@ exports[`renders two tracks, two regions 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
+            style="transform: scaleX(1) translate(0px, 0);"
           >
             <div
               class="css-1y9lrrz-display"
@@ -1463,7 +1463,7 @@ exports[`renders two tracks, two regions 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
+            style="transform: scaleX(1) translate(0px, 0);"
           >
             <div
               class="css-1y9lrrz-display"

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -152,6 +152,14 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
         /**
          * #property
+         * Distance in pixels that we have "preview scrolled", which is scrolling
+         * just the grid lines and existing content without fetching data and re-rendering.
+         * This is in addition to the offsetPx.
+         */
+        previewScrollOffsetPx: 0,
+
+        /**
+         * #property
          * Number of base-pairs per displayed pixel. Expresses the "zoom level" of
          * the view.
          */
@@ -833,12 +841,18 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
       /**
        * #action
+       * @param distance - distance to scroll in base pairs
        */
       horizontalScroll(distance: number) {
+        self.previewScrollOffsetPx = 0
         const oldOffsetPx = self.offsetPx
         // newOffsetPx is the actual offset after the scroll is clamped
         const newOffsetPx = self.scrollTo(self.offsetPx + distance)
         return newOffsetPx - oldOffsetPx
+      },
+
+      previewScroll(distance: number) {
+        self.previewScrollOffsetPx += distance
       },
 
       /**

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -584,7 +584,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
       scrollTo(offsetPx: number) {
         const newOffsetPx = clamp(offsetPx, self.minOffset, self.maxOffset)
         self.offsetPx = newOffsetPx
+        self.previewScrollOffsetPx = 0
         return newOffsetPx
+      },
+      /**
+       * #action
+       */
+      previewScrollTo(offsetPx: number) {
+        self.previewScrollOffsetPx = offsetPx
+        return offsetPx
       },
 
       /**
@@ -947,10 +955,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
        */
       function slide(viewWidths: number) {
         const [animate, cancelAnimation] = springAnimate(
-          self.offsetPx,
-          self.offsetPx + self.width * viewWidths,
-          self.scrollTo,
-          undefined,
+          self.previewScrollOffsetPx,
+          self.previewScrollOffsetPx + self.width * viewWidths,
+          self.previewScrollTo,
+          () => self.scrollTo(self.offsetPx + self.previewScrollOffsetPx),
           2,
           550,
           50,

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -145,13 +145,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
         /**
          * #property
-         * corresponds roughly to the horizontal scroll of the LGV
+         * Distance in pixels from the left edge of the view to the left edge of the
+         * first displayed region.
          */
         offsetPx: 0,
 
         /**
          * #property
-         * corresponds roughly to the zoom level, base-pairs per pixel
+         * Number of base-pairs per displayed pixel. Expresses the "zoom level" of
+         * the view.
          */
         bpPerPx: 1,
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -950,6 +950,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
           self.offsetPx,
           self.offsetPx + self.width * viewWidths,
           self.scrollTo,
+          undefined,
+          2,
+          550,
+          50,
         )
         cancelLastAnimation()
         cancelLastAnimation = cancelAnimation
@@ -984,6 +988,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
             self.zoomTo(targetBpPerPx)
             self.setScaleFactor(1)
           },
+          0.01,
+          300,
+          30,
         )
         cancelLastAnimation()
         cancelLastAnimation = cancelAnimation

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -152,14 +152,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
         /**
          * #property
-         * Distance in pixels that we have "preview scrolled", which is scrolling
-         * just the grid lines and existing content without fetching data and re-rendering.
-         * This is in addition to the offsetPx.
-         */
-        previewScrollOffsetPx: 0,
-
-        /**
-         * #property
          * Number of base-pairs per displayed pixel. Expresses the "zoom level" of
          * the view.
          */
@@ -262,6 +254,14 @@ export function stateModelFactory(pluginManager: PluginManager) {
       searchResults: undefined as undefined | BaseResult[],
       searchQuery: undefined as undefined | string,
       seqDialogDisplayed: false,
+
+      /**
+       * #property
+       * Distance in pixels that we have "preview scrolled", which is scrolling
+       * just the grid lines and existing content without fetching data and re-rendering.
+       * This is in addition to the offsetPx.
+       */
+      previewScrollOffsetPx: 0,
     }))
     .views(self => ({
       /**

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -1003,7 +1003,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <div
                     class="css-v11ioz-renderingComponentContainer"
-                    style="transform: scaleX(1);"
+                    style="transform: scaleX(1) translate(0px, 0);"
                   >
                     <div
                       class="css-1y9lrrz-display"


### PR DESCRIPTION
In the LGV, mostly on dynamicBlocks tracks, but a little bit on staticBlocks as well, dragging to side-scroll feels janky due to the tracks eagerly re-rendering while still in the middle of a drag gesture.

This changes the LGV to have a "previewScroll" piece of state that tracks a distance that we have scrolled left or write, but that we don't want to reflect in the rendered blocks. Also refactors the `useSideScroll` hook quite a bit to use the previewScroll.

Requested by @garrettjstevens due to jankiness in the Apollo editing track, which uses dynamicBlocks.