### PR TITLE
Render alignment track arcs instantly after bpPerPx change

### DIFF
--- a/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
@@ -18,7 +18,9 @@ const Arcs = observer(function ({
   const width = Math.round(view.dynamicBlocks.totalWidthPx)
   const height = model.height
   const cb = useCallback(
-    (ref: HTMLCanvasElement) => model.setRef(ref),
+    (ref: HTMLCanvasElement) => {
+      model.setRef(ref)
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [model, width, height],
   )

--- a/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
@@ -1,4 +1,4 @@
-import { getContainingView, getSession } from '@jbrowse/core/util'
+import { getContainingView, getSession, rIC } from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
 // locals
@@ -51,10 +51,11 @@ function drawLineAtOffset(
 export default function drawFeats(
   self: LinearReadArcsDisplayModel,
   ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
 ) {
   const {
     chainData,
-    height,
     colorBy,
     drawInter,
     drawLongRange,
@@ -73,82 +74,98 @@ export default function drawFeats(
   if (!asm) {
     return
   }
-  ctx.lineWidth = lineWidthSetting
-  function draw(
-    k1: CoreFeat & { tlen?: number; pair_orientation?: string },
-    k2: CoreFeat,
-    assembly: Assembly,
-    longRange?: boolean,
-  ) {
-    const s1 = k1.strand
-    const s2 = k2.strand
-    const f1 = s1 === -1
-    const f2 = s2 === -1
+  self.setDrawing(true)
+  rIC(() => {
+    ctx.clearRect(0, 0, width, height * 2)
+    ctx.resetTransform()
+    ctx.scale(2, 2)
+    ctx.lineWidth = lineWidthSetting
+    function draw(
+      k1: CoreFeat & { tlen?: number; pair_orientation?: string },
+      k2: CoreFeat,
+      assembly: Assembly,
+      longRange?: boolean,
+    ) {
+      const s1 = k1.strand
+      const s2 = k2.strand
+      const f1 = s1 === -1
+      const f2 = s2 === -1
 
-    const p1 = f1 ? k1.start : k1.end
-    const p2 = hasPaired ? (f2 ? k2.start : k2.end) : f2 ? k2.end : k2.start
-    const ra1 = assembly.getCanonicalRefName(k1.refName) || k1.refName
-    const ra2 = assembly.getCanonicalRefName(k2.refName) || k2.refName
-    const r1 = view.bpToPx({ refName: ra1, coord: p1 })
-    const r2 = view.bpToPx({ refName: ra2, coord: p2 })
+      const p1 = f1 ? k1.start : k1.end
+      const p2 = hasPaired ? (f2 ? k2.start : k2.end) : f2 ? k2.end : k2.start
+      const ra1 = assembly.getCanonicalRefName(k1.refName) || k1.refName
+      const ra2 = assembly.getCanonicalRefName(k2.refName) || k2.refName
+      const r1 = view.bpToPx({ refName: ra1, coord: p1 })
+      const r2 = view.bpToPx({ refName: ra2, coord: p2 })
 
-    if (r1 && r2) {
-      const radius = (r2.offsetPx - r1.offsetPx) / 2
-      const absrad = Math.abs(radius)
-      const p = r1.offsetPx - view.offsetPx
-      const p2 = r2.offsetPx - view.offsetPx
-      const drawArcInsteadOfBezier = absrad > 10_000
+      if (r1 && r2) {
+        const radius = (r2.offsetPx - r1.offsetPx) / 2
+        const absrad = Math.abs(radius)
+        const p = r1.offsetPx - view.offsetPx
+        const p2 = r2.offsetPx - view.offsetPx
+        const drawArcInsteadOfBezier = absrad > 10_000
 
-      // bezier (used for non-long-range arcs) requires moveTo before beginPath
-      // arc (used for long-range) requires moveTo after beginPath (or else a
-      // unwanted line at y=0 is rendered along with the arc)
-      if (longRange && drawArcInsteadOfBezier) {
-        ctx.moveTo(p, 0)
-        ctx.beginPath()
-      } else {
-        ctx.beginPath()
-        ctx.moveTo(p, 0)
-      }
-
-      if (longRange && drawArcInsteadOfBezier) {
-        ctx.strokeStyle = 'red'
-      } else {
-        if (hasPaired) {
-          if (type === 'insertSizeAndOrientation') {
-            ctx.strokeStyle = getInsertSizeAndOrientationColor(k1, k2, stats)
-          } else if (type === 'orientation') {
-            ctx.strokeStyle = getOrientationColor(k1)
-          } else if (type === 'insertSize') {
-            ctx.strokeStyle = getInsertSizeColor(k1, k2, stats) || 'grey'
-          } else if (type === 'gradient') {
-            ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
-          }
+        // bezier (used for non-long-range arcs) requires moveTo before beginPath
+        // arc (used for long-range) requires moveTo after beginPath (or else a
+        // unwanted line at y=0 is rendered along with the arc)
+        if (longRange && drawArcInsteadOfBezier) {
+          ctx.moveTo(p, 0)
+          ctx.beginPath()
         } else {
-          if (type === 'orientation' || type === 'insertSizeAndOrientation') {
-            if (s1 === -1 && s2 === 1) {
-              ctx.strokeStyle = 'navy'
-            } else if (s1 === 1 && s2 === -1) {
-              ctx.strokeStyle = 'green'
-            } else {
-              ctx.strokeStyle = 'grey'
+          ctx.beginPath()
+          ctx.moveTo(p, 0)
+        }
+
+        if (longRange && drawArcInsteadOfBezier) {
+          ctx.strokeStyle = 'red'
+        } else {
+          if (hasPaired) {
+            if (type === 'insertSizeAndOrientation') {
+              ctx.strokeStyle = getInsertSizeAndOrientationColor(k1, k2, stats)
+            } else if (type === 'orientation') {
+              ctx.strokeStyle = getOrientationColor(k1)
+            } else if (type === 'insertSize') {
+              ctx.strokeStyle = getInsertSizeColor(k1, k2, stats) || 'grey'
+            } else if (type === 'gradient') {
+              ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
             }
-          } else if (type === 'gradient') {
-            ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
+          } else {
+            if (type === 'orientation' || type === 'insertSizeAndOrientation') {
+              if (s1 === -1 && s2 === 1) {
+                ctx.strokeStyle = 'navy'
+              } else if (s1 === 1 && s2 === -1) {
+                ctx.strokeStyle = 'green'
+              } else {
+                ctx.strokeStyle = 'grey'
+              }
+            } else if (type === 'gradient') {
+              ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
+            }
           }
         }
-      }
 
-      const destX = p + radius * 2
-      const destY = Math.min(height + jitter(jitterVal), absrad)
-      if (longRange) {
-        // avoid drawing gigantic circles that glitch out the rendering,
-        // instead draw vertical lines
-        if (absrad > 100_000) {
-          drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
-          drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
-        } else if (drawArcInsteadOfBezier) {
-          ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
-          ctx.stroke()
+        const destX = p + radius * 2
+        const destY = Math.min(height + jitter(jitterVal), absrad)
+        if (longRange) {
+          // avoid drawing gigantic circles that glitch out the rendering,
+          // instead draw vertical lines
+          if (absrad > 100_000) {
+            drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
+            drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
+          } else if (drawArcInsteadOfBezier) {
+            ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
+            ctx.stroke()
+          } else {
+            ctx.bezierCurveTo(
+              p + jitter(jitterVal),
+              destY,
+              destX,
+              destY,
+              destX + jitter(jitterVal),
+              0,
+            )
+            ctx.stroke()
+          }
         } else {
           ctx.bezierCurveTo(
             p + jitter(jitterVal),
@@ -160,64 +177,59 @@ export default function drawFeats(
           )
           ctx.stroke()
         }
-      } else {
-        ctx.bezierCurveTo(
-          p + jitter(jitterVal),
-          destY,
-          destX,
-          destY,
-          destX + jitter(jitterVal),
-          0,
-        )
-        ctx.stroke()
+      } else if (r1 && drawInter) {
+        drawLineAtOffset(ctx, r1.offsetPx - view.offsetPx, height, 'purple')
       }
-    } else if (r1 && drawInter) {
-      drawLineAtOffset(ctx, r1.offsetPx - view.offsetPx, height, 'purple')
     }
-  }
 
-  for (const chain of chains) {
-    if (chain.length === 1 && drawLongRange) {
-      // singleton feature
-      const f = chain[0]
+    for (const chain of chains) {
+      if (chain.length === 1 && drawLongRange) {
+        // singleton feature
+        const f = chain[0]
 
-      // special case where we look at RPOS/RNEXT
-      if (hasPaired) {
-        const coord = f.next_pos || 0
-        draw(
-          f,
-          {
-            refName: f.next_ref || '',
-            start: coord,
-            end: coord,
-            strand: f.strand,
-          },
-          asm,
-          true,
-        )
-      }
+        // special case where we look at RPOS/RNEXT
+        if (hasPaired) {
+          const coord = f.next_pos || 0
+          draw(
+            f,
+            {
+              refName: f.next_ref || '',
+              start: coord,
+              end: coord,
+              strand: f.strand,
+            },
+            asm,
+            true,
+          )
+        }
 
-      // special case where we look at SA
-      else {
-        const suppAlns = featurizeSA(f.SA, f.id, f.strand, f.name)
-        const features = [f, ...suppAlns].sort((a, b) => a.clipPos - b.clipPos)
-        for (let i = 0; i < features.length - 1; i++) {
-          const f = features[i]
-          const v1 = features[i + 1]
-          draw(f, v1, asm, true)
+        // special case where we look at SA
+        else {
+          const suppAlns = featurizeSA(f.SA, f.id, f.strand, f.name)
+          const features = [f, ...suppAlns].sort(
+            (a, b) => a.clipPos - b.clipPos,
+          )
+          for (let i = 0; i < features.length - 1; i++) {
+            const f = features[i]
+            const v1 = features[i + 1]
+            draw(f, v1, asm, true)
+          }
+        }
+      } else {
+        const res = hasPaired
+          ? chain.filter(f => !(f.flags & 2048))
+          : chain
+              .sort((a, b) => a.clipPos - b.clipPos)
+              .filter(f => !(f.flags & 256))
+        for (let i = 0; i < res.length - 1; i++) {
+          draw(res[i], res[i + 1], asm, false)
         }
       }
-    } else {
-      const res = hasPaired
-        ? chain.filter(f => !(f.flags & 2048))
-        : chain
-            .sort((a, b) => a.clipPos - b.clipPos)
-            .filter(f => !(f.flags & 256))
-      for (let i = 0; i < res.length - 1; i++) {
-        draw(res[i], res[i + 1], asm, false)
-      }
     }
-  }
-  self.setDrawn(true)
-  self.setLastDrawnOffsetPx(view.offsetPx)
+    self.setLastDrawnOffsetPx(view.offsetPx)
+    rIC(() => {
+      self.setDrawn(true)
+      self.setDrawing(false)
+    })
+  })
 }

--- a/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
@@ -1,4 +1,4 @@
-import { getContainingView, getSession, rIC } from '@jbrowse/core/util'
+import { getContainingView, getSession } from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
 // locals
@@ -74,98 +74,83 @@ export default function drawFeats(
   if (!asm) {
     return
   }
-  self.setDrawing(true)
-  rIC(() => {
-    ctx.clearRect(0, 0, width, height * 2)
-    ctx.resetTransform()
-    ctx.scale(2, 2)
-    ctx.lineWidth = lineWidthSetting
-    function draw(
-      k1: CoreFeat & { tlen?: number; pair_orientation?: string },
-      k2: CoreFeat,
-      assembly: Assembly,
-      longRange?: boolean,
-    ) {
-      const s1 = k1.strand
-      const s2 = k2.strand
-      const f1 = s1 === -1
-      const f2 = s2 === -1
+  ctx.lineWidth = lineWidthSetting
 
-      const p1 = f1 ? k1.start : k1.end
-      const p2 = hasPaired ? (f2 ? k2.start : k2.end) : f2 ? k2.end : k2.start
-      const ra1 = assembly.getCanonicalRefName(k1.refName) || k1.refName
-      const ra2 = assembly.getCanonicalRefName(k2.refName) || k2.refName
-      const r1 = view.bpToPx({ refName: ra1, coord: p1 })
-      const r2 = view.bpToPx({ refName: ra2, coord: p2 })
+  function draw(
+    k1: CoreFeat & { tlen?: number; pair_orientation?: string },
+    k2: CoreFeat,
+    assembly: Assembly,
+    longRange?: boolean,
+  ) {
+    const s1 = k1.strand
+    const s2 = k2.strand
+    const f1 = s1 === -1
+    const f2 = s2 === -1
 
-      if (r1 && r2) {
-        const radius = (r2.offsetPx - r1.offsetPx) / 2
-        const absrad = Math.abs(radius)
-        const p = r1.offsetPx - view.offsetPx
-        const p2 = r2.offsetPx - view.offsetPx
-        const drawArcInsteadOfBezier = absrad > 10_000
+    const p1 = f1 ? k1.start : k1.end
+    const p2 = hasPaired ? (f2 ? k2.start : k2.end) : f2 ? k2.end : k2.start
+    const ra1 = assembly.getCanonicalRefName(k1.refName) || k1.refName
+    const ra2 = assembly.getCanonicalRefName(k2.refName) || k2.refName
+    const r1 = view.bpToPx({ refName: ra1, coord: p1 })
+    const r2 = view.bpToPx({ refName: ra2, coord: p2 })
 
-        // bezier (used for non-long-range arcs) requires moveTo before beginPath
-        // arc (used for long-range) requires moveTo after beginPath (or else a
-        // unwanted line at y=0 is rendered along with the arc)
-        if (longRange && drawArcInsteadOfBezier) {
-          ctx.moveTo(p, 0)
-          ctx.beginPath()
+    if (r1 && r2) {
+      const radius = (r2.offsetPx - r1.offsetPx) / 2
+      const absrad = Math.abs(radius)
+      const p = r1.offsetPx - view.offsetPx
+      const p2 = r2.offsetPx - view.offsetPx
+      const drawArcInsteadOfBezier = absrad > 10_000
+
+      // bezier (used for non-long-range arcs) requires moveTo before beginPath
+      // arc (used for long-range) requires moveTo after beginPath (or else a
+      // unwanted line at y=0 is rendered along with the arc)
+      if (longRange && drawArcInsteadOfBezier) {
+        ctx.moveTo(p, 0)
+        ctx.beginPath()
+      } else {
+        ctx.beginPath()
+        ctx.moveTo(p, 0)
+      }
+
+      if (longRange && drawArcInsteadOfBezier) {
+        ctx.strokeStyle = 'red'
+      } else {
+        if (hasPaired) {
+          if (type === 'insertSizeAndOrientation') {
+            ctx.strokeStyle = getInsertSizeAndOrientationColor(k1, k2, stats)
+          } else if (type === 'orientation') {
+            ctx.strokeStyle = getOrientationColor(k1)
+          } else if (type === 'insertSize') {
+            ctx.strokeStyle = getInsertSizeColor(k1, k2, stats) || 'grey'
+          } else if (type === 'gradient') {
+            ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
+          }
         } else {
-          ctx.beginPath()
-          ctx.moveTo(p, 0)
-        }
-
-        if (longRange && drawArcInsteadOfBezier) {
-          ctx.strokeStyle = 'red'
-        } else {
-          if (hasPaired) {
-            if (type === 'insertSizeAndOrientation') {
-              ctx.strokeStyle = getInsertSizeAndOrientationColor(k1, k2, stats)
-            } else if (type === 'orientation') {
-              ctx.strokeStyle = getOrientationColor(k1)
-            } else if (type === 'insertSize') {
-              ctx.strokeStyle = getInsertSizeColor(k1, k2, stats) || 'grey'
-            } else if (type === 'gradient') {
-              ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
+          if (type === 'orientation' || type === 'insertSizeAndOrientation') {
+            if (s1 === -1 && s2 === 1) {
+              ctx.strokeStyle = 'navy'
+            } else if (s1 === 1 && s2 === -1) {
+              ctx.strokeStyle = 'green'
+            } else {
+              ctx.strokeStyle = 'grey'
             }
-          } else {
-            if (type === 'orientation' || type === 'insertSizeAndOrientation') {
-              if (s1 === -1 && s2 === 1) {
-                ctx.strokeStyle = 'navy'
-              } else if (s1 === 1 && s2 === -1) {
-                ctx.strokeStyle = 'green'
-              } else {
-                ctx.strokeStyle = 'grey'
-              }
-            } else if (type === 'gradient') {
-              ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
-            }
+          } else if (type === 'gradient') {
+            ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
           }
         }
+      }
 
-        const destX = p + radius * 2
-        const destY = Math.min(height + jitter(jitterVal), absrad)
-        if (longRange) {
-          // avoid drawing gigantic circles that glitch out the rendering,
-          // instead draw vertical lines
-          if (absrad > 100_000) {
-            drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
-            drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
-          } else if (drawArcInsteadOfBezier) {
-            ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
-            ctx.stroke()
-          } else {
-            ctx.bezierCurveTo(
-              p + jitter(jitterVal),
-              destY,
-              destX,
-              destY,
-              destX + jitter(jitterVal),
-              0,
-            )
-            ctx.stroke()
-          }
+      const destX = p + radius * 2
+      const destY = Math.min(height + jitter(jitterVal), absrad)
+      if (longRange) {
+        // avoid drawing gigantic circles that glitch out the rendering,
+        // instead draw vertical lines
+        if (absrad > 100_000) {
+          drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
+          drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
+        } else if (drawArcInsteadOfBezier) {
+          ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
+          ctx.stroke()
         } else {
           ctx.bezierCurveTo(
             p + jitter(jitterVal),
@@ -177,59 +162,62 @@ export default function drawFeats(
           )
           ctx.stroke()
         }
-      } else if (r1 && drawInter) {
-        drawLineAtOffset(ctx, r1.offsetPx - view.offsetPx, height, 'purple')
-      }
-    }
-
-    for (const chain of chains) {
-      if (chain.length === 1 && drawLongRange) {
-        // singleton feature
-        const f = chain[0]
-
-        // special case where we look at RPOS/RNEXT
-        if (hasPaired) {
-          const coord = f.next_pos || 0
-          draw(
-            f,
-            {
-              refName: f.next_ref || '',
-              start: coord,
-              end: coord,
-              strand: f.strand,
-            },
-            asm,
-            true,
-          )
-        }
-
-        // special case where we look at SA
-        else {
-          const suppAlns = featurizeSA(f.SA, f.id, f.strand, f.name)
-          const features = [f, ...suppAlns].sort(
-            (a, b) => a.clipPos - b.clipPos,
-          )
-          for (let i = 0; i < features.length - 1; i++) {
-            const f = features[i]
-            const v1 = features[i + 1]
-            draw(f, v1, asm, true)
-          }
-        }
       } else {
-        const res = hasPaired
-          ? chain.filter(f => !(f.flags & 2048))
-          : chain
-              .sort((a, b) => a.clipPos - b.clipPos)
-              .filter(f => !(f.flags & 256))
-        for (let i = 0; i < res.length - 1; i++) {
-          draw(res[i], res[i + 1], asm, false)
+        ctx.bezierCurveTo(
+          p + jitter(jitterVal),
+          destY,
+          destX,
+          destY,
+          destX + jitter(jitterVal),
+          0,
+        )
+        ctx.stroke()
+      }
+    } else if (r1 && drawInter) {
+      drawLineAtOffset(ctx, r1.offsetPx - view.offsetPx, height, 'purple')
+    }
+  }
+
+  for (const chain of chains) {
+    if (chain.length === 1 && drawLongRange) {
+      // singleton feature
+      const f = chain[0]
+
+      // special case where we look at RPOS/RNEXT
+      if (hasPaired) {
+        const coord = f.next_pos || 0
+        draw(
+          f,
+          {
+            refName: f.next_ref || '',
+            start: coord,
+            end: coord,
+            strand: f.strand,
+          },
+          asm,
+          true,
+        )
+      }
+
+      // special case where we look at SA
+      else {
+        const suppAlns = featurizeSA(f.SA, f.id, f.strand, f.name)
+        const features = [f, ...suppAlns].sort((a, b) => a.clipPos - b.clipPos)
+        for (let i = 0; i < features.length - 1; i++) {
+          const f = features[i]
+          const v1 = features[i + 1]
+          draw(f, v1, asm, true)
         }
       }
+    } else {
+      const res = hasPaired
+        ? chain.filter(f => !(f.flags & 2048))
+        : chain
+            .sort((a, b) => a.clipPos - b.clipPos)
+            .filter(f => !(f.flags & 256))
+      for (let i = 0; i < res.length - 1; i++) {
+        draw(res[i], res[i + 1], asm, false)
+      }
     }
-    self.setLastDrawnOffsetPx(view.offsetPx)
-    rIC(() => {
-      self.setDrawn(true)
-      self.setDrawing(false)
-    })
-  })
+  }
 }

--- a/plugins/alignments/src/LinearReadArcsDisplay/model.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/model.tsx
@@ -93,6 +93,7 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
     )
     .volatile(() => ({
       loading: false,
+      drawing: false,
       drawn: false,
       chainData: undefined as ChainData | undefined,
       lastDrawnOffsetPx: 0,
@@ -110,6 +111,12 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       setLoading(f: boolean) {
         self.loading = f
+      },
+      /**
+       * #action
+       */
+      setDrawing(f: boolean) {
+        self.drawing = f
       },
       /**
        * #action
@@ -342,10 +349,8 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
             if (!ctx) {
               return
             }
-            ctx.clearRect(0, 0, canvas.width, self.height * 2)
-            ctx.resetTransform()
-            ctx.scale(2, 2)
-            drawFeats(self, ctx)
+
+            drawFeats(self, ctx, canvas.width, self.height)
           },
           { delay: 1000 },
         )

--- a/plugins/alignments/src/LinearReadCloudDisplay/drawFeats.ts
+++ b/plugins/alignments/src/LinearReadCloudDisplay/drawFeats.ts
@@ -175,5 +175,4 @@ export default function drawFeats(
     fillRectCtx(r1s - view.offsetPx, top, w1, featureHeight, ctx)
     fillRectCtx(r2s - view.offsetPx, top, w2, featureHeight, ctx)
   }
-  self.setDrawn(true)
 }

--- a/plugins/alignments/src/LinearReadCloudDisplay/model.tsx
+++ b/plugins/alignments/src/LinearReadCloudDisplay/model.tsx
@@ -3,7 +3,6 @@ import { cast, types, Instance } from 'mobx-state-tree'
 import {
   AnyConfigurationSchemaType,
   ConfigurationReference,
-  ConfigurationSchema,
 } from '@jbrowse/core/configuration'
 import { getSession } from '@jbrowse/core/util'
 
@@ -13,14 +12,14 @@ import FilterListIcon from '@mui/icons-material/ClearAll'
 
 // locals
 import { FilterModel } from '../shared'
-import { fetchChains, ChainData } from '../shared/fetchChains'
+import { ChainData } from '../shared/fetchChains'
 import drawFeats from './drawFeats'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes'
 import {
   FeatureDensityMixin,
   TrackHeightMixin,
 } from '@jbrowse/plugin-linear-genome-view'
-import { createAutorun } from '../util'
+import { doAfterAttach } from '../shared/dynamicTrackAfterAttach'
 
 // async
 const FilterByTagDlg = lazy(() => import('../shared/FilterByTag'))
@@ -72,11 +71,10 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
     )
     .volatile(() => ({
       loading: false,
-      drawing: false,
-      drawn: false,
       chainData: undefined as ChainData | undefined,
+      lastDrawnOffsetPx: undefined as number | undefined,
+      lastDrawnBpPerPx: 0,
       ref: null as HTMLCanvasElement | null,
-      lastDrawnOffsetPx: 0,
     }))
     .actions(self => ({
       /**
@@ -88,9 +86,10 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
       /**
        * #action
        */
-      setDrawing(f: boolean) {
-        self.drawing = f
+      setLastDrawnBpPerPx(n: number) {
+        self.lastDrawnBpPerPx = n
       },
+
       /**
        * #action
        */
@@ -126,15 +125,13 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
       /**
        * #action
        */
-      setDrawn(f: boolean) {
-        self.drawn = f
-      },
-
-      /**
-       * #action
-       */
       setFilterBy(filter: Filter) {
         self.filterBy = cast(filter)
+      },
+    }))
+    .views(self => ({
+      get drawn() {
+        return self.lastDrawnOffsetPx !== undefined
       },
     }))
     .views(self => {
@@ -150,7 +147,6 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
           return {
             ...superRenderProps(),
             notReady: !self.chainData,
-            config: ConfigurationSchema('empty', {}).create(),
           }
         },
 
@@ -203,29 +199,14 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
         async renderSvg(opts: {
           rasterizeLayers?: boolean
         }): Promise<React.ReactNode> {
-          const { renderReadCloudSvg } = await import('./renderSvg')
-          return renderReadCloudSvg(self as LinearReadCloudDisplayModel, opts)
+          const { renderSvg } = await import('../shared/renderSvg')
+          return renderSvg(self as LinearReadCloudDisplayModel, opts, drawFeats)
         },
       }
     })
     .actions(self => ({
       afterAttach() {
-        createAutorun(self, () => fetchChains(self), { delay: 1000 })
-
-        createAutorun(self, async () => {
-          const canvas = self.ref
-          if (!canvas) {
-            return
-          }
-          const ctx = canvas.getContext('2d')
-          if (!ctx) {
-            return
-          }
-
-          const width = canvas.width
-          const height = self.height
-          drawFeats(self, ctx, width, height)
-        })
+        doAfterAttach(self, drawFeats)
       },
     }))
 }

--- a/plugins/alignments/src/LinearReadCloudDisplay/model.tsx
+++ b/plugins/alignments/src/LinearReadCloudDisplay/model.tsx
@@ -72,6 +72,7 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
     )
     .volatile(() => ({
       loading: false,
+      drawing: false,
       drawn: false,
       chainData: undefined as ChainData | undefined,
       ref: null as HTMLCanvasElement | null,
@@ -83,6 +84,12 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       setLastDrawnOffsetPx(n: number) {
         self.lastDrawnOffsetPx = n
+      },
+      /**
+       * #action
+       */
+      setDrawing(f: boolean) {
+        self.drawing = f
       },
       /**
        * #action
@@ -214,11 +221,10 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
           if (!ctx) {
             return
           }
-          ctx.clearRect(0, 0, canvas.width, self.height * 2)
-          ctx.resetTransform()
-          ctx.scale(2, 2)
 
-          drawFeats(self, ctx)
+          const width = canvas.width
+          const height = self.height
+          drawFeats(self, ctx, width, height)
         })
       },
     }))

--- a/plugins/alignments/src/shared/BaseDisplayComponent.tsx
+++ b/plugins/alignments/src/shared/BaseDisplayComponent.tsx
@@ -55,22 +55,15 @@ const DataDisplay = observer(function ({
   model: LinearReadArcsDisplayModel | LinearReadCloudDisplayModel
   children?: React.ReactNode
 }) {
-  const { drawn, loading } = model
+  const { drawn, loading, drawing } = model
   const view = getContainingView(model)
   const left = model.lastDrawnOffsetPx - view.offsetPx
   return (
     // this data-testid is located here because changing props on the canvas
     // itself is very sensitive to triggering ref invalidation
     <div data-testid={`drawn-${drawn}`}>
-      <div
-        style={{
-          position: 'absolute',
-          left,
-        }}
-      >
-        {children}
-      </div>
-      {loading ? <LoadingBar model={model} /> : null}
+      <div style={{ position: 'absolute', left }}>{children}</div>
+      {left !== 0 || loading || drawing ? <LoadingBar model={model} /> : null}
     </div>
   )
 })
@@ -81,9 +74,10 @@ const LoadingBar = observer(function ({
   model: LinearReadArcsDisplayModel | LinearReadCloudDisplayModel
 }) {
   const { classes } = useStyles()
+  const { drawing, message } = model
   return (
     <div className={classes.loading}>
-      <LoadingEllipses message={model.message} />
+      <LoadingEllipses message={drawing ? 'Rendering...' : message} />
     </div>
   )
 })

--- a/plugins/alignments/src/shared/BaseDisplayComponent.tsx
+++ b/plugins/alignments/src/shared/BaseDisplayComponent.tsx
@@ -55,15 +55,15 @@ const DataDisplay = observer(function ({
   model: LinearReadArcsDisplayModel | LinearReadCloudDisplayModel
   children?: React.ReactNode
 }) {
-  const { drawn, loading, drawing } = model
+  const { drawn, loading } = model
   const view = getContainingView(model)
-  const left = model.lastDrawnOffsetPx - view.offsetPx
+  const left = (model.lastDrawnOffsetPx || 0) - view.offsetPx
   return (
     // this data-testid is located here because changing props on the canvas
     // itself is very sensitive to triggering ref invalidation
     <div data-testid={`drawn-${drawn}`}>
       <div style={{ position: 'absolute', left }}>{children}</div>
-      {left !== 0 || loading || drawing ? <LoadingBar model={model} /> : null}
+      {left !== 0 || loading ? <LoadingBar model={model} /> : null}
     </div>
   )
 })
@@ -74,10 +74,10 @@ const LoadingBar = observer(function ({
   model: LinearReadArcsDisplayModel | LinearReadCloudDisplayModel
 }) {
   const { classes } = useStyles()
-  const { drawing, message } = model
+  const { message } = model
   return (
     <div className={classes.loading}>
-      <LoadingEllipses message={drawing ? 'Rendering...' : message} />
+      <LoadingEllipses message={message} />
     </div>
   )
 })

--- a/plugins/alignments/src/shared/dynamicTrackAfterAttach.tsx
+++ b/plugins/alignments/src/shared/dynamicTrackAfterAttach.tsx
@@ -1,0 +1,66 @@
+import { getContainingView } from '@jbrowse/core/util'
+import { createAutorun } from '../util'
+import { fetchChains } from './fetchChains'
+import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
+
+type LGV = LinearGenomeViewModel
+
+export function doAfterAttach<T extends IAnyStateTreeNode>(
+  self: T,
+  cb: (
+    self: T,
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+  ) => void,
+) {
+  createAutorun(
+    self,
+    async () => {
+      await fetchChains(self)
+    },
+    { delay: 1000 },
+  )
+
+  function draw(view: LGV) {
+    const canvas = self.ref
+    if (!canvas) {
+      return
+    }
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+
+    if (!self.chainData) {
+      return
+    }
+
+    ctx.clearRect(0, 0, canvas.width, self.height * 2)
+    ctx.resetTransform()
+    ctx.scale(2, 2)
+    cb(self, ctx, canvas.width, self.height)
+    self.setLastDrawnOffsetPx(view.offsetPx)
+    self.setLastDrawnBpPerPx(view.bpPerPx)
+  }
+
+  // first autorun instantly draws if bpPerPx changes
+  createAutorun(self, async () => {
+    const view = getContainingView(self) as LGV
+    if (view.bpPerPx !== self.lastDrawnBpPerPx) {
+      draw(view)
+    }
+  })
+
+  // second autorun draws after delay 1000 e.g. if offsetPx changes
+  createAutorun(
+    self,
+    async () => {
+      const view = getContainingView(self) as LGV
+      draw(view)
+    },
+    { delay: 1000 },
+  )
+}

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1172,10 +1172,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
         /**
          * #getter
          * static blocks are an important concept jbrowse uses to avoid
-         * re-rendering when you scroll to the side. when you horizontally scroll to the
-         * right, old blocks to the left may be removed, and new blocks may be
-         * instantiated on the right. tracks may use the static blocks to render their
-         * data for the region represented by the block
+         * re-rendering when you scroll to the side. when you horizontally
+         * scroll to the right, old blocks to the left may be removed, and new
+         * blocks may be instantiated on the right. tracks may use the static
+         * blocks to render their data for the region represented by the block
          */
         get staticBlocks() {
           const ret = calculateStaticBlocks(self)
@@ -1189,9 +1189,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
         /**
          * #getter
          * dynamic blocks represent the exact coordinates of the currently
-         * visible genome regions on the screen. they are similar to static blocks, but
-         * static blocks can go offscreen while dynamic blocks represent exactly what
-         * is on screen
+         * visible genome regions on the screen. they are similar to static
+         * blocks, but static blocks can go offscreen while dynamic blocks
+         * represent exactly what is on screen
          */
         get dynamicBlocks() {
           return calculateDynamicBlocks(self)
@@ -1213,8 +1213,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
         /**
          * #getter
-         * a single "combo-locstring" representing all the regions visible
-         * on the screen
+         * a single "combo-locstring" representing all the regions visible on
+         * the screen
          */
         get visibleLocStrings() {
           return calculateVisibleLocStrings(this.dynamicBlocks.contentBlocks)

--- a/products/jbrowse-web/src/tests/AlignmentArcs.test.tsx
+++ b/products/jbrowse-web/src/tests/AlignmentArcs.test.tsx
@@ -71,7 +71,6 @@ test('toggle long-read arc display', async () => {
 test('toggle long-read arc display, use out of view pairing', async () => {
   const { view, getByTestId, findByTestId, findAllByText, findByText } =
     await createView()
-  await findByText('Help')
   await view.navToLocString('ctgA:478..6,191')
   fireEvent.click(await findByTestId(hts('volvox-long-reads-sv-cram'), ...opts))
   fireEvent.click(await findByTestId('track_menu_icon', ...opts))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,10 +2430,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@mui/base@5.0.0-alpha.128":
-  version "5.0.0-alpha.128"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.128.tgz#8ce4beb971ac989df0b1d3b2bd3e9274dbfa604f"
-  integrity sha512-wub3wxNN+hUp8hzilMlXX3sZrPo75vsy1cXEQpqdTfIFlE9HprP1jlulFiPg5tfPst2OKmygXr2hhmgvAKRrzQ==
+"@mui/base@5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.0.tgz#4145f8a700e04d68d703da70d3c26c62d278f4e5"
+  integrity sha512-ap+juKvt8R8n3cBqd/pGtZydQ4v2I/hgJKnvJRGjpSh3RvsvnDHO4rXov8MHQlH6VqpOekwgilFLGxMZjNTucA==
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@emotion/is-prop-valid" "^1.2.0"
@@ -2444,10 +2444,10 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/core-downloads-tracker@^5.12.3":
-  version "5.12.3"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.12.3.tgz#3dffe62dccc065ddd7338e97d7be4b917004287e"
-  integrity sha512-yiJZ+knaknPHuRKhRk4L6XiwppwkAahVal3LuYpvBH7GkA2g+D9WLEXOEnNYtVFUggyKf6fWGLGnx0iqzkU5YA==
+"@mui/core-downloads-tracker@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.0.tgz#cb2c732165f60533862707d9bcedfab8e6c0ff48"
+  integrity sha512-5nXz2k8Rv2ZjtQY6kXirJVyn2+ODaQuAJmXSJtLDUQDKWp3PFUj6j3bILqR0JGOs9R5ejgwz3crLKsl6GwjwkQ==
 
 "@mui/icons-material@^5.0.0", "@mui/icons-material@^5.0.1", "@mui/icons-material@^5.0.2":
   version "5.11.16"
@@ -2457,17 +2457,17 @@
     "@babel/runtime" "^7.21.0"
 
 "@mui/material@^5.0.0", "@mui/material@^5.10.17":
-  version "5.12.3"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.12.3.tgz#398c1b123fb065763558bc1f9fc47d1f8cb87d0c"
-  integrity sha512-xNmKlrEN4HsTaKFNLZfc7ie7CXx2YqEeO//hsXZx2p3MGtDdeMr2sV3jC4hsFs57RhQlF79weY7uVvC8xSuVbg==
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.13.0.tgz#23c63a9d117dca22b81bb82db6e9c4d761c8fbf1"
+  integrity sha512-ckS+9tCpAzpdJdaTF+btF0b6mF9wbXg/EVKtnoAWYi0UKXoXBAVvEUMNpLGA5xdpCdf+A6fPbVUEHs9TsfU+Yw==
   dependencies:
     "@babel/runtime" "^7.21.0"
-    "@mui/base" "5.0.0-alpha.128"
-    "@mui/core-downloads-tracker" "^5.12.3"
+    "@mui/base" "5.0.0-beta.0"
+    "@mui/core-downloads-tracker" "^5.13.0"
     "@mui/system" "^5.12.3"
     "@mui/types" "^7.2.4"
     "@mui/utils" "^5.12.3"
-    "@types/react-transition-group" "^4.4.5"
+    "@types/react-transition-group" "^4.4.6"
     clsx "^1.2.1"
     csstype "^3.1.2"
     prop-types "^15.8.1"
@@ -3043,10 +3043,10 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-14.0.0.tgz#949c5019028c93f189abbc2fb42f333290f7134a"
   integrity sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==
 
-"@octokit/openapi-types@^17.1.1":
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-17.1.1.tgz#b046979537d4209954206d29fbf9fe6893c5acec"
-  integrity sha512-/X7Gh/qWiWaooJmUnYD48SYy72fyrk2ceisOSe89JojK7r0j8YrTwYpDi76kI+c6QiqX1KSgdoBTMJvktsDkYw==
+"@octokit/openapi-types@^17.1.2":
+  version "17.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-17.1.2.tgz#b7bc1cc5d3581adac9dce197a21f0e5f2ceaabf1"
+  integrity sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw==
 
 "@octokit/plugin-enterprise-rest@6.0.1":
   version "6.0.1"
@@ -3119,11 +3119,11 @@
     "@octokit/openapi-types" "^14.0.0"
 
 "@octokit/types@^9.0.0":
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.2.1.tgz#34ab724b66ffbe210604593127bb47fd044abbc7"
-  integrity sha512-Vx4keMiD/CAiwVFasLcH0xBSVbKIHebIZke9i7ZbUWGNN4vJFWSYH6Nvga7UY9NIJCGa6x3QG849XTbi5wYmkA==
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.2.2.tgz#d111d33928f288f48083bfe49d8a9a5945e67db1"
+  integrity sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==
   dependencies:
-    "@octokit/openapi-types" "^17.1.1"
+    "@octokit/openapi-types" "^17.1.2"
 
 "@parcel/watcher@2.0.4":
   version "2.0.4"
@@ -4683,9 +4683,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "20.1.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.1.tgz#afc492e8dbe7f672dd3a13674823522b467a45ad"
-  integrity sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
+  integrity sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==
 
 "@types/node@^14.14.0":
   version "14.18.46"
@@ -4693,14 +4693,14 @@
   integrity sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng==
 
 "@types/node@^16.0.0":
-  version "16.18.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.27.tgz#d515767a4a7bc44eaec336ac7ff1bde338a17704"
-  integrity sha512-GFfndd/RINWD19W+xNJ9Qh/sOZ5ieTiOSagA86ER/12i/l+MEnQxsbldGRF23azWjRfe7zUlAldyrwN84a1E5w==
+  version "16.18.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.28.tgz#f674e1577827c5282e5005c3fa99ea06df835c49"
+  integrity sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==
 
 "@types/node@^18.11.18":
-  version "18.16.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.6.tgz#d0ffffe201b253989b17ea157ddabec677a4f4fe"
-  integrity sha512-N7KINmeB8IN3vRR8dhgHEp+YpWvGFcpDoh5XZ8jB5a00AdFKCKEyyGTOPTddUf4JqU1ZKTVxkOxakDvchNVI2Q==
+  version "18.16.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.7.tgz#86d0ba2541f808cb78d4dc5d3e40242a349d6db8"
+  integrity sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -4816,7 +4816,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react-transition-group@^4.4.5":
+"@types/react-transition-group@^4.4.6":
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.6.tgz#18187bcda5281f8e10dfc48f0943e2fdf4f75e2e"
   integrity sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==
@@ -8601,9 +8601,9 @@ electron-publish@23.6.0:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.388"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.388.tgz#ec0d1be823d5b14da56d91ec5c57e84b4624ea45"
-  integrity sha512-xZ0y4zjWZgp65okzwwt00f2rYibkFPHUv9qBz+Vzn8cB9UXIo9Zc6Dw81LJYhhNt0G/vR1OJEfStZ49NKl0YxQ==
+  version "1.4.391"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.391.tgz#197994210792e29e39baf3ce807df42f66e9b5f8"
+  integrity sha512-GqydVV1+kUWY5qlEzaw34/hyWTApuQrHiGrcGA2Kk/56nEK44i+YUW45VH43JuZT0Oo7uY8aVtpPhBBZXEWtSA==
 
 electron-updater@^5.0.1:
   version "5.3.0"
@@ -8708,7 +8708,7 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.13.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.14.0:
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz#0b6c676c8a3266c99fa281e4433a706f5c0c61c4"
   integrity sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==
@@ -9114,9 +9114,9 @@ eslint-plugin-react@^7.27.1:
     string.prototype.matchall "^4.0.8"
 
 eslint-plugin-testing-library@^5.0.1:
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.3.tgz#e613fbaf9a145e9eef115d080b32cb488fae622e"
-  integrity sha512-0yhsKFsjHLud5PM+f2dWr9K3rqYzMy4cSHs3lcmFYMa1CdSzRvHGgXvsFarBjZ41gU8jhTdMIkg8jHLxGJqLqw==
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.0.tgz#0bad7668e216e20dd12f8c3652ca353009163121"
+  integrity sha512-ELY7Gefo+61OfXKlQeXNIDVVLPcvKTeiQOoMZG9TeuWa7Ln4dUNRv8JdRWBQI9Mbb427XGlVB1aa1QPZxBJM8Q==
   dependencies:
     "@typescript-eslint/utils" "^5.58.0"
 
@@ -9763,9 +9763,9 @@ flatted@^3.1.0:
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 flow-parser@0.*:
-  version "0.205.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.205.1.tgz#337464aaf027b00b2514610386cf21a5f7c94137"
-  integrity sha512-+RF/e1Et6ZX2I/UG7SGAz3Z8+ulj9xKYLu5AD7Wi8H2llzncU8ZpdKfLR50pPvj4g2a/FbZWkXYL7qHc+zXJNA==
+  version "0.206.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.206.0.tgz#f4f794f8026535278393308e01ea72f31000bfef"
+  integrity sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==
 
 follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.2"
@@ -10270,9 +10270,9 @@ glob@7.1.6:
     path-is-absolute "^1.0.0"
 
 glob@^10.0.0, glob@^10.2.2:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.2.tgz#ce2468727de7e035e8ecf684669dc74d0526ab75"
-  integrity sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.3.tgz#aa6765963fe6c5936d5c2e00943e7af06302a1a7"
+  integrity sha512-Kb4rfmBVE3eQTAimgmeqc2LwSnN0wIOkkUL6HmxEFxNJ4fHghYHVbFba/HcGcRjE6s9KoMNK3rSOwkL4PioZjg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^2.0.3"
@@ -13177,7 +13177,7 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-lru-cache@^9.0.0:
+lru-cache@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.1.tgz#c58a93de58630b688de39ad04ef02ef26f1902f1"
   integrity sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==
@@ -14875,11 +14875,11 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-scurry@^1.6.1, path-scurry@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.7.0.tgz#99c741a2cfbce782294a39994d63748b5a24f6db"
-  integrity sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.8.0.tgz#809e09690c63817c76d0183f19a5b21b530ff7d2"
+  integrity sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==
   dependencies:
-    lru-cache "^9.0.0"
+    lru-cache "^9.1.1"
     minipass "^5.0.0"
 
 path-to-regexp@0.1.7:
@@ -17213,9 +17213,9 @@ signal-exit@3.0.7, signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, s
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 signal-exit@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.1.tgz#96a61033896120ec9335d96851d902cc98f0ba2a"
-  integrity sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.2.tgz#ff55bb1d9ff2114c13b400688fa544ac63c36967"
+  integrity sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==
 
 sigstore@^1.0.0, sigstore@^1.3.0, sigstore@^1.4.0:
   version "1.4.0"
@@ -18414,11 +18414,12 @@ tty-browserify@^0.0.1:
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
 tuf-js@^1.1.3:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/tuf-js/-/tuf-js-1.1.5.tgz#ad82a18c5db42f142d2d2e15d6d25655e30c03c3"
-  integrity sha512-inqodgxdsmuxrtQVbu6tPNgRKWD1Boy3VB6GO7KczJZpAHiTukwhSzXUSzvDcw5pE2Jo8ua+e1ykpHv7VdPVlQ==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/tuf-js/-/tuf-js-1.1.6.tgz#ad3e7a20237b83b51c2a8f9d1ddf093279a10fc2"
+  integrity sha512-CXwFVIsXGbVY4vFiWF7TJKWmlKJAT8TWkH4RmiohJRcDJInix++F0dznDmoVbtJNzZ8yLprKUG4YrDIhv3nBMg==
   dependencies:
     "@tufjs/models" "1.0.4"
+    debug "^4.3.4"
     make-fetch-happen "^11.1.0"
 
 tunnel-agent@^0.6.0:
@@ -19109,9 +19110,9 @@ webpack-virtual-modules@^0.4.3, webpack-virtual-modules@^0.4.5:
   integrity sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==
 
 webpack@5, webpack@^5.0.0, webpack@^5.64.4, webpack@^5.72.0:
-  version "5.82.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
-  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
+  version "5.82.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.1.tgz#8f38c78e53467556e8a89054ebd3ef6e9f67dbab"
+  integrity sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"
@@ -19122,7 +19123,7 @@ webpack@5, webpack@^5.0.0, webpack@^5.64.4, webpack@^5.72.0:
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
+    enhanced-resolve "^5.14.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"


### PR DESCRIPTION
https://github.com/GMOD/jbrowse-components/pull/3697 reintroduced the render delay for the non block based arc tracks, which only renders after a certain timeout instead of on every frame, but this PR adds code to instantly render after a zoom level change, instead of after a render delay, which helps avoid "blanking" (a new vocab word) of the screen