### PR TITLE
Fix browser back button behavior in jbrowse-web

### DIFF
--- a/products/jbrowse-web/src/components/JBrowse.tsx
+++ b/products/jbrowse-web/src/components/JBrowse.tsx
@@ -27,7 +27,7 @@ const JBrowse = observer(function ({
   const currentSessionId = session.id
 
   useEffect(() => {
-    setSessionId(`local-${currentSessionId}`)
+    setSessionId(`local-${currentSessionId}`, 'replaceIn')
     // @ts-expect-error
     window.JBrowseRootModel = rootModel
     // @ts-expect-error

--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -60,11 +60,11 @@ export function Loader({
   })
 
   useEffect(() => {
-    setLoc(undefined)
-    setTracks(undefined)
-    setAssembly(undefined)
-    setPassword(undefined)
-    setSessionTracks(undefined)
+    setLoc(undefined, 'replaceIn')
+    setTracks(undefined, 'replaceIn')
+    setAssembly(undefined, 'replaceIn')
+    setPassword(undefined, 'replaceIn')
+    setSessionTracks(undefined, 'replaceIn')
   }, [setAssembly, setLoc, setTracks, setPassword, setSessionTracks])
 
   return <Renderer loader={loader} />
@@ -144,7 +144,7 @@ const Renderer = observer(function ({
   }
 })
 
-const LoaderWrapper = ({ initialTimestamp }: { initialTimestamp: number }) => {
+function LoaderWrapper({ initialTimestamp }: { initialTimestamp: number }) {
   return (
     <ErrorBoundary
       FallbackComponent={props => (

--- a/products/jbrowse-web/src/components/ShareDialog.tsx
+++ b/products/jbrowse-web/src/components/ShareDialog.tsx
@@ -142,12 +142,12 @@ const ShareDialog = observer(function ({
             disabled={currentSetting === 'short' && loading}
             onClick={event => {
               event.preventDefault()
-              setPassword(passwordParam)
-              setSession(sessionParam)
+              setPassword(passwordParam, 'replaceIn')
+              setSession(sessionParam, 'replaceIn')
               alert('Now press Ctrl+D (PC) or Cmd+D (Mac)')
             }}
           >
-            Bookmark
+            Create browser Bookmark
           </Button>
 
           <Button

--- a/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
+++ b/products/jbrowse-web/src/tests/BreakpointSplitView.test.tsx
@@ -16,17 +16,19 @@ test(
   'breakpoint split view',
   () =>
     mockConsoleWarn(async () => {
-      const { findByTestId, queryAllByTestId } =
+      const { getByTestId, queryAllByTestId } =
         await createView(breakpointConfig)
 
       // the breakpoint could be partially loaded so explicitly wait for two items
-      await waitFor(() => expect(queryAllByTestId('r1').length).toBe(2), delay)
-
-      expect(
-        await findByTestId('pacbio_hg002_breakpoints-loaded'),
-      ).toMatchSnapshot()
-
-      expect(await findByTestId('pacbio_vcf-loaded')).toMatchSnapshot()
+      await waitFor(() => {
+        expect(queryAllByTestId('r1').length).toBe(2)
+      }, delay)
+      await waitFor(() => {
+        expect(getByTestId('pacbio_hg002_breakpoints-loaded')).toMatchSnapshot()
+      }, delay)
+      await waitFor(() => {
+        expect(getByTestId('pacbio_vcf-loaded')).toMatchSnapshot()
+      }, delay)
     }),
   40000,
 )


### PR DESCRIPTION
The URL manipulations we do in jbrowse-web are based on URL query params, but the default of the query param manipulation effectively used "pushState" (https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) instead of "replaceState" (https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)

this was managed by the library we used (use-query-params), but this PR changes it to use replace instead now. This allows the browser back button to work more intuitively I think now

Fixes https://github.com/GMOD/jbrowse-components/issues/1128