### PR TITLE
Add missing @jbrowse/plugin-linear-genome-view dependency to @jbrowse/react-circular-genome-view

### DIFF
--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -48,6 +48,7 @@
     "@jbrowse/plugin-config": "^2.6.2",
     "@jbrowse/plugin-data-management": "^2.6.2",
     "@jbrowse/plugin-sequence": "^2.6.2",
+    "@jbrowse/plugin-linear-genome-view": "^2.6.2",
     "@jbrowse/plugin-variants": "^2.6.2",
     "@jbrowse/plugin-wiggle": "^2.6.2",
     "@jbrowse/product-core": "^2.6.2",


### PR DESCRIPTION
The @jbrowse/react-circular-genome-view requires the @jbrowse/plugin-linear-genome-view 

The error message prints 


Import trace for requested module:
./node_modules/@jbrowse/plugin-sequence/esm/index.js
./node_modules/@jbrowse/react-circular-genome-view/esm/corePlugins.js
./node_modules/@jbrowse/react-circular-genome-view/esm/createModel/createModel.js
./node_modules/@jbrowse/react-circular-genome-view/esm/createModel/index.js
./node_modules/@jbrowse/react-circular-genome-view/esm/index.js

maybe then accesses plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts or plugins/sequence/src/LinearReferenceSequenceDisplay/index.ts

