### PR TITLE
Allow synteny data adapters to open files larger than 512Mb

### DIFF
--- a/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
@@ -13,11 +13,6 @@ export default class ChainAdapter extends PAFAdapter {
     const loc = openLocation(this.getConf('chainLocation'), this.pluginManager)
     const buffer = (await loc.readFile(opts)) as Buffer
     const buf = isGzip(buffer) ? await unzip(buffer) : buffer
-    // 512MB  max chrome string length is 512MB
-    if (buf.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
-    const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
-    return paf_chain2paf(text.split(/\n|\r\n|\r/).filter(line => !!line))
+    return paf_chain2paf(buf)
   }
 }

--- a/plugins/comparative-adapters/src/ChainAdapter/util.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/util.ts
@@ -1,3 +1,6 @@
+const decoder =
+  typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined
+
 /* adapted from chain2paf by Andrea Guarracino, license reproduced below
  *
  * MIT License
@@ -51,7 +54,7 @@ function generate_record(
   }
 }
 
-export function paf_chain2paf(lines: string[]) {
+export function paf_chain2paf(buffer: Buffer) {
   let t_name = ''
   let t_start = 0
   let t_end = 0
@@ -63,8 +66,16 @@ export function paf_chain2paf(lines: string[]) {
   let num_matches = 0
   let cigar = ''
   const records = []
-  for (let i = 0; i < lines.length; i++) {
-    const l = lines[i]
+
+  let blockStart = 0
+  while (blockStart < buffer.length) {
+    const n = buffer.indexOf('\n', blockStart)
+    if (n === -1) {
+      break
+    }
+    const b = buffer.slice(blockStart, n)
+    const l = (decoder?.decode(b) || b.toString()).trim()
+    blockStart = n + 1
     const l_tab = l.replace(/ /g, '\t') // There are CHAIN files with space-separated fields
     const l_vec = l_tab.split('\t')
 

--- a/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
@@ -13,12 +13,6 @@ export default class DeltaAdapter extends PAFAdapter {
     const loc = openLocation(this.getConf('deltaLocation'), this.pluginManager)
     const buffer = (await loc.readFile(opts)) as Buffer
     const buf = isGzip(buffer) ? await unzip(buffer) : buffer
-    // 512MB  max chrome string length is 512MB
-    if (buf.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
-    const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
-
-    return paf_delta2paf(text.split(/\n|\r\n|\r/).filter(line => !!line))
+    return paf_delta2paf(buf)
   }
 }

--- a/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
@@ -2,6 +2,7 @@ import { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { openLocation } from '@jbrowse/core/util/io'
 import { unzip } from '@gmod/bgzf-filehandle'
 import PAFAdapter from '../PAFAdapter/PAFAdapter'
+import { parseLineByLine } from '../util'
 
 function isGzip(buf: Buffer) {
   return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
@@ -12,37 +13,28 @@ export default class MashMapAdapter extends PAFAdapter {
     const outLoc = openLocation(this.getConf('outLocation'), this.pluginManager)
     const buffer = (await outLoc.readFile(opts)) as Buffer
     const buf = isGzip(buffer) ? await unzip(buffer) : buffer
-    // 512MB  max chrome string length is 512MB
-    if (buf.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
-    const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
+    return parseLineByLine(buf, parseMashMapLine)
+  }
+}
 
-    // mashmap produces PAF-like data that is space separated instead of tab
-    return text
-      .split(/\n|\r\n|\r/)
-      .filter(line => !!line)
-      .map(line => {
-        const fields = line.split(' ')
-        if (fields.length < 9) {
-          // xref https://github.com/marbl/MashMap/issues/38
-          throw new Error('improperly formatted line: ' + line)
-        }
-        const [qname, , qstart, qend, strand, tname, , tstart, tend, mq] =
-          fields
+function parseMashMapLine(line: string) {
+  const fields = line.split(' ')
+  if (fields.length < 9) {
+    // xref https://github.com/marbl/MashMap/issues/38
+    throw new Error('improperly formatted line: ' + line)
+  }
+  const [qname, , qstart, qend, strand, tname, , tstart, tend, mq] = fields
 
-        return {
-          tname,
-          tstart: +tstart,
-          tend: +tend,
-          qname,
-          qstart: +qstart,
-          qend: +qend,
-          strand: strand === '-' ? -1 : 1,
-          extra: {
-            mappingQual: +mq,
-          },
-        }
-      })
+  return {
+    tname,
+    tstart: +tstart,
+    tend: +tend,
+    qname,
+    qstart: +qstart,
+    qend: +qend,
+    strand: strand === '-' ? -1 : 1,
+    extra: {
+      mappingQual: +mq,
+    },
   }
 }

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -16,12 +16,12 @@ import { MismatchParser } from '@jbrowse/plugin-alignments'
 
 // locals
 import SyntenyFeature from './SyntenyFeature'
-import { isGzip } from '../util'
+import { isGzip, parseLineByLine } from '../util'
 import {
   getWeightedMeans,
   flipCigar,
-  parsePAF,
   swapIndelCigar,
+  parsePAFLine,
   PAFRecord,
 } from './util'
 
@@ -51,12 +51,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
     const pafLocation = openLocation(this.getConf('pafLocation'), pm)
     const buffer = (await pafLocation.readFile(opts)) as Buffer
     const buf = isGzip(buffer) ? await unzip(buffer) : buffer
-    // 512MB  max chrome string length is 512MB
-    if (buf.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
-    const text = new TextDecoder('utf8', { fatal: true }).decode(buf)
-    return parsePAF(text)
+    return parseLineByLine(buf, parsePAFLine)
   }
 
   async hasDataForRefName() {

--- a/plugins/comparative-adapters/src/PAFAdapter/util.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/util.ts
@@ -112,52 +112,47 @@ function weightedMean(tuples: [number, number][]) {
   return valueSum / weightSum
 }
 
-export function parsePAF(text: string) {
-  return text
-    .split(/\n|\r\n|\r/)
-    .filter(line => !!line)
-    .map(line => {
-      const [
-        qname,
-        ,
-        qstart,
-        qend,
-        strand,
-        tname,
-        ,
-        tstart,
-        tend,
-        numMatches,
-        blockLen,
-        mappingQual,
-        ...fields
-      ] = line.split('\t')
+export function parsePAFLine(line: string) {
+  const [
+    qname,
+    ,
+    qstart,
+    qend,
+    strand,
+    tname,
+    ,
+    tstart,
+    tend,
+    numMatches,
+    blockLen,
+    mappingQual,
+    ...fields
+  ] = line.split('\t')
 
-      const rest = Object.fromEntries(
-        fields.map(field => {
-          const r = field.indexOf(':')
-          const fieldName = field.slice(0, r)
-          const fieldValue = field.slice(r + 3)
-          return [fieldName, fieldValue]
-        }),
-      )
+  const rest = Object.fromEntries(
+    fields.map(field => {
+      const r = field.indexOf(':')
+      const fieldName = field.slice(0, r)
+      const fieldValue = field.slice(r + 3)
+      return [fieldName, fieldValue]
+    }),
+  )
 
-      return {
-        tname,
-        tstart: +tstart,
-        tend: +tend,
-        qname,
-        qstart: +qstart,
-        qend: +qend,
-        strand: strand === '-' ? -1 : 1,
-        extra: {
-          numMatches: +numMatches,
-          blockLen: +blockLen,
-          mappingQual: +mappingQual,
-          ...rest,
-        },
-      } as PAFRecord
-    })
+  return {
+    tname,
+    tstart: +tstart,
+    tend: +tend,
+    qname,
+    qstart: +qstart,
+    qend: +qend,
+    strand: strand === '-' ? -1 : 1,
+    extra: {
+      numMatches: +numMatches,
+      blockLen: +blockLen,
+      mappingQual: +mappingQual,
+      ...rest,
+    },
+  } as PAFRecord
 }
 
 export function flipCigar(cigar: string[]) {


### PR DESCRIPTION
This changes from string based parsing (which has a max string length of ~512Mb on chrome) to buffer based parsing (which can be up to maybe 2Gb or larger perhaps https://stackoverflow.com/a/8974841/2129219)



It may be that we need to improve performance in ways beyond just this PR to truly handle the larger files, but this would be a step towards enabling it

Fixes https://github.com/GMOD/jbrowse-components/issues/3664