### PR TITLE
v2.10.2 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.10.2.md
+++ b/website/release_announcement_drafts/v2.10.2.md
@@ -1,0 +1,27 @@
+## Get stack traces from error messages
+
+This release adds a new feature to allow getting the stack trace from error
+messages, which will show the exact line of code the error occured on and will
+help with debugging error reports.
+
+![](https://user-images.githubusercontent.com/6511937/300597947-6bf8056c-18cd-4033-9321-37e942a650f6.png)
+
+## Launch breakpoint split view from alignment feature details
+
+Previously, you could launch a breakpoint split view from a TRA/breakend type
+feature in the variant feature details, but this allows you to do it directly
+via a read
+
+![](https://user-images.githubusercontent.com/6511937/306055182-35cffedd-ce2e-4645-b3ca-b674c49febd1.png)
+
+Screenshot showing the workflow to launch a breakpoint split view from a read
+
+## @jbrowse/img tool fixes
+
+The jb2export command line image exporter from @jbrowse/img had issues with
+node.js preventing it from running, so this was fixed, and a new ability to
+export just snpcov visualizations was added. Example
+
+```bash
+jb2export --bam file.bam snpcov height:400 --fasta hg19.fa --out output.png
+```


### PR DESCRIPTION
Adds the new "Show stack trace" button to error messages, may help get better error reports from users without trying to instruct use of devtools (which doesn't even work in desktop also, i don't believe we have devtools enabled on our desktop build)