### PR TITLE
Adds safety checks on AlignmentsDisplay properties to avoid undefined rendering

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
@@ -21,7 +21,7 @@ function AlignmentsDisplay({ model }: { model: AlignmentsDisplayModel }) {
   if (!SNPCoverageDisplay) {
     return null
   }
-  const top = SNPCoverageDisplay.height ? SNPCoverageDisplay.height : 100
+  const top = SNPCoverageDisplay.height ?? 100
   return (
     <div
       data-testid={`display-${getConf(model, 'displayId')}`}

--- a/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
@@ -18,7 +18,10 @@ const useStyles = makeStyles()({
 function AlignmentsDisplay({ model }: { model: AlignmentsDisplayModel }) {
   const { PileupDisplay, SNPCoverageDisplay } = model
   const { classes } = useStyles()
-  const top = SNPCoverageDisplay.height
+  if (!SNPCoverageDisplay) {
+    return null
+  }
+  const top = SNPCoverageDisplay.height ? SNPCoverageDisplay.height : 100
   return (
     <div
       data-testid={`display-${getConf(model, 'displayId')}`}

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -367,8 +367,7 @@ function stateModelFactory(
           const extra = getLowerPanelDisplays(pluginManager).map(d => ({
             type: 'radio',
             label: d.displayName,
-            checked:
-              d.name === self.PileupDisplay ? self.PileupDisplay.type : false,
+            checked: d.name === self.PileupDisplay ?? false,
             onClick: () => self.setLowerPanelType(d.name),
           }))
           return [

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -361,10 +361,14 @@ function stateModelFactory(
          * #method
          */
         trackMenuItems(): MenuItem[] {
+          if (!self.PileupDisplay) {
+            return []
+          }
           const extra = getLowerPanelDisplays(pluginManager).map(d => ({
             type: 'radio',
             label: d.displayName,
-            checked: d.name === self.PileupDisplay.type,
+            checked:
+              d.name === self.PileupDisplay ? self.PileupDisplay.type : false,
             onClick: () => self.setLowerPanelType(d.name),
           }))
           return [

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx
@@ -367,7 +367,7 @@ function stateModelFactory(
           const extra = getLowerPanelDisplays(pluginManager).map(d => ({
             type: 'radio',
             label: d.displayName,
-            checked: d.name === self.PileupDisplay ?? false,
+            checked: d.name === self.PileupDisplay.type,
             onClick: () => self.setLowerPanelType(d.name),
           }))
           return [

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -73,7 +73,7 @@ const TrackLabel = React.forwardRef<HTMLDivElement, Props>(function (
     },
     ...(session.getTrackActionMenuItems?.(trackConf) || []),
     ...track.trackMenuItems(),
-  ].sort((a, b) => (b.priority || 0) - (a.priority || 0))
+  ].sort((a, b) => (b?.priority || 0) - (a?.priority || 0))
 
   return (
     <Paper ref={ref} className={cx(className, classes.root)}>


### PR DESCRIPTION
User experience when opening 2+ AlignmentsTracks one after another using jbrowse-react-linear-genome-view: application would crash on some undefined properties (SNPCoverageDisplay.height, self.PileupDisplay.type, and .priority of menu items)

Might be something weird with next.js rendering / race conditions / not sure what; adding these checks resolves the issue.

Tested on the JBrowse 2 app and everything working the same as before.

