### PR TITLE
Destroy rootModel on loader unmount

### DIFF
--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -18,6 +18,7 @@ import SessionLoader, { SessionLoaderModel } from '../SessionLoader'
 import StartScreenErrorMessage from './StartScreenErrorMessage'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { createPluginManager } from '../createPluginManager'
+import { destroy } from 'mobx-state-tree'
 
 const ConfigTriaged = lazy(() => import('./ConfigWarningDialog'))
 const SessionTriaged = lazy(() => import('./SessionWarningDialog'))
@@ -77,15 +78,21 @@ const Renderer = observer(function ({
   const [error, setError] = useState<unknown>()
 
   useEffect(() => {
+    let pm: PluginManager | undefined
     try {
       if (!ready || shareWarningOpen) {
         return
       }
-      const pm = createPluginManager(loader)
+      createPluginManager(loader)
       setPluginManager(pm)
     } catch (e) {
       console.error(e)
       setError(e)
+    }
+    return () => {
+      if (pm) {
+        destroy(pm.rootModel)
+      }
     }
   }, [loader, ready, shareWarningOpen])
   if (configError || error) {


### PR DESCRIPTION
This is a PR that may help with fixing flaky test observed in #3996, by properly running 'disposers' which in the case of the grid bookmark widget, included keyboard shortcuts

There is a downside to this PR: hot module reloads produce errors. This is not great, so I would consider this draft and not merge this