### PR TITLE
Fix mouse getting out of sync while dragging resize handle

### DIFF
--- a/packages/core/ui/ResizeHandle.tsx
+++ b/packages/core/ui/ResizeHandle.tsx
@@ -25,15 +25,18 @@ function ResizeHandle({
   vertical = false,
   flexbox = false,
   className: originalClassName,
+  onMouseDown,
   ...props
 }: {
-  onDrag: (arg: number) => number | void
+  onDrag: (lastFrameDistance: number, totalDistance: number) => number | void
+  onMouseDown?: (event: React.MouseEvent) => void
   vertical?: boolean
   flexbox?: boolean
   className?: string
   [props: string]: unknown
 }) {
   const [mouseDragging, setMouseDragging] = useState(false)
+  const initialPosition = useRef(0)
   const prevPos = useRef(0)
   const { classes, cx } = useStyles()
 
@@ -41,11 +44,10 @@ function ResizeHandle({
     function mouseMove(event: MouseEvent) {
       event.preventDefault()
       const pos = vertical ? event.clientX : event.clientY
-      const distance = pos - prevPos.current
-      if (distance) {
-        onDrag(distance)
-        prevPos.current = pos
-      }
+      const totalDistance = initialPosition.current - pos
+      const lastFrameDistance = pos - prevPos.current
+      prevPos.current = pos
+      onDrag(lastFrameDistance, totalDistance)
     }
 
     function mouseUp() {
@@ -78,8 +80,11 @@ function ResizeHandle({
       data-resizer="true"
       onMouseDown={event => {
         event.preventDefault()
-        prevPos.current = vertical ? event.clientX : event.clientY
+        const pos = vertical ? event.clientX : event.clientY
+        initialPosition.current = pos
+        prevPos.current = pos
         setMouseDragging(true)
+        onMouseDown?.(event)
       }}
       className={cx(className, originalClassName)}
       {...props}


### PR DESCRIPTION
The current method of using the resize handle is to continuously provide a "distance" value to an onDrag callback, and normally in response to that, the UI continuously aggregates those small distance values to update the UI with a total distance travelled by the drag, however these often get out of sync with the true mouse position.

This PR changes it so it keeps track of total distance travelled from the mouseDown to the current drag position, and provides that as a second argument to the onDrag callback

