### PR TITLE
Add removable-media to jbrowse desktop snap

### DIFF
--- a/packages/core/data_adapters/BaseAdapter/index.ts
+++ b/packages/core/data_adapters/BaseAdapter/index.ts
@@ -19,6 +19,6 @@ export interface AnyAdapter {
   new (
     config: AnyConfigurationModel,
     getSubAdapter?: getSubAdapterType,
-    pluginManager?: PluginManager | undefined,
+    pluginManager?: PluginManager,
   ): AnyDataAdapter
 }

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -117,6 +117,17 @@
     "appId": "org.jbrowse2.app",
     "productName": "JBrowse 2",
     "copyright": "Copyright © 2019",
+    "snap": {
+      "confinement": "strict",
+      "plugs": [
+        "default",
+        "removable-media"
+      ],
+      "slots": [
+        "default",
+        "removable-media"
+      ]
+    },
     "win": {
       "publish": [
         "github"


### PR DESCRIPTION
May help with https://github.com/GMOD/jbrowse-components/issues/3683

I am unable to build the electron-builder binaries locally (could be a separate issue, it is just confusing for my build environment) so difficult to test this