### PR TITLE
Fix "Color by"->"Mapping quality" for CRAM files

### DIFF
--- a/plugins/alignments/src/PileupRenderer/colorBy.ts
+++ b/plugins/alignments/src/PileupRenderer/colorBy.ts
@@ -14,7 +14,7 @@ export function colorByInsertSize(feature: Feature) {
 }
 
 export function colorByMappingQuality(feature: Feature) {
-  return `hsl(${feature.get('mq')},50%,50%)`
+  return `hsl(${feature.get('score')},50%,50%)`
 }
 
 function getOrientation(feature: Feature, config: AnyConfigurationModel) {


### PR DESCRIPTION
The "mq" tag does not exist for CRAM files, but it is mapped to the "score" field in both BAM and CRAM feature types

Without this fix, the "hsl" color value is invalid (produces e.g. hsl(undefined,50%,50%))