### PR TITLE
Remove ts-loader dependency used in storybooks

### DIFF
--- a/notes/package.json.explainer.md
+++ b/notes/package.json.explainer.md
@@ -1,5 +1,0 @@
-## Reasons for packages in package.json
-
-### ts-loader
-
-Used by storybook in e.g. products/jbrowse-react-linear-genome-view

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "storybook": "^7.0.0",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.2.5",
-    "ts-loader": "^9.5.0",
     "ts-node": "^10.4.0",
     "tslib": "^2.0.1",
     "tss-react": "^4.0.0",

--- a/products/jbrowse-react-app/.storybook/main.js
+++ b/products/jbrowse-react-app/.storybook/main.js
@@ -21,8 +21,11 @@ module.exports = {
       test: /\.(ts|tsx|js|jsx)$/,
       use: [
         {
-          loader: require.resolve('ts-loader'),
-          options: { transpileOnly: true },
+          loader: require.resolve('babel-loader'),
+          options: {
+            rootMode: 'upward',
+            presets: ['@babel/preset-react'],
+          },
         },
       ],
     })

--- a/products/jbrowse-react-circular-genome-view/.storybook/main.js
+++ b/products/jbrowse-react-circular-genome-view/.storybook/main.js
@@ -17,12 +17,16 @@ module.exports = {
         excludeAliases: ['console'],
       }),
     )
+
     config.module.rules.push({
       test: /\.(ts|tsx|js|jsx)$/,
       use: [
         {
-          loader: require.resolve('ts-loader'),
-          options: { transpileOnly: true },
+          loader: require.resolve('babel-loader'),
+          options: {
+            rootMode: 'upward',
+            presets: ['@babel/preset-react'],
+          },
         },
       ],
     })

--- a/products/jbrowse-react-linear-genome-view/.storybook/main.js
+++ b/products/jbrowse-react-linear-genome-view/.storybook/main.js
@@ -21,8 +21,11 @@ module.exports = {
       test: /\.(ts|tsx|js|jsx)$/,
       use: [
         {
-          loader: require.resolve('ts-loader'),
-          options: { transpileOnly: true },
+          loader: require.resolve('babel-loader'),
+          options: {
+            rootMode: 'upward',
+            presets: ['@babel/preset-react'],
+          },
         },
       ],
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8600,7 +8600,7 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.15.0:
+enhanced-resolve@^5.15.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
   integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
@@ -12613,7 +12613,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -16147,7 +16147,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@^0.7.4:
+source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
@@ -16955,17 +16955,6 @@ ts-dedent@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
-
-ts-loader@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.0.tgz#f0a51dda37cc4d8e43e6cb14edebbc599b0c3aa2"
-  integrity sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==
-  dependencies:
-    chalk "^4.1.0"
-    enhanced-resolve "^5.0.0"
-    micromatch "^4.0.0"
-    semver "^7.3.4"
-    source-map "^0.7.4"
 
 ts-node@^10.4.0, ts-node@^10.9.1:
   version "10.9.1"


### PR DESCRIPTION
One more dependency removed. The notes/package.json.explainer is removed also since it only mentions the ts-loader though it could be restored: there are some things that are worth annotating probably