### PR TITLE
Component test for the @jbrowse/react-app

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,6 +72,12 @@ jobs:
           yarn build
           yarn test:e2e
         working-directory: component_tests/cgv
+      - name: Test embedded react-app
+        run: |
+          yarn
+          yarn build
+          yarn test:e2e
+        working-directory: component_tests/react-app
 
   buildjbrowseweb:
     name: Build only jbrowse-web and upload to s3 on node 16 and ubuntu-latest

--- a/component_tests/react-app/package.json
+++ b/component_tests/react-app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@craco/craco": "^7.0.0",
     "@fontsource/roboto": "^4.5.5",
-    "@jbrowse/react-app": "^2.0.0",
+    "@jbrowse/react-app": "file:./packed/jbrowse-react-app.tgz",
     "@testing-library/cypress": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -49,7 +49,6 @@
     "react": ">=16.8.0",
     "tss-react": "^4.0.0"
   },
-  "private": true,
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",
   "module": ""

--- a/plugins/menus/package.json
+++ b/plugins/menus/package.json
@@ -51,7 +51,6 @@
     "react-dom": ">=16.8.0",
     "tss-react": "^4.0.0"
   },
-  "private": true,
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",
   "module": ""

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -46,7 +46,6 @@
     "mobx-state-tree": "^5.0.0",
     "rxjs": "^7.0.0"
   },
-  "private": true,
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",
   "module": ""

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -46,7 +46,6 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0"
   },
-  "private": true,
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",
   "module": ""

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -110,5 +110,7 @@
   "peerDependencies": {
     "react": ">=16.8.0"
   },
-  "private": true
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/products/jbrowse-react-app/stories/examples/BasicExample.tsx
+++ b/products/jbrowse-react-app/stories/examples/BasicExample.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 // replace with import {createViewState,JBrowseWebApp} from '@jbrowse/react-app' in your code
 import { createViewState, JBrowseWebApp } from '../../src'
-// replace with import makeWorkerInstance from '@jbrowse/react-app/esm/makeWorkerInstance' in your codea
+// replace with import makeWorkerInstance from '@jbrowse/react-app/esm/makeWorkerInstance' in your code
 import makeWorkerInstance from '../../src/makeWorkerInstance'
 import volvoxConfig from '../../public/test_data/volvox/config.json'
 import { addRelativeUris } from '../util'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,19 +3251,19 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@storybook/addon-actions@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.0.13.tgz#18dcf4d8410ddb5e087a9a092c2ff5b172c38e09"
-  integrity sha512-mS1e/6iRbszjxGNaClPXTeQ36R03AwUtprp5IOyaSfE/hjvUqLdAX3BIYU/1YwcILl3hJ9vIeqNg+IlqRNHcfg==
+"@storybook/addon-actions@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.0.15.tgz#e36a828d525a3a8c760c3e6dd7455db6b7d9bdcc"
+  integrity sha512-1urDxJpG5BTmZCbda+93iuCNwzj7AiPt/VlmpDpd9Mc/WTOKBg0cXo8oBLibOZgCTLEx+4sq5eVgdMVybBa87g==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     dequal "^2.0.2"
     lodash "^4.17.21"
     polished "^4.2.2"
@@ -3273,181 +3273,181 @@
     ts-dedent "^2.0.0"
     uuid "^9.0.0"
 
-"@storybook/addon-backgrounds@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.0.13.tgz#f6bb4badf296e254c3c5ae51cefa1196247eaacb"
-  integrity sha512-U9F1vMC/AyX8Td2/9bYTVyiCoqBkUOHxLmfDoZ+kcmheH85jIXl2s+NDK826LpkNYZo+JDXCr+2OGUBGFWI7SA==
+"@storybook/addon-backgrounds@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.0.15.tgz#1ebb884b6158b31e654adae53b6de993e69b7f31"
+  integrity sha512-cUb5i3dn4MhXFtCuA8p/ax6dtFaJ52+q6Dex8L40DtWC/fPrC2igAXN4o7WhRHztY6utZSLy4invEjqAFCEYRw==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     memoizerific "^1.11.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-controls@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.0.13.tgz#7c029f32b1394295af0eb371c1546dec6917bb6a"
-  integrity sha512-+ZfUNz5odeIkN4ZrxeE6vKlgI2wRCtN9Xy0a9FcmZb7n7jy9P2LCrom4r6MEnzI9TxyeoemHs/p6vrOwcuMVdw==
+"@storybook/addon-controls@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.0.15.tgz#0b676c1e3e54b8b6a029943fb5d519a8fea2f7e6"
+  integrity sha512-sLLYVgprrsC6k0/2ErKJSa6Jtlxo+lHSO41K6nB0WQmQ8Moroe2kBaNTP6C9+zhGuI427Eueuzs3cKHwn/eIKw==
   dependencies:
-    "@storybook/blocks" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/blocks" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.0.13.tgz#6b6685fe5379c8e135d4557261b093fb22061d3f"
-  integrity sha512-ME/15z1yQSFV2GWDXQaWpii4FoH531QlkgRPOfHbV9fWQxjIGc2IqyMAfImX4iyOjtevuXTtboTOSw/GbDW/Yw==
+"@storybook/addon-docs@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.0.15.tgz#c9c52412e4b61688e4bd2a2cdd2dfa56cbdd2cd7"
+  integrity sha512-FBXHFwm6wH3SYsv73SmVQMs+FxP8eSoWlDFBEZ1lulCK7f0NKflhzTTimyh9m+aRCsbvC2Vm+7/9CJ5OZU+GEQ==
   dependencies:
     "@babel/core" "^7.20.2"
     "@babel/plugin-transform-react-jsx" "^7.19.0"
     "@jest/transform" "^29.3.1"
     "@mdx-js/react" "^2.1.5"
-    "@storybook/blocks" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/csf-plugin" "7.0.13"
-    "@storybook/csf-tools" "7.0.13"
+    "@storybook/blocks" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/csf-plugin" "7.0.15"
+    "@storybook/csf-tools" "7.0.15"
     "@storybook/global" "^5.0.0"
     "@storybook/mdx2-csf" "^1.0.0"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/postinstall" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/react-dom-shim" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/postinstall" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/react-dom-shim" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     fs-extra "^11.1.0"
     remark-external-links "^8.0.0"
     remark-slug "^6.0.0"
     ts-dedent "^2.0.0"
 
 "@storybook/addon-essentials@^7.0.0":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.0.13.tgz#84866e369e575e02bf5e4396e19815ced1bbd792"
-  integrity sha512-MT5KiMTVAwpkn2rP/vPLtE2t5ti48IeodlwWJhy/Xx9TSInT0lM9PVHnrurzBQVRUiBG6+JxsGXmVUywLP5APA==
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.0.15.tgz#177d5fafe8925dfe693529a6b319d85c9253990e"
+  integrity sha512-YfacNHFOkXu3Ela/Bo7VIJ4cA7/KUFrSzQ463R9GxKsUpBOoXEowbZnur/Aa6ipX7arckdzpc7vXkPFGiRlsdw==
   dependencies:
-    "@storybook/addon-actions" "7.0.13"
-    "@storybook/addon-backgrounds" "7.0.13"
-    "@storybook/addon-controls" "7.0.13"
-    "@storybook/addon-docs" "7.0.13"
-    "@storybook/addon-highlight" "7.0.13"
-    "@storybook/addon-measure" "7.0.13"
-    "@storybook/addon-outline" "7.0.13"
-    "@storybook/addon-toolbars" "7.0.13"
-    "@storybook/addon-viewport" "7.0.13"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
+    "@storybook/addon-actions" "7.0.15"
+    "@storybook/addon-backgrounds" "7.0.15"
+    "@storybook/addon-controls" "7.0.15"
+    "@storybook/addon-docs" "7.0.15"
+    "@storybook/addon-highlight" "7.0.15"
+    "@storybook/addon-measure" "7.0.15"
+    "@storybook/addon-outline" "7.0.15"
+    "@storybook/addon-toolbars" "7.0.15"
+    "@storybook/addon-viewport" "7.0.15"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-highlight@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.0.13.tgz#af4a015838520f32dd6b6b67b8ad70653d717dab"
-  integrity sha512-9gDF8UT9LcUSe2SRAt2zs+Qoi1KbQrBMLjglMjpbE78wTjjipdEQu9laHLnh/d7yQkAO1wmoQLvgf5WSpv/PjA==
+"@storybook/addon-highlight@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.0.15.tgz#d6de7647b2b84309980a69217f1c19498543c2b5"
+  integrity sha512-lqf2rZkCpbxse0DXWjlRbCUTjCbUDNTh0aqt1L2NJkZKN2UrHjKbCXOHdtbMJewTLCuatKmjpHNbYp3sAzVq7w==
   dependencies:
-    "@storybook/core-events" "7.0.13"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.0.13"
+    "@storybook/preview-api" "7.0.15"
 
-"@storybook/addon-measure@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.0.13.tgz#0a92ea57d0727ca270c11600b7b0580205d9e787"
-  integrity sha512-CsvNw+dGcU0aUTEOY4BfgzZ27A3yRz+pGjmRjBZH5/h0xWxAhIs0+rN9XBhtTZ2PZJYA/uiBsUbnivlvo58CYA==
+"@storybook/addon-measure@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.0.15.tgz#f233564a8c9b0659948d131b66714503f2b257d1"
+  integrity sha512-jnLh/Kyb6DWL5wdtqcR8Quuf25GzU6bmAJfMbQ/WUbf60M2fXK4d6h6YiFY9HSiAzc/UaH66tiAvqwe+ztgf4A==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/types" "7.0.15"
 
-"@storybook/addon-outline@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.0.13.tgz#98afd33a861f19aeb57638602734055a722f8fa0"
-  integrity sha512-ntV04Ys7wbPF0dqTqSvmV8var0fhqKbW0VkpNbyWgV0oaEaL6S8sWS3t0EHM0/8VMBCtpEpF066GYGgs7OwMsw==
+"@storybook/addon-outline@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.0.15.tgz#31e60aa3c98f1db9127a8bd7595a71d15eb6316e"
+  integrity sha512-fc4P5f9bk0m8g5MDyj5V4MFsyNlMWEk1wPD6oBoi7VluTBZxfeLRaNrj9Ek6uDcuilTz2KBAf9aOMgluhEKEYw==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/types" "7.0.15"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.0.13.tgz#00f0ec37bd188b9a41fd7b4737e3c5a986f12469"
-  integrity sha512-ixJfuK0GMAJz2cutErnMMIokxCHfTWUs0fmHG6VBV1LsnMqyeBdECkBqhd32aUYpajckoeufxH12es7/+FWdFg==
+"@storybook/addon-toolbars@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.0.15.tgz#30b9eb08d9f8d71672e9a87085b5966f4d1b7381"
+  integrity sha512-DOyOHlChprAn/QLENBeu13MiGjNXHPJt+uOt+GlBY6b4oZbDUHC9l4uC+C/iDzuGBZ1hZ9VQlS2xM8GUcyy78w==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
 
-"@storybook/addon-viewport@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.0.13.tgz#7bd5ec2a7bad425619650978dd5878b60d479608"
-  integrity sha512-fgXwvzdQpTTLPk7p2HWDACBlaW1uSD1Sc8QPc5Md31tLOtYZPC5QGMl5TqArTG773J2NP0kcky+CYOEwDXQmEg==
+"@storybook/addon-viewport@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.0.15.tgz#c37c2ebf648f83168dc55ae6fd6cd08bc57abfc2"
+  integrity sha512-VIOEVKlgHlbzVz00aehSgFa8rSZZDBleadyGKm+XPtuZmY5ovyCYtp1CBtslTxmzJ/U1e2I++SCqeuT4bxNarw==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
     memoizerific "^1.11.3"
     prop-types "^15.7.2"
 
-"@storybook/addons@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-7.0.13.tgz#e243cb288d8194409c29059642d75943009891d8"
-  integrity sha512-KrgYUReM8uhZDub5gHUdUi4q5iPAvB7eeStzsbHVYJcrgOF1qA7kjOdXswzKBWyPf6wmznoVZ72W1sNLZPA3yA==
+"@storybook/addons@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-7.0.15.tgz#13c4b2868c9c8d1533ec46a3e2b1c7acd7d30ce3"
+  integrity sha512-7C9NlhFy9iJopulYhzUaxsNepOFG3tIMrzxfxkLVizlparffDybWfHtUa27wfMAnOu7G71jE7+PreJDz0Lyblg==
   dependencies:
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/types" "7.0.15"
 
-"@storybook/api@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-7.0.13.tgz#bbfa9164b0c03f95c6179d242c4404c19579a1d7"
-  integrity sha512-L9MlpJtUryg5GG2mo8sfa5pW67cgdeyPxD7gRLWZTVzYMkOPr2gdzyB7icNenGYTnrnisfKefUhZ5KI+lcd+0Q==
+"@storybook/api@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-7.0.15.tgz#f0c34a572205e1f2e98fe8f5c38f17300861749a"
+  integrity sha512-otetYqnA+uoptLk6G1Cah1IPS0A9AaRffbRmP1F5q7EMn+0HT9qQ+jOyw2o0qJTbmg4iXC0B2riOcnTm7Rjp9Q==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/manager-api" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/manager-api" "7.0.15"
 
-"@storybook/blocks@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.0.13.tgz#9ca8f06b653e656d0c99f42c86b196ac1b85bc25"
-  integrity sha512-iUHOWVpuzhBsT2HluyK048dw2fZLKig2huDAaXWvqo7vXgcS7I2t/hWtRwKiKkCyHrVPZrqNS6pfBe2GJYBT5A==
+"@storybook/blocks@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.0.15.tgz#46461c9cf905a7c63cea83c9b3fde0b8dcd732df"
+  integrity sha512-ygWH4UukbfEOdTnYs0uWVNQflR2ZEmX4izyLdDrbk3XCi8O5SdgAa4vb7/KW7sErIgkLWr/vo1INo/XXrX/Ceg==
   dependencies:
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/csf" "^0.1.0"
-    "@storybook/docs-tools" "7.0.13"
+    "@storybook/docs-tools" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/lodash" "^4.14.167"
     color-convert "^2.0.1"
     dequal "^2.0.2"
@@ -3460,15 +3460,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.0.13.tgz#d9386e92b5ccc945793734532ae8f6a84bbd4273"
-  integrity sha512-T3LkQIJ3TjGMes1yTrElgQQ8ABDooebPD5QNzxCACkEQdrgwEBh+/sLq62QEdKHTNZlfX3W5PxXtTqV1NMEnnQ==
+"@storybook/builder-manager@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.0.15.tgz#d20250b784ae6adbfcdb5101080f4caf5f996b3b"
+  integrity sha512-NeEhrE6NTL8aOcxyH4TWazAI+6JyrhN+GUk+0ZPwzaraGfgAefMxATACHhDteU8DeSMQW3pymUOvU1uwjLrjWA==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/manager" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/manager" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -3482,31 +3482,31 @@
     process "^0.11.10"
     util "^0.12.4"
 
-"@storybook/builder-webpack5@7.0.13", "@storybook/builder-webpack5@^7.0.0":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.0.13.tgz#1e25ca4c104dec6471e8454d94764c9d49920c34"
-  integrity sha512-8GP/Fph/DCJYsDRVnMRfHnofWXirXLv5lpX7CwZLBwtnUX9Ci+3wFrvkhIx9qIFnK+aqL5G4bTltOgKySn/qag==
+"@storybook/builder-webpack5@7.0.15", "@storybook/builder-webpack5@^7.0.0":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.0.15.tgz#cdd7e36b1a55639a7819da1d7e08b4b965eaad2f"
+  integrity sha512-kxT7oC817nMul6W/dU0lniAnYbiu6RzEFsHp/fu99xSukDmnt+Iea4qKvTJyOmiVJmytSQsSh62RFbLgnflYcQ==
   dependencies:
     "@babel/core" "^7.12.10"
-    "@storybook/addons" "7.0.13"
-    "@storybook/api" "7.0.13"
-    "@storybook/channel-postmessage" "7.0.13"
-    "@storybook/channel-websocket" "7.0.13"
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-api" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/components" "7.0.13"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/core-events" "7.0.13"
-    "@storybook/core-webpack" "7.0.13"
+    "@storybook/addons" "7.0.15"
+    "@storybook/api" "7.0.15"
+    "@storybook/channel-postmessage" "7.0.15"
+    "@storybook/channel-websocket" "7.0.15"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-api" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/components" "7.0.15"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/core-events" "7.0.15"
+    "@storybook/core-webpack" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/preview" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/router" "7.0.13"
-    "@storybook/store" "7.0.13"
-    "@storybook/theming" "7.0.13"
+    "@storybook/manager-api" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/preview" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/router" "7.0.15"
+    "@storybook/store" "7.0.15"
+    "@storybook/theming" "7.0.15"
     "@types/node" "^16.0.0"
     "@types/semver" "^7.3.4"
     babel-loader "^9.0.0"
@@ -3531,48 +3531,48 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.4.3"
 
-"@storybook/channel-postmessage@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-7.0.13.tgz#dbde2457cc20052c01e78554e4d982a1f05b7334"
-  integrity sha512-6cB27snb7zjF64cLtLeVujtJgx1hGhJO37QOaLWg8BUqUuYTdizWnqCoJe5Pn7V4BX5L02TfL2cV7iNdQ75okw==
+"@storybook/channel-postmessage@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-7.0.15.tgz#278bf09a70cb9e46ee6ba4d6c7f95ad5faa9adfe"
+  integrity sha512-5ZHIQI+Upb12C1lxeXHKVDBEtjjwtWN7XbTz+B1OQ09SRW4LEr8OMD/E9UHsQ2cuKrtBLPs8gkfYO+Ibvx5CkQ==
   dependencies:
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/global" "^5.0.0"
     qs "^6.10.0"
     telejson "^7.0.3"
 
-"@storybook/channel-websocket@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-7.0.13.tgz#48dcdd59187e2aa4d1942dc3be7b9b17211b1b35"
-  integrity sha512-oIqVHHXv2FgFcOaaV5fziMqY9Yyivg0KmMtwFw/kRRd5LnQMedLoayhog5cw70vDHfgNknU/68ShL4uVxGFo4w==
+"@storybook/channel-websocket@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-7.0.15.tgz#5d58417082406f6f8f62033f025fd3899fcf1a85"
+  integrity sha512-v+PWiSW0yLdDT+X8UXeacmWV9nmXu/AcWvodFEOj4/WUQnN2V5JJszbFm3lmFDrl1sGHEKZt8r3Q31yq3Jm5Lg==
   dependencies:
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
     "@storybook/global" "^5.0.0"
     telejson "^7.0.3"
 
-"@storybook/channels@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.13.tgz#33c2d59c78abc9541e75f641c6fb99762de33cf4"
-  integrity sha512-HcaAWe1Mp7X4FwUuvnga/wjZFkNDnVmD9A5SElnqOSnYLfptWT5tgoIDm2o8BDJNVckUvoxg0rDBWwhtAIHeoQ==
+"@storybook/channels@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.15.tgz#6e7f416e220d691fca877f6430a70b753ca5ab47"
+  integrity sha512-oCXop4qiikZPOWTeuBYyURszXUW81V4SkOJ1c76rU69DQzzMyTZArlGZCSk2OlwePjsLcKGj9bw+6410MaDtCA==
 
-"@storybook/cli@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.0.13.tgz#8d737c71fa0b6bb414045ab9d09a2bc5f16f5164"
-  integrity sha512-7TkvZD4e8cMKJG+Zmr3l+HE3F975XOy79iTVT4O9wG4zFxsvPjLw26vz9MjhB1X9Cc/aaIlO6B9LkQQo+RNrxQ==
+"@storybook/cli@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.0.15.tgz#2977e51e849bb2bdfa9bfa446d3012ae8603c404"
+  integrity sha512-BxnSAdxsgCFVsey7ASONVJQ7coOZARQou13w7Xleq6y+a7Wi6JQRXNEeNA6JHjMiceuq69BMkvBYr+sJ9Bzwhg==
   dependencies:
     "@babel/core" "^7.20.2"
     "@babel/preset-env" "^7.20.2"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.0.13"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/core-server" "7.0.13"
-    "@storybook/csf-tools" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/telemetry" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/codemod" "7.0.15"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/core-server" "7.0.15"
+    "@storybook/csf-tools" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/telemetry" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/semver" "^7.3.4"
     boxen "^5.1.2"
     chalk "^4.1.0"
@@ -3603,33 +3603,33 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-api@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-7.0.13.tgz#0fb2c31a3808cac1707fab62186207aba736d763"
-  integrity sha512-IWYF990gDgEvWQxKFjAAcpCTmJom+jtyrG7y5163LzOZhhidoXPcN9QOYenF4DK5VzmgaYqabRbFvVYO3fPmrQ==
+"@storybook/client-api@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-7.0.15.tgz#4af6f0126721328887e636f890b01cf0bf55306c"
+  integrity sha512-FpfTFeH7daggOXFmVQcCgMWNp1I90+A8t6RlwzOA2epMNneK12TxS7vqLga1yHNSEEQUXvGgeLgpxeKv9ZwSLQ==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
 
-"@storybook/client-logger@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.0.13.tgz#78041b5507147b5655cf017055906cf2fdca9af2"
-  integrity sha512-qsVVf1FHoy+tGw+d3IhiFWTj3WJ6+iG9EvdGMd/fVN42jMd+rGa0gnpo+2eQkonKhCFG/Ap2LUDGbcuZtsRszQ==
+"@storybook/client-logger@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.0.15.tgz#ad3576b44c05e70ac9cc7ec9a7989025c0d73926"
+  integrity sha512-ezy6i7e0PvNB+s+gAmE2vEHgdlFQZIzpFkNMZjM/lsJYX5+Q7Jgz/+i/fWEtFILUBPiRQGqcDsH7PAn2AfGRcw==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.0.13.tgz#ce60b31f410e67d2679945f910d1f0842d856473"
-  integrity sha512-MkFR5ymm8x2RCk4oA/DqY+6Xk2TSkDUvpIzeT6ghpc8HR1ddFXLTgvRXYcj6bJEm6BeCSbjOs1nDV9SVXBhNbA==
+"@storybook/codemod@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.0.15.tgz#9a24020368da34a0bef69d774bc9b78d88b6f718"
+  integrity sha512-mUoOuqjiPVeMU+Z1J+3QycTwc8IPZlvY24mqdHy6Q2y7vKgozu1G/D/OkJBV+zlleguBpBxQkDLRB3CHA+LVkQ==
   dependencies:
     "@babel/core" "~7.21.0"
     "@babel/preset-env" "~7.21.0"
     "@babel/types" "~7.21.2"
     "@storybook/csf" "^0.1.0"
-    "@storybook/csf-tools" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/csf-tools" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/types" "7.0.15"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
     jscodeshift "^0.14.0"
@@ -3637,35 +3637,35 @@
     prettier "^2.8.0"
     recast "^0.23.1"
 
-"@storybook/components@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.0.13.tgz#01f4e24069814fb59957e8b3ebd6773722a847f9"
-  integrity sha512-QIY0F0/rjiuL6EKcnodtKmTuW93TDoZJALKpixF4sbdTfc1JpBLSCYE20UvYztqF2OGUI4I3EQFVgLkVIeS11w==
+"@storybook/components@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.0.15.tgz#406e85d78302997ea3d8a2bcf1b84e2d4aae7294"
+  integrity sha512-aek4/F5h3DShxS17tUYzI2FBwDT8+IRkg3OnkvybJC2U0MizPjwNa8qUk0kt4lEzt1y1TwnXH7TFCjWYY5zS6A==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     memoizerific "^1.11.3"
     use-resize-observer "^9.1.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-client@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.0.13.tgz#150d5c0e0af44e6e2dc2cb95cf88600bd3135937"
-  integrity sha512-KWSaGOpc6d6aoJxjDzZgcCZ3hnPhPHuYelGhlJumvzeMJF6bTfHgXrGKo4CgPG3y+/YtFqESfVNwV5P8TBbNrQ==
+"@storybook/core-client@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.0.15.tgz#89a6a148e5f46ddcc908adad72084d3f1c269392"
+  integrity sha512-h4/X597DnWp3Ocpli1B27fpKLXEU1qD4PYCnJW4Pl9DyJXBbzCo2VFZ7LyG3Wrod7ZjrmGOYjOiSisS3f8pcPA==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
 
-"@storybook/core-common@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.0.13.tgz#5cbb7427e23e823d6ff8c6c70fa77843278df86b"
-  integrity sha512-0dWenGlxJGi/D6Rb4z+EHvpOwnC2xSkH4ymDnhANmxU25mAQ8BoFgPIiT/5Aw8m7tCcEBgripYS/e2xmXLCubw==
+"@storybook/core-common@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.0.15.tgz#d6c834b7b83e881dbd5270a207668ef70b45cef2"
+  integrity sha512-uAgpAqGedA7oRXstkZJfJYzuQuK4IrbdfJmA+fVlQ8wdpOtV/BL9YVy80W+YJQCkgUYW7KDagpQ8OMqIpiWt2w==
   dependencies:
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/node" "^16.0.0"
     "@types/pretty-hrtime" "^1.0.0"
     chalk "^4.1.0"
@@ -3684,30 +3684,30 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.0.13.tgz#f4097c6dcdb51d8f352d1d18499c0282e19ebff5"
-  integrity sha512-V5kjFn+nEZDv8tzz4OORnSonmKUkkbHoSmzU1LaE6dBPR1yafx/+u7HoiTKoLLvIZ4YvYZ4QvUjcC73dyae0TQ==
+"@storybook/core-events@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.0.15.tgz#cc2c1b9fa77322d97cad7f7d2c8d33323fdd935d"
+  integrity sha512-ffpOLFpDs1T/HVUpGNDyo7c81lfH3Vvga0Hl6uhxm6zi9PkayV3DCgtmZ/W7daC7DiJC+upG/ziMG+5Oj33PDQ==
 
-"@storybook/core-server@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.0.13.tgz#c71f0b87cb68d1cefa19a220e40f473cc74124ff"
-  integrity sha512-iFxlYUqe9SLOg2KsH+krugAgq+UapDyuzpMfmTyaCUxNyQiJ8YU8h4Z49tAdLLLys6bUvVSqrey/HyWdQMIzhg==
+"@storybook/core-server@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.0.15.tgz#112e78370316237ac5a18db68dbf6d668137a0f9"
+  integrity sha512-342wGx7uk4j2R8Zk03GLkiwONXUMV2Frpw2HG2HmGviWArN4B3UmU0YHj00GjFM51kyYtjhaJVyTMA20x+6/Yw==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.88"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.0.13"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/builder-manager" "7.0.15"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/csf" "^0.1.0"
-    "@storybook/csf-tools" "7.0.13"
+    "@storybook/csf-tools" "7.0.15"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/telemetry" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/manager" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/telemetry" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^16.0.0"
     "@types/node-fetch" "^2.5.7"
@@ -3737,36 +3737,36 @@
     watchpack "^2.2.0"
     ws "^8.2.3"
 
-"@storybook/core-webpack@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.0.13.tgz#be9b6b74c163b96a715b9be76446d575764d6442"
-  integrity sha512-BcxVGYpdQEAoXuS2N3X7CfE+7EbW8tfWCvoflXUqaXa1p4fA1tAW1KDKs43XDJeKLgdE6ZEGbAAXEvZnv6wfEw==
+"@storybook/core-webpack@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.0.15.tgz#c2c159d231479dabf0f547bec6ebe7fcdb3e66be"
+  integrity sha512-G/zOX56oQiwNFGCqyzT25tgS+KMhuLtmZwjS9y9v7rgmSkro6Nz6GvA1rI84c0Us/jXRJQAof+SetxbH8ntQhQ==
   dependencies:
-    "@storybook/core-common" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/node" "^16.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/csf-plugin@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.0.13.tgz#df4ce261c7ca0d1ee5b81ca3c422053d0d3dfe24"
-  integrity sha512-Xf47H1AnXgtACvnNQ2+MABfZ6ovdhOOOLpUW0+g+DmZQ9M/uaujgUnXiBDKi2/wtRqMPnrac1bGQW+luL1aGHw==
+"@storybook/csf-plugin@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.0.15.tgz#16faf5043bf1b44e0b02d66ad405511454308432"
+  integrity sha512-qJwZ6FhTt5HhsXY1rgwqwB1aMbuUSJYEVDM2Y5w0vOB+RHRT6JZpZgVlFz2C8qagX/F27seq6GF0VtfgOAJpaA==
   dependencies:
-    "@storybook/csf-tools" "7.0.13"
+    "@storybook/csf-tools" "7.0.15"
     unplugin "^0.10.2"
 
-"@storybook/csf-tools@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.0.13.tgz#99afc9e3ff87b2bc02e4a4138912f0286597f3c3"
-  integrity sha512-8zxHdiHs8F2DeIJUbbHCGj7gbuL6MAarBxuxAIp9eDkZBKFwVFgursRbmPXmwPUaWVkGPI1Du8wsVrd2cQk76Q==
+"@storybook/csf-tools@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.0.15.tgz#5ebda188bec27673844397890703ffb48fa8649f"
+  integrity sha512-PTA8NJTWsAtHsmJcU18PJZA66vyiZtKJJwNL7bTkKuG5HJLer8En6OarJERomhnnr8k0I6dycfWmWgcfeTNoxg==
   dependencies:
     "@babel/generator" "~7.21.1"
     "@babel/parser" "~7.21.2"
     "@babel/traverse" "~7.21.2"
     "@babel/types" "~7.21.2"
     "@storybook/csf" "^0.1.0"
-    "@storybook/types" "7.0.13"
+    "@storybook/types" "7.0.15"
     fs-extra "^11.1.0"
     recast "^0.23.1"
     ts-dedent "^2.0.0"
@@ -3783,15 +3783,15 @@
   resolved "https://registry.yarnpkg.com/@storybook/docs-mdx/-/docs-mdx-0.1.0.tgz#33ba0e39d1461caf048b57db354b2cc410705316"
   integrity sha512-JDaBR9lwVY4eSH5W8EGHrhODjygPd6QImRbwjAuJNEnY0Vw4ie3bPkeGfnacB3OBW6u/agqPv2aRlR46JcAQLg==
 
-"@storybook/docs-tools@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.0.13.tgz#e088ba568a07d15da1d947284305ff5361aa88fa"
-  integrity sha512-SR/vsf8Lel7YTM2Hlbue7L483/aO94A2gMR4QfONVssTK3671AMFlOFNgbU2AMIvLt8XnxeHauwwBAs9oK75Qw==
+"@storybook/docs-tools@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.0.15.tgz#392f0c5272bec980c62edff3444954bcfd5b58e4"
+  integrity sha512-d2GP3UGSz3TS6c/wcB+ngXRNwXlZzyy3vQRAFdirLeTjTN07koyr3aagd5mdJwlMbO2vEIVjNetY4TFX1zfuSQ==
   dependencies:
     "@babel/core" "^7.12.10"
-    "@storybook/core-common" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/core-common" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/doctrine" "^0.0.3"
     doctrine "^3.0.0"
     lodash "^4.17.21"
@@ -3801,19 +3801,19 @@
   resolved "https://registry.yarnpkg.com/@storybook/global/-/global-5.0.0.tgz#b793d34b94f572c1d7d9e0f44fac4e0dbc9572ed"
   integrity sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==
 
-"@storybook/manager-api@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.0.13.tgz#9b091566c41ef2654b3e570c4925e45e68c13dab"
-  integrity sha512-U7pgs9jsEA2CcAyeNfKpxO6+DPNb92ORCPcCi5/XlTf2BEqmdQtZJ4d36gGcM/ro6NBVUAkh96W9aaq+DtEYPQ==
+"@storybook/manager-api@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.0.15.tgz#ffa649f5d0ac75727495b8d5eabd49c7a6ea878e"
+  integrity sha512-S5OZz8QB8pABLFV4hDJrZE5DLk/EJhn/i48xiycuAtBCVcU4jw4xOyrF4f2ZbtsaWQ5GLAAanOb8yTJcqKnItA==
   dependencies:
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/router" "7.0.13"
-    "@storybook/theming" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/router" "7.0.15"
+    "@storybook/theming" "7.0.15"
+    "@storybook/types" "7.0.15"
     dequal "^2.0.2"
     lodash "^4.17.21"
     memoizerific "^1.11.3"
@@ -3822,43 +3822,43 @@
     telejson "^7.0.3"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.0.13.tgz#c6e3f9a399e1b0b1ad6b0985b0d894f1e535430b"
-  integrity sha512-2hQ1pO+5rICGeIrhMlY38cnx7FR9oq3qThBlbBfoEeXB0C912kvlY1vmyYgwhyI8CxIKi+BeFbS2fiVjuBh0eA==
+"@storybook/manager@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.0.15.tgz#adf0b502de0fe85fe39a26a924576d913ebb6674"
+  integrity sha512-ixx+E2Vb34VIY9JqKoWA+Qv3soJhSWW0ETdMaPn+QmcSoicqM4I861hmxm37ROhwRpAMi2U0sS0m4L+6VeB0lQ==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@storybook/mdx2-csf/-/mdx2-csf-1.1.0.tgz#97f6df04d0bf616991cc1005a073ac004a7281e5"
   integrity sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==
 
-"@storybook/node-logger@7.0.13", "@storybook/node-logger@^7.0.0":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.0.13.tgz#82d7bb397cc71c9a1d5a5175b14ecfb4e2c3ff6b"
-  integrity sha512-+rvOuRiREdWnycexAairee0SC8qWwGDaCC06vAN36QG9E6zqcYpAQfb2GmROtJpLOpd6MnUoL2+eYGXlurnfrQ==
+"@storybook/node-logger@7.0.15", "@storybook/node-logger@^7.0.0":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.0.15.tgz#cf4432646789af4d0c7a96933b1fd6512e4017ad"
+  integrity sha512-h7kAbugjW4OqVIs5fd3Lme8+WBaEZYAULaNJ1zdvVpvWepG6iBaF/j8RlZdJzrPDdwQvZ2g9gVk5HySXpeXOjA==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^4.1.0"
     npmlog "^5.0.1"
     pretty-hrtime "^1.0.3"
 
-"@storybook/postinstall@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.0.13.tgz#618cc370d30b5f59c7c1a49f21ab9f38b78739ef"
-  integrity sha512-XXBcmkw0TMoV4LLbTskm46I2XB0zM1U8GMMeETfa+ZVCskh7XOTGibFV7nZjddYSoGm3SGVYA3T3OBfdJUWiXQ==
+"@storybook/postinstall@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.0.15.tgz#dec278dc57072b1b56ffe29231b6944691bf42bb"
+  integrity sha512-oVw7E7iBDEN3toMJPH2bxkS/rLShSHNmK8cU8bO6kdxBVCmUdhqMME7TOzqy7bAZ+ODlFCqwdstp85pO6xarig==
 
-"@storybook/preset-react-webpack@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.0.13.tgz#4c887485923739f9907732a04c77496f4d6363fd"
-  integrity sha512-ztlATn/PbpFXFMN+N+e1jDsP9s+FCVcEhlEn8VlLafINHU5xbqqTDblZ1im3jUysgrncErFuOUzoxDEnqk0LxQ==
+"@storybook/preset-react-webpack@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.0.15.tgz#26973cd58c2863d99b0106967145416b882744e0"
+  integrity sha512-OlxqwnYBzBPvkdw4GlkwTDVcsnFIsLDmH6Ls59JO5/kyAsNKJpsEJuJr5o/ELrSBGX870Tu3/uWoO7J7KVXp1w==
   dependencies:
     "@babel/preset-flow" "^7.18.6"
     "@babel/preset-react" "^7.18.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.5"
-    "@storybook/core-webpack" "7.0.13"
-    "@storybook/docs-tools" "7.0.13"
-    "@storybook/node-logger" "7.0.13"
-    "@storybook/react" "7.0.13"
+    "@storybook/core-webpack" "7.0.15"
+    "@storybook/docs-tools" "7.0.15"
+    "@storybook/node-logger" "7.0.15"
+    "@storybook/react" "7.0.15"
     "@storybook/react-docgen-typescript-plugin" "1.0.6--canary.9.0c3f3b7.0"
     "@types/node" "^16.0.0"
     "@types/semver" "^7.3.4"
@@ -3869,18 +3869,18 @@
     semver "^7.3.7"
     webpack "5"
 
-"@storybook/preview-api@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.0.13.tgz#a0ab1978e1d8c1930430f2bec647380d36b4ac7c"
-  integrity sha512-XpHX74f7XCu3tiXEOtpCnv3AETuQv+wa1Q3JTIrbk29CUxDO19BPcjPTtBOOn7+eYDPMS2TT4j0rsDlrY+Dzew==
+"@storybook/preview-api@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.0.15.tgz#18709cdc75f09536c6cd0343f658aeced6b607b6"
+  integrity sha512-ZjqMFsOYVklO1h4BfyNGpn4FM6lHgQ9RZ+LmUnd1qh/GdxpRHIGLKtsvd4nxaSJLHNE53WO+1yUeJPiglEeE4g==
   dependencies:
-    "@storybook/channel-postmessage" "7.0.13"
-    "@storybook/channels" "7.0.13"
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/core-events" "7.0.13"
+    "@storybook/channel-postmessage" "7.0.15"
+    "@storybook/channels" "7.0.15"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/core-events" "7.0.15"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/types" "7.0.13"
+    "@storybook/types" "7.0.15"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -3890,10 +3890,10 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/preview@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.0.13.tgz#f81a187867646e369fa4a96d8b1d7ba081c412b1"
-  integrity sha512-1tdhOVgX4Sip/mF8PocIFGpyc8a8oS1pTZzd4yGH8KUH7OsMTKu+bcjQesXpEpAH0je0Q9yxWIhv9Vh9GIJndA==
+"@storybook/preview@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.0.15.tgz#510151fa6434f70f6b97f3d7284f06f88009ca4a"
+  integrity sha512-rTHgSCpKOnypMVQZdJ78Hlcnkm54UK6KTbQrM3LW41W5sbmTV3OpN6x0Ke7FY6tvrpWATJs26YrTTatDV8tbUA==
 
 "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0":
   version "1.0.6--canary.9.0c3f3b7.0"
@@ -3908,33 +3908,33 @@
     react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
-"@storybook/react-dom-shim@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.0.13.tgz#4a249e4228ec2b1248f7b753ae7bc2505b83347c"
-  integrity sha512-7tZL42BoN2GMpuYoVmeNKLwaWBsBkww4Lva9BuJxS03qBCAqz0o3c3ETU9SCFIAzEvFMO46UErjKGyZPSDx1zw==
+"@storybook/react-dom-shim@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.0.15.tgz#29d61890a4de207c5040d529d9449c18df53250a"
+  integrity sha512-Yi/1ZtzttAay3TMFyiF5oV317fUwdAT+Z595sBCMHEzhZWUA9zKxvR0KAQ2cBlCc6u7+tJvIMaGkcS/IZWVqPw==
 
 "@storybook/react-webpack5@^7.0.0":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.0.13.tgz#536956d0a31ef035f3afedadde98109f397fbb8d"
-  integrity sha512-2XtInWVpeLaKlIXlGoOKIknCVoXwnnCUchdSMhh1Gsn4CnyMTQxz7MFolNJHUTUT524X6J7sBPw+jPWnCWNHbw==
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.0.15.tgz#bf6c8d07f976dc8d6225772e971ee03a6aa01851"
+  integrity sha512-6R7hb93ZnEG1wXAMhi3RNL5+kivbanQ1uvWdGWVF4T41h/X5ipaVSS8kfTNQTc5DLyPh4bmi0a3l6ftoHvWrtQ==
   dependencies:
-    "@storybook/builder-webpack5" "7.0.13"
-    "@storybook/preset-react-webpack" "7.0.13"
-    "@storybook/react" "7.0.13"
+    "@storybook/builder-webpack5" "7.0.15"
+    "@storybook/preset-react-webpack" "7.0.15"
+    "@storybook/react" "7.0.15"
     "@types/node" "^16.0.0"
 
-"@storybook/react@7.0.13", "@storybook/react@^7.0.0":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.0.13.tgz#fc541fa68a58af63a9af4f24a4fbe5fb6cef8af9"
-  integrity sha512-+D/OYCUD/r0xX6ZWXIoNLqRptBtJS8pYWevKhEip0FvB3KL7m/9+5YXgh5b539N1+k3hP7cqQuYxY/ftoJBXQw==
+"@storybook/react@7.0.15", "@storybook/react@^7.0.0":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.0.15.tgz#1c8595c2676f70493ab378880797b3265e585d58"
+  integrity sha512-YuqUyfbPr4mFsRAIUTmVgx5mCNK00fg/Mztwyg3PRN4SuRWhx5MJy6kMX2GV3DcKqyeC5U2aWKHlzjzrGwXymw==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/core-client" "7.0.13"
-    "@storybook/docs-tools" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/core-client" "7.0.15"
+    "@storybook/docs-tools" "7.0.15"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.0.13"
-    "@storybook/react-dom-shim" "7.0.13"
-    "@storybook/types" "7.0.13"
+    "@storybook/preview-api" "7.0.15"
+    "@storybook/react-dom-shim" "7.0.15"
+    "@storybook/types" "7.0.15"
     "@types/escodegen" "^0.0.6"
     "@types/estree" "^0.0.51"
     "@types/node" "^16.0.0"
@@ -3950,30 +3950,30 @@
     type-fest "^2.19.0"
     util-deprecate "^1.0.2"
 
-"@storybook/router@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.0.13.tgz#2d1a13e15709d14e707b873df058f032dbcc4506"
-  integrity sha512-5tjzSXc0cd4Dcc4MCGWr40ozGNhzsMOT2K5negKZJYJgjaz/BAPD/zfFLo2SNvayN2uY62h7OmWQQD+NlYKGNA==
+"@storybook/router@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.0.15.tgz#cdda522ac825b8b03ff198ee3e2eb9879bad101d"
+  integrity sha512-iwW2bzoULMIHjzK7ok0l+4O5AafyZ1APMUcYv8S+lC1bOl7odAcV2dbUQ21M1D/L+no7LrcnfJBGOD8NKE4nTQ==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
-"@storybook/store@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/store/-/store-7.0.13.tgz#7d3fef7debcb2bacb87a4bb44302337843c6f662"
-  integrity sha512-RjTDZeyJFlenFjFMv5s8Vwocom0CuRf7UNuDzsbAdBx+8wKE3wFBV4ZjZW+rXe7dxV600l9QZwoWpT92wqItEA==
+"@storybook/store@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/store/-/store-7.0.15.tgz#d3a8a6b0a21f27e955e05900e6ebf9ce9698ec6c"
+  integrity sha512-r14KVdG8ehs3WRxciUdpBsaT2bmLx31BuAUOgE0kAyP+h7Iw6NINRKyYjZlHNNTxU6lJcA8HxCPuif32J8UqJw==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/preview-api" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/preview-api" "7.0.15"
 
-"@storybook/telemetry@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.0.13.tgz#db89fb81fa49ee0bba228bb18de050a8d727f127"
-  integrity sha512-th2GP+ELznviiRporN1L0VNGU9XRPD7wn7JzgMUvRfr8jPobTKUFI5/uRHDY5SIFx97R/Po8C6PtP7aFJaW9Jg==
+"@storybook/telemetry@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.0.15.tgz#98f2bf6534ad18c08557bf2088b110fce7418dfe"
+  integrity sha512-Tuf6Oy1Lxr+bGT9rILT1oKlQtHrO9oCzk/6/wSSZnV08yzwqe5Tmc8OUd9ytc2BbQb67yObsT9Lb9YC+9+X3+g==
   dependencies:
-    "@storybook/client-logger" "7.0.13"
-    "@storybook/core-common" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
+    "@storybook/core-common" "7.0.15"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
@@ -3982,22 +3982,22 @@
     nanoid "^3.3.1"
     read-pkg-up "^7.0.1"
 
-"@storybook/theming@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.0.13.tgz#20bc10f23bd22ee6036e7c9c2f47eb1f437a925e"
-  integrity sha512-m4gdvmwWUCRPxqY4BVyRd74pS704f0DS5HpNw3sSdBCgAaMIZX70LYwwxvVWhBR5zjBHABf1t+A93lfm+zS1MQ==
+"@storybook/theming@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.0.15.tgz#9a8699b41279bb47595c28ce72a30de6cdcbd064"
+  integrity sha512-oxy1jTt1lYLWCRXhSnjvxIzJHW+tQS4kqD/F8mr3/C0WbMXbSv/rKlS2fkIYbOecjqs0C/8ypa1KzEMcBTfIRQ==
   dependencies:
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@storybook/client-logger" "7.0.13"
+    "@storybook/client-logger" "7.0.15"
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
 
-"@storybook/types@7.0.13":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.13.tgz#b6328bd3998f1091a8d1025781ad6f67aa503967"
-  integrity sha512-xCGkgWnP636M6QuLr/c0vC83ZysMrnj/NclYhSORX4SZJi2yov6MU79zD+p6eUodGmlO8b5hsGTDeyR/hns6Yw==
+"@storybook/types@7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.15.tgz#606c0b55978c99c40d86bc296508231b6a8db894"
+  integrity sha512-WjrTpRxCZDL7noDv7ziRdOsuYMppbKRsWlH53HY5GFXJZPYaFWs6lKZOo7+T8OxYXegD4Y5AcD8tGQrX8GtycQ==
   dependencies:
-    "@storybook/channels" "7.0.13"
+    "@storybook/channels" "7.0.15"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"
@@ -4951,9 +4951,9 @@
   integrity sha512-7VFuFekVzbr0uktqfBmsJc/CqjwnXWWOc5mHn7rajxzhLO9aM9nMMhtpa+90UK1GW6C0ctQF/9Fh0qJBwjqNXg==
 
 "@types/testing-library__jest-dom@^5.9.1":
-  version "5.14.5"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
-  integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
+  version "5.14.6"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz#4887f6e1af11215428ab02777873bcede98a53b0"
+  integrity sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==
   dependencies:
     "@types/jest" "*"
 
@@ -8605,9 +8605,9 @@ electron-publish@23.6.0:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.404"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz#16baf653a7a2613e221da61480ad02fe84e40231"
-  integrity sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw==
+  version "1.4.405"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz#487bdba2d82a59b092d6b6e4602bf733cec6a7ef"
+  integrity sha512-JdDgnwU69FMZURoesf9gNOej2Cms1XJFfLk24y1IBtnAdhTcJY/mXnokmpmxHN59PcykBP4bgUU98vLY44Lhuw==
 
 electron-updater@^5.0.1:
   version "5.3.0"
@@ -13970,9 +13970,9 @@ node-polyfill-webpack-plugin@^2.0.1:
     vm-browserify "^1.1.2"
 
 node-releases@^2.0.8:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.11.tgz#59d7cef999d13f908e43b5a70001cf3129542f0f"
-  integrity sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.12.tgz#35627cc224a23bfb06fb3380f2b3afaaa7eb1039"
+  integrity sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -15347,9 +15347,9 @@ postcss-modules-extract-imports@^3.0.0:
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
 
 postcss-modules-local-by-default@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.2.tgz#586297f6ed3f307102feaacfad77473f05f15b80"
-  integrity sha512-mR/pcIsQhU2UgKYOPjRCSgacmjn08pyrHk+Vrm8WEKjDWgqO43vdRkzmxyZOZWiKr6Ed9gpReQHhLUGVAcn9jw==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz#b08eb4f083050708998ba2c6061b50c2870ca524"
+  integrity sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==
   dependencies:
     icss-utils "^5.0.0"
     postcss-selector-parser "^6.0.2"
@@ -17589,11 +17589,11 @@ store2@^2.14.2:
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
 storybook@^7.0.0:
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.0.13.tgz#9072aea5bb628b404a1ae6db773217a1e704c14f"
-  integrity sha512-p12kIjcAZtpO7Z8DKYWFTsjEcU+D8unGclJOEtZlkUmgbCORcR4eOKH4JMRsH3QefH/EsCtXcxUgonbmolHIEg==
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.0.15.tgz#7c2f804f0422274a6f6e3a01ca4dda00689111b2"
+  integrity sha512-GYGRH20H2G0oUhoh40p0o0AGPXN/cKntpt/BX7NKB1Dr4OqbawBw/65yGhuFuYA+HFjBUonWixicOgPkrsyuKg==
   dependencies:
-    "@storybook/cli" "7.0.13"
+    "@storybook/cli" "7.0.15"
 
 stream-browserify@^3.0.0:
   version "3.0.0"
@@ -18124,9 +18124,9 @@ terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugi
     terser "^5.16.8"
 
 terser@^5.0.0, terser@^5.10.0, terser@^5.16.8:
-  version "5.17.5"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.5.tgz#557141b662b5978ac3d6a2f3d6455a26267ddcd4"
-  integrity sha512-NqFkzBX34WExkCbk3K5urmNCpEWqMPZnwGI1pMHwqvJ/zDlXC75u3NI7BrzoR8/pryy8Abx2e1i8ChrWkhH1Hg==
+  version "5.17.6"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.6.tgz#d810e75e1bb3350c799cd90ebefe19c9412c12de"
+  integrity sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -18344,9 +18344,9 @@ ts-interface-checker@^0.1.9:
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
 ts-loader@^9.3.0:
-  version "9.4.2"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.4.2.tgz#80a45eee92dd5170b900b3d00abcfa14949aeb78"
-  integrity sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.4.3.tgz#55cfa7c28dd82a2de968ae45c3adb75fb888b27e"
+  integrity sha512-n3hBnm6ozJYzwiwt5YRiJZkzktftRpMiBApHaJPoWLA+qetQBAXkHqCLM6nwSdRDimqVtA5ocIkcTRLMTt7yzA==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.0.0"
@@ -19666,9 +19666,9 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.1.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
-  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.0.tgz#47ebe58ee718f772ce65862beb1db816210589a0"
+  integrity sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
Fixes #3721 

greatly aided by pairing with @garrettjstevens

We discovered that you cannot use "yarn resolutions" to resolve things that are explicitly listed in the package.json "dependencies" and not on npm yet. it works for implicit dependencies (e.g. dependencies of dependencies) but not explicit ones (it tries to fetch from npmjs.org and fails with a 404)

This therefore changes what is explicitly listed in the dependencies to refer to the packed file