### PR TITLE
Avoid undefined getConf on assembly.configuration safeReference

### DIFF
--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -181,6 +181,11 @@ export default function assemblyFactory(
       cytobands: undefined as Feature[] | undefined,
     }))
     .views(self => ({
+      getConf(arg: string) {
+        return self.configuration ? getConf(self, arg) : undefined
+      },
+    }))
+    .views(self => ({
       /**
        * #getter
        */
@@ -193,7 +198,7 @@ export default function assemblyFactory(
        * #getter
        */
       get name(): string {
-        return getConf(self, 'name')
+        return self.getConf('name') || ''
       },
       /**
        * #getter
@@ -207,13 +212,13 @@ export default function assemblyFactory(
        * #getter
        */
       get aliases(): string[] {
-        return getConf(self, 'aliases')
+        return self.getConf('aliases') || []
       },
       /**
        * #getter
        */
       get displayName(): string | undefined {
-        return getConf(self, 'displayName')
+        return self.getConf('displayName')
       },
       /**
        * #getter
@@ -266,7 +271,7 @@ export default function assemblyFactory(
        * #getter
        */
       get refNameColors() {
-        const colors: string[] = getConf(self, 'refNameColors')
+        const colors: string[] = self.getConf('refNameColors') || []
         return colors.length === 0 ? refNameColors : colors
       },
     }))


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/3911

The issue #3911 mentions the issue this bisects to, which may be somewhat of a red herring or at least is a bit odd. The ideal solution to me seems to be properly checking that the getConf config entry is defined