### PR TITLE
Fix text being invisible on overview scalebar when cytobands shown

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
@@ -170,7 +170,7 @@ const OverviewBox = observer(function ({
         style={{
           left: block.offsetPx + 3,
           color: canDisplayCytobands
-            ? theme.palette.primary.contrastText
+            ? theme.palette.text.primary
             : refNameColor,
         }}
         className={classes.scalebarRefName}


### PR DESCRIPTION
v2.4.0-v2.4.2 affected

There is a chromosome label on the overview scale bar and it was invisible when cytobands where shown

It has a different mode when cytobands are shown where it doesn't use the rainbow colors, and accidentally used the wrong contrasting text mode when themes were added in v2.4.0