### PR TITLE
Fix lazy loading regression after app-core/embedded-core PR

### DIFF
--- a/packages/app-core/src/ui/App.tsx
+++ b/packages/app-core/src/ui/App.tsx
@@ -1,25 +1,24 @@
-import React, { Suspense } from 'react'
+import React from 'react'
 import { AppBar, Fab, Tooltip } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
-
-// icons
-import LaunchIcon from '@mui/icons-material/Launch'
-
-// locals
 import {
   NotificationLevel,
   SessionWithDrawerWidgets,
   SnackAction,
 } from '@jbrowse/core/util'
-
-// ui elements
-import DrawerWidget from './DrawerWidget'
-import AppToolbar from './AppToolbar'
 import Snackbar from '@jbrowse/core/ui/Snackbar'
 import { MenuItem as JBMenuItem } from '@jbrowse/core/ui/Menu'
+
+// icons
+import LaunchIcon from '@mui/icons-material/Launch'
+
+// locals
+import DrawerWidget from './DrawerWidget'
+import AppToolbar from './AppToolbar'
 import ViewLauncher from './ViewLauncher'
 import ViewPanel from './ViewPanel'
+import DialogQueue from './DialogQueue'
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -61,7 +60,7 @@ const useStyles = makeStyles()(theme => ({
 
 type SnackbarMessage = [string, NotificationLevel, SnackAction]
 
-const App = observer(function (props: {
+type Props = {
   HeaderButtons?: React.ReactElement
   session: SessionWithDrawerWidgets & {
     savedSessionNames: string[]
@@ -70,7 +69,9 @@ const App = observer(function (props: {
     snackbarMessages: SnackbarMessage[]
     popSnackbarMessage: () => unknown
   }
-}) {
+}
+
+const App = observer(function (props: Props) {
   const { session } = props
   const { classes } = useStyles()
 
@@ -79,7 +80,6 @@ const App = observer(function (props: {
     visibleWidget,
     drawerWidth,
     activeWidgets,
-    views,
     drawerPosition,
   } = session
 
@@ -98,29 +98,7 @@ const App = observer(function (props: {
         <DrawerWidget session={session} />
       ) : null}
       <DialogQueue session={session} />
-      <div className={classes.menuBarAndComponents}>
-        <div className={classes.menuBar}>
-          <AppBar className={classes.appBar} position="static">
-            <AppToolbar {...props} />
-          </AppBar>
-        </div>
-        <div className={classes.components}>
-          {views.length > 0 ? (
-            views.map(view => (
-              <ViewPanel
-                key={`view-${view.id}`}
-                view={view}
-                session={session}
-              />
-            ))
-          ) : (
-            <ViewLauncher {...props} />
-          )}
-
-          {/* blank space at the bottom of screen allows scroll */}
-          <div style={{ height: 300 }} />
-        </div>
-      </div>
+      <AppContainer {...props} />
 
       {activeWidgets.size > 0 && minimized ? (
         <Tooltip title="Open drawer widget">
@@ -146,19 +124,37 @@ const App = observer(function (props: {
   )
 })
 
-const DialogQueue = observer(function ({
-  session,
-}: {
-  session: SessionWithDrawerWidgets
-}) {
+const AppContainer = observer(function AppContainer(props: Props) {
+  const { classes } = useStyles()
   return (
-    <>
-      {session.DialogComponent ? (
-        <Suspense fallback={<React.Fragment />}>
-          <session.DialogComponent {...session.DialogProps} />
-        </Suspense>
-      ) : null}
-    </>
+    <div className={classes.menuBarAndComponents}>
+      <div className={classes.menuBar}>
+        <AppBar className={classes.appBar} position="static">
+          <AppToolbar {...props} />
+        </AppBar>
+      </div>
+      <ViewContainer {...props} />
+    </div>
+  )
+})
+
+const ViewContainer = observer(function ViewContainer(props: Props) {
+  const { session } = props
+  const { views } = session
+  const { classes } = useStyles()
+  return (
+    <div className={classes.components}>
+      {views.length > 0 ? (
+        views.map(view => (
+          <ViewPanel key={`view-${view.id}`} view={view} session={session} />
+        ))
+      ) : (
+        <ViewLauncher {...props} />
+      )}
+
+      {/* blank space at the bottom of screen allows scroll */}
+      <div style={{ height: 300 }} />
+    </div>
   )
 })
 

--- a/packages/app-core/src/ui/App.tsx
+++ b/packages/app-core/src/ui/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { AppBar, Fab, Tooltip } from '@mui/material'
+import React, { Suspense, lazy } from 'react'
+import { AppBar } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import {
@@ -10,15 +10,14 @@ import {
 import Snackbar from '@jbrowse/core/ui/Snackbar'
 import { MenuItem as JBMenuItem } from '@jbrowse/core/ui/Menu'
 
-// icons
-import LaunchIcon from '@mui/icons-material/Launch'
-
 // locals
-import DrawerWidget from './DrawerWidget'
 import AppToolbar from './AppToolbar'
 import ViewLauncher from './ViewLauncher'
 import ViewPanel from './ViewPanel'
 import DialogQueue from './DialogQueue'
+import AppFab from './AppFab'
+
+const DrawerWidget = lazy(() => import('./DrawerWidget'))
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -28,33 +27,19 @@ const useStyles = makeStyles()(theme => ({
     width: '100%',
     colorScheme: theme.palette.mode,
   },
-  fabLeft: {
-    zIndex: 10000,
-    position: 'fixed',
-    bottom: theme.spacing(2),
-    left: theme.spacing(2),
-  },
-  fabRight: {
-    zIndex: 10000,
-    position: 'fixed',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-  },
-  menuBarAndComponents: {
+  appContainer: {
     gridColumn: 'main',
     display: 'grid',
     gridTemplateRows: '[menubar] min-content [components] auto',
     height: '100vh',
   },
-  menuBar: {
-    gridRow: 'menubar',
-  },
-  components: {
+  viewContainer: {
     overflowY: 'auto',
     gridRow: 'components',
   },
   appBar: {
     flexGrow: 1,
+    gridRow: 'menubar',
   },
 }))
 
@@ -71,79 +56,21 @@ type Props = {
   }
 }
 
-const App = observer(function (props: Props) {
+const LazyDrawerWidget = observer(function (props: Props) {
   const { session } = props
-  const { classes } = useStyles()
-
-  const {
-    minimized,
-    visibleWidget,
-    drawerWidth,
-    activeWidgets,
-    drawerPosition,
-  } = session
-
-  const drawerVisible = visibleWidget && !minimized
-
-  const d = drawerVisible ? `[drawer] ${drawerWidth}px` : undefined
-  const grid =
-    drawerPosition === 'right' ? ['[main] 1fr', d] : [d, '[main] 1fr']
-
   return (
-    <div
-      className={classes.root}
-      style={{ gridTemplateColumns: grid?.filter(f => !!f).join(' ') }}
-    >
-      {drawerVisible && drawerPosition === 'left' ? (
-        <DrawerWidget session={session} />
-      ) : null}
-      <DialogQueue session={session} />
-      <AppContainer {...props} />
-
-      {activeWidgets.size > 0 && minimized ? (
-        <Tooltip title="Open drawer widget">
-          <Fab
-            className={
-              drawerPosition === 'right' ? classes.fabRight : classes.fabLeft
-            }
-            color="primary"
-            data-testid="drawer-maximize"
-            onClick={() => session.showWidgetDrawer()}
-          >
-            <LaunchIcon />
-          </Fab>
-        </Tooltip>
-      ) : null}
-
-      {drawerVisible && drawerPosition === 'right' ? (
-        <DrawerWidget session={session} />
-      ) : null}
-
-      <Snackbar session={session} />
-    </div>
+    <Suspense fallback={<React.Fragment />}>
+      <DrawerWidget session={session} />
+    </Suspense>
   )
 })
 
-const AppContainer = observer(function AppContainer(props: Props) {
-  const { classes } = useStyles()
-  return (
-    <div className={classes.menuBarAndComponents}>
-      <div className={classes.menuBar}>
-        <AppBar className={classes.appBar} position="static">
-          <AppToolbar {...props} />
-        </AppBar>
-      </div>
-      <ViewContainer {...props} />
-    </div>
-  )
-})
-
-const ViewContainer = observer(function ViewContainer(props: Props) {
+const ViewContainer = observer(function (props: Props) {
   const { session } = props
   const { views } = session
   const { classes } = useStyles()
   return (
-    <div className={classes.components}>
+    <div className={classes.viewContainer}>
       {views.length > 0 ? (
         views.map(view => (
           <ViewPanel key={`view-${view.id}`} view={view} session={session} />
@@ -154,6 +81,41 @@ const ViewContainer = observer(function ViewContainer(props: Props) {
 
       {/* blank space at the bottom of screen allows scroll */}
       <div style={{ height: 300 }} />
+    </div>
+  )
+})
+
+const App = observer(function (props: Props) {
+  const { session } = props
+  const { classes } = useStyles()
+  const { minimized, visibleWidget, drawerWidth, drawerPosition } = session
+  const drawerVisible = visibleWidget && !minimized
+  const d = drawerVisible ? `[drawer] ${drawerWidth}px` : undefined
+  const grid =
+    drawerPosition === 'right' ? ['[main] 1fr', d] : [d, '[main] 1fr']
+
+  return (
+    <div
+      className={classes.root}
+      style={{ gridTemplateColumns: grid?.filter(f => !!f).join(' ') }}
+    >
+      {drawerVisible && drawerPosition === 'left' ? (
+        <LazyDrawerWidget session={session} />
+      ) : null}
+      <DialogQueue session={session} />
+      <div className={classes.appContainer}>
+        <AppBar className={classes.appBar} position="static">
+          <AppToolbar {...props} />
+        </AppBar>
+        <ViewContainer {...props} />
+      </div>
+      <AppFab session={session} />
+
+      {drawerVisible && drawerPosition === 'right' ? (
+        <LazyDrawerWidget session={session} />
+      ) : null}
+
+      <Snackbar session={session} />
     </div>
   )
 })

--- a/packages/app-core/src/ui/AppFab.tsx
+++ b/packages/app-core/src/ui/AppFab.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Fab, Tooltip } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+import { observer } from 'mobx-react'
+import { SessionWithDrawerWidgets } from '@jbrowse/core/util'
+
+// icons
+import LaunchIcon from '@mui/icons-material/Launch'
+
+const useStyles = makeStyles()(theme => ({
+  left: {
+    zIndex: 10000,
+    position: 'fixed',
+    bottom: theme.spacing(2),
+    left: theme.spacing(2),
+  },
+  right: {
+    zIndex: 10000,
+    position: 'fixed',
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
+  },
+}))
+
+export default observer(function AppFab({
+  session,
+}: {
+  session: SessionWithDrawerWidgets
+}) {
+  const { minimized, activeWidgets, drawerPosition } = session
+  const { classes } = useStyles()
+
+  return activeWidgets.size > 0 && minimized ? (
+    <Tooltip title="Open drawer widget">
+      <Fab
+        className={drawerPosition === 'right' ? classes.right : classes.left}
+        color="primary"
+        data-testid="drawer-maximize"
+        onClick={() => session.showWidgetDrawer()}
+      >
+        <LaunchIcon />
+      </Fab>
+    </Tooltip>
+  ) : null
+})

--- a/packages/app-core/src/ui/DialogQueue.tsx
+++ b/packages/app-core/src/ui/DialogQueue.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from 'react'
+import { observer } from 'mobx-react'
+
+// locals
+import { SessionWithDrawerWidgets } from '@jbrowse/core/util'
+
+export default observer(function ({
+  session,
+}: {
+  session: SessionWithDrawerWidgets
+}) {
+  const { DialogComponent, DialogProps } = session
+  return (
+    <>
+      {DialogComponent ? (
+        <Suspense fallback={<React.Fragment />}>
+          <DialogComponent {...DialogProps} />
+        </Suspense>
+      ) : null}
+    </>
+  )
+})

--- a/packages/embedded-core/src/ui/ViewTitle.tsx
+++ b/packages/embedded-core/src/ui/ViewTitle.tsx
@@ -3,9 +3,11 @@ import { IconButton, Typography, alpha } from '@mui/material'
 import { observer } from 'mobx-react'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Logomark } from '@jbrowse/core/ui'
-import ViewMenu from './ViewMenu'
 import { makeStyles } from 'tss-react/mui'
 import { getSession } from '@jbrowse/core/util'
+
+// locals
+import ViewMenu from './ViewMenu'
 
 const VersionAboutDialog = lazy(() => import('./VersionAboutDialog'))
 

--- a/packages/product-core/package.json
+++ b/packages/product-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jbrowse/product-core",
   "version": "2.5.0",
+  "sideEffects": false,
   "description": "JBrowse 2 code shared between products but not used by plugins",
   "keywords": [
     "jbrowse",
@@ -23,7 +24,7 @@
   "srcMain": "src/index.ts",
   "srcModule": "src/index.ts",
   "main": "src/index.ts",
-  "module": "",
+  "module": "src/index.ts",
   "files": [
     "dist",
     "esm",

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy } from 'react'
 import {
   types,
   getParent,
@@ -26,8 +26,9 @@ import LinkIcon from '@mui/icons-material/Link'
 
 // locals
 import { intersect } from './util'
-import { renderToSvg } from './svgcomponents/SVGBreakpointSplitView'
-import ExportSvgDlg from './components/ExportSvgDialog'
+
+// lazies
+const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
 
 function calc(
   track: { displays: { searchFeatureByID: (str: string) => LayoutRecord }[] },
@@ -120,8 +121,10 @@ export default function stateModelFactory(pluginManager: PluginManager) {
        * creates an svg export and save using FileSaver
        */
       async exportSvg(opts: ExportSvgOptions = {}) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
+        const { renderToSvg } = await import(
+          './svgcomponents/SVGBreakpointSplitView'
+        )
+        const html = await renderToSvg(self as BreakpointViewModel, opts)
         const blob = new Blob([html], { type: 'image/svg+xml' })
         saveAs(blob, opts.filename || 'image.svg')
       },
@@ -320,7 +323,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             icon: PhotoCamera,
             onClick: () => {
               getSession(self).queueDialog(handleClose => [
-                ExportSvgDlg,
+                ExportSvgDialog,
                 { model: self, handleClose },
               ])
             },

--- a/plugins/circular-view/src/CircularView/models/CircularView.ts
+++ b/plugins/circular-view/src/CircularView/models/CircularView.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy } from 'react'
 import PluginManager from '@jbrowse/core/PluginManager'
 import {
   cast,
@@ -12,7 +12,6 @@ import {
 import { Region } from '@jbrowse/core/util/types/mst'
 import { transaction } from 'mobx'
 import { saveAs } from 'file-saver'
-import { renderToSvg } from '../svgcomponents/SVGCircularView'
 import {
   AnyConfigurationModel,
   readConfObject,
@@ -31,9 +30,11 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
 
 // locals
-import ExportSvgDlg from '../components/ExportSvgDialog'
 import { calculateStaticSlices, sliceIsVisible, SliceRegion } from './slices'
 import { viewportVisibleSection } from './viewportVisibleRegion'
+
+// lazies
+const ExportSvgDialog = lazy(() => import('../components/ExportSvgDialog'))
 
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
@@ -576,8 +577,8 @@ function stateModelFactory(pluginManager: PluginManager) {
        * creates an svg export and save using FileSaver
        */
       async exportSvg(opts: ExportSvgOptions = {}) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
+        const { renderToSvg } = await import('../svgcomponents/SVGCircularView')
+        const html = await renderToSvg(self as CircularViewModel, opts)
         const blob = new Blob([html], { type: 'image/svg+xml' })
         saveAs(blob, opts.filename || 'image.svg')
       },
@@ -599,7 +600,7 @@ function stateModelFactory(pluginManager: PluginManager) {
             icon: PhotoCameraIcon,
             onClick: () => {
               getSession(self).queueDialog(handleClose => [
-                ExportSvgDlg,
+                ExportSvgDialog,
                 { model: self, handleClose },
               ])
             },

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy } from 'react'
 import {
   addDisposer,
   cast,
@@ -14,7 +14,6 @@ import { saveAs } from 'file-saver'
 import { autorun, transaction } from 'mobx'
 
 import { getParentRenderProps } from '@jbrowse/core/util/tracks'
-import { ReturnToImportFormDialog } from '@jbrowse/core/ui'
 import { BaseTrackStateModel } from '@jbrowse/core/pluggableElementTypes/models'
 import BaseViewModel from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
 import { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
@@ -38,9 +37,12 @@ import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
 // locals
 import { Dotplot1DView, DotplotHView, DotplotVView } from './1dview'
 import { getBlockLabelKeysToHide, makeTicks } from './components/util'
-import { renderToSvg } from './svgcomponents/SVGDotplotView'
-import ExportSvgDlg from './components/ExportSvgDialog'
 
+// lazies
+const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
+const ReturnToImportFormDialog = lazy(
+  () => import('@jbrowse/core/ui/ReturnToImportFormDialog'),
+)
 type Coord = [number, number]
 
 export interface ExportSvgOptions {
@@ -535,8 +537,8 @@ export default function stateModelFactory(pm: PluginManager) {
        * creates an svg export and save using FileSaver
        */
       async exportSvg(opts: ExportSvgOptions = {}) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
+        const { renderToSvg } = await import('./svgcomponents/SVGDotplotView')
+        const html = await renderToSvg(self as DotplotViewModel, opts)
         const blob = new Blob([html], { type: 'image/svg+xml' })
         saveAs(blob, opts.filename || 'image.svg')
       },
@@ -686,7 +688,7 @@ export default function stateModelFactory(pm: PluginManager) {
             icon: PhotoCameraIcon,
             onClick: () => {
               getSession(self).queueDialog(handleClose => [
-                ExportSvgDlg,
+                ExportSvgDialog,
                 { model: self, handleClose },
               ])
             },

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -1,3 +1,4 @@
+import { lazy } from 'react'
 import {
   addDisposer,
   cast,
@@ -14,7 +15,7 @@ import { autorun, transaction } from 'mobx'
 
 // jbrowse
 import BaseViewModel from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
-import { MenuItem, ReturnToImportFormDialog } from '@jbrowse/core/ui'
+import { MenuItem } from '@jbrowse/core/ui'
 import { getSession, isSessionModelWithWidgets, avg } from '@jbrowse/core/util'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration'
@@ -27,6 +28,11 @@ import {
 // icons
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
+
+// lazies
+const ReturnToImportFormDialog = lazy(
+  () => import('@jbrowse/core/ui/ReturnToImportFormDialog'),
+)
 
 /**
  * #stateModel LinearComparativeView

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy } from 'react'
 import { types, Instance } from 'mobx-state-tree'
 import { transaction } from 'mobx'
 import { getSession } from '@jbrowse/core/util'
@@ -14,8 +14,9 @@ import { Curves } from './components/Icons'
 
 // locals
 import baseModel from '../LinearComparativeView/model'
-import ExportSvgDlg from './components/ExportSvgDialog'
-import { renderToSvg } from './svgcomponents/SVGLinearSyntenyView'
+
+// lazies
+const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
 
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
@@ -80,8 +81,10 @@ export default function stateModelFactory(pluginManager: PluginManager) {
     }))
     .actions(self => ({
       async exportSvg(opts: ExportSvgOptions) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
+        const { renderToSvg } = await import(
+          './svgcomponents/SVGLinearSyntenyView'
+        )
+        const html = await renderToSvg(self as LinearSyntenyViewModel, opts)
         const blob = new Blob([html], { type: 'image/svg+xml' })
         saveAs(blob, opts.filename || 'image.svg')
       },
@@ -137,7 +140,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               icon: PhotoCameraIcon,
               onClick: () => {
                 getSession(self).queueDialog(handleClose => [
-                  ExportSvgDlg,
+                  ExportSvgDialog,
                   { model: self, handleClose },
                 ])
               },
@@ -152,7 +155,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               icon: PhotoCameraIcon,
               onClick: () => {
                 getSession(self).queueDialog(handleClose => [
-                  ExportSvgDlg,
+                  ExportSvgDialog,
                   { model: self, handleClose },
                 ])
               },

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -3,7 +3,7 @@ import { getConf, AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { Region } from '@jbrowse/core/util/types'
 import { ElementId, Region as MUIRegion } from '@jbrowse/core/util/types/mst'
-import { MenuItem, ReturnToImportFormDialog } from '@jbrowse/core/ui'
+import { MenuItem } from '@jbrowse/core/ui'
 import {
   assembleLocString,
   clamp,
@@ -51,21 +51,19 @@ import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
 import ZoomInIcon from '@mui/icons-material/ZoomIn'
 import MenuOpenIcon from '@mui/icons-material/MenuOpen'
 
-// locals
-import { renderToSvg } from './svgcomponents/SVGLinearGenomeView'
-
-import ExportSvgDlg from './components/ExportSvgDialog'
 import MiniControls from './components/MiniControls'
 import Header from './components/Header'
 import { generateLocations, parseLocStrings } from './util'
 
 // lazies
+const ReturnToImportFormDialog = lazy(
+  () => import('@jbrowse/core/ui/ReturnToImportFormDialog'),
+)
 const SequenceSearchDialog = lazy(
   () => import('./components/SequenceSearchDialog'),
 )
-
+const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
 const GetSequenceDialog = lazy(() => import('./components/GetSequenceDialog'))
-
 const SearchResultsDialog = lazy(
   () => import('./components/SearchResultsDialog'),
 )
@@ -622,10 +620,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
       ) {
         getSession(self).queueDialog(handleClose => [
           SearchResultsDialog,
-
           {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            model: self as any,
+            model: self as LinearGenomeViewModel,
             searchResults,
             searchQuery,
             handleClose,
@@ -926,8 +922,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * creates an svg export and save using FileSaver
        */
       async exportSvg(opts: ExportSvgOptions = {}) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const html = await renderToSvg(self as any, opts)
+        const { renderToSvg } = await import(
+          './svgcomponents/SVGLinearGenomeView'
+        )
+        const html = await renderToSvg(self as LinearGenomeViewModel, opts)
         const blob = new Blob([html], { type: 'image/svg+xml' })
         saveAs(blob, opts.filename || 'image.svg')
       },
@@ -1056,7 +1054,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             icon: PhotoCameraIcon,
             onClick: () => {
               getSession(self).queueDialog(handleClose => [
-                ExportSvgDlg,
+                ExportSvgDialog,
                 { model: self, handleClose },
               ])
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,14 +2835,14 @@
     nx "15.9.4"
 
 "@oclif/command@^1.8.11", "@oclif/command@^1.8.14", "@oclif/command@^1.8.15", "@oclif/command@^1.8.9":
-  version "1.8.25"
-  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.25.tgz#9bc7fea9d03320837ca82d851b43b1f089d7b7b9"
-  integrity sha512-teCfKH6GNF46fiCn/P5EMHX93RE3KJAW4i0sq3X9phrzs6807WRauhythdc8OKINxd+LpqwQ1i5bnaCKvLZRcQ==
+  version "1.8.26"
+  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.26.tgz#302a1886992352f8f967b80b2728806e5e0b0501"
+  integrity sha512-IT9kOLFRMc3s6KJ1FymsNjbHShI211eVgAg+JMiDVl8LXwOJxYe8ybesgL1kpV9IUFByOBwZKNG2mmrVeNBHPg==
   dependencies:
     "@oclif/config" "^1.18.2"
     "@oclif/errors" "^1.3.6"
     "@oclif/help" "^1.0.1"
-    "@oclif/parser" "^3.8.10"
+    "@oclif/parser" "^3.8.11"
     debug "^4.1.1"
     semver "^7.5.1"
 
@@ -2943,7 +2943,7 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.10", "@oclif/parser@^3.8.9":
+"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.10", "@oclif/parser@^3.8.11", "@oclif/parser@^3.8.9":
   version "3.8.11"
   resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.11.tgz#991a629a053d9fd38b73cc564d4a05e26b329838"
   integrity sha512-B3NweRn1yZw2g7xaF10Zh/zwlqTJJINfU+CRkqll+LaTisSNvZbW0RR9WGan26EqqLp4qzNjzX/e90Ew8l9NLw==
@@ -10273,13 +10273,13 @@ glob@7.1.6:
     path-is-absolute "^1.0.0"
 
 glob@^10.2.2, glob@^10.2.5:
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.5.tgz#73c1850ac8f077810d8370ba414b382ad1a86083"
-  integrity sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.2.6.tgz#1e27edbb3bbac055cb97113e27a066c100a4e5e1"
+  integrity sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^2.0.3"
-    minimatch "^9.0.0"
+    minimatch "^9.0.1"
     minipass "^5.0.0 || ^6.0.2"
     path-scurry "^1.7.0"
 
@@ -13561,10 +13561,10 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.0.tgz#bfc8e88a1c40ffd40c172ddac3decb8451503b56"
-  integrity sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==
+minimatch@^9.0.0, minimatch@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
+  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -13969,9 +13969,9 @@ node-polyfill-webpack-plugin@^2.0.1:
     vm-browserify "^1.1.2"
 
 node-releases@^2.0.8:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
-  integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.11.tgz#59d7cef999d13f908e43b5a70001cf3129542f0f"
+  integrity sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
There is an approx 350kb bundle size regression between v2.5.0 and current main

It is likely due to x-data-grid being packaged by default so this PR doesn't address it head on but may help