### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/products/jbrowse-web/src/tests/Hic.test.tsx
+++ b/products/jbrowse-web/src/tests/Hic.test.tsx
@@ -16,7 +16,7 @@ beforeEach(() => {
 
 setup()
 
-const delay = { timeout: 20000 }
+const delay = { timeout: 10000 }
 
 test('hic', async () => {
   const { view, findByTestId } = await createView(hicConfig)


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 20000ms to 10000ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.