### PR TITLE
Fix rendering error in alignments tracks when filtering by tag in CRAM file

### DIFF
--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -253,8 +253,7 @@ export default class CramAdapter extends BaseFeatureDataAdapter {
 
       if (tagFilter) {
         filtered = filtered.filter(record => {
-          // @ts-expect-error
-          const val = record[tagFilter.tag]
+          const val = record.tags[tagFilter.tag]
           return val === '*' ? val !== undefined : `${val}` === tagFilter.value
         })
       }


### PR DESCRIPTION
When filtering by tag name and value in a CRAM file's alignments track, no features are rendered.

before filtering by tag:
<img width="584" alt="Screen Shot 2023-05-12 at 15 31 09" src="https://github.com/GMOD/jbrowse-components/assets/81499006/f515fd2b-74a1-4c13-8c4d-18bac4e313ae">

after filtering by tag:
<img width="603" alt="Screen Shot 2023-05-12 at 15 23 04" src="https://github.com/GMOD/jbrowse-components/assets/81499006/feb055e9-ff7a-4520-965a-be082be62442">

I fixed it by changing `const val = record[tagFilter.tag]` into `const val = record.tags[tagFilter.tag]`.