### PR TITLE
Make adapter optional when checking indexing

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1108,7 +1108,7 @@ export interface ViewSnap {
 
 // supported adapter types by text indexer
 //  ensure that this matches the method found in @jbrowse/text-indexing/util
-export function supportedIndexingAdapters(type: string) {
+export function isSupportedIndexingAdapter(type: string) {
   return [
     'Gff3TabixAdapter',
     'VcfTabixAdapter',

--- a/packages/text-indexing/src/TextIndexing.ts
+++ b/packages/text-indexing/src/TextIndexing.ts
@@ -6,7 +6,10 @@ import { indexVcf } from './types/vcfAdapter'
 import { generateMeta } from './types/common'
 import { ixIxxStream } from 'ixixx'
 import { Track, indexType } from './util'
-import { checkAbortSignal, isSupportedIndexingAdapter } from '@jbrowse/core/util'
+import {
+  checkAbortSignal,
+  isSupportedIndexingAdapter,
+} from '@jbrowse/core/util'
 
 export async function indexTracks(args: {
   tracks: Track[]

--- a/packages/text-indexing/src/TextIndexing.ts
+++ b/packages/text-indexing/src/TextIndexing.ts
@@ -5,8 +5,8 @@ import { indexGff3 } from './types/gff3Adapter'
 import { indexVcf } from './types/vcfAdapter'
 import { generateMeta } from './types/common'
 import { ixIxxStream } from 'ixixx'
-import { Track, indexType, supportedIndexingAdapters } from './util'
-import { checkAbortSignal } from '@jbrowse/core/util'
+import { Track, indexType } from './util'
+import { checkAbortSignal, isSupportedIndexingAdapter } from '@jbrowse/core/util'
 
 export async function indexTracks(args: {
   tracks: Track[]
@@ -75,7 +75,7 @@ async function perTrackIndex(
   const excludeTypes = exclude || ['exon', 'CDS']
   const force = true
   const supportedTracks = tracks.filter(track =>
-    supportedIndexingAdapters(track.adapter?.type),
+    isSupportedIndexingAdapter(track.adapter?.type),
   )
   for (const trackConfig of supportedTracks) {
     const { textSearching, trackId, assemblyNames } = trackConfig
@@ -133,7 +133,7 @@ async function aggregateIndex(
     const quiet = true
     // supported tracks for given assembly
     const supportedTracks = tracks
-      .filter(track => supportedIndexingAdapters(track.adapter?.type))
+      .filter(track => isSupportedIndexingAdapter(track.adapter?.type))
       .filter(track => (asm ? track.assemblyNames.includes(asm) : true))
 
     await indexDriver(

--- a/packages/text-indexing/src/types/common.test.ts
+++ b/packages/text-indexing/src/types/common.test.ts
@@ -1,5 +1,5 @@
+import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
 import { guessAdapterFromFileName, isURL, makeLocation } from './common'
-import { supportedIndexingAdapters } from '../util'
 
 describe('utils for text indexing', () => {
   const local = './volvox.sort.gff3.gz'
@@ -26,7 +26,7 @@ describe('utils for text indexing', () => {
   it('test guess adapter from file name', () => {
     const conf1 = guessAdapterFromFileName(gff3)
     expect(conf1.adapter.type).toBe('Gff3TabixAdapter')
-    expect(supportedIndexingAdapters(conf1.adapter.type)).toBe(true)
+    expect(isSupportedIndexingAdapter(conf1.adapter.type)).toBe(true)
     const conf2 = guessAdapterFromFileName(gff)
     expect(conf2.adapter.type).toBe('Gff3TabixAdapter')
     const conf3 = guessAdapterFromFileName(vcf)

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -1,3 +1,5 @@
+import { isSupportedIndexingAdapter } from "@jbrowse/core/util"
+
 export interface UriLocation {
   uri: string
   locationType: 'UriLocation'
@@ -115,17 +117,6 @@ export interface Config {
 
 export type indexType = 'aggregate' | 'perTrack'
 
-// supported adapter types by text indexer
-//  ensure that this matches the method found in @jbrowse/core/util
-export function supportedIndexingAdapters(type: string) {
-  return [
-    'Gff3TabixAdapter',
-    'VcfTabixAdapter',
-    'Gff3Adapter',
-    'VcfAdapter',
-  ].includes(type)
-}
-
 export function createTextSearchConf(
   name: string,
   trackIds: string[],
@@ -172,5 +163,5 @@ export function findTrackConfigsToIndex(
     .filter(track =>
       assemblyName ? track.assemblyNames.includes(assemblyName) : true,
     )
-    .filter(track => supportedIndexingAdapters(track.adapter.type))
+    .filter(track => isSupportedIndexingAdapter(track.adapter?.type))
 }

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -1,4 +1,4 @@
-import { isSupportedIndexingAdapter } from "@jbrowse/core/util"
+import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
 
 export interface UriLocation {
   uri: string

--- a/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/ConfirmTrack.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import {
-  supportedIndexingAdapters,
+  isSupportedIndexingAdapter,
   getSession,
   isElectron,
 } from '@jbrowse/core/util'
@@ -132,7 +132,7 @@ export default observer(function ConfirmTrack({
     return <Typography>Could not recognize this data type.</Typography>
   }
 
-  const supportedForIndexing = supportedIndexingAdapters(trackAdapter?.type)
+  const supportedForIndexing = isSupportedIndexingAdapter(trackAdapter?.type)
   return (
     <div>
       {trackAdapter ? (

--- a/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
@@ -14,7 +14,7 @@ import { getRoot } from 'mobx-state-tree'
 import {
   getSession,
   isElectron,
-  supportedIndexingAdapters,
+  isSupportedIndexingAdapter,
 } from '@jbrowse/core/util'
 import { getConf } from '@jbrowse/core/configuration'
 import { observer } from 'mobx-react'
@@ -103,7 +103,7 @@ function AddTrackWorkflow({ model }: { model: AddTrackModel }) {
         if (
           isElectron &&
           textIndexTrack &&
-          supportedIndexingAdapters(trackAdapter.type)
+          isSupportedIndexingAdapter(trackAdapter.type)
         ) {
           const attr = textIndexingConf || {
             attributes: ['Name', 'ID'],

--- a/products/jbrowse-desktop/src/sessionModel/TrackMenu.ts
+++ b/products/jbrowse-desktop/src/sessionModel/TrackMenu.ts
@@ -7,10 +7,10 @@ import CopyIcon from '@mui/icons-material/FileCopy'
 import DeleteIcon from '@mui/icons-material/Delete'
 import InfoIcon from '@mui/icons-material/Info'
 import { Indexing } from '@jbrowse/core/ui/Icons'
+import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
 
 import PluginManager from '@jbrowse/core/PluginManager'
 import { BaseTrackConfig } from '@jbrowse/core/pluggableElementTypes'
-import { supportedIndexingAdapters } from '@jbrowse/text-indexing'
 
 import type {
   SessionWithDialogs,
@@ -71,7 +71,7 @@ export function DesktopSessionTrackMenuMixin(_pluginManager: PluginManager) {
           },
           icon: CopyIcon,
         },
-        ...(supportedIndexingAdapters(trackSnapshot.adapter.type)
+        ...(isSupportedIndexingAdapter(trackSnapshot.adapter?.type)
           ? [
               {
                 label: trackSnapshot.textSearching


### PR DESCRIPTION
This PR started when the JBrowse Desktop `TrackMenu` threw errors because there was no adapter on the track (which is normal for Apollo). This makes the adapter optional in that file, and also refactors a bit to deduplicate a function and rename it to something a bit more intuitive.