### PR TITLE
Fix synteny rubberband tooltips when views are exactly the same

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -805,18 +805,26 @@ export function shorten(name: string, max = 70, short = 30) {
     : name
 }
 
-export function stringify({
-  refName,
-  coord,
-  oob,
-}: {
-  coord: number
-  refName?: string
-  oob?: boolean
-}) {
-  return refName
-    ? `${shorten(refName)}:${toLocale(coord)}${oob ? ' (out of bounds)' : ''}`
-    : ''
+export function stringify(
+  {
+    refName,
+    coord,
+    assemblyName,
+    oob,
+  }: {
+    assemblyName?: string
+    coord: number
+    refName?: string
+    oob?: boolean
+  },
+  useAssemblyName?: boolean,
+) {
+  return [
+    assemblyName && useAssemblyName ? `{${assemblyName}}` : '',
+    refName
+      ? `${shorten(refName)}:${toLocale(coord)}${oob ? ' (out of bounds)' : ''}`
+      : '',
+  ].join('')
 }
 
 // this is recommended in a later comment in

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
@@ -1,11 +1,14 @@
 import React, { useRef, useEffect, useState } from 'react'
 import { observer } from 'mobx-react'
-import { Popover, Tooltip, Typography, alpha } from '@mui/material'
+import { Popover, Typography, alpha } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { stringify } from '@jbrowse/core/util'
 import { Menu } from '@jbrowse/core/ui'
 import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+
+// locals
 import { LinearComparativeViewModel } from '../model'
+import VerticalGuide from './VerticalGuide'
 
 type LCV = LinearComparativeViewModel
 type LGV = LinearGenomeViewModel
@@ -40,46 +43,8 @@ const useStyles = makeStyles()(theme => {
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),
     },
-    guide: {
-      pointerEvents: 'none',
-      height: '100%',
-      width: 1,
-      position: 'absolute',
-      zIndex: 10,
-    },
-    sm: {
-      fontSize: 10,
-    },
   }
 })
-
-const VerticalGuide = observer(
-  ({ model, coordX }: { model: LCV; coordX: number }) => {
-    const { classes } = useStyles()
-    return (
-      <Tooltip
-        open
-        placement="top"
-        title={model.views
-          .map(view => view.pxToBp(coordX))
-          .map(elt => (
-            <Typography className={classes.sm} key={JSON.stringify(elt)}>
-              {stringify(elt)}
-            </Typography>
-          ))}
-        arrow
-      >
-        <div
-          className={classes.guide}
-          style={{
-            left: coordX,
-            background: 'red',
-          }}
-        />
-      </Tooltip>
-    )
-  },
-)
 
 function Rubberband({
   model,
@@ -213,10 +178,8 @@ function Rubberband({
           <VerticalGuide model={model} coordX={guideX} />
         ) : null}
         <div
-          data-testid="rubberband_controls"
-          className={classes.rubberbandControl}
-          role="presentation"
           ref={controlsRef}
+          className={classes.rubberbandControl}
           onMouseDown={mouseDown}
           onMouseOut={mouseOut}
           onMouseMove={mouseMove}
@@ -227,7 +190,6 @@ function Rubberband({
     )
   }
 
-  /* Calculating Pixels for Mouse Dragging */
   const right = anchorPosition ? anchorPosition.offsetX : currentX || 0
   const left = right < startX ? right : startX
   const width = Math.abs(right - startX)
@@ -241,9 +203,7 @@ function Rubberband({
         <>
           <Popover
             className={classes.popover}
-            classes={{
-              paper: classes.paper,
-            }}
+            classes={{ paper: classes.paper }}
             open
             anchorEl={rubberbandRef.current}
             anchorOrigin={{
@@ -257,15 +217,15 @@ function Rubberband({
             keepMounted
             disableRestoreFocus
           >
-            {leftBpOffset.map(l => (
-              <Typography key={JSON.stringify(l)}>{stringify(l)}</Typography>
+            {leftBpOffset.map((l, idx) => (
+              <Typography key={[JSON.stringify(l), idx, 'left'].join('-')}>
+                {stringify(l, true)}
+              </Typography>
             ))}
           </Popover>
           <Popover
             className={classes.popover}
-            classes={{
-              paper: classes.paper,
-            }}
+            classes={{ paper: classes.paper }}
             open
             anchorEl={rubberbandRef.current}
             anchorOrigin={{
@@ -279,8 +239,10 @@ function Rubberband({
             keepMounted
             disableRestoreFocus
           >
-            {rightBpOffset.map(l => (
-              <Typography key={JSON.stringify(l)}>{stringify(l)}</Typography>
+            {rightBpOffset.map((l, idx) => (
+              <Typography key={[JSON.stringify(l), idx, 'right'].join('-')}>
+                {stringify(l, true)}
+              </Typography>
             ))}
           </Popover>
         </>
@@ -292,16 +254,14 @@ function Rubberband({
       >
         <Typography variant="h6" className={classes.rubberbandText}>
           {numOfBpSelected.map((n, i) => (
-            <Typography key={`${n}_${i}`}>{`${n.toLocaleString(
-              'en-US',
-            )}bp`}</Typography>
+            <Typography key={`${n}_${i}`}>
+              {`${n.toLocaleString('en-US')}bp`}
+            </Typography>
           ))}
         </Typography>
       </div>
       <div
-        data-testid="rubberband_controls"
         className={classes.rubberbandControl}
-        role="presentation"
         ref={controlsRef}
         onMouseDown={mouseDown}
         onMouseOut={mouseOut}

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Tooltip, Typography } from '@mui/material'
+import { observer } from 'mobx-react'
+import { stringify } from '@jbrowse/core/util'
+import { makeStyles } from 'tss-react/mui'
+import { LinearComparativeViewModel } from '../model'
+
+type LCV = LinearComparativeViewModel
+
+const useStyles = makeStyles()({
+  guide: {
+    pointerEvents: 'none',
+    height: '100%',
+    width: 1,
+    position: 'absolute',
+    zIndex: 10,
+  },
+  sm: {
+    fontSize: 10,
+  },
+})
+
+const VerticalGuide = observer(function ({
+  model,
+  coordX,
+}: {
+  model: LCV
+  coordX: number
+}) {
+  const { classes } = useStyles()
+  return (
+    <Tooltip
+      open
+      placement="top"
+      title={model.views
+        .map(view => view.pxToBp(coordX))
+        .map((elt, idx) => (
+          <Typography
+            className={classes.sm}
+            key={[JSON.stringify(elt), idx].join('-')}
+          >
+            {stringify(elt, true)}
+          </Typography>
+        ))}
+      arrow
+    >
+      <div
+        className={classes.guide}
+        style={{
+          left: coordX,
+          background: 'red',
+        }}
+      />
+    </Tooltip>
+  )
+})
+
+export default VerticalGuide


### PR DESCRIPTION
If the synteny view is showing volvox vs volvox at the exact same positions (which can happen if you open a synteny view and select the default choice of volvox vs volvox for example)


This is a picture of the bug, which is due to colliding React keys on the tooltips

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/3c0b66fa-e814-4b2b-9c4d-8e5ecf72da7b)

This additionally modifies the tooltips to make it more clear what the text represents by specifying the assembly name and "row number" 

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/99ddd622-900c-4fdf-a3b6-fcd00897b0df)

