### PR TITLE
Allow searching the text-index by gene name from the URL bar

### DIFF
--- a/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
@@ -1,6 +1,7 @@
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, when } from '@jbrowse/core/util'
 import { LinearGenomeViewModel } from '../LinearGenomeView'
+import { handleSelectedRegion } from '..//searchUtils'
 
 type LGV = LinearGenomeViewModel
 
@@ -38,7 +39,7 @@ export default (pluginManager: PluginManager) => {
           )
         }
 
-        await view.navToLocString(loc, assembly)
+        await handleSelectedRegion({ input: loc, model: view, assembly: asm })
 
         const idsNotFound = [] as string[]
         tracks.forEach(track => {

--- a/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
@@ -42,17 +42,7 @@ export default (pluginManager: PluginManager) => {
         await handleSelectedRegion({ input: loc, model: view, assembly: asm })
 
         const idsNotFound = [] as string[]
-        tracks.forEach(track => {
-          try {
-            view.showTrack(track)
-          } catch (e) {
-            if (`${e}`.match('Could not resolve identifier')) {
-              idsNotFound.push(track)
-            } else {
-              throw e
-            }
-          }
-        })
+        tracks.forEach(track => tryTrack(view, track, idsNotFound))
         if (idsNotFound.length) {
           throw new Error(
             `Could not resolve identifiers: ${idsNotFound.join(',')}`,
@@ -64,4 +54,20 @@ export default (pluginManager: PluginManager) => {
       }
     },
   )
+}
+
+function tryTrack(
+  model: { showTrack: (arg: string) => void },
+  trackId: string,
+  idsNotFound: string[],
+) {
+  try {
+    model.showTrack(trackId)
+  } catch (e) {
+    if (`${e}`.match('Could not resolve identifier')) {
+      idsNotFound.push(trackId)
+    } else {
+      throw e
+    }
+  }
 }

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -1,6 +1,8 @@
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import { types } from 'mobx-state-tree'
 
 // icons
 import LineStyleIcon from '@mui/icons-material/LineStyle'
@@ -22,8 +24,6 @@ import LinearBasicDisplayF from './LinearBasicDisplay'
 import FeatureTrackF from './FeatureTrack'
 import BasicTrackF from './BasicTrack'
 import LaunchLinearGenomeViewF from './LaunchLinearGenomeView'
-import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { types } from 'mobx-state-tree'
 
 export default class LinearGenomeViewPlugin extends Plugin {
   name = 'LinearGenomeViewPlugin'

--- a/plugins/linear-genome-view/src/searchUtils.ts
+++ b/plugins/linear-genome-view/src/searchUtils.ts
@@ -1,10 +1,12 @@
 import { getSession } from '@jbrowse/core/util'
 import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
-import { LinearGenomeViewModel } from '..'
 import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
 import { SearchType } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { SearchScope } from '@jbrowse/core/TextSearch/TextSearchManager'
 import { dedupe, TextSearchManager } from '@jbrowse/core/util'
+
+// locals
+import { LinearGenomeViewModel } from './LinearGenomeView'
 
 export async function navToOption({
   option,

--- a/plugins/linear-genome-view/src/searchUtils.ts
+++ b/plugins/linear-genome-view/src/searchUtils.ts
@@ -1,0 +1,134 @@
+import { getSession } from '@jbrowse/core/util'
+import BaseResult from '@jbrowse/core/TextSearch/BaseResults'
+import { LinearGenomeViewModel } from '..'
+import { Assembly } from '@jbrowse/core/assemblyManager/assembly'
+import { SearchType } from '@jbrowse/core/data_adapters/BaseAdapter'
+import { SearchScope } from '@jbrowse/core/TextSearch/TextSearchManager'
+import { dedupe, TextSearchManager } from '@jbrowse/core/util'
+
+export async function navToOption({
+  option,
+  model,
+  assemblyName,
+}: {
+  model: LinearGenomeViewModel
+  option: BaseResult
+  assemblyName: string
+}) {
+  const location = option.getLocation()
+  const trackId = option.getTrackId()
+  if (location) {
+    await model.navToLocString(location, assemblyName)
+    if (trackId) {
+      model.showTrack(trackId)
+    }
+  }
+}
+
+// gets a string as input, or use stored option results from previous query,
+// then re-query and
+// 1) if it has multiple results: pop a dialog
+// 2) if it's a single result navigate to it
+// 3) else assume it's a locstring and navigate to it
+export async function handleSelectedRegion({
+  input,
+  model,
+  assembly,
+}: {
+  input: string
+  model: LinearGenomeViewModel
+  assembly: Assembly
+}) {
+  try {
+    const allRefs = assembly?.allRefNamesWithLowerCase || []
+    const assemblyName = assembly.name
+    if (input.split(' ').every(entry => checkRef(entry, allRefs))) {
+      await model.navToLocString(input, assembly.name)
+    } else {
+      const searchScope = model.searchScope(assemblyName)
+      const { textSearchManager } = getSession(model)
+      const results = await fetchResults({
+        queryString: input,
+        searchType: 'exact',
+        searchScope,
+        rankSearchResults: model.rankSearchResults,
+        textSearchManager,
+        assembly,
+      })
+
+      if (results.length > 1) {
+        model.setSearchResults(results, input.toLowerCase(), assemblyName)
+      } else if (results.length === 1) {
+        await navToOption({
+          option: results[0],
+          model,
+          assemblyName,
+        })
+      } else {
+        await model.navToLocString(input, assemblyName)
+      }
+    }
+  } catch (e) {
+    console.error(e)
+    getSession(model).notify(`${e}`, 'warning')
+  }
+}
+
+export function checkRef(str: string, allRefs: string[]) {
+  const [ref, rest] = splitLast(str, ':')
+  return (
+    allRefs.includes(str) ||
+    (allRefs.includes(ref) && !Number.isNaN(Number.parseInt(rest, 10)))
+  )
+}
+
+export async function fetchResults({
+  queryString,
+  searchType,
+  searchScope,
+  rankSearchResults,
+  textSearchManager,
+  assembly,
+}: {
+  queryString: string
+  searchScope: SearchScope
+  rankSearchResults: (results: BaseResult[]) => BaseResult[]
+  searchType?: SearchType
+  textSearchManager?: TextSearchManager
+  assembly?: Assembly
+}) {
+  if (!textSearchManager) {
+    console.warn('No text search manager')
+  }
+
+  const textSearchResults = await textSearchManager?.search(
+    {
+      queryString,
+      searchType,
+    },
+    searchScope,
+    rankSearchResults,
+  )
+
+  const refNameResults = assembly?.allRefNames
+    ?.filter(ref => ref.toLowerCase().startsWith(queryString.toLowerCase()))
+    .slice(0, 10)
+    .map(r => new BaseResult({ label: r }))
+
+  return dedupe(
+    [...(refNameResults || []), ...(textSearchResults || [])],
+    elt => elt.getId(),
+  )
+}
+
+// splits on the last instance of a character
+export function splitLast(str: string, split: string): [string, string] {
+  const lastIndex = str.lastIndexOf(split)
+  if (lastIndex === -1) {
+    return [str, '']
+  } else {
+    const before = str.slice(0, lastIndex)
+    const after = str.slice(lastIndex + 1)
+    return [before, after]
+  }
+}


### PR DESCRIPTION
This adds the ability to search by gene name from the &loc= in the URL bar for launching a linear genome view.

This would not yet work for synteny view because the synteny view still uses just navToLocString which assumes a locstring


Examples

```
## no search box popup since EDEN is a unique feature
localhost:3000/?config=test_data/volvox/config.json&loc=EDEN&assembly=volvox

## pops up a selection box since there are multiple seg08 features
localhost:3000/?config=test_data/volvox/config.json&loc=seg08&assembly=volvox
```

note that this may be just a larger issue of search box behavior, but I believe that it might popup if e.g. there are two gene tracks (e.g. ensembl and ncbi) with the same gene name even if they have "the same location"...it's not that bad but it may be undesirable for the URL bar to popup the selection box too much, its better to just jump right into the genome view if possible

this PR is in response to a office hours issue

xref https://github.com/GMOD/jbrowse-components/issues/3149