### PR TITLE
Check session tracks for text search adapters

### DIFF
--- a/packages/core/TextSearch/TextSearchManager.ts
+++ b/packages/core/TextSearch/TextSearchManager.ts
@@ -38,9 +38,11 @@ export default class TextSearchManager {
 
   relevantAdapters(searchScope: SearchScope) {
     const pm = this.pluginManager
-    const { aggregateTextSearchAdapters, tracks } = pm.rootModel?.jbrowse as {
-      tracks: AnyConfigurationModel[]
+    const { aggregateTextSearchAdapters } = pm.rootModel?.jbrowse as {
       aggregateTextSearchAdapters: AnyConfigurationModel[]
+    }
+    const { tracks } = pm.rootModel?.session as {
+      tracks: AnyConfigurationModel[]
     }
 
     const { assemblyName } = searchScope


### PR DESCRIPTION
This uses `tracks` on the session instead of from the JBrowse config when checking for track-level text search adapters. This way session tracks get checked for text search adapters as well as tracks in the config.

Credit to @shashankbrgowda for figuring out that the text search manager was missing the session tracks: https://github.com/GMOD/Apollo3/pull/231#issuecomment-1610034986.