### PR TITLE
Add `jbrowse sort-gff` subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/base64-js": "^1.2.5",
     "@types/buffer-crc32": "^0.2.2",
     "@types/cli-progress": "^3.9.2",
+    "@types/command-exists": "^1.2.2",
     "@types/cors": "^2.8.13",
     "@types/cross-spawn": "^6.0.2",
     "@types/crypto-js": "^4.0.1",

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -56,6 +56,7 @@ It is likely preferable in most cases to install the tools globally with
 - [`jbrowse help [COMMANDS]`](#jbrowse-help-commands)
 - [`jbrowse remove-track TRACK`](#jbrowse-remove-track-track)
 - [`jbrowse set-default-session`](#jbrowse-set-default-session)
+- [`jbrowse sort-gff FILE`](#jbrowse-sort-gff-file)
 - [`jbrowse text-index`](#jbrowse-text-index)
 - [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
 
@@ -542,6 +543,31 @@ EXAMPLES
 
 _See code:
 [src/commands/set-default-session.ts](https://github.com/GMOD/jbrowse-components/blob/v2.7.2/products/jbrowse-cli/src/commands/set-default-session.ts)_
+
+## `jbrowse sort-gff FILE`
+
+Helper utility to sort GFF files for tabix
+
+```
+USAGE
+  $ jbrowse sort-gff FILE
+
+ARGUMENTS
+  FILE  GFF file
+
+DESCRIPTION
+  Helper utility to sort GFF files for tabix
+
+EXAMPLES
+  # sort gff and pipe to bgzip
+
+  $ jbrowse sort-gff input.gff | bgzip > sorted.gff.gz
+
+  $ tabix sorted.gff.gz
+```
+
+_See code:
+[src/commands/sort-gff.ts](https://github.com/GMOD/jbrowse-components/blob/v2.7.2/products/jbrowse-cli/src/commands/sort-gff.ts)_
 
 ## `jbrowse text-index`
 

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -546,7 +546,9 @@ _See code:
 
 ## `jbrowse sort-gff FILE`
 
-Helper utility to sort GFF files for tabix
+Helper utility to sort GFF files for tabix. Moves all lines starting with # to
+the top of the file, and sort by refname and start position using unix utilities
+sort and grep
 
 ```
 USAGE
@@ -556,7 +558,8 @@ ARGUMENTS
   FILE  GFF file
 
 DESCRIPTION
-  Helper utility to sort GFF files for tabix
+  Helper utility to sort GFF files for tabix. Moves all lines starting with # to the top of the file, and sort by
+  refname and start position using unix utilities sort and grep
 
 EXAMPLES
   # sort gff and pipe to bgzip

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -50,6 +50,7 @@
     "boxen": "^4.2.0",
     "chalk": "^4.1.0",
     "cli-progress": "^3.9.0",
+    "command-exists": "^1.2.9",
     "cors": "^2.8.5",
     "decompress": "^4.0.0",
     "express": "^4.17.1",

--- a/products/jbrowse-cli/src/commands/sort-gff.ts
+++ b/products/jbrowse-cli/src/commands/sort-gff.ts
@@ -5,7 +5,8 @@ import { spawn } from 'child_process'
 import JBrowseCommand from '../base'
 
 export default class SortGff extends JBrowseCommand {
-  static description = 'Helper utility to sort GFF files for tabix'
+  static description =
+    'Helper utility to sort GFF files for tabix. Moves all lines starting with # to the top of the file, and sort by refname and start position using unix utilities sort and grep'
 
   static examples = [
     '# sort gff and pipe to bgzip',
@@ -25,7 +26,12 @@ export default class SortGff extends JBrowseCommand {
       args: { file },
     } = await this.parse(SortGff)
 
-    if (commandExistsSync('sort') && commandExistsSync('grep')) {
+    if (
+      commandExistsSync('sh') &&
+      commandExistsSync('sort') &&
+      commandExistsSync('grep')
+    ) {
+      // this command comes from the tabix docs http://www.htslib.org/doc/tabix.html
       spawn(
         'sh',
         [

--- a/products/jbrowse-cli/src/commands/sort-gff.ts
+++ b/products/jbrowse-cli/src/commands/sort-gff.ts
@@ -1,0 +1,46 @@
+import { Args } from '@oclif/core'
+import { sync as commandExistsSync } from 'command-exists'
+
+import { spawn } from 'child_process'
+import JBrowseCommand from '../base'
+
+export default class SortGff extends JBrowseCommand {
+  static description = 'Helper utility to sort GFF files for tabix'
+
+  static examples = [
+    '# sort gff and pipe to bgzip',
+    '$ jbrowse sort-gff input.gff | bgzip > sorted.gff.gz',
+    '$ tabix sorted.gff.gz',
+  ]
+
+  static args = {
+    file: Args.string({
+      required: true,
+      description: `GFF file`,
+    }),
+  }
+
+  async run() {
+    const {
+      args: { file },
+    } = await this.parse(SortGff)
+
+    if (commandExistsSync('sort') && commandExistsSync('grep')) {
+      spawn(
+        'sh',
+        [
+          '-c',
+          `(grep "^#" "${file}"; grep -v "^#" "${file}" | sort -t"\`printf '\t'\`" -k1,1 -k4,4n)`,
+        ],
+        {
+          env: { ...process.env, LC_ALL: 'C' },
+          stdio: 'inherit',
+        },
+      )
+    } else {
+      throw new Error(
+        'Unable to sort, requires unix type environment with sort, grep',
+      )
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,6 +4364,11 @@
   resolved "https://registry.yarnpkg.com/@types/clone/-/clone-2.1.3.tgz#91d16af4006a24fd3d683f5454d48b29a695b0e9"
   integrity sha512-DxFaNYaIUXW1OSRCVCC1UHoLcvk6bVJ0v9VvUaZ6kR5zK8/QazXlOThgdvnK0Xpa4sBq+b/Yoq/mnNn383hVRw==
 
+"@types/command-exists@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/command-exists/-/command-exists-1.2.2.tgz#b386d1deb4b423122467dfb536b7262589216827"
+  integrity sha512-1qKPTkjLmghE5C7UUHXGcLaG8MNftchOcLAIryUXNKahRO5beS+iJ9rIL8XD4+B8K2phjYUsPQDox1FRX4KMTQ==
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.2.tgz#acf51e088b3bb6507f7b093bd2b0de20940179cc"


### PR DESCRIPTION
This helps automate the sorting of a gff, which can require tedious typing

This could be used in the Current Protocols paper also as a way to reduce steps

Assumes a unix-y type system with sh, sort, grep

