### PR TITLE
Create concept of global hovered state

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -92,6 +92,8 @@ export interface AbstractSessionModel extends AbstractViewContainer {
   selection?: unknown
   focusedViewId?: string
   themeName?: string
+  hovered: unknown
+  setHovered: (arg: unknown) => void
   setFocusedViewId?: (id: string) => void
   allThemes?: () => Record<string, ThemeOptions | undefined>
   setSelection: (feature: Feature) => void

--- a/packages/product-core/src/Session/BaseSession.ts
+++ b/packages/product-core/src/Session/BaseSession.ts
@@ -45,6 +45,13 @@ export function BaseSessionModel<
        * is.
        */
       selection: undefined as unknown,
+      /**
+       * #volatile
+       * this is the globally "hovered" object. can be anything. code that
+       * wants to deal with this should examine it to see what kind of thing it
+       * is.
+       */
+      hovered: undefined as unknown,
     }))
     .views(self => ({
       get root() {
@@ -108,6 +115,12 @@ export function BaseSessionModel<
        */
       clearSelection() {
         self.selection = undefined
+      },
+      /**
+       * #action
+       */
+      setHovered(thing: unknown) {
+        self.hovered = thing
       },
     }))
 }

--- a/packages/web-core/src/BaseWebSession/index.ts
+++ b/packages/web-core/src/BaseWebSession/index.ts
@@ -235,14 +235,14 @@ export function BaseWebSession({
       /**
        * #action
        */
-      removeSessionPlugin(pluginDefinition: PluginDefinition) {
+      removeSessionPlugin(d: PluginDefinition) {
         self.sessionPlugins = cast(
           self.sessionPlugins.filter(
-            plugin =>
-              plugin.url !== pluginDefinition.url ||
-              plugin.umdUrl !== pluginDefinition.umdUrl ||
-              plugin.cjsUrl !== pluginDefinition.cjsUrl ||
-              plugin.esmUrl !== pluginDefinition.esmUrl,
+            p =>
+              p.url !== d.url ||
+              p.umdUrl !== d.umdUrl ||
+              p.cjsUrl !== d.cjsUrl ||
+              p.esmUrl !== d.esmUrl,
           ),
         )
         getParent<any>(self).setPluginsUpdated(true)

--- a/packages/web-core/src/BaseWebSession/index.ts
+++ b/packages/web-core/src/BaseWebSession/index.ts
@@ -235,14 +235,14 @@ export function BaseWebSession({
       /**
        * #action
        */
-      removeSessionPlugin(d: PluginDefinition) {
+      removeSessionPlugin(pluginDefinition: PluginDefinition) {
         self.sessionPlugins = cast(
           self.sessionPlugins.filter(
-            p =>
-              p.url !== d.url ||
-              p.umdUrl !== d.umdUrl ||
-              p.cjsUrl !== d.cjsUrl ||
-              p.esmUrl !== d.esmUrl,
+            plugin =>
+              plugin.url !== pluginDefinition.url ||
+              plugin.umdUrl !== pluginDefinition.umdUrl ||
+              plugin.cjsUrl !== pluginDefinition.cjsUrl ||
+              plugin.esmUrl !== pluginDefinition.esmUrl,
           ),
         )
         getParent<any>(self).setPluginsUpdated(true)

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -90,7 +90,23 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
   const HeaderComponent = model.HeaderComponent()
 
   return (
-    <div className={classes.rel} ref={ref}>
+    <div
+      className={classes.rel}
+      ref={ref}
+      onMouseMove={event => {
+        const c = ref.current
+        if (!c) {
+          return
+        }
+        const hoverPosition = model.pxToBp(
+          event.clientX - c.getBoundingClientRect().left,
+        )
+        const hoverFeature = model.tracks.find(
+          t => t.displays[0].featureUnderMouse,
+        )
+        session.setHovered({ hoverPosition, hoverFeature })
+      }}
+    >
       <HeaderComponent model={model} />
       <MiniControlsComponent model={model} />
       <TracksContainer model={model}>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -93,17 +93,16 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
     <div
       className={classes.rel}
       ref={ref}
+      onMouseLeave={() => session.setHovered(undefined)}
       onMouseMove={event => {
         const c = ref.current
         if (!c) {
           return
         }
-        const hoverPosition = model.pxToBp(
-          event.clientX - c.getBoundingClientRect().left,
-        )
-        const hoverFeature = model.tracks.find(
-          t => t.displays[0].featureUnderMouse,
-        )
+        const { tracks } = model
+        const leftPx = event.clientX - c.getBoundingClientRect().left
+        const hoverPosition = model.pxToBp(leftPx)
+        const hoverFeature = tracks.find(t => t.displays[0].featureUnderMouse)
         session.setHovered({ hoverPosition, hoverFeature })
       }}
     >

--- a/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/configSchema.ts
@@ -155,7 +155,7 @@ const SvgFeatureRenderer = ConfigurationSchema(
     maxHeight: {
       type: 'integer',
       description: 'the maximum height to be used in a svg rendering',
-      defaultValue: 600,
+      defaultValue: 1200,
     },
 
     /**


### PR DESCRIPTION
This creates an object session.hovered, similar to session.selected

The hovered state is rapidly updated by all onMouseMove events from LinearGenomeView, and includes hoveredPosition (result of pxToBp of the current mouseover x coordinate) and hoveredFeature which is the result of searching through `view.tracks.find(t=>t.displays[0].featureUnderMouse)` 

- This hover state is updated in a single place, which reduces the need to wire the code through many track types.

-  The "downside" is that it is always performing that views.tracks.find call instead of some more targeted session.setHovered right at the point-of-setting the `featureUnderMouse` but that seems like a hypothetical concern in terms of performance

- Any track type that wishes to opt in should make the top level display have the featureUnderMouse getter (displays with subviews like alignments display can "lift this state up")

This hover state can be observed by potential applications like the msaview and protein view and to translate the genome hoveredPosition to protein coordinates

Possible enhancements could include 'sub-feature mouseovers' so that the plugin would be aware of the exact exon being mouse-overed, etc.

Interested in feedback