### PR TITLE
Update webpage citation

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -177,9 +177,8 @@ function Home() {
               publish, please cite the most recent JBrowse paper:
             </p>
             <cite>
-              Diesh, C., Stevens, G.J., Xie, P. et al. JBrowse 2: a modular
-              genome browser with views of synteny and structural variation.
-              Genome Biol 24, 74 (2023).{' '}
+              JBrowse 2: a modular genome browser with views of synteny and
+              structural variation. Genome Biology (2023).{' '}
               <a href="https://doi.org/10.1186/s13059-023-02914-z">
                 https://doi.org/10.1186/s13059-023-02914-z
               </a>


### PR DESCRIPTION
This removes the abbreviated author list from our front page citation.

We did not have an abbreviated author list when it showed the biorxiv preprint, so this PR removes it again, just having the paper title and journal. People can use their own citation manager to get their formatted citation, rather than try to get a formatted copy and pasteable citation on our webpage
