### PR TITLE
bug on synteny_track.md

### DIFF
--- a/website/docs/config_guides/synteny_track.md
+++ b/website/docs/config_guides/synteny_track.md
@@ -83,10 +83,7 @@ Slots
   it is not an indexed file format.
 - `assemblyNames` - list of assembly names, typically two (first in list is
   target, second is query)
-- `queryAssembly` - alternative to assemblyNames: just the assemblyName of the
-  query
-- `targetAssembly` - alternative to assemblyNames: just the assemblyName of the
-  target
+
 
 ### ChainAdapter config
 


### PR DESCRIPTION
if you provide  `queryAssembly` or  `targetAssembly` to the config.json, it croaks. assemblyNames and only is assemblyNames necessary