### PR TITLE
Turn off the github checks for codecov patch/project

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
+coverage:
+  status:
+    patch: false
+    project: false
 github_checks:
   annotations: false


### PR DESCRIPTION
Many of our main branch commits 'fail' the codecov patch or project 'coverage requirements'. We can adjust the thresholds to help, or just turn them off entirely. I think turning them off is probably the best thing for us
I looked at https://community.codecov.com/t/cannot-disable-codecov-patch-check/682 to try to help solve this