### PR TITLE
Make faceted track selector facet filters responsive to adjacent filter selections

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilter.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilter.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import {
+  Typography,
+  FormControl,
+  Select,
+  IconButton,
+  Tooltip,
+} from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+
+// icon
+import ClearIcon from '@mui/icons-material/Clear'
+import MinimizeIcon from '@mui/icons-material/Minimize'
+import AddIcon from '@mui/icons-material/Add'
+
+const useStyles = makeStyles()(theme => ({
+  facet: {
+    margin: 0,
+    marginLeft: theme.spacing(2),
+  },
+  select: {
+    marginBottom: theme.spacing(2),
+  },
+}))
+
+export default function FacetFilter({
+  column,
+  vals,
+  width,
+  dispatch,
+  filters,
+}: {
+  column: { field: string }
+  vals: [string, number][]
+  width: number
+  dispatch: (arg: { key: string; val: string[] }) => void
+  filters: Record<string, string[]>
+}) {
+  const { classes } = useStyles()
+  const [visible, setVisible] = useState(true)
+  return (
+    <FormControl key={column.field} className={classes.facet} style={{ width }}>
+      <div style={{ display: 'flex' }}>
+        <Typography>{column.field}</Typography>
+        <Tooltip title="Clear selection on this facet filter">
+          <IconButton
+            onClick={() => dispatch({ key: column.field, val: [] })}
+            size="small"
+          >
+            <ClearIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Minimize/expand this facet filter">
+          <IconButton onClick={() => setVisible(!visible)} size="small">
+            {visible ? <MinimizeIcon /> : <AddIcon />}
+          </IconButton>
+        </Tooltip>
+      </div>
+      {visible ? (
+        <Select
+          multiple
+          native
+          className={classes.select}
+          value={filters[column.field]}
+          onChange={event => {
+            dispatch({
+              key: column.field,
+              // @ts-expect-error
+              val: [...event.target.options]
+                .filter(opt => opt.selected)
+                .map(opt => opt.value),
+            })
+          }}
+        >
+          {vals
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([name, count]) => (
+              <option key={name} value={name}>
+                {name} ({count})
+              </option>
+            ))}
+        </Select>
+      ) : null}
+    </FormControl>
+  )
+}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
@@ -18,11 +18,18 @@ export default function FacetFilters({
   const uniqs = new Map(
     facets.map(f => [f.field, new Map<string, number>()] as const),
   )
+
+  // this code "stages the facet filters" in order that the user has selected
+  // them, which relies on the js behavior that the order of the returned keys is
+  // related to the insertion order.
   const filterKeys = Object.keys(filters)
   const facetKeys = facets.map(f => f.field)
   const ret = new Set<string>()
   for (const entry of filterKeys) {
-    ret.add(entry)
+    // give non-empty filters priority
+    if (filters[entry]?.length) {
+      ret.add(entry)
+    }
   }
   for (const entry of facetKeys) {
     ret.add(entry)

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
@@ -1,94 +1,5 @@
-import React, { useState } from 'react'
-import {
-  Typography,
-  FormControl,
-  Select,
-  IconButton,
-  Tooltip,
-} from '@mui/material'
-import { makeStyles } from 'tss-react/mui'
-
-// icon
-import ClearIcon from '@mui/icons-material/Clear'
-import MinimizeIcon from '@mui/icons-material/Minimize'
-import AddIcon from '@mui/icons-material/Add'
-
-const useStyles = makeStyles()(theme => ({
-  facet: {
-    margin: 0,
-    marginLeft: theme.spacing(2),
-  },
-  select: {
-    marginBottom: theme.spacing(2),
-  },
-}))
-
-function FacetFilter({
-  column,
-  vals,
-  width,
-  dispatch,
-  filters,
-}: {
-  column: { field: string }
-  vals: [string, number][]
-  width: number
-  dispatch: (arg: { key: string; val: string[] }) => void
-  filters: Record<string, string[]>
-}) {
-  const { classes } = useStyles()
-  const [visible, setVisible] = useState(true)
-  return (
-    <FormControl key={column.field} className={classes.facet} style={{ width }}>
-      <div style={{ display: 'flex' }}>
-        <Typography>{column.field}</Typography>
-        <Tooltip title="Clear selection on this facet filter">
-          <IconButton
-            onClick={() => {
-              dispatch({ key: column.field, val: [] })
-            }}
-            size="small"
-          >
-            <ClearIcon />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Minimize/expand this facet filter">
-          <IconButton onClick={() => setVisible(!visible)} size="small">
-            {visible ? <MinimizeIcon /> : <AddIcon />}
-          </IconButton>
-        </Tooltip>
-      </div>
-      {visible ? (
-        <Select
-          multiple
-          native
-          className={classes.select}
-          value={filters[column.field]}
-          onChange={event => {
-            // @ts-expect-error
-            const { options } = event.target
-            const val: string[] = []
-            const len = options.length
-            for (let i = 0; i < len; i++) {
-              if (options[i].selected) {
-                val.push(options[i].value)
-              }
-            }
-            dispatch({ key: column.field, val })
-          }}
-        >
-          {vals
-            .sort((a, b) => a[0].localeCompare(b[0]))
-            .map(([name, count]) => (
-              <option key={name} value={name}>
-                {name} ({count})
-              </option>
-            ))}
-        </Select>
-      ) : null}
-    </FormControl>
-  )
-}
+import React from 'react'
+import FacetFilter from './FacetFilter'
 
 export default function FacetFilters({
   rows,
@@ -104,11 +15,13 @@ export default function FacetFilters({
   width: number
 }) {
   const facets = columns.slice(1)
-  const uniqs = facets.map(() => new Map<string, number>())
-  for (const row of rows) {
-    for (const [index, column] of facets.entries()) {
-      const elt = uniqs[index]
-      const key = `${row[column.field] || ''}`
+  const uniqs = new Map(
+    facets.map(f => [f.field, new Map<string, number>()] as const),
+  )
+  for (const facet of facets) {
+    const elt = uniqs.get(facet.field)!
+    for (const row of rows) {
+      const key = `${row[facet.field] || ''}`
       const val = elt.get(key)
       // we don't allow filtering on empty yet
       if (key) {
@@ -123,16 +36,18 @@ export default function FacetFilters({
 
   return (
     <div>
-      {facets.map((column, index) => (
-        <FacetFilter
-          key={column.field}
-          vals={[...uniqs[index]]}
-          column={column}
-          width={width}
-          dispatch={dispatch}
-          filters={filters}
-        />
-      ))}
+      {facets.map(column => {
+        return (
+          <FacetFilter
+            key={column.field}
+            vals={[...uniqs.get(column.field)!]}
+            column={column}
+            width={width}
+            dispatch={dispatch}
+            filters={filters}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
@@ -18,10 +18,21 @@ export default function FacetFilters({
   const uniqs = new Map(
     facets.map(f => [f.field, new Map<string, number>()] as const),
   )
-  for (const facet of facets) {
-    const elt = uniqs.get(facet.field)!
-    for (const row of rows) {
-      const key = `${row[facet.field] || ''}`
+  const filterKeys = Object.keys(filters)
+  const facetKeys = facets.map(f => f.field)
+  const ret = new Set<string>()
+  for (const entry of filterKeys) {
+    ret.add(entry)
+  }
+  for (const entry of facetKeys) {
+    ret.add(entry)
+  }
+
+  let currentRows = rows
+  for (const facet of ret) {
+    const elt = uniqs.get(facet)!
+    for (const row of currentRows) {
+      const key = `${row[facet] || ''}`
       const val = elt.get(key)
       // we don't allow filtering on empty yet
       if (key) {
@@ -32,6 +43,10 @@ export default function FacetFilters({
         }
       }
     }
+    const filter = filters[facet]?.length ? new Set(filters[facet]) : undefined
+    currentRows = currentRows.filter(row => {
+      return filter !== undefined ? filter.has(row[facet] as string) : true
+    })
   }
 
   return (

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedHeader.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedHeader.tsx
@@ -13,22 +13,26 @@ import { HierarchicalTrackSelectorModel } from '../../model'
 export default function FacetedHeader({
   setFilterText,
   setUseShoppingCart,
-  setHideSparse,
+  setShowSparse,
+  setShowFilters,
   setShowOptions,
   showOptions,
-  hideSparse,
+  showSparse,
+  showFilters,
   useShoppingCart,
   filterText,
   model,
 }: {
   setFilterText: (arg: string) => void
   setUseShoppingCart: (arg: boolean) => void
-  setHideSparse: (arg: boolean) => void
+  setShowSparse: (arg: boolean) => void
+  setShowFilters: (arg: boolean) => void
   setShowOptions: (arg: boolean) => void
   filterText: string
   showOptions: boolean
   useShoppingCart: boolean
-  hideSparse: boolean
+  showSparse: boolean
+  showFilters: boolean
   model: HierarchicalTrackSelectorModel
 }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
@@ -78,9 +82,15 @@ export default function FacetedHeader({
             checked: useShoppingCart,
           },
           {
-            label: 'Hide sparse metadata columns',
-            onClick: () => setHideSparse(!hideSparse),
-            checked: hideSparse,
+            label: 'Show sparse metadata columns',
+            onClick: () => setShowSparse(!showSparse),
+            checked: showSparse,
+            type: 'checkbox',
+          },
+          {
+            label: 'Show facet filters',
+            onClick: () => setShowFilters(!showFilters),
+            checked: showFilters,
             type: 'checkbox',
           },
           {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
@@ -16,6 +16,7 @@ import {
   getSession,
   measureGridWidth,
   useDebounce,
+  useLocalStorage,
 } from '@jbrowse/core/util'
 import {
   AnyConfigurationModel,
@@ -63,11 +64,18 @@ const FacetedSelector = observer(function FacetedSelector({
   const { ref, scrollLeft } = useResizeBar()
 
   const [filterText, setFilterText] = useState('')
-  const [showOptions, setShowOptions] = useState(false)
+  const [showOptions, setShowOptions] = useLocalStorage(
+    'facet-showTableOptions',
+    false,
+  )
   const [info, setInfo] = useState<InfoArgs>()
   const [useShoppingCart, setUseShoppingCart] = useState(false)
-  const [hideSparse, setHideSparse] = useState(true)
-  const [panelWidth, setPanelWidth] = useState(400)
+  const [showSparse, setShowSparse] = useLocalStorage('facet-showSparse', false)
+  const [showFilters, setShowFilters] = useLocalStorage(
+    'facet-showFilters',
+    true,
+  )
+  const [panelWidth, setPanelWidth] = useLocalStorage('facet-panelWidth', 400)
   const session = getSession(model)
   const filterDebounced = useDebounce(filterText, 400)
   const tracks = view.tracks as AnyConfigurationModel[]
@@ -75,9 +83,7 @@ const FacetedSelector = observer(function FacetedSelector({
     (
       state: Record<string, string[]>,
       update: { key: string; val: string[] },
-    ) => {
-      return { ...state, [update.key]: update.val }
-    },
+    ) => ({ ...state, [update.key]: update.val }),
     {},
   )
 
@@ -104,19 +110,19 @@ const FacetedSelector = observer(function FacetedSelector({
   const filteredNonMetadataKeys = useMemo(
     () =>
       nonMetadataKeys.filter(f =>
-        !hideSparse ? true : rows.map(r => r[f]).filter(f => !!f).length > 5,
+        showSparse ? true : rows.map(r => r[f]).filter(f => !!f).length > 5,
       ),
-    [hideSparse, rows],
+    [showSparse, rows],
   )
 
   const filteredMetadataKeys = useMemo(
     () =>
       [...new Set(rows.flatMap(row => getRootKeys(row.metadata)))].filter(f =>
-        !hideSparse
+        showSparse
           ? true
           : rows.map(r => r.metadata[f]).filter(f => !!f).length > 5,
       ),
-    [hideSparse, rows],
+    [showSparse, rows],
   )
 
   const fields = useMemo(
@@ -186,7 +192,7 @@ const FacetedSelector = observer(function FacetedSelector({
           ]),
       ),
     }))
-  }, [filteredMetadataKeys, visible, filteredNonMetadataKeys, hideSparse, rows])
+  }, [filteredMetadataKeys, visible, filteredNonMetadataKeys, showSparse, rows])
 
   const widthsDebounced = useDebounce(widths, 200)
 
@@ -266,11 +272,13 @@ const FacetedSelector = observer(function FacetedSelector({
         />
       ) : null}
       <FacetedHeader
-        setHideSparse={setHideSparse}
+        setShowSparse={setShowSparse}
+        setShowFilters={setShowFilters}
         setShowOptions={setShowOptions}
         setFilterText={setFilterText}
         setUseShoppingCart={setUseShoppingCart}
-        hideSparse={hideSparse}
+        showFilters={showFilters}
+        showSparse={showSparse}
         showOptions={showOptions}
         filterText={filterText}
         useShoppingCart={useShoppingCart}
@@ -289,7 +297,7 @@ const FacetedSelector = observer(function FacetedSelector({
         <div
           style={{
             height: window.innerHeight * frac,
-            width: window.innerWidth * frac - panelWidth,
+            width: window.innerWidth * frac - (showFilters ? panelWidth : 0),
           }}
         >
           <ResizeBar
@@ -347,22 +355,31 @@ const FacetedSelector = observer(function FacetedSelector({
             rowHeight={25}
           />
         </div>
-        <ResizeHandle
-          vertical
-          onDrag={dist => setPanelWidth(panelWidth - dist)}
-          style={{ background: 'grey', width: 5 }}
-        />
-        <div
-          style={{ width: panelWidth, overflowY: 'auto', overflowX: 'hidden' }}
-        >
-          <FacetFilters
-            width={panelWidth - 10}
-            rows={rows}
-            columns={columns}
-            dispatch={dispatch}
-            filters={filters}
-          />
-        </div>
+
+        {showFilters ? (
+          <>
+            <ResizeHandle
+              vertical
+              onDrag={dist => setPanelWidth(panelWidth - dist)}
+              style={{ marginLeft: 5, background: 'grey', width: 5 }}
+            />
+            <div
+              style={{
+                width: panelWidth,
+                overflowY: 'auto',
+                overflowX: 'hidden',
+              }}
+            >
+              <FacetFilters
+                width={panelWidth - 10}
+                rows={rows}
+                columns={columns}
+                dispatch={dispatch}
+                filters={filters}
+              />
+            </div>
+          </>
+        ) : null}
       </div>
     </>
   )

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedSelector.tsx
@@ -245,9 +245,11 @@ const FacetedSelector = observer(function FacetedSelector({
     tracks.map(t => t.configuration.trackId as string),
   )
 
-  const arrFilters = Object.entries(filters).filter(f => f[1].length > 0)
+  const arrFilters = Object.entries(filters)
+    .filter(f => f[1].length > 0)
+    .map(([key, val]) => [key, new Set<string>(val)] as const)
   const filteredRows = rows.filter(row =>
-    arrFilters.every(([key, val]) => val.includes(row[key])),
+    arrFilters.every(([key, val]) => val.has(row[key] as string)),
   )
   return (
     <>


### PR DESCRIPTION
This mirrors more closely the jbrowse 1 behavior of the faceted track selector where:

1) You select a specific facet filter
2) The other facet filters update in response to this

The behavior is a little tricky because each facet "progressively" filters so e.g. if you select all "BamAdapter" from e.g. the adapter facet, you don't want that to result in the adapter facet only showing BamAdapter.

Therefore, it stages it so that all the other facets are filtered on that BamAdapter selection.
