### PR TITLE
Fix subfeature refNames on BED and BEDTabix parsers

### DIFF
--- a/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
+++ b/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
@@ -112,6 +112,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
       {
         "end": 2,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 1,
         "strand": 0,
         "type": "three_prime_UTR",
@@ -215,6 +216,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1200,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -223,6 +225,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1500,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -231,6 +234,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 3902,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "CDS",
@@ -239,6 +243,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -247,6 +252,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7608,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -255,6 +261,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 9000,
         "parentId": "test-ctgA-0",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -276,6 +283,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1200,
         "parentId": "test-ctgA-1",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -284,6 +292,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1500,
         "parentId": "test-ctgA-1",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -292,6 +301,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-1",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -300,6 +310,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7608,
         "parentId": "test-ctgA-1",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -308,6 +319,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 9000,
         "parentId": "test-ctgA-1",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -329,6 +341,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1500,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 1299,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -337,6 +350,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 3300,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -345,6 +359,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 3902,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 3300,
         "strand": 1,
         "type": "CDS",
@@ -353,6 +368,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -361,6 +377,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7600,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -369,6 +386,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 9000,
         "parentId": "test-ctgA-2",
+        "refName": "ctgA",
         "start": 7600,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -390,6 +408,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 17999,
         "parentId": "test-ctgA-3",
+        "refName": "ctgA",
         "start": 17399,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -398,6 +417,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 18800,
         "parentId": "test-ctgA-3",
+        "refName": "ctgA",
         "start": 17999,
         "strand": 1,
         "type": "CDS",
@@ -406,6 +426,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 19500,
         "parentId": "test-ctgA-3",
+        "refName": "ctgA",
         "start": 18999,
         "strand": 1,
         "type": "CDS",
@@ -414,6 +435,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 21200,
         "parentId": "test-ctgA-3",
+        "refName": "ctgA",
         "start": 20999,
         "strand": 1,
         "type": "CDS",
@@ -422,6 +444,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 23000,
         "parentId": "test-ctgA-3",
+        "refName": "ctgA",
         "start": 21200,
         "strand": 1,
         "type": "three_prime_UTR",

--- a/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
+++ b/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
@@ -112,6 +112,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
       {
         "end": 2,
         "parentId": "test-52986",
+        "refName": "ctgA",
         "start": 1,
         "strand": 0,
         "type": "three_prime_UTR",
@@ -215,6 +216,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1200,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -223,6 +225,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1500,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -231,6 +234,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 3902,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "CDS",
@@ -239,6 +243,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -247,6 +252,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7608,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -255,6 +261,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 9000,
         "parentId": "test-45690",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -276,6 +283,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1200,
         "parentId": "test-45787",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -284,6 +292,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1500,
         "parentId": "test-45787",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -292,6 +301,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45787",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -300,6 +310,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7608,
         "parentId": "test-45787",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -308,6 +319,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 9000,
         "parentId": "test-45787",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -329,6 +341,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1500,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 1299,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -337,6 +350,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 3300,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -345,6 +359,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 3902,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 3300,
         "strand": 1,
         "type": "CDS",
@@ -353,6 +368,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -361,6 +377,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7600,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -369,6 +386,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 9000,
         "parentId": "test-45875",
+        "refName": "ctgA",
         "start": 7600,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -390,6 +408,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 17999,
         "parentId": "test-45972",
+        "refName": "ctgA",
         "start": 17399,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -398,6 +417,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 18800,
         "parentId": "test-45972",
+        "refName": "ctgA",
         "start": 17999,
         "strand": 1,
         "type": "CDS",
@@ -406,6 +426,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 19500,
         "parentId": "test-45972",
+        "refName": "ctgA",
         "start": 18999,
         "strand": 1,
         "type": "CDS",
@@ -414,6 +435,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 21200,
         "parentId": "test-45972",
+        "refName": "ctgA",
         "start": 20999,
         "strand": 1,
         "type": "CDS",
@@ -422,6 +444,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 23000,
         "parentId": "test-45972",
+        "refName": "ctgA",
         "start": 21200,
         "strand": 1,
         "type": "three_prime_UTR",

--- a/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
+++ b/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
@@ -18,6 +18,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1200,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -26,6 +27,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1500,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -34,6 +36,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 3902,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "CDS",
@@ -42,6 +45,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -50,6 +54,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7608,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -58,6 +63,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 9000,
         "parentId": "test-bb-358912",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -84,6 +90,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1200,
         "parentId": "test-bb-359006",
+        "refName": "ctgA",
         "start": 1049,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -92,6 +99,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1500,
         "parentId": "test-bb-359006",
+        "refName": "ctgA",
         "start": 1200,
         "strand": 1,
         "type": "CDS",
@@ -100,6 +108,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-359006",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -108,6 +117,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7608,
         "parentId": "test-bb-359006",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -116,6 +126,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 9000,
         "parentId": "test-bb-359006",
+        "refName": "ctgA",
         "start": 7608,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -142,6 +153,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1500,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 1299,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -150,6 +162,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 3300,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 2999,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -158,6 +171,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 3902,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 3300,
         "strand": 1,
         "type": "CDS",
@@ -166,6 +180,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 4999,
         "strand": 1,
         "type": "CDS",
@@ -174,6 +189,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7600,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 6999,
         "strand": 1,
         "type": "CDS",
@@ -182,6 +198,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 9000,
         "parentId": "test-bb-359091",
+        "refName": "ctgA",
         "start": 7600,
         "strand": 1,
         "type": "three_prime_UTR",
@@ -208,6 +225,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 17999,
         "parentId": "test-bb-359185",
+        "refName": "ctgA",
         "start": 17399,
         "strand": 1,
         "type": "five_prime_UTR",
@@ -216,6 +234,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 18800,
         "parentId": "test-bb-359185",
+        "refName": "ctgA",
         "start": 17999,
         "strand": 1,
         "type": "CDS",
@@ -224,6 +243,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 19500,
         "parentId": "test-bb-359185",
+        "refName": "ctgA",
         "start": 18999,
         "strand": 1,
         "type": "CDS",
@@ -232,6 +252,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 21200,
         "parentId": "test-bb-359185",
+        "refName": "ctgA",
         "start": 20999,
         "strand": 1,
         "type": "CDS",
@@ -240,6 +261,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 23000,
         "parentId": "test-bb-359185",
+        "refName": "ctgA",
         "start": 21200,
         "strand": 1,
         "type": "three_prime_UTR",


### PR DESCRIPTION
Adds a refName field to all subfeatures.

Fixes #4157 

An alternative could potentially be done so that the subfeatures always look at their parent feature for the refName but this is interim or easy fix