### PR TITLE
Fix zip build for mac auto-update

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -149,6 +149,12 @@
           "arch": [
             "universal"
           ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "universal"
+          ]
         }
       ],
       "publish": [


### PR DESCRIPTION
It was observed on chat that the auto-update was not working on mac

This is due to the 'zip' files being unavailable for mac in the release in v2.7.2 forward which was a change that was unintentionally introduced by #4011 

This restores the zip file build

we could "potentially" restore the zip file builds on both v2.7.2 and v2.8.0 but it might be tricky to create proper app signing for them, so it might just be worth cutting a new release with the restored zip file and then the auto-updater will just look for the latest release