### PR TITLE
Remove --tracks and --view options from set-default-session CLI

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -543,22 +543,16 @@ Set a default session with views and tracks
 
 ```
 USAGE
-  $ jbrowse set-default-session [-s <value>] [-n <value>] [-v <value>] [--viewId <value>] [-t <value>] [-c] [--target
-    <value>] [--out <value>] [--delete] [-h]
+  $ jbrowse set-default-session [-s <value>] [-n <value>] [-c] [--target <value>] [--out <value>] [--delete] [-h]
 
 FLAGS
   -c, --currentSession   List out the current default session
   -h, --help             Show CLI help.
   -n, --name=<value>     [default: New Default Session] Give a name for the default session
   -s, --session=<value>  set path to a file containing session in json format
-  -t, --tracks=<value>   Track id or track ids as comma separated string to put into default session
-  -v, --view=<value>     View type in config to be added as default session, i.e LinearGenomeView, CircularView,
-                         DotplotView.
-                         Must be provided if no default session file provided
       --delete           Delete any existing default session.
       --out=<value>      synonym for target
       --target=<value>   path to config file in JB2 installation directory to write out to
-      --viewId=<value>   Identifier for the view. Will be generated on default
 
 DESCRIPTION
   Set a default session with views and tracks
@@ -566,9 +560,9 @@ DESCRIPTION
 EXAMPLES
   $ jbrowse set-default-session --session /path/to/default/session.json
 
-  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1, track2, track3
+  $ jbrowse set-default-session --target /path/to/jb2/installation/config.json
 
-  $ jbrowse set-default-session --view LinearGenomeView, --name newName --viewId view-no-tracks
+  $ jbrowse set-default-session --view LinearGenomeView, --name newName
 
   $ jbrowse set-default-session --currentSession # Prints out current default session
 ```

--- a/products/jbrowse-cli/src/commands/set-default-session.test.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.test.ts
@@ -65,17 +65,8 @@ const simpleBam = dataDir('simple.bam')
 const simpleDefaultSession = dataDir('sampleDefaultSession.json')
 const testConfig = dataDir('test_config.json')
 
-const setupWithAddTrack = setup
-  .do(async ctx => {
-    await copyFile(testConfig, path.join(ctx.dir, path.basename(testConfig)))
-    await rename(
-      path.join(ctx.dir, path.basename(testConfig)),
-      path.join(ctx.dir, 'config.json'),
-    )
-  })
-  .command(['add-track', simpleBam, '--load', 'copy'])
-
-// Cleaning up exitCode in Node.js 20, xref https://github.com/jestjs/jest/issues/14501
+// Cleaning up exitCode in Node.js 20, xref
+// https://github.com/jestjs/jest/issues/14501
 afterAll(() => (process.exitCode = 0))
 
 describe('set-default-session', () => {
@@ -130,28 +121,6 @@ describe('set-default-session', () => {
     .exit(160)
     .it('fails when file is does not have a default session to read')
 
-  setupWithAddTrack
-    .do(async ctx => {
-      await copyFile(testConfig, path.join(ctx.dir, path.basename(testConfig)))
-
-      await rename(
-        path.join(ctx.dir, path.basename(testConfig)),
-        path.join(ctx.dir, 'config.json'),
-      )
-    })
-    .command(['set-default-session', '--tracks', 'simple'])
-    .exit(130)
-    .it('fails when specifying a track without specifying a view')
-  setupWithAddTrack
-    .command([
-      'set-default-session',
-      '--view',
-      'LinearGenomeView',
-      '--tracks',
-      'track-non-exist',
-    ])
-    .exit(140)
-    .it('fails when specifying a track that does not exist')
   setup
     .do(async ctx => {
       await copyFile(testConfig, path.join(ctx.dir, path.basename(testConfig)))
@@ -203,36 +172,4 @@ describe('set-default-session', () => {
         },
       })
     })
-  setupWithAddTrack
-    .command([
-      'set-default-session',
-      '--view',
-      'LinearGenomeView',
-      '--tracks',
-      'simple',
-    ])
-    .it(
-      'adds a default session that is a linear genome view and a simple track',
-      async ctx => {
-        const contents = readConf(ctx)
-        expect(contents).toEqual({
-          ...defaultConfig,
-          defaultSession: {
-            name: 'New Default Session',
-            views: [
-              {
-                id: 'LinearGenomeView-1',
-                type: 'LinearGenomeView',
-                tracks: [
-                  {
-                    type: 'AlignmentsTrack',
-                    configuration: 'simple',
-                  },
-                ],
-              },
-            ],
-          },
-        })
-      },
-    )
 })

--- a/products/jbrowse-cli/src/commands/set-default-session.ts
+++ b/products/jbrowse-cli/src/commands/set-default-session.ts
@@ -6,14 +6,11 @@ import JBrowseCommand from '../base'
 
 const fsPromises = fs.promises
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DefaultSession = Record<string, any>
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Track = Record<string, any>
+type DefaultSession = Record<string, unknown>
+type Track = Record<string, unknown>
 
 interface Config {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  assemblies?: { name: string; sequence: Record<string, any> }[]
+  assemblies?: { name: string; sequence: Record<string, unknown> }[]
   configuration?: {}
   connections?: unknown[]
   defaultSession?: DefaultSession
@@ -28,8 +25,8 @@ export default class SetDefaultSession extends JBrowseCommand {
 
   static examples = [
     '$ jbrowse set-default-session --session /path/to/default/session.json',
-    '$ jbrowse set-default-session --target /path/to/jb2/installation/config.json --view LinearGenomeView --tracks track1, track2, track3',
-    '$ jbrowse set-default-session --view LinearGenomeView, --name newName --viewId view-no-tracks',
+    '$ jbrowse set-default-session --target /path/to/jb2/installation/config.json',
+    '$ jbrowse set-default-session --view LinearGenomeView, --name newName',
     '$ jbrowse set-default-session --currentSession # Prints out current default session',
   ]
 
@@ -42,19 +39,6 @@ export default class SetDefaultSession extends JBrowseCommand {
       char: 'n',
       description: 'Give a name for the default session',
       default: 'New Default Session',
-    }),
-    view: Flags.string({
-      char: 'v',
-      description:
-        'View type in config to be added as default session, i.e LinearGenomeView, CircularView, DotplotView.\nMust be provided if no default session file provided',
-    }),
-    viewId: Flags.string({
-      description: 'Identifier for the view. Will be generated on default',
-    }),
-    tracks: Flags.string({
-      char: 't',
-      description:
-        'Track id or track ids as comma separated string to put into default session',
     }),
     currentSession: Flags.boolean({
       char: 'c',
@@ -77,15 +61,7 @@ export default class SetDefaultSession extends JBrowseCommand {
 
   async run() {
     const { flags: runFlags } = await this.parse(SetDefaultSession)
-    const {
-      session,
-      name,
-      tracks,
-      currentSession,
-      view,
-      viewId,
-      delete: deleteDefaultSession,
-    } = runFlags
+    const { session, currentSession, delete: deleteDefaultSession } = runFlags
     const output = runFlags.target || runFlags.out || '.'
     const isDir = (await fsPromises.lstat(output)).isDirectory()
     this.target = isDir ? `${output}/config.json` : output
@@ -93,86 +69,22 @@ export default class SetDefaultSession extends JBrowseCommand {
 
     if (deleteDefaultSession) {
       delete configContents.defaultSession
-      this.debug(`Writing configuration to file ${this.target}`)
       await this.writeJsonFile(this.target, configContents)
-      this.log(`Deleted defaultSession from ${this.target}`)
-      return
-    }
-
-    // if user passes current session flag, print out and exit
-    if (currentSession) {
+    } else if (currentSession) {
       this.log(
         `The current default session is ${JSON.stringify(
           configContents.defaultSession,
         )}`,
       )
       this.exit()
-    }
-
-    const foundTracks: Track[] = []
-    const existingDefaultSession = configContents.defaultSession?.length > 0
-
-    // must provide default session, or view, or tracks + view
-    if (!session && !view && !tracks) {
-      this.error(
-        `No default session information provided, Please either provide a default session file or enter information to build a default session`,
-        { exit: 120 },
-      )
+    } else if (!session) {
+      this.error(`Please either provide a default session file`, { exit: 120 })
     } else if (session) {
-      // if user provides a file, process and set as default session and exit
-      const defaultJson = await this.readDefaultSessionFile(session)
-      configContents.defaultSession = defaultJson
-    } else {
-      // use trackids if any to match to tracks in the config
-      let trackIds = []
-      if (tracks && configContents.tracks) {
-        if (!view) {
-          this.error(
-            'Tracks must have a view type specified. Please rerun using the --view flag',
-            { exit: 130 },
-          )
-        }
-        trackIds = tracks.split(',').map(c => c.trim())
-        trackIds.forEach(trackId => {
-          this.log(trackId)
-          const matchingTrack = configContents.tracks?.find(
-            track => trackId === track.trackId,
-          )
-          if (!matchingTrack) {
-            this.error(
-              `Track ${trackId} has not been added to config yet.\nPlease add the track with the add-track command before adding to the default session`,
-              { exit: 140 },
-            )
-          } else {
-            foundTracks.push({
-              type: matchingTrack.type,
-              configuration: matchingTrack.trackId,
-            })
-          }
-        })
-      }
-
-      configContents.defaultSession = {
-        name,
-        views: [
-          {
-            id: viewId || `${view}-${foundTracks.length}`,
-            type: view,
-            tracks: foundTracks,
-          },
-        ],
-      }
+      await this.writeJsonFile(this.target, {
+        ...configContents,
+        defaultSession: await this.readDefaultSessionFile(session),
+      })
     }
-    this.debug(`Writing configuration to file ${this.target}`)
-    await this.writeJsonFile(this.target, configContents)
-
-    this.log(
-      `${
-        existingDefaultSession ? 'Overwrote' : 'Added'
-      } defaultSession "${name}" ${existingDefaultSession ? 'in' : 'to'} ${
-        this.target
-      }`,
-    )
   }
 
   async readDefaultSessionFile(defaultSessionFile: string) {


### PR DESCRIPTION
These options were created very early on but they have not worked for awhile and generated incomplete state snapshots of the session which could not be loaded

the alternative to removing this would be to either (a) make the CLI make a more complete snapshot or (b) make our code allow incomplete state snapshots to load

fixes https://github.com/GMOD/jbrowse-components/issues/2708
