### PR TITLE
allow manifest to work with authentication

### DIFF
--- a/products/jbrowse-desktop/public/index.html
+++ b/products/jbrowse-desktop/public/index.html
@@ -10,8 +10,9 @@
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+      crossorigin="use-credentials" is needed for authentication AuthType Basic
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" crossorigin="use-credentials" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/products/jbrowse-web/public/index.html
+++ b/products/jbrowse-web/public/index.html
@@ -9,8 +9,9 @@
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+      crossorigin="use-credentials" is needed for authentication AuthType Basic
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" crossorigin="use-credentials" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Currently Manifest throws an error when behind authbasic authentication.
This fixes it.

(kudos to https://stackoverflow.com/questions/6294622/html5-manifest-cache-behind-basic-auth)