### PR TITLE
Add links between autogen docs

### DIFF
--- a/docs/generateStateModelDocs.ts
+++ b/docs/generateStateModelDocs.ts
@@ -115,70 +115,57 @@ function generateStateModelDocs(files: string[]) {
           `${getters.length ? `### ${model.name} - Getters` : ''}\n` +
           getters
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map(({ name, docs, signature }: any) => {
-              return `#### getter: ${name}
-
-${docs}
-
-\`\`\`js
-// type
-${signature || ''}
-\`\`\`
-`
-            })
+            .map(({ name, docs, signature }: any) =>
+              join(
+                `#### getter: ${name}`,
+                docs,
+                codeBlock('// type', signature || ''),
+              ),
+            )
             .join('\n')
 
         const methodstr =
           `${methods.length ? `### ${model.name} - Methods` : ''}\n` +
           methods
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map(({ name, docs, signature }: any) => {
-              return `#### method: ${name}
-
-${docs}
-
-\`\`\`js
-// type signature
-${name}: ${signature || ''}
-\`\`\`
-`
-            })
+            .map(({ name, docs, signature }: any) =>
+              join(
+                `#### method: ${name}`,
+                docs,
+                codeBlock('// type signature', `${name}: ${signature || ''}`),
+              ),
+            )
             .join('\n')
 
         const propertiesstr =
           `${properties.length ? `### ${model.name} - Properties` : ''}\n` +
           properties
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map(({ name, docs, code, signature }: any) => {
-              return `#### property: ${name}
-
-${docs}
-
-\`\`\`js
-// type signature
-${signature || ''}
-// code
-${code}
-\`\`\`
-`
-            })
+            .map(({ name, docs, code, signature }: any) =>
+              join(
+                `#### property: ${name}`,
+                docs,
+                codeBlock(
+                  '// type signature',
+                  signature || '',
+                  '// code',
+                  code,
+                ),
+              ),
+            )
             .join('\n')
 
         const actionstr =
           `${actions.length ? `### ${model.name} - Actions` : ''}\n` +
           actions
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map(({ name, docs, signature }: any) => {
-              return `#### action: ${name}
-
-${docs}
-
-\`\`\`js
-// type signature
-${name}: ${signature || ''}
-\`\`\`
-`
-            })
+            .map(({ name, docs, signature }: any) =>
+              join(
+                `#### action: ${name}`,
+                docs,
+                codeBlock('// type signature', `${name}: ${signature || ''}`),
+              ),
+            )
             .join('\n')
 
         const dir = `website/docs/models`
@@ -216,3 +203,16 @@ ${actionstr}
     },
   )
 })()
+
+function codeBlock(...lines: string[]) {
+  return `
+
+\`\`\`js
+${lines.join('\n')}
+\`\`\`
+`
+}
+
+function join(...lines: string[]) {
+  return lines.join('\n\n')
+}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "dependency-graph": "^0.11.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",
-    "electron": "27.1.2",
+    "electron": "27.1.3",
     "electron-builder": "^24.8.0",
     "electron-mock-ipc": "^0.3.8",
     "eslint": "^8.0.0",

--- a/packages/app-core/src/AppFocus/index.ts
+++ b/packages/app-core/src/AppFocus/index.ts
@@ -14,6 +14,9 @@ export function AppFocusMixin() {
       focusedViewId: types.maybe(types.string),
     })
     .actions(self => ({
+      /**
+       * #action
+       */
       setFocusedViewId(viewId: string) {
         self.focusedViewId = viewId
       },

--- a/packages/app-core/src/JBrowseConfig/index.ts
+++ b/packages/app-core/src/JBrowseConfig/index.ts
@@ -16,7 +16,22 @@ import { types } from 'mobx-state-tree'
 /**
  * #config JBrowseRootConfig
  * #category root
- * configuration in a config.json/file.jbrowse
+ *
+ * this is a config model representing a config.json (for jbrowse-web) or
+ * somefile.jbrowse (for jbrowse-desktop, where configs have the .jbrowse
+ * extension)
+ *
+ * includes
+ * - [FormatDetails](../formatdetails) for global (instead of per-track)
+ *   feature detail formatters
+ * - [FormatAbout](../formatabout) for global (instead of per-track) about
+ *   track formatters
+ * - [HierarchicalConfigSchema](../hierarchicalconfigschema) for track selector
+ *   configs
+ *
+ * also includes any pluginManager.pluginConfigurationSchemas(), so plugins
+ * that have a configurationSchema field on their class are mixed into this
+ * object
  */
 export function JBrowseConfigF({
   pluginManager,
@@ -116,6 +131,8 @@ export function JBrowseConfigF({
     ),
     /**
      * #slot
+     * configuration for aggregate text search adapters (created by e.g.
+     * jbrowse text-index, but can be a pluggable TextSearchAdapter type)
      */
     aggregateTextSearchAdapters: types.array(
       pluginManager.pluggableConfigSchemaType('text search adapter'),
@@ -123,6 +140,7 @@ export function JBrowseConfigF({
 
     /**
      * #slot
+     * configuration for connections
      */
     connections: types.array(
       pluginManager.pluggableConfigSchemaType('connection'),

--- a/packages/app-core/src/JBrowseModel/index.ts
+++ b/packages/app-core/src/JBrowseModel/index.ts
@@ -12,6 +12,17 @@ import { toJS } from 'mobx'
 // locals
 import { JBrowseConfigF } from '../JBrowseConfig'
 
+/**
+ * #stateModel AppCoreJBrowseModel
+ * note that JBrowseRootConfig is a config model, but config models are MST
+ * trees themselves, which is why this stateModel is allowed to extend it
+ *
+ * the AppCoreJBrowseModel is generally on a property named rootModel.jbrowse
+ *
+ * extends
+ * - [JBrowseRootConfig](/docs/config/jbrowserootconfig)
+
+ */
 export function JBrowseModelF({
   pluginManager,
   assemblyConfigSchema,

--- a/packages/app-core/src/RootMenu/index.ts
+++ b/packages/app-core/src/RootMenu/index.ts
@@ -5,6 +5,10 @@ export interface Menu {
   label: string
   menuItems: MenuItem[]
 }
+
+/**
+ * #stateModel RootAppMenuMixin
+ */
 export function RootAppMenuMixin() {
   return types.model({}).actions(s => {
     const self = s as { menus: Menu[] }
@@ -18,7 +22,9 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Add a top-level menu
+       *
        * @param menuName - Name of the menu to insert.
+       *
        * @returns The new length of the top-level menus array
        */
       appendMenu(menuName: string) {
@@ -27,10 +33,13 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Insert a top-level menu
+       *
        * @param menuName - Name of the menu to insert.
+       *
        * @param position - Position to insert menu. If negative, counts from th
        * end, e.g. `insertMenu('My Menu', -1)` will insert the menu as the
        * second-to-last one.
+       *
        * @returns The new length of the top-level menus array
        */
       insertMenu(menuName: string, position: number) {
@@ -47,8 +56,11 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Add a menu item to a top-level menu
+       *
        * @param menuName - Name of the top-level menu to append to.
+       *
        * @param menuItem - Menu item to append.
+       *
        * @returns The new length of the menu
        */
       appendToMenu(menuName: string, menuItem: MenuItem) {
@@ -62,11 +74,15 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Insert a menu item into a top-level menu
+       *
        * @param menuName - Name of the top-level menu to insert into
+       *
        * @param menuItem - Menu item to insert
+       *
        * @param position - Position to insert menu item. If negative, counts
        * from the end, e.g. `insertMenu('My Menu', -1)` will insert the menu as
        * the second-to-last one.
+       *
        * @returns The new length of the menu
        */
       insertInMenu(menuName: string, menuItem: MenuItem, position: number) {
@@ -83,9 +99,12 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Add a menu item to a sub-menu
+       *
        * @param menuPath - Path to the sub-menu to add to, starting with the
        * top-level menu (e.g. `['File', 'Insert']`).
+       *
        * @param menuItem - Menu item to append.
+       *
        * @returns The new length of the sub-menu
        */
       appendToSubMenu(menuPath: string[], menuItem: MenuItem) {
@@ -115,12 +134,16 @@ export function RootAppMenuMixin() {
       /**
        * #action
        * Insert a menu item into a sub-menu
+       *
        * @param menuPath - Path to the sub-menu to add to, starting with the
        * top-level menu (e.g. `['File', 'Insert']`).
+       *
        * @param menuItem - Menu item to insert.
+       *
        * @param position - Position to insert menu item. If negative, counts
        * from the end, e.g. `insertMenu('My Menu', -1)` will insert the menu as
        * the second-to-last one.
+       *
        * @returns The new length of the sub-menu
        */
       insertInSubMenu(

--- a/packages/product-core/src/Session/BaseSession.ts
+++ b/packages/product-core/src/Session/BaseSession.ts
@@ -15,7 +15,8 @@ import { ElementId } from '@jbrowse/core/util/types/mst'
 
 /**
  * #stateModel BaseSessionModel
- * base session shared by **all** JBrowse products. Be careful what you include
+ *
+ * base session shared by all JBrowse products. Be careful what you include
  * here, everything will use it.
  */
 export function BaseSessionModel<
@@ -54,6 +55,9 @@ export function BaseSessionModel<
       hovered: undefined as unknown,
     }))
     .views(self => ({
+      /**
+       * #getter
+       */
       get root() {
         return getParent<ROOT_MODEL_TYPE>(self)
       },

--- a/packages/product-core/src/Session/MultipleViews.ts
+++ b/packages/product-core/src/Session/MultipleViews.ts
@@ -17,6 +17,9 @@ import { BaseSessionModel, isBaseSession } from './BaseSession'
 
 /**
  * #stateModel MultipleViewsSessionMixin
+ * composed of
+ * - [BaseSessionModel](../basesessionmodel)
+ * - [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
  */
 export function MultipleViewsSessionMixin(pluginManager: PluginManager) {
   return types

--- a/packages/web-core/src/BaseWebSession/index.ts
+++ b/packages/web-core/src/BaseWebSession/index.ts
@@ -55,17 +55,17 @@ const AboutDialog = lazy(() => import('./AboutDialog'))
 /**
  * #stateModel BaseWebSession
  * used for "web based" products, including jbrowse-web and react-app
- * extends
- * - ReferenceManagementSessionMixin
- * - DrawerWidgetSessionMixin
- * - DialogQueueSessionMixin
- * - ThemeManagerSessionMixin
- * - MultipleViewsSessionMixin
- * - SessionTracksManagerSessionMixin
- * - SessionAssembliesMixin
- * - TemporaryAssembliesMixin
- * - WebSessionConnectionsMixin
- * - AppFocusMixin
+ * composed of
+ * - [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+ * - [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+ * - [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+ * - [ThemeManagerSessionMixin](../thememanagersessionmixin)
+ * - [MultipleViewsSessionMixin](../multipleviewssessionmixin)
+ * - [SessionTracksManagerSessionMixin](../sessiontracksmanagersessionmixin)
+ * - [SessionAssembliesMixin](../sessionassembliesmixin)
+ * - [TemporaryAssembliesMixin](../temporaryassembliesmixin)
+ * - [WebSessionConnectionsMixin](../websessionconnectionsmixin)
+ * - [AppFocusMixin](../appfocusmixin)
  */
 export function BaseWebSession({
   pluginManager,

--- a/packages/web-core/src/BaseWebSession/index.ts
+++ b/packages/web-core/src/BaseWebSession/index.ts
@@ -52,6 +52,21 @@ import { BaseConnectionConfigModel } from '@jbrowse/core/pluggableElementTypes/m
 
 const AboutDialog = lazy(() => import('./AboutDialog'))
 
+/**
+ * #stateModel BaseWebSession
+ * used for "web based" products, including jbrowse-web and react-app
+ * extends
+ * - ReferenceManagementSessionMixin
+ * - DrawerWidgetSessionMixin
+ * - DialogQueueSessionMixin
+ * - ThemeManagerSessionMixin
+ * - MultipleViewsSessionMixin
+ * - SessionTracksManagerSessionMixin
+ * - SessionAssembliesMixin
+ * - TemporaryAssembliesMixin
+ * - WebSessionConnectionsMixin
+ * - AppFocusMixin
+ */
 export function BaseWebSession({
   pluginManager,
   assemblyConfigSchema,

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx
@@ -1,0 +1,60 @@
+import { types } from 'mobx-state-tree'
+
+// jbrowse
+import {
+  ConfigurationReference,
+  AnyConfigurationSchemaType,
+} from '@jbrowse/core/configuration'
+import PluginManager from '@jbrowse/core/PluginManager'
+import { getLowerPanelDisplays } from './util'
+
+/**
+ * #stateModel LinearAlignmentsDisplayMixin
+ */
+export function LinearAlignmentsDisplayMixin(
+  pluginManager: PluginManager,
+  configSchema: AnyConfigurationSchemaType,
+) {
+  const lowerPanelDisplays = getLowerPanelDisplays(pluginManager).map(
+    f => f.stateModel,
+  )
+
+  return types.model({
+    /**
+     * #property
+     * refers to LinearPileupDisplay sub-display model
+     */
+    PileupDisplay: types.maybe(types.union(...lowerPanelDisplays)),
+    /**
+     * #property
+     * refers to LinearSNPCoverageDisplay sub-display model
+     */
+    SNPCoverageDisplay: types.maybe(
+      pluginManager.getDisplayType('LinearSNPCoverageDisplay').stateModel,
+    ),
+    /**
+     * #property
+     */
+    snpCovHeight: 45,
+    /**
+     * #property
+     */
+    type: types.literal('LinearAlignmentsDisplay'),
+    /**
+     * #property
+     */
+    configuration: ConfigurationReference(configSchema),
+    /**
+     * #property
+     */
+    heightPreConfig: types.maybe(types.number),
+    /**
+     * #property
+     */
+    userFeatureScreenDensity: types.maybe(types.number),
+    /**
+     * #property
+     */
+    lowerPanelType: 'LinearPileupDisplay',
+  })
+}

--- a/plugins/alignments/src/LinearAlignmentsDisplay/models/util.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/models/util.ts
@@ -1,0 +1,12 @@
+import PluginManager from '@jbrowse/core/PluginManager'
+
+export function getLowerPanelDisplays(pluginManager: PluginManager) {
+  return (
+    pluginManager
+      .getDisplayElements()
+      // @ts-expect-error
+      .filter(f => f.subDisplay?.type === 'LinearAlignmentsDisplay')
+      // @ts-expect-error
+      .filter(f => f.subDisplay?.lowerPanel)
+  )
+}

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -30,7 +30,8 @@ type LGV = LinearGenomeViewModel
 /**
  * #stateModel LinearPileupDisplay
  * #category display
- * extends `BaseLinearDisplay`
+ * extends
+ *- [SharedLinearPileupDisplayMixin](../sharedlinearpileupdisplaymixin)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/alignments/src/LinearReadArcsDisplay/model.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/model.ts
@@ -25,8 +25,12 @@ const FilterByTagDlg = lazy(() => import('../shared/FilterByTag'))
 
 /**
  * #stateModel LinearReadArcsDisplay
- * extends `BaseDisplay`, it is not a block based track, hence not
- * BaseLinearDisplay
+ * the arc display is a non-block-based track, so draws to a single canvas and
+ * can connect multiple regions
+ * extends
+ * - [BaseDisplay](../basedisplay)
+ * - [TrackHeightMixin](../trackheightmixin)
+ * - [FeatureDensityMixin](../featuredensitymixin)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/alignments/src/LinearReadCloudDisplay/model.ts
+++ b/plugins/alignments/src/LinearReadCloudDisplay/model.ts
@@ -24,7 +24,11 @@ const FilterByTagDlg = lazy(() => import('../shared/FilterByTag'))
 
 /**
  * #stateModel LinearReadCloudDisplay
- * extends `BaseDisplay`, it is not a block based track, hence not BaseLinearDisplay
+ * it is not a block based track, hence not BaseLinearDisplay
+ * extends
+ * - [BaseDisplay](../basedisplay)
+ * - [TrackHeightMixin](../trackheightmixin)
+ * - [FeatureDensityMixin](../featuredensitymixin)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts
@@ -5,6 +5,9 @@ import PluginManager from '@jbrowse/core/PluginManager'
 
 /**
  * #config LinearSNPCoverageDisplay
+ *
+ * extends
+ * - [BaseLinearDisplay](../baselineardisplay)
  */
 function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -27,7 +27,8 @@ type LGV = LinearGenomeViewModel
 
 /**
  * #stateModel LinearSNPCoverageDisplay
- * extends `LinearWiggleDisplay`
+ * extends
+ * - [LinearWiggleDisplay](../linearwiggledisplay)
  */
 function stateModelFactory(
   pluginManager: PluginManager,

--- a/plugins/arc/src/LinearArcDisplay/model.ts
+++ b/plugins/arc/src/LinearArcDisplay/model.ts
@@ -9,7 +9,8 @@ import { getEnv } from '@jbrowse/core/util'
 
 /**
  * #stateModel LinearArcDisplay
- * extends BaseLinearDisplay
+ * extends
+ * - [BaseLinearDisplay](../baselineardisplay)
  */
 export function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/arc/src/LinearPairedArcDisplay/model.ts
+++ b/plugins/arc/src/LinearPairedArcDisplay/model.ts
@@ -21,7 +21,13 @@ import {
 
 /**
  * #stateModel LinearPairedArcDisplay
- * extends BaseDisplay, TrackHeightMixin, FeatureDensityMixin
+ * this is a non-block-based track type, and can connect arcs across multiple
+ * displayedRegions
+ *
+ * extends
+ * - [BaseDisplay](../basedisplay)
+ * - [TrackHeightMixin](../trackheightmixin)
+ * - [FeatureDensityMixin](../featuredensitymixin)
  */
 export function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
@@ -95,6 +95,8 @@ async function getBlockFeatures(
 
 /**
  * #stateModel BreakpointSplitView
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 export default function stateModelFactory(pluginManager: PluginManager) {
   const minHeight = 40

--- a/plugins/circular-view/src/BaseChordDisplay/models/model.tsx
+++ b/plugins/circular-view/src/BaseChordDisplay/models/model.tsx
@@ -34,7 +34,8 @@ import { baseChordDisplayConfig } from './configSchema'
 
 /**
  * #stateModel BaseChordDisplay
- * extends `BaseDisplay`
+ * extends
+ * - [BaseDisplay](../basedisplay)
  */
 function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/plugins/circular-view/src/CircularView/models/CircularView.ts
+++ b/plugins/circular-view/src/CircularView/models/CircularView.ts
@@ -46,7 +46,8 @@ export interface ExportSvgOptions {
 
 /**
  * #stateModel CircularView
- * extends `BaseViewModel`
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 function stateModelFactory(pluginManager: PluginManager) {
   const minHeight = 40

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -67,7 +67,8 @@ const pxWidthForBlocks = (blocks: BaseBlock[], hide: Set<string>) => {
 /**
  * #stateModel DotplotView
  * #category view
- * extends  `BaseViewModel`
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 export default function stateModelFactory(pm: PluginManager) {
   return types

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
@@ -4,6 +4,8 @@ import { linearPileupDisplayConfigSchemaFactory } from '@jbrowse/plugin-alignmen
 
 /**
  * #config LGVSyntenyDisplay
+ * extends config
+ * - [LinearPileupDisplay](../linearpileupdisplay)
  */
 function configSchemaF(pluginManager: PluginManager) {
   return ConfigurationSchema(

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts
@@ -13,8 +13,11 @@ const LaunchSyntenyViewDialog = lazy(
 
 /**
  * #stateModel LGVSyntenyDisplay
- * extends `LinearPileupDisplay`, displays location of "synteny" feature in a
- * plain LGV, allowing linking out to external synteny views
+ * displays location of "synteny" feature in a plain LGV, allowing linking out
+ * to external synteny views
+ *
+ * extends
+ * - [SharedLinearPileupDisplayMixin](../sharedlinearpileupdisplaymixin)
  */
 function stateModelFactory(schema: AnyConfigurationSchemaType) {
   return types
@@ -35,6 +38,9 @@ function stateModelFactory(schema: AnyConfigurationSchemaType) {
     .views(self => {
       const superContextMenuItems = self.contextMenuItems
       return {
+        /**
+         * #method
+         */
         contextMenuItems() {
           const feature = self.contextMenuFeature
           return [
@@ -66,6 +72,9 @@ function stateModelFactory(schema: AnyConfigurationSchemaType) {
         colorSchemeSubMenuItems: superColorSchemeSubMenuItems,
       } = self
       return {
+        /**
+         * #method
+         */
         trackMenuItems() {
           return [
             ...superTrackMenuItems(),
@@ -79,7 +88,8 @@ function stateModelFactory(schema: AnyConfigurationSchemaType) {
     })
     .actions(self => ({
       afterCreate() {
-        // use color by stand to help indicate inversions better on first load, otherwise use selected orientation
+        // use color by stand to help indicate inversions better on first load,
+        // otherwise use selected orientation
         if (self.colorBy) {
           self.setColorScheme({ ...self.colorBy })
         } else {

--- a/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
@@ -17,6 +17,8 @@ import { LinearComparativeViewModel } from '../LinearComparativeView/model'
 
 /**
  * #stateModel LinearComparativeDisplay
+ * extends
+ * - [BaseDisplay](../basedisplay)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -36,6 +36,8 @@ const ReturnToImportFormDialog = lazy(
 
 /**
  * #stateModel LinearComparativeView
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 function stateModelFactory(pluginManager: PluginManager) {
   return types

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
@@ -24,7 +24,8 @@ interface FeatPos {
 
 /**
  * #stateModel LinearSyntenyDisplay
- * extends `LinearComparativeDisplay` model
+ * extends
+ * - [LinearComparativeDisplay](../linearcomparativedisplay)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
@@ -36,7 +36,8 @@ export interface ExportSvgOptions {
 
 /**
  * #stateModel LinearSyntenyView
- * extends the `LinearComparativeView` base model
+ * extends
+ * - [LinearComparativeView](../linearcomparativeview)
  */
 export default function stateModelFactory(pluginManager: PluginManager) {
   return types
@@ -81,6 +82,9 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions(self => ({
+      /**
+       * #action
+       */
       async exportSvg(opts: ExportSvgOptions) {
         const { renderToSvg } = await import(
           './svgcomponents/SVGLinearSyntenyView'
@@ -148,6 +152,9 @@ export default function stateModelFactory(pluginManager: PluginManager) {
             },
           ]
         },
+        /**
+         * #method
+         */
         menuItems() {
           return [
             ...superMenuItems(),

--- a/plugins/linear-comparative-view/src/SyntenyTrack/configSchema.ts
+++ b/plugins/linear-comparative-view/src/SyntenyTrack/configSchema.ts
@@ -5,6 +5,8 @@ import PluginManager from '@jbrowse/core/PluginManager'
 
 /**
  * #config SyntenyTrack
+ * extends
+ * - [BaseTrack](../basetrack)
  */
 function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -50,7 +50,14 @@ export interface ExportSvgDisplayOptions extends ExportSvgOptions {
 /**
  * #stateModel BaseLinearDisplay
  * #category display
- * extends `BaseDisplay`
+ *
+ * BaseLinearDisplay is used as the basis for many linear genome view tracks.
+ * It is block based, and can use 'static blocks' or 'dynamic blocks'
+ *
+ * extends
+ * - [BaseDisplay](../basedisplay)
+ * - [TrackHeightMixin](../trackheightmixin)
+ * - [FeatureDensityMixin](../featuredensitymixin)
  */
 function stateModelFactory() {
   return types

--- a/plugins/linear-genome-view/src/LinearBareDisplay/model.ts
+++ b/plugins/linear-genome-view/src/LinearBareDisplay/model.ts
@@ -9,7 +9,8 @@ import { BaseLinearDisplay } from '../BaseLinearDisplay'
 /**
  * #stateModel LinearBareDisplay
  * #category display
- * extends `BaseLinearDisplay`
+ * extends
+ * - [BaseLinearDisplay](../baselineardisplay)
  */
 export function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
@@ -21,6 +21,9 @@ const SetMaxHeightDlg = lazy(() => import('./components/SetMaxHeight'))
  * #category display
  * used by `FeatureTrack`, has simple settings like "show/hide feature labels",
  * etc.
+ *
+ * extends
+ * - [BaseLinearDisplay](../baselineardisplay)
  */
 function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
   return types

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -131,6 +131,9 @@ export const WIDGET_HEIGHT = 32
 /**
  * #stateModel LinearGenomeView
  * #category view
+ *
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 export function stateModelFactory(pluginManager: PluginManager) {
   return types

--- a/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
+++ b/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts
@@ -24,7 +24,12 @@ import {
 /**
  * #stateModel SvInspectorView
  * #category view
- * combination of a spreadsheetview and a circularview
+ * does not extend, but is a combination of a
+ * - [SpreadsheetView](../spreadsheetview)
+ * - [CircularView](../circularview)
+ *
+ * extends
+ * - [BaseViewModel](../baseviewmodel)
  */
 function SvInspectorViewF(pluginManager: PluginManager) {
   const SpreadsheetViewType = pluginManager.getViewType('SpreadsheetView')

--- a/plugins/variants/src/ChordVariantDisplay/models/stateModelFactory.ts
+++ b/plugins/variants/src/ChordVariantDisplay/models/stateModelFactory.ts
@@ -12,7 +12,8 @@ import { getParentRenderProps } from '@jbrowse/core/util/tracks'
 
 /**
  * #stateModel ChordVariantDisplay
- * extends `BaseChordDisplay`
+ * extends
+ * - [BaseChordDisplay](../basechorddisplay)
  */
 const stateModelFactory = (configSchema: AnyConfigurationSchemaType) => {
   return types

--- a/plugins/variants/src/LinearVariantDisplay/model.ts
+++ b/plugins/variants/src/LinearVariantDisplay/model.ts
@@ -14,8 +14,10 @@ import { AnyConfigurationSchemaType } from '@jbrowse/core/configuration'
 
 /**
  * #stateModel LinearVariantDisplay
- * extends `LinearBasicDisplay`
- * very similar to basic display, but provides custom widget on feature click
+ * similar to basic display, but provides custom widget on feature click
+ * extends
+ *
+ * - [LinearBasicDisplay](../linearbasicdisplay)
  */
 export default function stateModelFactory(
   configSchema: AnyConfigurationSchemaType,

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts
@@ -7,6 +7,8 @@ import sharedWiggleConfigFactory from '../../shared/configShared'
 
 /**
  * #config LinearWiggleDisplay
+ * extends
+ * - [SharedWiggleDisplay](../sharedwiggledisplay)
  */
 export default function WiggleConfigFactory(pluginManager: PluginManager) {
   const XYPlotRendererConfigSchema =

--- a/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts
@@ -31,7 +31,8 @@ const rendererTypes = new Map([
 
 /**
  * #stateModel LinearWiggleDisplay
- * extends `SharedWiggleMixin`
+ * extends
+ * - [SharedWiggleMixin](../sharedwigglemixin)
  */
 function stateModelFactory(
   pluginManager: PluginManager,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts
@@ -7,6 +7,8 @@ import sharedWiggleConfigFactory from '../../shared/configShared'
 
 /**
  * #config MultiLinearWiggleDisplay
+ * extends
+ * - [SharedWiggleDisplay](../sharedwiggledisplay)
  */
 function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts
@@ -48,7 +48,8 @@ interface Source {
 
 /**
  * #stateModel MultiLinearWiggleDisplay
- * extends `SharedWiggleMixin`
+ * extends
+ * - [SharedWiggleMixin](../sharedwigglemixin)
  */
 export function stateModelFactory(
   pluginManager: PluginManager,

--- a/plugins/wiggle/src/shared/configShared.ts
+++ b/plugins/wiggle/src/shared/configShared.ts
@@ -4,10 +4,12 @@ import { types } from 'mobx-state-tree'
 
 /**
  * #config SharedWiggleDisplay
+ * extends
+ * - [BaseLinearDisplay](../baselineardisplay)
  */
 export default function sharedWiggleConfigFactory() {
   return ConfigurationSchema(
-    'MultiLinearWiggleDisplay',
+    'SharedWiggleDisplay',
     {
       /**
        * #slot

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -105,13 +105,13 @@
     "use-query-params": "^2.0.0"
   },
   "devDependencies": {
-    "electron": "27.1.2"
+    "electron": "27.1.3"
   },
   "browserslist": [
     "last 1 chrome version"
   ],
   "build": {
-    "electronVersion": "27.1.2",
+    "electronVersion": "27.1.3",
     "extraMetadata": {
       "main": "build/electron.js"
     },

--- a/products/jbrowse-desktop/src/rootModel/index.ts
+++ b/products/jbrowse-desktop/src/rootModel/index.ts
@@ -29,12 +29,12 @@ type SessionModelFactory = (args: {
  * #stateModel JBrowseDesktopRootModel
  * #category root
  * composed of
- * - BaseRootModel
- * - InternetAccountsMixin
- * - DesktopMenuMixin
- * - DesktopSessionManagementMixin
- * - HistoryManagementMixin
- * - RootAppMenuMixin
+ * - [BaseRootModel](../baserootmodel)
+ * - [InternetAccountsMixin](../internetaccountsmixin)
+ * - [DesktopMenusMixin](../desktopmenusmixin)
+ * - [DesktopSessionManagementMixin](../desktopsessionmanagementmixin)
+ * - [HistoryManagementMixin](../historymanagementmixin)
+ * - [RootAppMenuMixin](../rootappmenumixin)
  *
  * note: many properties of the root model are available through the session,
  * and we generally prefer using the session model (via e.g. getSession) over

--- a/products/jbrowse-desktop/src/sessionModel/DesktopSession.ts
+++ b/products/jbrowse-desktop/src/sessionModel/DesktopSession.ts
@@ -5,6 +5,7 @@ import { BaseSessionModel } from '@jbrowse/product-core'
 /**
  * #stateModel DesktopSessionModel
  * #category session
+ * extends [BaseSessionModel](../basesessionmodel)
  */
 export function DesktopSessionFactory(pluginManager: PluginManager) {
   return BaseSessionModel(pluginManager)

--- a/products/jbrowse-react-app/src/rootModel/index.ts
+++ b/products/jbrowse-react-app/src/rootModel/index.ts
@@ -52,8 +52,9 @@ type SessionModelFactory = (args: {
  * #stateModel JBrowseReactAppRootModel
  *
  * composed of
- * - BaseRootModelFactory
- * - InternetAccountsMixin
+ * - [BaseRootModel](../baserootmodel)
+ * - [InternetAccountsMixin](../internetaccountsmixin)
+ * - [RootAppMenuMixin](../rootappmenumixin)
  *
  * note: many properties of the root model are available through the session,
  * and we generally prefer using the session model (via e.g. getSession) over

--- a/products/jbrowse-react-app/src/sessionModel/index.ts
+++ b/products/jbrowse-react-app/src/sessionModel/index.ts
@@ -7,15 +7,7 @@ import { BaseAssemblyConfigSchema } from '@jbrowse/core/assemblyManager'
 /**
  * #stateModel JBrowseWebSessionModel
  * composed of
- * - SnackbarModel
- * - JBrowseWebSessionConnectionsModel
- * - JBrowseWebSessionAssembliesModel
- * - ReferenceManagementSessionMixin
- * - DrawerWidgetSessionMixin
- * - DialogQueueSessionMixin
- * - ThemeManagerSessionMixin
- * - MultipleViewsSessionMixin
- * - SessionTracksManagerSessionMixin
+ * - [BaseWebSession](../basewebsession)
  */
 export default function sessionModelFactory({
   pluginManager,

--- a/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-circular-genome-view/src/createModel/createSessionModel.ts
@@ -20,13 +20,13 @@ const AboutDialog = lazy(() => import('./AboutDialog'))
 /**
  * #stateModel JBrowseReactCircularGenomeViewSessionModel
  * composed of
- * - BaseSessionModel
- * - DrawerWidgetSessionMixin
- * - ConnectionManagementSessionMixin
- * - DialogQueueSessionMixin
- * - TracksManagerSessionMixin
- * - ReferenceManagementSessionMixin
- * - SnackbarModel
+ * - [BaseSessionModel](../basesessionmodel)
+ * - [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+ * - [ConnectionManagementSessionMixin](../connectionmanagementsessionmixin)
+ * - [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+ * - [TracksManagerSessionMixin](../tracksmanagersessionmixin)
+ * - [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+ * - [SnackbarModel](../snackbarmodel)
  */
 export default function sessionModelFactory(pluginManager: PluginManager) {
   const model = types

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -22,14 +22,14 @@ const AboutDialog = lazy(() => import('./AboutDialog'))
 /**
  * #stateModel JBrowseReactLinearGenomeViewSessionModel
  * composed of
- * - [BaseSessionModel](../BaseSessionModel)
- * - DrawerWidgetsSessionMixin
- * - ConnectionManagementSessionMixin
- * - DialogQueueSessionMixin
- * - TracksManagerSessionMixin
- * - ReferenceManagementSessionMixin
- * - SessionTracksManagerSessionMixin
- * - SnackbarModel
+ * - [BaseSessionModel](../basesessionmodel)
+ * - [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+ * - [ConnectionManagementSessionMixin](../connectionmanagementsessionmixin)
+ * - [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+ * - [TracksManagerSessionMixin](../tracksmanagersessionmixin)
+ * - [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+ * - [SessionTracksManagerSessionMixin](../sessiontracksmanagersessionmixin)
+ * - [SnackbarModel](../snackbarmodel)
  */
 function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createModel/createSessionModel.ts
@@ -22,7 +22,7 @@ const AboutDialog = lazy(() => import('./AboutDialog'))
 /**
  * #stateModel JBrowseReactLinearGenomeViewSessionModel
  * composed of
- * - BaseSessionModel
+ * - [BaseSessionModel](../BaseSessionModel)
  * - DrawerWidgetsSessionMixin
  * - ConnectionManagementSessionMixin
  * - DialogQueueSessionMixin
@@ -31,6 +31,8 @@ const AboutDialog = lazy(() => import('./AboutDialog'))
  * - SessionTracksManagerSessionMixin
  * - SnackbarModel
  */
+function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
+
 export default function sessionModelFactory(pluginManager: PluginManager) {
   const model = types
     .compose(

--- a/products/jbrowse-web/src/sessionModel/index.ts
+++ b/products/jbrowse-web/src/sessionModel/index.ts
@@ -6,19 +6,7 @@ import { BaseWebSession } from '@jbrowse/web-core'
 
 /**
  * #stateModel JBrowseWebSessionModel
- * composed of
- * - SnackbarModel
- * - ReferenceManagementSessionMixin
- * - DrawerWidgetSessionMixin
- * - DialogQueueSessionMixin
- * - ThemeManagerSessionMixin
- * - MultipleViewsSessionMixin
- * - SessionTracksManagerSessionMixin
- * - SessionAssembliesMixin
- * - TemporaryAssembliesMixin
- * - WebSessionConnectionsMixin
- * - AppFocusMixin
- *
+ * extends BaseWebSession
  */
 export default function sessionModelFactory({
   pluginManager,

--- a/products/jbrowse-web/src/sessionModel/index.ts
+++ b/products/jbrowse-web/src/sessionModel/index.ts
@@ -6,7 +6,7 @@ import { BaseWebSession } from '@jbrowse/web-core'
 
 /**
  * #stateModel JBrowseWebSessionModel
- * extends BaseWebSession
+ * extends [BaseWebSession](../basewebsession)
  */
 export default function sessionModelFactory({
   pluginManager,

--- a/website/docs/config/JBrowseRootConfig.md
+++ b/website/docs/config/JBrowseRootConfig.md
@@ -10,7 +10,21 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [packages/app-core/src/JBrowseConfig/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/app-core/src/JBrowseConfig/index.ts)
 
-configuration in a config.json/file.jbrowse
+this is a config model representing a config.json (for jbrowse-web) or
+somefile.jbrowse (for jbrowse-desktop, where configs have the .jbrowse
+extension)
+
+includes
+
+- [FormatDetails](../formatdetails) for global (instead of per-track) feature
+  detail formatters
+- [FormatAbout](../formatabout) for global (instead of per-track) about track
+  formatters
+- [HierarchicalConfigSchema](../hierarchicalconfigschema) for track selector
+  configs
+
+also includes any pluginManager.pluginConfigurationSchemas(), so plugins that
+have a configurationSchema field on their class are mixed into this object
 
 ### JBrowseRootConfig - Slots
 
@@ -112,6 +126,9 @@ internetAccounts: types.array(
 
 #### slot: aggregateTextSearchAdapters
 
+configuration for aggregate text search adapters (created by e.g. jbrowse
+text-index, but can be a pluggable TextSearchAdapter type)
+
 ```js
 aggregateTextSearchAdapters: types.array(
   pluginManager.pluggableConfigSchemaType('text search adapter'),
@@ -119,6 +136,8 @@ aggregateTextSearchAdapters: types.array(
 ```
 
 #### slot: connections
+
+configuration for connections
 
 ```js
 connections: types.array(pluginManager.pluggableConfigSchemaType('connection'))

--- a/website/docs/config/LGVSyntenyDisplay.md
+++ b/website/docs/config/LGVSyntenyDisplay.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts)
 
+extends config
+
+- [LinearPileupDisplay](../linearpileupdisplay)
+
 ### LGVSyntenyDisplay - Derives from
 
 ```js

--- a/website/docs/config/LinearSNPCoverageDisplay.md
+++ b/website/docs/config/LinearSNPCoverageDisplay.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts)
 
+extends
+
+- [BaseLinearDisplay](../baselineardisplay)
+
 ### LinearSNPCoverageDisplay - Slots
 
 #### slot: autoscale

--- a/website/docs/config/LinearWiggleDisplay.md
+++ b/website/docs/config/LinearWiggleDisplay.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts)
 
+extends
+
+- [SharedWiggleDisplay](../sharedwiggledisplay)
+
 ### LinearWiggleDisplay - Slots
 
 #### slot: defaultRendering

--- a/website/docs/config/MultiLinearWiggleDisplay.md
+++ b/website/docs/config/MultiLinearWiggleDisplay.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts)
 
+extends
+
+- [SharedWiggleDisplay](../sharedwiggledisplay)
+
 ### MultiLinearWiggleDisplay - Slots
 
 #### slot: defaultRendering

--- a/website/docs/config/SharedWiggleDisplay.md
+++ b/website/docs/config/SharedWiggleDisplay.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/wiggle/src/shared/configShared.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/shared/configShared.ts)
 
+extends
+
+- [BaseLinearDisplay](../baselineardisplay)
+
 ### SharedWiggleDisplay - Slots
 
 #### slot: autoscale

--- a/website/docs/config/SyntenyTrack.md
+++ b/website/docs/config/SyntenyTrack.md
@@ -10,6 +10,10 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 [plugins/linear-comparative-view/src/SyntenyTrack/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/SyntenyTrack/configSchema.ts)
 
+extends
+
+- [BaseTrack](../basetrack)
+
 ### SyntenyTrack - Derives from
 
 ```js

--- a/website/docs/models/AppCoreJBrowseModel.md
+++ b/website/docs/models/AppCoreJBrowseModel.md
@@ -1,0 +1,117 @@
+---
+id: appcorejbrowsemodel
+title: AppCoreJBrowseModel
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+### Source file
+
+[packages/app-core/src/JBrowseModel/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/app-core/src/JBrowseModel/index.ts)
+
+note that JBrowseRootConfig is a config model, but config models are MST trees
+themselves, which is why this stateModel is allowed to extend it
+
+the AppCoreJBrowseModel is generally on a property named rootModel.jbrowse
+
+extends
+
+- [JBrowseRootConfig](/docs/config/jbrowserootconfig)
+
+### AppCoreJBrowseModel - Getters
+
+#### getter: assemblyNames
+
+```js
+// type
+string[]
+```
+
+#### getter: rpcManager
+
+```js
+// type
+RpcManager
+```
+
+### AppCoreJBrowseModel - Actions
+
+#### action: addAssemblyConf
+
+```js
+// type signature
+addAssemblyConf: (conf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => { ...; } & ... 2 more ... & IStateTreeNode<...>
+```
+
+#### action: removeAssemblyConf
+
+```js
+// type signature
+removeAssemblyConf: (assemblyName: string) => void
+```
+
+#### action: addTrackConf
+
+```js
+// type signature
+addTrackConf: (trackConf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => any
+```
+
+#### action: addConnectionConf
+
+```js
+// type signature
+addConnectionConf: (connectionConf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => any
+```
+
+#### action: deleteConnectionConf
+
+```js
+// type signature
+deleteConnectionConf: (configuration: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => boolean
+```
+
+#### action: deleteTrackConf
+
+```js
+// type signature
+deleteTrackConf: (trackConf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => boolean
+```
+
+#### action: addPlugin
+
+```js
+// type signature
+addPlugin: (pluginDefinition: PluginDefinition) => void
+```
+
+#### action: removePlugin
+
+```js
+// type signature
+removePlugin: (pluginDefinition: PluginDefinition) => void
+```
+
+#### action: setDefaultSessionConf
+
+```js
+// type signature
+setDefaultSessionConf: (sessionConf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => void
+```
+
+#### action: addInternetAccountConf
+
+```js
+// type signature
+addInternetAccountConf: (internetAccountConf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => any
+```
+
+#### action: deleteInternetAccountConf
+
+```js
+// type signature
+deleteInternetAccountConf: (configuration: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => boolean
+```

--- a/website/docs/models/AppFocusMixin.md
+++ b/website/docs/models/AppFocusMixin.md
@@ -24,3 +24,12 @@ IMaybe<ISimpleType<string>>
 // code
 focusedViewId: types.maybe(types.string)
 ```
+
+### AppFocusMixin - Actions
+
+#### action: setFocusedViewId
+
+```js
+// type signature
+setFocusedViewId: (viewId: string) => void
+```

--- a/website/docs/models/BaseChordDisplay.md
+++ b/website/docs/models/BaseChordDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/circular-view/src/BaseChordDisplay/models/model.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/circular-view/src/BaseChordDisplay/models/model.tsx)
 
-extends `BaseDisplay`
+extends
+
+- [BaseDisplay](../basedisplay)
 
 ### BaseChordDisplay - Properties
 

--- a/website/docs/models/BaseLinearDisplay.md
+++ b/website/docs/models/BaseLinearDisplay.md
@@ -12,7 +12,14 @@ info
 
 [plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx)
 
-extends `BaseDisplay`
+BaseLinearDisplay is used as the basis for many linear genome view tracks. It is
+block based, and can use 'static blocks' or 'dynamic blocks'
+
+extends
+
+- [BaseDisplay](../basedisplay)
+- [TrackHeightMixin](../trackheightmixin)
+- [FeatureDensityMixin](../featuredensitymixin)
 
 ### BaseLinearDisplay - Properties
 

--- a/website/docs/models/BaseSessionModel.md
+++ b/website/docs/models/BaseSessionModel.md
@@ -12,8 +12,8 @@ info
 
 [packages/product-core/src/Session/BaseSession.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/product-core/src/Session/BaseSession.ts)
 
-base session shared by **all** JBrowse products. Be careful what you include
-here, everything will use it.
+base session shared by all JBrowse products. Be careful what you include here,
+everything will use it.
 
 ### BaseSessionModel - Properties
 
@@ -45,6 +45,13 @@ margin: 0
 ```
 
 ### BaseSessionModel - Getters
+
+#### getter: root
+
+```js
+// type
+TypeOrStateTreeNodeToStateTreeNode<ROOT_MODEL_TYPE>
+```
 
 #### getter: jbrowse
 

--- a/website/docs/models/BaseWebSession.md
+++ b/website/docs/models/BaseWebSession.md
@@ -1,0 +1,274 @@
+---
+id: basewebsession
+title: BaseWebSession
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+### Source file
+
+[packages/web-core/src/BaseWebSession/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/web-core/src/BaseWebSession/index.ts)
+
+used for "web based" products, including jbrowse-web and react-app extends
+
+- ReferenceManagementSessionMixin
+- DrawerWidgetSessionMixin
+- DialogQueueSessionMixin
+- ThemeManagerSessionMixin
+- MultipleViewsSessionMixin
+- SessionTracksManagerSessionMixin
+- SessionAssembliesMixin
+- TemporaryAssembliesMixin
+- WebSessionConnectionsMixin
+- AppFocusMixin
+
+### BaseWebSession - Properties
+
+#### property: margin
+
+```js
+// type signature
+number
+// code
+margin: 0
+```
+
+#### property: sessionPlugins
+
+```js
+// type signature
+IArrayType<IType<any, any, any>>
+// code
+sessionPlugins: types.array(types.frozen())
+```
+
+### BaseWebSession - Getters
+
+#### getter: tracks
+
+```js
+// type
+({ [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>)[]
+```
+
+#### getter: root
+
+```js
+// type
+any
+```
+
+#### getter: assemblies
+
+list of sessionAssemblies and jbrowse config assemblies, does not include
+temporaryAssemblies. basically the list to be displayed in a AssemblySelector
+dropdown
+
+```js
+// type
+ConfigurationSchemaType<{ aliases: { type: string; defaultValue: any[]; description: string; }; sequence: AnyConfigurationSchemaType; refNameColors: { type: string; defaultValue: any[]; description: string; }; refNameAliases: ConfigurationSchemaType<...>; cytobands: ConfigurationSchemaType<...>; displayName: { ...; ...
+```
+
+#### getter: connections
+
+list of config connections and session connections
+
+```js
+// type
+({ [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<ConfigurationSchemaType<{ name: { type: string; defaultValue: string; description: string; }; assemblyNames: { ...; }; }, ConfigurationSchemaOptions<...>>>)[]
+```
+
+#### getter: assemblyNames
+
+list of sessionAssemblies and jbrowse config assemblies, does not include
+temporaryAssemblies. basically the list to be displayed in a AssemblySelector
+dropdown
+
+```js
+// type
+string[]
+```
+
+#### getter: version
+
+```js
+// type
+any
+```
+
+#### getter: shareURL
+
+```js
+// type
+any
+```
+
+#### getter: textSearchManager
+
+```js
+// type
+TextSearchManager
+```
+
+#### getter: assemblyManager
+
+```js
+// type
+{ assemblies: IMSTArray<IModelType<{ configuration: IMaybe<IReferenceType<IAnyType>>; }, { error: unknown; loaded: boolean; loadingP: Promise<void>; volatileRegions: BasicRegion[]; refNameAliases: RefNameAliases; lowerCaseRefNameAliases: RefNameAliases; cytobands: Feature[]; } & ... 5 more ... & { ...; }, _NotCustom...
+```
+
+#### getter: savedSessions
+
+```js
+// type
+any
+```
+
+#### getter: previousAutosaveId
+
+```js
+// type
+any
+```
+
+#### getter: savedSessionNames
+
+```js
+// type
+any
+```
+
+#### getter: history
+
+```js
+// type
+any
+```
+
+#### getter: menus
+
+```js
+// type
+any
+```
+
+### BaseWebSession - Methods
+
+#### method: renderProps
+
+```js
+// type signature
+renderProps: () => {
+  theme: Theme
+}
+```
+
+#### method: getTrackActionMenuItems
+
+```js
+// type signature
+getTrackActionMenuItems: (config: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<ConfigurationSchemaType<{ name: { description: string; type: string; defaultValue: string; }; ... 8 more ...; formatAbout: ConfigurationSchemaType<...>; }, ConfigurationSchemaOptions<...>>>) => ...
+```
+
+### BaseWebSession - Actions
+
+#### action: setName
+
+```js
+// type signature
+setName: (str: string) => void
+```
+
+#### action: addAssemblyConf
+
+```js
+// type signature
+addAssemblyConf: (conf: AnyConfiguration) => void
+```
+
+#### action: addSessionPlugin
+
+```js
+// type signature
+addSessionPlugin: (plugin: JBrowsePlugin) => void
+```
+
+#### action: removeSessionPlugin
+
+```js
+// type signature
+removeSessionPlugin: (pluginDefinition: PluginDefinition) => void
+```
+
+#### action: addSavedSession
+
+```js
+// type signature
+addSavedSession: (sessionSnapshot: ModelCreationType<ExtractCFromProps<{ drawerPosition: IOptionalIType<ISimpleType<string>, [undefined]>; drawerWidth: IOptionalIType<ISimpleType<number>, [undefined]>; widgets: IMapType<...>; activeWidgets: IMapType<...>; minimized: IOptionalIType<...>; } & ... 8 more ... & { ...; }>>) => any
+```
+
+#### action: removeSavedSession
+
+```js
+// type signature
+removeSavedSession: (sessionSnapshot: { name: string; }) => any
+```
+
+#### action: renameCurrentSession
+
+```js
+// type signature
+renameCurrentSession: (sessionName: string) => any
+```
+
+#### action: duplicateCurrentSession
+
+```js
+// type signature
+duplicateCurrentSession: () => any
+```
+
+#### action: activateSession
+
+```js
+// type signature
+activateSession: (sessionName: string) => any
+```
+
+#### action: setDefaultSession
+
+```js
+// type signature
+setDefaultSession: () => any
+```
+
+#### action: saveSessionToLocalStorage
+
+```js
+// type signature
+saveSessionToLocalStorage: () => any
+```
+
+#### action: loadAutosaveSession
+
+```js
+// type signature
+loadAutosaveSession: () => any
+```
+
+#### action: setSession
+
+```js
+// type signature
+setSession: (sessionSnapshot: ModelCreationType<ExtractCFromProps<{ drawerPosition: IOptionalIType<ISimpleType<string>, [undefined]>; drawerWidth: IOptionalIType<ISimpleType<number>, [undefined]>; widgets: IMapType<...>; activeWidgets: IMapType<...>; minimized: IOptionalIType<...>; } & ... 8 more ... & { ...; }>>) => any
+```
+
+#### action: editTrackConfiguration
+
+```js
+// type signature
+editTrackConfiguration: (configuration: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotName: string, data: unknown): any; } & IStateTreeNode<AnyConfigurationSchemaType>) => void
+```

--- a/website/docs/models/BaseWebSession.md
+++ b/website/docs/models/BaseWebSession.md
@@ -12,18 +12,18 @@ info
 
 [packages/web-core/src/BaseWebSession/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/web-core/src/BaseWebSession/index.ts)
 
-used for "web based" products, including jbrowse-web and react-app extends
+used for "web based" products, including jbrowse-web and react-app composed of
 
-- ReferenceManagementSessionMixin
-- DrawerWidgetSessionMixin
-- DialogQueueSessionMixin
-- ThemeManagerSessionMixin
-- MultipleViewsSessionMixin
-- SessionTracksManagerSessionMixin
-- SessionAssembliesMixin
-- TemporaryAssembliesMixin
-- WebSessionConnectionsMixin
-- AppFocusMixin
+- [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+- [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+- [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+- [ThemeManagerSessionMixin](../thememanagersessionmixin)
+- [MultipleViewsSessionMixin](../multipleviewssessionmixin)
+- [SessionTracksManagerSessionMixin](../sessiontracksmanagersessionmixin)
+- [SessionAssembliesMixin](../sessionassembliesmixin)
+- [TemporaryAssembliesMixin](../temporaryassembliesmixin)
+- [WebSessionConnectionsMixin](../websessionconnectionsmixin)
+- [AppFocusMixin](../appfocusmixin)
 
 ### BaseWebSession - Properties
 

--- a/website/docs/models/BreakpointSplitView.md
+++ b/website/docs/models/BreakpointSplitView.md
@@ -12,6 +12,10 @@ info
 
 [plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts)
 
+extends
+
+- [BaseViewModel](../baseviewmodel)
+
 ### BreakpointSplitView - Properties
 
 #### property: type

--- a/website/docs/models/CircularView.md
+++ b/website/docs/models/CircularView.md
@@ -12,7 +12,9 @@ info
 
 [plugins/circular-view/src/CircularView/models/CircularView.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/circular-view/src/CircularView/models/CircularView.ts)
 
-extends `BaseViewModel`
+extends
+
+- [BaseViewModel](../baseviewmodel)
 
 ### CircularView - Properties
 

--- a/website/docs/models/DesktopSessionModel.md
+++ b/website/docs/models/DesktopSessionModel.md
@@ -12,6 +12,8 @@ info
 
 [products/jbrowse-desktop/src/sessionModel/DesktopSession.ts](https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-desktop/src/sessionModel/DesktopSession.ts)
 
+extends [BaseSessionModel](../basesessionmodel)
+
 ### DesktopSessionModel - Properties
 
 #### property: margin

--- a/website/docs/models/DotplotView.md
+++ b/website/docs/models/DotplotView.md
@@ -12,7 +12,9 @@ info
 
 [plugins/dotplot-view/src/DotplotView/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/dotplot-view/src/DotplotView/model.ts)
 
-extends `BaseViewModel`
+extends
+
+- [BaseViewModel](../baseviewmodel)
 
 ### DotplotView - Properties
 

--- a/website/docs/models/JBrowseDesktopRootModel.md
+++ b/website/docs/models/JBrowseDesktopRootModel.md
@@ -14,12 +14,12 @@ info
 
 composed of
 
-- BaseRootModel
-- InternetAccountsMixin
-- DesktopMenuMixin
-- DesktopSessionManagementMixin
-- HistoryManagementMixin
-- RootAppMenuMixin
+- [BaseRootModel](../baserootmodel)
+- [InternetAccountsMixin](../internetaccountsmixin)
+- [DesktopMenusMixin](../desktopmenusmixin)
+- [DesktopSessionManagementMixin](../desktopsessionmanagementmixin)
+- [HistoryManagementMixin](../historymanagementmixin)
+- [RootAppMenuMixin](../rootappmenumixin)
 
 note: many properties of the root model are available through the session, and
 we generally prefer using the session model (via e.g. getSession) over the root

--- a/website/docs/models/JBrowseReactAppRootModel.md
+++ b/website/docs/models/JBrowseReactAppRootModel.md
@@ -14,8 +14,9 @@ info
 
 composed of
 
-- BaseRootModelFactory
-- InternetAccountsMixin
+- [BaseRootModel](../baserootmodel)
+- [InternetAccountsMixin](../internetaccountsmixin)
+- [RootAppMenuMixin](../rootappmenumixin)
 
 note: many properties of the root model are available through the session, and
 we generally prefer using the session model (via e.g. getSession) over the root

--- a/website/docs/models/JBrowseReactCircularGenomeViewSessionModel.md
+++ b/website/docs/models/JBrowseReactCircularGenomeViewSessionModel.md
@@ -14,13 +14,13 @@ info
 
 composed of
 
-- BaseSessionModel
-- DrawerWidgetSessionMixin
-- ConnectionManagementSessionMixin
-- DialogQueueSessionMixin
-- TracksManagerSessionMixin
-- ReferenceManagementSessionMixin
-- SnackbarModel
+- [BaseSessionModel](../basesessionmodel)
+- [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+- [ConnectionManagementSessionMixin](../connectionmanagementsessionmixin)
+- [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+- [TracksManagerSessionMixin](../tracksmanagersessionmixin)
+- [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+- [SnackbarModel](../snackbarmodel)
 
 ### JBrowseReactCircularGenomeViewSessionModel - Properties
 

--- a/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
+++ b/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
@@ -14,7 +14,7 @@ info
 
 composed of
 
-- [BaseSessionModel](../basesessionmodel)
+- [BaseSessionModel](../BaseSessionModel)
 - DrawerWidgetsSessionMixin
 - ConnectionManagementSessionMixin
 - DialogQueueSessionMixin

--- a/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
+++ b/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
@@ -14,14 +14,14 @@ info
 
 composed of
 
-- [BaseSessionModel](../BaseSessionModel)
-- DrawerWidgetsSessionMixin
-- ConnectionManagementSessionMixin
-- DialogQueueSessionMixin
-- TracksManagerSessionMixin
-- ReferenceManagementSessionMixin
-- SessionTracksManagerSessionMixin
-- SnackbarModel
+- [BaseSessionModel](../basesessionmodel)
+- [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+- [ConnectionManagementSessionMixin](../connectionmanagementsessionmixin)
+- [DialogQueueSessionMixin](../dialogqueuesessionmixin)
+- [TracksManagerSessionMixin](../tracksmanagersessionmixin)
+- [ReferenceManagementSessionMixin](../referencemanagementsessionmixin)
+- [SessionTracksManagerSessionMixin](../sessiontracksmanagersessionmixin)
+- [SnackbarModel](../snackbarmodel)
 
 ### JBrowseReactLinearGenomeViewSessionModel - Properties
 

--- a/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
+++ b/website/docs/models/JBrowseReactLinearGenomeViewSessionModel.md
@@ -14,7 +14,7 @@ info
 
 composed of
 
-- BaseSessionModel
+- [BaseSessionModel](../basesessionmodel)
 - DrawerWidgetsSessionMixin
 - ConnectionManagementSessionMixin
 - DialogQueueSessionMixin

--- a/website/docs/models/JBrowseWebSessionModel.md
+++ b/website/docs/models/JBrowseWebSessionModel.md
@@ -14,12 +14,4 @@ info
 
 composed of
 
-- SnackbarModel
-- JBrowseWebSessionConnectionsModel
-- JBrowseWebSessionAssembliesModel
-- ReferenceManagementSessionMixin
-- DrawerWidgetSessionMixin
-- DialogQueueSessionMixin
-- ThemeManagerSessionMixin
-- MultipleViewsSessionMixin
-- SessionTracksManagerSessionMixin
+- [BaseWebSession](../basewebsession)

--- a/website/docs/models/LGVSyntenyDisplay.md
+++ b/website/docs/models/LGVSyntenyDisplay.md
@@ -12,8 +12,12 @@ info
 
 [plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LGVSyntenyDisplay/model.ts)
 
-extends `LinearPileupDisplay`, displays location of "synteny" feature in a plain
-LGV, allowing linking out to external synteny views
+displays location of "synteny" feature in a plain LGV, allowing linking out to
+external synteny views
+
+extends
+
+- [SharedLinearPileupDisplayMixin](../sharedlinearpileupdisplaymixin)
 
 ### LGVSyntenyDisplay - Properties
 
@@ -33,4 +37,20 @@ type: types.literal('LGVSyntenyDisplay')
 AnyConfigurationSchemaType
 // code
 configuration: ConfigurationReference(schema)
+```
+
+### LGVSyntenyDisplay - Methods
+
+#### method: contextMenuItems
+
+```js
+// type signature
+contextMenuItems: () => MenuItem[]
+```
+
+#### method: trackMenuItems
+
+```js
+// type signature
+trackMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; })[]
 ```

--- a/website/docs/models/LinearAlignmentsDisplay.md
+++ b/website/docs/models/LinearAlignmentsDisplay.md
@@ -12,91 +12,21 @@ info
 
 [plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx)
 
-extends `BaseDisplay`
+extends
 
-### LinearAlignmentsDisplay - Properties
-
-#### property: PileupDisplay
-
-refers to LinearPileupDisplay sub-display model
-
-```js
-// type signature
-IMaybe<IAnyType>
-// code
-PileupDisplay: types.maybe(types.union(...lowerPanelDisplays))
-```
-
-#### property: SNPCoverageDisplay
-
-refers to LinearSNPCoverageDisplay sub-display model
-
-```js
-// type signature
-IMaybe<IAnyModelType>
-// code
-SNPCoverageDisplay: types.maybe(
-      pluginManager.getDisplayType('LinearSNPCoverageDisplay').stateModel,
-    )
-```
-
-#### property: snpCovHeight
-
-```js
-// type signature
-number
-// code
-snpCovHeight: 45
-```
-
-#### property: type
-
-```js
-// type signature
-ISimpleType<"LinearAlignmentsDisplay">
-// code
-type: types.literal('LinearAlignmentsDisplay')
-```
-
-#### property: configuration
-
-```js
-// type signature
-AnyConfigurationSchemaType
-// code
-configuration: ConfigurationReference(configSchema)
-```
-
-#### property: heightPreConfig
-
-```js
-// type signature
-IMaybe<ISimpleType<number>>
-// code
-heightPreConfig: types.maybe(types.number)
-```
-
-#### property: userFeatureScreenDensity
-
-```js
-// type signature
-IMaybe<ISimpleType<number>>
-// code
-userFeatureScreenDensity: types.maybe(types.number)
-```
-
-#### property: lowerPanelType
-
-```js
-// type signature
-string
-// code
-lowerPanelType: 'LinearPileupDisplay'
-```
+- [BaseDisplay](../basedisplay)
+- [LinearAlignmentsDisplayMixin](../linearalignmentsdisplaymixin)
 
 ### LinearAlignmentsDisplay - Getters
 
 #### getter: height
+
+```js
+// type
+any
+```
+
+#### getter: featureIdUnderMouse
 
 ```js
 // type

--- a/website/docs/models/LinearAlignmentsDisplayMixin.md
+++ b/website/docs/models/LinearAlignmentsDisplayMixin.md
@@ -1,0 +1,93 @@
+---
+id: linearalignmentsdisplaymixin
+title: LinearAlignmentsDisplayMixin
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+### Source file
+
+[plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx)
+
+### LinearAlignmentsDisplayMixin - Properties
+
+#### property: PileupDisplay
+
+refers to LinearPileupDisplay sub-display model
+
+```js
+// type signature
+IMaybe<IAnyType>
+// code
+PileupDisplay: types.maybe(types.union(...lowerPanelDisplays))
+```
+
+#### property: SNPCoverageDisplay
+
+refers to LinearSNPCoverageDisplay sub-display model
+
+```js
+// type signature
+IMaybe<IAnyModelType>
+// code
+SNPCoverageDisplay: types.maybe(
+      pluginManager.getDisplayType('LinearSNPCoverageDisplay').stateModel,
+    )
+```
+
+#### property: snpCovHeight
+
+```js
+// type signature
+number
+// code
+snpCovHeight: 45
+```
+
+#### property: type
+
+```js
+// type signature
+ISimpleType<"LinearAlignmentsDisplay">
+// code
+type: types.literal('LinearAlignmentsDisplay')
+```
+
+#### property: configuration
+
+```js
+// type signature
+AnyConfigurationSchemaType
+// code
+configuration: ConfigurationReference(configSchema)
+```
+
+#### property: heightPreConfig
+
+```js
+// type signature
+IMaybe<ISimpleType<number>>
+// code
+heightPreConfig: types.maybe(types.number)
+```
+
+#### property: userFeatureScreenDensity
+
+```js
+// type signature
+IMaybe<ISimpleType<number>>
+// code
+userFeatureScreenDensity: types.maybe(types.number)
+```
+
+#### property: lowerPanelType
+
+```js
+// type signature
+string
+// code
+lowerPanelType: 'LinearPileupDisplay'
+```

--- a/website/docs/models/LinearArcDisplay.md
+++ b/website/docs/models/LinearArcDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/arc/src/LinearArcDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/arc/src/LinearArcDisplay/model.ts)
 
-extends BaseLinearDisplay
+extends
+
+- [BaseLinearDisplay](../baselineardisplay)
 
 ### LinearArcDisplay - Properties
 

--- a/website/docs/models/LinearBareDisplay.md
+++ b/website/docs/models/LinearBareDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/linear-genome-view/src/LinearBareDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-genome-view/src/LinearBareDisplay/model.ts)
 
-extends `BaseLinearDisplay`
+extends
+
+- [BaseLinearDisplay](../baselineardisplay)
 
 ### LinearBareDisplay - Properties
 

--- a/website/docs/models/LinearBasicDisplay.md
+++ b/website/docs/models/LinearBasicDisplay.md
@@ -15,6 +15,10 @@ info
 used by `FeatureTrack`, has simple settings like "show/hide feature labels",
 etc.
 
+extends
+
+- [BaseLinearDisplay](../baselineardisplay)
+
 ### LinearBasicDisplay - Properties
 
 #### property: type

--- a/website/docs/models/LinearComparativeDisplay.md
+++ b/website/docs/models/LinearComparativeDisplay.md
@@ -12,6 +12,10 @@ info
 
 [plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts)
 
+extends
+
+- [BaseDisplay](../basedisplay)
+
 ### LinearComparativeDisplay - Properties
 
 #### property: type

--- a/website/docs/models/LinearComparativeView.md
+++ b/website/docs/models/LinearComparativeView.md
@@ -12,6 +12,10 @@ info
 
 [plugins/linear-comparative-view/src/LinearComparativeView/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LinearComparativeView/model.ts)
 
+extends
+
+- [BaseViewModel](../baseviewmodel)
+
 ### LinearComparativeView - Properties
 
 #### property: id

--- a/website/docs/models/LinearGenomeView.md
+++ b/website/docs/models/LinearGenomeView.md
@@ -12,6 +12,10 @@ info
 
 [plugins/linear-genome-view/src/LinearGenomeView/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-genome-view/src/LinearGenomeView/model.ts)
 
+extends
+
+- [BaseViewModel](../baseviewmodel)
+
 ### LinearGenomeView - Properties
 
 #### property: id

--- a/website/docs/models/LinearPairedArcDisplay.md
+++ b/website/docs/models/LinearPairedArcDisplay.md
@@ -12,7 +12,14 @@ info
 
 [plugins/arc/src/LinearPairedArcDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/arc/src/LinearPairedArcDisplay/model.ts)
 
-extends BaseDisplay, TrackHeightMixin, FeatureDensityMixin
+this is a non-block-based track type, and can connect arcs across multiple
+displayedRegions
+
+extends
+
+- [BaseDisplay](../basedisplay)
+- [TrackHeightMixin](../trackheightmixin)
+- [FeatureDensityMixin](../featuredensitymixin)
 
 ### LinearPairedArcDisplay - Properties
 

--- a/website/docs/models/LinearPileupDisplay.md
+++ b/website/docs/models/LinearPileupDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/alignments/src/LinearPileupDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearPileupDisplay/model.ts)
 
-extends `BaseLinearDisplay`
+extends
+
+- [SharedLinearPileupDisplayMixin](../sharedlinearpileupdisplaymixin)
 
 ### LinearPileupDisplay - Properties
 

--- a/website/docs/models/LinearReadArcsDisplay.md
+++ b/website/docs/models/LinearReadArcsDisplay.md
@@ -12,8 +12,12 @@ info
 
 [plugins/alignments/src/LinearReadArcsDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearReadArcsDisplay/model.ts)
 
-extends `BaseDisplay`, it is not a block based track, hence not
-BaseLinearDisplay
+the arc display is a non-block-based track, so draws to a single canvas and can
+connect multiple regions extends
+
+- [BaseDisplay](../basedisplay)
+- [TrackHeightMixin](../trackheightmixin)
+- [FeatureDensityMixin](../featuredensitymixin)
 
 ### LinearReadArcsDisplay - Properties
 

--- a/website/docs/models/LinearReadCloudDisplay.md
+++ b/website/docs/models/LinearReadCloudDisplay.md
@@ -12,8 +12,11 @@ info
 
 [plugins/alignments/src/LinearReadCloudDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearReadCloudDisplay/model.ts)
 
-extends `BaseDisplay`, it is not a block based track, hence not
-BaseLinearDisplay
+it is not a block based track, hence not BaseLinearDisplay extends
+
+- [BaseDisplay](../basedisplay)
+- [TrackHeightMixin](../trackheightmixin)
+- [FeatureDensityMixin](../featuredensitymixin)
 
 ### LinearReadCloudDisplay - Properties
 

--- a/website/docs/models/LinearSNPCoverageDisplay.md
+++ b/website/docs/models/LinearSNPCoverageDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts)
 
-extends `LinearWiggleDisplay`
+extends
+
+- [LinearWiggleDisplay](../linearwiggledisplay)
 
 ### LinearSNPCoverageDisplay - Properties
 

--- a/website/docs/models/LinearSyntenyDisplay.md
+++ b/website/docs/models/LinearSyntenyDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts)
 
-extends `LinearComparativeDisplay` model
+extends
+
+- [LinearComparativeDisplay](../linearcomparativedisplay)
 
 ### LinearSyntenyDisplay - Properties
 

--- a/website/docs/models/LinearSyntenyView.md
+++ b/website/docs/models/LinearSyntenyView.md
@@ -12,7 +12,9 @@ info
 
 [plugins/linear-comparative-view/src/LinearSyntenyView/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts)
 
-extends the `LinearComparativeView` base model
+extends
+
+- [LinearComparativeView](../linearcomparativeview)
 
 ### LinearSyntenyView - Properties
 
@@ -55,6 +57,13 @@ overwhelming
 headerMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; } | { ...; } | { ...; })[]
 ```
 
+#### method: menuItems
+
+```js
+// type signature
+menuItems: () => MenuItem[]
+```
+
 ### LinearSyntenyView - Actions
 
 #### action: toggleCurves
@@ -76,4 +85,11 @@ toggleCIGAR: () => void
 ```js
 // type signature
 showAllRegions: () => void
+```
+
+#### action: exportSvg
+
+```js
+// type signature
+exportSvg: (opts: ExportSvgOptions) => Promise<void>
 ```

--- a/website/docs/models/LinearVariantDisplay.md
+++ b/website/docs/models/LinearVariantDisplay.md
@@ -12,8 +12,9 @@ info
 
 [plugins/variants/src/LinearVariantDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/variants/src/LinearVariantDisplay/model.ts)
 
-extends `LinearBasicDisplay` very similar to basic display, but provides custom
-widget on feature click
+similar to basic display, but provides custom widget on feature click extends
+
+- [LinearBasicDisplay](../linearbasicdisplay)
 
 ### LinearVariantDisplay - Properties
 

--- a/website/docs/models/LinearWiggleDisplay.md
+++ b/website/docs/models/LinearWiggleDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/wiggle/src/LinearWiggleDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts)
 
-extends `SharedWiggleMixin`
+extends
+
+- [SharedWiggleMixin](../sharedwigglemixin)
 
 ### LinearWiggleDisplay - Properties
 

--- a/website/docs/models/MultiLinearWiggleDisplay.md
+++ b/website/docs/models/MultiLinearWiggleDisplay.md
@@ -12,7 +12,9 @@ info
 
 [plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts)
 
-extends `SharedWiggleMixin`
+extends
+
+- [SharedWiggleMixin](../sharedwigglemixin)
 
 ### MultiLinearWiggleDisplay - Properties
 

--- a/website/docs/models/MultipleViewsSessionMixin.md
+++ b/website/docs/models/MultipleViewsSessionMixin.md
@@ -12,6 +12,11 @@ info
 
 [packages/product-core/src/Session/MultipleViews.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/product-core/src/Session/MultipleViews.ts)
 
+composed of
+
+- [BaseSessionModel](../basesessionmodel)
+- [DrawerWidgetSessionMixin](../drawerwidgetsessionmixin)
+
 ### MultipleViewsSessionMixin - Properties
 
 #### property: views

--- a/website/docs/models/RootAppMenuMixin.md
+++ b/website/docs/models/RootAppMenuMixin.md
@@ -1,0 +1,76 @@
+---
+id: rootappmenumixin
+title: RootAppMenuMixin
+---
+
+Note: this document is automatically generated from mobx-state-tree objects in
+our source code. See
+[Core concepts and intro to pluggable elements](/docs/developer_guide/) for more
+info
+
+### Source file
+
+[packages/app-core/src/RootMenu/index.ts](https://github.com/GMOD/jbrowse-components/blob/main/packages/app-core/src/RootMenu/index.ts)
+
+### RootAppMenuMixin - Actions
+
+#### action: setMenus
+
+```js
+// type signature
+setMenus: (newMenus: Menu[]) => void
+```
+
+#### action: appendMenu
+
+Add a top-level menu
+
+```js
+// type signature
+appendMenu: (menuName: string) => number
+```
+
+#### action: insertMenu
+
+Insert a top-level menu
+
+```js
+// type signature
+insertMenu: (menuName: string, position: number) => number
+```
+
+#### action: appendToMenu
+
+Add a menu item to a top-level menu
+
+```js
+// type signature
+appendToMenu: (menuName: string, menuItem: MenuItem) => number
+```
+
+#### action: insertInMenu
+
+Insert a menu item into a top-level menu
+
+```js
+// type signature
+insertInMenu: (menuName: string, menuItem: MenuItem, position: number) => number
+```
+
+#### action: appendToSubMenu
+
+Add a menu item to a sub-menu
+
+```js
+// type signature
+appendToSubMenu: (menuPath: string[], menuItem: MenuItem) => number
+```
+
+#### action: insertInSubMenu
+
+Insert a menu item into a sub-menu
+
+```js
+// type signature
+insertInSubMenu: (menuPath: string[], menuItem: MenuItem, position: number) => number
+```

--- a/website/docs/models/SvInspectorView.md
+++ b/website/docs/models/SvInspectorView.md
@@ -12,7 +12,14 @@ info
 
 [plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/sv-inspector/src/SvInspectorView/models/SvInspectorView.ts)
 
-combination of a spreadsheetview and a circularview
+does not extend, but is a combination of a
+
+- [SpreadsheetView](../spreadsheetview)
+- [CircularView](../circularview)
+
+extends
+
+- [BaseViewModel](../baseviewmodel)
 
 ### SvInspectorView - Properties
 

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "@mdx-js/react": "^3.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.0",
+    "@swc/core": "^1.3.100",
     "acorn": "^8.8.2",
     "acorn-jsx": "^5.3.2",
     "clsx": "^2.0.0",
@@ -32,7 +33,8 @@
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-player": "^2.12.0"
+    "react-player": "^2.12.0",
+    "swc-loader": "^0.2.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,6 @@
     "@mdx-js/react": "^3.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.0",
-    "@swc/core": "^1.3.100",
     "acorn": "^8.8.2",
     "acorn-jsx": "^5.3.2",
     "clsx": "^2.0.0",
@@ -33,8 +32,7 @@
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-player": "^2.12.0",
-    "swc-loader": "^0.2.3"
+    "react-player": "^2.12.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.0",

--- a/website/src/components/MiniPlugins/index.tsx
+++ b/website/src/components/MiniPlugins/index.tsx
@@ -1,22 +1,18 @@
 import React from 'react'
 import pluginStyles from './styles.module.css'
-import {
-  Link,
-  Typography,
-  Card,
-  CardActions,
-  CardContent,
-  CardMedia,
-  Button,
-} from '@mui/material'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import Card from '@mui/material/Card'
+import CardActions from '@mui/material/CardActions'
+import CardMedia from '@mui/material/CardMedia'
+import CardContent from '@mui/material/CardContent'
+import Button from '@mui/material/Button'
 
-import {
-  Person,
-  AccountBalance,
-  GitHub,
-  Book,
-  Outbound,
-} from '@mui/icons-material'
+import Person from '@mui/icons-material/Person'
+import AccountBalance from '@mui/icons-material/AccountBalance'
+import GitHub from '@mui/icons-material/GitHub'
+import Book from '@mui/icons-material/Book'
+import Outbound from '@mui/icons-material/Outbound'
 
 const plugins = [
   {

--- a/website/src/pages/cancer.tsx
+++ b/website/src/pages/cancer.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Alert, AlertTitle } from '@mui/material'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
 import clsx from 'clsx'
 import Link from '@docusaurus/Link'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'

--- a/website/src/pages/download.mdx
+++ b/website/src/pages/download.mdx
@@ -1,6 +1,13 @@
 import config from '../../docusaurus.config.json'
-import { Button, Card, CardContent, Typography, Link, Box } from '@mui/material'
-import { Apple, DesktopWindows, ArrowDownward } from '@mui/icons-material'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
+import Link from '@mui/material/Link'
+import Box from '@mui/material/Box'
+import Apple from '@mui/icons-material/Apple'
+import DesktopWindows from '@mui/icons-material/DesktopWindows'
+import ArrowDownward from '@mui/icons-material/ArrowDownward'
 
 export const GithubLink = () => {
   const curr = `https://github.com/GMOD/jbrowse-components/releases/tag/${config.customFields.currentVersion}`

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,17 +2,13 @@ import React from 'react'
 import Layout from '@theme/Layout'
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
-import {
-  Link,
-  ThemeProvider,
-  Typography,
-  Button,
-  Box,
-  Alert,
-  createTheme,
-} from '@mui/material'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import Box from '@mui/material/Box'
 import GetAppIcon from '@mui/icons-material/GetApp'
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
 import GoogleCalendarScheduleFunction from './util'
 
 function Home() {

--- a/website/src/pages/plugin_store.tsx
+++ b/website/src/pages/plugin_store.tsx
@@ -4,32 +4,27 @@ import copy from 'copy-to-clipboard'
 import Layout from '@theme/Layout'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 
-import {
-  Link,
-  Typography,
-  Card,
-  CardActions,
-  CardContent,
-  CardMedia,
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  IconButton,
-  ThemeProvider,
-  createTheme,
-} from '@mui/material'
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import Card from '@mui/material/Card'
+import CardActions from '@mui/material/CardActions'
+import CardContent from '@mui/material/CardContent'
+import CardMedia from '@mui/material/CardMedia'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogTitle from '@mui/material/DialogTitle'
+import DialogContent from '@mui/material/DialogContent'
+import IconButton from '@mui/material/IconButton'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
 
-import {
-  Person,
-  AccountBalance,
-  GitHub,
-  Assignment,
-  AssignmentTurnedIn,
-  Help,
-  Code,
-  Close,
-} from '@mui/icons-material'
+import Person from '@mui/icons-material/Person'
+import AccountBalance from '@mui/icons-material/AccountBalance'
+import GitHub from '@mui/icons-material/GitHub'
+import Assignment from '@mui/icons-material/Assignment'
+import AssignmentTurnedIn from '@mui/icons-material/AssignmentTurnedIn'
+import Help from '@mui/icons-material/Help'
+import Code from '@mui/icons-material/Code'
+import Close from '@mui/icons-material/Close'
 
 import pluginJSON from '../../plugins.json'
 

--- a/website/src/pages/util.tsx
+++ b/website/src/pages/util.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-import { Typography, Button, Alert } from '@mui/material'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import Alert from '@mui/material/Alert'
 
 export default function GoogleCalendarScheduleFunction() {
   return (

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2231,79 +2231,6 @@
     "@svgr/plugin-jsx" "^6.5.1"
     "@svgr/plugin-svgo" "^6.5.1"
 
-"@swc/core-darwin-arm64@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.100.tgz#f582c5bbc9c49506f728fc1d14dff33c2cc226d5"
-  integrity sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==
-
-"@swc/core-darwin-x64@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.100.tgz#d84f5c0bb4603c252884d011a698ed7c634b1505"
-  integrity sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==
-
-"@swc/core-linux-arm64-gnu@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.100.tgz#1ed4b92b373882d8f338c4e0a0aa64cdaa6106f1"
-  integrity sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==
-
-"@swc/core-linux-arm64-musl@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.100.tgz#9db560f7459e42e65ec02670d6a8316e7c850cfc"
-  integrity sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==
-
-"@swc/core-linux-x64-gnu@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.100.tgz#228826ea48879bf1e73683fbef4373e3e762e424"
-  integrity sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==
-
-"@swc/core-linux-x64-musl@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.100.tgz#09a234dbbf625d071ecb663680e997a62d230d49"
-  integrity sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==
-
-"@swc/core-win32-arm64-msvc@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.100.tgz#add1c82884c10a9054ed6a48f884097aa85c6d2b"
-  integrity sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==
-
-"@swc/core-win32-ia32-msvc@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.100.tgz#e0b6c5ae7f3250adeeb88dae83558d3f45148c56"
-  integrity sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==
-
-"@swc/core-win32-x64-msvc@1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.100.tgz#34721dff151d7dcf165675f18aeed0a12264d88c"
-  integrity sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==
-
-"@swc/core@^1.3.100":
-  version "1.3.100"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.100.tgz#8fa36f26a35137620234b084224c9fa9b8a0fee2"
-  integrity sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==
-  dependencies:
-    "@swc/counter" "^0.1.1"
-    "@swc/types" "^0.1.5"
-  optionalDependencies:
-    "@swc/core-darwin-arm64" "1.3.100"
-    "@swc/core-darwin-x64" "1.3.100"
-    "@swc/core-linux-arm64-gnu" "1.3.100"
-    "@swc/core-linux-arm64-musl" "1.3.100"
-    "@swc/core-linux-x64-gnu" "1.3.100"
-    "@swc/core-linux-x64-musl" "1.3.100"
-    "@swc/core-win32-arm64-msvc" "1.3.100"
-    "@swc/core-win32-ia32-msvc" "1.3.100"
-    "@swc/core-win32-x64-msvc" "1.3.100"
-
-"@swc/counter@^0.1.1":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.2.tgz#bf06d0770e47c6f1102270b744e17b934586985e"
-  integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
-
-"@swc/types@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
-  integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
-
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
@@ -8240,11 +8167,6 @@ svgo@^2.7.0, svgo@^2.8.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
-
-swc-loader@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
-  integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
 tapable@^1.0.0:
   version "1.1.3"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2231,6 +2231,79 @@
     "@svgr/plugin-jsx" "^6.5.1"
     "@svgr/plugin-svgo" "^6.5.1"
 
+"@swc/core-darwin-arm64@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.100.tgz#f582c5bbc9c49506f728fc1d14dff33c2cc226d5"
+  integrity sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==
+
+"@swc/core-darwin-x64@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.100.tgz#d84f5c0bb4603c252884d011a698ed7c634b1505"
+  integrity sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==
+
+"@swc/core-linux-arm64-gnu@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.100.tgz#1ed4b92b373882d8f338c4e0a0aa64cdaa6106f1"
+  integrity sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==
+
+"@swc/core-linux-arm64-musl@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.100.tgz#9db560f7459e42e65ec02670d6a8316e7c850cfc"
+  integrity sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==
+
+"@swc/core-linux-x64-gnu@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.100.tgz#228826ea48879bf1e73683fbef4373e3e762e424"
+  integrity sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==
+
+"@swc/core-linux-x64-musl@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.100.tgz#09a234dbbf625d071ecb663680e997a62d230d49"
+  integrity sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==
+
+"@swc/core-win32-arm64-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.100.tgz#add1c82884c10a9054ed6a48f884097aa85c6d2b"
+  integrity sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==
+
+"@swc/core-win32-ia32-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.100.tgz#e0b6c5ae7f3250adeeb88dae83558d3f45148c56"
+  integrity sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==
+
+"@swc/core-win32-x64-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.100.tgz#34721dff151d7dcf165675f18aeed0a12264d88c"
+  integrity sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==
+
+"@swc/core@^1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.100.tgz#8fa36f26a35137620234b084224c9fa9b8a0fee2"
+  integrity sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==
+  dependencies:
+    "@swc/counter" "^0.1.1"
+    "@swc/types" "^0.1.5"
+  optionalDependencies:
+    "@swc/core-darwin-arm64" "1.3.100"
+    "@swc/core-darwin-x64" "1.3.100"
+    "@swc/core-linux-arm64-gnu" "1.3.100"
+    "@swc/core-linux-arm64-musl" "1.3.100"
+    "@swc/core-linux-x64-gnu" "1.3.100"
+    "@swc/core-linux-x64-musl" "1.3.100"
+    "@swc/core-win32-arm64-msvc" "1.3.100"
+    "@swc/core-win32-ia32-msvc" "1.3.100"
+    "@swc/core-win32-x64-msvc" "1.3.100"
+
+"@swc/counter@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.2.tgz#bf06d0770e47c6f1102270b744e17b934586985e"
+  integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
+
+"@swc/types@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
+  integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
+
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
@@ -8167,6 +8240,11 @@ svgo@^2.7.0, svgo@^2.8.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+swc-loader@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
+  integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
 tapable@^1.0.0:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,9 +13,9 @@
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@adobe/css-tools@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
-  integrity sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
+  integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -1455,9 +1455,9 @@
   integrity sha512-IsD8MPvzlbrUZnqychSEPM0dX6DXFG6ObFVbJs8asb5cwUOCek+Qi10W/mK7N9aqKkNpOSSzEIkrhHOiOXZlXw==
 
 "@floating-ui/core@^1.4.2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
-  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.1.tgz#62707d7ec585d0929f882321a1b1f4ea9c680da5"
+  integrity sha512-QgcKYwzcc8vvZ4n/5uklchy8KVdjJwcOeI+HnnTNclJjs2nYsy23DOCf+sSV1kBwD9yDAoVKCkv/gEPzgQU3Pw==
   dependencies:
     "@floating-ui/utils" "^0.1.3"
 
@@ -2535,9 +2535,9 @@
     wrap-ansi "^7.0.0"
 
 "@oclif/core@^3.0.4", "@oclif/core@^3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.12.0.tgz#4b38b1b5dab2f7585f89c3927a8a157b258b4bd6"
-  integrity sha512-mT1Vpd1E20IJ7P6GDYOivylPdTHq/xVgFjeCDjitFW86UAklFM8BEFyFB7KpsTvpmjRbCoda3yU10lSI1224lw==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.13.1.tgz#dbd5e604ec78a716a33bfa6fec6c988a507b7f38"
+  integrity sha512-bpnF6BL+j7D0k0T+dZ4g7LwcZzctCoKjIYm8zcSNgrItS2pgIlvsRf8SdkGNu6djzRD7vzM657ZO9fWU6goz0g==
   dependencies:
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
@@ -3206,132 +3206,132 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@storybook/addon-actions@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.6.1.tgz#63f9dfd1ce9d0277b9403e110898cedb8f827a9b"
-  integrity sha512-KSaIv1LKGyaCJuPuEIwwLtMp/Md8t/jprng3FwYW/lChbsYw40lexiLYRy2LHomsyvXT0acsjLuSmJ8FrynSoA==
+"@storybook/addon-actions@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.6.3.tgz#c84980d8cf95b47918d87f996844c309c45252e3"
+  integrity sha512-f4HXteYE8IJXztAK+ab5heSjXWNWvyIAU63T3Fqe3zmqONwCerUKY54Op+RkAZc/R6aALTxvGRKAH2ff8g2vjQ==
   dependencies:
-    "@storybook/core-events" "7.6.1"
+    "@storybook/core-events" "7.6.3"
     "@storybook/global" "^5.0.0"
     "@types/uuid" "^9.0.1"
     dequal "^2.0.2"
     polished "^4.2.2"
     uuid "^9.0.0"
 
-"@storybook/addon-backgrounds@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.6.1.tgz#9dbb60e5324dd9b70cb1e453e4f90f2582ba9435"
-  integrity sha512-o4PFWTAmc9VjSQA3zT1XOM6WoFBmUxtrH0lFsBeeXHh9mIhnCmmYOGDt09ZVC20QrAfp35qo0UouVIOy5MC6ng==
+"@storybook/addon-backgrounds@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.6.3.tgz#4f4ca4ed998fb2267d2a056f8921a43d9869bff8"
+  integrity sha512-ZZFNf8FBYBsuXvXdVk3sBgxJTn6s0HznuEE9OmAA7tMsLEDlUiWS9LEvjX2jX5K0kWivHTkJDTXV0NcLL1vWAg==
   dependencies:
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-controls@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.6.1.tgz#d15b22376ad2f9e97a2ee16271e1d50529ec7056"
-  integrity sha512-yc9uLEGCjEdMlp12gwPesZOklD2rQfELMI8VZXR0PUa5lhmj4oMkdRAMYltf7Fk5CtMgjdDs7jVn5UnfxwqEWg==
+"@storybook/addon-controls@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.6.3.tgz#1ade53748b04c37d9b604f76e1da82dfe4721c0b"
+  integrity sha512-xsM3z+CY1YOPqrcCldQLoon947fbd/o3gSO7hM3NwKiw/2WikExPO3VM4R2oi4W4PvnhkSOIO+ZDRuSs1yFmOg==
   dependencies:
-    "@storybook/blocks" "7.6.1"
+    "@storybook/blocks" "7.6.3"
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.6.1.tgz#2d867966c94b3223604076bad0b6a8b791e173f2"
-  integrity sha512-f4d+0R582DUxJvoALgOtPAGnWOQ7aB1OOovMp3YNTv6rO2bMpC9umhjvBaf4RJCM83MLHiGA9CkReHJz6V0sUA==
+"@storybook/addon-docs@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.6.3.tgz#113e62a13729489e2657d2b779b5be33893f6758"
+  integrity sha512-2Ts+3EFg9ehkQdbjBWnCH1SE0BdyCLN6hO2N030tGxi0Vko9t9O7NLj5qdBwxLcEzb/XzL4zWukzfU17pktQwA==
   dependencies:
     "@jest/transform" "^29.3.1"
     "@mdx-js/react" "^2.1.5"
-    "@storybook/blocks" "7.6.1"
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/components" "7.6.1"
-    "@storybook/csf-plugin" "7.6.1"
-    "@storybook/csf-tools" "7.6.1"
+    "@storybook/blocks" "7.6.3"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/components" "7.6.3"
+    "@storybook/csf-plugin" "7.6.3"
+    "@storybook/csf-tools" "7.6.3"
     "@storybook/global" "^5.0.0"
     "@storybook/mdx2-csf" "^1.0.0"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/postinstall" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
-    "@storybook/react-dom-shim" "7.6.1"
-    "@storybook/theming" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/postinstall" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
+    "@storybook/react-dom-shim" "7.6.3"
+    "@storybook/theming" "7.6.3"
+    "@storybook/types" "7.6.3"
     fs-extra "^11.1.0"
     remark-external-links "^8.0.0"
     remark-slug "^6.0.0"
     ts-dedent "^2.0.0"
 
 "@storybook/addon-essentials@^7.0.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.6.1.tgz#e4024c616e2c45728e4ddbd6cda55d37b0d57a89"
-  integrity sha512-MNhA6wd/oYvU2Xd8lCDuyY9vazEPn40/TO2tmT3+8VdxzzP8D7fISjNhy4L3Cg8SvQqrQxeWmh+yETtn48VplA==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.6.3.tgz#04bec8eadfe22833cdeacac105a295b3099c2c72"
+  integrity sha512-bpbt5O0wcB83VLZg8QMXut+8g+7EF4iuevpwiynN9mbpQFvG49c6SE6T2eFJKTvVb4zszyfcNA0Opne2G83wZw==
   dependencies:
-    "@storybook/addon-actions" "7.6.1"
-    "@storybook/addon-backgrounds" "7.6.1"
-    "@storybook/addon-controls" "7.6.1"
-    "@storybook/addon-docs" "7.6.1"
-    "@storybook/addon-highlight" "7.6.1"
-    "@storybook/addon-measure" "7.6.1"
-    "@storybook/addon-outline" "7.6.1"
-    "@storybook/addon-toolbars" "7.6.1"
-    "@storybook/addon-viewport" "7.6.1"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/manager-api" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
+    "@storybook/addon-actions" "7.6.3"
+    "@storybook/addon-backgrounds" "7.6.3"
+    "@storybook/addon-controls" "7.6.3"
+    "@storybook/addon-docs" "7.6.3"
+    "@storybook/addon-highlight" "7.6.3"
+    "@storybook/addon-measure" "7.6.3"
+    "@storybook/addon-outline" "7.6.3"
+    "@storybook/addon-toolbars" "7.6.3"
+    "@storybook/addon-viewport" "7.6.3"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/manager-api" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-highlight@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.6.1.tgz#387e2e72e5955225ece1e0e4588b64c17295a080"
-  integrity sha512-NcaIQA1clfKY8P13PlL7yypASaxNcLQ3+fjYa6ysS1dnXw4dV2ecPpYQD8/+sUXOTVtbSdtlVZIvPlmKrO2c5g==
+"@storybook/addon-highlight@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.6.3.tgz#e6c9b8fe88acbf91c76c82e519eda7f2d129da61"
+  integrity sha512-Z9AJ05XCTzFZPAxQSkQf9/Hazf5/QQI0jYSsvKqt7Vk+03q5727oD9KcIY5IHPYqQqN9fHExQh1eyqY8AnS8mg==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/addon-measure@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.6.1.tgz#704d82ac9a3719026fb62c38810fe9bd74ddebe7"
-  integrity sha512-RREJsDnBtLcI7kpay6fXvSjnGOwEHQQ14TyuhtWjbSRmP/H3mGgUUk6Aty/qi0nKuQPoj6RFSM2r/khTYOd0eg==
+"@storybook/addon-measure@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.6.3.tgz#56fd1c21c220b2023462c07219f4644b8c4f17ea"
+  integrity sha512-DqxADof04ktA5GSA8XnckYGdVYyC4oN8vfKSGcPzpcKrJ2uVr0BXbcyJAEcJAshEJimmpA6nH5TxabXDFBZgPQ==
   dependencies:
     "@storybook/global" "^5.0.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/addon-outline@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.6.1.tgz#88df21a1a06fa724c0ecae143f4032e5f36c3229"
-  integrity sha512-SaVqwbpD42iThYL69ypNozgQ2rOE5QaNRiKg4n5OkskFMsFi35/ZyOlufnKRBLgad2TUmVIS4vYerMiSGNOjew==
+"@storybook/addon-outline@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.6.3.tgz#09969830938c803c9ad24037acdd4bb56eff98bf"
+  integrity sha512-M7d2tcqBBl+mPBUS6Nrwis50QYSCcmT/uKamud7CnlIWsMH/5GZFfAzGSLY5ETfiGsSFYssOwrXLOV4y0enu2g==
   dependencies:
     "@storybook/global" "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.6.1.tgz#23366ef8dcca85caeb599997f3e5cdc1ce602ef0"
-  integrity sha512-nOE9q/57tuGed2z4+NGDhKfCii0Xh2SUt4C9O4tajoyVl2vs5MG+YnipbuIzmrmgPjs8oh0Bk+z7PtQGoRi7Xw==
+"@storybook/addon-toolbars@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.6.3.tgz#f95704d054ac418a3410c424cc81e9b4d28ad8c5"
+  integrity sha512-8GpwOt0J5yLrJhTr9/h0a/LTDjt49FhdvdxiVWLlLMrjIXSIc7j193ZgoHfnlwVhJS5zojcjB+HmRw/E+AneoA==
 
-"@storybook/addon-viewport@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.6.1.tgz#4343dbc4cad3e010b8080f4b641783638ad963c1"
-  integrity sha512-f+CYKLk6ftEzwf7Q48CBiJBaERzGzxBcMlcS1/xPg6n2AGpVl++HvFRpvDR/vuE22YpHVz5B1mwUusoXHemhyw==
+"@storybook/addon-viewport@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.6.3.tgz#70b8920f0b272ab723b5b2a3819cdaf10acfa051"
+  integrity sha512-I9FQxHi4W7RUyZut4NziYa+nkBCpD1k2YpEDE5IwSC3lqQpDzFZN89eNWQtZ38tIU4c90jL3L1k69IHvANGHsA==
   dependencies:
     memoizerific "^1.11.3"
 
-"@storybook/blocks@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.6.1.tgz#71e9d31ebde30d02f9b97353dd81eea48ea9e21a"
-  integrity sha512-thK7W/RrhDRkGGwm+Le8E2ffVY3oXtLl7UPR/IT8+waBXgeBzQz6Mjl4KQiV38sloRyz9ZRUiXT96mnrXIkeMQ==
+"@storybook/blocks@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.6.3.tgz#61f1ce2935b20f6fd55a95f1a970809be53bdcc7"
+  integrity sha512-EyjyNNCZMcV9UnBSujwduiq+F1VLVX/f16fTTPqqZOHigyfrG5LoEYC6dwOC4yO/xfWY+h3qJ51yiugMxVl0Vg==
   dependencies:
-    "@storybook/channels" "7.6.1"
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/components" "7.6.1"
-    "@storybook/core-events" "7.6.1"
+    "@storybook/channels" "7.6.3"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/components" "7.6.3"
+    "@storybook/core-events" "7.6.3"
     "@storybook/csf" "^0.1.2"
-    "@storybook/docs-tools" "7.6.1"
+    "@storybook/docs-tools" "7.6.3"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
-    "@storybook/theming" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/manager-api" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
+    "@storybook/theming" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/lodash" "^4.14.167"
     color-convert "^2.0.1"
     dequal "^2.0.2"
@@ -3345,15 +3345,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.1.tgz#1799c52f27990083322decce9018b6de71ca8520"
-  integrity sha512-Hxp2y3XR5UgfsWWqVM7R4jb+4DZNe8LBb9ko3PzMRAySY0ED45/lPTK+zEEFhOX4mc1Ftqmj0RAJHmbwr0vQRg==
+"@storybook/builder-manager@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.3.tgz#bb16bbf945872d1acff7edc9f9e6b42cec4841d5"
+  integrity sha512-eLMjRudhiRsg7kgbmPcCkuVf2ut753fbiVR7REtqIYwq5vu8UeNOzt1vA6HgfsUj77/7+1zG8/zeyBv/5nY5mw==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/manager" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/manager" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -3367,20 +3367,20 @@
     process "^0.11.10"
     util "^0.12.4"
 
-"@storybook/builder-webpack5@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.6.1.tgz#e48a7331e20dff143fa688eb7aae17cd97ec5e2b"
-  integrity sha512-0bo8nNU/YhIgrfNBaebd9ruWLKZZmn/C/5ubkYCc8Yo1JxxZIJj3Hm45JCuSWMW2RO9DLnTF5TGpzNyVPtODpA==
+"@storybook/builder-webpack5@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.6.3.tgz#a8532b6f03802257f222fa20302acbf81617cd7b"
+  integrity sha512-hK8eOTihB61L+R4wUfHBffPoV3u6Bu7QEnhCQYd6AimNOgjnCvN33ceZjtYFM3taYpQgI6Q723vtOyL1IMh48Q==
   dependencies:
     "@babel/core" "^7.23.2"
-    "@storybook/channels" "7.6.1"
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/core-events" "7.6.1"
-    "@storybook/core-webpack" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/preview" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
+    "@storybook/channels" "7.6.3"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/core-events" "7.6.3"
+    "@storybook/core-webpack" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/preview" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
     "@swc/core" "^1.3.82"
     "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
@@ -3410,35 +3410,35 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.5.0"
 
-"@storybook/channels@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.1.tgz#00df76421901a7b1bdd63a21e5cdac4b07ff0215"
-  integrity sha512-wQBiY8gLRs6I3V8Cr5xHNx3OImDhzsYGOMM8tUnVKO4HpcxsJ7ipQ8UvIU88MNbk+gx3WCsM4FZBBPF4f1Ar/g==
+"@storybook/channels@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.3.tgz#b3e0a8d92dfd553ba582fdb5dd0c55272790d3f9"
+  integrity sha512-o9J0TBbFon16tUlU5V6kJgzAlsloJcS1cTHWqh3VWczohbRm+X1PLNUihJ7Q8kBWXAuuJkgBu7RQH7Ib46WyYg==
   dependencies:
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-events" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-events" "7.6.3"
     "@storybook/global" "^5.0.0"
     qs "^6.10.0"
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/cli@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.1.tgz#be66394896f86170cdc685e0d23f1ca8abe70885"
-  integrity sha512-o0KDj9E5VYVn55/l9j7YwncehlfIHX2CCBCp0opSmsv3ohw9ME9aTdl2q19j4SXV30UQFFbi/4Yn/FBWsShxRg==
+"@storybook/cli@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.3.tgz#3c1935c0bee5e805d2fb55a875e5c377cb3503ae"
+  integrity sha512-OuYnzZlAtpGm4rDgI4ZWkNbAkddutlJh6KmoU9oQAlZP0zmETyJN8REUWjj5T9Z1AS2iXjCMGlFVd4TC8nKocw==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.6.1"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/core-events" "7.6.1"
-    "@storybook/core-server" "7.6.1"
-    "@storybook/csf-tools" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/telemetry" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/codemod" "7.6.3"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/core-events" "7.6.3"
+    "@storybook/core-server" "7.6.3"
+    "@storybook/csf-tools" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/telemetry" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/semver" "^7.3.4"
     "@yarnpkg/fslib" "2.10.3"
     "@yarnpkg/libzip" "2.3.0"
@@ -3469,25 +3469,25 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-logger@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.1.tgz#c0910d8fe2aabc6729c185030958efd5dac15106"
-  integrity sha512-klaeDFGK2NAXoRDgp8+55Qn9mdVVNk16POb2/lbXYo8ydZDYaNjjLISO9+dLA65SL8NUEQw1m8YVhzyAQCE5bg==
+"@storybook/client-logger@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.3.tgz#221d6617e6874025b94602bc7ba6bf09d154bf5f"
+  integrity sha512-BpsCnefrBFdxD6ukMjAblm1D6zB4U5HR1I85VWw6LOqZrfzA6l/1uBxItz0XG96HTjngbvAabWf5k7ZFCx5UCg==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.1.tgz#03258dfde9057895bcf581a83cef364b26c34c47"
-  integrity sha512-V9zzrNVfJZ3y7Y0MIL3PySDmMuxKM207wE+XYectOCTTyz7pObylwpp3UugNRptj2vvinLfCx1SjKVQ6RpYarQ==
+"@storybook/codemod@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.3.tgz#02db1a61f1fc088348f694b80aef18a929111da5"
+  integrity sha512-A1i8+WQfNg3frVcwSyu8E/cDkCu88Sw7JiGNnq9iW2e2oWMr2awpCDgXp8WfTK+HiDb2X1Pq5y/GmUlh3qr77Q==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/csf-tools" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/cross-spawn" "^6.0.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -3496,38 +3496,38 @@
     prettier "^2.8.0"
     recast "^0.23.1"
 
-"@storybook/components@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.6.1.tgz#6f5a04a2a2158e87d8a687b3f2a63f70ac1e5d32"
-  integrity sha512-jZNGVepmn/iwZ/WSwchZfBo8r4knUpHLwrffMc8FSltmzyKxlEmtZwzlTbBCi48mBc0CqucI1GYtnhzzgX6N8w==
+"@storybook/components@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.6.3.tgz#07ab85253abd62d3725ccf23542362ddf11ece2d"
+  integrity sha512-UNV0WoUo+W0huOLvoEMuqRN/VB4p0CNswrXN1mi/oGWvAFJ8idu63lSuV4uQ/LKxAZ6v3Kpdd+oK/o+OeOoL6w==
   dependencies:
     "@radix-ui/react-select" "^1.2.2"
     "@radix-ui/react-toolbar" "^1.0.4"
-    "@storybook/client-logger" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/theming" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/theming" "7.6.3"
+    "@storybook/types" "7.6.3"
     memoizerific "^1.11.3"
     use-resize-observer "^9.1.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-client@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.6.1.tgz#5462ed57292f335655fbea88a9453d3705b57aa0"
-  integrity sha512-izolLY0QAPREwm3ZCp9PZasa0OBchzxWYFaVekgbX66lhFJvAVfp84L17oi3HyVbQt7xbAlGPoSoP6wcfMecTw==
+"@storybook/core-client@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.6.3.tgz#6324400b71e007c7414135d6d97054d515356677"
+  integrity sha512-RM0Svlajddl8PP4Vq7LK8T22sFefNcTDgo82iRPZzGz0oH8LT0oXGFanj2Nkn0jruOBFClkiJ7EcwrbGJZHELg==
   dependencies:
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
 
-"@storybook/core-common@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.1.tgz#9253fffc3d2a3aeabf75125cc0a52115923e28e9"
-  integrity sha512-6K9UXUxO708T0H29Z2QDrLHU5nFL3VEWuS1vzbC/naJVt/yg+w1jzgknP7IFmmDf2e02tLQS886cE+M23249Tg==
+"@storybook/core-common@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.3.tgz#33d726c0178d4336da581c74620680c2a59050cc"
+  integrity sha512-/ZE4BEyGwBHCQCOo681GyBKF4IqCiwVV/ZJCHTMTHFCPLJT2r+Qwv4tnI7xt1kwflOlbBlG6B6CvAqTjjVw/Ew==
   dependencies:
-    "@storybook/core-events" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/core-events" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/find-cache-dir" "^3.2.1"
     "@types/node" "^18.0.0"
     "@types/node-fetch" "^2.6.4"
@@ -3549,33 +3549,33 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.1.tgz#4d284a4e7e125ef7b7236c55fad25139f33172b3"
-  integrity sha512-4B55//oGyvdiKQUCMRHLlA6v7HW69tf4mqjHdPbwETyj9PzFTpo4S8tsYxkba/azCxvqncotPDsMkxycritGbA==
+"@storybook/core-events@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.3.tgz#55ea88f5355bd995daf9ed0287293536b3eb7091"
+  integrity sha512-Vu3JX1mjtR8AX84lyqWsi2s2lhD997jKRWVznI3wx+UpTk8t7TTMLFk2rGYJRjaornhrqwvLYpnmtxRSxW9BOQ==
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-server@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.1.tgz#cfd61872b3c1c65c5dc64e11333befa3403c770f"
-  integrity sha512-WqiNpcyS8j+AgrJSqF4FLKvgXKVYpvk0kouNzLHyXmknjfqcGPySKpEP/MYD9tALdAnZhA80M5suuLFSAWlXxw==
+"@storybook/core-server@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.3.tgz#a5172b20f7ac813d332ba0dcab62dd81a7a07e00"
+  integrity sha512-IsM24MmiFmtZeyqoijiExpIPkJNBaWQg9ttkkHS6iYwf3yFNBpYVbvuX2OpT7FDdiF3uTl0R8IvfnJR58tHD7w==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.126"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.6.1"
-    "@storybook/channels" "7.6.1"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/core-events" "7.6.1"
+    "@storybook/builder-manager" "7.6.3"
+    "@storybook/channels" "7.6.3"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/core-events" "7.6.3"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.1"
+    "@storybook/csf-tools" "7.6.3"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
-    "@storybook/telemetry" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/manager" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
+    "@storybook/telemetry" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^18.0.0"
     "@types/pretty-hrtime" "^1.0.0"
@@ -3603,36 +3603,36 @@
     watchpack "^2.2.0"
     ws "^8.2.3"
 
-"@storybook/core-webpack@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.6.1.tgz#6e14b8ddc35a08f1f0551afdb33cd92105680bb0"
-  integrity sha512-IPxDICZAu5nAU+MHzmha5uaLirHrLpC6StNc2aeQ75YOk0MwdRj49F7AAqWegBlnvOy0wdfYf5jxQD7N/C//rA==
+"@storybook/core-webpack@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.6.3.tgz#926f904e6fb096487e40de72e60d8412c5cef88a"
+  integrity sha512-dM1orHixZWF5tKYoyMYBxg7OJ8joR2r5Ckj9SShXd8lutL7so5ljyxfEz/+pYakTNK7ezeQmMIFYZQD3JTr5JA==
   dependencies:
-    "@storybook/core-common" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/node" "^18.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/csf-plugin@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.6.1.tgz#0d66d6052e3548dfbdde3924a825009607364ce6"
-  integrity sha512-wkUNl3nJGoUFyVk7lPFwStCqD4e51jqYFCxCSFifsLHtVKpNZPIR5AmiRTExmx4VL0xlmloTvOE9Mdkc7pWhiw==
+"@storybook/csf-plugin@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.6.3.tgz#d42e04f0ea9c92f584031300a32ebe59187ae99f"
+  integrity sha512-8bMYPsWw2tv+fqZ5H436l4x1KLSB6gIcm6snsjyF916yCHG6WcWm+EI6+wNUoySEtrQY2AiwFJqE37wI5OUJFg==
   dependencies:
-    "@storybook/csf-tools" "7.6.1"
+    "@storybook/csf-tools" "7.6.3"
     unplugin "^1.3.1"
 
-"@storybook/csf-tools@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.1.tgz#a92ad74d6d156c8a407a5da26900fae9bd9cbaab"
-  integrity sha512-+fkVma/Qbm5Lips9jwlN/wZybikYHJNGiAyjT1qjtfis9115XSUKXJtGhnAUtB6sbYtoFBNvBJ9QrFKa1lEZ/A==
+"@storybook/csf-tools@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.3.tgz#e79bc4219626240a1d4acff1217a7f630c62533a"
+  integrity sha512-Zi3pg2pg88/mvBKewkfWhFUR1J4uYpHI5fSjOE+J/FeZObX/DIE7r+wJxZ0UBGyrk0Wy7Jajlb2uSP56Y0i19w==
   dependencies:
     "@babel/generator" "^7.23.0"
     "@babel/parser" "^7.23.0"
     "@babel/traverse" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/types" "7.6.1"
+    "@storybook/types" "7.6.3"
     fs-extra "^11.1.0"
     recast "^0.23.1"
     ts-dedent "^2.0.0"
@@ -3649,14 +3649,14 @@
   resolved "https://registry.yarnpkg.com/@storybook/docs-mdx/-/docs-mdx-0.1.0.tgz#33ba0e39d1461caf048b57db354b2cc410705316"
   integrity sha512-JDaBR9lwVY4eSH5W8EGHrhODjygPd6QImRbwjAuJNEnY0Vw4ie3bPkeGfnacB3OBW6u/agqPv2aRlR46JcAQLg==
 
-"@storybook/docs-tools@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.6.1.tgz#516f87bface58da87739ecd9b75d75b3f4b07489"
-  integrity sha512-F6mbKFWwqzCTM39xnsW5FH/wSxeQTZ/N9j1MM8J+x39QbWbLi2VodSuPjKyS1L7CPcYhc3N1Re/F3lIgpF2piw==
+"@storybook/docs-tools@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.6.3.tgz#f04dc5916fc157cc70d1e4222be605c4241fd0b4"
+  integrity sha512-6MtirRCQIkBeQ3bksPignZgUuFmjWqcFleTEN6vrNEfbCzMlMvuBGfm9tl4sS3n8ATWmKGj87DcJepPOT3FB4A==
   dependencies:
-    "@storybook/core-common" "7.6.1"
-    "@storybook/preview-api" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/preview-api" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/doctrine" "^0.0.3"
     assert "^2.1.0"
     doctrine "^3.0.0"
@@ -3667,19 +3667,19 @@
   resolved "https://registry.yarnpkg.com/@storybook/global/-/global-5.0.0.tgz#b793d34b94f572c1d7d9e0f44fac4e0dbc9572ed"
   integrity sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==
 
-"@storybook/manager-api@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.6.1.tgz#95d4f956468a211ba79422cb45d98d8726f95dfe"
-  integrity sha512-Fo+sM5ExbZ3UWWVMd5A3+Mee9/YGtLAla3yActaemcWmR2r/THjoFtL4GU2qmUnUvTvSYLYir6s1+90cUyfSvA==
+"@storybook/manager-api@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.6.3.tgz#b3b6e5f4b248f724ba8351dcb2ef485e034a5436"
+  integrity sha512-soDH7GZuukkhYRGzlw4jhCm5EzjfkuIAtb37/DFplqxuVbvlyJEVzkMUM2KQO7kq0/8GlWPiZ5mn56wagYyhKQ==
   dependencies:
-    "@storybook/channels" "7.6.1"
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-events" "7.6.1"
+    "@storybook/channels" "7.6.3"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-events" "7.6.3"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/router" "7.6.1"
-    "@storybook/theming" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/router" "7.6.3"
+    "@storybook/theming" "7.6.3"
+    "@storybook/types" "7.6.3"
     dequal "^2.0.2"
     lodash "^4.17.21"
     memoizerific "^1.11.3"
@@ -3688,38 +3688,38 @@
     telejson "^7.2.0"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.1.tgz#d43f9314e88737e9f1772ff20f84629c11bd7506"
-  integrity sha512-e2cYvMl01TZj+s++aqlCkeyvZoIFAUaRyG8d6rj2S1mIfzSl41NL2e76cdm5nIdrgkZFv4fMNaWpXyJp1p3wfg==
+"@storybook/manager@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.3.tgz#10fc8171e02d19aac8e0c0bfa05b4897f1179b78"
+  integrity sha512-6eMaogHANCSVV2zLPt4Q7fp8RT+AdlOe6IR0583AuqpepcFzj33iGNYABk2rmXAlkD0WzoLcC4H5mouU0fduLA==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@storybook/mdx2-csf/-/mdx2-csf-1.1.0.tgz#97f6df04d0bf616991cc1005a073ac004a7281e5"
   integrity sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==
 
-"@storybook/node-logger@7.6.1", "@storybook/node-logger@^7.0.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.1.tgz#57eea244b63670b9908b077d1e7f72d78b438637"
-  integrity sha512-aHQUfWJBJBBof4WfNN552I76QZmMwLHeerI+98NE3IphRHlM+OW96crKXKvX7DWaN5otgxdXroZFpEABKhHIwQ==
+"@storybook/node-logger@7.6.3", "@storybook/node-logger@^7.0.0":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.3.tgz#f3fd7cd029fa21621129210d5f282f4d4c745174"
+  integrity sha512-7yL0CMHuh1DhpUAoKCU0a53DvxBpkUom9SX5RaC1G2A9BK/B3XcHtDPAC0uyUwNCKLJMZo9QtmJspvxWjR0LtA==
 
-"@storybook/postinstall@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.6.1.tgz#1d800f8b285cab184fb999709fd59f3ad9df2edd"
-  integrity sha512-XYJPzJ4ZCxTn6r/mTXKCtLUBLo0yPiA4fnCPE+ltyYvhLZ0Hm7o0TP4ew7zvoXKuGJZUH4vuEBCt+AdqrSp6Qw==
+"@storybook/postinstall@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.6.3.tgz#d72d7a6f076b4a8571fea1b64d424a4e2b25b884"
+  integrity sha512-WpgdpJpY6rionluxjFZLbKiSDjvQJ5cPgufjvBRuXTsnVOsH3JNRWnPdkQkJLT9uTUMoNcyBMxbjYkK3vU6wSg==
 
-"@storybook/preset-react-webpack@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.6.1.tgz#6f7e784c30b4dcf1ff8914b96b45cf8f38984635"
-  integrity sha512-dgLFsdylKF3Bfa00a2aCs7N1LsZU9GH3pmCrERpXUUEMVdS4oPoExRsEjFoTrV9FrToAHWf8TRY8LLEyA/I/zg==
+"@storybook/preset-react-webpack@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.6.3.tgz#114ae11e2f2effabce6ca840692a19beaff6bdff"
+  integrity sha512-rWDzjl4g3+UDG/qKYou7NFU8s+RrgF3PSKtzTPsmqOUF/Edntzr7Z2VYqlK4RD5Wmr2VChtu3EC/frFcqSJQBQ==
   dependencies:
     "@babel/preset-flow" "^7.22.15"
     "@babel/preset-react" "^7.22.15"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.11"
-    "@storybook/core-webpack" "7.6.1"
-    "@storybook/docs-tools" "7.6.1"
-    "@storybook/node-logger" "7.6.1"
-    "@storybook/react" "7.6.1"
+    "@storybook/core-webpack" "7.6.3"
+    "@storybook/docs-tools" "7.6.3"
+    "@storybook/node-logger" "7.6.3"
+    "@storybook/react" "7.6.3"
     "@storybook/react-docgen-typescript-plugin" "1.0.6--canary.9.0c3f3b7.0"
     "@types/node" "^18.0.0"
     "@types/semver" "^7.3.4"
@@ -3731,17 +3731,17 @@
     semver "^7.3.7"
     webpack "5"
 
-"@storybook/preview-api@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.1.tgz#710abeaa86040f9f2f8ebeb19ef662a86d8d564e"
-  integrity sha512-lhuwkDHBZCq3UtQXRkGKTBntINkXPXyAA7fSYWrwfQBr/3NhaCoj859b+71Ax8sYcSFF4+U3S6+o8XE3dz+kwA==
+"@storybook/preview-api@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.3.tgz#da8e30e5cbe1c0ca5e40af5dc01a4714c37d5af8"
+  integrity sha512-uPaK7yLE1P++F+IOb/1j9pgdCwfMYZrUPHogF/Mf9r4cfEjDCcIeKgGMcsbU1KnkzNQQGPh8JRzRr/iYnLjswg==
   dependencies:
-    "@storybook/channels" "7.6.1"
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-events" "7.6.1"
+    "@storybook/channels" "7.6.3"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-events" "7.6.3"
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
-    "@storybook/types" "7.6.1"
+    "@storybook/types" "7.6.3"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -3751,10 +3751,10 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/preview@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.6.1.tgz#0d953c4523bb4d7df9b9b9e0a3ddf43aa5f58b54"
-  integrity sha512-5qC/skcs0gQenTfCNa2LLp7X9++ZuLQwoweNmAtRJ8Gxn9ac6Yd3/pf9xjxAhlLDhb4Ojdrb9owrPAOf9b4woA==
+"@storybook/preview@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.6.3.tgz#80bb73cc4106f1b38e54bc153d11d067431db364"
+  integrity sha512-obSmKN8arWSHuLbCDM1H0lTVRMvAP/l7vOi6TQtFi6TxBz9MRCJA3Ugc0PZrbDADVZP+cp0ZJA0JQtAm+SqNAA==
 
 "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0":
   version "1.0.6--canary.9.0c3f3b7.0"
@@ -3769,33 +3769,33 @@
     react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
-"@storybook/react-dom-shim@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.6.1.tgz#a3279b39fac311b138106a21256db172e5228a60"
-  integrity sha512-COIVtG33Pfa8o8PR7VlQKjBOD5jG3dUPLuRBwvomy3+fkoS5JZNTnehZrgDDMkevpZr8eb0A+uCfLckicsg/ig==
+"@storybook/react-dom-shim@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.6.3.tgz#cf634b816cc600968e27359824d82d8117b669ee"
+  integrity sha512-UtaEaTQB27aBsAmn5IfAYkX2xl4wWWXkoAO/jUtx86FQ/r85FG0zxh/rac6IgzjYUqzjJtjIeLdeciG/48hMMA==
 
 "@storybook/react-webpack5@^7.0.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.6.1.tgz#b09c51b34a415bcead8f435b61e0bc6c95d42905"
-  integrity sha512-u+iJ6Q5Quj/aacf2qzCcEsNuevqSfl/FPOwTGIAZCuN78DFDaEvrzZ4yT81NJww7NA/M8d4N3P+yd/aqCvWKvQ==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.6.3.tgz#497de2271606661ccaf5a7f184f372e8d868214a"
+  integrity sha512-5427xYUQhCL2CUkFuYmq6Sz9R3PXBRspzZ/BUW3UII3hjrtSPJkwxkrV+rnisaokrF7jXCYtzkwV2VATpJv8Cw==
   dependencies:
-    "@storybook/builder-webpack5" "7.6.1"
-    "@storybook/preset-react-webpack" "7.6.1"
-    "@storybook/react" "7.6.1"
+    "@storybook/builder-webpack5" "7.6.3"
+    "@storybook/preset-react-webpack" "7.6.3"
+    "@storybook/react" "7.6.3"
     "@types/node" "^18.0.0"
 
-"@storybook/react@7.6.1", "@storybook/react@^7.0.0":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.6.1.tgz#13b47df620756884b68a77d345802891373b45b1"
-  integrity sha512-zl157OA2ihP7sGDzgiU9lnXJ+iDDnxcEJu0xVCVsAjD1BvAKYB1Otc6aRIRCHLQLP8yoM7ekxzWYl9lGjXunNA==
+"@storybook/react@7.6.3", "@storybook/react@^7.0.0":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.6.3.tgz#f8f17a032e12e41fcc03b52b8c1f22651e904e29"
+  integrity sha512-W+530cC0BAU+yBc7NzSXYWR3e8Lo5qMsmFJjWYK7zGW/YZGhSG3mjhF9pDzNM+cMtHvUS6qf5PJPQM8jePpPhg==
   dependencies:
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-client" "7.6.1"
-    "@storybook/docs-tools" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-client" "7.6.3"
+    "@storybook/docs-tools" "7.6.3"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.6.1"
-    "@storybook/react-dom-shim" "7.6.1"
-    "@storybook/types" "7.6.1"
+    "@storybook/preview-api" "7.6.3"
+    "@storybook/react-dom-shim" "7.6.3"
+    "@storybook/types" "7.6.3"
     "@types/escodegen" "^0.0.6"
     "@types/estree" "^0.0.51"
     "@types/node" "^18.0.0"
@@ -3811,45 +3811,45 @@
     type-fest "~2.19"
     util-deprecate "^1.0.2"
 
-"@storybook/router@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.6.1.tgz#8fe94ddbef506864343d73a65e182a2af64a50f3"
-  integrity sha512-zoIRDhes/4R9jsJ6c48xqmhcGYrSoPBzxEWnIaeSv0rEZFLhkTgruyAG0/rJ0FrCsSwFxVSI6ecYfCPVYMVr7w==
+"@storybook/router@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.6.3.tgz#4aab0c4ac23948338440c568feb8a92268c9abf9"
+  integrity sha512-NZfhJqsXYca9mZCL/LGx6FmZDbrxX2S4ImW7Tqdtcc/sSlZ0BpCDkNUTesCA287cmoKMhXZRh/+bU+C2h2a+bw==
   dependencies:
-    "@storybook/client-logger" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
-"@storybook/telemetry@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.1.tgz#750a22ad879d8aa3bc32e5b3145aa1a873bbc881"
-  integrity sha512-xR2OUqoANSjHReu4RONXNAkoy9WPwZfk3IfajtqgMsYlwXY/yvLZqDkp/eZNhI6gps8IsP7gMx9E1WDqS3ghcA==
+"@storybook/telemetry@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.3.tgz#c41dfed339e60b9e87fd6b4375c84f145793c9e5"
+  integrity sha512-NDCZWhVIUI3M6Lq4M/HPOvZqDXqANDNbI3kyHr4pFGoVaCUXuDPokL9wR+CZcMvATkJ1gHrfLPBdcRq6Biw3Iw==
   dependencies:
-    "@storybook/client-logger" "7.6.1"
-    "@storybook/core-common" "7.6.1"
-    "@storybook/csf-tools" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
+    "@storybook/core-common" "7.6.3"
+    "@storybook/csf-tools" "7.6.3"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
     fs-extra "^11.1.0"
     read-pkg-up "^7.0.1"
 
-"@storybook/theming@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.6.1.tgz#97c7aa09842af2c11f5d04b0afe39b234aebcb23"
-  integrity sha512-e6S5jRn90etnvlJKIJ4wlFauFn9tNQ2YJ/Uyo8yUUGrA665yc7zdBZPUwD6oHYXP6znEfXMJ2dbx/hs1I/V7Gw==
+"@storybook/theming@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.6.3.tgz#69adc0c7c2e6cad67cf327834fe57ab4ae698575"
+  integrity sha512-9ToNU2LM6a2kVBjOXitXEeEOuMurVLhn+uaZO1dJjv8NGnJVYiLwNPwrLsImiUD8/XXNuil972aanBR6+Aj9jw==
   dependencies:
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@storybook/client-logger" "7.6.1"
+    "@storybook/client-logger" "7.6.3"
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
 
-"@storybook/types@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.1.tgz#3bb7f5e8ee39af53fb5aaf6ed713f8ad656151cf"
-  integrity sha512-xwEdMHbms7nnyPugqrxjz62n1CoAZ6I+m6y7Rfk/2C0nsgpS0Go1UXUNmcWNxx2ZYX7bEgSPZtcYZa9buPSY3g==
+"@storybook/types@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.3.tgz#cd37997cfcd349d3eb4d2c9da9eb7f334d2fb937"
+  integrity sha512-vj9Jzg5eR52l8O9512QywbQpNdo67Z6BQWR8QoZRcG+/Bhzt08YI8IZMPQLFMKzcmWDPK0blQ4GfyKDYplMjPA==
   dependencies:
-    "@storybook/channels" "7.6.1"
+    "@storybook/channels" "7.6.3"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
@@ -3960,68 +3960,68 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swc/core-darwin-arm64@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.99.tgz#def204349ac645b8de21a800fa784907642a6c91"
-  integrity sha512-Qj7Jct68q3ZKeuJrjPx7k8SxzWN6PqLh+VFxzA+KwLDpQDPzOlKRZwkIMzuFjLhITO4RHgSnXoDk/Syz0ZeN+Q==
+"@swc/core-darwin-arm64@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.100.tgz#f582c5bbc9c49506f728fc1d14dff33c2cc226d5"
+  integrity sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==
 
-"@swc/core-darwin-x64@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.99.tgz#2633f1ac1668ec569f34f86eb5250d56fcacd952"
-  integrity sha512-wR7m9QVJjgiBu1PSOHy7s66uJPa45Kf9bZExXUL+JAa9OQxt5y+XVzr+n+F045VXQOwdGWplgPnWjgbUUHEVyw==
+"@swc/core-darwin-x64@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.100.tgz#d84f5c0bb4603c252884d011a698ed7c634b1505"
+  integrity sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==
 
-"@swc/core-linux-arm64-gnu@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.99.tgz#871c2f049a3a5d88bcc7317ac004230517a08ba4"
-  integrity sha512-gcGv1l5t0DScEONmw5OhdVmEI/o49HCe9Ik38zzH0NtDkc+PDYaCcXU5rvfZP2qJFaAAr8cua8iJcOunOSLmnA==
+"@swc/core-linux-arm64-gnu@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.100.tgz#1ed4b92b373882d8f338c4e0a0aa64cdaa6106f1"
+  integrity sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==
 
-"@swc/core-linux-arm64-musl@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.99.tgz#28ed1622e92bc13aab4b650f2af695af8695289b"
-  integrity sha512-XL1/eUsTO8BiKsWq9i3iWh7H99iPO61+9HYiWVKhSavknfj4Plbn+XyajDpxsauln5o8t+BRGitymtnAWJM4UQ==
+"@swc/core-linux-arm64-musl@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.100.tgz#9db560f7459e42e65ec02670d6a8316e7c850cfc"
+  integrity sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==
 
-"@swc/core-linux-x64-gnu@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.99.tgz#8e07add9cc8b76d542959e3240340effa6c6e446"
-  integrity sha512-fGrXYE6DbTfGNIGQmBefYxSk3rp/1lgbD0nVg4rl4mfFRQPi7CgGhrrqSuqZ/ezXInUIgoCyvYGWFSwjLXt/Qg==
+"@swc/core-linux-x64-gnu@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.100.tgz#228826ea48879bf1e73683fbef4373e3e762e424"
+  integrity sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==
 
-"@swc/core-linux-x64-musl@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.99.tgz#677eb82d6862605cb0a81ec5b732bef2a9861b16"
-  integrity sha512-kvgZp/mqf3IJ806gUOL6gN6VU15+DfzM1Zv4Udn8GqgXiUAvbQehrtruid4Snn5pZTLj4PEpSCBbxgxK1jbssA==
+"@swc/core-linux-x64-musl@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.100.tgz#09a234dbbf625d071ecb663680e997a62d230d49"
+  integrity sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==
 
-"@swc/core-win32-arm64-msvc@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.99.tgz#6c9bf96dd4cb81b5960884906766dc47a49efb0d"
-  integrity sha512-yt8RtZ4W/QgFF+JUemOUQAkVW58cCST7mbfKFZ1v16w3pl3NcWd9OrtppFIXpbjU1rrUX2zp2R7HZZzZ2Zk/aQ==
+"@swc/core-win32-arm64-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.100.tgz#add1c82884c10a9054ed6a48f884097aa85c6d2b"
+  integrity sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==
 
-"@swc/core-win32-ia32-msvc@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.99.tgz#6940a602b65137eee30f09ced7cd9fcb6e162b88"
-  integrity sha512-62p5fWnOJR/rlbmbUIpQEVRconICy5KDScWVuJg1v3GPLBrmacjphyHiJC1mp6dYvvoEWCk/77c/jcQwlXrDXw==
+"@swc/core-win32-ia32-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.100.tgz#e0b6c5ae7f3250adeeb88dae83558d3f45148c56"
+  integrity sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==
 
-"@swc/core-win32-x64-msvc@1.3.99":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.99.tgz#7fcdfe6577f015604f7e69f71dda99822e946385"
-  integrity sha512-PdppWhkoS45VGdMBxvClVgF1hVjqamtvYd82Gab1i4IV45OSym2KinoDCKE1b6j3LwBLOn2J9fvChGSgGfDCHQ==
+"@swc/core-win32-x64-msvc@1.3.100":
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.100.tgz#34721dff151d7dcf165675f18aeed0a12264d88c"
+  integrity sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==
 
 "@swc/core@^1.3.82":
-  version "1.3.99"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.99.tgz#24a2ff0aaa1096b31046c8099b043936db0c4ca6"
-  integrity sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==
+  version "1.3.100"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.100.tgz#8fa36f26a35137620234b084224c9fa9b8a0fee2"
+  integrity sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==
   dependencies:
     "@swc/counter" "^0.1.1"
     "@swc/types" "^0.1.5"
   optionalDependencies:
-    "@swc/core-darwin-arm64" "1.3.99"
-    "@swc/core-darwin-x64" "1.3.99"
-    "@swc/core-linux-arm64-gnu" "1.3.99"
-    "@swc/core-linux-arm64-musl" "1.3.99"
-    "@swc/core-linux-x64-gnu" "1.3.99"
-    "@swc/core-linux-x64-musl" "1.3.99"
-    "@swc/core-win32-arm64-msvc" "1.3.99"
-    "@swc/core-win32-ia32-msvc" "1.3.99"
-    "@swc/core-win32-x64-msvc" "1.3.99"
+    "@swc/core-darwin-arm64" "1.3.100"
+    "@swc/core-darwin-x64" "1.3.100"
+    "@swc/core-linux-arm64-gnu" "1.3.100"
+    "@swc/core-linux-arm64-musl" "1.3.100"
+    "@swc/core-linux-x64-gnu" "1.3.100"
+    "@swc/core-linux-x64-musl" "1.3.100"
+    "@swc/core-win32-arm64-msvc" "1.3.100"
+    "@swc/core-win32-ia32-msvc" "1.3.100"
+    "@swc/core-win32-x64-msvc" "1.3.100"
 
 "@swc/counter@^0.1.1":
   version "0.1.2"
@@ -4055,9 +4055,9 @@
     pretty-format "^27.0.2"
 
 "@testing-library/jest-dom@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.1.4.tgz#cf0835c33bc5ef00befb9e672b1e3e6a710e30e3"
-  integrity sha512-wpoYrCYwSZ5/AxcrjLxJmCU6I5QAJXslEeSiMQqaWmP2Kzpd1LvF/qxmAIW2qposULGWq2gw30GgVNFLSc2Jnw==
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.1.5.tgz#0a635d0ad4a1a880089d967299d94e9cfc81fbe1"
+  integrity sha512-3y04JLW+EceVPy2Em3VwNr95dOKqA8DhR0RJHhHKDZNYXcVXnEK7WIrpj4eYU8SVt/qYZ2aRWt/WgQ+grNES8g==
   dependencies:
     "@adobe/css-tools" "^4.3.1"
     "@babel/runtime" "^7.9.2"
@@ -4611,9 +4611,9 @@
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
 "@types/node@^18.0.0", "@types/node@^18.11.18":
-  version "18.18.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.14.tgz#26771c647f2842af57eb96191cd615d845164295"
-  integrity sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==
+  version "18.19.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.0.tgz#e86ce256c46661016fa83360bf8738eb4efdc88c"
+  integrity sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -5710,9 +5710,9 @@ available-typed-arrays@^1.0.5:
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sdk@^2.1231.0:
-  version "2.1508.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1508.0.tgz#ef88fd45e3cd4ac179aef073acb0a03e1218b0da"
-  integrity sha512-YiUzYqtPLIRwVkbWaA2dFSFaBLrtCUr3dE6gDJmadiH5NL2mNNZBOW+1JyFT33VOVdU8Pp8OWeNBEGCay9Psxg==
+  version "2.1509.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1509.0.tgz#1e5bea1a0befc0e5368db7a63cda0e4ec543e9f7"
+  integrity sha512-5h27GXv5/M1Cfgw5StYqTyCesnqscez3QOsKGnShCXP6saGkSEvV3TUHTXQBqdfsrBmz5hVCa8doqP3r3yJD/w==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -6632,9 +6632,9 @@ classnames@^2.2.6:
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^5.2.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"
-  integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
+  integrity sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==
   dependencies:
     source-map "~0.6.0"
 
@@ -7840,7 +7840,7 @@ define-lazy-prop@^3.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
-define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0, define-properties@^1.2.1:
+define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
   integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
@@ -8307,9 +8307,9 @@ electron-publish@24.8.1:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.535:
-  version "1.4.597"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.597.tgz#9848b9aa52749bf35be88013bab52be232889d94"
-  integrity sha512-0XOQNqHhg2YgRVRUrS4M4vWjFCFIP2ETXcXe/0KIQBjXE9Cpy+tgzzYfuq6HGai3hWq0YywtG+5XK8fyG08EjA==
+  version "1.4.600"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.600.tgz#10ad8a5edc3f92a9a70b4453157ec2261c6db088"
+  integrity sha512-KD6CWjf1BnQG+NsXuyiTDDT1eV13sKuYsOUioXkQweYTQIbgHkXPry9K7M+7cKtYHnSUPitVaLrXYB1jTkkYrw==
 
 electron-updater@^6.1.1:
   version "6.1.7"
@@ -8333,10 +8333,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@27.1.2:
-  version "27.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-27.1.2.tgz#d3074c91cce94c1e19b5904b1cdf78c830f2558d"
-  integrity sha512-Dy6BUuGLiIJv+zfsXwr78TV2TNppi24rXF4PIIS+OjDblEKdkI9r1iM8JUd3/x3sbGUy5mdLMSPhvmu//IhkgA==
+electron@27.1.3:
+  version "27.1.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-27.1.3.tgz#3fd6decda95c1dd0a7e51a9ac77ee0ba37b7c5c6"
+  integrity sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
@@ -11569,9 +11569,9 @@ jsdom@^20.0.0:
     xml-name-validator "^4.0.0"
 
 jsdom@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-23.0.0.tgz#7c8bac82e32e1ac3eef29096ea59d519c72ce4eb"
-  integrity sha512-cbL/UCtohJguhFC7c2/hgW6BeZCNvP7URQGnx9tSJRYKCdnfbfWOrtuLTMfiB2VxKsx5wPHVsh/J0aBy9lIIhQ==
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-23.0.1.tgz#ede7ff76e89ca035b11178d200710d8982ebfee0"
+  integrity sha512-2i27vgvlUsGEBO9+/kJQRbtqtm+191b5zAZrU/UezVmnC2dlDAFLgDYJvAEi94T4kjsRKkezEtLQTgsNEsW2lQ==
   dependencies:
     cssstyle "^3.0.0"
     data-urls "^5.0.0"
@@ -12959,9 +12959,9 @@ node-polyfill-webpack-plugin@^2.0.1:
     vm-browserify "^1.1.2"
 
 node-releases@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
-  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
+  integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -13307,12 +13307,12 @@ object-treeify@^1.1.33:
   integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
 
 object.assign@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
-  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.5.tgz#3a833f9ab7fdb80fc9e8d2300c803d216d8fdbb0"
+  integrity sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.4"
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
@@ -16095,11 +16095,11 @@ store2@^2.14.2:
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
 storybook@^7.0.0:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.1.tgz#ecbc09b66532d1bdfaa22dc34b7bc928d3183578"
-  integrity sha512-JarHWZ7PLnGFPvapcSTdmneckGi1nCez18JozXsFXunDLZWUEn8kui0FLUhc579glZ8yDaSr9zsxWG8ZIFUm+A==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.3.tgz#6b87d0b96b2f9f4911408f6d3d0435de3226e58c"
+  integrity sha512-H3odxahMiR8vVW7ltlqcHhn3UVH5ta03weKlY7xvpv5DV+thZ+mEO2cDYfsufCSg0Ldb5LQ4qq3OyLVdpDBN8g==
   dependencies:
-    "@storybook/cli" "7.6.1"
+    "@storybook/cli" "7.6.3"
 
 stream-browserify@^3.0.0:
   version "3.0.0"
@@ -16381,9 +16381,9 @@ svg-path-generator@^1.1.0:
   integrity sha512-eapn3syFa828HJRI3Wv+ceq7K/TUo/wA31w5oyerA3CNz02YkLM8aSjXA851+0qhc1ibihiJHxy54eacm2/euQ==
 
 svgo@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.4.tgz#67b40a710743e358e8d19ec288de8f1e388afbb4"
-  integrity sha512-T+Xul3JwuJ6VGXKo/p2ndqx1ibxNKnLTvRc1ZTWKCfyKS/GgNjRZcYsK84fxTsy/izr91g/Rwx6fGnVgaFSI5g==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.5.tgz#0595cf3c762c4e5180713d7b92dc67deaf46c6a0"
+  integrity sha512-HQKHEo73pMNOlDlBcLgZRcHW2+1wo7bFYayAXkGN0l/2+h68KjlfZyMRhdhaGvoHV2eApOovl12zoFz42sT6rQ==
   dependencies:
     "@trysound/sax" "0.2.0"
     commander "^7.2.0"


### PR DESCRIPTION
Uses markdown syntax in the javadoc-style doc comments to create links between doc pages on jbrowse.org

Also speeds up the launch of the dev server for the website substantially by avoiding "barrel imports" of both @mui/material and @mui/icons-material

a barrel import looks like


```
import {Link} from '@mui/material'
```

a non-barrel import looks like

```
import Link from '@mui/material/Link'
```
as much as i like the syntax for barrell imports, it can be very beneficial to avoid them especially on the icon pack