### PR TITLE
Fix specifying the assemblyNames config slot on add-connection CLI

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -189,31 +189,31 @@ ARGUMENTS
                        For JBrowse 1, location of JB1 data directory similar to http://mysite.com/jbrowse/data/
 
 OPTIONS
-  -a, --assemblyName=assemblyName  Assembly name of the connection If none, will default to the assembly in your config
-                                   file
+  -a, --assemblyNames=assemblyNames  Comma separated list of assembly name(s) to filter from this connection. Optional,
+                                     will show all assemblies from connection if unspecified
 
-  -c, --config=config              Any extra config settings to add to connection in JSON object format, such as
-                                   '{"uri":"url":"https://sample.com"}, "locationType": "UriLocation"}'
+  -c, --config=config                Any extra config settings to add to connection in JSON object format, such as
+                                     '{"uri":"url":"https://sample.com"}, "locationType": "UriLocation"}'
 
-  -f, --force                      Equivalent to `--skipCheck --overwrite`
+  -f, --force                        Equivalent to `--skipCheck --overwrite`
 
-  -h, --help                       show CLI help
+  -h, --help                         show CLI help
 
-  -n, --name=name                  Name of the connection. Defaults to connectionId if not provided
+  -n, --name=name                    Name of the connection. Defaults to connectionId if not provided
 
-  -t, --type=type                  type of connection, ex. JBrowse1Connection, UCSCTrackHubConnection, custom
+  -t, --type=type                    type of connection, ex. JBrowse1Connection, UCSCTrackHubConnection, custom
 
-  --connectionId=connectionId      Id for the connection that must be unique to JBrowse.  Defaults to
-                                   'connectionType-assemblyName-currentTime'
+  --connectionId=connectionId        Id for the connection that must be unique to JBrowse.  Defaults to
+                                     'connectionType-assemblyName-currentTime'
 
-  --out=out                        synonym for target
+  --out=out                          synonym for target
 
-  --overwrite                      Overwrites any existing connections if same connection id
+  --overwrite                        Overwrites any existing connections if same connection id
 
-  --skipCheck                      Don't check whether or not the data directory URL exists or if you are in a JBrowse
-                                   directory
+  --skipCheck                        Don't check whether or not the data directory URL exists or if you are in a JBrowse
+                                     directory
 
-  --target=target                  path to config file in JB2 installation directory to write out to.
+  --target=target                    path to config file in JB2 installation directory to write out to.
 
 EXAMPLES
   $ jbrowse add-connection http://mysite.com/jbrowse/data/

--- a/products/jbrowse-cli/src/commands/add-connection.test.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.test.ts
@@ -68,24 +68,6 @@ describe('add-connection', () => {
     .command(['add-connection', 'https://mysite.com/notafile.txt'])
     .exit(170)
     .it('fails when fetching from url fails')
-  setup
-    .nock('https://example.com', site => site.head('/hub.txt').reply(200))
-    .do(async ctx => {
-      await copyFile(testConfig, path.join(ctx.dir, path.basename(testConfig)))
-
-      await rename(
-        path.join(ctx.dir, path.basename(testConfig)),
-        path.join(ctx.dir, 'config.json'),
-      )
-    })
-    .command([
-      'add-connection',
-      'https://example.com/hub.txt',
-      '--assemblyName',
-      'nonexistAssembly',
-    ])
-    .exit(130)
-    .it('fails if not a matching assembly name')
 
   setupWithDateMock
     .nock('https://mysite.com', site => site.head('/data/hub.txt').reply(200))
@@ -105,13 +87,12 @@ describe('add-connection', () => {
         connections: [
           {
             type: 'UCSCTrackHubConnection',
-            assemblyName: 'testAssembly',
-            connectionId: 'UCSCTrackHubConnection-testAssembly-1',
+            connectionId: 'UCSCTrackHubConnection-1',
             hubTxtLocation: {
               uri: 'https://mysite.com/data/hub.txt',
               locationType: 'UriLocation',
             },
-            name: 'UCSCTrackHubConnection-testAssembly-1',
+            name: 'UCSCTrackHubConnection-1',
           },
         ],
       })
@@ -134,13 +115,12 @@ describe('add-connection', () => {
         connections: [
           {
             type: 'JBrowse1Connection',
-            assemblyName: 'testAssembly',
-            connectionId: 'JBrowse1Connection-testAssembly-1',
+            connectionId: 'JBrowse1Connection-1',
             dataDirLocation: {
               uri: 'https://mysite.com/jbrowse/data',
               locationType: 'UriLocation',
             },
-            name: 'JBrowse1Connection-testAssembly-1',
+            name: 'JBrowse1Connection-1',
           },
         ],
       })
@@ -186,7 +166,7 @@ describe('add-connection', () => {
       'newConnectionId',
       '--name',
       'newName',
-      '--assemblyName',
+      '--assemblyNames',
       'testAssembly',
       '--config',
       '{"url":{"uri":"https://mysite.com/custom"}, "locationType": "UriLocation"}',
@@ -198,7 +178,7 @@ describe('add-connection', () => {
         connections: [
           {
             type: 'newType',
-            assemblyName: 'testAssembly',
+            assemblyNames: ['testAssembly'],
             connectionId: 'newConnectionId',
             locationType: 'UriLocation',
             url: {
@@ -274,7 +254,6 @@ describe('add-connection', () => {
           connections: [
             {
               type: 'custom',
-              assemblyName: 'testAssembly',
               connectionId: 'newConnectionId',
               locationType: 'UriLocation',
               url: {


### PR DESCRIPTION
Renames --assemblyName to --assemblyNames in the add-connection CLI, and makes clear that it is optional and is a comma separated list of multiple assembly names

Also makes some miscellaneous code simplifications