### PR TITLE
Rename bookmarkedRegions model slot to avoid loading bookmarks from older jbrowse sessions

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
@@ -33,7 +33,7 @@ const BookmarkGrid = observer(function ({
   const [dialogRow, setDialogRow] = useState<IExtendedLabeledRegionModel>()
   const { ref, scrollLeft } = useResizeBar()
   const {
-    bookmarkedRegions,
+    bookmarks,
     bookmarksWithValidAssemblies,
     selectedAssemblies,
     selectedBookmarks,
@@ -41,7 +41,7 @@ const BookmarkGrid = observer(function ({
 
   const session = getSession(model)
   const selectedSet = new Set(selectedAssemblies)
-  const rows = bookmarkedRegions
+  const rows = bookmarks
     .filter(r => selectedSet.has(r.assemblyName))
     .map((region, index) => {
       const { assemblyName, ...rest } = region

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/model.ts
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/model.ts
@@ -71,7 +71,7 @@ export default function f(_pluginManager: PluginManager) {
        * #property
        * removed by postProcessSnapshot, only loaded from localStorage
        */
-      bookmarkedRegions: types.optional(types.array(LabeledRegionModel), () =>
+      bookmarks: types.optional(types.array(LabeledRegionModel), () =>
         JSON.parse(localStorageGetItem(localStorageKeyF()) || '[]'),
       ),
     })
@@ -82,7 +82,7 @@ export default function f(_pluginManager: PluginManager) {
 
     .views(self => ({
       get bookmarkAssemblies() {
-        return [...new Set(self.bookmarkedRegions.map(r => r.assemblyName))]
+        return [...new Set(self.bookmarks.map(r => r.assemblyName))]
       },
       get validAssemblies() {
         const { assemblyManager } = getSession(self)
@@ -93,7 +93,7 @@ export default function f(_pluginManager: PluginManager) {
     }))
     .views(self => ({
       get bookmarksWithValidAssemblies() {
-        return self.bookmarkedRegions.filter(e =>
+        return self.bookmarks.filter(e =>
           self.validAssemblies.has(e.assemblyName),
         )
       },
@@ -136,13 +136,13 @@ export default function f(_pluginManager: PluginManager) {
     }))
     .actions(self => ({
       importBookmarks(regions: Region[]) {
-        self.bookmarkedRegions = cast([...self.bookmarkedRegions, ...regions])
+        self.bookmarks = cast([...self.bookmarks, ...regions])
       },
       addBookmark(region: Region) {
-        self.bookmarkedRegions.push(region)
+        self.bookmarks.push(region)
       },
       removeBookmark(index: number) {
-        self.bookmarkedRegions.splice(index, 1)
+        self.bookmarks.splice(index, 1)
       },
       updateBookmarkLabel(
         bookmark: IExtendedLabeledRegionModel,
@@ -154,20 +154,20 @@ export default function f(_pluginManager: PluginManager) {
         self.selectedBookmarks = bookmarks
       },
       setBookmarkedRegions(regions: IMSTArray<typeof LabeledRegionModel>) {
-        self.bookmarkedRegions = cast(regions)
+        self.bookmarks = cast(regions)
       },
     }))
     .actions(self => ({
       clearAllBookmarks() {
-        for (const bookmark of self.bookmarkedRegions) {
+        for (const bookmark of self.bookmarks) {
           if (self.validAssemblies.has(bookmark.assemblyName)) {
-            self.bookmarkedRegions.remove(bookmark)
+            self.bookmarks.remove(bookmark)
           }
         }
       },
       clearSelectedBookmarks() {
         for (const bookmark of self.selectedBookmarks) {
-          self.bookmarkedRegions.remove(bookmark.correspondingObj)
+          self.bookmarks.remove(bookmark.correspondingObj)
         }
         self.selectedBookmarks = []
       },
@@ -178,16 +178,13 @@ export default function f(_pluginManager: PluginManager) {
         addDisposer(
           self,
           autorun(() => {
-            localStorageSetItem(key, JSON.stringify(self.bookmarkedRegions))
+            localStorageSetItem(key, JSON.stringify(self.bookmarks))
           }),
         )
       },
     }))
     .postProcessSnapshot(snap => {
-      const { bookmarkedRegions: _, ...rest } = snap as Omit<
-        typeof snap,
-        symbol
-      >
+      const { bookmarks: _, ...rest } = snap as Omit<typeof snap, symbol>
       return rest
     })
 }

--- a/plugins/grid-bookmark/src/index.ts
+++ b/plugins/grid-bookmark/src/index.ts
@@ -57,7 +57,7 @@ export default class extends Plugin {
               navigateNewestBookmark() {
                 const session = getSession(self)
                 const bookmarkWidget = self.activateBookmarkWidget()
-                const regions = bookmarkWidget.bookmarkedRegions
+                const regions = bookmarkWidget.bookmarks
                 if (regions?.length) {
                   self.navTo(regions.at(-1)!)
                 } else {

--- a/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
+++ b/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
@@ -43,7 +43,7 @@ test('using the click and drag rubberband', async () => {
 
   // @ts-expect-error
   const bookmarkWidget = session.widgets.get('GridBookmark')
-  expect(bookmarkWidget.bookmarkedRegions[0].assemblyName).toBe('volvox')
+  expect(bookmarkWidget.bookmarks[0].assemblyName).toBe('volvox')
 }, 40000)
 
 test('using the hotkey to bookmark the current region', async () => {
@@ -61,9 +61,9 @@ test('using the hotkey to bookmark the current region', async () => {
   )
 
   // @ts-expect-error
-  const { bookmarkedRegions } = session.widgets.get('GridBookmark')
-  expect(bookmarkedRegions[0].start).toBe(100)
-  expect(bookmarkedRegions[0].end).toBe(140)
+  const { bookmarks } = session.widgets.get('GridBookmark')
+  expect(bookmarks[0].start).toBe(100)
+  expect(bookmarks[0].end).toBe(140)
 })
 
 test('using the menu button to bookmark the current region', async () => {
@@ -75,10 +75,10 @@ test('using the menu button to bookmark the current region', async () => {
   await user.click(await findByText('Bookmark current region'))
 
   // @ts-expect-error
-  const { bookmarkedRegions } = session.widgets.get('GridBookmark')
-  expect(bookmarkedRegions.length).toBe(1)
-  expect(bookmarkedRegions[0].start).toBe(100)
-  expect(bookmarkedRegions[0].end).toBe(140)
+  const { bookmarks } = session.widgets.get('GridBookmark')
+  expect(bookmarks.length).toBe(1)
+  expect(bookmarks[0].start).toBe(100)
+  expect(bookmarks[0].end).toBe(140)
 }, 40000)
 
 test('using the embedded link in the widget data grid', async () => {


### PR DESCRIPTION
This is in line with the decision to only load bookmark data from localStorage. there is a small loss of functionality not loading older bookmarks from the session data itself, but i think the localstorage only decision is ok going forward