### PR TITLE
Only double-click zoom if not clicking on feature

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -111,7 +111,17 @@ function TrackContainer({
   }, [model.trackRefs, trackId])
 
   return (
-    <Paper className={classes.root} variant="outlined">
+    <Paper
+      ref={ref}
+      className={classes.root}
+      variant="outlined"
+      onClick={event => {
+        if (event.detail === 2 && !track.displays[0].featureIdUnderMouse) {
+          const left = ref.current?.getBoundingClientRect().left || 0
+          model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
+        }
+      }}
+    >
       <TrackContainerLabel model={track} view={model} />
       <ErrorBoundary
         key={track.id}
@@ -127,17 +137,7 @@ function TrackContainer({
           {!minimized ? (
             <>
               <div
-                ref={ref}
                 className={classes.renderingComponentContainer}
-                onClick={event => {
-                  if (
-                    event.detail === 2 &&
-                    !track.displays[0].featureIdUnderMouse
-                  ) {
-                    const left = ref.current?.getBoundingClientRect().left || 0
-                    model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
-                  }
-                }}
                 style={{ transform: `scaleX(${model.scaleFactor})` }}
               >
                 <RenderingComponent

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -93,7 +93,7 @@ function TrackContainer({
   const { horizontalScroll, draggingTrackId, moveTrack } = model
   const { height, RenderingComponent, DisplayBlurb } = display
   const trackId = getConf(track, 'trackId')
-  const ref = useRef(null)
+  const ref = useRef<HTMLDivElement>(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
   const minimized = track.minimized
   const debouncedOnDragEnter = useDebouncedCallback(() => {
@@ -129,6 +129,15 @@ function TrackContainer({
               <div
                 ref={ref}
                 className={classes.renderingComponentContainer}
+                onClick={event => {
+                  if (
+                    event.detail === 2 &&
+                    !track.displays[0].featureIdUnderMouse
+                  ) {
+                    const left = ref.current?.getBoundingClientRect().left || 0
+                    model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
+                  }
+                }}
                 style={{ transform: `scaleX(${model.scaleFactor})` }}
               >
                 <RenderingComponent

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -64,12 +64,6 @@ export default observer(function TracksContainer({
       ref={ref}
       data-testid="trackContainer"
       className={classes.tracksContainer}
-      onClick={event => {
-        if (event.detail === 2) {
-          const left = ref.current?.getBoundingClientRect().left || 0
-          model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
-        }
-      }}
       onMouseDown={event => {
         mouseDown1(event)
         mouseDown2(event)


### PR DESCRIPTION
I noticed along with @carolinebridge-oicr that double clicking a feature toggles a zoom in. This only zooms in if the featureIdUnderMouse is undefined. Only particular display types may use the 'featureIdUnderMouse' concept, but this does help double click on feature not performing a zoom in