### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
@@ -6,7 +6,7 @@ beforeEach(() => {
   doBeforeEach()
 })
 
-const delay = { timeout: 10000 }
+const delay = { timeout: 1000 }
 const opts = [{}, delay]
 
 test('access about menu', async () => {


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 10000ms to 1000ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.