### PR TITLE
Proposal: Add "extendWorker" extension point

### DIFF
--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -201,7 +201,11 @@ export default abstract class BaseRpcDriver {
       throw new TypeError('sessionId is required')
     }
     let done = false
-    const worker = await this.getWorker(sessionId)
+    const unextendedWorker = await this.getWorker(sessionId)
+    const worker = pluginManager.evaluateExtensionPoint(
+      'Core-extendWorker',
+      unextendedWorker,
+    ) as WorkerHandle
     const rpcMethod = pluginManager.getRpcMethodType(functionName)
     const serializedArgs = await rpcMethod.serializeArguments(args, this.name)
     const filteredAndSerializedArgs = this.filterArgs(serializedArgs, sessionId)

--- a/packages/core/rpc/BaseRpcDriver.ts
+++ b/packages/core/rpc/BaseRpcDriver.ts
@@ -59,18 +59,11 @@ class LazyWorker {
 
   constructor(public driver: BaseRpcDriver) {}
 
-  async getWorker(pluginManager?: PluginManager) {
+  async getWorker() {
     if (!this.workerP) {
-      if (!pluginManager) {
-        throw new Error("Can't make new worker without plugin manager")
-      }
       this.workerP = this.driver
         .makeWorker()
-        .then(unextendedWorker => {
-          const worker = pluginManager.evaluateExtensionPoint(
-            'Core-extendWorker',
-            unextendedWorker,
-          ) as typeof unextendedWorker
+        .then(worker => {
           watchWorker(worker, this.driver.maxPingTime, this.driver.name).catch(
             error => {
               if (worker) {
@@ -184,10 +177,7 @@ export default abstract class BaseRpcDriver {
     return this.workerPool
   }
 
-  async getWorker(
-    sessionId: string,
-    pluginManager?: PluginManager,
-  ): Promise<WorkerHandle> {
+  async getWorker(sessionId: string): Promise<WorkerHandle> {
     const workers = this.getWorkerPool()
     let workerNumber = this.workerAssignments.get(sessionId)
     if (workerNumber === undefined) {
@@ -197,7 +187,7 @@ export default abstract class BaseRpcDriver {
       workerNumber = workerAssignment
     }
 
-    return workers[workerNumber].getWorker(pluginManager)
+    return workers[workerNumber].getWorker()
   }
 
   async call(
@@ -211,7 +201,7 @@ export default abstract class BaseRpcDriver {
       throw new TypeError('sessionId is required')
     }
     let done = false
-    const worker = await this.getWorker(sessionId, pluginManager)
+    const worker = await this.getWorker(sessionId)
     const rpcMethod = pluginManager.getRpcMethodType(functionName)
     const serializedArgs = await rpcMethod.serializeArguments(args, this.name)
     const filteredAndSerializedArgs = this.filterArgs(serializedArgs, sessionId)


### PR DESCRIPTION
I'll explain the reasoning behind this extension point, and I'm certainly open to other ideas of ways to solve it if needed.

In Apollo, data about assemblies, features, sequences, etc. are stored in the session, and the Apollo display doesn't use web workers since it directly observes that store. For things like the regular JBrowse sequence track, though, it does use a web worker, and so can't read from the Apollo store in the session. We've gotten around this by creating a "FromConfigSequenceAdapter" when opening local GFF3s, but that duplicates a lot of data.

This extension point allows us to extend workers, which I've then used in Apollo to add an extra event listener in the worker. This allows the worker to query the main thread for data, which goes outside the normal RPC architecture.

If we ever do a server-side RPC driver, this extension point could also potentially be used to add web socket connections to the server.