### PR TITLE
Allow configuring LGV trackLabels setting via config

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelContainer.tsx
@@ -36,11 +36,11 @@ const TrackLabelContainer = observer(function ({
   const display = track.displays[0]
   const { trackLabel, trackLabelOverlap, trackLabelOffset } = classes
   const labelStyle =
-    view.trackLabels !== 'overlapping' || display.prefersOffset
+    view.trackLabelsSetting !== 'overlapping' || display.prefersOffset
       ? trackLabelOffset
       : trackLabelOverlap
 
-  return view.trackLabels !== 'hidden' ? (
+  return view.trackLabelsSetting !== 'hidden' ? (
     <TrackLabel track={track} className={cx(trackLabel, labelStyle)} />
   ) : null
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -223,13 +223,17 @@ export function stateModelFactory(pluginManager: PluginManager) {
 
         /**
          * #property
+         */
+        trackLabels: types.maybe(types.string),
+
+        /**
+         * #property
          * show the "gridlines" in the track area
          */
         showGridlines: true,
       }),
     )
     .volatile(() => ({
-      trackLabelsVolatile: localStorageGetItem('lgv-trackLabels'),
       volatileWidth: undefined as number | undefined,
       minimumBlockWidth: 3,
       draggingTrackId: undefined as undefined | string,
@@ -246,12 +250,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
       rightOffset: undefined as undefined | BpOffset,
     }))
     .views(self => ({
-      get trackLabels() {
+      get trackLabelsSetting() {
         const sessionSetting = getConf(getSession(self), [
           'LinearGenomeViewPlugin',
           'trackLabels',
         ])
-        return self.trackLabelsVolatile ?? sessionSetting
+        return self.trackLabels ?? sessionSetting
       },
       /**
        * #getter
@@ -757,7 +761,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * #action
        */
       setTrackLabels(setting: 'overlapping' | 'offset' | 'hidden') {
-        self.trackLabelsVolatile = setting
+        localStorage.setItem('lgv-trackLabels', setting)
+        self.trackLabels = setting
       },
 
       /**
@@ -1250,15 +1255,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
           self,
           autorun(() => {
             const s = (s: unknown) => JSON.stringify(s)
-            const {
-              trackLabelsVolatile,
-              showCytobandsSetting,
-              showCenterLine,
-            } = self
+            const { showCytobandsSetting, showCenterLine } = self
             if (typeof localStorage !== 'undefined') {
-              if (trackLabelsVolatile) {
-                localStorage.setItem('lgv-trackLabels', trackLabelsVolatile)
-              }
               localStorage.setItem('lgv-showCytobands', s(showCytobandsSetting))
               localStorage.setItem('lgv-showCenterLine', s(showCenterLine))
             }

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -255,7 +255,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
           'LinearGenomeViewPlugin',
           'trackLabels',
         ])
-        return self.trackLabels ?? sessionSetting
+        const localStorageTrackLabels = localStorageGetItem('lgv-trackLabels')
+        return self.trackLabels ?? localStorageTrackLabels ?? sessionSetting
       },
       /**
        * #getter

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -201,17 +201,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
           types.enumeration(['hierarchical']),
           'hierarchical',
         ),
-
-        /**
-         * #property
-         * how to display the track labels, can be "overlapping", "offset", or
-         * "hidden"
-         */
-        trackLabels: types.optional(
-          types.string,
-          () => localStorageGetItem('lgv-trackLabels') || 'overlapping',
-        ),
-
         /**
          * #property
          * show the "center line"
@@ -240,6 +229,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
       }),
     )
     .volatile(() => ({
+      trackLabelsVolatile: localStorageGetItem('lgv-trackLabels'),
       volatileWidth: undefined as number | undefined,
       minimumBlockWidth: 3,
       draggingTrackId: undefined as undefined | string,
@@ -256,6 +246,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
       rightOffset: undefined as undefined | BpOffset,
     }))
     .views(self => ({
+      get trackLabels() {
+        const sessionSetting = getConf(getSession(self), [
+          'LinearGenomeViewPlugin',
+          'trackLabels',
+        ])
+        return self.trackLabelsVolatile ?? sessionSetting
+      },
       /**
        * #getter
        */
@@ -760,7 +757,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * #action
        */
       setTrackLabels(setting: 'overlapping' | 'offset' | 'hidden') {
-        self.trackLabels = setting
+        self.trackLabelsVolatile = setting
       },
 
       /**
@@ -1253,9 +1250,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
           self,
           autorun(() => {
             const s = (s: unknown) => JSON.stringify(s)
-            const { trackLabels, showCytobandsSetting, showCenterLine } = self
+            const {
+              trackLabelsVolatile,
+              showCytobandsSetting,
+              showCenterLine,
+            } = self
             if (typeof localStorage !== 'undefined') {
-              localStorage.setItem('lgv-trackLabels', trackLabels)
+              if (trackLabelsVolatile) {
+                localStorage.setItem('lgv-trackLabels', trackLabelsVolatile)
+              }
               localStorage.setItem('lgv-showCytobands', s(showCytobandsSetting))
               localStorage.setItem('lgv-showCenterLine', s(showCenterLine))
             }

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -22,6 +22,8 @@ import LinearBasicDisplayF from './LinearBasicDisplay'
 import FeatureTrackF from './FeatureTrack'
 import BasicTrackF from './BasicTrack'
 import LaunchLinearGenomeViewF from './LaunchLinearGenomeView'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import { types } from 'mobx-state-tree'
 
 export default class LinearGenomeViewPlugin extends Plugin {
   name = 'LinearGenomeViewPlugin'
@@ -34,6 +36,24 @@ export default class LinearGenomeViewPlugin extends Plugin {
     ZoomControls,
     LinearGenomeView,
   }
+
+  /**
+   * #config LinearGenomeViewConfigSchema
+   */
+  configurationSchema = ConfigurationSchema('LinearGenomeViewConfigSchema', {
+    /**
+     * #slot configuration.LinearGenomeViewPlugin.trackLabels
+     */
+    trackLabels: {
+      type: 'string',
+      defaultValue: 'overlapping',
+      model: types.enumeration('trackLabelOptions', [
+        'offset',
+        'overlapping',
+        'hidden',
+      ]),
+    },
+  })
 
   install(pluginManager: PluginManager) {
     FeatureTrackF(pluginManager)

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -923,7 +923,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-dewezf-MuiPaper-root-root"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-lv7b0o-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-80j8um-MuiPaper-root-trackLabel-trackLabelOffset-root"
                 >
                   <span
                     class="css-k4omgw-dragHandle"

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -431,6 +431,9 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
     },
   ],
   "configuration": {
+    "LinearGenomeViewPlugin": {
+      "trackLabels": "offset",
+    },
     "extraThemes": {
       "darkForest": {
         "name": "Dark (forest, from config file)",

--- a/products/jbrowse-web/src/util.ts
+++ b/products/jbrowse-web/src/util.ts
@@ -152,13 +152,11 @@ export function readConf({ configuration }: Root, attr: string, def: string) {
 }
 
 export async function fetchPlugins() {
-  const response = await fetch('https://jbrowse.org/plugin-store/plugins.json')
-  if (!response.ok) {
-    throw new Error(
-      `HTTP ${response.status} ${response.statusText} fetching plugins`,
-    )
+  const res = await fetch('https://jbrowse.org/plugin-store/plugins.json')
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${await res.text()} fetching plugins`)
   }
-  return response.json() as Promise<{ plugins: PluginDefinition[] }>
+  return res.json() as Promise<{ plugins: PluginDefinition[] }>
 }
 
 export async function checkPlugins(pluginsToCheck: PluginDefinition[]) {

--- a/products/jbrowse-web/src/util.ts
+++ b/products/jbrowse-web/src/util.ts
@@ -152,11 +152,13 @@ export function readConf({ configuration }: Root, attr: string, def: string) {
 }
 
 export async function fetchPlugins() {
-  const res = await fetch('https://jbrowse.org/plugin-store/plugins.json')
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status} ${await res.text()} fetching plugins`)
+  const response = await fetch('https://jbrowse.org/plugin-store/plugins.json')
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} fetching plugins`,
+    )
   }
-  return res.json() as Promise<{ plugins: PluginDefinition[] }>
+  return response.json() as Promise<{ plugins: PluginDefinition[] }>
 }
 
 export async function checkPlugins(pluginsToCheck: PluginDefinition[]) {

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -187,6 +187,9 @@
     }
   ],
   "configuration": {
+    "LinearGenomeViewPlugin": {
+      "trackLabels": "offset"
+    },
     "hierarchical": {
       "defaultCollapsed": {
         "categoryNames": ["Methylation"]

--- a/website/docs/config/LinearGenomeViewConfigSchema.md
+++ b/website/docs/config/LinearGenomeViewConfigSchema.md
@@ -1,0 +1,27 @@
+---
+id: lineargenomeviewconfigschema
+title: LinearGenomeViewConfigSchema
+---
+
+Note: this document is automatically generated from configuration objects in our
+source code. See [Config guide](/docs/config_guide) for more info
+
+### Source file
+
+[plugins/linear-genome-view/src/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-genome-view/src/index.ts)
+
+### LinearGenomeViewConfigSchema - Slots
+
+#### slot: configuration.LinearGenomeViewPlugin.trackLabels
+
+```js
+trackLabels: {
+      type: 'string',
+      defaultValue: 'overlapping',
+      model: types.enumeration('trackLabelOptions', [
+        'offset',
+        'overlapping',
+        'hidden',
+      ]),
+    }
+```


### PR DESCRIPTION
This creates a configuration setting that allows admins to specify a preferred track label setting for their instance

It uses a 'rarely used' configuration setup where the LinearGenomeView plugin class has a configurationSchema property that provides some 'global config slots'

Therefore we have

configuration.LinearGenomeViewPlugin.trackLabels being a config types.enum('offset','overlapping','hidden')

this is accessible by calling

getConf(session,['LinearGenomeViewPlugin','trackLabels'])

there is a complex interplay between current session state, configuration, and user preference with this setting


one problem that actually currently exists is that visiting share link with e.g. trackLabels hidden would cause your current localStorage preference for lgv-trackLabels to automatically become hidden

this PR changes it so that your localstorage preference only changes when you manually change the track labels setting in the UI (on the lgv.setTrackLabels action)

then, the resulting trackLabels setting is determined from

current session state view.trackLabels ?? localStorage trackLabels setting ?? global configuration trackLabels

This allows session shares to have first order of preference, then user preference, then configuration preference