### PR TITLE
v2.7.1 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.7.1.md
+++ b/website/release_announcement_drafts/v2.7.1.md
@@ -1,0 +1,3 @@
+This release fixes a issue with jbrowse-desktop failing on certain platforms,
+adds ability to auto-render links from metadata without adding `<a href='...'>`
+tags, and fixes another issue on sparse multi-bigwigs


### PR DESCRIPTION
```
## Unreleased (2023-10-17)

#### :rocket: Enhancement
* `core`
  * [#3982](https://github.com/GMOD/jbrowse-components/pull/3982) Allow rendering semi-circles in the arc renderer + SVG rendering of arcs ([@cmdcolin](https://github.com/cmdcolin))
* `__mocks__`, `core`
  * [#3981](https://github.com/GMOD/jbrowse-components/pull/3981) Auto-create HTML links for URLs, and strip HTML tags where they can't be rendered ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* Other
  * [#3980](https://github.com/GMOD/jbrowse-components/pull/3980) Downgrade electron 26->25 to fix screen blanking ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#3971](https://github.com/GMOD/jbrowse-components/pull/3971) Fix rendering multi-quantitative tracks when blank data is present ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 1
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 0.96s.

```