### PR TITLE
Prompt to horizontally flip view when launching linear synteny view on inverted feature

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail/index.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail/index.tsx
@@ -139,8 +139,9 @@ function CoreDetails(props: BaseProps) {
 }
 
 export const BaseCoreDetails = (props: BaseProps) => {
+  const { title = 'Primary data' } = props
   return (
-    <BaseCard {...props} title="Primary data">
+    <BaseCard {...props} title={title}>
       <CoreDetails {...props} />
     </BaseCard>
   )

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/LaunchSyntenyViewDialog.tsx
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/LaunchSyntenyViewDialog.tsx
@@ -45,8 +45,8 @@ export default function LaunchSyntenyViewDialog({
               />
             }
             label="Note: The feature is inverted in orientation on the target
-              sequence. Apply horizontal flip? This will result in the lower
-              panel having genomic coordinates decreasing left to right. Horizontally flip?"
+            sequence. This will result in the lower panel having genomic
+            coordinates decreasing left to right. Horizontally flip?"
           />
         ) : null}
         <TextField

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/LaunchSyntenyViewDialog.tsx
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/LaunchSyntenyViewDialog.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { Dialog } from '@jbrowse/core/ui'
+import { Feature, getSession } from '@jbrowse/core/util'
+import {
+  Button,
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  FormControlLabel,
+  TextField,
+} from '@mui/material'
+import { navToSynteny } from './util'
+import { makeStyles } from 'tss-react/mui'
+
+const useStyles = makeStyles()({
+  padding: {
+    margin: 10,
+    border: '1px solid #ccc',
+  },
+})
+
+export default function LaunchSyntenyViewDialog({
+  model,
+  feature,
+  handleClose,
+}: {
+  model: unknown
+  feature: Feature
+  handleClose: () => void
+}) {
+  const { classes } = useStyles()
+  const inverted = feature.get('strand') === -1
+  const [horizontallyFlip, setHorizontallyFlip] = useState(inverted)
+  const [windowSize, setWindowSize] = useState('1000')
+  return (
+    <Dialog open title="Launch synteny view" onClose={handleClose}>
+      <DialogContent>
+        {inverted ? (
+          <FormControlLabel
+            className={classes.padding}
+            control={
+              <Checkbox
+                checked={horizontallyFlip}
+                onChange={event => setHorizontallyFlip(event.target.checked)}
+              />
+            }
+            label="Note: The feature is inverted in orientation on the target
+              sequence. Apply horizontal flip? This will result in the lower
+              panel having genomic coordinates decreasing left to right. Horizontally flip?"
+          />
+        ) : null}
+        <TextField
+          label="Add window size in bp"
+          value={windowSize}
+          onChange={event => setWindowSize(event.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          onClick={() => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            ;(async () => {
+              try {
+                await navToSynteny({
+                  feature,
+                  windowSize: +windowSize,
+                  horizontallyFlip,
+                  model,
+                })
+              } catch (e) {
+                getSession(model).notify(`${e}`, 'error')
+              }
+            })()
+            handleClose()
+          }}
+        >
+          Submit
+        </Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => handleClose()}
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/util.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/components/util.ts
@@ -1,0 +1,135 @@
+import {
+  getSession,
+  getContainingTrack,
+  getContainingView,
+  Feature,
+} from '@jbrowse/core/util'
+import { MismatchParser } from '@jbrowse/plugin-alignments'
+import { IAnyStateTreeNode } from 'mobx-state-tree'
+import { when } from 'mobx'
+import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+
+// locals
+import { LinearSyntenyViewModel } from '../../LinearSyntenyView/model'
+
+type LSV = LinearSyntenyViewModel
+
+const { parseCigar } = MismatchParser
+
+function f(n: number) {
+  return Math.floor(n)
+}
+function findPosInCigar(cigar: string[], startX: number) {
+  let featX = 0
+  let mateX = 0
+  for (let i = 0; i < cigar.length; i++) {
+    const len = +cigar[i]
+    const op = cigar[i + 1]
+    const min = Math.min(len, startX - featX)
+
+    if (featX >= startX) {
+      break
+    } else if (op === 'I') {
+      mateX += len
+    } else if (op === 'D') {
+      featX += min
+    } else if (op === 'M') {
+      mateX += min
+      featX += min
+    }
+  }
+  return [featX, mateX]
+}
+
+export async function navToSynteny({
+  feature,
+  windowSize: ws,
+  model,
+  horizontallyFlip,
+}: {
+  windowSize: number
+  horizontallyFlip: boolean
+  feature: Feature
+  model: IAnyStateTreeNode
+}) {
+  const session = getSession(model)
+  const track = getContainingTrack(model)
+  const view = getContainingView(model) as LinearGenomeViewModel
+  const reg = view.dynamicBlocks.contentBlocks[0]
+  const cigar = feature.get('CIGAR')
+  const strand = feature.get('strand')
+  const regStart = reg.start
+  const regEnd = reg.end
+  const featStart = feature.get('start')
+  const featEnd = feature.get('end')
+  const mate = feature.get('mate')
+  const mateStart = mate.start
+  const mateEnd = mate.end
+  const mateAsm = mate.assemblyName
+  const mateRef = mate.refName
+  const featAsm = reg.assemblyName
+  const featRef = reg.refName
+
+  let rMateStart: number
+  let rMateEnd: number
+  let rFeatStart: number
+  let rFeatEnd: number
+
+  if (cigar) {
+    const p = parseCigar(cigar)
+    const [fStartX, mStartX] = findPosInCigar(p, regStart - featStart)
+    const [fEndX, mEndX] = findPosInCigar(p, regEnd - featStart)
+
+    // avoid multiply by 0 with strand undefined
+    const flipper = strand === -1 ? -1 : 1
+    rFeatStart = featStart + fStartX
+    rFeatEnd = featStart + fEndX
+    rMateStart = (strand === -1 ? mateEnd : mateStart) + mStartX * flipper
+    rMateEnd = (strand === -1 ? mateEnd : mateStart) + mEndX * flipper
+  } else {
+    rFeatStart = featStart
+    rFeatEnd = featEnd
+    rMateStart = mateStart
+    rMateEnd = mateEnd
+  }
+  const trackId = track.configuration.trackId
+
+  const view2 = session.addView('LinearSyntenyView', {
+    type: 'LinearSyntenyView',
+    views: [
+      {
+        id: `${Math.random()}`,
+        type: 'LinearGenomeView',
+        hideHeader: true,
+      },
+      {
+        id: `${Math.random()}`,
+        type: 'LinearGenomeView',
+        hideHeader: true,
+      },
+    ],
+    tracks: [
+      {
+        configuration: trackId,
+        type: 'SyntenyTrack',
+        displays: [
+          {
+            type: 'LinearSyntenyDisplay',
+            configuration: `${trackId}-LinearSyntenyDisplay`,
+          },
+        ],
+      },
+    ],
+  }) as LSV
+  const l1 = `${featRef}:${f(rFeatStart - ws)}-${f(rFeatEnd + ws)}`
+  const m1 = Math.min(rMateStart, rMateEnd)
+  const m2 = Math.max(rMateStart, rMateEnd)
+  const l2 = `${mateRef}:${f(m1 - ws)}-${f(m2 + ws)}${
+    horizontallyFlip ? '[rev]' : ''
+  }`
+  await when(() => view2.width !== undefined)
+  await Promise.all([
+    view2.views[0].navToLocString(l1, featAsm),
+    view2.views[1].navToLocString(l2, mateAsm),
+  ])
+}

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts
@@ -1,131 +1,15 @@
+import { lazy } from 'react'
 import {
   ConfigurationReference,
   AnyConfigurationSchemaType,
 } from '@jbrowse/core/configuration'
-import {
-  getSession,
-  getContainingTrack,
-  getContainingView,
-  Feature,
-} from '@jbrowse/core/util'
-import {
-  MismatchParser,
-  SharedLinearPileupDisplayMixin,
-} from '@jbrowse/plugin-alignments'
-import { IAnyStateTreeNode, types } from 'mobx-state-tree'
-import { when } from 'mobx'
+import { getSession } from '@jbrowse/core/util'
+import { SharedLinearPileupDisplayMixin } from '@jbrowse/plugin-alignments'
+import { types } from 'mobx-state-tree'
 
-// locals
-import { LinearSyntenyViewModel } from '../LinearSyntenyView/model'
-import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
-
-type LSV = LinearSyntenyViewModel
-
-const { parseCigar } = MismatchParser
-
-function findPosInCigar(cigar: string[], startX: number) {
-  let featX = 0
-  let mateX = 0
-  for (let i = 0; i < cigar.length; i++) {
-    const len = +cigar[i]
-    const op = cigar[i + 1]
-    const min = Math.min(len, startX - featX)
-
-    if (featX >= startX) {
-      break
-    } else if (op === 'I') {
-      mateX += len
-    } else if (op === 'D') {
-      featX += min
-    } else if (op === 'M') {
-      mateX += min
-      featX += min
-    }
-  }
-  return [featX, mateX]
-}
-
-async function navToSynteny(feature: Feature, self: IAnyStateTreeNode) {
-  const session = getSession(self)
-  const track = getContainingTrack(self)
-  const view = getContainingView(self) as LinearGenomeViewModel
-  const reg = view.dynamicBlocks.contentBlocks[0]
-  const cigar = feature.get('CIGAR')
-  const strand = feature.get('strand')
-  const regStart = reg.start
-  const regEnd = reg.end
-  const featStart = feature.get('start')
-  const featEnd = feature.get('end')
-  const mate = feature.get('mate')
-  const mateStart = mate.start
-  const mateEnd = mate.end
-  const mateAsm = mate.assemblyName
-  const mateRef = mate.refName
-  const featAsm = reg.assemblyName
-  const featRef = reg.refName
-
-  let rMateStart: number
-  let rMateEnd: number
-  let rFeatStart: number
-  let rFeatEnd: number
-
-  if (cigar) {
-    const p = parseCigar(cigar)
-    const [fStartX, mStartX] = findPosInCigar(p, regStart - featStart)
-    const [fEndX, mEndX] = findPosInCigar(p, regEnd - featStart)
-
-    // avoid multiply by 0 with strand undefined
-    const flipper = strand === -1 ? -1 : 1
-    rFeatStart = featStart + fStartX
-    rFeatEnd = featStart + fEndX
-    rMateStart = (strand === -1 ? mateEnd : mateStart) + mStartX * flipper
-    rMateEnd = (strand === -1 ? mateEnd : mateStart) + mEndX * flipper
-  } else {
-    rFeatStart = featStart
-    rFeatEnd = featEnd
-    rMateStart = mateStart
-    rMateEnd = mateEnd
-  }
-  const trackId = track.configuration.trackId
-
-  const view2 = session.addView('LinearSyntenyView', {
-    type: 'LinearSyntenyView',
-    views: [
-      {
-        id: `${Math.random()}`,
-        type: 'LinearGenomeView',
-        hideHeader: true,
-      },
-      {
-        id: `${Math.random()}`,
-        type: 'LinearGenomeView',
-        hideHeader: true,
-      },
-    ],
-    tracks: [
-      {
-        configuration: trackId,
-        type: 'SyntenyTrack',
-        displays: [
-          {
-            type: 'LinearSyntenyDisplay',
-            configuration: `${trackId}-LinearSyntenyDisplay`,
-          },
-        ],
-      },
-    ],
-  }) as LSV
-  const f = (n: number) => Math.floor(n)
-  const l1 = `${featRef}:${f(rFeatStart)}-${f(rFeatEnd)}`
-  const m1 = Math.min(rMateStart, rMateEnd)
-  const m2 = Math.max(rMateStart, rMateEnd)
-  const l2 = `${mateRef}:${f(m1)}-${f(m2)}${strand === -1 ? '[rev]' : ''}`
-  await when(() => view2.width !== undefined)
-  await Promise.all([
-    view2.views[0].navToLocString(l1, featAsm),
-    view2.views[1].navToLocString(l2, mateAsm),
-  ])
-}
+const LaunchSyntenyViewDialog = lazy(
+  () => import('./components/LaunchSyntenyViewDialog'),
+)
 
 /**
  * #stateModel LGVSyntenyDisplay
@@ -159,7 +43,16 @@ function stateModelFactory(schema: AnyConfigurationSchemaType) {
               ? [
                   {
                     label: 'Open synteny view for this position',
-                    onClick: () => navToSynteny(feature, self),
+                    onClick: () => {
+                      getSession(self).queueDialog(handleClose => [
+                        LaunchSyntenyViewDialog,
+                        {
+                          model: self,
+                          handleClose,
+                          feature,
+                        },
+                      ])
+                    },
                   },
                 ]
               : []),

--- a/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
+++ b/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
@@ -11,6 +11,7 @@ beforeEach(() => {
 })
 
 const delay = { timeout: 30000 }
+const opts = [{}, delay]
 
 test('from the top level menu', async () => {
   const { findByText } = await createView()
@@ -50,7 +51,7 @@ test('using the hotkey to bookmark the current region', async () => {
   const { session, findByTestId } = await createView()
 
   const user = userEvent.setup()
-  await user.click(await findByTestId('trackContainer'))
+  await user.click(await findByTestId('trackContainer', ...opts))
 
   document.dispatchEvent(
     new KeyboardEvent('keydown', {

--- a/products/jbrowse-web/src/tests/Spreadsheet.test.tsx
+++ b/products/jbrowse-web/src/tests/Spreadsheet.test.tsx
@@ -10,6 +10,7 @@ beforeEach(() => {
 })
 
 const delay = { timeout: 50000 }
+const opts = [{}, delay]
 
 async function waitForReady() {
   await waitFor(
@@ -26,7 +27,7 @@ test('opens a vcf.gz file in the spreadsheet view', async () => {
   await user.click(await screen.findByText('Add'))
   await user.click(await screen.findByText('Spreadsheet view'))
 
-  fireEvent.change(await screen.findByTestId('urlInput'), {
+  fireEvent.change(await screen.findByTestId('urlInput', ...opts), {
     target: { value: 'volvox.filtered.vcf.gz' },
   })
 
@@ -42,7 +43,7 @@ test('opens a bed.gz file in the spreadsheet view', async () => {
   await user.click(await screen.findByText('Add'))
   await user.click(await screen.findByText('Spreadsheet view'))
 
-  fireEvent.change(await screen.findByTestId('urlInput'), {
+  fireEvent.change(await screen.findByTestId('urlInput', ...opts), {
     target: { value: 'volvox-bed12.bed.gz' },
   })
   await waitForReady()


### PR DESCRIPTION
The text description of this text box is a little lengthy, but I think it helps clarify the behavior. Currently, it automatically horizontally flips the lower panel if an inverted feature is used to launch the linear synteny view, but this instead prompts the user for this behavior. The checkbox is not shown at all if the feature is not inverted, but the window size is still prompted (which kind of is just a small thing to justify showing a dialog box)


inverted feature

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/05f61e3c-ba55-4134-82be-e57352ecd4de)


non inverted feature

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/4d4eeac4-64f9-431e-b981-014d67c7bdbc)

