### PR TITLE
Make the default setting for the dotplot/synteny views use 'Existing tracks' by default

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/index.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/index.tsx
@@ -52,7 +52,16 @@ function TrackSelector({
   assembly1: string
   assembly2: string
 }) {
-  const [choice, setChoice] = useState('none')
+  const session = getSession(model)
+  const { tracks, sessionTracks } = session
+  const allTracks = [
+    ...tracks,
+    ...(sessionTracks || []),
+  ] as AnyConfigurationModel[]
+  const filteredTracks = allTracks.filter(t => f(t, assembly2, assembly1))
+  const [choice, setChoice] = useState(
+    filteredTracks.length > 0 ? 'tracklist' : 'none',
+  )
 
   useEffect(() => {
     if (choice === 'none') {

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/index.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/index.tsx
@@ -50,7 +50,7 @@ function TrackSelector({
   assembly1: string
   assembly2: string
 }) {
-  const [choice, setChoice] = useState('none')
+  const [choice, setChoice] = useState('tracklist')
 
   useEffect(() => {
     if (choice === 'none') {


### PR DESCRIPTION
fixes #3941 

Changed the default "import form" for synteny views to show existing synteny tracks to launch rather than the "None" option by default.

If there are no synteny tracks available, it shows a red error, which isn't great, but the alternatives are some code that dynamically changes to new track or none if no synteny tracks are available. Not sure what the user expectation would be