### PR TITLE
Add extension point to allow plugins to render arbitrary e.g. highlighting components in TracksContainer

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -14,6 +14,7 @@ import Gridlines from './Gridlines'
 import CenterLine from './CenterLine'
 import VerticalGuide from './VerticalGuide'
 import RubberbandSpan from './RubberbandSpan'
+import { getEnv } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()({
   tracksContainer: {
@@ -32,6 +33,7 @@ export default observer(function TracksContainer({
   model: LGV
 }) {
   const { classes } = useStyles()
+  const { pluginManager } = getEnv(model)
   const { mouseDown: mouseDown1, mouseUp } = useSideScroll(model)
   const ref = useRef<HTMLDivElement>(null)
   const {
@@ -50,6 +52,12 @@ export default observer(function TracksContainer({
     mouseDown: mouseDown2,
   } = useRangeSelect(ref, model, true)
   useWheelScroll(ref, model)
+
+  const additionals = pluginManager.evaluateExtensionPoint(
+    'LinearGenomeView-TracksContainerComponent',
+    undefined,
+    { model },
+  ) as React.ReactNode
 
   return (
     <div
@@ -105,6 +113,7 @@ export default observer(function TracksContainer({
           />
         }
       />
+      {additionals}
       {children}
     </div>
   )


### PR DESCRIPTION
This adds an extension point `'LinearGenomeView-TracksContainerComponent'` which can be used by plugins to implement, in my interest, their own e.g. "highlight" component. 

It may be able to do things beyond that also, but this small PR seemed like it could be useful in case the the 'general concept of highlighting' in #3648 is stalled...it is difficult to deliver a highlighting functionality that is sound, however, just allowing a plugin to add their own type of component at the TracksContainer level allows it to create it's own highlight functionality.

This is useful for the protein viewer