### PR TITLE
Remove session.focusedView, only use session.focusedViewId

### DIFF
--- a/packages/app-core/src/AppFocus/index.ts
+++ b/packages/app-core/src/AppFocus/index.ts
@@ -1,5 +1,4 @@
 import { types } from 'mobx-state-tree'
-import { AbstractViewModel } from '@jbrowse/core/util'
 
 /**
  * #stateModel AppFocusMixin
@@ -14,26 +13,6 @@ export function AppFocusMixin() {
        */
       focusedViewId: types.maybe(types.string),
     })
-    .views(self => ({
-      get focusedView() {
-        let target = undefined as unknown
-        // @ts-ignore
-        self.views.forEach((view: AbstractViewModel) => {
-          // seeks out potential matches for view and subviews
-          // @ts-ignore
-          if (view.views) {
-            // @ts-ignore
-            target = view.views.find(
-              (subView: AbstractViewModel) => subView.id === self.focusedViewId,
-            )
-          }
-          if (view.id === self.focusedViewId) {
-            target = view
-          }
-        })
-        return target as AbstractViewModel
-      },
-    }))
     .actions(self => ({
       setFocusedViewId(viewId: string) {
         self.focusedViewId = viewId

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   focusedBackground: {
     background: theme.palette.secondary.light,
     svg: {
-      fill: 'white',
+      fill: theme.palette.secondary.contrastText,
     },
   },
 }))
@@ -33,16 +33,15 @@ const MiniControls = observer(function ({
 }: {
   model: LinearGenomeViewModel
 }) {
-  const { classes } = useStyles()
-  const { bpPerPx, maxBpPerPx, minBpPerPx, scaleFactor, hideHeader } = model
-  const session = getSession(model)
+  const { classes, cx } = useStyles()
+  const { id, bpPerPx, maxBpPerPx, minBpPerPx, scaleFactor, hideHeader } = model
+  const { focusedViewId } = getSession(model)
   return hideHeader ? (
     <Paper
-      className={
-        session.focusedViewId === model.id
-          ? `${classes.background} ${classes.focusedBackground}`
-          : classes.background
-      }
+      className={cx(
+        classes.background,
+        focusedViewId === id ? classes.focusedBackground : undefined,
+      )}
     >
       <CascadingMenuButton menuItems={model.menuItems()}>
         <ArrowDown fontSize="small" />
@@ -56,7 +55,7 @@ const MiniControls = observer(function ({
       </IconButton>
       <IconButton
         data-testid="zoom_in"
-        onClick={() => model.zoom(model.bpPerPx / 2)}
+        onClick={() => model.zoom(bpPerPx / 2)}
         disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
       >
         <ZoomIn fontSize="small" />


### PR DESCRIPTION
I think that the session.focusedView getter might be unneeded, and indeed, can even have cases where it doesn't fit well. Properly, I think it should resolveIdentifier instead of looping through views, but resolveIdentifier can be tricky because it requires a type argument. Instead of trying to fix the session.focusedView getter, I think it may be valid to just remove it and rely on checking only session.focusedViewId in client code