### PR TITLE
Use theme.secondary.main instead of theme.secondary.light on focusedView

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -45,6 +45,7 @@
     "@jbrowse/product-core": "^2.6.3",
     "@mui/icons-material": "^5.0.0",
     "@mui/material": "^5.10.17",
+    "clsx": "^2.0.0",
     "copy-to-clipboard": "^3.3.1",
     "react-error-boundary": "^4.0.3"
   },

--- a/packages/app-core/src/ui/App/DrawerHeader.tsx
+++ b/packages/app-core/src/ui/App/DrawerHeader.tsx
@@ -36,11 +36,8 @@ const useStyles = makeStyles()(theme => ({
   dropDownIcon: {
     color: theme.palette.secondary.contrastText,
   },
-  header: {
-    background: theme.palette.secondary.main,
-  },
   headerFocused: {
-    background: theme.palette.secondary.light,
+    background: theme.palette.secondary.main,
   },
   headerUnfocused: {
     background: theme.palette.secondary.dark,
@@ -58,17 +55,14 @@ export default observer(function ({
   const focusedViewId = session.focusedViewId
   // @ts-ignore
   const viewWidgetId = session.visibleWidget?.view?.id
-  const isFocused = focusedViewId && focusedViewId === viewWidgetId
 
   return (
     <AppBar
       position="sticky"
       className={
-        isFocused
-          ? `${classes.headerFocused}`
-          : viewWidgetId
-          ? `${classes.headerUnfocused}`
-          : classes.header
+        focusedViewId === viewWidgetId
+          ? classes.headerFocused
+          : classes.headerUnfocused
       }
       ref={ref => setToolbarHeight(ref?.getBoundingClientRect().height || 0)}
     >

--- a/packages/app-core/src/ui/App/ViewContainer.tsx
+++ b/packages/app-core/src/ui/App/ViewContainer.tsx
@@ -3,6 +3,7 @@ import { IconButton, Paper, useTheme } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { getSession, useWidthSetter } from '@jbrowse/core/util'
+import clsx from 'clsx'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { SessionWithFocusedViewAndDrawerWidgets } from '@jbrowse/core/util'
 
@@ -18,7 +19,6 @@ import ViewContainerTitle from './ViewContainerTitle'
 const useStyles = makeStyles()(theme => ({
   viewContainer: {
     overflow: 'hidden',
-    background: theme.palette.secondary.dark,
     margin: theme.spacing(0.5),
     padding: `0 ${theme.spacing(1)} ${theme.spacing(1)}`,
   },
@@ -29,7 +29,10 @@ const useStyles = makeStyles()(theme => ({
     flexGrow: 1,
   },
   focusedView: {
-    background: theme.palette.secondary.light,
+    background: theme.palette.secondary.main,
+  },
+  unfocusedView: {
+    background: theme.palette.secondary.dark,
   },
 }))
 
@@ -77,11 +80,12 @@ export default observer(function ({
     <Paper
       ref={ref}
       elevation={12}
-      className={
+      className={clsx(
+        classes.viewContainer,
         session.focusedViewId === view.id
-          ? `${classes.viewContainer} ${classes.focusedView}`
-          : classes.viewContainer
-      }
+          ? classes.focusedView
+          : classes.unfocusedView,
+      )}
     >
       <div ref={scrollRef} style={{ display: 'flex' }}>
         <ViewMenu model={view} IconProps={{ className: classes.icon }} />


### PR DESCRIPTION
This is a more subtle change compared to the current theme.secondary.light, but it matches the color thats used for all previous versions and I think is still reasonably noticeable