### PR TITLE
Adds workflow to automatically dispatch updates to dependent GMOD repos

### DIFF
--- a/.github/workflows/repo_dispatch.yml
+++ b/.github/workflows/repo_dispatch.yml
@@ -1,0 +1,36 @@
+name: Repository dispatch (publish)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  repo_dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - 'GMOD/dash_jbrowse'
+          - 'GMOD/jbrowse-react-linear-genome-view-vanillajs-demo'
+          - 'GMOD/jbrowse-react-linear-genome-view-cra5-demo'
+          - 'GMOD/jbrowse-react-linear-genome-view-cra4-demo'
+          - 'GMOD/jbrowse-react-linear-genome-view-vite-demo'
+          - 'GMOD/jbrowse-react-linear-genome-view-nextjs-demo'
+          - 'GMOD/jbrowse-react-circular-genome-view-vanillajs-demo'
+          - 'GMOD/jbrowse-react-circular-genome-view-cra5-demo'
+          - 'GMOD/jbrowse-react-circular-genome-view-cra4-demo'
+          - 'GMOD/jbrowse-react-circular-genome-view-nextjs-demo'
+          - 'GMOD/jbrowse-react-app-nextjs-demo'
+          - 'GMOD/jbrowse-react-app-vite-demo'
+          - 'GMOD/jbrowse-react-app-cra5-demo'
+
+    steps:
+      - name:
+          Dispatch jbrowse-components release event to dependent GMOD
+          repositories
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ACTIONS_KEY }}
+          repository: ${{ matrix.repo }}
+          event-type: auto_publish
+          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
When a new version of jbrowse-components is published, this workflow will trigger and will dispatch an event to dependent GMOD workflows.

Relevant permissions in this repo, and dependent repos:
- Workflow permissions > read and write permissions
- Actions secrets > repository secrets > ACTIONS_KEY === github personal access token

A publish action MUST be invoked for this workflow to trigger / work (because it needs the version from the publish action)