### PR TITLE
Small refactoring for hierarchical track selector

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ShoppingCart.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ShoppingCart.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react'
-import { Badge, IconButton } from '@mui/material'
-import { makeStyles } from 'tss-react/mui'
+import React from 'react'
+import { Badge } from '@mui/material'
 import { observer } from 'mobx-react'
-import JBrowseMenu, { MenuItem } from '@jbrowse/core/ui/Menu'
+import { MenuItem } from '@jbrowse/core/ui/Menu'
 import { getSession, getEnv } from '@jbrowse/core/util'
 
 // icons
@@ -10,66 +9,37 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart'
 
 // locals
 import { HierarchicalTrackSelectorModel } from '../model'
-
-const useStyles = makeStyles()(theme => ({
-  searchBox: {
-    margin: theme.spacing(2),
-  },
-  menuIcon: {
-    marginRight: theme.spacing(1),
-    marginBottom: 0,
-  },
-}))
+import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
 
 const ShoppingCart = observer(function ({
   model,
 }: {
   model: HierarchicalTrackSelectorModel
 }) {
-  const { classes } = useStyles()
   const { selection } = model
   const { pluginManager } = getEnv(model)
   const session = getSession(model)
-  const [selectionEl, setSelectionEl] = useState<HTMLButtonElement>()
   const items = pluginManager.evaluateExtensionPoint(
     'TrackSelector-multiTrackMenuItems',
     [],
     { session },
   ) as MenuItem[]
 
-  return (
-    <>
-      {selection.length ? (
-        <IconButton
-          className={classes.menuIcon}
-          onClick={event => setSelectionEl(event.currentTarget)}
-        >
-          <Badge badgeContent={selection.length} color="primary">
-            <ShoppingCartIcon />
-          </Badge>
-        </IconButton>
-      ) : null}
-
-      <JBrowseMenu
-        anchorEl={selectionEl}
-        open={Boolean(selectionEl)}
-        onMenuItemClick={(_, callback) => {
-          callback()
-          setSelectionEl(undefined)
-        }}
-        onClose={() => setSelectionEl(undefined)}
-        menuItems={[
-          { label: 'Clear', onClick: () => model.clearSelection() },
-          ...items.map(item => ({
-            ...item,
-            ...('onClick' in item
-              ? { onClick: () => item.onClick(model) }
-              : {}),
-          })),
-        ]}
-      />
-    </>
-  )
+  return selection.length ? (
+    <CascadingMenuButton
+      menuItems={[
+        { label: 'Clear', onClick: () => model.clearSelection() },
+        ...items.map(item => ({
+          ...item,
+          ...('onClick' in item ? { onClick: () => item.onClick(model) } : {}),
+        })),
+      ]}
+    >
+      <Badge badgeContent={selection.length} color="primary">
+        <ShoppingCartIcon />
+      </Badge>
+    </CascadingMenuButton>
+  ) : null
 })
 
 export default ShoppingCart

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.tsx.snap
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/__snapshots__/HierarchicalTrackSelector.test.tsx.snap
@@ -586,9 +586,8 @@ exports[`renders with a couple of categorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,sequenceConfigId"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >
@@ -724,9 +723,8 @@ exports[`renders with a couple of categorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,fooC"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >
@@ -870,9 +868,8 @@ exports[`renders with a couple of categorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,barC"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >
@@ -1225,9 +1222,8 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,sequenceConfigId"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >
@@ -1301,9 +1297,8 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,fooC"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >
@@ -1377,9 +1372,8 @@ exports[`renders with a couple of uncategorized tracks 1`] = `
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-9vna8i-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1kmuk0e-MuiButtonBase-root-MuiIconButton-root-cascadingStyle"
               data-testid="htsTrackEntryMenu-Tracks,barC"
-              style="padding: 0px;"
               tabindex="0"
               type="button"
             >

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
@@ -163,13 +163,17 @@ const HamburgerMenu = observer(function ({
             label: 'Show favorite tracks',
             type: 'checkbox',
             checked: model.showFavoritesCategory,
-            onClick: () => model.toggleFavoritesCategory(),
+            onClick: () =>
+              model.setShowFavoritesCategory(!model.showFavoritesCategory),
           },
           {
             label: 'Show recently used tracks',
             type: 'checkbox',
             checked: model.showRecentlyUsedCategory,
-            onClick: () => model.toggleRecentlyUsedCategory(),
+            onClick: () =>
+              model.setShowRecentlyUsedCategory(
+                !model.showRecentlyUsedCategory,
+              ),
           },
         ]}
       >

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
@@ -13,8 +13,8 @@ function getNodeData(
   extra: Record<string, unknown>,
   selection: Record<string, unknown>,
 ) {
-  const isLeaf = !!node.conf
-  const selected = !!selection[node.id]
+  const isLeaf = node.type === 'track'
+  const selected = isLeaf ? selection[node.trackId] : false
   return {
     data: {
       defaultHeight: isLeaf ? 22 : 40,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
@@ -13,7 +13,7 @@ function getNodeData(
   extra: Record<string, unknown>,
   selection: Record<string, unknown>,
 ) {
-  const isLeaf = 'conf' in node && !!node.conf
+  const isLeaf = !!node.conf
   const selected = !!selection[node.id]
   return {
     data: {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
@@ -35,7 +35,7 @@ export default function Category({
 }) {
   const { classes } = useStyles()
   const [menuEl, setMenuEl] = useState<HTMLElement | null>(null)
-  const { menuItems, name, model, id, tree, toggleCollapse } = data
+  const { menuItems = [], name, model, id, tree } = data
 
   console.log(data.menuItems)
 
@@ -44,7 +44,7 @@ export default function Category({
       className={classes.accordionText}
       onClick={() => {
         if (!menuEl) {
-          toggleCollapse(id)
+          data.toggleCollapse(id)
           setOpen(!isOpen)
         }
       }}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
@@ -37,8 +37,6 @@ export default function Category({
   const [menuEl, setMenuEl] = useState<HTMLElement | null>(null)
   const { menuItems = [], name, model, id, tree } = data
 
-  console.log(data.menuItems)
-
   return (
     <div
       className={classes.accordionText}
@@ -84,7 +82,7 @@ export default function Category({
               label: 'Show all tracks',
               onClick: () => {
                 for (const entry of treeToMap(tree).get(id)?.children || []) {
-                  if (!entry.children.length) {
+                  if (entry.type === 'track') {
                     model.view.showTrack(entry.trackId)
                   }
                 }
@@ -94,7 +92,7 @@ export default function Category({
               label: 'Hide all tracks',
               onClick: () => {
                 for (const entry of treeToMap(tree).get(id)?.children || []) {
-                  if (!entry.children.length) {
+                  if (entry.type === 'track') {
                     model.view.hideTrack(entry.trackId)
                   }
                 }

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
@@ -37,6 +37,8 @@ export default function Category({
   const [menuEl, setMenuEl] = useState<HTMLElement | null>(null)
   const { menuItems, name, model, id, tree, toggleCollapse } = data
 
+  console.log(data.menuItems)
+
   return (
     <div
       className={classes.accordionText}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -1,22 +1,14 @@
 import React from 'react'
 import { Checkbox, FormControlLabel, Tooltip } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
-import { getSession } from '@jbrowse/core/util'
 import SanitizedHTML from '@jbrowse/core/ui/SanitizedHTML'
 import {
   AnyConfigurationModel,
   readConfObject,
 } from '@jbrowse/core/configuration'
-
-// icons
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
-import StarIcon from '@mui/icons-material/StarBorderOutlined'
-import FilledStarIcon from '@mui/icons-material/Star'
-
 // locals
 import { isUnsupported, NodeData } from '../util'
-import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
-import { HierarchicalTrackSelectorModel } from '../../model'
+import TrackLabelMenu from './TrackLabelMenu'
 
 const useStyles = makeStyles()(theme => ({
   compactCheckbox: {
@@ -31,9 +23,6 @@ const useStyles = makeStyles()(theme => ({
   },
   selected: {
     background: '#cccc',
-  },
-  cascadingStyle: {
-    padding: 0,
   },
 }))
 
@@ -83,14 +72,14 @@ export default function TrackLabel({ data }: { data: NodeData }) {
           label={
             <div
               data-testid={`htsTrackLabel-${id}`}
-              className={selected ? classes.selected : undefined}
+              style={{ background: selected ? '#cccc' : undefined }}
             >
               <SanitizedHTML html={name} />
             </div>
           }
         />
       </Tooltip>
-      <TrackMenuButton
+      <TrackLabelMenu
         model={model}
         selected={selected}
         trackId={trackId}
@@ -98,55 +87,5 @@ export default function TrackLabel({ data }: { data: NodeData }) {
         conf={conf}
       />
     </>
-  )
-}
-
-function TrackMenuButton({
-  id,
-  trackId,
-  model,
-  selected,
-  conf,
-}: {
-  id: string
-  trackId: string
-  selected: boolean
-  conf: AnyConfigurationModel
-  model: HierarchicalTrackSelectorModel
-}) {
-  const { classes } = useStyles()
-  return (
-    <CascadingMenuButton
-      className={classes.cascadingStyle}
-      data-testid={`htsTrackEntryMenu-${id}`}
-      menuItems={[
-        ...(getSession(model).getTrackActionMenuItems?.(conf) || []),
-        model.isFavorite(trackId)
-          ? {
-              label: 'Remove from favorites',
-              onClick: () => model.removeFromFavorites(trackId),
-              icon: StarIcon,
-            }
-          : {
-              label: 'Add to favorites',
-              onClick: () => model.addToFavorites(trackId),
-              icon: FilledStarIcon,
-            },
-        {
-          label: 'Add to selection',
-          onClick: () => model.addToSelection([conf]),
-        },
-        ...(selected
-          ? [
-              {
-                label: 'Remove from selection',
-                onClick: () => model.removeFromSelection([conf]),
-              },
-            ]
-          : []),
-      ]}
-    >
-      <MoreHorizIcon />
-    </CascadingMenuButton>
   )
 }

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -100,6 +100,7 @@ function TrackMenuButton({
   conf: AnyConfigurationModel
   model: HierarchicalTrackSelectorModel
 }) {
+  console.log({ id })
   return (
     <CascadingMenuButton
       style={{ padding: 0 }}

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -45,7 +45,7 @@ export default function TrackLabel({ data }: { data: NodeData }) {
     onChange,
     selected,
   } = data
-  const description = (conf && readConfObject(conf, ['description'])) || ''
+  const description = (conf && readConfObject(conf, 'description')) || ''
   return (
     <>
       <Tooltip

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -29,6 +29,12 @@ const useStyles = makeStyles()(theme => ({
       backgroundColor: theme.palette.action.selected,
     },
   },
+  selected: {
+    background: '#cccc',
+  },
+  cascadingStyle: {
+    padding: 0,
+  },
 }))
 
 export interface InfoArgs {
@@ -77,45 +83,53 @@ export default function TrackLabel({ data }: { data: NodeData }) {
           label={
             <div
               data-testid={`htsTrackLabel-${id}`}
-              style={{ background: selected ? '#cccc' : undefined }}
+              className={selected ? classes.selected : undefined}
             >
               <SanitizedHTML html={name} />
             </div>
           }
         />
       </Tooltip>
-      <TrackMenuButton model={model} selected={selected} id={id} conf={conf} />
+      <TrackMenuButton
+        model={model}
+        selected={selected}
+        trackId={trackId}
+        id={id}
+        conf={conf}
+      />
     </>
   )
 }
 
 function TrackMenuButton({
   id,
+  trackId,
   model,
   selected,
   conf,
 }: {
   id: string
+  trackId: string
   selected: boolean
   conf: AnyConfigurationModel
   model: HierarchicalTrackSelectorModel
 }) {
-  console.log({ id })
+  const { classes } = useStyles()
   return (
     <CascadingMenuButton
-      style={{ padding: 0 }}
+      className={classes.cascadingStyle}
       data-testid={`htsTrackEntryMenu-${id}`}
       menuItems={[
         ...(getSession(model).getTrackActionMenuItems?.(conf) || []),
-        model.isFavorite(conf)
+        model.isFavorite(trackId)
           ? {
               label: 'Remove from favorites',
-              onClick: () => model.removeFromFavorites(conf),
+              onClick: () => model.removeFromFavorites(trackId),
               icon: StarIcon,
             }
           : {
               label: 'Add to favorites',
-              onClick: () => model.addToFavorites(conf),
+              onClick: () => model.addToFavorites(trackId),
               icon: FilledStarIcon,
             },
         {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabelMenu.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabelMenu.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { makeStyles } from 'tss-react/mui'
+import { getSession } from '@jbrowse/core/util'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration'
+
+// icons
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
+import StarIcon from '@mui/icons-material/StarBorderOutlined'
+import FilledStarIcon from '@mui/icons-material/Star'
+
+// locals
+import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
+import { HierarchicalTrackSelectorModel } from '../../model'
+
+const useStyles = makeStyles()({
+  cascadingStyle: {
+    padding: 0,
+  },
+})
+
+const TrackLabelMenu = function ({
+  id,
+  trackId,
+  model,
+  selected,
+  conf,
+}: {
+  id: string
+  trackId: string
+  selected: boolean
+  conf: AnyConfigurationModel
+  model: HierarchicalTrackSelectorModel
+}) {
+  const { classes } = useStyles()
+  return (
+    <CascadingMenuButton
+      className={classes.cascadingStyle}
+      data-testid={`htsTrackEntryMenu-${id}`}
+      menuItems={[
+        ...(getSession(model).getTrackActionMenuItems?.(conf) || []),
+        model.isFavorite(trackId)
+          ? {
+              label: 'Remove from favorites',
+              onClick: () => model.removeFromFavorites(trackId),
+              icon: StarIcon,
+            }
+          : {
+              label: 'Add to favorites',
+              onClick: () => model.addToFavorites(trackId),
+              icon: FilledStarIcon,
+            },
+        {
+          label: 'Add to selection',
+          onClick: () => model.addToSelection([conf]),
+        },
+        ...(selected
+          ? [
+              {
+                label: 'Remove from selection',
+                onClick: () => model.removeFromSelection([conf]),
+              },
+            ]
+          : []),
+      ]}
+    >
+      <MoreHorizIcon />
+    </CascadingMenuButton>
+  )
+}
+
+export default TrackLabelMenu

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/util.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/util.ts
@@ -22,11 +22,11 @@ export interface NodeData {
 
 export function getAllChildren(subtree?: TreeNode): AnyConfigurationModel[] {
   // @ts-expect-error
-  return (
-    subtree?.children.map(t =>
-      t.children.length ? getAllChildren(t) : t.conf!,
-    ) || []
-  ).flat(Infinity)
+  return subtree?.type === 'category'
+    ? subtree.children
+        .map(t => (t.type === 'category' ? getAllChildren(t) : t.conf))
+        .flat(Infinity)
+    : []
 }
 
 export function treeToMap(tree: TreeNode, map = new Map<string, TreeNode>()) {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/util.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/util.ts
@@ -16,7 +16,7 @@ export interface NodeData {
   toggleCollapse: (arg: string) => void
   tree: TreeNode
   selected: boolean
-  menuItems: MenuItem[]
+  menuItems?: MenuItem[]
   model: HierarchicalTrackSelectorModel
 }
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/generateHierarchy.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/generateHierarchy.ts
@@ -43,15 +43,25 @@ function sortConfs(
   return ret.map(a => a[0])
 }
 
-export interface TreeNode {
+export interface TreeTrackNode {
   name: string
   id: string
-  trackId?: string
-  conf?: AnyConfigurationModel
-  checked?: boolean
-  isOpenByDefault?: boolean
-  children: TreeNode[]
+  trackId: string
+  conf: AnyConfigurationModel
+  checked: boolean
+  children: TreeNode[] // empty
+  type: 'track'
 }
+
+export interface TreeCategoryNode {
+  name: string
+  id: string
+  isOpenByDefault: boolean
+  children: TreeNode[]
+  type: 'category'
+}
+
+export type TreeNode = TreeTrackNode | TreeCategoryNode
 
 export function generateHierarchy({
   model,
@@ -121,6 +131,7 @@ export function generateHierarchy({
             id,
             isOpenByDefault: !collapsed.get(id),
             menuItems,
+            type: 'category' as const,
           }
           currLevel.children.push(n)
           currLevel = n
@@ -142,6 +153,7 @@ export function generateHierarchy({
       conf,
       checked: viewTracks.some(f => f.configuration === conf),
       children: [],
+      type: 'track' as const,
     })
   }
 

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
@@ -20,6 +20,8 @@ import { filterTracks } from './filterTracks'
 import { generateHierarchy } from './generateHierarchy'
 import { findSubCategories, findTopLevelCategories } from './util'
 
+type MaybeAnyConfigurationModel = AnyConfigurationModel | undefined
+
 function postfixF() {
   return typeof window !== undefined
     ? [
@@ -244,9 +246,7 @@ export default function stateTreeFactory(pluginManager: PluginManager) {
       /**
        * #method
        */
-      getRefSeqTrackConf(
-        assemblyName: string,
-      ): AnyConfigurationModel | undefined {
+      getRefSeqTrackConf(assemblyName: string): MaybeAnyConfigurationModel {
         const { assemblyManager } = getSession(self)
         const assembly = assemblyManager.get(assemblyName)
         const trackConf = assembly?.configuration.sequence
@@ -389,19 +389,17 @@ export default function stateTreeFactory(pluginManager: PluginManager) {
         return {
           name: 'Root',
           id: 'Root',
-          children: self.allTracks.map(s => {
-            return {
-              name: s.group,
-              id: s.group,
-              menuItems: s.menuItems,
-              children: generateHierarchy({
-                model: self,
-                trackConfs: s.tracks,
-                extra: s.group,
-                noCategories: s.noCategories,
-              }),
-            }
-          }),
+          children: self.allTracks.map(s => ({
+            name: s.group,
+            id: s.group,
+            menuItems: s.menuItems,
+            children: generateHierarchy({
+              model: self,
+              trackConfs: s.tracks,
+              extra: s.group,
+              noCategories: s.noCategories,
+            }),
+          })),
         }
       },
     }))
@@ -433,14 +431,14 @@ export default function stateTreeFactory(pluginManager: PluginManager) {
       /**
        * #action
        */
-      toggleRecentlyUsedCategory() {
-        self.showRecentlyUsedCategory = !self.showRecentlyUsedCategory
+      setShowRecentlyUsedCategory(f: boolean) {
+        self.showRecentlyUsedCategory = f
       },
       /**
        * #action
        */
-      toggleFavoritesCategory() {
-        self.showFavoritesCategory = !self.showFavoritesCategory
+      setShowFavoritesCategory(f: boolean) {
+        self.showFavoritesCategory = f
       },
     }))
     .actions(self => ({


### PR DESCRIPTION
1) Fixes "Add to selection" highlighting of tracks
2) Passes trackId instead of full config objects for functions that manipulate recently used/favorites arrays, simplifies some logic (also uses set operations in some cases)
3) Renames some localStorage keys, makes more clear which are related to the option of showing
4) Changes the TreeNode to a tagged union of TreeCategoryNode and TreeTrackNode, simplifies some typescript

