### PR TITLE
Jexl re-export

### DIFF
--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -139,8 +139,7 @@ export interface RuntimePluginLoadRecord extends PluginLoadRecord {
 export default class PluginManager {
   plugins: Plugin[] = []
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  jexl: any = createJexlInstance()
+  jexl = createJexlInstance()
 
   pluginMetadata: Record<string, PluginMetadata> = {}
 


### PR DESCRIPTION
for some reason the 'jexl' property is explicitly marked as type any, when it might not need to be. this makes usage of e.g. pluginManager.jexl.addFunction not recognized by typescript. this PR tries to type it better