### PR TITLE
Add column resizing for jbrowse-desktop start screen recent sessions panel

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
@@ -15,6 +15,12 @@ const useStyles = makeStyles()(theme => ({
     margin: theme.spacing(1),
     width: '100%',
   },
+
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
 }))
 
 interface Entry {
@@ -101,10 +107,14 @@ export default function DataGridDetails({
               field: val,
               renderCell: params => {
                 const value = params.value as string
-                return isUriLocation(value) ? (
-                  <UriLink value={value} />
-                ) : (
-                  <>{getStr(value)}</>
+                return (
+                  <div className={classes.cell}>
+                    {isUriLocation(value) ? (
+                      <UriLink value={value} />
+                    ) : (
+                      <>{getStr(value)}</>
+                    )}
+                  </div>
                 )
               },
               width: widths[index],

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
@@ -32,6 +32,7 @@ import FacetedHeader from './FacetedHeader'
 import FacetFilters from './FacetFilters'
 import { getRootKeys } from './util'
 import { useResizeBar } from '@jbrowse/core/ui/useResizeBar'
+import { makeStyles } from 'tss-react/mui'
 
 const nonMetadataKeys = ['category', 'adapter', 'description'] as const
 
@@ -41,6 +42,14 @@ export interface InfoArgs {
   conf: AnyConfigurationModel
 }
 
+const useStyles = makeStyles()({
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+})
+
 const frac = 0.75
 
 const FacetedSelector = observer(function FacetedSelector({
@@ -48,6 +57,7 @@ const FacetedSelector = observer(function FacetedSelector({
 }: {
   model: HierarchicalTrackSelectorModel
 }) {
+  const { classes } = useStyles()
   const { view, selection } = model
   const { pluginManager } = getEnv(model)
   const { ref, scrollLeft } = useResizeBar()
@@ -178,7 +188,7 @@ const FacetedSelector = observer(function FacetedSelector({
     }))
   }, [filteredMetadataKeys, visible, filteredNonMetadataKeys, hideSparse, rows])
 
-  const widthsDebounced = useDebounce(widths, 400)
+  const widthsDebounced = useDebounce(widths, 200)
 
   const columns = [
     {
@@ -187,7 +197,7 @@ const FacetedSelector = observer(function FacetedSelector({
       renderCell: (params: GridCellParams) => {
         const { value, id, row } = params
         return (
-          <>
+          <div className={classes.cell}>
             <SanitizedHTML html={value as string} />
             <IconButton
               onClick={e =>
@@ -200,7 +210,7 @@ const FacetedSelector = observer(function FacetedSelector({
             >
               <MoreHoriz />
             </IconButton>
-          </>
+          </div>
         )
       },
       width: widthsDebounced.name ?? 100,
@@ -210,7 +220,11 @@ const FacetedSelector = observer(function FacetedSelector({
       width: widthsDebounced[e] ?? 100,
       renderCell: (params: GridCellParams) => {
         const { value } = params
-        return value ? <SanitizedHTML html={value as string} /> : ''
+        return (
+          <div className={classes.cell}>
+            {value ? <SanitizedHTML html={value as string} /> : ''}
+          </div>
+        )
       },
     })),
     ...filteredMetadataKeys.map(e => ({
@@ -218,7 +232,11 @@ const FacetedSelector = observer(function FacetedSelector({
       width: widthsDebounced[e] ?? 100,
       renderCell: (params: GridCellParams) => {
         const { value } = params
-        return value ? <SanitizedHTML html={value as string} /> : ''
+        return (
+          <div className={classes.cell}>
+            {value ? <SanitizedHTML html={value as string} /> : ''}
+          </div>
+        )
       },
     })),
   ]

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
@@ -22,6 +22,11 @@ const useStyles = makeStyles()(() => ({
   link: {
     cursor: 'pointer',
   },
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
 }))
 
 const BookmarkGrid = observer(function ({
@@ -29,7 +34,7 @@ const BookmarkGrid = observer(function ({
 }: {
   model: GridBookmarkModel
 }) {
-  const { classes } = useStyles()
+  const { classes, cx } = useStyles()
   const [dialogRow, setDialogRow] = useState<IExtendedLabeledRegionModel>()
   const { ref, scrollLeft } = useResizeBar()
   const {
@@ -95,7 +100,7 @@ const BookmarkGrid = observer(function ({
               width: widths[1],
               renderCell: ({ value, row }) => (
                 <Link
-                  className={classes.link}
+                  className={cx(classes.link, classes.cell)}
                   href="#"
                   onClick={async event => {
                     event.preventDefault()

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
@@ -27,6 +27,12 @@ const useStyles = makeStyles()({
   content: {
     minWidth: 800,
   },
+
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
 })
 
 export default function SetColorDialog({
@@ -143,6 +149,7 @@ function SourcesGrid({
   onChange: (arg: Source[]) => void
   showTips: boolean
 }) {
+  const { classes } = useStyles()
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [selected, setSelected] = useState([] as string[])
 
@@ -246,10 +253,14 @@ function SourcesGrid({
               sortingOrder: [null],
               renderCell: (params: GridCellParams) => {
                 const { value } = params
-                return isUriLocation(value) ? (
-                  <UriLink value={value} />
-                ) : (
-                  getStr(value)
+                return (
+                  <div className={classes.cell}>
+                    {isUriLocation(value) ? (
+                      <UriLink value={value} />
+                    ) : (
+                      <>{getStr(value)}</>
+                    )}
+                  </div>
                 )
               },
               // @ts-ignore

--- a/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
@@ -1,15 +1,19 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { IconButton, Link, Tooltip } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { DataGrid } from '@mui/x-data-grid'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { format } from 'timeago.js'
 
+import { useResizeBar } from '@jbrowse/core/ui/useResizeBar'
+import ResizeBar from '@jbrowse/core/ui/ResizeBar'
+
 // icons
 import EditIcon from '@mui/icons-material/Edit'
 
 // locals
 import { loadPluginManager, RecentSessionData } from './util'
+import { measureGridWidth } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()({
   pointer: {
@@ -17,16 +21,19 @@ const useStyles = makeStyles()({
   },
 })
 
-function DateSinceLastUsed({ value }: { value: string }) {
-  const lastModified = new Date(value)
-  const now = Date.now()
-  const oneDayLength = 24 * 60 * 60 * 1000
-  return now - lastModified.getTime() < oneDayLength ? (
-    <Tooltip title={lastModified.toLocaleString('en-US')}>
-      <div>{format(lastModified)}</div>
+function DateSinceLastUsed({
+  row,
+}: {
+  row: { updated?: number; showDateTooltip: boolean; lastModified: string }
+}) {
+  const { updated = 0, lastModified } = row
+  const date = new Date(updated)
+  return row.showDateTooltip ? (
+    <Tooltip title={date.toLocaleString('en-US')}>
+      <div>{lastModified}</div>
     </Tooltip>
   ) : (
-    <>{lastModified.toLocaleString('en-US')}</>
+    <div>{lastModified}</div>
   )
 }
 
@@ -44,30 +51,72 @@ export default function RecentSessionsList({
   sessions: RecentSessionData[]
 }) {
   const { classes } = useStyles()
+  const { ref, scrollLeft } = useResizeBar()
+
+  const now = Date.now()
+  const oneDayLength = 24 * 60 * 60 * 1000
+  const rows = sessions.map(session => {
+    const { updated = 0 } = session
+    const date = new Date(updated)
+    const showDateTooltip = now - date.getTime() < oneDayLength
+    return {
+      id: session.path,
+      name: session.name,
+      rename: session.name,
+      showDateTooltip,
+      lastModified: showDateTooltip
+        ? format(updated)
+        : date.toLocaleString('en-US'),
+      updated: session.updated,
+      path: session.path,
+    }
+  })
+  const arr = ['name', 'path', 'lastModified']
+
+  const [widths, setWidths] = useState({
+    rename: 40,
+    ...Object.fromEntries(
+      arr.map(e => [
+        e,
+        measureGridWidth(
+          rows.map(r => r[e as keyof (typeof rows)[0]]),
+          { maxWidth: 600, stripHTML: true },
+        ),
+      ]),
+    ),
+  } as Record<string, number | undefined>)
 
   return (
-    <div style={{ height: 400, width: '100%' }}>
+    <div ref={ref} style={{ height: 400, width: '100%' }}>
+      <ResizeBar
+        checkbox
+        widths={Object.values(widths).map(f => f ?? 100)}
+        setWidths={newWidths =>
+          setWidths(
+            Object.fromEntries(
+              Object.entries(widths).map((entry, idx) => [
+                entry[0],
+                newWidths[idx],
+              ]),
+            ),
+          )
+        }
+        scrollLeft={scrollLeft}
+      />
       <DataGrid
         checkboxSelection
         disableRowSelectionOnClick
         onRowSelectionModelChange={args =>
           setSelectedSessions(sessions.filter(s => args.includes(s.path)))
         }
-        rows={sessions.map(session => ({
-          id: session.path,
-          name: session.name,
-          rename: session.name,
-          delete: session.name,
-          lastModified: session.updated,
-          path: session.path,
-        }))}
+        rows={rows}
         rowHeight={25}
         columnHeaderHeight={33}
         columns={[
           {
             field: 'rename',
             minWidth: 40,
-            width: 40,
+            width: widths.rename,
             sortable: false,
             filterable: false,
             headerName: ' ',
@@ -75,10 +124,9 @@ export default function RecentSessionsList({
               return (
                 <IconButton
                   onClick={() => {
-                    const { lastModified: updated, ...rest } = params.row
+                    const { lastModified, ...rest } = params.row
                     setSessionToRename({
                       ...rest,
-                      updated,
                     })
                   }}
                 >
@@ -92,7 +140,7 @@ export default function RecentSessionsList({
           {
             field: 'name',
             headerName: 'Session name',
-            flex: 0.7,
+            width: widths.name,
             renderCell: params => {
               const { value } = params
               return (
@@ -115,7 +163,7 @@ export default function RecentSessionsList({
           {
             field: 'path',
             headerName: 'Session path',
-            flex: 0.7,
+            width: widths.path,
             renderCell: params => {
               const { value } = params
               return (
@@ -128,9 +176,9 @@ export default function RecentSessionsList({
           {
             field: 'lastModified',
             headerName: 'Last modified',
-            renderCell: ({ value }) =>
-              !value ? null : <DateSinceLastUsed value={value} />,
-            width: 150,
+            renderCell: row =>
+              !row.value ? null : <DateSinceLastUsed row={row.row} />,
+            width: widths.lastModified,
           },
         ]}
       />

--- a/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
@@ -19,6 +19,11 @@ const useStyles = makeStyles()({
   pointer: {
     cursor: 'pointer',
   },
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
 })
 
 function DateSinceLastUsed({
@@ -28,12 +33,13 @@ function DateSinceLastUsed({
 }) {
   const { updated = 0, lastModified } = row
   const date = new Date(updated)
+  const { classes } = useStyles()
   return row.showDateTooltip ? (
     <Tooltip title={date.toLocaleString('en-US')}>
-      <div>{lastModified}</div>
+      <div className={classes.cell}>{lastModified}</div>
     </Tooltip>
   ) : (
-    <div>{lastModified}</div>
+    <div className={classes.cell}>{lastModified}</div>
   )
 }
 
@@ -50,7 +56,7 @@ export default function RecentSessionsList({
   setSelectedSessions: (arg: RecentSessionData[]) => void
   sessions: RecentSessionData[]
 }) {
-  const { classes } = useStyles()
+  const { classes, cx } = useStyles()
   const { ref, scrollLeft } = useResizeBar()
 
   const now = Date.now()
@@ -80,8 +86,8 @@ export default function RecentSessionsList({
         e,
         measureGridWidth(
           rows.map(r => r[e as keyof (typeof rows)[0]]),
-          { maxWidth: 600, stripHTML: true },
-        ),
+          { stripHTML: true },
+        ) + 20,
       ]),
     ),
   } as Record<string, number | undefined>)
@@ -145,7 +151,7 @@ export default function RecentSessionsList({
               const { value } = params
               return (
                 <Link
-                  className={classes.pointer}
+                  className={cx(classes.pointer, classes.cell)}
                   onClick={async () => {
                     try {
                       setPluginManager(await loadPluginManager(params.row.path))
@@ -168,7 +174,7 @@ export default function RecentSessionsList({
               const { value } = params
               return (
                 <Tooltip title={String(value)}>
-                  <div>{value as string}</div>
+                  <div className={classes.cell}>{value as string}</div>
                 </Tooltip>
               )
             },


### PR DESCRIPTION
uses our 'grid sizing' to measure grid widths and add column resizing instead of relying on the grid 'flex'

before
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/605c6910-cf9e-446f-97b1-d3c93f897a9a)

after
![Screenshot from 2023-10-02 13-36-09](https://github.com/GMOD/jbrowse-components/assets/6511937/370fefca-d14a-461d-9530-36072bfc3b0b)
