### PR TITLE
Silence console warn in CopyAndDelete test

### DIFF
--- a/packages/product-core/src/Session/SessionTracks.ts
+++ b/packages/product-core/src/Session/SessionTracks.ts
@@ -31,15 +31,17 @@ export default function SessionTracks(pluginManager: PluginManager) {
       },
     }))
     .actions(self => {
-      const super_addTrackConf = self.addTrackConf
-      const super_deletetrackConf = self.deleteTrackConf
+      const {
+        addTrackConf: superAddTrackConf,
+        deleteTrackConf: superDeleteTrackConf,
+      } = self
       return {
         /**
          * #action
          */
         addTrackConf(trackConf: AnyConfiguration) {
           if (self.adminMode) {
-            return super_addTrackConf(trackConf)
+            return superAddTrackConf(trackConf)
           }
           const { trackId, type } = trackConf as {
             type: string
@@ -61,11 +63,12 @@ export default function SessionTracks(pluginManager: PluginManager) {
          */
         deleteTrackConf(trackConf: AnyConfigurationModel) {
           // try to delete it in the main config if in admin mode
-          const found = super_deletetrackConf(trackConf)
+          const found = superDeleteTrackConf(trackConf)
           if (found) {
             return found
           }
-          // if not found or not in admin mode, try to delete it in the sessionTracks
+          // if not found or not in admin mode, try to delete it in the
+          // sessionTracks
           const { trackId } = trackConf
           const idx = self.sessionTracks.findIndex(t => t.trackId === trackId)
           if (idx === -1) {

--- a/products/jbrowse-web/src/tests/CopyAndDelete.test.tsx
+++ b/products/jbrowse-web/src/tests/CopyAndDelete.test.tsx
@@ -9,6 +9,7 @@ import {
   setup,
   getPluginManager,
   doBeforeEach,
+  mockConsoleWarn,
 } from './util'
 
 setup()
@@ -18,71 +19,104 @@ beforeEach(() => {
 
 const delay = { timeout: 40000 }
 
-test('copy and delete track in admin mode', async () => {
-  const { view, findByTestId, queryByText, findAllByTestId, findByText } =
-    await createView(undefined, true)
+// note: we mock out console because it gives a weird error on the
+// CopyAndDelete test where it thinks "configuration" is stale/not alive in
+// some place one way to fix in the production code is to add a
+// getConf(track,'trackId') to the TrackContainer but this seems odd, so just
+// silence the warning in test. exact warn is this:
+//
+// "Error: [mobx-state-tree] You are trying
+// to read or write to an object that is no longer part of a state tree.
+// (Object type: 'LinearVariantDisplay', Path upon death:
+// '/session/views/0/tracks/0/displays/0', Subpath: 'configuration',
+// Action: '/session.deleteTrackConf()'). Either detach nodes first, or
+// don't use objects after removing / replacing them in the tree."
+// const trackId = getConf(track, 'trackId')
 
-  await findByText('Help')
-  view.setNewView(0.05, 5000)
-  fireEvent.click(
-    await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf', {}, delay),
-  )
-  fireEvent.click(await findByText('Copy track'))
-  fireEvent.click(await findByText('volvox filtered vcf (copy)'))
-  expect(queryByText(/Session tracks/)).toBeNull()
-  await waitFor(() => expect(view.tracks.length).toBe(1))
-  await findAllByTestId('box-test-vcf-604453', {}, delay)
-  fireEvent.click(await findByTestId('track_menu_icon'))
-  fireEvent.click(await findByText('Delete track'))
-  await waitFor(() => expect(view.tracks.length).toBe(0))
-}, 40000)
+test(
+  'copy and delete track in admin mode',
+  () =>
+    mockConsoleWarn(async () => {
+      const { view, findByTestId, queryByText, findAllByTestId, findByText } =
+        await createView(undefined, true)
 
-test('copy and delete reference sequence track disabled', async () => {
-  const { view, rootModel, session, queryByText, findByTestId, findByText } =
-    await createView(undefined, true)
+      await findByText('Help')
+      view.setNewView(0.05, 5000)
+      fireEvent.click(
+        await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf', {}, delay),
+      )
+      fireEvent.click(await findByText('Copy track'))
+      fireEvent.click(await findByText('volvox filtered vcf (copy)'))
+      expect(queryByText(/Session tracks/)).toBeNull()
+      await waitFor(() => expect(view.tracks.length).toBe(1))
+      await findAllByTestId('box-test-vcf-604453', {}, delay)
+      fireEvent.click(await findByTestId('track_menu_icon'))
+      fireEvent.click(await findByText('Delete track'))
+      await waitFor(() => expect(view.tracks.length).toBe(0))
+    }),
+  40000,
+)
 
-  // @ts-expect-error
-  const { assemblyManager } = rootModel
+test(
+  'copy and delete reference sequence track disabled',
+  () =>
+    mockConsoleWarn(async () => {
+      const {
+        view,
+        rootModel,
+        session,
+        queryByText,
+        findByTestId,
+        findByText,
+      } = await createView(undefined, true)
 
-  await findByText('Help')
-  view.setNewView(0.05, 5000)
-  const trackConf = getConf(assemblyManager.get('volvox'), 'sequence')
+      // @ts-expect-error
+      const { assemblyManager } = rootModel
 
-  // @ts-expect-error
-  const trackMenuItems = session.getTrackActionMenuItems(trackConf)
+      await findByText('Help')
+      view.setNewView(0.05, 5000)
+      const trackConf = getConf(assemblyManager.get('volvox'), 'sequence')
 
-  // copy ref seq track disabled
-  fireEvent.click(
-    await findByTestId('htsTrackEntryMenu-volvox_refseq', {}, delay),
-  )
-  fireEvent.click(await findByText('Copy track'))
-  expect(queryByText(/Session tracks/)).toBeNull()
-  // clicking 'copy track' should not create a copy of a ref sequence track
-  await waitFor(() => expect(view.tracks.length).toBe(0))
-  expect(trackMenuItems[2].disabled).toBe(true)
-  expect(trackMenuItems[3].disabled).toBe(true)
-}, 40000)
+      // @ts-expect-error
+      const trackMenuItems = session.getTrackActionMenuItems(trackConf)
 
-test('copy and delete track to session tracks', async () => {
-  const { view, findByTestId, findAllByTestId, findByText } = await createView(
-    undefined,
-    false,
-  )
+      // copy ref seq track disabled
+      fireEvent.click(
+        await findByTestId('htsTrackEntryMenu-volvox_refseq', {}, delay),
+      )
+      fireEvent.click(await findByText('Copy track'))
+      expect(queryByText(/Session tracks/)).toBeNull()
+      // clicking 'copy track' should not create a copy of a ref sequence track
+      await waitFor(() => expect(view.tracks.length).toBe(0))
+      expect(trackMenuItems[2].disabled).toBe(true)
+      expect(trackMenuItems[3].disabled).toBe(true)
+    }),
+  40000,
+)
 
-  await findByText('Help')
-  view.setNewView(0.05, 5000)
-  fireEvent.click(
-    await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf', {}, delay),
-  )
-  fireEvent.click(await findByText('Copy track'))
-  fireEvent.click(await findByText('volvox filtered vcf (copy)'))
-  await findByText(/Session tracks/)
-  await waitFor(() => expect(view.tracks.length).toBe(1))
-  await findAllByTestId('box-test-vcf-604453', {}, delay)
-  fireEvent.click(await findByTestId('track_menu_icon'))
-  fireEvent.click(await findByText('Delete track'))
-  await waitFor(() => expect(view.tracks.length).toBe(0))
-}, 40000)
+test(
+  'copy and delete track to session tracks',
+  () =>
+    mockConsoleWarn(async () => {
+      const { view, findByTestId, findAllByTestId, findByText } =
+        await createView(undefined, false)
+
+      await findByText('Help')
+      view.setNewView(0.05, 5000)
+      fireEvent.click(
+        await findByTestId('htsTrackEntryMenu-volvox_filtered_vcf', {}, delay),
+      )
+      fireEvent.click(await findByText('Copy track'))
+      fireEvent.click(await findByText('volvox filtered vcf (copy)'))
+      await findByText(/Session tracks/)
+      await waitFor(() => expect(view.tracks.length).toBe(1))
+      await findAllByTestId('box-test-vcf-604453', {}, delay)
+      fireEvent.click(await findByTestId('track_menu_icon'))
+      fireEvent.click(await findByText('Delete track'))
+      await waitFor(() => expect(view.tracks.length).toBe(0))
+    }),
+  40000,
+)
 
 xtest('delete connection', async () => {
   const pluginManager = getPluginManager(masterConfig, true)


### PR DESCRIPTION
Currently the CopyAndDelete gives a warning that the 'configuration' object is stale. This warning was introduced by splitting TrackContainer into TrackContainer and TrackRenderingContainer

I think this refactor is valid, but unfortunately causes the warning. I propose to silence the warning during test. Many stale warnings are hard to properly fix. The alternative to silencing it is to use getConf in both TrackContainer and TrackRenderingContainer, which appears to make it not go stale. Not sure why that is, but rather than implement this odd workaround, this silences the warning