### PR TITLE
Fix text boxes being too small in Dialog boxes

### DIFF
--- a/packages/core/ui/Dialog.tsx
+++ b/packages/core/ui/Dialog.tsx
@@ -39,7 +39,7 @@ function JBrowseDialog(props: DialogProps & { title: string }) {
 
   return (
     <Dialog {...props}>
-      <ScopedCssBaseline sx={{ boxSizing: 'content-box' }}>
+      <ScopedCssBaseline>
         <DialogTitle>
           {title}
           {onClose ? (

--- a/packages/core/ui/Dialog.tsx
+++ b/packages/core/ui/Dialog.tsx
@@ -39,7 +39,7 @@ function JBrowseDialog(props: DialogProps & { title: string }) {
 
   return (
     <Dialog {...props}>
-      <ScopedCssBaseline>
+      <ScopedCssBaseline sx={{ boxSizing: 'content-box' }}>
         <DialogTitle>
           {title}
           {onClose ? (

--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -167,7 +167,7 @@ export const defaultThemes = {
   darkStock: getDarkStockTheme(),
 } as ThemeMap
 
-function createDefaultProps(theme?: ThemeOptions) {
+function createDefaultProps(theme?: ThemeOptions): ThemeOptions {
   return {
     components: {
       MuiButton: {
@@ -225,6 +225,11 @@ function createDefaultProps(theme?: ThemeOptions) {
       MuiInputBase: {
         defaultProps: {
           margin: 'dense' as const,
+        },
+        styleOverrides: {
+          input: {
+            boxSizing: 'content-box!important' as 'content-box',
+          },
         },
       },
       MuiAutocomplete: {


### PR DESCRIPTION
Fixes #3665 


This forces box-sizing:content-box with the an !important the styling on MUI InputBase elements via our theme


The use of !important's to achieve not great, but it is otherwise difficult to overcome a weird issue with CSS ordering which caused box-sizing:inherit to be used, which for some reason made the text boxes tiny. The CSS ordering issue may be caused by "ScopedCssBaseline" (which allows users of embedded components to have good styling on dialogs without them having to use the MUI CssBaseline on the whole page) and some interplay with the emotion styling system we are using (there are other styling systems e.g. styled components, sx, system, but we are using emotion+tss-react)

xref
https://github.com/mui/material-ui/issues/33507
