### PR TITLE
Fix linux snap package removable_media error in v2.6.1

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -125,8 +125,7 @@
         "removable-media"
       ],
       "slots": [
-        "default",
-        "removable-media"
+        "default"
       ]
     },
     "win": {


### PR DESCRIPTION
Removes from slot, keeping it only in plugs

Xref https://github.com/GMOD/jbrowse-components/pull/3708