### PR TITLE
v2.8.0 release announcement

### DIFF
--- a/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
+++ b/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
@@ -42,7 +42,7 @@ export function featureData(
     start: start1,
     end: end1,
     refName: ref1,
-    ALT: [ALT], // it's an array in VCF
+    ...(ALT ? { ALT: [ALT] } : {}), // it's an array in VCF
     strand: strand1,
     name,
     ...rest,

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -20,9 +20,6 @@ import config from '../docusaurus.config.json'
 - [tabix](http://www.htslib.org/doc/tabix.html) installed e.g.
   `sudo apt install tabix` and `brew install htslib`, used for creating tabix
   indexes for BED/VCF/GFF files
-- (optional) [`genometools`](http://genometools.org/) installed e.g.
-  `sudo apt install genometools` or `brew install brewsci/bio/genometools` used
-  for sorting GFF3. can use grep and sort instead of `genometools` also
 
 ## Installing the JBrowse CLI
 
@@ -227,22 +224,16 @@ jbrowse add-track file.bw --load copy --out /var/www/html/jbrowse
 
 ### Adding a GFF3 file with GFF3Tabix
 
-To load a GFF3 file, we can sort and index it with tabix, make sure you have
-[GenomeTools](http://genometools.org/) (to install can use
-`sudo apt install genometools`).
-
 ```bash
-gt gff3 -sortlines -tidy -retainids yourfile.gff > yourfile.sorted.gff
-bgzip yourfile.sorted.gff
+jbrowse sort-gff yourfile.gff | bgzip > yourfile.sorted.gff.gz
 tabix yourfile.sorted.gff.gz
 jbrowse add-track yourfile.sorted.gff.gz --load copy
 ```
 
-As an alternative to `gt gff3 -sortlines`, use `awk` and GNU `sort`, as follows:
+Note: the `jbrowse sort-gff` command just automates the following shell command
 
 ```bash
-(grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\t'`" -k1,1 -k4,4n) | bgzip > file.sorted.gff.gz;
-tabix file.sorted.gff.gz
+(grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\t'`" -k1,1 -k4,4n)  > sorted.gff;
 ```
 
 This command comes from the

--- a/website/release_announcement_drafts/v2.7.3.md
+++ b/website/release_announcement_drafts/v2.7.3.md
@@ -1,9 +1,0 @@
-This release adds a couple small bugfixes. It also adds a new CLI command called
-`jbrowse sort-gff` that intends to help simplify the loading of GFF tabix
-tracks. The usage is as follows
-
-```
-jbrowse sort-gff yourfile.gff | bgzip > yourfile.sorted.gff.gz
-tabix yourfile.sorted.gff.gz
-jbrowse add-track yourfile.sorted.gff.gz --load copy --out /var/www/html/jbrowse2
-```

--- a/website/release_announcement_drafts/v2.7.3.md
+++ b/website/release_announcement_drafts/v2.7.3.md
@@ -1,0 +1,9 @@
+This release adds a couple small bugfixes. It also adds a new CLI command called
+`jbrowse sort-gff` that intends to help simplify the loading of GFF tabix
+tracks. The usage is as follows
+
+```
+jbrowse sort-gff yourfile.gff | bgzip > yourfile.sorted.gff.gz
+tabix yourfile.sorted.gff.gz
+jbrowse add-track yourfile.sorted.gff.gz --load copy --out /var/www/html/jbrowse2
+```

--- a/website/release_announcement_drafts/v2.8.0.md
+++ b/website/release_announcement_drafts/v2.8.0.md
@@ -1,6 +1,10 @@
-This release adds a couple small bugfixes. It also adds a new CLI command called
-`jbrowse sort-gff` that intends to help simplify the loading of GFF tabix
-tracks. The usage is as follows
+This release improves support for BEDPE and arc rendering of structural
+variants.
+
+It also adds a new CLI command called `jbrowse sort-gff` that intends to help
+simplify the loading of GFF tabix tracks.
+
+Usage:
 
 ```
 jbrowse sort-gff yourfile.gff | bgzip > yourfile.sorted.gff.gz
@@ -8,10 +12,10 @@ tabix yourfile.sorted.gff.gz
 jbrowse add-track yourfile.sorted.gff.gz --load copy --out /var/www/html/jbrowse2
 ```
 
-This release also improves support for plotting arcs from breakend and SV style
-VCF and BEDPE files. The jbrowse CLI tool can load BEDPE files
+The jbrowse CLI tool can load BEDPE files with simply
+`jbrowse add-track yourfile.bedpe` (optionall yourfile.bedpe.gz)
 
 ![](https://user-images.githubusercontent.com/6511937/281789167-aef6ccd2-c7e4-444e-b213-f3876fedabf9.png)
 
 Screenshot showing the same data rendered as both a BEDPE file and VCF file with
-different variant types (DUP, DEL, INV, TRA)
+different variant types (`<DUP>, <DEL>, <INV>, <TRA>`)

--- a/website/release_announcement_drafts/v2.8.0.md
+++ b/website/release_announcement_drafts/v2.8.0.md
@@ -13,7 +13,8 @@ jbrowse add-track yourfile.sorted.gff.gz --load copy --out /var/www/html/jbrowse
 ```
 
 The jbrowse CLI tool can load BEDPE files with simply
-`jbrowse add-track yourfile.bedpe` (optionall yourfile.bedpe.gz)
+`jbrowse add-track yourfile.bedpe` (or, optionally gzipped e.g.
+yourfile.bedpe.gz)
 
 ![](https://user-images.githubusercontent.com/6511937/281789167-aef6ccd2-c7e4-444e-b213-f3876fedabf9.png)
 

--- a/website/release_announcement_drafts/v2.8.0.md
+++ b/website/release_announcement_drafts/v2.8.0.md
@@ -1,0 +1,17 @@
+This release adds a couple small bugfixes. It also adds a new CLI command called
+`jbrowse sort-gff` that intends to help simplify the loading of GFF tabix
+tracks. The usage is as follows
+
+```
+jbrowse sort-gff yourfile.gff | bgzip > yourfile.sorted.gff.gz
+tabix yourfile.sorted.gff.gz
+jbrowse add-track yourfile.sorted.gff.gz --load copy --out /var/www/html/jbrowse2
+```
+
+This release also improves support for plotting arcs from breakend and SV style
+VCF and BEDPE files. The jbrowse CLI tool can load BEDPE files
+
+![](https://user-images.githubusercontent.com/6511937/281789167-aef6ccd2-c7e4-444e-b213-f3876fedabf9.png)
+
+Screenshot showing the same data rendered as both a BEDPE file and VCF file with
+different variant types (DUP, DEL, INV, TRA)


### PR DESCRIPTION
current changelog
## Unreleased (2023-11-06)

#### :rocket: Enhancement
* Other
  * [#4046](https://github.com/GMOD/jbrowse-components/pull/4046) Show last autosave on jbrowse-web start screen ([@cmdcolin](https://github.com/cmdcolin))
  * [#4044](https://github.com/GMOD/jbrowse-components/pull/4044) Speed up "multi-region" navigation in search box ([@cmdcolin](https://github.com/cmdcolin))
  * [#4032](https://github.com/GMOD/jbrowse-components/pull/4032) Add `jbrowse sort-gff` subcommand ([@cmdcolin](https://github.com/cmdcolin))
* `product-core`
  * [#4040](https://github.com/GMOD/jbrowse-components/pull/4040) Strip baseUri in 'About track' copy config ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4035](https://github.com/GMOD/jbrowse-components/pull/4035) Prompt to horizontally flip view when launching linear synteny view on inverted feature ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`
  * [#4024](https://github.com/GMOD/jbrowse-components/pull/4024) Add right-handed arrow to view title to emphasize the focused view ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))

#### :bug: Bug Fix
* [#4043](https://github.com/GMOD/jbrowse-components/pull/4043) Fix crash in "Open session" widget for sessions that have 'track-less views' ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation
* [#4027](https://github.com/GMOD/jbrowse-components/pull/4027) Schedule meeting link on the website ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 2
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 1.12s.

