### PR TITLE
Fix feature label offsets in SVG exports with main thread RPC

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -52,7 +52,7 @@ export default observer(function ({
   const totalWidth = featureWidth + allowedWidthExpansion
   const measuredTextWidth = measureText(text, fontHeight)
   const params =
-    isStateTreeNode(displayModel) && isAlive(displayModel)
+    isStateTreeNode(displayModel) && isAlive(displayModel) && !exportSVG
       ? getViewParams(displayModel)
       : viewParams
 

--- a/test_data/volvox/config_main_thread.json
+++ b/test_data/volvox/config_main_thread.json
@@ -106,6 +106,30 @@
           }
         }
       }
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "gff3tabix_genes",
+      "assemblyNames": ["volvox"],
+      "name": "GFF3Tabix genes",
+      "formatDetails": {
+        "feature": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>',extrafield:'Field added with custom callback:' + feature.name,phase:undefined,type:undefined}",
+        "subfeatures": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>Subfeature: '+(!feature.name?'No name':feature.name)+'</a>'}"
+      },
+      "category": ["Miscellaneous"],
+      "adapter": {
+        "type": "Gff3TabixAdapter",
+        "gffGzLocation": {
+          "uri": "volvox.sort.gff3.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "volvox.sort.gff3.gz.tbi",
+            "locationType": "UriLocation"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Commonly embedded configurations use main thread RPC, so this helps SVG exports for many embedded users

Fixes https://github.com/GMOD/jbrowse-components/issues/3909