### PR TITLE
Use react-popper for tooltips in DotplotView

### DIFF
--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@mui/icons-material": "^5.0.1",
     "@mui/x-data-grid": "^6.0.1",
+    "@popperjs/core": "^2.11.0",
     "@types/file-saver": "^2.0.1",
     "@types/normalize-wheel": "^1.0.0",
     "clone": "^2.1.2",

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -43,7 +43,8 @@
     "@types/normalize-wheel": "^1.0.0",
     "clone": "^2.1.2",
     "file-saver": "^2.0.0",
-    "normalize-wheel": "^1.0.1"
+    "normalize-wheel": "^1.0.1",
+    "react-popper": "^2.0.0"
   },
   "peerDependencies": {
     "@jbrowse/core": "^2.0.0",

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotTooltip.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotTooltip.tsx
@@ -1,11 +1,16 @@
-import React, { useRef } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
 // locals
 import { DotplotViewModel } from '../model'
 import { locstr } from './util'
+import { Portal, alpha } from '@mui/material'
+import { usePopper } from 'react-popper'
 
+export function round(value: number) {
+  return Math.round(value * 1e5) / 1e5
+}
 const useStyles = makeStyles()(theme => ({
   popover: {
     background: theme.palette.background.paper,
@@ -16,6 +21,22 @@ const useStyles = makeStyles()(theme => ({
     pointerEvents: 'none',
     position: 'absolute',
   },
+
+  // these styles come from
+  // https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js
+  tooltip: {
+    position: 'absolute',
+    pointerEvents: 'none',
+    backgroundColor: alpha(theme.palette.grey[700], 0.9),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.common.white,
+    fontFamily: theme.typography.fontFamily,
+    padding: '4px 8px',
+    fontSize: theme.typography.pxToRem(12),
+    lineHeight: `${round(14 / 10)}em`,
+    maxWidth: 300,
+    wordWrap: 'break-word',
+  },
 }))
 
 type Coord = [number, number] | undefined
@@ -24,36 +45,65 @@ const blank = { left: 0, top: 0, width: 0, height: 0 }
 export const TooltipWhereMouseovered = observer(function ({
   model,
   mouserect,
+  mouserectClient,
   xdistance,
   ydistance,
 }: {
   model: DotplotViewModel
   mouserect: Coord
+  mouserectClient: Coord
   xdistance: number
   ydistance: number
 }) {
   const { classes } = useStyles()
   const { hview, vview, viewHeight } = model
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
   const ref = useRef<HTMLDivElement>(null)
   const rect = ref.current?.getBoundingClientRect() || blank
   const offset = 6
   const w = rect.height + offset * 2
+
+  // must be memoized a la https://github.com/popperjs/react-popper/issues/391
+  const virtElement = useMemo(
+    () => ({
+      getBoundingClientRect: () => {
+        const x = offset + (mouserectClient?.[0] || 0) - (xdistance < 0 ? w : 0)
+        const y = offset + (mouserectClient?.[1] || 0) - (ydistance < 0 ? w : 0)
+        return {
+          top: y,
+          left: x,
+          bottom: y,
+          right: x,
+          width: 0,
+          height: 0,
+          x,
+          y,
+          toJSON() {},
+        }
+      },
+    }),
+    [mouserectClient, xdistance, ydistance, w],
+  )
+  const { styles, attributes } = usePopper(virtElement, anchorEl, {
+    placement: xdistance < 0 ? 'left' : 'right',
+  })
   return (
     <>
       {mouserect ? (
-        <div
-          ref={ref}
-          className={classes.popover}
-          style={{
-            left: offset + mouserect[0] - (xdistance < 0 ? w : 0),
-            top: offset + mouserect[1] - (ydistance < 0 ? w : 0),
-          }}
-        >
-          {`x - ${locstr(mouserect[0], hview)}`}
-          <br />
-          {`y - ${locstr(viewHeight - mouserect[1], vview)}`}
-          <br />
-        </div>
+        <Portal>
+          <div
+            ref={setAnchorEl}
+            className={classes.tooltip}
+            // zIndex needed to go over widget drawer
+            style={{ ...styles.popper, zIndex: 100000 }}
+            {...attributes.popper}
+          >
+            {`x - ${locstr(mouserect[0], hview)}`}
+            <br />
+            {`y - ${locstr(viewHeight - mouserect[1], vview)}`}
+            <br />
+          </div>
+        </Portal>
       ) : null}
     </>
   )
@@ -62,34 +112,61 @@ export const TooltipWhereMouseovered = observer(function ({
 export const TooltipWhereClicked = observer(function ({
   model,
   mousedown,
+  mousedownClient,
   xdistance,
   ydistance,
 }: {
   model: DotplotViewModel
   mousedown: Coord
+  mousedownClient: Coord
   xdistance: number
   ydistance: number
 }) {
   const { classes } = useStyles()
   const { hview, vview, viewHeight } = model
-  const ref = useRef<HTMLDivElement>(null)
-  const rect = ref.current?.getBoundingClientRect() || blank
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
+
+  // must be memoized a la https://github.com/popperjs/react-popper/issues/391
+  const virtElement = useMemo(
+    () => ({
+      getBoundingClientRect: () => {
+        const x = (mousedownClient?.[0] || 0) - (xdistance < 0 ? 0 : 0)
+        const y = (mousedownClient?.[1] || 0) - (ydistance < 0 ? 0 : 0)
+        return {
+          top: y,
+          left: x,
+          bottom: y,
+          right: x,
+          width: 0,
+          height: 0,
+          x,
+          y,
+          toJSON() {},
+        }
+      },
+    }),
+    [mousedownClient, xdistance, ydistance],
+  )
+  const { styles, attributes } = usePopper(virtElement, anchorEl, {
+    placement: xdistance < 0 ? 'right' : 'left',
+  })
   return (
     <>
       {mousedown && Math.abs(xdistance) > 3 && Math.abs(ydistance) > 3 ? (
-        <div
-          ref={ref}
-          className={classes.popover}
-          style={{
-            left: mousedown[0] - (xdistance < 0 ? 0 : rect.width),
-            top: mousedown[1] - (ydistance < 0 ? 0 : rect.height),
-          }}
-        >
-          {`x - ${locstr(mousedown[0], hview)}`}
-          <br />
-          {`y - ${locstr(viewHeight - mousedown[1], vview)}`}
-          <br />
-        </div>
+        <Portal>
+          <div
+            ref={setAnchorEl}
+            className={classes.tooltip}
+            // zIndex needed to go over widget drawer
+            style={{ ...styles.popper, zIndex: 100000 }}
+            {...attributes.popper}
+          >
+            {`x - ${locstr(mousedown[0], hview)}`}
+            <br />
+            {`y - ${locstr(viewHeight - mousedown[1], vview)}`}
+            <br />
+          </div>
+        </Portal>
       ) : null}
     </>
   )

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotTooltip.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotTooltip.tsx
@@ -12,16 +12,6 @@ export function round(value: number) {
   return Math.round(value * 1e5) / 1e5
 }
 const useStyles = makeStyles()(theme => ({
-  popover: {
-    background: theme.palette.background.paper,
-    maxWidth: 400,
-    wordBreak: 'break-all',
-    zIndex: 1000,
-    border: `1px solid ${theme.palette.action.active}`,
-    pointerEvents: 'none',
-    position: 'absolute',
-  },
-
   // these styles come from
   // https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js
   tooltip: {

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -107,6 +107,7 @@ const DotplotViewInternal = observer(function ({
   const mousedown = getOffset(mousedownClient, svg)
   const mousecurr = getOffset(mousecurrClient, svg)
   const mouseup = getOffset(mouseupClient, svg)
+  const mouserectClient = mouseupClient || mousecurrClient
   const mouserect = mouseup || mousecurr
   const xdistance = mousedown && mouserect ? mouserect[0] - mousedown[0] : 0
   const ydistance = mousedown && mouserect ? mouserect[1] - mousedown[1] : 0
@@ -241,7 +242,7 @@ const DotplotViewInternal = observer(function ({
               <TooltipWhereMouseovered
                 model={model}
                 mouserect={mouserect}
-                mouserectClient={mousecurrClient}
+                mouserectClient={mouserectClient}
                 xdistance={xdistance}
                 ydistance={ydistance}
               />

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -241,6 +241,7 @@ const DotplotViewInternal = observer(function ({
               <TooltipWhereMouseovered
                 model={model}
                 mouserect={mouserect}
+                mouserectClient={mousecurrClient}
                 xdistance={xdistance}
                 ydistance={ydistance}
               />
@@ -249,6 +250,7 @@ const DotplotViewInternal = observer(function ({
               <TooltipWhereClicked
                 model={model}
                 mousedown={mousedown}
+                mousedownClient={mousedownClient}
                 xdistance={xdistance}
                 ydistance={ydistance}
               />


### PR DESCRIPTION
This updates the dotplot view tooltips to use react-popper instead of an absolute-positioned div with text

The absolute-positioned div can run into text-formatting issues near the margins, but the popper tries to lay out the text more nicely

Comparison

after

![Screenshot from 2023-05-01 13-07-18](https://user-images.githubusercontent.com/6511937/235512690-7b2b7df9-495e-4b5e-a067-c04d44253ae8.png)


before

![Screenshot from 2023-05-01 13-05-46](https://user-images.githubusercontent.com/6511937/235512614-8e3ab179-79a8-4ff0-bb73-5cd06aedb897.png)
