### PR TITLE
Get rid of scrollbar on default sequence display

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/ServerSideRenderedContent.tsx
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRenderedContent.tsx
@@ -65,7 +65,6 @@ const NewHydrate = observer(function ServerSideRenderedContent({
     <div
       data-testid="hydrationContainer"
       ref={ref}
-      style={{ display: 'flex' }}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/core/pluggableElementTypes/renderers/ServerSideRenderedContent.tsx
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRenderedContent.tsx
@@ -61,8 +61,15 @@ const NewHydrate = observer(function ServerSideRenderedContent({
     }
   }, [html, theme, rest, hydrateFn, RenderingComponent])
 
-  // eslint-disable-next-line react/no-danger
-  return <div ref={ref} dangerouslySetInnerHTML={{ __html: html }} />
+  return (
+    <div
+      data-testid="hydrationContainer"
+      ref={ref}
+      style={{ display: 'flex' }}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
 })
 
 const OldHydrate = observer(function ({

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -532,6 +532,7 @@ exports[`renders one track, one region 1`] = `
                   <svg
                     data-testid="svgfeatures"
                     height="100"
+                    style="display: block;"
                     width="100"
                   />
                 </div>
@@ -1350,6 +1351,7 @@ exports[`renders two tracks, two regions 1`] = `
                   <svg
                     data-testid="svgfeatures"
                     height="100"
+                    style="display: block;"
                     width="100"
                   />
                 </div>
@@ -1364,6 +1366,7 @@ exports[`renders two tracks, two regions 1`] = `
                   <svg
                     data-testid="svgfeatures"
                     height="100"
+                    style="display: block;"
                     width="800"
                   />
                 </div>
@@ -1481,6 +1484,7 @@ exports[`renders two tracks, two regions 1`] = `
                   <svg
                     data-testid="svgfeatures"
                     height="100"
+                    style="display: block;"
                     width="100"
                   />
                 </div>
@@ -1495,6 +1499,7 @@ exports[`renders two tracks, two regions 1`] = `
                   <svg
                     data-testid="svgfeatures"
                     height="100"
+                    style="display: block;"
                     width="800"
                   />
                 </div>

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.tsx
@@ -48,6 +48,7 @@ test('renders with one, zoomed way out', () => {
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={3}
+      height={160}
     />,
   )
 
@@ -67,6 +68,7 @@ test('renders with one feature with no seq, zoomed in, should throw', () => {
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
+      height={160}
     />,
   )
 
@@ -94,6 +96,7 @@ test('renders with one feature with an incorrect seq, zoomed in, should throw', 
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
+      height={160}
     />,
   )
 
@@ -121,6 +124,7 @@ test('renders with one feature with a correct seq, zoomed in, should render nice
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
+      height={160}
     />,
   )
 
@@ -154,6 +158,7 @@ test('renders with one feature reversed with a correct seq, zoomed in, should re
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
+      height={160}
     />,
   )
 

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.test.tsx
@@ -48,7 +48,8 @@ test('renders with one, zoomed way out', () => {
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={3}
-      height={160}
+      sequenceHeight={160}
+      rowHeight={20}
     />,
   )
 
@@ -68,7 +69,8 @@ test('renders with one feature with no seq, zoomed in, should throw', () => {
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
-      height={160}
+      sequenceHeight={160}
+      rowHeight={20}
     />,
   )
 
@@ -96,7 +98,8 @@ test('renders with one feature with an incorrect seq, zoomed in, should throw', 
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
-      height={160}
+      sequenceHeight={160}
+      rowHeight={20}
     />,
   )
 
@@ -124,7 +127,8 @@ test('renders with one feature with a correct seq, zoomed in, should render nice
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
-      height={160}
+      sequenceHeight={160}
+      rowHeight={20}
     />,
   )
 
@@ -158,7 +162,8 @@ test('renders with one feature reversed with a correct seq, zoomed in, should re
       }
       config={DivRenderingConfigSchema.create({})}
       bpPerPx={0.05}
-      height={160}
+      sequenceHeight={160}
+      rowHeight={20}
     />,
   )
 

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -172,6 +172,7 @@ function SequenceSVG({
   showForward = true,
   showTranslation = true,
   bpPerPx,
+  rowHeight,
 }: {
   regions: Region[]
   theme?: Theme
@@ -180,11 +181,11 @@ function SequenceSVG({
   showForward?: boolean
   showTranslation?: boolean
   bpPerPx: number
+  rowHeight: number
 }) {
   const [region] = regions
   const theme = createJBrowseTheme(configTheme)
   const codonTable = generateCodonTable(defaultCodonTable)
-  const height = 20
   const [feature] = [...features.values()]
   if (!feature) {
     return null
@@ -196,7 +197,7 @@ function SequenceSVG({
 
   // incrementer for the y-position of the current sequence being rendered
   // (applies to both translation rows and dna rows)
-  let currY = -20
+  let currY = -rowHeight
 
   return (
     <>
@@ -207,13 +208,13 @@ function SequenceSVG({
             <Translation
               key={`translation-${index}`}
               seq={seq}
-              y={(currY += 20)}
+              y={(currY += rowHeight)}
               codonTable={codonTable}
               frame={index}
               bpPerPx={bpPerPx}
               region={region}
               theme={theme}
-              height={height}
+              height={rowHeight}
               reverse={region.reversed}
             />
           ))
@@ -221,8 +222,8 @@ function SequenceSVG({
 
       {showForward ? (
         <DNA
-          height={height}
-          y={(currY += 20)}
+          height={rowHeight}
+          y={(currY += rowHeight)}
           feature={feature}
           region={region}
           seq={region.reversed ? complement(seq) : seq}
@@ -233,8 +234,8 @@ function SequenceSVG({
 
       {showReverse ? (
         <DNA
-          height={height}
-          y={(currY += 20)}
+          height={rowHeight}
+          y={(currY += rowHeight)}
           feature={feature}
           region={region}
           seq={region.reversed ? seq : complement(seq)}
@@ -250,13 +251,13 @@ function SequenceSVG({
             <Translation
               key={`rev-translation-${index}`}
               seq={seq}
-              y={(currY += 20)}
+              y={(currY += rowHeight)}
               codonTable={codonTable}
               frame={index}
               bpPerPx={bpPerPx}
               region={region}
               theme={theme}
-              height={height}
+              height={rowHeight}
               reverse={!region.reversed}
             />
           ))
@@ -295,19 +296,20 @@ const DivSequenceRendering = observer(function (props: {
   features: Map<string, Feature>
   regions: Region[]
   bpPerPx: number
-  height: number
+  rowHeight: number
+  sequenceHeight: number
   config: AnyConfigurationModel
   theme?: Theme
   showForward?: boolean
   showReverse?: boolean
   showTranslation?: boolean
 }) {
-  const { regions, bpPerPx, height } = props
+  const { regions, bpPerPx, sequenceHeight } = props
   const [region] = regions
   const width = (region.end - region.start) / bpPerPx
 
   return (
-    <Wrapper {...props} totalHeight={height} width={width}>
+    <Wrapper {...props} totalHeight={sequenceHeight} width={width}>
       <SequenceSVG {...props} />
     </Wrapper>
   )

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -295,19 +295,19 @@ const DivSequenceRendering = observer(function (props: {
   features: Map<string, Feature>
   regions: Region[]
   bpPerPx: number
+  height: number
   config: AnyConfigurationModel
   theme?: Theme
   showForward?: boolean
   showReverse?: boolean
   showTranslation?: boolean
 }) {
-  const { regions, bpPerPx } = props
+  const { regions, bpPerPx, height } = props
   const [region] = regions
   const width = (region.end - region.start) / bpPerPx
-  const totalHeight = 200
 
   return (
-    <Wrapper {...props} totalHeight={totalHeight} width={width}>
+    <Wrapper {...props} totalHeight={height} width={width}>
       <SequenceSVG {...props} />
     </Wrapper>
   )

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -284,7 +284,12 @@ function Wrapper({
       data-testid="sequence_track"
       width={width}
       height={totalHeight}
-      style={{ width, height: totalHeight, userSelect: 'none' }}
+      style={{
+        width,
+        height: totalHeight,
+        userSelect: 'none',
+        display: 'block',
+      }}
     >
       {children}
     </svg>

--- a/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
+++ b/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
 <div>
   <svg
     data-testid="sequence_track"
-    style="width: 20000px; user-select: none;"
+    height="160"
+    style="width: 20000px; height: 160px; user-select: none;"
     width="20000"
   >
     <rect
@@ -573,7 +574,8 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
 <div>
   <svg
     data-testid="sequence_track"
-    style="width: 20000px; user-select: none;"
+    height="160"
+    style="width: 20000px; height: 160px; user-select: none;"
     width="20000"
   >
     <rect
@@ -1142,7 +1144,8 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
 <div>
   <svg
     data-testid="sequence_track"
-    style="width: 20000px; user-select: none;"
+    height="160"
+    style="width: 20000px; height: 160px; user-select: none;"
     width="20000"
   >
     <rect
@@ -1339,7 +1342,8 @@ exports[`renders with one feature with no seq, zoomed in, should throw 1`] = `
 <div>
   <svg
     data-testid="sequence_track"
-    style="width: 20000px; user-select: none;"
+    height="160"
+    style="width: 20000px; height: 160px; user-select: none;"
     width="20000"
   />
 </div>
@@ -1349,7 +1353,8 @@ exports[`renders with one, zoomed way out 1`] = `
 <div>
   <svg
     data-testid="sequence_track"
-    style="width: 333.3333333333333px; user-select: none;"
+    height="160"
+    style="width: 333.3333333333333px; height: 160px; user-select: none;"
     width="333.3333333333333"
   >
     <rect

--- a/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
+++ b/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
   <svg
     data-testid="sequence_track"
     height="160"
-    style="width: 20000px; height: 160px; user-select: none;"
+    style="width: 20000px; height: 160px; user-select: none; display: block;"
     width="20000"
   >
     <rect
@@ -575,7 +575,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
   <svg
     data-testid="sequence_track"
     height="160"
-    style="width: 20000px; height: 160px; user-select: none;"
+    style="width: 20000px; height: 160px; user-select: none; display: block;"
     width="20000"
   >
     <rect
@@ -1145,7 +1145,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
   <svg
     data-testid="sequence_track"
     height="160"
-    style="width: 20000px; height: 160px; user-select: none;"
+    style="width: 20000px; height: 160px; user-select: none; display: block;"
     width="20000"
   >
     <rect
@@ -1343,7 +1343,7 @@ exports[`renders with one feature with no seq, zoomed in, should throw 1`] = `
   <svg
     data-testid="sequence_track"
     height="160"
-    style="width: 20000px; height: 160px; user-select: none;"
+    style="width: 20000px; height: 160px; user-select: none; display: block;"
     width="20000"
   />
 </div>
@@ -1354,7 +1354,7 @@ exports[`renders with one, zoomed way out 1`] = `
   <svg
     data-testid="sequence_track"
     height="160"
-    style="width: 333.3333333333333px; height: 160px; user-select: none;"
+    style="width: 333.3333333333333px; height: 160px; user-select: none; display: block;"
     width="333.3333333333333"
   >
     <rect

--- a/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
+++ b/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
@@ -4,8 +4,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
 <div>
   <svg
     data-testid="sequence_track"
-    height="200"
-    style="width: 20000px; height: 200px; user-select: none;"
+    style="width: 20000px; user-select: none;"
     width="20000"
   >
     <rect
@@ -574,8 +573,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
 <div>
   <svg
     data-testid="sequence_track"
-    height="200"
-    style="width: 20000px; height: 200px; user-select: none;"
+    style="width: 20000px; user-select: none;"
     width="20000"
   >
     <rect
@@ -1144,8 +1142,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
 <div>
   <svg
     data-testid="sequence_track"
-    height="200"
-    style="width: 20000px; height: 200px; user-select: none;"
+    style="width: 20000px; user-select: none;"
     width="20000"
   >
     <rect
@@ -1342,8 +1339,7 @@ exports[`renders with one feature with no seq, zoomed in, should throw 1`] = `
 <div>
   <svg
     data-testid="sequence_track"
-    height="200"
-    style="width: 20000px; height: 200px; user-select: none;"
+    style="width: 20000px; user-select: none;"
     width="20000"
   />
 </div>
@@ -1353,8 +1349,7 @@ exports[`renders with one, zoomed way out 1`] = `
 <div>
   <svg
     data-testid="sequence_track"
-    height="200"
-    style="width: 333.3333333333333px; height: 200px; user-select: none;"
+    style="width: 333.3333333333333px; user-select: none;"
     width="333.3333333333333"
   >
     <rect

--- a/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
+++ b/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
@@ -51,8 +51,13 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
          * #method
          */
         renderProps() {
-          const { showForward, rpcDriverName, showReverse, showTranslation } =
-            self
+          const {
+            showForward,
+            rpcDriverName,
+            showReverse,
+            showTranslation,
+            height,
+          } = self
           return {
             ...superRenderProps(),
             config: self.configuration.renderer,
@@ -60,6 +65,7 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
             showForward,
             showReverse,
             showTranslation,
+            height,
           }
         },
       }

--- a/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
+++ b/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
@@ -42,8 +42,26 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
          * #property
          */
         showTranslation: true,
+        /**
+         * #property
+         */
+        rowHeight: 20,
       }),
     )
+    .views(self => ({
+      /**
+       * #getter
+       */
+      get sequenceHeight() {
+        const { showTranslation, showReverse, showForward } = self
+        const r1 = showReverse && showTranslation ? self.rowHeight * 3 : 0
+        const r2 = showForward && showTranslation ? self.rowHeight * 3 : 0
+        const t = r1 + r2
+        const r = showReverse ? self.rowHeight : 0
+        const s = showForward ? self.rowHeight : 0
+        return t + r + s
+      },
+    }))
     .views(self => {
       const { renderProps: superRenderProps } = self
       return {
@@ -56,7 +74,8 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
             rpcDriverName,
             showReverse,
             showTranslation,
-            height,
+            rowHeight,
+            sequenceHeight,
           } = self
           return {
             ...superRenderProps(),
@@ -65,7 +84,8 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
             showForward,
             showReverse,
             showTranslation,
-            height,
+            rowHeight,
+            sequenceHeight,
           }
         },
       }
@@ -83,6 +103,15 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       get rendererTypeName() {
         return self.configuration.renderer.type
+      },
+      get sequenceHeight() {
+        const { showTranslation, showReverse, showForward } = self
+        const r1 = showReverse && showTranslation ? self.rowHeight * 3 : 0
+        const r2 = showForward && showTranslation ? self.rowHeight * 3 : 0
+        const t = r1 + r2
+        const r = showReverse ? self.rowHeight : 0
+        const s = showForward ? self.rowHeight : 0
+        return t + r + s
       },
     }))
     .actions(self => ({
@@ -112,13 +141,7 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
             if (view?.bpPerPx >= 1) {
               self.setHeight(50)
             } else {
-              const { showTranslation, showReverse, showForward } = self
-              const r1 = showReverse && showTranslation ? 60 : 0
-              const r2 = showForward && showTranslation ? 60 : 0
-              const t = r1 + r2
-              const r = showReverse ? 20 : 0
-              const s = showForward ? 20 : 0
-              self.setHeight(t + r + s)
+              self.setHeight(self.sequenceHeight)
             }
           }),
         )

--- a/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
+++ b/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
@@ -104,15 +104,6 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
       get rendererTypeName() {
         return self.configuration.renderer.type
       },
-      get sequenceHeight() {
-        const { showTranslation, showReverse, showForward } = self
-        const r1 = showReverse && showTranslation ? self.rowHeight * 3 : 0
-        const r2 = showForward && showTranslation ? self.rowHeight * 3 : 0
-        const t = r1 + r2
-        const r = showReverse ? self.rowHeight : 0
-        const s = showForward ? self.rowHeight : 0
-        return t + r + s
-      },
     }))
     .actions(self => ({
       /**

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -326,6 +326,7 @@ const SvgFeatureRendering = observer(function SvgFeatureRendering(props: {
       data-testid="svgfeatures"
       width={width}
       height={height + svgHeightPadding}
+      style={{ display: 'block' }}
       onMouseDown={mouseDown}
       onMouseUp={mouseUp}
       onMouseEnter={onMouseEnter}

--- a/plugins/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.tsx.snap
+++ b/plugins/svg/src/SvgFeatureRenderer/components/__snapshots__/SvgFeatureRendering.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`click on one feature, and do not re-render 1`] = `
 <svg
   data-testid="svgfeatures"
   height="145"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>
@@ -46,6 +47,7 @@ exports[`no features 1`] = `
 <svg
   data-testid="svgfeatures"
   height="120"
+  style="display: block;"
   width="100"
 />
 `;
@@ -54,6 +56,7 @@ exports[`one feature (compact mode) 1`] = `
 <svg
   data-testid="svgfeatures"
   height="122"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>
@@ -219,6 +222,7 @@ exports[`one feature 1`] = `
 <svg
   data-testid="svgfeatures"
   height="115"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>
@@ -239,6 +243,7 @@ exports[`processed transcript (exons + impliedUTR) 1`] = `
 <svg
   data-testid="svgfeatures"
   height="139"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>
@@ -430,6 +435,7 @@ exports[`processed transcript (reducedRepresentation mode) 1`] = `
 <svg
   data-testid="svgfeatures"
   height="115"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>
@@ -450,6 +456,7 @@ exports[`processed transcript 1`] = `
 <svg
   data-testid="svgfeatures"
   height="127"
+  style="display: block;"
   width="333.3333333333333"
 >
   <g>

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -1023,7 +1023,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           <svg
                             data-testid="sequence_track"
                             height="160"
-                            style="width: 800px; height: 160px; user-select: none;"
+                            style="width: 800px; height: 160px; user-select: none; display: block;"
                             width="800"
                           >
                             <rect
@@ -3865,7 +3865,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           <svg
                             data-testid="sequence_track"
                             height="160"
-                            style="width: 800px; height: 160px; user-select: none;"
+                            style="width: 800px; height: 160px; user-select: none; display: block;"
                             width="800"
                           >
                             <rect

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -1022,8 +1022,8 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         >
                           <svg
                             data-testid="sequence_track"
-                            height="200"
-                            style="width: 800px; height: 200px; user-select: none;"
+                            height="160"
+                            style="width: 800px; height: 160px; user-select: none;"
                             width="800"
                           >
                             <rect
@@ -3864,8 +3864,8 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         >
                           <svg
                             data-testid="sequence_track"
-                            height="200"
-                            style="width: 800px; height: 200px; user-select: none;"
+                            height="160"
+                            style="width: 800px; height: 160px; user-select: none;"
                             width="800"
                           >
                             <rect


### PR DESCRIPTION
I wanted to see if I could get rid of the scrollbar on the default sequence display:

![image](https://github.com/GMOD/jbrowse-components/assets/25592344/c4578924-483a-46bb-b25f-15aca1cc1743)

I started by passing the height for the display model to the renderer and using that as the SVG height. The height was previously hardcoded to 200px, and this change made the scrollable amount smaller, but the scrollbar was still there:

![image](https://github.com/GMOD/jbrowse-components/assets/25592344/68364697-b05b-45ea-acae-9a82eb4152e3)

Inspecting the document, I saw that the `div` wrapping the SVG was a few pixels bigger that the SVG height, but it didn't have any padding, and the SVG inside didn't have a margin, so I wasn't sure what was making the height taller.

![image](https://github.com/GMOD/jbrowse-components/assets/25592344/a011b762-a398-4b71-9821-9748eca5662a)

I also wasn't sure where that `div` was at first, but figured out that it's the `div` that the SSR content get hydrated into. I figured the extra spacing must be some built-in browser behavior related to block spacing. I tried setting `margin`, `padding`, `margin-block`, `padding-block`, `margin-inline`, and `padding-inline` on the hydration `div`, though, and none of those fixed it. The only way I was able to get the height to be what I wanted was by setting `display: flex;` on the hydration `div`. I tried other displays as well, but that's the only one I found to work. I'm not entirely sure why that fixes it, but it works for me on both Chrome and FireFox.

![image](https://github.com/GMOD/jbrowse-components/assets/25592344/caf8f586-d93a-4799-b980-7c33302579b4)
