### PR TITLE
Fix centering of the ImportForm on SV inspector

### DIFF
--- a/packages/app-core/src/ui/ViewContainer.tsx
+++ b/packages/app-core/src/ui/ViewContainer.tsx
@@ -45,9 +45,8 @@ export default observer(function ({
   const ref = useWidthSetter(view, theme.spacing(1))
   const scrollRef = useRef<HTMLDivElement>(null)
 
-  // scroll the view into view when first mounted
-  // note that this effect will run only once, because of
-  // the empty array second param
+  // scroll the view into view when first mounted. note: this effect will run
+  // only once, because of the empty array second param
   useEffect(() => {
     scrollRef.current?.scrollIntoView?.({ block: 'center' })
   }, [])

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/BreakpointSplitView.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/BreakpointSplitView.ts
@@ -55,19 +55,17 @@ export default class BreakpointSplitViewType extends ViewType {
     }
 
     if (!mateRefName) {
-      console.warn(
+      throw new Error(
         `unable to resolve mate refName ${mateRefName} in reference genome`,
       )
-      return {}
     }
 
     const bottomRegion = assembly.regions.find(f => f.refName === mateRefName)
 
     if (!topRegion || !bottomRegion) {
-      console.warn(
+      throw new Error(
         `unable to find the refName for the top or bottom of the breakpoint view`,
       )
-      return {}
     }
 
     const topMarkedRegion = [{ ...topRegion }, { ...topRegion }]

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -1,17 +1,14 @@
 import React, { useState } from 'react'
 import {
+  Button,
+  Checkbox,
   FormControl,
   FormGroup,
   FormLabel,
   FormControlLabel,
-  Checkbox,
   RadioGroup,
   Radio,
-  Container,
-  Button,
-  Grid,
 } from '@mui/material'
-import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { getRoot } from 'mobx-state-tree'
 import { AbstractRootModel, getSession } from '@jbrowse/core/util'
@@ -20,19 +17,15 @@ import { FileSelector, ErrorMessage, AssemblySelector } from '@jbrowse/core/ui'
 // locals
 import { ImportWizardModel } from '../models/ImportWizard'
 import NumberEditor from './NumberEditor'
+import { makeStyles } from 'tss-react/mui'
 
-const useStyles = makeStyles()(theme => ({
-  buttonContainer: {
-    marginTop: theme.spacing(1),
-  },
-  grid: {
-    width: '25rem',
-    margin: '0 auto',
-  },
+const useStyles = makeStyles()({
   container: {
-    margin: theme.spacing(2),
+    margin: '0 auto',
+    maxWidth: '25em',
+    padding: 20,
   },
-}))
+})
 
 const ImportWizard = observer(({ model }: { model: ImportWizardModel }) => {
   const session = getSession(model)
@@ -53,106 +46,93 @@ const ImportWizard = observer(({ model }: { model: ImportWizardModel }) => {
   const rootModel = getRoot(model)
 
   return (
-    <Container className={classes.container}>
+    <div className={classes.container}>
       {err ? <ErrorMessage error={err} /> : null}
-      <Grid
-        className={classes.grid}
-        container
-        spacing={1}
-        direction="column"
-        alignItems="flex-start"
-      >
-        <Grid item>
-          <FormControl component="fieldset">
-            <FormLabel component="legend">Tabular file</FormLabel>
-            <FormGroup>
-              <FileSelector
-                location={fileSource}
-                setLocation={arg => model.setFileSource(arg)}
-                rootModel={rootModel as AbstractRootModel}
+      <div>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Tabular file</FormLabel>
+          <FormGroup>
+            <FileSelector
+              location={fileSource}
+              setLocation={arg => model.setFileSource(arg)}
+              rootModel={rootModel as AbstractRootModel}
+            />
+          </FormGroup>
+        </FormControl>
+      </div>
+      <div>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">File Type</FormLabel>
+          <RadioGroup row aria-label="file type" name="type" value={fileType}>
+            {fileTypes.map(fileTypeName => (
+              <FormControlLabel
+                key={fileTypeName}
+                checked={fileType === fileTypeName}
+                value={fileTypeName}
+                onClick={() => model.setFileType(fileTypeName)}
+                control={<Radio />}
+                label={fileTypeName}
               />
-            </FormGroup>
-          </FormControl>
-        </Grid>
-        <Grid item>
+            ))}
+          </RadioGroup>
+        </FormControl>
+      </div>
+      {showRowControls ? (
+        <div>
           <FormControl component="fieldset">
-            <FormLabel component="legend">File Type</FormLabel>
-            <RadioGroup aria-label="file type" name="type" value={fileType}>
-              <Grid container spacing={1} direction="row">
-                {fileTypes.map(fileTypeName => (
-                  <Grid item key={fileTypeName}>
-                    <FormControlLabel
-                      checked={fileType === fileTypeName}
-                      value={fileTypeName}
-                      onClick={() => model.setFileType(fileTypeName)}
-                      control={<Radio />}
-                      label={fileTypeName}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            </RadioGroup>
+            <FormLabel component="legend">Column Names</FormLabel>
+            <FormControlLabel
+              disabled={!showRowControls}
+              label="has column names on line"
+              labelPlacement="end"
+              control={
+                <Checkbox
+                  checked={hasColumnNameLine}
+                  onClick={() => model.toggleHasColumnNameLine()}
+                />
+              }
+            />
+            <NumberEditor
+              model={model}
+              disabled={!showRowControls || !hasColumnNameLine}
+              modelPropName="columnNameLineNumber"
+              modelSetterName="setColumnNameLineNumber"
+            />
           </FormControl>
-        </Grid>
-        {showRowControls ? (
-          <Grid item>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">Column Names</FormLabel>
-              <div>
-                <FormControlLabel
-                  disabled={!showRowControls}
-                  label="has column names on line"
-                  labelPlacement="end"
-                  control={
-                    <Checkbox
-                      checked={hasColumnNameLine}
-                      onClick={() => model.toggleHasColumnNameLine()}
-                    />
-                  }
-                />
-                <NumberEditor
-                  model={model}
-                  disabled={!showRowControls || !hasColumnNameLine}
-                  modelPropName="columnNameLineNumber"
-                  modelSetterName="setColumnNameLineNumber"
-                />
-              </div>
-            </FormControl>
-          </Grid>
-        ) : null}
-        <Grid item>
-          <AssemblySelector
-            session={session}
-            selected={selected}
-            onChange={val => setSelected(val)}
-          />
-        </Grid>
-        <Grid item className={classes.buttonContainer}>
-          {canCancel ? (
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={() => model.cancelButton()}
-              disabled={!canCancel}
-            >
-              Cancel
-            </Button>
-          ) : null}{' '}
+        </div>
+      ) : null}
+      <div>
+        <AssemblySelector
+          session={session}
+          selected={selected}
+          onChange={val => setSelected(val)}
+        />
+      </div>
+      <div>
+        {canCancel ? (
           <Button
-            disabled={!isReadyToOpen || !!err}
             variant="contained"
-            data-testid="open_spreadsheet"
-            color="primary"
-            onClick={() => {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              model.import(selected)
-            }}
+            color="secondary"
+            onClick={() => model.cancelButton()}
+            disabled={!canCancel}
           >
-            Open
+            Cancel
           </Button>
-        </Grid>
-      </Grid>
-    </Container>
+        ) : null}{' '}
+        <Button
+          disabled={!isReadyToOpen || !!err}
+          variant="contained"
+          data-testid="open_spreadsheet"
+          color="primary"
+          onClick={() => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            model.import(selected)
+          }}
+        >
+          Open
+        </Button>
+      </div>
+    </div>
   )
 })
 

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -131,6 +131,7 @@ const ImportWizard = observer(({ model }: { model: ImportWizardModel }) => {
           {canCancel ? (
             <Button
               variant="contained"
+              color="secondary"
               onClick={() => model.cancelButton()}
               disabled={!canCancel}
             >

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/RowCountMessage.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/RowCountMessage.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { Instance } from 'mobx-state-tree'
+
+// locals
+import SpreadsheetStateModel from '../models/Spreadsheet'
+
+type SpreadsheetModel = Instance<typeof SpreadsheetStateModel>
+
+const RowCountMessage = observer(function ({
+  spreadsheet,
+}: {
+  spreadsheet: SpreadsheetModel
+}) {
+  if (spreadsheet.rowSet.isLoaded) {
+    const {
+      passingFiltersCount,
+      count,
+      selectedCount,
+      selectedAndPassingFiltersCount,
+    } = spreadsheet.rowSet
+
+    let rowMessage
+    if (passingFiltersCount !== count) {
+      rowMessage = `${spreadsheet.rowSet.passingFiltersCount} rows of ${spreadsheet.rowSet.count} total`
+      if (selectedCount) {
+        rowMessage += `, ${selectedAndPassingFiltersCount} selected`
+        const selectedAndNotPassingFiltersCount =
+          selectedCount - selectedAndPassingFiltersCount
+        if (selectedAndNotPassingFiltersCount) {
+          rowMessage += ` (${selectedAndNotPassingFiltersCount} selected rows do not pass filters)`
+        }
+      }
+    } else {
+      rowMessage = `${spreadsheet.rowSet.count} rows`
+      if (selectedCount) {
+        rowMessage += `, ${selectedCount} selected`
+      }
+    }
+    return <>{rowMessage}</>
+  }
+  return null
+})
+export default RowCountMessage

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { FormGroup, Grid, TablePagination } from '@mui/material'
+import { Grid } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { ResizeHandle } from '@jbrowse/core/ui'
@@ -9,20 +9,14 @@ import ImportWizard from './ImportWizard'
 import Spreadsheet from './Spreadsheet'
 import GlobalFilterControls from './GlobalFilterControls'
 import ColumnFilterControls from './ColumnFilterControls'
-import RowCountMessage from './RowCountMessage'
-import { SpreadsheetModel } from '../models/Spreadsheet'
 import { SpreadsheetViewModel } from '../models/SpreadsheetView'
+import StatusBar from './StatusBar'
 
 const headerHeight = 52
 const colFilterHeight = 46
 const statusBarHeight = 40
 
 const useStyles = makeStyles()(theme => ({
-  root: {
-    position: 'relative',
-    marginBottom: theme.spacing(1),
-    overflow: 'hidden',
-  },
   header: {
     overflow: 'hidden',
     whiteSpace: 'nowrap',
@@ -33,38 +27,6 @@ const useStyles = makeStyles()(theme => ({
   contentArea: {
     overflow: 'auto',
   },
-  columnFilter: {
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    boxSizing: 'border-box',
-    height: headerHeight,
-    paddingLeft: theme.spacing(1),
-  },
-  viewControls: {
-    margin: 0,
-  },
-  rowCount: {
-    marginLeft: theme.spacing(1),
-  },
-  statusBar: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    height: statusBarHeight,
-    width: '100%',
-    boxSizing: 'border-box',
-    borderTop: '1px outset #b1b1b1',
-    paddingLeft: theme.spacing(1),
-  },
-  verticallyCenter: {
-    display: 'flex',
-    justifyContent: 'center',
-    flexDirection: 'column',
-  },
-  spacer: {
-    flexGrow: 1,
-  },
-
   resizeHandle: {
     height: 3,
     position: 'absolute',
@@ -75,52 +37,6 @@ const useStyles = makeStyles()(theme => ({
     borderTop: '1px solid #fafafa',
   },
 }))
-
-function StatusBar({
-  page,
-  rowsPerPage,
-  setPage,
-  setRowsPerPage,
-  spreadsheet,
-  mode,
-}: {
-  page: number
-  mode: string
-  spreadsheet: SpreadsheetModel
-  rowsPerPage: number
-  setPage: (arg: number) => void
-  setRowsPerPage: (arg: number) => void
-}) {
-  const { classes } = useStyles()
-  return (
-    <div
-      className={classes.statusBar}
-      style={{ display: mode === 'display' ? undefined : 'none' }}
-    >
-      {spreadsheet ? (
-        <FormGroup row>
-          <div className={classes.verticallyCenter}>
-            <RowCountMessage spreadsheet={spreadsheet} />
-          </div>
-          <div className={classes.spacer} />
-          <TablePagination
-            rowsPerPageOptions={[10, 25, 100, 1000]}
-            count={spreadsheet.rowSet.count}
-            component="div"
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(_, newPage) => setPage(newPage)}
-            onRowsPerPageChange={event => {
-              setRowsPerPage(+event.target.value)
-              setPage(0)
-            }}
-          />
-          <div className={classes.spacer} />
-        </FormGroup>
-      ) : null}
-    </div>
-  )
-}
 
 export default observer(function ({ model }: { model: SpreadsheetViewModel }) {
   const { classes } = useStyles()
@@ -159,10 +75,7 @@ export default observer(function ({ model }: { model: SpreadsheetViewModel }) {
       {mode === 'import' ? (
         <ImportWizard model={model.importWizard} />
       ) : (
-        <div
-          className={classes.contentArea}
-          style={{ height: height - headerHeight }}
-        >
+        <div className={classes.contentArea}>
           <div
             style={{
               position: 'relative',

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/StatusBar.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/StatusBar.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { FormGroup, TablePagination } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+
+// locals
+import RowCountMessage from './RowCountMessage'
+import { SpreadsheetModel } from '../models/Spreadsheet'
+import { observer } from 'mobx-react'
+
+const statusBarHeight = 40
+
+const useStyles = makeStyles()(theme => ({
+  statusBar: {
+    height: statusBarHeight,
+    boxSizing: 'border-box',
+    borderTop: '1px outset #b1b1b1',
+    paddingLeft: theme.spacing(1),
+  },
+  verticallyCenter: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  spacer: {
+    flexGrow: 1,
+  },
+}))
+
+const StatusBar = observer(function StatusBar({
+  page,
+  rowsPerPage,
+  setPage,
+  setRowsPerPage,
+  spreadsheet,
+  mode,
+}: {
+  page: number
+  mode: string
+  spreadsheet: SpreadsheetModel
+  rowsPerPage: number
+  setPage: (arg: number) => void
+  setRowsPerPage: (arg: number) => void
+}) {
+  const { classes } = useStyles()
+  return (
+    <div
+      className={classes.statusBar}
+      style={{ display: mode === 'display' ? undefined : 'none' }}
+    >
+      {spreadsheet ? (
+        <FormGroup row>
+          <div className={classes.verticallyCenter}>
+            <RowCountMessage spreadsheet={spreadsheet} />
+          </div>
+          <div className={classes.spacer} />
+          <TablePagination
+            rowsPerPageOptions={[10, 25, 100, 1000]}
+            count={spreadsheet.rowSet.count}
+            component="div"
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            onRowsPerPageChange={event => {
+              setRowsPerPage(+event.target.value)
+              setPage(0)
+            }}
+          />
+          <div className={classes.spacer} />
+        </FormGroup>
+      ) : null}
+    </div>
+  )
+})
+
+export default StatusBar

--- a/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/models/SpreadsheetView.ts
@@ -13,6 +13,7 @@ import { getSession } from '@jbrowse/core/util'
 
 // icons
 import DoneIcon from '@mui/icons-material/Done'
+import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 
 import SpreadsheetModel from './Spreadsheet'
 import ImportWizardModel from './ImportWizard'
@@ -74,11 +75,6 @@ const model = types
       ),
       defaultHeight,
     ),
-
-    /**
-     * #property
-     */
-    hideViewControls: false,
     /**
      * #property
      */
@@ -222,6 +218,20 @@ const model = types
     closeView() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getParent<any>(self, 2).removeView(self)
+    },
+  }))
+  .views(self => ({
+    /**
+     * #method
+     */
+    menuItems() {
+      return [
+        {
+          label: 'Return to import form',
+          onClick: () => self.setImportMode(),
+          icon: FolderOpenIcon,
+        },
+      ]
     },
   }))
 

--- a/plugins/sv-inspector/src/SvInspectorView/components/CircularViewOptions.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/CircularViewOptions.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+import { Grid, FormControlLabel, Checkbox } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+
+// locals
+import { SvInspectorViewModel } from '../models/SvInspectorView'
+
+const useStyles = makeStyles()(theme => ({
+  circularViewOptions: {
+    padding: theme.spacing(1),
+  },
+}))
+
+const CircularViewOptions = observer(function ({
+  svInspector,
+}: {
+  svInspector: SvInspectorViewModel
+}) {
+  const { classes } = useStyles()
+
+  return (
+    <Grid
+      container
+      className={classes.circularViewOptions}
+      style={{ height: svInspector.circularViewOptionsBarHeight }}
+    >
+      <Grid item>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={svInspector.onlyDisplayRelevantRegionsInCircularView}
+              onChange={e =>
+                svInspector.setOnlyDisplayRelevantRegionsInCircularView(
+                  e.target.checked,
+                )
+              }
+            />
+          }
+          label="show only regions with data"
+        />
+      </Grid>
+    </Grid>
+  )
+})
+
+export default CircularViewOptions

--- a/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import { Grid, FormControlLabel, Checkbox } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { ResizeHandle } from '@jbrowse/core/ui'
 
 // locals
 import { SvInspectorViewModel } from '../models/SvInspectorView'
+import CircularViewOptions from './CircularViewOptions'
 
 const useStyles = makeStyles()(theme => ({
   resizeHandleVert: {
@@ -26,46 +26,10 @@ const useStyles = makeStyles()(theme => ({
   viewsContainer: {
     display: 'flex',
   },
-  spreadsheetViewContainer: {
-    borderRight: '1px solid #ccc',
+  container: {
     overflow: 'hidden',
   },
-  circularViewOptions: {
-    padding: theme.spacing(1),
-  },
 }))
-
-const CircularViewOptions = observer(function ({
-  svInspector,
-}: {
-  svInspector: SvInspectorViewModel
-}) {
-  const { classes } = useStyles()
-
-  return (
-    <Grid
-      container
-      className={classes.circularViewOptions}
-      style={{ height: svInspector.circularViewOptionsBarHeight }}
-    >
-      <Grid item>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={svInspector.onlyDisplayRelevantRegionsInCircularView}
-              onChange={e =>
-                svInspector.setOnlyDisplayRelevantRegionsInCircularView(
-                  e.target.checked,
-                )
-              }
-            />
-          }
-          label="show only regions with data"
-        />
-      </Grid>
-    </Grid>
-  )
-})
 
 export default observer(function SvInspectorView({
   model,
@@ -81,9 +45,12 @@ export default observer(function SvInspectorView({
   } = model
 
   return (
-    <div>
+    <div className={classes.container}>
       <div className={classes.viewsContainer}>
-        <div style={{ width: model.spreadsheetView.width }}>
+        <div
+          style={{ width: model.spreadsheetView.width }}
+          className={classes.container}
+        >
           <SpreadsheetViewReactComponent model={model.spreadsheetView} />
         </div>
 

--- a/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
@@ -13,9 +13,15 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 const headerHeight = 52
 
 const useStyles = makeStyles()(theme => ({
-  resizeHandle: {
-    width: 4,
+  resizeHandleVert: {
     background: theme.palette.action.selected,
+    width: 4,
+    boxSizing: 'border-box',
+    borderTop: '1px solid #fafafa',
+  },
+  resizeHandleHoriz: {
+    background: theme.palette.action.selected,
+    height: 4,
     boxSizing: 'border-box',
     borderTop: '1px solid #fafafa',
   },
@@ -99,26 +105,29 @@ const CircularViewOptions = observer(function ({
   )
 })
 
-function SvInspectorView({ model }: { model: SvInspectorViewModel }) {
+export default observer(function SvInspectorView({
+  model,
+}: {
+  model: SvInspectorViewModel
+}) {
   const { classes } = useStyles()
 
   const {
-    resizeHeight,
-    dragHandleHeight,
     SpreadsheetViewReactComponent,
     CircularViewReactComponent,
+    dragHandleHeight,
     showCircularView,
   } = model
 
   return (
-    <div className={classes.root} data-testid={model.id}>
+    <div>
       <Grid container direction="row" className={classes.header}>
         <Grid item>
           <ViewControls model={model} />
         </Grid>
       </Grid>
       <div className={classes.viewsContainer}>
-        <div className={classes.spreadsheetViewContainer}>
+        <div style={{ width: model.spreadsheetView.width }}>
           <SpreadsheetViewReactComponent model={model.spreadsheetView} />
         </div>
 
@@ -132,7 +141,7 @@ function SvInspectorView({ model }: { model: SvInspectorViewModel }) {
               }}
               vertical
               flexbox
-              className={classes.resizeHandle}
+              className={classes.resizeHandleVert}
             />
             <div style={{ width: model.circularView.width }}>
               <CircularViewOptions svInspector={model} />
@@ -142,16 +151,10 @@ function SvInspectorView({ model }: { model: SvInspectorViewModel }) {
         ) : null}
       </div>
       <ResizeHandle
-        onDrag={resizeHeight}
-        style={{
-          height: dragHandleHeight,
-          background: '#ccc',
-          boxSizing: 'border-box',
-          borderTop: '1px solid #fafafa',
-        }}
+        onDrag={model.resizeHeight}
+        className={classes.resizeHandleHoriz}
+        style={{ height: dragHandleHeight, width: 4 }}
       />
     </div>
   )
-}
-
-export default observer(SvInspectorView)
+})

--- a/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
@@ -1,16 +1,11 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import { IconButton, Grid, FormControlLabel, Checkbox } from '@mui/material'
+import { Grid, FormControlLabel, Checkbox } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { ResizeHandle } from '@jbrowse/core/ui'
 
 // locals
 import { SvInspectorViewModel } from '../models/SvInspectorView'
-
-// icons
-import FolderOpenIcon from '@mui/icons-material/FolderOpen'
-
-const headerHeight = 52
 
 const useStyles = makeStyles()(theme => ({
   resizeHandleVert: {
@@ -24,16 +19,6 @@ const useStyles = makeStyles()(theme => ({
     height: 4,
     boxSizing: 'border-box',
     borderTop: '1px solid #fafafa',
-  },
-  root: {
-    marginBottom: theme.spacing(1),
-    overflow: 'hidden',
-  },
-  header: {
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    boxSizing: 'border-box',
-    height: headerHeight,
   },
   viewControls: {
     margin: 0,
@@ -49,29 +34,6 @@ const useStyles = makeStyles()(theme => ({
     padding: theme.spacing(1),
   },
 }))
-
-const ViewControls = observer(({ model }: { model: SvInspectorViewModel }) => {
-  const { classes } = useStyles()
-  return (
-    <Grid
-      className={classes.viewControls}
-      container
-      spacing={1}
-      direction="row"
-      alignItems="center"
-    >
-      <Grid item>
-        <IconButton
-          onClick={() => model.setImportMode()}
-          title="open a tabular file"
-          data-testid="sv_inspector_view_open"
-        >
-          <FolderOpenIcon />
-        </IconButton>
-      </Grid>
-    </Grid>
-  )
-})
 
 const CircularViewOptions = observer(function ({
   svInspector,
@@ -115,17 +77,11 @@ export default observer(function SvInspectorView({
   const {
     SpreadsheetViewReactComponent,
     CircularViewReactComponent,
-    dragHandleHeight,
     showCircularView,
   } = model
 
   return (
     <div>
-      <Grid container direction="row" className={classes.header}>
-        <Grid item>
-          <ViewControls model={model} />
-        </Grid>
-      </Grid>
       <div className={classes.viewsContainer}>
         <div style={{ width: model.spreadsheetView.width }}>
           <SpreadsheetViewReactComponent model={model.spreadsheetView} />
@@ -153,7 +109,6 @@ export default observer(function SvInspectorView({
       <ResizeHandle
         onDrag={model.resizeHeight}
         className={classes.resizeHandleHoriz}
-        style={{ height: dragHandleHeight, width: 4 }}
       />
     </div>
   )

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -81,7 +81,6 @@ function SvInspectorViewF(pluginManager: PluginManager) {
         spreadsheetView: types.optional(SpreadsheetModel, () =>
           SpreadsheetModel.create({
             type: 'SpreadsheetView',
-            hideViewControls: true,
             hideVerticalResizeHandle: true,
           }),
         ),

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -12,6 +12,7 @@ import { CircularViewStateModel } from '@jbrowse/plugin-circular-view'
 
 // icons
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 
 // locals
 import {
@@ -99,7 +100,6 @@ function SvInspectorViewF(pluginManager: PluginManager) {
     )
     .volatile(() => ({
       width: 800,
-      dragHandleHeight: 4,
     }))
     .views(self => ({
       /**
@@ -123,6 +123,9 @@ function SvInspectorViewF(pluginManager: PluginManager) {
         return self.spreadsheetView.mode === 'display'
       },
 
+      /**
+       * #getter
+       */
       get features() {
         const session = getSession(self)
         const { spreadsheetView } = self
@@ -218,6 +221,17 @@ function SvInspectorViewF(pluginManager: PluginManager) {
        */
       setOnlyDisplayRelevantRegionsInCircularView(val: boolean) {
         self.onlyDisplayRelevantRegionsInCircularView = Boolean(val)
+      },
+    }))
+    .views(self => ({
+      get menuItems() {
+        return [
+          {
+            label: 'Return to import form',
+            onClick: () => self.setImportMode(),
+            icon: FolderOpenIcon,
+          },
+        ]
       },
     }))
     .actions(self => ({

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -223,7 +223,10 @@ function SvInspectorViewF(pluginManager: PluginManager) {
       },
     }))
     .views(self => ({
-      get menuItems() {
+      /**
+       * #method
+       */
+      menuItems() {
         return [
           {
             label: 'Return to import form',
@@ -274,8 +277,9 @@ function SvInspectorViewF(pluginManager: PluginManager) {
             { name: 'SvInspectorView height binding' },
           ),
         )
-        // bind circularview displayedRegions to spreadsheet assembly, mediated by
-        // the onlyRelevantRegions toggle
+
+        // bind circularview displayedRegions to spreadsheet assembly, mediated
+        // by the onlyRelevantRegions toggle
         addDisposer(
           self,
           autorun(

--- a/products/jbrowse-web/src/tests/SVInspector.test.tsx
+++ b/products/jbrowse-web/src/tests/SVInspector.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, waitFor } from '@testing-library/react'
-import { doBeforeEach, createView, setup } from './util'
+import { doBeforeEach, createView, setup, mockConsoleWarn } from './util'
 
 setup()
 
@@ -10,28 +10,34 @@ beforeEach(() => {
 
 const delay = { timeout: 20000 }
 
-test('opens a vcf.gz file in the sv inspector view', async () => {
-  const consoleMock = jest.spyOn(console, 'warn').mockImplementation()
-  const { session, findByTestId, getByTestId, findByText } = await createView()
+test(
+  'opens a vcf.gz file in the sv inspector view',
+  () =>
+    mockConsoleWarn(async () => {
+      const consoleMock = jest.spyOn(console, 'warn').mockImplementation()
+      const { session, findByTestId, getByTestId, findByText } =
+        await createView()
 
-  fireEvent.click(await findByText('File'))
-  fireEvent.click(await findByText('Add'))
-  fireEvent.click(await findByText('SV inspector'))
+      fireEvent.click(await findByText('File'))
+      fireEvent.click(await findByText('Add'))
+      fireEvent.click(await findByText('SV inspector'))
 
-  fireEvent.change(await findByTestId('urlInput', {}, delay), {
-    target: { value: 'volvox.dup.renamed.vcf.gz' },
-  })
-  await waitFor(() =>
-    expect(
-      getByTestId('open_spreadsheet').closest('button'),
-    ).not.toBeDisabled(),
-  )
-  fireEvent.click(await findByTestId('open_spreadsheet'))
-  fireEvent.click(await findByTestId('chord-vcf-0', {}, delay))
+      fireEvent.change(await findByTestId('urlInput', {}, delay), {
+        target: { value: 'volvox.dup.renamed.vcf.gz' },
+      })
+      await waitFor(() =>
+        expect(
+          getByTestId('open_spreadsheet').closest('button'),
+        ).not.toBeDisabled(),
+      )
+      fireEvent.click(await findByTestId('open_spreadsheet'))
+      fireEvent.click(await findByTestId('chord-vcf-0', {}, delay))
 
-  // confirm breakpoint split view opened
-  expect(session.views.length).toBe(3)
-  expect(session.views[2].displayName).toBe('bnd_A split detail')
+      // confirm breakpoint split view opened
+      expect(session.views.length).toBe(3)
+      expect(session.views[2].displayName).toBe('bnd_A split detail')
 
-  consoleMock.mockRestore()
-}, 30000)
+      consoleMock.mockRestore()
+    }),
+  30000,
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,9 +2524,9 @@
     react-is "^18.2.0"
 
 "@mui/x-data-grid@^6.0.1":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.4.0.tgz#1ce476c9a213e0e651288ff3384b2bf43f5d238f"
-  integrity sha512-rFpjJh4ZTJW3JnjmTsn5B32PMMJtjxTdRZyjn3Re5K/BA/iJQvN1qHO26qoqbo4Vt3b3dbRLThM/Q0N59PL2Fw==
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.5.0.tgz#7cb8c0049c7d701f23374ec604cfa9ea10b9e34b"
+  integrity sha512-S90o+hwUvm0XC/tCyqSMpL3fGzYSF3P1FfybZPCe3ayVQVV/aR0LQUbfUEHlHUv49qUJ+y9c/QsElrr7BsYrNw==
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@mui/utils" "^5.12.3"
@@ -3006,9 +3006,9 @@
     "@octokit/types" "^9.0.0"
 
 "@octokit/core@^4.0.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-4.2.0.tgz#8c253ba9605aca605bc46187c34fcccae6a96648"
-  integrity sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-4.2.1.tgz#fee6341ad0ce60c29cc455e056cd5b500410a588"
+  integrity sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==
   dependencies:
     "@octokit/auth-token" "^3.0.0"
     "@octokit/graphql" "^5.0.0"
@@ -3046,7 +3046,7 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-14.0.0.tgz#949c5019028c93f189abbc2fb42f333290f7134a"
   integrity sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==
 
-"@octokit/openapi-types@^17.1.2":
+"@octokit/openapi-types@^17.2.0":
   version "17.2.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-17.2.0.tgz#f1800b5f9652b8e1b85cc6dfb1e0dc888810bdb5"
   integrity sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==
@@ -3086,9 +3086,9 @@
     once "^1.4.0"
 
 "@octokit/request@^6.0.0":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.4.tgz#b00a7185865c72bdd432e63168b1e900953ded0c"
-  integrity sha512-at92SYQstwh7HH6+Kf3bFMnHrle7aIrC0r5rTP+Bb30118B6j1vI2/M4walh6qcQgfuLIKs8NUO5CytHTnUI3A==
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.5.tgz#7beef1065042998f7455973ef3f818e7b84d6ec2"
+  integrity sha512-z83E8UIlPNaJUsXpjD8E0V5o/5f+vJJNbNcBwVZsX3/vC650U41cOkTLjq4PKk9BYonQGOnx7N17gvLyNjgGcQ==
   dependencies:
     "@octokit/endpoint" "^7.0.0"
     "@octokit/request-error" "^3.0.0"
@@ -3122,11 +3122,11 @@
     "@octokit/openapi-types" "^14.0.0"
 
 "@octokit/types@^9.0.0":
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.2.2.tgz#d111d33928f288f48083bfe49d8a9a5945e67db1"
-  integrity sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.2.3.tgz#d0af522f394d74b585cefb7efd6197ca44d183a9"
+  integrity sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==
   dependencies:
-    "@octokit/openapi-types" "^17.1.2"
+    "@octokit/openapi-types" "^17.2.0"
 
 "@parcel/watcher@2.0.4":
   version "2.0.4"
@@ -3238,9 +3238,9 @@
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^10.0.2":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz#3595e42b3f0a7df80a9681cf58d8cb418eac1e99"
-  integrity sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz#b3e322a34c5f26e3184e7f6115695f299c1b1194"
+  integrity sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
@@ -4686,9 +4686,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "20.1.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.7.tgz#ce10c802f7731909d0a44ac9888e8b3a9125eb62"
-  integrity sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.1.tgz#de559d4b33be9a808fd43372ccee822c70f39704"
+  integrity sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==
 
 "@types/node@^14.14.0":
   version "14.18.47"
@@ -4701,9 +4701,9 @@
   integrity sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==
 
 "@types/node@^18.11.18":
-  version "18.16.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.12.tgz#f11e19055c5b3daeb79dc6eb7ccdd3d036313034"
-  integrity sha512-tIRrjbY9C277MOfP8M3zjMIhtMlUJ6YVqkGgLjz+74jVsdf4/UjC6Hku4+1N0BS0qyC0JAS6tJLUk9H6JUKviQ==
+  version "18.16.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.13.tgz#984c48275c718b5b3e47371938f3cff482790598"
+  integrity sha512-uZRomboV1vBL61EBXneL4j9/hEn+1Yqa4LQdpGrKmXFyJmVfWc9JV9+yb2AlnOnuaDnb2PDO3hC6/LKmzJxP1A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6601,9 +6601,9 @@ cacache@^16.1.0:
     unique-filename "^2.0.0"
 
 cacache@^17.0.0, cacache@^17.0.4:
-  version "17.1.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-17.1.2.tgz#57ce9b79d300373f7266f2f1e4e1718fe09e84b4"
-  integrity sha512-VcRDUtZd9r7yfGDpdm3dBDBSQbLd19IqWs9q1tuB9g6kmxYLwIjfLngRKMCfDHxReuf0SBclRuYn66Xds7jzUQ==
+  version "17.1.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-17.1.3.tgz#c6ac23bec56516a7c0c52020fd48b4909d7c7044"
+  integrity sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==
   dependencies:
     "@npmcli/fs" "^3.1.0"
     fs-minipass "^3.0.0"
@@ -7622,14 +7622,14 @@ css-has-pseudo@^3.0.4:
     postcss-selector-parser "^6.0.9"
 
 css-loader@^6.5.1, css-loader@^6.7.1:
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.7.3.tgz#1e8799f3ccc5874fdd55461af51137fcc5befbcd"
-  integrity sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.7.4.tgz#a5d8ec28a73f3e0823998cfee2a1f7e564b91f9b"
+  integrity sha512-0Y5uHtK5BswfaGJ+jrO+4pPg1msFBc0pwPIE1VqfpmVn6YbDfYfXMj8rfd7nt+4goAhJueO+H/I40VWJfcP1mQ==
   dependencies:
     icss-utils "^5.1.0"
-    postcss "^8.4.19"
+    postcss "^8.4.21"
     postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-local-by-default "^4.0.1"
     postcss-modules-scope "^3.0.0"
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
@@ -8604,9 +8604,9 @@ electron-publish@23.6.0:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.397"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz#82a7e26c657538d59bb713b97ac22f97ea3a90ea"
-  integrity sha512-jwnPxhh350Q/aMatQia31KAIQdhEsYS0fFZ0BQQlN9tfvOEwShu6ZNwI4kL/xBabjcB/nTy6lSt17kNIluJZ8Q==
+  version "1.4.402"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz#9aa7bbb63081513127870af6d22f829344c5ba57"
+  integrity sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA==
 
 electron-updater@^5.0.1:
   version "5.3.0"
@@ -9499,9 +9499,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@3.2.7:
   version "3.2.7"
@@ -9579,9 +9579,9 @@ fd-slicer@~1.1.0:
     pend "~1.2.0"
 
 fetch-retry@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.5.tgz#61079b816b6651d88a022ebd45d51d83aa72b521"
-  integrity sha512-q9SvpKH5Ka6h7X2C6r1sP31pQoeDb3o6/R9cg21ahfPAqbIOkW9tus1dXfwYb6G6dOI4F7nVS4Q+LSssBGIz0A==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.6.tgz#17d0bc90423405b7a88b74355bf364acd2a7fa56"
+  integrity sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==
 
 figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
@@ -10273,15 +10273,15 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.0.0, glob@^10.2.2:
-  version "10.2.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.4.tgz#f5bf7ddb080e3e9039b148a9e2aef3d5ebfc0a25"
-  integrity sha512-fDboBse/sl1oXSLhIp0FcCJgzW9KmhC/q8ULTKC82zc+DL3TL7FNb8qlt5qqXN53MsKEUSIcb+7DLmEygOE5Yw==
+glob@^10.2.2, glob@^10.2.5:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.5.tgz#73c1850ac8f077810d8370ba414b382ad1a86083"
+  integrity sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^2.0.3"
     minimatch "^9.0.0"
-    minipass "^5.0.0 || ^6.0.0"
+    minipass "^5.0.0 || ^6.0.2"
     path-scurry "^1.7.0"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
@@ -13504,9 +13504,9 @@ min-indent@^1.0.0:
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@^2.4.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz#afbb344977659ec0f1f6e050c7aea456b121cfc5"
-  integrity sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz#282a3d38863fddcd2e0c220aaed5b90bc156564d"
+  integrity sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==
   dependencies:
     schema-utils "^4.0.0"
 
@@ -13669,10 +13669,10 @@ minipass@^5.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-6.0.1.tgz#315417c259cb32a1b2fc530c0e7f55c901a60a6d"
-  integrity sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==
+"minipass@^5.0.0 || ^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-6.0.2.tgz#542844b6c4ce95b202c0995b0a471f1229de4c81"
+  integrity sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==
 
 minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -14688,9 +14688,9 @@ pacote@15.1.1:
     tar "^6.1.11"
 
 pacote@^15.0.0, pacote@^15.0.8:
-  version "15.1.3"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-15.1.3.tgz#4c0e7fb5e7ab3b27fb3f86514b451ad4c4f64e9d"
-  integrity sha512-aRts8cZqxiJVDitmAh+3z+FxuO3tLNWEmwDRPEpDDiZJaRz06clP4XX112ynMT5uF0QNoMPajBBHnaStUEPJXA==
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-15.2.0.tgz#0f0dfcc3e60c7b39121b2ac612bf8596e95344d3"
+  integrity sha512-rJVZeIwHTUta23sIZgEIM62WYwbmGbThdbnkt81ravBplQv+HjyroqnLRNH2+sLJHcGZmLRmhPwACqhfTcOmnA==
   dependencies:
     "@npmcli/git" "^4.0.0"
     "@npmcli/installed-package-contents" "^2.0.1"
@@ -14884,12 +14884,12 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-scurry@^1.6.1, path-scurry@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.9.1.tgz#838566bb22e38feaf80ecd49ae06cd12acd782ee"
-  integrity sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.9.2.tgz#90f9d296ac5e37e608028e28a447b11d385b3f63"
+  integrity sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==
   dependencies:
     lru-cache "^9.1.1"
-    minipass "^5.0.0 || ^6.0.0"
+    minipass "^5.0.0 || ^6.0.2"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -15346,10 +15346,10 @@ postcss-modules-extract-imports@^3.0.0:
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
 
-postcss-modules-local-by-default@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
-  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+postcss-modules-local-by-default@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.1.tgz#7beae6bb99ee5bfe1d8273b0d47a3463209e5cef"
+  integrity sha512-Zr/dB+IlXaEqdoslLHhhqecwj73vc3rDmOpsBNBEVk7P2aqAlz+Ijy0fFbU5Ie9PtreDOIgGa9MsLWakVGl+fA==
   dependencies:
     icss-utils "^5.0.0"
     postcss-selector-parser "^6.0.2"
@@ -15613,7 +15613,7 @@ postcss@^7.0.35:
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.23, postcss@^8.4.4:
+postcss@^8.3.5, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.4:
   version "8.4.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
   integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
@@ -16156,9 +16156,9 @@ react-error-overlay@^6.0.11:
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
 react-fast-compare@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
-  integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-inspector@^6.0.0:
   version "6.0.1"
@@ -16769,11 +16769,11 @@ rimraf@^4.4.1:
     glob "^9.2.0"
 
 rimraf@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.0.tgz#5bda14e410d7e4dd522154891395802ce032c2cb"
-  integrity sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.1.tgz#0881323ab94ad45fec7c0221f27ea1a142f3f0d0"
+  integrity sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==
   dependencies:
-    glob "^10.0.0"
+    glob "^10.2.5"
 
 rimraf@~2.6.2:
   version "2.6.3"
@@ -17815,9 +17815,9 @@ strong-log-transformer@2.1.0, strong-log-transformer@^2.1.0:
     through "^2.3.4"
 
 style-loader@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.2.tgz#eaebca714d9e462c19aa1e3599057bc363924899"
-  integrity sha512-RHs/vcrKdQK8wZliteNK4NKzxvLBzpuHMqYmUVWeKa6MkaIQ97ZTOS0b+zapZhy6GcrgWnvWYCMHRirC3FsUmw==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
+  integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
 
 stylehacks@^5.1.1:
   version "5.1.1"
@@ -18113,9 +18113,9 @@ terminal-link@^2.0.0:
     supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.7:
-  version "5.3.8"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz#415e03d2508f7de63d59eca85c5d102838f06610"
-  integrity sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
+  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.17"
     jest-worker "^27.4.5"
@@ -18397,14 +18397,14 @@ tslib@^1.8.1:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
 
 tss-react@^4.0.0, tss-react@^4.4.1:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.8.3.tgz#5a5fd0e216b0cd338e2ab52c28bb73de13934587"
-  integrity sha512-zxHffa5PB8pv72/fGWVZS5GykmFca2wfqxha2P0nAdQElurh7pLDQfhHS3hHkW8lTWqkns46dBaTvDUw5zKQcQ==
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.8.4.tgz#0a5fb97bc5e1613d98ec69e3ec9bce8a5987976f"
+  integrity sha512-OaCOc7Gfx4TcNsiLczZ1CZC2dkzyUx8Q/NoTO0n7pxk+cAxKQJrDV7x2nl+fB05bnjlbNkR8/jHLmoCaUwzEtg==
   dependencies:
     "@emotion/cache" "*"
     "@emotion/serialize" "*"


### PR DESCRIPTION
v2.4.2 introduced a regression where the SV inspector import form layout was not centered

This fixes that, and provides a couple of CSS style refactors


current main
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/908ad2e5-232a-442b-89bc-02b69527d779)


this branch
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/7391835d-6cde-4a35-bfbb-cffaef06edf9)



also fixes an issue with "Open split view" not properly showing a disabled state when the features are not TRA/BND events