### PR TITLE
Fix ability to click on the text of the 'Select all' in the bookmark assembly selector

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
@@ -37,14 +37,20 @@ const AssemblySelector = observer(function ({
         input={<OutlinedInput label={label} />}
         renderValue={selected => selected.join(', ')}
       >
-        <MenuItem value="all">
+        <MenuItem
+          onClickCapture={event => {
+            // onClickCapture allows us to avoid the parent Select onChange from triggering
+            if (isAllSelected) {
+              model.setSelectedAssemblies([])
+            } else {
+              model.setSelectedAssemblies(undefined)
+            }
+            event.preventDefault()
+          }}
+        >
           <Checkbox
             checked={isAllSelected}
             indeterminate={!isAllSelected && selectedAssemblies.length > 0}
-            onChange={event => {
-              model.setSelectedAssemblies(event.target.checked ? undefined : [])
-              event.stopPropagation()
-            }}
           />
           <ListItemText primary="Select all" />
         </MenuItem>


### PR DESCRIPTION
Currently the UI component only lets you click on the checkbox and clicking the "Select all" text does nothing in contrast to the other menu items. This fixes it