### PR TITLE
Add check for document.activeElement == INPUT before undo/redo

### DIFF
--- a/packages/app-core/src/HistoryManagement/index.ts
+++ b/packages/app-core/src/HistoryManagement/index.ts
@@ -24,7 +24,8 @@ export function HistoryManagementMixin() {
             // ctrl+shift+z or cmd+shift+z
             (((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'KeyZ') ||
               // ctrl+y
-              (e.ctrlKey && !e.shiftKey && e.code === 'KeyY'))
+              (e.ctrlKey && !e.shiftKey && e.code === 'KeyY')) &&
+            document.activeElement?.tagName.toUpperCase() !== 'INPUT'
           ) {
             self.history.redo()
           }
@@ -33,7 +34,8 @@ export function HistoryManagementMixin() {
             // ctrl+z or cmd+z
             (e.ctrlKey || e.metaKey) &&
             !e.shiftKey &&
-            e.code === 'KeyZ'
+            e.code === 'KeyZ' &&
+            document.activeElement?.tagName.toUpperCase() !== 'INPUT'
           ) {
             self.history.undo()
           }


### PR DESCRIPTION
I found that there is a field called document.activeElement. We can check it for html tag type INPUT to avoid undo'ing in this case

This helps us preserve the browser behavior of undo in a text field while keeping the browser-native ctrl+z hotkey

Fixes https://github.com/GMOD/jbrowse-components/issues/3638