### PR TITLE
Create defaultSession spec for config.json files to load simplified default sessions

### DIFF
--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -470,34 +470,26 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
   },
   "connections": [],
   "defaultSession": {
-    "activeWidgets": {
-      "hierarchicalTrackSelector": "hierarchicalTrackSelector",
-    },
-    "name": "Integration test example",
+    "name": "Session",
+    "type": "spec",
     "views": [
       {
-        "bpPerPx": 0.05,
-        "displayedRegions": [
-          {
-            "assemblyName": "volvox",
-            "end": 50001,
-            "refName": "ctgA",
-            "start": 0,
-          },
+        "assembly": "volvox",
+        "loc": "ctgA:1-100",
+        "tracks": [
+          "volvox_cram_pileup",
         ],
-        "id": "integration_test",
-        "offsetPx": 2000,
+        "type": "LinearGenomeView",
+      },
+      {
+        "assembly": "volvox",
+        "loc": "ctgB:1-100",
+        "tracks": [
+          "volvox_cram_pileup",
+        ],
         "type": "LinearGenomeView",
       },
     ],
-    "widgets": {
-      "hierarchicalTrackSelector": {
-        "filterText": "",
-        "id": "hierarchicalTrackSelector",
-        "type": "HierarchicalTrackSelectorWidget",
-        "view": "integration_test",
-      },
-    },
   },
   "internetAccounts": [],
   "plugins": [

--- a/products/jbrowse-web/src/components/NoConfigMessage.tsx
+++ b/products/jbrowse-web/src/components/NoConfigMessage.tsx
@@ -23,6 +23,7 @@ export default function NoConfigMessage() {
     ['test_data/volvox/config_auth_main.json', 'Volvox (auth, mainthreadrpc)'],
     ['test_data/volvox/config_auth.json', 'Volvox (auth)'],
     ['test_data/volvoxhub/config.json', 'Volvox (with ucsc-hub)'],
+    ['test_data/volvox/spec.json', 'Volvox (with spec defaultsession)'],
   ]
   const { href, search } = window.location
   const { config, ...rest } = Object.fromEntries(new URLSearchParams(search))

--- a/products/jbrowse-web/src/rootModel/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel/rootModel.ts
@@ -278,6 +278,7 @@ export default function RootModel({
 
         this.setSession(newSession)
       },
+
       /**
        * #action
        */

--- a/test_data/volvox/spec.json
+++ b/test_data/volvox/spec.json
@@ -1,0 +1,63 @@
+{
+  "assemblies": [
+    {
+      "name": "volvox",
+      "aliases": ["vvx"],
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "volvox_refseq",
+        "adapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "volvox.2bit",
+            "locationType": "UriLocation"
+          }
+        }
+      }
+    }
+  ],
+  "connections": [],
+  "defaultSession": {
+    "name": "Session",
+    "type": "spec",
+    "views": [
+      {
+        "type": "LinearGenomeView",
+        "tracks": ["volvox_cram_pileup"],
+        "loc": "ctgA:1-100",
+        "assembly": "volvox"
+      },
+      {
+        "type": "LinearGenomeView",
+        "tracks": ["volvox_cram_pileup"],
+        "loc": "ctgB:1-100",
+        "assembly": "volvox"
+      }
+    ]
+  },
+  "tracks": [
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "volvox_cram_pileup",
+      "name": "volvox-sorted.cram",
+      "category": ["Integration test"],
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "volvox-sorted-altname.cram"
+        },
+        "craiLocation": {
+          "uri": "volvox-sorted-altname.cram.crai"
+        },
+        "sequenceAdapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "volvox.2bit"
+          }
+        },
+        "fetchSizeLimit": 1000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Currently, the defaultSession is a raw snapshot of internal app state. There are efforts that can be made to simplify that internal state to some extent, but in addition to or alternative to that, we can create helpers like this PR does that make extra APIs to load data instead of providing raw app state to defaultSession.

 This PR is essentially making the "url query param" API available from the config.json on a slot named "defaultSessionSpec", similar to "spec-" type URLs that the jbrowse-web app accepts