### PR TITLE
Fix alignments track infinite loading when applying same "Color by" or "Sort by" setting twice

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
@@ -545,9 +545,9 @@ export function SharedLinearPileupDisplayMixin(
               return
             }
 
-            const { colorBy } = self
+            const { colorBy, tagsReady } = self
             const { staticBlocks } = view
-            if (colorBy?.tag) {
+            if (colorBy?.tag && !tagsReady) {
               const vals = await getUniqueTagValues(self, colorBy, staticBlocks)
               self.updateColorTagMap(vals)
             }

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -356,7 +356,10 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
             const { sortedBy, adapterConfig, rendererType, sortReady } = self
             const { bpPerPx } = view
 
-            if (sortedBy && !sortReady) {
+            if (
+              sortedBy &&
+              (!sortReady || self.currSortBpPerPx === view.bpPerPx)
+            ) {
               const { pos, refName, assemblyName } = sortedBy
               // render just the sorted region first
               // @ts-expect-error

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -353,10 +353,10 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
               return
             }
 
-            const { sortedBy, adapterConfig, rendererType } = self
+            const { sortedBy, adapterConfig, rendererType, sortReady } = self
             const { bpPerPx } = view
 
-            if (sortedBy) {
+            if (sortedBy && !sortReady) {
               const { pos, refName, assemblyName } = sortedBy
               // render just the sorted region first
               // @ts-expect-error


### PR DESCRIPTION
Current main branch has a bug where applying e.g. "Color by"->"Tag" (select HP) or similarly "Sort by"->"Tag" (select HP) twice results in it hanging the second time

This is because it sets "sortReady:false", but the autorun does not detect that the "sortedBy" structure has changed since it is the same, so it doesn't change. This makes the autorun also listen for !sortReady (an analogous setting+autorun for colorBy)