### PR TITLE
Use shortened VCF feature description for some types of insertions and deletions

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -15009,7 +15009,7 @@ exports[`vcf file import 1`] = `
             "QUAL": 1112.65,
             "REF": "AAAAAAAAAGAAAAG",
             "aliases": undefined,
-            "description": "deletion AAAAAAAAAGAAAAG -> A",
+            "description": "14bp DEL",
             "end": 41256103,
             "name": "rs373413425",
             "refName": "17",

--- a/plugins/variants/src/VcfFeature/util.ts
+++ b/plugins/variants/src/VcfFeature/util.ts
@@ -50,16 +50,16 @@ export function getSOTermAndDescription(
     )
 
     descriptions = new Set(
-      [...prefixes].map(prefix => {
-        const suffixes = descs
-          .map(desc => {
-            const pref = desc.split('-> ')
-            return pref[1] && pref[0] === prefix ? pref[1] : ''
-          })
-          .filter(f => !!f)
+      [...prefixes]
+        .map(r => r.trim())
+        .map(prefix => {
+          const suffixes = descs
+            .map(desc => desc.split('->').map(r => r.trim()))
+            .map(pref => (pref[1] && pref[0] === prefix ? pref[1] : ''))
+            .filter(f => !!f)
 
-        return suffixes.length ? prefix + '-> ' + suffixes.join(',') : prefix
-      }),
+          return suffixes.length ? `${prefix} -> ${suffixes.join(',')}` : prefix
+        }),
     )
   }
   if (soTerms.size) {
@@ -115,7 +115,7 @@ export function getSOAndDescByExamination(ref: string, alt: string) {
   } else if (alt === '<DEL>') {
     return ['deletion', alt]
   } else if (alt === '<INV>') {
-    return ['deletion', alt]
+    return ['inversion', alt]
   } else if (alt === '<TRA>') {
     return ['translocation', alt]
   } else if (alt.includes('<')) {
@@ -125,9 +125,19 @@ export function getSOAndDescByExamination(ref: string, alt: string) {
       ? ['inversion', makeDescriptionString('inversion', ref, alt)]
       : ['substitution', makeDescriptionString('substitution', ref, alt)]
   } else if (ref.length <= alt.length) {
-    return ['insertion', makeDescriptionString('insertion', ref, alt)]
+    const len = alt.length - ref.length
+    const lena = len.toLocaleString('en-US')
+    return [
+      'insertion',
+      len > 5 ? lena + 'bp INS' : makeDescriptionString('insertion', ref, alt),
+    ]
   } else if (ref.length > alt.length) {
-    return ['deletion', makeDescriptionString('deletion', ref, alt)]
+    const len = ref.length - alt.length
+    const lena = len.toLocaleString('en-US')
+    return [
+      'deletion',
+      len > 5 ? lena + 'bp DEL' : makeDescriptionString('deletion', ref, alt),
+    ]
   }
 
   return ['indel', makeDescriptionString('indel', ref, alt)]


### PR DESCRIPTION
The HG002 SV benchmark VCF has a particular way of describing insertions and deletions where it exactly specifies the deletion and insertion sequence in REF and ALT fields, even when these are quite long.

The resulting description strings generated on the VCF track are kind of unreadable as a result. This PR makes it so that insertions and deletions longer than 5bp are turned into just a string saying e.g. "10bp DEL" or "10bp INS"

current main
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/d5b44911-2423-4797-9cdf-3f053f584b5d)

this branch
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/556772c6-4125-4760-a6fe-6a8cdf713f3e)
