### PR TITLE
Add ability for track selector button in synteny view to select individual views

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
@@ -11,6 +11,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 // locals
 import { LinearComparativeViewModel } from '../model'
 import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
 
 type LCV = LinearComparativeViewModel
 
@@ -40,12 +41,20 @@ const useStyles = makeStyles()(() => ({
 
 const TrackSelector = observer(({ model }: { model: LCV }) => {
   return (
-    <IconButton
-      onClick={model.activateTrackSelector}
-      title="Open track selector"
+    <CascadingMenuButton
+      menuItems={[
+        {
+          label: 'Synteny track selector',
+          onClick: () => model.activateTrackSelector(),
+        },
+        ...model.views.map((view, idx) => ({
+          label: `View ${idx + 1} track selector`,
+          onClick: () => view.activateTrackSelector(),
+        })),
+      ]}
     >
       <TrackSelectorIcon />
-    </IconButton>
+    </CascadingMenuButton>
   )
 })
 


### PR DESCRIPTION
This makes it easier to access the track selector of the individual views. Was mentioned in discussions with @carolinebridge-oicr 

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/32883690-d2f5-463d-9b5b-6c2c0bfb197c)
