### PR TITLE
Avoid re-prompting a user login when refresh token is processed

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "cross-spawn": "^7.0.1",
     "crypto-js": "^3.0.0",
     "dependency-graph": "^0.11.0",
-    "electron": "25.0.1",
+    "electron": "25.1.0",
     "electron-builder": "^23.0.3",
     "electron-mock-ipc": "^0.3.8",
     "eslint": "^8.0.0",

--- a/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
+++ b/packages/core/pluggableElementTypes/models/InternetAccountModel.ts
@@ -210,12 +210,15 @@ export const InternetAccount = types
      * #action
      */
     addAuthHeaderToInit(init: RequestInit = {}, token: string) {
-      const newHeaders = new Headers(init.headers || {})
-      newHeaders.append(
-        self.authHeader,
-        self.tokenType ? `${self.tokenType} ${token}` : token,
-      )
-      return { ...init, headers: newHeaders }
+      return {
+        ...init,
+        headers: new Headers({
+          ...init.headers,
+          [self.authHeader]: self.tokenType
+            ? `${self.tokenType} ${token}`
+            : token,
+        }),
+      }
     },
     /**
      * #action

--- a/plugins/authentication/src/DropboxOAuthModel/configSchema.ts
+++ b/plugins/authentication/src/DropboxOAuthModel/configSchema.ts
@@ -51,14 +51,6 @@ const DropboxOAuthConfigSchema = ConfigurationSchema(
         'getdropbox.com',
       ],
     },
-    /**
-     * #slot
-     */
-    hasRefreshToken: {
-      description: 'true if the endpoint can supply a refresh token',
-      type: 'boolean',
-      defaultValue: true,
-    },
   },
   {
     /**

--- a/plugins/authentication/src/DropboxOAuthModel/model.tsx
+++ b/plugins/authentication/src/DropboxOAuthModel/model.tsx
@@ -97,8 +97,7 @@ const stateModelFactory = (
           },
         )
         if (!response.ok) {
-          const refreshToken =
-            self.hasRefreshToken && self.retrieveRefreshToken()
+          const refreshToken = self.retrieveRefreshToken()
           if (refreshToken) {
             self.removeRefreshToken()
             const newToken = await self.exchangeRefreshForAccessToken(

--- a/plugins/authentication/src/HTTPBasicModel/HTTPBasicLoginForm.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/HTTPBasicLoginForm.tsx
@@ -17,7 +17,7 @@ export const HTTPBasicLoginForm = ({
       open
       maxWidth="xl"
       data-testid="login-httpbasic"
-      title={`Log In for {internetAccountId}`}
+      title={`Log In for ${internetAccountId}`}
     >
       <form
         onSubmit={event => {

--- a/plugins/authentication/src/OAuthModel/configSchema.ts
+++ b/plugins/authentication/src/OAuthModel/configSchema.ts
@@ -70,17 +70,10 @@ const OAuthConfigSchema = ConfigurationSchema(
      * #slot
      */
     responseType: {
-      description: 'the type of response from the authorization endpoint',
+      description:
+        "the type of response from the authorization endpoint. can be 'token' or 'code'",
       type: 'string',
       defaultValue: 'code',
-    },
-    /**
-     * #slot
-     */
-    hasRefreshToken: {
-      description: 'true if the endpoint can supply a refresh token',
-      type: 'boolean',
-      defaultValue: false,
     },
   },
   {

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -342,17 +342,23 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           reject: (error: Error) => void,
         ) {
           const refreshToken = self.retrieveRefreshToken()
+          let doUserFlow = true
+
+          // if there is a refresh token, then try it out, and only if that
+          // refresh token succeeds, set doUserFlow to false
           if (refreshToken) {
             try {
               const token = await self.exchangeRefreshForAccessToken(
                 refreshToken,
               )
               resolve(token)
+              doUserFlow = false
             } catch (e) {
               console.error(e)
               self.removeRefreshToken()
             }
-          } else {
+          }
+          if (doUserFlow) {
             this.addMessageChannel(resolve, reject)
             // may want to improve handling
             // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -416,18 +416,9 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           const fetcher = superGetFetcher(loc)
           return async (input: RequestInfo, init?: RequestInit) => {
             if (loc) {
-              try {
-                await self.getPreAuthorizationInformation(loc)
-              } catch (e) {
-                console.error(e)
-                /* ignore error */
-              }
+              await self.validateToken(await self.getToken(loc), loc)
             }
-            const response = await fetcher(input, init)
-            if (!response.ok) {
-              throw new Error(await getResponseError({ response }))
-            }
-            return response
+            return fetcher(input, init)
           }
         },
       }

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -5,7 +5,12 @@ import { Instance, types } from 'mobx-state-tree'
 
 // locals
 import { OAuthInternetAccountConfigModel } from './configSchema'
-import { fixup, generateChallenge } from './util'
+import {
+  fixup,
+  generateChallenge,
+  processError,
+  processTokenResponse,
+} from './util'
 import { getResponseError } from '../util'
 
 interface OAuthData {
@@ -17,14 +22,6 @@ interface OAuthData {
   code_challenge_method?: string
   token_access_type?: string
   state?: string
-}
-
-interface OAuthExchangeData {
-  code: string
-  grant_type: string
-  client_id: string
-  redirect_uri: string
-  code_verifier?: string
 }
 
 /**
@@ -98,7 +95,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
        * Can override or extend if dynamic state is needed.
        */
       state(): string | undefined {
-        return getConf(self, 'state') || undefined
+        return getConf(self, 'state')
       },
       /**
        * #getter
@@ -109,16 +106,11 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
       /**
        * #getter
        */
-      get hasRefreshToken(): boolean {
-        return getConf(self, 'hasRefreshToken')
-      },
-      /**
-       * #getter
-       */
       get refreshTokenKey() {
         return `${self.internetAccountId}-refreshToken`
       },
     }))
+
     .actions(self => ({
       /**
        * #action
@@ -145,17 +137,15 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
         token: string,
         redirectUri: string,
       ): Promise<string> {
-        const data: OAuthExchangeData = {
-          code: token,
-          grant_type: 'authorization_code',
-          client_id: self.clientId,
-          redirect_uri: redirectUri,
-        }
-        if (self.needsPKCE) {
-          data.code_verifier = self.codeVerifierPKCE
-        }
-
-        const params = new URLSearchParams(Object.entries(data))
+        const params = new URLSearchParams(
+          Object.entries({
+            code: token,
+            grant_type: 'authorization_code',
+            client_id: self.clientId,
+            redirect_uri: redirectUri,
+            ...(self.needsPKCE ? { code_verifier: self.codeVerifierPKCE } : {}),
+          }),
+        )
 
         const response = await fetch(self.tokenEndpoint, {
           method: 'POST',
@@ -172,11 +162,10 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           )
         }
 
-        const accessToken = await response.json()
-        if (accessToken.refresh_token) {
-          this.storeRefreshToken(accessToken.refresh_token)
-        }
-        return accessToken.access_token
+        const data = await response.json()
+        return processTokenResponse(data, token =>
+          this.storeRefreshToken(token),
+        )
       },
       /**
        * #action
@@ -184,43 +173,32 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
       async exchangeRefreshForAccessToken(
         refreshToken: string,
       ): Promise<string> {
-        const data = {
-          grant_type: 'refresh_token',
-          refresh_token: refreshToken,
-          client_id: self.clientId,
-        }
-
-        const params = new URLSearchParams(Object.entries(data))
-
         const response = await fetch(self.tokenEndpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: params.toString(),
+          body: new URLSearchParams(
+            Object.entries({
+              grant_type: 'refresh_token',
+              refresh_token: refreshToken,
+              client_id: self.clientId,
+            }),
+          ).toString(),
         })
 
         if (!response.ok) {
           self.removeToken()
-          let text = await response.text()
-          try {
-            const obj = JSON.parse(text)
-            if (obj.error === 'invalid_grant') {
-              this.removeRefreshToken()
-            }
-            text = obj?.error_description ?? text
-          } catch (e) {
-            /* just use original text as error */
-          }
-
+          const text = await response.text()
           throw new Error(
-            await getResponseError({ response, statusText: text }),
+            await getResponseError({
+              response,
+              statusText: processError(text, () => this.removeRefreshToken()),
+            }),
           )
         }
-
-        const accessToken = await response.json()
-        if (accessToken.refresh_token) {
-          this.storeRefreshToken(accessToken.refresh_token)
-        }
-        return accessToken.access_token
+        const data = await response.json()
+        return processTokenResponse(data, token =>
+          this.storeRefreshToken(token),
+        )
       },
     }))
     .actions(self => {
@@ -286,10 +264,10 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
               )
               self.storeToken(token)
               return resolve(token)
-            } catch (error) {
-              return error instanceof Error
-                ? reject(error)
-                : reject(new Error(String(error)))
+            } catch (e) {
+              return e instanceof Error
+                ? reject(e)
+                : reject(new Error(String(e)))
             }
           }
           if (redirectUriWithInfo.includes('access_denied')) {
@@ -316,6 +294,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
             client_id: self.clientId,
             redirect_uri: redirectUri,
             response_type: self.responseType || 'code',
+            token_access_type: 'offline',
           }
 
           if (self.state()) {
@@ -329,10 +308,6 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           if (self.needsPKCE) {
             data.code_challenge = await generateChallenge(self.codeVerifierPKCE)
             data.code_challenge_method = 'S256'
-          }
-
-          if (self.hasRefreshToken) {
-            data.token_access_type = 'offline'
           }
 
           const params = new URLSearchParams(Object.entries(data))
@@ -356,8 +331,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.finishOAuthWindow(eventFromDesktop, resolve, reject)
           } else {
-            const options = `width=500,height=600,left=0,top=0`
-            window.open(url, eventName, options)
+            window.open(url, eventName, `width=500,height=600,left=0,top=0`)
           }
         },
         /**
@@ -367,22 +341,23 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           resolve: (token: string) => void,
           reject: (error: Error) => void,
         ) {
-          const refreshToken =
-            self.hasRefreshToken && self.retrieveRefreshToken()
+          const refreshToken = self.retrieveRefreshToken()
           if (refreshToken) {
             try {
               const token = await self.exchangeRefreshForAccessToken(
                 refreshToken,
               )
               resolve(token)
-            } catch (err) {
+            } catch (e) {
+              console.error(e)
               self.removeRefreshToken()
             }
+          } else {
+            this.addMessageChannel(resolve, reject)
+            // may want to improve handling
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.useEndpointForAuthorization(resolve, reject)
           }
-          this.addMessageChannel(resolve, reject)
-          // may want to improve handling
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.useEndpointForAuthorization(resolve, reject)
         },
         /**
          * #action
@@ -392,8 +367,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           const response = await fetch(location.uri, newInit)
           if (!response.ok) {
             self.removeToken()
-            const refreshToken =
-              self.hasRefreshToken && self.retrieveRefreshToken()
+            const refreshToken = self.retrieveRefreshToken()
             if (refreshToken) {
               try {
                 if (!exchangedTokenPromise) {
@@ -439,6 +413,7 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
               try {
                 await self.getPreAuthorizationInformation(loc)
               } catch (e) {
+                console.error(e)
                 /* ignore error */
               }
             }

--- a/plugins/authentication/src/OAuthModel/util.ts
+++ b/plugins/authentication/src/OAuthModel/util.ts
@@ -7,3 +7,27 @@ export async function generateChallenge(val: string) {
   const Base64 = await import('crypto-js/enc-base64')
   return fixup(Base64.stringify(sha256(val)))
 }
+
+// if response is JSON, checks if it needs to remove tokens in error, or just plain throw
+export function processError(text: string, invalidErrorCb: () => void) {
+  try {
+    const obj = JSON.parse(text)
+    if (obj.error === 'invalid_grant') {
+      invalidErrorCb()
+    }
+    return obj?.error_description ?? text
+  } catch (e) {
+    /* response text is not json, just use original text as error */
+  }
+  return text
+}
+
+export function processTokenResponse(
+  data: { refresh_token?: string; access_token: string },
+  storeRefreshTokenCb: (str: string) => void,
+) {
+  if (data.refresh_token) {
+    storeRefreshTokenCb(data.refresh_token)
+  }
+  return data.access_token
+}

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -105,13 +105,13 @@
     "webpack": "^5.72.0"
   },
   "devDependencies": {
-    "electron": "25.0.1"
+    "electron": "25.1.0"
   },
   "browserslist": [
     "last 1 chrome version"
   ],
   "build": {
-    "electronVersion": "25.0.1",
+    "electronVersion": "25.1.0",
     "extraMetadata": {
       "main": "build/electron.js"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,9 +5195,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16", "@types/react@^18.0.26":
-  version "18.2.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.8.tgz#a77dcffe4e9af148ca4aa8000c51a1e8ed99e2c8"
-  integrity sha512-lTyWUNrd8ntVkqycEEplasWy2OxNlShj3zqS0LuB1ENUGis5HodmhM7DtCoUGbxj3VW/WsGA0DUhpG6XrM7gPA==
+  version "18.2.9"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.9.tgz#9207f8571afdc59a9c9c30df50e8ad2591ecefaf"
+  integrity sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -9063,10 +9063,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@25.0.1:
-  version "25.0.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-25.0.1.tgz#19b28fa9f2a0575c5ba49b4d53343240b1515b09"
-  integrity sha512-YD3xCrH01LiPeLlG90DWgMXJK69UxY4NiXKqXT12HOiXLqEaKrLWap+CiiS7J7SWUXz+4XOItQI8g1dtG7zkkA==
+electron@25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.1.0.tgz#78c79aba4bef941217c337dca46745b5551b5735"
+  integrity sha512-VKk4G/0euO7ysMKQKHXmI4d3/qR4uHsAtVFXK2WfQUVxBmc160OAm2R6PN9/EXmgXEioKQBtbc2/lvWyYpDbuA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
Follow up to the oauth PR

Also does a couple refactors

a) disables the need to have any config slot for "hasRefreshToken". it is just there or not in the responses, and eagerly attempted to use
b) misc immutable js syntax sugar
c) adds more console.error logs where before they were silent, which may make the log noisier but may improve debugging

