### PR TITLE
Smaller fontSize in global theme by default

### DIFF
--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -294,9 +294,7 @@ function createDefaultProps(theme?: ThemeOptions): ThemeOptions {
         styleOverrides: {
           // the default link color uses theme.palette.primary.main which is
           // very bad with dark mode+midnight primary
-          //
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          root: ({ theme }: any) => ({
+          root: ({ theme }) => ({
             color: theme.palette.text.secondary,
           }),
         },
@@ -310,10 +308,7 @@ function createDefaultProps(theme?: ThemeOptions): ThemeOptions {
           // keeps the forest-green checkbox by default but for darkmode, uses
           // a text-like coloring to ensure contrast
           // xref https://stackoverflow.com/a/72546130/2129219
-          //
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          root: (props: any) => {
-            const { theme } = props
+          root: ({ theme }) => {
             return theme.palette.mode === 'dark'
               ? {
                   color: theme.palette.text.secondary,
@@ -334,10 +329,7 @@ function createDefaultProps(theme?: ThemeOptions): ThemeOptions {
           // keeps the forest-green checkbox by default but for darkmode, uses
           // a text-like coloring to ensure contrast
           // xref https://stackoverflow.com/a/72546130/2129219
-          //
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          root: (props: any) => {
-            const { theme } = props
+          root: ({ theme }) => {
             return theme.palette.mode === 'dark'
               ? {
                   color: theme.palette.text.secondary,
@@ -359,9 +351,8 @@ function createDefaultProps(theme?: ThemeOptions): ThemeOptions {
           // a text-like coloring to ensure contrast
           // xref https://stackoverflow.com/a/72546130/2129219
           //
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          root: (props: any) => {
-            const { theme } = props
+
+          root: ({ theme }) => {
             return theme.palette.mode === 'dark'
               ? {
                   color: theme.palette.text.secondary,
@@ -398,7 +389,7 @@ export function createJBrowseBaseTheme(theme?: ThemeOptions): ThemeOptions {
   return deepmerge(
     {
       palette: theme?.palette,
-      typography: { fontSize: 12 },
+      typography: { fontSize: 11 },
       spacing: 4,
       ...createDefaultProps(theme),
     },

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.tsx.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`renders nothing with no assembly 1`] = `
 <button
-  class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-15opis6-MuiButtonBase-root-MuiFab-root-fab"
+  class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-1qcd8kx-MuiButtonBase-root-MuiFab-root-fab"
   tabindex="0"
   type="button"
 >
   <svg
     aria-hidden="true"
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
     data-testid="AddIcon"
     focusable="false"
     viewBox="0 0 24 24"
@@ -31,13 +31,13 @@ exports[`renders with a couple of categorized tracks 1`] = `
     style="display: flex;"
   >
     <button
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kgqocu-MuiButtonBase-root-MuiIconButton-root-menuIcon"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-15u0slq-MuiButtonBase-root-MuiIconButton-root-menuIcon"
       tabindex="0"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
         data-testid="MenuIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -54,7 +54,7 @@ exports[`renders with a couple of categorized tracks 1`] = `
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-rlnh8o-MuiFormControl-root-MuiTextField-root-searchBox"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-1s1jvl0-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-8ajfgw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
         for="mui-5"
         id="mui-5-label"
@@ -62,7 +62,7 @@ exports[`renders with a couple of categorized tracks 1`] = `
         Filter tracks
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1blad95-MuiInputBase-root-MuiInput-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-e5xmlq-MuiInputBase-root-MuiInput-root"
       >
         <input
           aria-invalid="false"
@@ -75,13 +75,13 @@ exports[`renders with a couple of categorized tracks 1`] = `
           class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
         >
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
               data-testid="ClearIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -98,7 +98,7 @@ exports[`renders with a couple of categorized tracks 1`] = `
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-1c8zr45-MuiButtonBase-root-MuiButton-root-menuIcon"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-qsk2yr-MuiButtonBase-root-MuiButton-root-menuIcon"
       tabindex="0"
       type="button"
     >
@@ -119,13 +119,13 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
     style="display: flex;"
   >
     <button
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kgqocu-MuiButtonBase-root-MuiIconButton-root-menuIcon"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-15u0slq-MuiButtonBase-root-MuiIconButton-root-menuIcon"
       tabindex="0"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
         data-testid="MenuIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -142,7 +142,7 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-rlnh8o-MuiFormControl-root-MuiTextField-root-searchBox"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-1s1jvl0-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-8ajfgw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
         for="mui-1"
         id="mui-1-label"
@@ -150,7 +150,7 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
         Filter tracks
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1blad95-MuiInputBase-root-MuiInput-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-e5xmlq-MuiInputBase-root-MuiInput-root"
       >
         <input
           aria-invalid="false"
@@ -163,13 +163,13 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
           class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
         >
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
               data-testid="ClearIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -186,7 +186,7 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-1c8zr45-MuiButtonBase-root-MuiButton-root-menuIcon"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-qsk2yr-MuiButtonBase-root-MuiButton-root-menuIcon"
       tabindex="0"
       type="button"
     >

--- a/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.tsx.snap
+++ b/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders with the available plugins 1`] = `
     class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-1z10yd4-MuiFormControl-root-MuiTextField-root"
   >
     <label
-      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-1s1jvl0-MuiFormLabel-root-MuiInputLabel-root"
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-standard css-8ajfgw-MuiFormLabel-root-MuiInputLabel-root"
       data-shrink="false"
       for="mui-1"
       id="mui-1-label"
@@ -16,7 +16,7 @@ exports[`renders with the available plugins 1`] = `
       Filter plugins
     </label>
     <div
-      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1blad95-MuiInputBase-root-MuiInput-root"
+      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-e5xmlq-MuiInputBase-root-MuiInput-root"
     >
       <input
         aria-invalid="false"
@@ -29,13 +29,13 @@ exports[`renders with the available plugins 1`] = `
         class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
             data-testid="ClearIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -64,7 +64,7 @@ exports[`renders with the available plugins 1`] = `
         class="MuiAccordionSummary-content Mui-expanded css-1rhnrrr-MuiAccordionSummary-content"
       >
         <h5
-          class="MuiTypography-root MuiTypography-h5 css-1ldbtdh-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 css-dy7l2v-MuiTypography-root"
         >
           Installed plugins
         </h5>
@@ -74,7 +74,7 @@ exports[`renders with the available plugins 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kbgf2m-MuiSvgIcon-root-expandIcon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pl3opc-MuiSvgIcon-root-expandIcon"
           data-testid="ExpandMoreIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -111,7 +111,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -122,7 +122,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     SVGPlugin
                   </p>
@@ -133,7 +133,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -144,7 +144,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     LinearGenomeViewPlugin
                   </p>
@@ -155,7 +155,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -166,7 +166,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     AlignmentsPlugin
                   </p>
@@ -177,7 +177,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -188,7 +188,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     AuthenticationPlugin
                   </p>
@@ -199,7 +199,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -210,7 +210,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     BedPlugin
                   </p>
@@ -221,7 +221,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -232,7 +232,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     CircularViewPlugin
                   </p>
@@ -243,7 +243,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -254,7 +254,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     ConfigurationPlugin
                   </p>
@@ -265,7 +265,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -276,7 +276,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     DataManagementPlugin
                   </p>
@@ -287,7 +287,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -298,7 +298,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     DotplotPlugin
                   </p>
@@ -309,7 +309,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -320,7 +320,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     GTFPlugin
                   </p>
@@ -331,7 +331,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -342,7 +342,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     GFF3Plugin
                   </p>
@@ -353,7 +353,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -364,7 +364,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     LegacyJBrowsePlugin
                   </p>
@@ -375,7 +375,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -386,7 +386,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     LinearComparativeViewPlugin
                   </p>
@@ -397,7 +397,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -408,7 +408,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     LollipopPlugin
                   </p>
@@ -419,7 +419,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -430,7 +430,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     ArcRenderer
                   </p>
@@ -441,7 +441,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -452,7 +452,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     MenusPlugin
                   </p>
@@ -463,7 +463,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -474,7 +474,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     RdfPlugin
                   </p>
@@ -485,7 +485,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -496,7 +496,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     SequencePlugin
                   </p>
@@ -507,7 +507,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -518,7 +518,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     VariantsPlugin
                   </p>
@@ -529,7 +529,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -540,7 +540,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     WigglePlugin
                   </p>
@@ -551,7 +551,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -562,7 +562,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     GCContentPlugin
                   </p>
@@ -573,7 +573,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -584,7 +584,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     SpreadsheetViewPlugin
                   </p>
@@ -595,7 +595,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -606,7 +606,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     SvInspectorViewPlugin
                   </p>
@@ -617,7 +617,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -628,7 +628,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     BreakpointSplitViewPlugin
                   </p>
@@ -639,7 +639,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -650,7 +650,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     HicPlugin
                   </p>
@@ -661,7 +661,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -672,7 +672,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     TrixPlugin
                   </p>
@@ -683,7 +683,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -694,7 +694,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     GridBookmarkPlugin
                   </p>
@@ -705,7 +705,7 @@ exports[`renders with the available plugins 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="This plugin was installed by an administrator, you cannot remove it."
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1a34d00-MuiSvgIcon-root-lockedPluginTooltip"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktnuse-MuiSvgIcon-root-lockedPluginTooltip"
                     data-mui-internal-clone-element="true"
                     data-testid="LockIcon"
                     focusable="false"
@@ -716,7 +716,7 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     ComparativeAdaptersPlugin
                   </p>
@@ -741,7 +741,7 @@ exports[`renders with the available plugins 1`] = `
         class="MuiAccordionSummary-content Mui-expanded css-1rhnrrr-MuiAccordionSummary-content"
       >
         <h5
-          class="MuiTypography-root MuiTypography-h5 css-1ldbtdh-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 css-dy7l2v-MuiTypography-root"
         >
           Available plugins
         </h5>
@@ -751,7 +751,7 @@ exports[`renders with the available plugins 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kbgf2m-MuiSvgIcon-root-expandIcon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pl3opc-MuiSvgIcon-root-expandIcon"
           data-testid="ExpandMoreIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -786,7 +786,7 @@ exports[`renders with the available plugins 1`] = `
                   class="css-yyi66y-dataField"
                 >
                   <h5
-                    class="MuiTypography-root MuiTypography-h5 css-1ldbtdh-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-h5 css-dy7l2v-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-ygjubp-MuiTypography-root-MuiLink-root"
@@ -803,7 +803,7 @@ exports[`renders with the available plugins 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                     data-testid="PersonIcon"
                     focusable="false"
                     style="margin-right: 0.5em;"
@@ -814,18 +814,18 @@ exports[`renders with the available plugins 1`] = `
                     />
                   </svg>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                   >
                     Colin Diesh
                   </p>
                 </div>
                 <p
-                  class="MuiTypography-root MuiTypography-body1 css-1w7qu8c-MuiTypography-root-bold"
+                  class="MuiTypography-root MuiTypography-body1 css-1r4z4ba-MuiTypography-root-bold"
                 >
                   Description:
                 </p>
                 <p
-                  class="MuiTypography-root MuiTypography-body1 css-k0xfey-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1p9x5wm-MuiTypography-root"
                 >
                   multiple sequence alignment browser plugin for JBrowse 2
                 </p>
@@ -834,7 +834,7 @@ exports[`renders with the available plugins 1`] = `
                 class="MuiCardActions-root MuiCardActions-spacing css-1t6e9jv-MuiCardActions-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall css-1cpxz0y-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall css-tj95ca-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
@@ -843,7 +843,7 @@ exports[`renders with the available plugins 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                       data-testid="AddIcon"
                       focusable="false"
                       viewBox="0 0 24 24"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -6,6 +6,7 @@ import BaseResult, {
 } from '@jbrowse/core/TextSearch/BaseResults'
 import {
   Autocomplete,
+  AutocompleteRenderInputParams,
   IconButton,
   InputAdornment,
   TextField,
@@ -69,6 +70,23 @@ function filterOptions(options: Option[], searchQuery: string) {
   )
 }
 
+function getFiltered(opts: Option[], inputValue: string) {
+  const filtered = filterOptions(opts, inputValue.toLocaleLowerCase())
+  return [
+    ...filtered.slice(0, 100),
+    ...(filtered.length > 100
+      ? [
+          {
+            group: 'limitOption',
+            result: new BaseResult({
+              label: 'keep typing for more results',
+            }),
+          },
+        ]
+      : []),
+  ]
+}
+
 function RefNameAutocomplete({
   model,
   onSelect,
@@ -98,7 +116,6 @@ function RefNameAutocomplete({
   const { assemblyManager } = session
   const [open, setOpen] = useState(false)
   const [loaded, setLoaded] = useState(true)
-  const [isHelpDialogDisplayed, setHelpDialogDisplayed] = useState(false)
   const [currentSearch, setCurrentSearch] = useState('')
   const [inputValue, setInputValue] = useState('')
   const [searchOptions, setSearchOptions] = useState<Option[]>()
@@ -154,7 +171,7 @@ function RefNameAutocomplete({
   // heuristic, text width + icon width + 50 accommodates help icon and search
   // icon
   const width = Math.min(
-    Math.max(measureText(inputBoxVal, 16) + 50, minWidth),
+    Math.max(measureText(inputBoxVal, 16) + 100, minWidth),
     maxWidth,
   )
 
@@ -203,75 +220,102 @@ function RefNameAutocomplete({
           setInputValue(inputBoxVal)
         }}
         options={!searchOptions?.length ? options : searchOptions}
-        getOptionDisabled={option => option?.group === 'limitOption'}
-        filterOptions={(options, params) => {
-          const filtered = filterOptions(
-            options,
-            params.inputValue.toLocaleLowerCase(),
-          )
-          return [
-            ...filtered.slice(0, 100),
-            ...(filtered.length > 100
-              ? [
-                  {
-                    group: 'limitOption',
-                    result: new BaseResult({
-                      label: 'keep typing for more results',
-                    }),
-                  },
-                ]
-              : []),
-          ]
-        }}
-        renderInput={params => {
-          const { helperText, InputProps = {} } = TextFieldProps
-          return (
-            <TextField
-              onBlur={() =>
-                // this is used to restore a refName or the non-user-typed input
-                // to the box on blurring
-                setInputValue(inputBoxVal)
-              }
-              {...params}
-              {...TextFieldProps}
-              helperText={helperText}
-              InputProps={{
-                ...params.InputProps,
-                ...InputProps,
-
-                endAdornment: (
-                  <>
-                    <InputAdornment position="end" style={{ marginRight: 7 }}>
-                      <SearchIcon fontSize="small" />
-                      {showHelp ? (
-                        <IconButton
-                          onClick={() => setHelpDialogDisplayed(true)}
-                          size="small"
-                        >
-                          <HelpIcon fontSize="small" />
-                        </IconButton>
-                      ) : null}
-                    </InputAdornment>
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-              placeholder="Search for location"
-              onChange={e => setCurrentSearch(e.target.value)}
-            />
-          )
-        }}
-        getOptionLabel={option =>
-          (typeof option === 'string'
-            ? option
-            : option.result.getDisplayString()) || ''
+        getOptionDisabled={option => option.group === 'limitOption'}
+        filterOptions={(opts, { inputValue }) => getFiltered(opts, inputValue)}
+        renderInput={params => (
+          <AutocompleteTextField
+            showHelp={showHelp}
+            params={params}
+            inputBoxVal={inputBoxVal}
+            TextFieldProps={TextFieldProps}
+            setCurrentSearch={setCurrentSearch}
+            setInputValue={setInputValue}
+          />
+        )}
+        getOptionLabel={opt =>
+          typeof opt === 'string' ? opt : opt.result.getDisplayString()
         }
       />
+    </>
+  )
+}
+
+function AutocompleteTextField({
+  TextFieldProps,
+  inputBoxVal,
+  params,
+  showHelp,
+  setInputValue,
+  setCurrentSearch,
+}: {
+  TextFieldProps: TFP
+  inputBoxVal: string
+  showHelp?: boolean
+  params: AutocompleteRenderInputParams
+  setInputValue: (arg: string) => void
+  setCurrentSearch: (arg: string) => void
+}) {
+  const { helperText, InputProps = {} } = TextFieldProps
+  return (
+    <TextField
+      onBlur={() =>
+        // this is used to restore a refName or the non-user-typed input
+        // to the box on blurring
+        setInputValue(inputBoxVal)
+      }
+      {...params}
+      {...TextFieldProps}
+      size="small"
+      helperText={helperText}
+      InputProps={{
+        ...params.InputProps,
+        ...InputProps,
+
+        style: { ...InputProps.style, fontSize: '0.8rem' },
+
+        endAdornment: (
+          <EndAdornment
+            showHelp={showHelp}
+            endAdornment={params.InputProps.endAdornment}
+          />
+        ),
+      }}
+      placeholder="Search for location"
+      onChange={e => setCurrentSearch(e.target.value)}
+    />
+  )
+}
+
+function HelpAdornment() {
+  const [isHelpDialogDisplayed, setHelpDialogDisplayed] = useState(false)
+  return (
+    <>
+      <IconButton onClick={() => setHelpDialogDisplayed(true)} size="small">
+        <HelpIcon fontSize="small" />
+      </IconButton>
       {isHelpDialogDisplayed ? (
         <Suspense fallback={<div />}>
           <HelpDialog handleClose={() => setHelpDialogDisplayed(false)} />
         </Suspense>
       ) : null}
+    </>
+  )
+}
+
+function EndAdornment({
+  showHelp,
+  endAdornment,
+}: {
+  showHelp?: boolean
+  endAdornment: React.ReactNode
+}) {
+  return (
+    <>
+      <InputAdornment position="end" style={{ marginRight: 7 }}>
+        <SearchIcon fontSize="small" />
+        {showHelp ? <HelpAdornment /> : null}
+      </InputAdornment>
+      {endAdornment}
     </>
   )
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.tsx
@@ -168,10 +168,10 @@ function RefNameAutocomplete({
 
   const inputBoxVal = coarseVisibleLocStrings || value || ''
 
-  // heuristic, text width + icon width + 50 accommodates help icon and search
+  // heuristic, text width + 60 accommodates help icon and search
   // icon
   const width = Math.min(
-    Math.max(measureText(inputBoxVal, 16) + 100, minWidth),
+    Math.max(measureText(inputBoxVal, 13) + 100, minWidth),
     maxWidth,
   )
 
@@ -270,8 +270,6 @@ function AutocompleteTextField({
       InputProps={{
         ...params.InputProps,
         ...InputProps,
-
-        style: { ...InputProps.style, fontSize: '0.8rem' },
 
         endAdornment: (
           <EndAdornment

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`renders one track, one region 1`] = `
                 style="margin: 7px;"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
                   style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
                 >
                   <input
@@ -175,7 +175,7 @@ exports[`renders one track, one region 1`] = `
                     aria-invalid="false"
                     autocapitalize="none"
                     autocomplete="off"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                     id="mui-7"
                     placeholder="Search for location"
                     role="combobox"
@@ -184,7 +184,7 @@ exports[`renders one track, one region 1`] = `
                     value="ctgA:1..100"
                   />
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
                     style="margin-right: 7px;"
                   >
                     <svg
@@ -733,14 +733,14 @@ exports[`renders two tracks, two regions 1`] = `
             <div
               class="MuiAutocomplete-root css-1h51icj-MuiAutocomplete-root"
               data-testid="autocomplete"
-              style="width: 260.27500000000003px;"
+              style="width: 270.84843750000005px;"
             >
               <div
                 class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1efd6m0-MuiFormControl-root-MuiTextField-root-headerRefName"
                 style="margin: 7px;"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-154xyx0-MuiInputBase-root-MuiOutlinedInput-root"
                   style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
                 >
                   <input
@@ -749,7 +749,7 @@ exports[`renders two tracks, two regions 1`] = `
                     aria-invalid="false"
                     autocapitalize="none"
                     autocomplete="off"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                     id="mui-9"
                     placeholder="Search for location"
                     role="combobox"
@@ -758,7 +758,7 @@ exports[`renders two tracks, two regions 1`] = `
                     value="ctgA:1..100 ctgB:1,001..1,698"
                   />
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
                     style="margin-right: 7px;"
                   >
                     <svg

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
   class="css-jn2cxo-avoidParentStyle"
 >
   <div
-    class="MuiScopedCssBaseline-root css-1pa2gw3-MuiScopedCssBaseline-root"
+    class="MuiScopedCssBaseline-root css-1j22uat-MuiScopedCssBaseline-root"
   >
     <div
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-tgvt3g-MuiPaper-root-viewContainer"
@@ -17,14 +17,14 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
           aria-controls="view-menu"
           aria-haspopup="true"
           aria-label="more"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-15c2os-MuiButtonBase-root-MuiIconButton-root-iconRoot"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-edvdg1-MuiButtonBase-root-MuiIconButton-root-iconRoot"
           data-testid="view_menu_icon"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pgqsr-MuiSvgIcon-root-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-16o3vun-MuiSvgIcon-root-icon"
             data-testid="MenuIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -44,7 +44,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
           class="css-122lw0e-grow"
         />
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           type="button"
         >
@@ -148,7 +148,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
             class="css-1vhj25i-controls"
           >
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               disabled=""
               tabindex="-1"
               title="unlock to zoom out"
@@ -156,7 +156,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="ZoomOutIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -167,14 +167,14 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="zoom in"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="ZoomInIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -191,14 +191,14 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="rotate counter-clockwise"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="RotateLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -212,14 +212,14 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="rotate clockwise"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="RotateRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -233,14 +233,14 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="locked model to window size"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="LockIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -254,13 +254,13 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 data-testid="MoreVertIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -274,7 +274,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
               />
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
               data-testid="circular_track_select"
               tabindex="0"
               title="Open track selector"
@@ -282,7 +282,7 @@ exports[`<JBrowseCircularGenomeView /> renders successfully 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                 focusable="false"
                 viewBox="0 0 24 24"
               >

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
     class="css-jn2cxo-avoidParentStyle"
   >
     <div
-      class="MuiScopedCssBaseline-root css-1pa2gw3-MuiScopedCssBaseline-root"
+      class="MuiScopedCssBaseline-root css-1j22uat-MuiScopedCssBaseline-root"
     >
       <div
         class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation12 css-tgvt3g-MuiPaper-root-viewContainer"
@@ -18,14 +18,14 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
             aria-controls="view-menu"
             aria-haspopup="true"
             aria-label="more"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-15c2os-MuiButtonBase-root-MuiIconButton-root-iconRoot"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-edvdg1-MuiButtonBase-root-MuiIconButton-root-iconRoot"
             data-testid="view_menu_icon"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pgqsr-MuiSvgIcon-root-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-16o3vun-MuiSvgIcon-root-icon"
               data-testid="MenuIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -45,7 +45,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
             class="css-122lw0e-grow"
           />
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
@@ -108,7 +108,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     />
                     <div>
                       <p
-                        class="MuiTypography-root MuiTypography-body1 css-2pm20q-MuiTypography-root-scalebarRefName"
+                        class="MuiTypography-root MuiTypography-body1 css-16f3d84-MuiTypography-root-scalebarRefName"
                         style="left: 3px; color: rgb(153, 102, 0);"
                       >
                         ctgA
@@ -118,37 +118,37 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         style="left: 0px; width: 800px; border-color: rgb(153, 102, 0);"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 133.33333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           20
                         </p>
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 266.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           40
                         </p>
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 400px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           60
                         </p>
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 533.3333333333334px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           80
                         </p>
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 666.6666666666667px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           100
                         </p>
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-1d41t5x-MuiTypography-root-scalebarLabel"
+                          class="MuiTypography-root MuiTypography-body2 css-vofugi-MuiTypography-root-scalebarLabel"
                           style="left: 800px; pointer-events: none; color: rgb(153, 102, 0);"
                         >
                           120
@@ -179,7 +179,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   class="css-cwpsam-headerBar"
                 >
                   <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1iml0wn-MuiButtonBase-root-MuiIconButton-root-toggleButton"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z7eix0-MuiButtonBase-root-MuiIconButton-root-toggleButton"
                     tabindex="0"
                     title="Open track selector"
                     type="button"
@@ -187,7 +187,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-7t563h-MuiSvgIcon-root-buttonSpacer"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1b3u7r9-MuiSvgIcon-root-buttonSpacer"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
@@ -206,13 +206,13 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="MuiFormGroup-root MuiFormGroup-row css-1gwpy8f-MuiFormGroup-root-headerForm"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall css-1th20m7-MuiButtonBase-root-MuiButton-root-panButton"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall css-1bqfj9g-MuiButtonBase-root-MuiButton-root-panButton"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                         data-testid="ArrowBackIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -226,13 +226,13 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       />
                     </button>
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall css-1th20m7-MuiButtonBase-root-MuiButton-root-panButton"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall css-1bqfj9g-MuiButtonBase-root-MuiButton-root-panButton"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                         data-testid="ArrowForwardIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -255,7 +255,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         style="margin: 7px;"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1dityd8-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-mtw0yb-MuiInputBase-root-MuiOutlinedInput-root"
                           style="padding: 0px; height: 32px; background: rgba(255, 255, 255, 0.8);"
                         >
                           <input
@@ -278,7 +278,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-196n7va-MuiSvgIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-s9tlq4-MuiSvgIcon-root"
                               data-testid="SearchIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -288,13 +288,13 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                               />
                             </svg>
                             <button
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1lruqhb-MuiButtonBase-root-MuiIconButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-196n7va-MuiSvgIcon-root"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-s9tlq4-MuiSvgIcon-root"
                                 data-testid="HelpIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -327,7 +327,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     </div>
                   </div>
                   <p
-                    class="MuiTypography-root MuiTypography-body2 css-1uinl1m-MuiTypography-root-bp"
+                    class="MuiTypography-root MuiTypography-body2 css-1x3v8tw-MuiTypography-root-bp"
                   >
                     40bp
                   </p>
@@ -335,14 +335,14 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="css-z84q6m-container"
                   >
                     <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-h7w2ds-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-10yvg5c-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="zoom_out"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                         data-testid="ZoomOutIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -386,14 +386,14 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       </span>
                     </span>
                     <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-h7w2ds-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-10yvg5c-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="zoom_in"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-havevq-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-thxhq5-MuiSvgIcon-root"
                         data-testid="ZoomInIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -820,7 +820,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 180px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             10
                           </p>
@@ -830,7 +830,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 380px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             20
                           </p>
@@ -840,7 +840,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 580px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             30
                           </p>
@@ -850,7 +850,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 780px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             40
                           </p>
@@ -865,7 +865,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: -20px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             40
                           </p>
@@ -875,7 +875,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 180px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             50
                           </p>
@@ -885,7 +885,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 380px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             60
                           </p>
@@ -895,7 +895,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 580px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             70
                           </p>
@@ -905,7 +905,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 780px;"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 css-1e8tst7-MuiTypography-root-majorTickLabel"
+                            class="MuiTypography-root MuiTypography-body1 css-c2kt6-MuiTypography-root-majorTickLabel"
                           >
                             80
                           </p>
@@ -914,7 +914,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     </div>
                   </div>
                   <p
-                    class="MuiTypography-root MuiTypography-body1 css-x1763-MuiTypography-root-refLabel"
+                    class="MuiTypography-root MuiTypography-body1 css-br3pag-MuiTypography-root-refLabel"
                     data-testid="refLabel-ctgA"
                     style="left: -1px; padding-left: 1px;"
                   >
@@ -935,7 +935,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-dqspj3-MuiSvgIcon-root-dragHandleIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-14lfwyp-MuiSvgIcon-root-dragHandleIcon"
                       data-testid="DragIndicatorIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -946,14 +946,14 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     </svg>
                   </span>
                   <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1hm0p9d-MuiButtonBase-root-MuiIconButton-root-iconButton"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-3pd37o-MuiButtonBase-root-MuiIconButton-root-iconButton"
                     tabindex="0"
                     title="close this track"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-196n7va-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-s9tlq4-MuiSvgIcon-root"
                       data-testid="CloseIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -967,7 +967,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     />
                   </button>
                   <span
-                    class="MuiTypography-root MuiTypography-body1 css-bpawrf-MuiTypography-root-trackName"
+                    class="MuiTypography-root MuiTypography-body1 css-dybvnz-MuiTypography-root-trackName"
                   >
                     <span>
                       Reference sequence (volvox)
@@ -975,14 +975,14 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   </span>
                   <button
                     aria-haspopup="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1hm0p9d-MuiButtonBase-root-MuiIconButton-root-iconButton"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-3pd37o-MuiButtonBase-root-MuiIconButton-root-iconButton"
                     data-testid="track_menu_icon"
                     tabindex="0"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-196n7va-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-s9tlq4-MuiSvgIcon-root"
                       data-testid="MoreVertIcon"
                       focusable="false"
                       viewBox="0 0 24 24"

--- a/products/jbrowse-web/src/tests/ReloadCram.test.tsx
+++ b/products/jbrowse-web/src/tests/ReloadCram.test.tsx
@@ -21,7 +21,7 @@ beforeEach(() => {
   doBeforeEach()
 })
 
-const delay = { timeout: 10000 }
+const delay = { timeout: 40000 }
 const opts = [{}, delay]
 
 // this tests reloading after an initial track error
@@ -51,7 +51,7 @@ test('reloads alignments track (CRAI 404)', async () => {
     fireEvent.click(buttons[0])
     expectCanvasMatch(await findByTestId(pv('1..400-0'), ...opts))
   })
-}, 20000)
+}, 50000)
 
 test('reloads alignments track (CRAM 404)', async () => {
   await mockConsole(async () => {
@@ -76,4 +76,4 @@ test('reloads alignments track (CRAM 404)', async () => {
     fireEvent.click(buttons[0])
     expectCanvasMatch(await findByTestId(pv('1..400-0'), ...opts))
   })
-}, 20000)
+}, 50000)

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,9 +70,9 @@
   integrity sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==
 
 "@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.16.0", "@babel/core@^7.20.2", "@babel/core@^7.3.4", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0", "@babel/core@~7.21.0":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.5.tgz#92f753e8b9f96e15d4b398dbe2f25d1408c9c426"
-  integrity sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.8.tgz#2a8c7f0f53d60100ba4c32470ba0281c92aa9aa4"
+  integrity sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.21.4"
@@ -80,7 +80,7 @@
     "@babel/helper-compilation-targets" "^7.21.5"
     "@babel/helper-module-transforms" "^7.21.5"
     "@babel/helpers" "^7.21.5"
-    "@babel/parser" "^7.21.5"
+    "@babel/parser" "^7.21.8"
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.21.5"
     "@babel/types" "^7.21.5"
@@ -91,9 +91,9 @@
     semver "^6.3.0"
 
 "@babel/eslint-parser@^7.16.3":
-  version "7.21.3"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz#d79e822050f2de65d7f368a076846e7184234af7"
-  integrity sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.21.8.tgz#59fb6fc4f3b017ab86987c076226ceef7b2b2ef2"
+  integrity sha512-HLhI+2q+BP3sf78mFUZNCGc10KEmoUqtUT1OCdMZsN+qr4qFeLUod62/zAnF3jNQstwyasDkZnVXwfK2Bml7MQ==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -135,9 +135,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.5.tgz#09a259305467d2020bd2492119ee1c1bc55029e9"
-  integrity sha512-yNSEck9SuDvPTEUYm4BSXl6ZVC7yO5ZLEMAhG3v3zi7RDxyL/nQDemWWZmw4L0stPWwhpnznRRyJHPRcbXR2jw==
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz#205b26330258625ef8869672ebca1e0dee5a0f02"
+  integrity sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-environment-visitor" "^7.21.5"
@@ -150,9 +150,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.20.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.5.tgz#4ce6ffaf497a241aa6c62192416b273987a8daa3"
-  integrity sha512-1+DPMcln46eNAta/rPIqQYXYRGvQ/LRy6bRKnSt9Dzt/yLjNUbbsh+6yzD6fUHmtzc9kWvVnAhtcMSMyziHmUA==
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.8.tgz#a7886f61c2e29e21fd4aaeaf1e473deba6b571dc"
+  integrity sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     regexpu-core "^5.3.1"
@@ -316,10 +316,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.21.5", "@babel/parser@~7.21.2":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.5.tgz#821bb520118fd25b982eaf8d37421cf5c64a312b"
-  integrity sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.21.5", "@babel/parser@^7.21.8", "@babel/parser@~7.21.2":
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
+  integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1354,7 +1354,7 @@
     source-map "^0.5.7"
     stylis "4.1.4"
 
-"@emotion/cache@*", "@emotion/cache@^11.10.7", "@emotion/cache@^11.10.8", "@emotion/cache@^11.7.1":
+"@emotion/cache@*", "@emotion/cache@^11.10.8", "@emotion/cache@^11.7.1":
   version "11.10.8"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.8.tgz#3b39b4761bea0ae2f4f07f0a425eec8b6977c03e"
   integrity sha512-5fyqGHi51LU95o7qQ/vD1jyvC4uCY5GcBT+UgP4LHdpO9jPDlXqhrRr9/wCKmfoAvh5G/F7aOh4MwQa+8uEqhA==
@@ -1766,6 +1766,18 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
@@ -2419,24 +2431,24 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@mui/base@5.0.0-alpha.127":
-  version "5.0.0-alpha.127"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.127.tgz#bc61eaf1fd31094c939b6521cfea21643207c3b4"
-  integrity sha512-FoRQd0IOH9MnfyL5yXssyQRnC4vXI+1bwkU1idr+wNkP1ZfxE+JsThHcfl1dy5azLssVUGTtQFD9edQLdbyJog==
+"@mui/base@5.0.0-alpha.128":
+  version "5.0.0-alpha.128"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.128.tgz#8ce4beb971ac989df0b1d3b2bd3e9274dbfa604f"
+  integrity sha512-wub3wxNN+hUp8hzilMlXX3sZrPo75vsy1cXEQpqdTfIFlE9HprP1jlulFiPg5tfPst2OKmygXr2hhmgvAKRrzQ==
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@emotion/is-prop-valid" "^1.2.0"
     "@mui/types" "^7.2.4"
-    "@mui/utils" "^5.12.0"
+    "@mui/utils" "^5.12.3"
     "@popperjs/core" "^2.11.7"
     clsx "^1.2.1"
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/core-downloads-tracker@^5.12.2":
-  version "5.12.2"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.2.tgz#4a0186d25b01d693171366e1c00de0e7c8c35f6a"
-  integrity sha512-Qn7dy8tql6T0hY6gTFPkpWlnqVVFGu5Z6QzEzUSzzmLZpfAx4kf8sFz0PHiB7gU5yrqcZF9picMx1shpRY/rXw==
+"@mui/core-downloads-tracker@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.3.tgz#3dffe62dccc065ddd7338e97d7be4b917004287e"
+  integrity sha512-yiJZ+knaknPHuRKhRk4L6XiwppwkAahVal3LuYpvBH7GkA2g+D9WLEXOEnNYtVFUggyKf6fWGLGnx0iqzkU5YA==
 
 "@mui/icons-material@^5.0.0", "@mui/icons-material@^5.0.1", "@mui/icons-material@^5.0.2":
   version "5.11.16"
@@ -2446,16 +2458,16 @@
     "@babel/runtime" "^7.21.0"
 
 "@mui/material@^5.0.0", "@mui/material@^5.10.17":
-  version "5.12.2"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.12.2.tgz#c3fcc94e523d9e673e2e045dfad04d12ab454a80"
-  integrity sha512-XOVy6fVC0rI2dEwDq/1s4Te2hewTUe6lznzeVnruyATGkdmM06WnHqkZOoLVIWo9hWwAxpcgTDcAIVpFtt1nrw==
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.12.3.tgz#398c1b123fb065763558bc1f9fc47d1f8cb87d0c"
+  integrity sha512-xNmKlrEN4HsTaKFNLZfc7ie7CXx2YqEeO//hsXZx2p3MGtDdeMr2sV3jC4hsFs57RhQlF79weY7uVvC8xSuVbg==
   dependencies:
     "@babel/runtime" "^7.21.0"
-    "@mui/base" "5.0.0-alpha.127"
-    "@mui/core-downloads-tracker" "^5.12.2"
-    "@mui/system" "^5.12.1"
+    "@mui/base" "5.0.0-alpha.128"
+    "@mui/core-downloads-tracker" "^5.12.3"
+    "@mui/system" "^5.12.3"
     "@mui/types" "^7.2.4"
-    "@mui/utils" "^5.12.0"
+    "@mui/utils" "^5.12.3"
     "@types/react-transition-group" "^4.4.5"
     clsx "^1.2.1"
     csstype "^3.1.2"
@@ -2463,35 +2475,35 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/private-theming@^5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.12.0.tgz#5f1e6fd09b1447c387fdac1eef7f23efca5c6d69"
-  integrity sha512-w5dwMen1CUm1puAtubqxY9BIzrBxbOThsg2iWMvRJmWyJAPdf3Z583fPXpqeA2lhTW79uH2jajk5Ka4FuGlTPg==
+"@mui/private-theming@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.12.3.tgz#f5e4704e25d9d91b906561cae573cda8f3801e10"
+  integrity sha512-o1e7Z1Bp27n4x2iUHhegV4/Jp6H3T6iBKHJdLivS5GbwsuAE/5l4SnZ+7+K+e5u9TuhwcAKZLkjvqzkDe8zqfA==
   dependencies:
     "@babel/runtime" "^7.21.0"
-    "@mui/utils" "^5.12.0"
+    "@mui/utils" "^5.12.3"
     prop-types "^15.8.1"
 
-"@mui/styled-engine@^5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.12.0.tgz#44640cad961adcc9413ae32116237cd1c8f7ddb0"
-  integrity sha512-frh8L7CRnvD0RDmIqEv6jFeKQUIXqW90BaZ6OrxJ2j4kIsiVLu29Gss4SbBvvrWwwatR72sBmC3w1aG4fjp9mQ==
+"@mui/styled-engine@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.12.3.tgz#3307643d52c81947a624cdd0437536cc8109c4f0"
+  integrity sha512-AhZtiRyT8Bjr7fufxE/mLS+QJ3LxwX1kghIcM2B2dvJzSSg9rnIuXDXM959QfUVIM3C8U4x3mgVoPFMQJvc4/g==
   dependencies:
     "@babel/runtime" "^7.21.0"
-    "@emotion/cache" "^11.10.7"
+    "@emotion/cache" "^11.10.8"
     csstype "^3.1.2"
     prop-types "^15.8.1"
 
-"@mui/system@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.12.1.tgz#8452bc03159f0a6725b96bde1dee1316e308231b"
-  integrity sha512-Po+sicdV3bbRYXdU29XZaHPZrW7HUYUqU1qCu77GCCEMbahC756YpeyefdIYuPMUg0OdO3gKIUfDISBrkjJL+w==
+"@mui/system@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.12.3.tgz#306b3cdffa3046067640219c1e5dd7e3dae38ff9"
+  integrity sha512-JB/6sypHqeJCqwldWeQ1MKkijH829EcZAKKizxbU2MJdxGG5KSwZvTBa5D9qiJUA1hJFYYupjiuy9ZdJt6rV6w==
   dependencies:
     "@babel/runtime" "^7.21.0"
-    "@mui/private-theming" "^5.12.0"
-    "@mui/styled-engine" "^5.12.0"
+    "@mui/private-theming" "^5.12.3"
+    "@mui/styled-engine" "^5.12.3"
     "@mui/types" "^7.2.4"
-    "@mui/utils" "^5.12.0"
+    "@mui/utils" "^5.12.3"
     clsx "^1.2.1"
     csstype "^3.1.2"
     prop-types "^15.8.1"
@@ -2501,10 +2513,10 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.4.tgz#b6fade19323b754c5c6de679a38f068fd50b9328"
   integrity sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==
 
-"@mui/utils@^5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.12.0.tgz#284db48b36ac26f3d34076379072c1dc8aed1ad0"
-  integrity sha512-RmQwgzF72p7Yr4+AAUO6j1v2uzt6wr7SWXn68KBsnfVpdOHyclCzH2lr/Xu6YOw9su4JRtdAIYfJFXsS6Cjkmw==
+"@mui/utils@^5.12.0", "@mui/utils@^5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.12.3.tgz#3fa3570dac7ec66bb9cc84ab7c16ab6e1b7200f2"
+  integrity sha512-D/Z4Ub3MRl7HiUccid7sQYclTr24TqUAQFFlxHQF8FR177BrCTQ0JJZom7EqYjZCdXhwnSkOj2ph685MSKNtIA==
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@types/prop-types" "^15.7.5"
@@ -6967,9 +6979,9 @@ cli-spinners@2.6.1:
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
 
 cli-spinners@^2.5.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.8.0.tgz#e97a3e2bd00e6d85aa0c13d7f9e3ce236f7787fc"
-  integrity sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
+  integrity sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==
 
 cli-table3@^0.6.1:
   version "0.6.3"
@@ -7042,17 +7054,6 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
-
-"cliui@github:isaacs/cliui#isaacs/esm-cjs-consistency":
-  version "8.0.1"
-  resolved "https://codeload.github.com/isaacs/cliui/tar.gz/9f97090165675fdda63a79c29bc36bb1033506b0"
-  dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 clone-deep@4.0.1, clone-deep@^4.0.1:
   version "4.0.1"
@@ -8606,9 +8607,9 @@ electron-publish@23.6.0:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.378"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.378.tgz#73431ffd5fffebc18b4e897fac2e7d4ae6d559d9"
-  integrity sha512-RfCD26kGStl6+XalfX3DGgt3z2DNwJS5DKRHCpkPq5T/PqpZMPB1moSRXuK9xhkt/sF57LlpzJgNoYl7mO7Z6w==
+  version "1.4.379"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.379.tgz#c9b597e090ce738e7a76db84e5678f27817bd644"
+  integrity sha512-eRMq6Cf4PhjB14R9U6QcXM/VRQ54Gc3OL9LKnFugUIh2AXm3KJlOizlSfVIgjH76bII4zHGK4t0PVTE5qq8dZg==
 
 electron-updater@^5.0.1:
   version "5.3.0"
@@ -11547,11 +11548,11 @@ ixixx@^2.0.1:
     tmp "^0.2.1"
 
 jackspeak@^2.0.3:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.1.2.tgz#48fe59eb39e145b79487794fa360c0a8f54b0e38"
-  integrity sha512-IEVVfX66eop4fvm6VP252GgiIY8ttDfFSrPD439JJucDHdASn9kd+WL209Bhcwvbhu7VYcYFGZMSXPjCvb9ASA==
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.1.5.tgz#9a6741037b58257dc92eb28e9c8f54d33a1c09ba"
+  integrity sha512-NeK3mbF9vwNS3SjhzlEfO6WREJqoKtCwLoUPoUVtGJrpecxN3ZxlDuF22MzNSbOk/AA/VFWi+nFMV89xkXh2og==
   dependencies:
-    cliui "github:isaacs/cliui#isaacs/esm-cjs-consistency"
+    "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 


### PR DESCRIPTION
We use 'fontSize:12' but in many places MUI bumps this up, so the effective font size for most elements is 13.8px (track list items, refnameautocomplete, etc).

I propose making the global theme use fontSize:11, which makes the effective font size for most elements 12.5px, which (I think) improves UI  information density without compromising readability.  


Extra Motivation: the RefNameAutocomplete was actually cutting off the text for even small refnames e.g. which was actually a regression between v2.4.0 and v2.4.1

## Result

Current v2.4.2 (lack of padding results in ellipses of the text prematurely on RefNameAutocomplete, uses fontSize:12 in the theme globally, which results in effective font size 13.7px for most elements)

![image](https://user-images.githubusercontent.com/6511937/235755751-33e194df-0fcd-44ec-81a2-070f8a9834ee.png)


This branch (adds extra padding to RefNameAutocomplete and makes theme fontSize:11 globally, which results in 12.5px effective font size in most elements)

![Screenshot from 2023-05-02 12-27-53](https://user-images.githubusercontent.com/6511937/235753584-9810f028-7dfb-4514-9d34-832193c96982.png)
