### PR TITLE
Allow workers to load CJS plugins

### DIFF
--- a/products/jbrowse-desktop/src/rpcWorker.ts
+++ b/products/jbrowse-desktop/src/rpcWorker.ts
@@ -4,6 +4,7 @@ import { enableStaticRendering } from 'mobx-react'
 
 // locals
 import corePlugins from './corePlugins'
+import { fetchCJS } from './util'
 
 // static rendering is used for "SSR" style rendering which is done on the
 // worker
@@ -12,6 +13,7 @@ enableStaticRendering(true)
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 initializeWorker(corePlugins, {
   fetchESM: url => import(/* webpackIgnore:true */ url),
+  fetchCJS,
 })
 
 export default () => {

--- a/products/jbrowse-desktop/src/util.tsx
+++ b/products/jbrowse-desktop/src/util.tsx
@@ -1,12 +1,11 @@
+import fsPromises from 'fs/promises'
+import path from 'path'
+import os from 'os'
+
 import { LoadedPlugin } from '@jbrowse/core/PluginLoader'
 import sanitize from 'sanitize-filename'
 
 export async function fetchCJS(url: string): Promise<LoadedPlugin> {
-  const fs: typeof import('fs') = window.require('fs')
-  const path: typeof import('path') = window.require('path')
-  const os: typeof import('os') = window.require('os')
-  const http: typeof import('http') = window.require('http')
-  const fsPromises = fs.promises
   // On macOS `os.tmpdir()` returns the path to a symlink, see:
   // https://github.com/nodejs/node/issues/11422
   const tmpDir = await fsPromises.mkdtemp(
@@ -16,19 +15,20 @@ export async function fetchCJS(url: string): Promise<LoadedPlugin> {
     const pluginLocation = path.join(tmpDir, sanitize(url))
     const pluginLocationRelative = path.relative('.', pluginLocation)
 
-    await new Promise((resolve, reject) => {
-      const file = fs.createWriteStream(pluginLocation)
-      http
-        .get(url, res => {
-          res.pipe(file)
-          file.on('finish', resolve)
-        })
-        .on('error', err => {
-          fs.unlinkSync(pluginLocation)
-          reject(err)
-        })
-    })
-    return window.require(pluginLocationRelative) as LoadedPlugin
+    let pluginText = ''
+    try {
+      const pluginResponse = await fetch(url)
+      if (!pluginResponse.ok) {
+        throw new Error('Bad response')
+      }
+      pluginText = await pluginResponse.text()
+    } catch (error) {
+      console.error(error)
+      await fsPromises.unlink(pluginLocation)
+      throw error
+    }
+    await fsPromises.writeFile(pluginLocation, pluginText)
+    return globalThis.require(pluginLocationRelative) as LoadedPlugin
   } finally {
     await fsPromises.rmdir(tmpDir, { recursive: true })
   }

--- a/products/jbrowse-desktop/src/util.tsx
+++ b/products/jbrowse-desktop/src/util.tsx
@@ -14,19 +14,13 @@ export async function fetchCJS(url: string): Promise<LoadedPlugin> {
   try {
     const pluginLocation = path.join(tmpDir, sanitize(url))
     const pluginLocationRelative = path.relative('.', pluginLocation)
-
-    let pluginText = ''
-    try {
-      const pluginResponse = await fetch(url)
-      if (!pluginResponse.ok) {
-        throw new Error('Bad response')
-      }
-      pluginText = await pluginResponse.text()
-    } catch (error) {
-      console.error(error)
-      await fsPromises.unlink(pluginLocation)
-      throw error
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(
+        `HTTP ${response.status} ${response.statusText} when fetching plugin: ${url})`,
+      )
     }
+    const pluginText = await response.text()
     await fsPromises.writeFile(pluginLocation, pluginText)
     return globalThis.require(pluginLocationRelative) as LoadedPlugin
   } finally {


### PR DESCRIPTION
Fixes #3785 

Worked on this with @cmdcolin during our pairing yesterday, and since then I've created a CJS plugin to test with that does node-native module import on the worker.

Because our electron version now uses node 18, we can use `fetch` natively. Also because webpack 5 doesn't do any polyfilling, we can avoid a bunch of `window.require`s that were a workaround to avoid the polyfilling.