### PR TITLE
Remove some unused "renameReference" code in static blocks/dynamic blocks

### DIFF
--- a/packages/core/util/blockTypes.ts
+++ b/packages/core/util/blockTypes.ts
@@ -1,3 +1,5 @@
+import { sum } from '.'
+
 type Func<T> = (value: BaseBlock, index: number, array: BaseBlock[]) => T
 
 export class BlockSet {
@@ -39,16 +41,17 @@ export class BlockSet {
 
   get totalWidthPx() {
     return this.blocks.length > 0
-      ? this.blocks.map(blocks => blocks.widthPx).reduce((a, b) => a + b)
+      ? sum(this.blocks.map(blocks => blocks.widthPx))
       : 0
   }
 
   get totalWidthPxWithoutBorders() {
     return this.blocks.length > 0
-      ? this.blocks
-          .filter(block => block.variant !== 'boundary')
-          .map(blocks => blocks.widthPx)
-          .reduce((a, b) => a + b)
+      ? sum(
+          this.blocks
+            .filter(block => block.variant !== 'boundary')
+            .map(blocks => blocks.widthPx),
+        )
       : 0
   }
 
@@ -61,9 +64,7 @@ export class BlockSet {
   }
 
   get totalBp() {
-    return this.contentBlocks
-      .map(block => block.end - block.start)
-      .reduce((a, b) => a + b, 0)
+    return sum(this.contentBlocks.map(block => block.end - block.start))
   }
 }
 
@@ -94,7 +95,7 @@ export class BaseBlock {
    * a block that should be shown as filled with data
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(data: any) {
+  constructor(data: Record<string, any>) {
     Object.assign(this, data)
     this.assemblyName = data.assemblyName
     this.refName = data.refName
@@ -102,21 +103,6 @@ export class BaseBlock {
     this.end = data.end
     this.key = data.key
     this.offsetPx = data.offsetPx
-  }
-
-  /**
-   * rename the reference sequence of this block and return a new one
-   *
-   * @param refName -
-   * @returns either a new block with a renamed reference sequence,
-   * or the same block, if the ref name is not actually different
-   */
-  renameReference(refName: string) {
-    if (this.refName && refName !== this.refName) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return new (this.constructor as any)({ ...this, refName })
-    }
-    return this
   }
 
   toRegion() {

--- a/plugins/dotplot-view/src/DotplotView/blockTypes.ts
+++ b/plugins/dotplot-view/src/DotplotView/blockTypes.ts
@@ -1,3 +1,5 @@
+import { sum } from '@jbrowse/core/util'
+
 type Func<T> = (value: BaseBlock, index: number, array: BaseBlock[]) => T
 
 export class BlockSet {
@@ -35,7 +37,7 @@ export class BlockSet {
 
   get totalWidthPx() {
     return this.blocks.length
-      ? this.blocks.map(blocks => blocks.widthPx).reduce((a, b) => a + b)
+      ? sum(this.blocks.map(blocks => blocks.widthPx))
       : 0
   }
 
@@ -69,28 +71,13 @@ export class BaseBlock {
    * a block that should be shown as filled with data
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(data: any) {
+  constructor(data: Record<string, any>) {
     Object.assign(this, data)
     this.assemblyName = data.assemblyName
     this.refName = data.refName
     this.start = data.start
     this.end = data.end
     this.key = data.key
-  }
-
-  /**
-   * rename the reference sequence of this block and return a new one
-   *
-   * @param refName -
-   * @returns either a new block with a renamed reference sequence,
-   * or the same block, if the ref name is not actually different
-   */
-  renameReference(refName: string) {
-    if (this.refName && refName !== this.refName) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return new (this.constructor as any)({ ...this, refName })
-    }
-    return this
   }
 
   toRegion() {


### PR DESCRIPTION
There is a function called renameReference on the blocks, but this code is unused and a bit hairy, I think it is probably ok to just remove. also converts the Array.prototype.reduce into plain for loop based "sum" helper