### PR TITLE
Add forwardRef to wrapped re-exported lazy components

### DIFF
--- a/packages/core/ReExports/modules.tsx
+++ b/packages/core/ReExports/modules.tsx
@@ -594,7 +594,7 @@ const libsList = Object.keys(libs)
 const inLibsOnly = libsList.filter(mod => !reExportsList.includes(mod))
 if (inLibsOnly.length > 0) {
   throw new Error(
-    `The following modules are in the re-exports list, but not the modules libs: ${inLibsOnly.join(
+    `The following modules are in the modules libs, but not the re-exports list: ${inLibsOnly.join(
       ', ',
     )}`,
   )
@@ -602,7 +602,7 @@ if (inLibsOnly.length > 0) {
 const inReExportsOnly = reExportsList.filter(mod => !libsList.includes(mod))
 if (inReExportsOnly.length) {
   throw new Error(
-    `The following modules are in the modules libs, but not the re-exports list: ${inReExportsOnly.join(
+    `The following modules are in the re-exports list, but not the modules libs: ${inReExportsOnly.join(
       ', ',
     )}`,
   )

--- a/packages/core/ReExports/modules.tsx
+++ b/packages/core/ReExports/modules.tsx
@@ -164,15 +164,16 @@ const Entries = {
 }
 
 const LazyMUICore = Object.fromEntries(
-  Object.entries(Entries).map(([key, ReactComponent]) => [
-    key,
+  Object.entries(Entries).map(([key, ReactComponent]) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (props: any) => (
+    const Component = React.forwardRef((props: any, ref) => (
       <Suspense fallback={<div />}>
-        <ReactComponent {...props} />
+        <ReactComponent {...props} ref={ref} />
       </Suspense>
-    ),
-  ]),
+    ))
+    Component.displayName = key
+    return [key, Component]
+  }),
 )
 
 const MaterialPrefixMUI = Object.fromEntries(
@@ -458,37 +459,41 @@ const DataGridEntries: Record<string, LazyExoticComponent<any>> = {
 }
 
 const LazyDataGridComponents = Object.fromEntries(
-  Object.entries(DataGridEntries).map(([key, ReactComponent]) => [
-    key,
+  Object.entries(DataGridEntries).map(([key, ReactComponent]) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (props: any) => (
+    const Component = React.forwardRef((props: any, ref) => (
       <Suspense fallback={<div />}>
-        <ReactComponent {...props} />
+        <ReactComponent {...props} ref={ref} />
       </Suspense>
-    ),
-  ]),
+    ))
+    Component.displayName = key
+    return [key, Component]
+  }),
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LazyAttributes = (props: any) => (
+const LazyAttributes = React.forwardRef((props: any, ref) => (
   <Suspense fallback={<div />}>
-    <Attributes {...props} />
+    <Attributes {...props} ref={ref} />
   </Suspense>
-)
+))
+LazyAttributes.displayName = 'Attributes'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LazyFeatureDetails = (props: any) => (
+const LazyFeatureDetails = React.forwardRef((props: any, ref) => (
   <Suspense fallback={<div />}>
-    <FeatureDetails {...props} />
+    <FeatureDetails {...props} ref={ref} />
   </Suspense>
-)
+))
+LazyFeatureDetails.displayName = 'FeatureDetails'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LazyBaseCard = (props: any) => (
+const LazyBaseCard = React.forwardRef((props: any, ref) => (
   <Suspense fallback={<div />}>
-    <BaseCard {...props} />
+    <BaseCard {...props} ref={ref} />
   </Suspense>
-)
+))
+LazyBaseCard.displayName = 'BaseCard'
 
 const libs = {
   mobx,


### PR DESCRIPTION
I noticed I was getting console errors and strange behavior when using the MUI `Tooltip` on another MUI component. Specifically I was using `Tooltip` to wrap `IconButton`, but the tooltip wouldn't appear until after the button had been clicked on. Eventually I found this docs page: https://mui.com/material-ui/guides/composition/#caveat-with-refs

What I eventually figured out is that basically, when we wrap lazy components in `Suspsense`, we have to use `React.forwardRef` to pass any refs on to the wrapped component. This allows things like `Tooltip` to work as usual.

I also had to add some display names after adding `forwardRef` to satisfy the "react/display-name" lint rule.