### PR TITLE
Add arc plugin to lgv product

### DIFF
--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -51,6 +51,7 @@
     "@jbrowse/core": "^2.8.0",
     "@jbrowse/embedded-core": "^2.8.0",
     "@jbrowse/plugin-alignments": "^2.8.0",
+    "@jbrowse/plugin-arc": "^2.8.0",
     "@jbrowse/plugin-authentication": "^2.8.0",
     "@jbrowse/plugin-bed": "^2.8.0",
     "@jbrowse/plugin-circular-view": "^2.8.0",

--- a/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
+++ b/products/jbrowse-react-linear-genome-view/src/corePlugins.ts
@@ -12,6 +12,7 @@ import Variants from '@jbrowse/plugin-variants'
 import Wiggle from '@jbrowse/plugin-wiggle'
 import GCContent from '@jbrowse/plugin-gccontent'
 import Trix from '@jbrowse/plugin-trix'
+import Arc from '@jbrowse/plugin-arc'
 
 const corePlugins = [
   SVG,
@@ -28,6 +29,7 @@ const corePlugins = [
   Wiggle,
   GCContent,
   Trix,
+  Arc,
 ]
 
 export default corePlugins


### PR DESCRIPTION
Currently the lgv storybook actually crashes because the volvox config added a sample track that is a LinearPairedArcDisplay, which is supplied by plugin-arc, which works in jbrowse-web but not in the @jbrowse/react-linear-genome-view because plugin-arc is not added to the react-linear-genome-view


We could filter this out but IMO its probably just better to add this arc plugin to the lgv. It has useful variant viewing  characteristics for SVs which embedded can use