### PR TITLE
 Fix breakpoint split view alignment connections not pointing at right position (pt 2)

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -69,7 +69,11 @@ export default observer(function TrackContainer({
     >
       <TrackLabelContainer track={track} view={model} />
       <ErrorBoundary FallbackComponent={e => <ErrorMessage error={e.error} />}>
-        <TrackRenderingContainer model={model} track={track} />
+        <TrackRenderingContainer
+          model={model}
+          track={track}
+          onDragEnter={debouncedOnDragEnter}
+        />
       </ErrorBoundary>
       <div
         className={classes.overlay}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -69,6 +69,7 @@ export default observer(function TrackContainer({
   const { height, RenderingComponent, DisplayBlurb } = display
   const trackId = getConf(track, 'trackId')
   const ref = useRef(null)
+  const ref2 = useRef<HTMLDivElement>(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
   const minimized = track.minimized
   const debouncedOnDragEnter = useDebouncedCallback(() => {
@@ -86,7 +87,17 @@ export default observer(function TrackContainer({
   }, [model.trackRefs, trackId])
 
   return (
-    <Paper className={classes.root} variant="outlined">
+    <Paper
+      ref={ref2}
+      className={classes.root}
+      variant="outlined"
+      onClick={event => {
+        if (event.detail === 2 && !track.displays[0].featureIdUnderMouse) {
+          const left = ref2.current?.getBoundingClientRect().left || 0
+          model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
+        }
+      }}
+    >
       <TrackLabelContainer track={track} view={model} />
       <ErrorBoundary FallbackComponent={e => <ErrorMessage error={e.error} />}>
         <div

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -68,7 +68,7 @@ export default observer(function TrackContainer({
   const { horizontalScroll, draggingTrackId, moveTrack } = model
   const { height, RenderingComponent, DisplayBlurb } = display
   const trackId = getConf(track, 'trackId')
-  const ref = useRef(null)
+  const ref = useRef<HTMLDivElement>(null)
   const ref2 = useRef<HTMLDivElement>(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
   const minimized = track.minimized

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import { Paper } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
@@ -7,13 +7,13 @@ import { ErrorBoundary } from 'react-error-boundary'
 
 // jbrowse core
 import { BaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
-import { getConf } from '@jbrowse/core/configuration'
 import { ResizeHandle, ErrorMessage } from '@jbrowse/core/ui'
 import { useDebouncedCallback } from '@jbrowse/core/util'
 
 // locals
 import { LinearGenomeViewModel } from '..'
 import TrackLabelContainer from './TrackLabelContainer'
+import TrackRenderingContainer from './TrackRenderingContainer'
 
 const useStyles = makeStyles()({
   root: {
@@ -33,25 +33,6 @@ const useStyles = makeStyles()({
     width: '100%',
     zIndex: 3,
   },
-
-  // aligns with block boundaries. check for example the breakpoint split view
-  // demo to see if features align if wanting to change things
-  renderingComponentContainer: {
-    position: 'absolute',
-    // -1 offset because of the 1px border of the Paper
-    left: -1,
-    height: '100%',
-    width: '100%',
-  },
-
-  trackRenderingContainer: {
-    overflowY: 'auto',
-    overflowX: 'hidden',
-    whiteSpace: 'nowrap',
-    position: 'relative',
-    background: 'none',
-    zIndex: 2,
-  },
 })
 
 type LGV = LinearGenomeViewModel
@@ -65,26 +46,14 @@ export default observer(function TrackContainer({
 }) {
   const { classes } = useStyles()
   const display = track.displays[0]
-  const { horizontalScroll, draggingTrackId, moveTrack } = model
-  const { height, RenderingComponent, DisplayBlurb } = display
-  const trackId = getConf(track, 'trackId')
-  const ref = useRef<HTMLDivElement>(null)
+  const { draggingTrackId } = model
   const ref2 = useRef<HTMLDivElement>(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
-  const minimized = track.minimized
   const debouncedOnDragEnter = useDebouncedCallback(() => {
     if (isAlive(display) && dimmed) {
-      moveTrack(draggingTrackId, track.id)
+      model.moveTrack(draggingTrackId, track.id)
     }
   }, 100)
-  useEffect(() => {
-    if (ref.current) {
-      model.trackRefs[trackId] = ref.current
-    }
-    return () => {
-      delete model.trackRefs[trackId]
-    }
-  }, [model.trackRefs, trackId])
 
   return (
     <Paper
@@ -100,40 +69,7 @@ export default observer(function TrackContainer({
     >
       <TrackLabelContainer track={track} view={model} />
       <ErrorBoundary FallbackComponent={e => <ErrorMessage error={e.error} />}>
-        <div
-          className={classes.trackRenderingContainer}
-          style={{ height: minimized ? 20 : height }}
-          onScroll={evt => display.setScrollTop(evt.currentTarget.scrollTop)}
-          onDragEnter={debouncedOnDragEnter}
-          data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
-        >
-          {!minimized ? (
-            <>
-              <div
-                ref={ref}
-                className={classes.renderingComponentContainer}
-                style={{ transform: `scaleX(${model.scaleFactor})` }}
-              >
-                <RenderingComponent
-                  model={display}
-                  onHorizontalScroll={horizontalScroll}
-                />
-              </div>
-
-              {DisplayBlurb ? (
-                <div
-                  style={{
-                    position: 'absolute',
-                    left: 0,
-                    top: display.height - 20,
-                  }}
-                >
-                  <DisplayBlurb model={display} />
-                </div>
-              ) : null}
-            </>
-          ) : null}
-        </div>
+        <TrackRenderingContainer model={model} track={track} />
       </ErrorBoundary>
       <div
         className={classes.overlay}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles()({
 
 type LGV = LinearGenomeViewModel
 
-function TrackContainer({
+export default observer(function TrackContainer({
   model,
   track,
 }: {
@@ -68,7 +68,7 @@ function TrackContainer({
   const { horizontalScroll, draggingTrackId, moveTrack } = model
   const { height, RenderingComponent, DisplayBlurb } = display
   const trackId = getConf(track, 'trackId')
-  const ref = useRef<HTMLDivElement>(null)
+  const ref = useRef(null)
   const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
   const minimized = track.minimized
   const debouncedOnDragEnter = useDebouncedCallback(() => {
@@ -86,22 +86,9 @@ function TrackContainer({
   }, [model.trackRefs, trackId])
 
   return (
-    <Paper
-      ref={ref}
-      className={classes.root}
-      variant="outlined"
-      onClick={event => {
-        if (event.detail === 2 && !track.displays[0].featureIdUnderMouse) {
-          const left = ref.current?.getBoundingClientRect().left || 0
-          model.zoomTo(model.bpPerPx / 2, event.clientX - left, true)
-        }
-      }}
-    >
+    <Paper className={classes.root} variant="outlined">
       <TrackLabelContainer track={track} view={model} />
-      <ErrorBoundary
-        key={track.id}
-        FallbackComponent={({ error }) => <ErrorMessage error={error} />}
-      >
+      <ErrorBoundary FallbackComponent={e => <ErrorMessage error={e.error} />}>
         <div
           className={classes.trackRenderingContainer}
           style={{ height: minimized ? 20 : height }}
@@ -112,6 +99,7 @@ function TrackContainer({
           {!minimized ? (
             <>
               <div
+                ref={ref}
                 className={classes.renderingComponentContainer}
                 style={{ transform: `scaleX(${model.scaleFactor})` }}
               >
@@ -150,6 +138,4 @@ function TrackContainer({
       />
     </Paper>
   )
-}
-
-export default observer(TrackContainer)
+})

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useRef } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
-import { isAlive } from 'mobx-state-tree'
 
 // jbrowse core
 import { BaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { getConf } from '@jbrowse/core/configuration'
-import { useDebouncedCallback } from '@jbrowse/core/util'
 
 // locals
 import { LinearGenomeViewModel } from '..'
@@ -37,23 +35,19 @@ type LGV = LinearGenomeViewModel
 export default observer(function TrackRenderingContainer({
   model,
   track,
+  onDragEnter,
 }: {
   model: LGV
   track: BaseTrackModel
+  onDragEnter: () => void
 }) {
   const { classes } = useStyles()
   const display = track.displays[0]
-  const { draggingTrackId } = model
   const { height, RenderingComponent, DisplayBlurb } = display
   const trackId = getConf(track, 'trackId')
   const ref = useRef<HTMLDivElement>(null)
-  const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
   const minimized = track.minimized
-  const debouncedOnDragEnter = useDebouncedCallback(() => {
-    if (isAlive(display) && dimmed) {
-      model.moveTrack(draggingTrackId, track.id)
-    }
-  }, 100)
+
   useEffect(() => {
     if (ref.current) {
       model.trackRefs[trackId] = ref.current
@@ -68,7 +62,7 @@ export default observer(function TrackRenderingContainer({
       className={classes.trackRenderingContainer}
       style={{ height: minimized ? 20 : height }}
       onScroll={evt => display.setScrollTop(evt.currentTarget.scrollTop)}
-      onDragEnter={debouncedOnDragEnter}
+      onDragEnter={onDragEnter}
       data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
     >
       {!minimized ? (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from 'react'
+import { makeStyles } from 'tss-react/mui'
+import { observer } from 'mobx-react'
+import { isAlive } from 'mobx-state-tree'
+
+// jbrowse core
+import { BaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
+import { getConf } from '@jbrowse/core/configuration'
+import { useDebouncedCallback } from '@jbrowse/core/util'
+
+// locals
+import { LinearGenomeViewModel } from '..'
+
+const useStyles = makeStyles()({
+  // aligns with block boundaries. check for example the breakpoint split view
+  // demo to see if features align if wanting to change things
+  renderingComponentContainer: {
+    position: 'absolute',
+    // -1 offset because of the 1px border of the Paper
+    left: -1,
+    height: '100%',
+    width: '100%',
+  },
+
+  trackRenderingContainer: {
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    whiteSpace: 'nowrap',
+    position: 'relative',
+    background: 'none',
+    zIndex: 2,
+  },
+})
+
+type LGV = LinearGenomeViewModel
+
+export default observer(function TrackRenderingContainer({
+  model,
+  track,
+}: {
+  model: LGV
+  track: BaseTrackModel
+}) {
+  const { classes } = useStyles()
+  const display = track.displays[0]
+  const { draggingTrackId } = model
+  const { height, RenderingComponent, DisplayBlurb } = display
+  const trackId = getConf(track, 'trackId')
+  const ref = useRef<HTMLDivElement>(null)
+  const dimmed = draggingTrackId !== undefined && draggingTrackId !== display.id
+  const minimized = track.minimized
+  const debouncedOnDragEnter = useDebouncedCallback(() => {
+    if (isAlive(display) && dimmed) {
+      model.moveTrack(draggingTrackId, track.id)
+    }
+  }, 100)
+  useEffect(() => {
+    if (ref.current) {
+      model.trackRefs[trackId] = ref.current
+    }
+    return () => {
+      delete model.trackRefs[trackId]
+    }
+  }, [model.trackRefs, trackId])
+
+  return (
+    <div
+      className={classes.trackRenderingContainer}
+      style={{ height: minimized ? 20 : height }}
+      onScroll={evt => display.setScrollTop(evt.currentTarget.scrollTop)}
+      onDragEnter={debouncedOnDragEnter}
+      data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
+    >
+      {!minimized ? (
+        <>
+          <div
+            ref={ref}
+            className={classes.renderingComponentContainer}
+            style={{ transform: `scaleX(${model.scaleFactor})` }}
+          >
+            <RenderingComponent
+              model={display}
+              onHorizontalScroll={model.horizontalScroll}
+            />
+          </div>
+
+          {DisplayBlurb ? (
+            <div
+              style={{
+                position: 'absolute',
+                left: 0,
+                top: display.height - 20,
+              }}
+            >
+              <DisplayBlurb model={display} />
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+})

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -14,18 +14,21 @@ import Gridlines from './Gridlines'
 import CenterLine from './CenterLine'
 import VerticalGuide from './VerticalGuide'
 import RubberbandSpan from './RubberbandSpan'
-import { getEnv } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()({
   tracksContainer: {
     position: 'relative',
     overflow: 'hidden',
   },
+  spacer: {
+    position: 'relative',
+    height: 3,
+  },
 })
 
 type LGV = LinearGenomeViewModel
 
-export default observer(function TracksContainer({
+function TracksContainer({
   children,
   model,
 }: {
@@ -33,7 +36,6 @@ export default observer(function TracksContainer({
   model: LGV
 }) {
   const { classes } = useStyles()
-  const { pluginManager } = getEnv(model)
   const { mouseDown: mouseDown1, mouseUp } = useSideScroll(model)
   const ref = useRef<HTMLDivElement>(null)
   const {
@@ -52,12 +54,6 @@ export default observer(function TracksContainer({
     mouseDown: mouseDown2,
   } = useRangeSelect(ref, model, true)
   useWheelScroll(ref, model)
-
-  const additionals = pluginManager.evaluateExtensionPoint(
-    'LinearGenomeView-TracksContainerComponent',
-    undefined,
-    { model },
-  ) as React.ReactNode
 
   return (
     <div
@@ -107,8 +103,9 @@ export default observer(function TracksContainer({
           />
         }
       />
-      {additionals}
       {children}
     </div>
   )
-})
+}
+
+export default observer(TracksContainer)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -14,6 +14,7 @@ import Gridlines from './Gridlines'
 import CenterLine from './CenterLine'
 import VerticalGuide from './VerticalGuide'
 import RubberbandSpan from './RubberbandSpan'
+import { getEnv } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()({
   tracksContainer: {
@@ -32,6 +33,7 @@ export default observer(function TracksContainer({
   model: LGV
 }) {
   const { classes } = useStyles()
+  const { pluginManager } = getEnv(model)
   const { mouseDown: mouseDown1, mouseUp } = useSideScroll(model)
   const ref = useRef<HTMLDivElement>(null)
   const {
@@ -50,6 +52,12 @@ export default observer(function TracksContainer({
     mouseDown: mouseDown2,
   } = useRangeSelect(ref, model, true)
   useWheelScroll(ref, model)
+
+  const additionals = pluginManager.evaluateExtensionPoint(
+    'LinearGenomeView-TracksContainerComponent',
+    undefined,
+    { model },
+  ) as React.ReactNode
 
   return (
     <div
@@ -99,6 +107,7 @@ export default observer(function TracksContainer({
           />
         }
       />
+      {additionals}
       {children}
     </div>
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -20,15 +20,11 @@ const useStyles = makeStyles()({
     position: 'relative',
     overflow: 'hidden',
   },
-  spacer: {
-    position: 'relative',
-    height: 3,
-  },
 })
 
 type LGV = LinearGenomeViewModel
 
-function TracksContainer({
+export default observer(function TracksContainer({
   children,
   model,
 }: {
@@ -106,6 +102,4 @@ function TracksContainer({
       {children}
     </div>
   )
-}
-
-export default observer(TracksContainer)
+})

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1,4 +1,4 @@
-import React, { Ref, lazy } from 'react'
+import React, { lazy } from 'react'
 import { getConf, AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { Region } from '@jbrowse/core/util/types'

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react'
+import React, { Ref, lazy } from 'react'
 import { getConf, AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { Region } from '@jbrowse/core/util/types'
@@ -251,8 +251,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       // which is basically like an onLoad
       afterDisplayedRegionsSetCallbacks: [] as Function[],
       scaleFactor: 1,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      trackRefs: {} as { [key: string]: any },
+      trackRefs: {} as { [key: string]: HTMLDivElement },
       coarseDynamicBlocks: [] as BaseBlock[],
       coarseTotalBp: 0,
       leftOffset: undefined as undefined | BpOffset,


### PR DESCRIPTION
Additional follow up to https://github.com/GMOD/jbrowse-components/pull/3691

Restores the modularization that was reverted in that PR, and fixes an issue where vertical scrolling wasn't working