### PR TITLE
Allow specifying alternative config.json path via global variable

### DIFF
--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -180,7 +180,9 @@ const SessionLoader = types
     },
 
     async fetchConfig() {
-      let { configPath = 'config.json' } = self
+      // @ts-expect-error
+      // eslint-disable-next-line no-underscore-dangle
+      let { configPath = window.__jbrowseConfigPath || 'config.json' } = self
 
       // @ts-expect-error
       // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
fixes https://github.com/GMOD/jbrowse-components/issues/4012

True programmability for config loading probably is best to use @jbrowse/react-app but this may help some use cases

