### PR TITLE
Add session assemblies to assemblyNames in session

### DIFF
--- a/packages/web-core/src/BaseWebSession/index.ts
+++ b/packages/web-core/src/BaseWebSession/index.ts
@@ -123,7 +123,9 @@ export function BaseWebSession({
        * AssemblySelector dropdown
        */
       get assemblyNames() {
-        return self.assemblies.map(f => readConfObject(f, 'name') as string)
+        return [...self.assemblies, ...self.sessionAssemblies].map(
+          f => readConfObject(f, 'name') as string,
+        )
       },
       /**
        * #getter


### PR DESCRIPTION
The jsdoc description of assemblyNames says it should include session assemblies, so this makes the code match that. Restores the behavior introduced in #3197.