### PR TITLE
Adds new extension point that permits appending to the top or bottom of a given widget

### DIFF
--- a/packages/app-core/src/ui/App/DrawerWidget.tsx
+++ b/packages/app-core/src/ui/App/DrawerWidget.tsx
@@ -11,7 +11,7 @@ import { SessionWithDrawerWidgets } from '@jbrowse/core/util/types'
 import Drawer from './Drawer'
 import DrawerHeader from './DrawerHeader'
 
-interface AdditonalComponentsObject {
+interface AdditionalComponentsObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Components: React.FC<any>
   configuration: 'top' | 'bottom'
@@ -45,7 +45,7 @@ const DrawerWidget = observer(function ({
           session,
           model: visibleWidget,
         },
-      ) as AdditonalComponentsObject)
+      ) as AdditionalComponentsObject)
     : null
 
   // we track the toolbar height because components that use virtualized

--- a/packages/app-core/src/ui/App/DrawerWidget.tsx
+++ b/packages/app-core/src/ui/App/DrawerWidget.tsx
@@ -68,14 +68,11 @@ const DrawerWidget = observer(function ({
             />
           ) : null}
           {DrawerComponent ? (
-            <>
-              <DrawerComponent
-                model={visibleWidget}
-                session={session}
-                toolbarHeight={toolbarHeight}
-              />
-              <div style={{ height: 300 }} />
-            </>
+            <DrawerComponent
+              model={visibleWidget}
+              session={session}
+              toolbarHeight={toolbarHeight}
+            />
           ) : null}
           {AdditionalComponents?.Components &&
           AdditionalComponents?.configuration === 'bottom' ? (
@@ -83,6 +80,9 @@ const DrawerWidget = observer(function ({
               model={visibleWidget}
               session={session}
             />
+          ) : null}
+          {DrawerComponent || AdditionalComponents?.Components ? (
+            <div style={{ height: 300 }} />
           ) : null}
         </ErrorBoundary>
       </Suspense>

--- a/packages/app-core/src/ui/App/DrawerWidget.tsx
+++ b/packages/app-core/src/ui/App/DrawerWidget.tsx
@@ -27,6 +27,12 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 // locals
 import Drawer from './Drawer'
 
+interface AdditonalComponentsObject {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Components: React.FC<any>
+  configuration: 'top' | 'bottom'
+}
+
 const useStyles = makeStyles()(theme => ({
   formControl: {
     margin: 0,
@@ -207,6 +213,17 @@ const DrawerWidget = observer(function ({
       ) as React.FC<any>)
     : null
 
+  const AdditionalComponents = visibleWidget
+    ? (pluginManager.evaluateExtensionPoint(
+        'Core-addToWidget',
+        pluginManager.getWidgetType(visibleWidget.type).ReactComponent,
+        {
+          session,
+          model: visibleWidget,
+        },
+      ) as AdditonalComponentsObject)
+    : null
+
   // we track the toolbar height because components that use virtualized
   // height want to be able to fill the contained, minus the toolbar height
   // (the position static/sticky is included in AutoSizer estimates)
@@ -219,6 +236,13 @@ const DrawerWidget = observer(function ({
         <ErrorBoundary
           FallbackComponent={({ error }) => <ErrorMessage error={error} />}
         >
+          {AdditionalComponents?.Components &&
+          AdditionalComponents.configuration === 'top' ? (
+            <AdditionalComponents.Components
+              model={visibleWidget}
+              session={session}
+            />
+          ) : null}
           {DrawerComponent ? (
             <>
               <DrawerComponent
@@ -228,6 +252,13 @@ const DrawerWidget = observer(function ({
               />
               <div style={{ height: 300 }} />
             </>
+          ) : null}
+          {AdditionalComponents?.Components &&
+          AdditionalComponents?.configuration === 'bottom' ? (
+            <AdditionalComponents.Components
+              model={visibleWidget}
+              session={session}
+            />
           ) : null}
         </ErrorBoundary>
       </Suspense>

--- a/packages/embedded-core/src/ui/ModalWidget.tsx
+++ b/packages/embedded-core/src/ui/ModalWidget.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import { getEnv } from 'mobx-state-tree'
 import { SessionWithWidgets } from '@jbrowse/core/util'
 
-interface AdditonalComponentsObject {
+interface AdditionalComponentsObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Components: React.FC<any>
   configuration: 'top' | 'bottom'
@@ -52,7 +52,7 @@ export default observer(function ({
           session,
           model: visibleWidget,
         },
-      ) as AdditonalComponentsObject)
+      ) as AdditionalComponentsObject)
     : null
   return (
     <Dialog

--- a/packages/embedded-core/src/ui/ModalWidget.tsx
+++ b/packages/embedded-core/src/ui/ModalWidget.tsx
@@ -6,6 +6,12 @@ import { observer } from 'mobx-react'
 import { getEnv } from 'mobx-state-tree'
 import { SessionWithWidgets } from '@jbrowse/core/util'
 
+interface AdditonalComponentsObject {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Components: React.FC<any>
+  configuration: 'top' | 'bottom'
+}
+
 const useStyles = makeStyles()({
   paper: {
     overflow: 'auto',
@@ -38,6 +44,16 @@ export default observer(function ({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) as React.FC<any>)
     : null
+  const AdditionalComponents = visibleWidget
+    ? (pluginManager.evaluateExtensionPoint(
+        'Core-addToWidget',
+        pluginManager.getWidgetType(visibleWidget.type).ReactComponent,
+        {
+          session,
+          model: visibleWidget,
+        },
+      ) as AdditonalComponentsObject)
+    : null
   return (
     <Dialog
       open
@@ -58,6 +74,13 @@ export default observer(function ({
       {Component ? (
         <Suspense fallback={<div>Loading...</div>}>
           <Paper className={classes.paper}>
+            {AdditionalComponents?.Components &&
+            AdditionalComponents.configuration === 'top' ? (
+              <AdditionalComponents.Components
+                model={visibleWidget}
+                session={session}
+              />
+            ) : null}
             <Component
               model={visibleWidget}
               session={session}
@@ -66,6 +89,13 @@ export default observer(function ({
                 width: 800,
               }}
             />
+            {AdditionalComponents?.Components &&
+            AdditionalComponents?.configuration === 'bottom' ? (
+              <AdditionalComponents.Components
+                model={visibleWidget}
+                session={session}
+              />
+            ) : null}
           </Paper>
         </Suspense>
       ) : null}

--- a/website/docs/developer_guides/extension_points.md
+++ b/website/docs/developer_guides/extension_points.md
@@ -413,6 +413,7 @@ pluginManager.addToExtensionPoint(
       ? { Components: AdditionalComponent, configuration: 'top' }
       : DefaultComponent
   },
+)
 ```
 
 ### Core-extraFeaturePanel

--- a/website/docs/developer_guides/extension_points.md
+++ b/website/docs/developer_guides/extension_points.md
@@ -334,9 +334,9 @@ Return value: New config snapshot object
 
 type: synchronous
 
-adds option to provide a different component for the "About this track" dialog
+adds option to provide a different component for a given widget, drawer or modal
 
-- `args` - a `ReactComponent`, the default AboutTrack dialog
+- `args` - a `ReactComponent`
 - `props` - an object of the type below
 
 ```typescript
@@ -356,7 +356,7 @@ Example: replaces about feature details widget for a particular track ID
 
 ```typescript
 pluginManager.addToExtensionPoint(
-  'Core-replaceAbout',
+  'Core-replaceWidget',
   (DefaultAboutComponent, { model }) => {
     return model.trackId === 'volvox.inv.vcf'
       ? NewAboutComponent
@@ -370,6 +370,50 @@ track that produced the feature details. Therefore, we check model.trackId that
 produced the popup instead. note that if you want copies of your track to get
 same treatment, might use a regex to loose match the trackId (the copy of a
 track will have a timestamp and -sessionTrack added to it).
+
+### Core-addToWidget
+
+type: synchronous
+
+adds option to append UI components to the top or bottom of a given widget,
+drawer or modal
+
+- `args` - a `ReactComponent`, default for the Widget of choice
+
+- `props` - an object of the type:
+
+```ts
+interface props {
+  session: AbstractSessionModel
+  model: WidgetModel
+}
+```
+
+note: this is called for every widget type, including configuration, feature
+details, about panel, and more. The feature details may be a common one. See
+`Core-extraFeaturePanel` also, matches the model attribute from there
+
+Return value: an object of the type:
+
+```ts
+interface AdditonalComponentsObject {
+  Components: React.FC<any>
+  configuration: 'top' | 'bottom'
+}
+```
+
+Example: appends a UI element to the top of the GridBookmark Widget
+
+```ts
+pluginManager.addToExtensionPoint(
+  'Core-addToWidget',
+  (DefaultComponent, { model }) => {
+    // @ts-ignore
+    return model.type === 'GridBookmarkWidget'
+      ? { Components: AdditionalComponent, configuration: 'top' }
+      : DefaultComponent
+  },
+```
 
 ### Core-extraFeaturePanel
 

--- a/website/docs/developer_guides/extension_points.md
+++ b/website/docs/developer_guides/extension_points.md
@@ -396,7 +396,7 @@ details, about panel, and more. The feature details may be a common one. See
 Return value: an object of the type:
 
 ```ts
-interface AdditonalComponentsObject {
+interface AdditionalComponentsObject {
   Components: React.FC<any>
   configuration: 'top' | 'bottom'
 }


### PR DESCRIPTION
> Adds new extension point that permits appending to the top or bottom of a given widget

Just an idea I had when drafting possible ways to extend the bookmarks plugin via an external plugin. Pretty simple and similar to the existing `Core-replaceWidget` without completely replacing the existing UI; I can see plugin developers using this extension point.