### PR TITLE
Fix for missing INFO.STRANDS tag for TRA features in breakpoint split view

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Translocations.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Translocations.tsx
@@ -10,6 +10,16 @@ import { BreakpointViewModel, LayoutRecord } from '../model'
 
 const [LEFT] = [0, 1, 2, 3]
 
+function str(s: string) {
+  if (s === '+') {
+    return 1
+  } else if (s === '-') {
+    return -1
+  } else {
+    return 0
+  }
+}
+
 const Translocations = observer(function ({
   model,
   trackId,
@@ -78,7 +88,8 @@ const Translocations = observer(function ({
           const info = f1.get('INFO')
           const chr2 = info.CHR2[0]
           const end2 = info.END[0]
-          const [myDirection, mateDirection] = info.STRANDS[0].split('')
+          const res = info.STRANDS?.[0]?.split('') // not all files have STRANDS
+          const [myDirection, mateDirection] = res ?? ['.', '.']
 
           const r = getPxFromCoordinate(views[level2], chr2, end2)
           if (r) {
@@ -102,7 +113,7 @@ const Translocations = observer(function ({
 
             const path = [
               'M', // move to
-              x1 - 20 * (myDirection === '+' ? 1 : -1) * (reversed1 ? -1 : 1),
+              x1 - 20 * str(myDirection) * (reversed1 ? -1 : 1),
               y1,
               'L', // line to
               x1,
@@ -111,7 +122,7 @@ const Translocations = observer(function ({
               x2,
               y2,
               'L', // line to
-              x2 - 20 * (mateDirection === '+' ? 1 : -1) * (reversed2 ? -1 : 1),
+              x2 - 20 * str(mateDirection) * (reversed2 ? -1 : 1),
               y2,
             ].join(' ')
             ret.push(

--- a/products/jbrowse-web/src/tests/JBrowse.test.tsx
+++ b/products/jbrowse-web/src/tests/JBrowse.test.tsx
@@ -104,7 +104,7 @@ test('looks at about this track dialog', async () => {
   const { findByTestId, findAllByText, findByText } = await createView()
 
   // load track
-  fireEvent.click(await findByTestId(hts('volvox-long-reads-cram')))
+  fireEvent.click(await findByTestId(hts('volvox-long-reads-cram'), {}, delay))
   fireEvent.click(await findByTestId('track_menu_icon', {}, delay))
   fireEvent.click(await findByText('About track'))
   await findAllByText(/SQ/, {}, delay)


### PR DESCRIPTION
this fix will not have the "directional feet" that the strands tag helps with, but it at least does not crash :)

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/fcda788f-fd16-440d-8935-068121730317)

fixes usage with some DELLY VCF, potentially (as a follow on) can use a different tag from DELLY called "CT" which says "5to3" and "5to5" as an equivalent to STRAND

Fixes https://github.com/GMOD/jbrowse-components/issues/4188

Fix follows from office hours meeting