### PR TITLE
Make contributing to docs easier

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,15 +18,15 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.json'),
-          // Please change this to your repo.
-          editUrl:
-            'https://github.com/GMOD/jbrowse-components/edit/main/website/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/GMOD/jbrowse-components/main/editor/website/docs/${docPath}`
+          },
         },
         blog: {
           blogSidebarCount: 'ALL',
-          // Please change this to your repo.
-          editUrl:
-            'https://github.com/GMOD/jbrowse-components/edit/main/website/blog/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/GMOD/jbrowse-components/main/editor/website/blog/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/GMOD/jbrowse-components/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb