### PR TITLE
Fix rendering multi-quantitative tracks when blank data is present

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1288,8 +1288,8 @@ export function avg(arr: number[]) {
   return sum(arr) / arr.length
 }
 
-export function groupBy<T>(array: T[], predicate: (v: T) => string) {
-  const result = {} as Record<string, T[]>
+export function groupBy<T>(array: Iterable<T>, predicate: (v: T) => string) {
+  const result = {} as Record<string, T[] | undefined>
   for (const value of array) {
     const entry = (result[predicate(value)] ||= [])
     entry.push(value)

--- a/plugins/wiggle/src/DensityRenderer/DensityRenderer.ts
+++ b/plugins/wiggle/src/DensityRenderer/DensityRenderer.ts
@@ -1,4 +1,4 @@
-import { drawDensity } from '../drawxy'
+import { drawDensity } from '../drawDensity'
 
 import WiggleBaseRenderer, {
   RenderArgsDeserializedWithFeatures,

--- a/plugins/wiggle/src/LinePlotRenderer/LinePlotRenderer.ts
+++ b/plugins/wiggle/src/LinePlotRenderer/LinePlotRenderer.ts
@@ -3,7 +3,7 @@ import WiggleBaseRenderer, {
 } from '../WiggleBaseRenderer'
 
 import { YSCALEBAR_LABEL_OFFSET } from '../util'
-import { drawLine } from '../drawxy'
+import { drawLine } from '../drawLine'
 
 export default class LinePlotRenderer extends WiggleBaseRenderer {
   async draw(

--- a/plugins/wiggle/src/MultiDensityRenderer/MultiDensityRenderer.ts
+++ b/plugins/wiggle/src/MultiDensityRenderer/MultiDensityRenderer.ts
@@ -9,16 +9,13 @@ export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
   async draw(ctx: CanvasRenderingContext2D, props: MultiArgs) {
     const { bpPerPx, sources, regions, features } = props
     const [region] = regions
-    const groups = groupBy([...features.values()], f => f.get('source'))
+    const groups = groupBy(features.values(), f => f.get('source'))
     const height = props.height / sources.length
     const width = (region.end - region.start) / bpPerPx
     let feats = [] as Feature[]
     ctx.save()
     sources.forEach(source => {
-      const features = groups[source.name]
-      if (!features) {
-        return
-      }
+      const features = groups[source.name] || []
       const { reducedFeatures } = drawDensity(ctx, {
         ...props,
         features,
@@ -30,7 +27,7 @@ export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
       ctx.lineTo(width, height)
       ctx.stroke()
       ctx.translate(0, height)
-      feats = [...feats, ...reducedFeatures]
+      feats = feats.concat(reducedFeatures)
     })
     ctx.restore()
     return { reducedFeatures: feats }

--- a/plugins/wiggle/src/MultiDensityRenderer/MultiDensityRenderer.ts
+++ b/plugins/wiggle/src/MultiDensityRenderer/MultiDensityRenderer.ts
@@ -2,7 +2,7 @@ import { groupBy, Feature } from '@jbrowse/core/util'
 import WiggleBaseRenderer, {
   MultiRenderArgsDeserialized as MultiArgs,
 } from '../WiggleBaseRenderer'
-import { drawDensity } from '../drawxy'
+import { drawDensity } from '../drawDensity'
 
 export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
   // @ts-expect-error

--- a/plugins/wiggle/src/MultiLineRenderer/MultiLineRenderer.ts
+++ b/plugins/wiggle/src/MultiLineRenderer/MultiLineRenderer.ts
@@ -9,19 +9,15 @@ export default class MultiLineRenderer extends WiggleBaseRenderer {
   // @ts-expect-error
   async draw(ctx: CanvasRenderingContext2D, props: MultiArgs) {
     const { sources, features } = props
-    const groups = groupBy([...features.values()], f => f.get('source'))
+    const groups = groupBy(features.values(), f => f.get('source'))
     let feats = [] as Feature[]
     sources.forEach(source => {
-      const features = groups[source.name]
-      if (!features) {
-        return
-      }
       const { reducedFeatures } = drawLine(ctx, {
         ...props,
-        features,
+        features: groups[source.name] || [],
         colorCallback: () => source.color || 'blue',
       })
-      feats = [...feats, ...reducedFeatures]
+      feats = feats.concat(reducedFeatures)
     })
     return { reducedFeatures: feats }
   }

--- a/plugins/wiggle/src/MultiLineRenderer/MultiLineRenderer.ts
+++ b/plugins/wiggle/src/MultiLineRenderer/MultiLineRenderer.ts
@@ -1,5 +1,5 @@
 import { groupBy, Feature } from '@jbrowse/core/util'
-import { drawLine } from '../drawxy'
+import { drawLine } from '../drawLine'
 
 import WiggleBaseRenderer, {
   MultiRenderArgsDeserialized as MultiArgs,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SetColorDialog.tsx
@@ -1,37 +1,17 @@
 import React, { useState } from 'react'
 import { Button, DialogContent, DialogActions } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import {
-  getStr,
-  isUriLocation,
-  measureGridWidth,
-  useLocalStorage,
-} from '@jbrowse/core/util'
-import { DataGrid, GridCellParams } from '@mui/x-data-grid'
+import { useLocalStorage } from '@jbrowse/core/util'
 import clone from 'clone'
 
 // locals
 import DraggableDialog from './DraggableDialog'
-import ColorPicker, { ColorPopover } from '@jbrowse/core/ui/ColorPicker'
-import { moveUp, moveDown } from './util'
 import { Source } from '../../util'
-
-// icons
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp'
-import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown'
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
-import UriLink from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/UriLink'
+import SourcesGrid from './SourcesGrid'
 
 const useStyles = makeStyles()({
   content: {
     minWidth: 800,
-  },
-
-  cell: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
   },
 })
 
@@ -132,167 +112,5 @@ export default function SetColorDialog({
         </Button>
       </DialogActions>
     </DraggableDialog>
-  )
-}
-
-interface SortField {
-  idx: number
-  field: string | null
-}
-
-function SourcesGrid({
-  rows,
-  onChange,
-  showTips,
-}: {
-  rows: Source[]
-  onChange: (arg: Source[]) => void
-  showTips: boolean
-}) {
-  const { classes } = useStyles()
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const [selected, setSelected] = useState([] as string[])
-
-  // @ts-expect-error
-  const { name: _name, color: _color, baseUri: _baseUri, ...rest } = rows[0]
-  const [widgetColor, setWidgetColor] = useState('blue')
-  const [currSort, setCurrSort] = useState<SortField>({
-    idx: 0,
-    field: null,
-  })
-
-  return (
-    <div>
-      <Button
-        disabled={!selected.length}
-        onClick={event => setAnchorEl(event.currentTarget)}
-      >
-        Change color of selected items
-      </Button>
-      <Button
-        onClick={() => onChange(moveUp([...rows], selected))}
-        disabled={!selected.length}
-      >
-        <KeyboardArrowUpIcon />
-        {showTips ? 'Move selected items up' : null}
-      </Button>
-      <Button
-        onClick={() => onChange(moveDown([...rows], selected))}
-        disabled={!selected.length}
-      >
-        <KeyboardArrowDownIcon />
-        {showTips ? 'Move selected items down' : null}
-      </Button>
-      <Button
-        onClick={() => onChange(moveUp([...rows], selected, rows.length))}
-        disabled={!selected.length}
-      >
-        <KeyboardDoubleArrowUpIcon />
-        {showTips ? 'Move selected items to top' : null}
-      </Button>
-      <Button
-        onClick={() => onChange(moveDown([...rows], selected, rows.length))}
-        disabled={!selected.length}
-      >
-        <KeyboardDoubleArrowDownIcon />
-        {showTips ? 'Move selected items to bottom' : null}
-      </Button>
-      <ColorPopover
-        anchorEl={anchorEl}
-        color={widgetColor}
-        onChange={c => {
-          setWidgetColor(c)
-          selected.forEach(id => {
-            const elt = rows.find(f => f.name === id)
-            if (elt) {
-              elt.color = c
-            }
-          })
-
-          onChange([...rows])
-        }}
-        onClose={() => setAnchorEl(null)}
-      />
-      <div style={{ height: 400, width: '100%' }}>
-        <DataGrid
-          getRowId={row => row.name}
-          checkboxSelection
-          disableRowSelectionOnClick
-          onRowSelectionModelChange={arg => setSelected(arg as string[])}
-          rows={rows}
-          rowHeight={25}
-          columnHeaderHeight={33}
-          columns={[
-            {
-              field: 'color',
-              headerName: 'Color',
-              renderCell: params => {
-                const { value, id } = params
-                return (
-                  <ColorPicker
-                    color={value || 'blue'}
-                    onChange={c => {
-                      const elt = rows.find(f => f.name === id)
-                      if (elt) {
-                        elt.color = c
-                      }
-                      onChange([...rows])
-                    }}
-                  />
-                )
-              },
-            },
-            {
-              field: 'name',
-              sortingOrder: [null],
-              headerName: 'Name',
-              width: measureGridWidth(rows.map(r => r.name)),
-            },
-            ...Object.keys(rest).map(val => ({
-              field: val,
-              sortingOrder: [null],
-              renderCell: (params: GridCellParams) => {
-                const { value } = params
-                return (
-                  <div className={classes.cell}>
-                    {isUriLocation(value) ? (
-                      <UriLink value={value} />
-                    ) : (
-                      <>{getStr(value)}</>
-                    )}
-                  </div>
-                )
-              },
-              // @ts-ignore
-              width: measureGridWidth(rows.map(r => r[val])),
-            })),
-          ]}
-          sortModel={
-            [
-              /* we control the sort as a controlled component using onSortModelChange */
-            ]
-          }
-          onSortModelChange={args => {
-            const sort = args[0]
-            const idx = (currSort.idx + 1) % 2
-            const field = sort?.field || currSort.field
-            setCurrSort({ idx, field })
-            onChange(
-              field
-                ? [...rows].sort((a, b) => {
-                    // @ts-expect-error
-                    const aa = getStr(a[field])
-                    // @ts-expect-error
-                    const bb = getStr(b[field])
-                    return idx === 1
-                      ? aa.localeCompare(bb)
-                      : bb.localeCompare(aa)
-                  })
-                : rows,
-            )
-          }}
-        />
-      </div>
-    </div>
   )
 }

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react'
+import { Button } from '@mui/material'
+import { getStr, isUriLocation, measureGridWidth } from '@jbrowse/core/util'
+import { DataGrid, GridCellParams } from '@mui/x-data-grid'
+import { makeStyles } from 'tss-react/mui'
+
+// locals
+import ColorPicker, { ColorPopover } from '@jbrowse/core/ui/ColorPicker'
+import { moveUp, moveDown } from './util'
+import { Source } from '../../util'
+
+// icons
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp'
+import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown'
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
+import UriLink from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/UriLink'
+
+const useStyles = makeStyles()({
+  cell: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+})
+interface SortField {
+  idx: number
+  field: string | null
+}
+
+function SourcesGrid({
+  rows,
+  onChange,
+  showTips,
+}: {
+  rows: Source[]
+  onChange: (arg: Source[]) => void
+  showTips: boolean
+}) {
+  const { classes } = useStyles()
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [selected, setSelected] = useState([] as string[])
+
+  // @ts-expect-error
+  const { name: _name, color: _color, baseUri: _baseUri, ...rest } = rows[0]
+  const [widgetColor, setWidgetColor] = useState('blue')
+  const [currSort, setCurrSort] = useState<SortField>({
+    idx: 0,
+    field: null,
+  })
+
+  return (
+    <div>
+      <Button
+        disabled={!selected.length}
+        onClick={event => setAnchorEl(event.currentTarget)}
+      >
+        Change color of selected items
+      </Button>
+      <Button
+        onClick={() => onChange(moveUp([...rows], selected))}
+        disabled={!selected.length}
+      >
+        <KeyboardArrowUpIcon />
+        {showTips ? 'Move selected items up' : null}
+      </Button>
+      <Button
+        onClick={() => onChange(moveDown([...rows], selected))}
+        disabled={!selected.length}
+      >
+        <KeyboardArrowDownIcon />
+        {showTips ? 'Move selected items down' : null}
+      </Button>
+      <Button
+        onClick={() => onChange(moveUp([...rows], selected, rows.length))}
+        disabled={!selected.length}
+      >
+        <KeyboardDoubleArrowUpIcon />
+        {showTips ? 'Move selected items to top' : null}
+      </Button>
+      <Button
+        onClick={() => onChange(moveDown([...rows], selected, rows.length))}
+        disabled={!selected.length}
+      >
+        <KeyboardDoubleArrowDownIcon />
+        {showTips ? 'Move selected items to bottom' : null}
+      </Button>
+      <ColorPopover
+        anchorEl={anchorEl}
+        color={widgetColor}
+        onChange={c => {
+          setWidgetColor(c)
+          selected.forEach(id => {
+            const elt = rows.find(f => f.name === id)
+            if (elt) {
+              elt.color = c
+            }
+          })
+
+          onChange([...rows])
+        }}
+        onClose={() => setAnchorEl(null)}
+      />
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          getRowId={row => row.name}
+          checkboxSelection
+          disableRowSelectionOnClick
+          onRowSelectionModelChange={arg => setSelected(arg as string[])}
+          rows={rows}
+          rowHeight={25}
+          columnHeaderHeight={33}
+          columns={[
+            {
+              field: 'color',
+              headerName: 'Color',
+              renderCell: params => {
+                const { value, id } = params
+                return (
+                  <ColorPicker
+                    color={value || 'blue'}
+                    onChange={c => {
+                      const elt = rows.find(f => f.name === id)
+                      if (elt) {
+                        elt.color = c
+                      }
+                      onChange([...rows])
+                    }}
+                  />
+                )
+              },
+            },
+            {
+              field: 'name',
+              sortingOrder: [null],
+              headerName: 'Name',
+              width: measureGridWidth(rows.map(r => r.name)),
+            },
+            ...Object.keys(rest).map(val => ({
+              field: val,
+              sortingOrder: [null],
+              renderCell: (params: GridCellParams) => {
+                const { value } = params
+                return (
+                  <div className={classes.cell}>
+                    {isUriLocation(value) ? (
+                      <UriLink value={value} />
+                    ) : (
+                      <>{getStr(value)}</>
+                    )}
+                  </div>
+                )
+              },
+              // @ts-ignore
+              width: measureGridWidth(rows.map(r => r[val])),
+            })),
+          ]}
+          sortModel={
+            [
+              /* we control the sort as a controlled component using onSortModelChange */
+            ]
+          }
+          onSortModelChange={args => {
+            const sort = args[0]
+            const idx = (currSort.idx + 1) % 2
+            const field = sort?.field || currSort.field
+            setCurrSort({ idx, field })
+            onChange(
+              field
+                ? [...rows].sort((a, b) => {
+                    // @ts-expect-error
+                    const aa = getStr(a[field])
+                    // @ts-expect-error
+                    const bb = getStr(b[field])
+                    return idx === 1
+                      ? aa.localeCompare(bb)
+                      : bb.localeCompare(aa)
+                  })
+                : rows,
+            )
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default SourcesGrid

--- a/plugins/wiggle/src/MultiRowLineRenderer/MultiRowLineRenderer.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/MultiRowLineRenderer.ts
@@ -1,5 +1,6 @@
 import { groupBy, Feature } from '@jbrowse/core/util'
-import { drawLine } from '../drawxy'
+import { drawLine } from '../drawLine'
+
 import WiggleBaseRenderer, {
   MultiRenderArgsDeserialized as MultiArgs,
 } from '../WiggleBaseRenderer'

--- a/plugins/wiggle/src/MultiRowLineRenderer/MultiRowLineRenderer.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/MultiRowLineRenderer.ts
@@ -9,7 +9,7 @@ export default class MultiRowLineRenderer extends WiggleBaseRenderer {
   async draw(ctx: CanvasRenderingContext2D, props: MultiArgs) {
     const { bpPerPx, sources, regions, features } = props
     const [region] = regions
-    const groups = groupBy([...features.values()], f => f.get('source'))
+    const groups = groupBy(features.values(), f => f.get('source'))
     const height = props.height / sources.length
     const width = (region.end - region.start) / bpPerPx
     let feats = [] as Feature[]
@@ -17,7 +17,7 @@ export default class MultiRowLineRenderer extends WiggleBaseRenderer {
     sources.forEach(source => {
       const { reducedFeatures } = drawLine(ctx, {
         ...props,
-        features: groups[source.name],
+        features: groups[source.name] || [],
         height,
         colorCallback: () => source.color || 'blue',
       })
@@ -27,7 +27,7 @@ export default class MultiRowLineRenderer extends WiggleBaseRenderer {
       ctx.lineTo(width, height)
       ctx.stroke()
       ctx.translate(0, height)
-      feats = [...feats, ...reducedFeatures]
+      feats = feats.concat(reducedFeatures)
     })
     ctx.restore()
     return { reducedFeatures: feats }

--- a/plugins/wiggle/src/MultiRowXYPlotRenderer/MultiRowXYPlotRenderer.ts
+++ b/plugins/wiggle/src/MultiRowXYPlotRenderer/MultiRowXYPlotRenderer.ts
@@ -10,19 +10,15 @@ export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
   async draw(ctx: CanvasRenderingContext2D, props: MultiArgs) {
     const { bpPerPx, sources, regions, features } = props
     const [region] = regions
-    const groups = groupBy([...features.values()], f => f.get('source'))
+    const groups = groupBy(features.values(), f => f.get('source'))
     const height = props.height / sources.length
     const width = (region.end - region.start) / bpPerPx
     let feats = [] as Feature[]
     ctx.save()
     sources.forEach(source => {
-      const features = groups[source.name]
-      if (!features) {
-        return
-      }
       const { reducedFeatures } = drawXY(ctx, {
         ...props,
-        features,
+        features: groups[source.name] || [],
         height,
         colorCallback: () => source.color || 'blue',
       })
@@ -32,7 +28,7 @@ export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
       ctx.lineTo(width, height)
       ctx.stroke()
       ctx.translate(0, height)
-      feats = [...feats, ...reducedFeatures]
+      feats = feats.concat(reducedFeatures)
     })
     ctx.restore()
     return { reducedFeatures: feats }

--- a/plugins/wiggle/src/MultiRowXYPlotRenderer/MultiRowXYPlotRenderer.ts
+++ b/plugins/wiggle/src/MultiRowXYPlotRenderer/MultiRowXYPlotRenderer.ts
@@ -1,5 +1,5 @@
 import { groupBy, Feature } from '@jbrowse/core/util'
-import { drawXY } from '../drawxy'
+import { drawXY } from '../drawXY'
 
 import WiggleBaseRenderer, {
   MultiRenderArgsDeserialized as MultiArgs,

--- a/plugins/wiggle/src/MultiXYPlotRenderer/MultiXYPlotRenderer.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/MultiXYPlotRenderer.ts
@@ -1,5 +1,5 @@
 import { groupBy, Feature } from '@jbrowse/core/util'
-import { drawXY } from '../drawxy'
+import { drawXY } from '../drawXY'
 import { YSCALEBAR_LABEL_OFFSET } from '../util'
 
 import WiggleBaseRenderer, {

--- a/plugins/wiggle/src/MultiXYPlotRenderer/MultiXYPlotRenderer.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/MultiXYPlotRenderer.ts
@@ -10,20 +10,17 @@ export default class MultiXYPlotRenderer extends WiggleBaseRenderer {
   // @ts-expect-error
   async draw(ctx: CanvasRenderingContext2D, props: MultiArgs) {
     const { sources, features } = props
-    const groups = groupBy([...features.values()], f => f.get('source'))
+    const groups = groupBy(features.values(), f => f.get('source'))
     let feats = [] as Feature[]
     for (const source of sources) {
-      const features = groups[source.name]
-      if (!features) {
-        continue
-      }
+      const features = groups[source.name] || []
       const { reducedFeatures } = drawXY(ctx, {
         ...props,
         features,
         offset: YSCALEBAR_LABEL_OFFSET,
         colorCallback: () => source.color || 'blue',
       })
-      feats = [...feats, ...reducedFeatures]
+      feats = feats.concat(reducedFeatures)
     }
     return { reducedFeatures: feats }
   }

--- a/plugins/wiggle/src/WiggleRendering.test.tsx
+++ b/plugins/wiggle/src/WiggleRendering.test.tsx
@@ -9,10 +9,12 @@ test('one', async () => {
       width={500}
       height={500}
       features={new Map()}
-      highResolutionScaling={1}
-      regions={[{ refName: 'chr1', start: 1, end: 3 }]}
+      regions={[{ refName: 'chr1', start: 1, end: 3, assemblyName: 'volvox' }]}
       bpPerPx={3}
-      config={{ type: 'DummyRenderer' }}
+      blockKey="test"
+      onMouseMove={() => {}}
+      onMouseLeave={() => {}}
+      onFeatureClick={() => {}}
     />,
   )
   const test = getByTestId('wiggle-rendering-test')

--- a/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
+++ b/plugins/wiggle/src/XYPlotRenderer/XYPlotRenderer.ts
@@ -1,6 +1,6 @@
 import { readConfObject } from '@jbrowse/core/configuration'
 import { Feature } from '@jbrowse/core/util'
-import { drawXY } from '../drawxy'
+import { drawXY } from '../drawXY'
 import WiggleBaseRenderer, {
   RenderArgsDeserializedWithFeatures,
 } from '../WiggleBaseRenderer'

--- a/plugins/wiggle/src/__snapshots__/WiggleRendering.test.tsx.snap
+++ b/plugins/wiggle/src/__snapshots__/WiggleRendering.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`one 1`] = `
   style="overflow: visible; position: relative; height: 500px;"
 >
   <canvas
-    data-testid="prerendered_canvas"
+    data-testid="prerendered_canvas_test"
     height="500"
     style="width: 500px; height: 500px;"
     width="500"

--- a/plugins/wiggle/src/drawDensity.ts
+++ b/plugins/wiggle/src/drawDensity.ts
@@ -1,0 +1,86 @@
+import {
+  AnyConfigurationModel,
+  readConfObject,
+} from '@jbrowse/core/configuration'
+import { featureSpanPx, Feature, Region } from '@jbrowse/core/util'
+
+// locals
+import { fillRectCtx, getScale, ScaleOpts } from './util'
+
+const fudgeFactor = 0.3
+const clipHeight = 2
+
+export function drawDensity(
+  ctx: CanvasRenderingContext2D,
+  props: {
+    features: Map<string, Feature> | Feature[]
+    regions: Region[]
+    bpPerPx: number
+    scaleOpts: ScaleOpts
+    height: number
+    ticks: { values: number[] }
+    displayCrossHatches: boolean
+    config: AnyConfigurationModel
+  },
+) {
+  const { features, regions, bpPerPx, scaleOpts, height, config } = props
+  const [region] = regions
+  const pivot = readConfObject(config, 'bicolorPivot')
+  const pivotValue = readConfObject(config, 'bicolorPivotValue')
+  const negColor = readConfObject(config, 'negColor')
+  const posColor = readConfObject(config, 'posColor')
+  const color = readConfObject(config, 'color')
+  const clipColor = readConfObject(config, 'clipColor')
+  const crossing = pivot !== 'none' && scaleOpts.scaleType !== 'log'
+  const scale = getScale({
+    ...scaleOpts,
+    pivotValue: crossing ? pivotValue : undefined,
+    range: crossing ? [negColor, 'white', posColor] : ['white', posColor],
+  })
+
+  const scale2 = getScale({ ...scaleOpts, range: [0, height] })
+  const cb =
+    color === '#f0f'
+      ? (_: Feature, score: number) => scale(score)
+      : (feature: Feature, score: number) =>
+          readConfObject(config, 'color', { feature, score })
+  const [niceMin, niceMax] = scale2.domain()
+
+  let prevLeftPx = -Infinity
+  let hasClipping = false
+  const reducedFeatures = []
+  for (const feature of features.values()) {
+    const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
+
+    // create reduced features, avoiding multiple features per px
+    if (Math.floor(leftPx) !== Math.floor(prevLeftPx)) {
+      reducedFeatures.push(feature)
+      prevLeftPx = leftPx
+    }
+    const score = feature.get('score')
+    hasClipping = hasClipping || score > niceMax || score < niceMin
+    const w = rightPx - leftPx + fudgeFactor
+    ctx.fillStyle = cb(feature, score)
+    ctx.fillRect(leftPx, 0, w, height)
+  }
+
+  // second pass: draw clipping
+  // avoid persisting the red fillstyle with save/restore
+  ctx.save()
+  if (hasClipping) {
+    ctx.fillStyle = clipColor
+    for (const feature of features.values()) {
+      const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
+      const w = rightPx - leftPx + fudgeFactor
+      const score = feature.get('score')
+      if (score > niceMax) {
+        fillRectCtx(leftPx, 0, w, clipHeight, ctx)
+      } else if (score < niceMin && scaleOpts.scaleType !== 'log') {
+        fillRectCtx(leftPx, 0, w, clipHeight, ctx)
+      }
+    }
+  }
+  ctx.restore()
+
+  return { reducedFeatures }
+}

--- a/plugins/wiggle/src/drawLine.ts
+++ b/plugins/wiggle/src/drawLine.ts
@@ -1,0 +1,105 @@
+import {
+  AnyConfigurationModel,
+  readConfObject,
+} from '@jbrowse/core/configuration'
+import { clamp, featureSpanPx, Feature, Region } from '@jbrowse/core/util'
+
+// locals
+import { getScale, ScaleOpts } from './util'
+
+const fudgeFactor = 0.3
+const clipHeight = 2
+
+export function drawLine(
+  ctx: CanvasRenderingContext2D,
+  props: {
+    features: Map<string, Feature> | Feature[]
+    regions: Region[]
+    bpPerPx: number
+    scaleOpts: ScaleOpts
+    height: number
+    ticks: { values: number[] }
+    displayCrossHatches: boolean
+    colorCallback: (f: Feature, score: number) => string
+    config: AnyConfigurationModel
+    offset?: number
+  },
+) {
+  const {
+    features,
+    regions,
+    bpPerPx,
+    scaleOpts,
+    height: unadjustedHeight,
+    ticks: { values },
+    displayCrossHatches,
+    colorCallback,
+    config,
+    offset = 0,
+  } = props
+  const [region] = regions
+  const width = (region.end - region.start) / bpPerPx
+
+  // the adjusted height takes into account YSCALEBAR_LABEL_OFFSET from the
+  // wiggle display, and makes the height of the actual drawn area add
+  // "padding" to the top and bottom of the display
+  const height = unadjustedHeight - offset * 2
+  const clipColor = readConfObject(config, 'clipColor')
+  const scale = getScale({ ...scaleOpts, range: [0, height] })
+  const [niceMin, niceMax] = scale.domain()
+  const toY = (n: number) => clamp(height - (scale(n) || 0), 0, height) + offset
+
+  let lastVal: number | undefined
+  let prevLeftPx = -Infinity
+  const reducedFeatures = []
+  for (const feature of features.values()) {
+    const [leftPx, rightPx] = featureSpanPx(feature, region, bpPerPx)
+
+    // create reduced features, avoiding multiple features per px
+    if (Math.floor(leftPx) !== Math.floor(prevLeftPx)) {
+      reducedFeatures.push(feature)
+      prevLeftPx = leftPx
+    }
+    const score = feature.get('score')
+    const lowClipping = score < niceMin
+    const highClipping = score > niceMax
+    const w = rightPx - leftPx + fudgeFactor
+
+    const c = colorCallback(feature, score)
+
+    ctx.beginPath()
+    ctx.strokeStyle = c
+    const startPos = lastVal !== undefined ? lastVal : score
+    if (!region.reversed) {
+      ctx.moveTo(leftPx, toY(startPos))
+      ctx.lineTo(leftPx, toY(score))
+      ctx.lineTo(rightPx, toY(score))
+    } else {
+      ctx.moveTo(rightPx, toY(startPos))
+      ctx.lineTo(rightPx, toY(score))
+      ctx.lineTo(leftPx, toY(score))
+    }
+    ctx.stroke()
+    lastVal = score
+
+    if (highClipping) {
+      ctx.fillStyle = clipColor
+      ctx.fillRect(leftPx, offset, w, clipHeight)
+    } else if (lowClipping && scaleOpts.scaleType !== 'log') {
+      ctx.fillStyle = clipColor
+      ctx.fillRect(leftPx, height - clipHeight, w, height)
+    }
+  }
+
+  if (displayCrossHatches) {
+    ctx.lineWidth = 1
+    ctx.strokeStyle = 'rgba(200,200,200,0.5)'
+    values.forEach(tick => {
+      ctx.beginPath()
+      ctx.moveTo(0, Math.round(toY(tick)))
+      ctx.lineTo(width, Math.round(toY(tick)))
+      ctx.stroke()
+    })
+  }
+  return { reducedFeatures }
+}

--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -316,3 +316,27 @@ export function toP(s = 0) {
 export function round(value: number) {
   return Math.round(value * 1e5) / 1e5
 }
+
+// avoid drawing negative width features for SVG exports
+export function fillRectCtx(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  ctx: CanvasRenderingContext2D,
+  color?: string,
+) {
+  if (width < 0) {
+    x += width
+    width = -width
+  }
+  if (height < 0) {
+    y += height
+    height = -height
+  }
+
+  if (color) {
+    ctx.fillStyle = color
+  }
+  ctx.fillRect(x, y, width, height)
+}


### PR DESCRIPTION
The code to render multi-quantiative tracks iteratively goes to the 'next row', and requires calling a ctx.translate(0,height) to move down to the next row on each round of the loop, but the code was short circuiting the loop and not hitting that translate if the features in a particular row was empty

This fixes the issue