### PR TITLE
Use validateToken to exchange refresh token in OAuth getFetcher

### DIFF
--- a/plugins/authentication/src/HTTPBasicModel/HTTPBasicLoginForm.tsx
+++ b/plugins/authentication/src/HTTPBasicModel/HTTPBasicLoginForm.tsx
@@ -17,7 +17,7 @@ export const HTTPBasicLoginForm = ({
       open
       maxWidth="xl"
       data-testid="login-httpbasic"
-      title={`Log In for {internetAccountId}`}
+      title={`Log In for ${internetAccountId}`}
     >
       <form
         onSubmit={event => {

--- a/plugins/authentication/src/OAuthModel/model.tsx
+++ b/plugins/authentication/src/OAuthModel/model.tsx
@@ -416,18 +416,9 @@ const stateModelFactory = (configSchema: OAuthInternetAccountConfigModel) => {
           const fetcher = superGetFetcher(loc)
           return async (input: RequestInfo, init?: RequestInit) => {
             if (loc) {
-              try {
-                await self.getPreAuthorizationInformation(loc)
-              } catch (e) {
-                console.error(e)
-                /* ignore error */
-              }
+              await self.validateToken(await self.getToken(loc), loc)
             }
-            const response = await fetcher(input, init)
-            if (!response.ok) {
-              throw new Error(await getResponseError({ response }))
-            }
-            return response
+            return fetcher(input, init)
           }
         },
       }


### PR DESCRIPTION
One tiny bugfix in this (was missing a "$" in a template literal substitution). Feel free to cherry-pick that commit out if the other commit requires more discussion.

Side note, it seems like there should be some sort of eslint rule that warns about `{` instead of `${` in template literals, but the closest thing I could find was disallowing backticks unless they contain a substitution or a newline:
```json
{
  "quotes":  ["warn", "single", { "avoidEscape": true }]
}
```

The other commit is something where when I was reviewing #3742 I kept feeling like I'd tried to do something similar before, and I finally remembered what it was. It's possible to use `validateToken` to accomplish what I think is the same thing using `getPreAuthorizationInformation` does, which is basically making sure the refresh token for something that doesn't use RPC gets exchanged correctly. It seems to work fine in my testing.

I thought it might be a bit less confusing since `getPreAuthorizationInformation` was originally created specifically for RPC, so calling it in the main thread might be counterintuitive.