### PR TITLE
Fix text indexing on jbrowse desktop with MS Windows

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -157,7 +157,7 @@ export function getFileName(track: FileLocation) {
   return (
     blob?.name ||
     uri?.slice(uri.lastIndexOf('/') + 1) ||
-    localPath?.slice(localPath.lastIndexOf('/') + 1) ||
+    localPath?.slice(localPath?.replace(/\\/g, '/').lastIndexOf('/') + 1) ||
     ''
   )
 }

--- a/packages/text-indexing/package.json
+++ b/packages/text-indexing/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@babel/runtime": "^7.16.3",
     "ixixx": "^2.0.1",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "sanitize-filename": "^1.6.3"
   },
   "peerDependencies": {
     "mobx": "^6.0.0",

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -1,4 +1,5 @@
 import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
+import sanitize from 'sanitize-filename'
 import path from 'path'
 
 export interface UriLocation {
@@ -125,19 +126,20 @@ export function createTextSearchConf(
   locationPath: string,
 ) {
   const base = path.join(locationPath, 'trix')
+  const n = sanitize(name)
   return {
     type: 'TrixTextSearchAdapter',
     textSearchAdapterId: name,
     ixFilePath: {
-      localPath: path.join(base, `${name}.ix`),
+      localPath: path.join(base, `${n}.ix`),
       locationType: 'LocalPathLocation',
     },
     ixxFilePath: {
-      localPath: path.join(base, `${name}.ixx`),
+      localPath: path.join(base, `${n}.ixx`),
       locationType: 'LocalPathLocation',
     },
     metaFilePath: {
-      localPath: path.join(base, `${name}.json`),
+      localPath: path.join(base, `${n}.json`),
       locationType: 'LocalPathLocation',
     },
     tracks: trackIds,

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -1,4 +1,5 @@
 import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
+import path from 'path'
 
 export interface UriLocation {
   uri: string
@@ -123,23 +124,20 @@ export function createTextSearchConf(
   assemblyNames: string[],
   locationPath: string,
 ) {
-  // const locationPath = self.sessionPath.substring(
-  //   0,
-  //   self.sessionPath.lastIndexOf('/'),
-  // )
+  const base = path.join(locationPath, 'trix')
   return {
     type: 'TrixTextSearchAdapter',
     textSearchAdapterId: name,
     ixFilePath: {
-      localPath: locationPath + `/trix/${name}.ix`,
+      localPath: path.join(base, `${name}.ix`),
       locationType: 'LocalPathLocation',
     },
     ixxFilePath: {
-      localPath: locationPath + `/trix/${name}.ixx`,
+      localPath: path.join(base, `${name}.ixx`),
       locationType: 'LocalPathLocation',
     },
     metaFilePath: {
-      localPath: locationPath + `/trix/${name}.json`,
+      localPath: path.join(base, `${name}.json`),
       locationType: 'LocalPathLocation',
     },
     tracks: trackIds,

--- a/products/jbrowse-desktop/src/indexJobsModel.ts
+++ b/products/jbrowse-desktop/src/indexJobsModel.ts
@@ -72,8 +72,7 @@ export default function jobsModelFactory(_pluginManager: PluginManager) {
       },
       get location() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const sessionPath = getParent<any>(self).sessionPath
-        return path.basename(sessionPath)
+        return path.dirname(getParent<any>(self).sessionPath)
       },
     }))
     .actions(self => ({

--- a/products/jbrowse-desktop/src/indexJobsModel.ts
+++ b/products/jbrowse-desktop/src/indexJobsModel.ts
@@ -12,6 +12,7 @@ import {
   findTrackConfigsToIndex,
 } from '@jbrowse/text-indexing'
 import { isAbortException, isSessionModelWithWidgets } from '@jbrowse/core/util'
+import path from 'path'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Track = Record<string, any>
@@ -33,11 +34,7 @@ interface JobsEntry {
   statusMessage?: string
 }
 export interface TextJobsEntry extends JobsEntry {
-  name: string
   indexingParams: TrackTextIndexing
-  cancelCallback?: () => void
-  progressPct?: number
-  statusMessage?: string
 }
 
 export default function jobsModelFactory(_pluginManager: PluginManager) {
@@ -75,8 +72,8 @@ export default function jobsModelFactory(_pluginManager: PluginManager) {
       },
       get location() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const path = getParent<any>(self).sessionPath
-        return path.slice(0, Math.max(0, path.lastIndexOf('/')))
+        const sessionPath = getParent<any>(self).sessionPath
+        return path.basename(sessionPath)
       },
     }))
     .actions(self => ({


### PR DESCRIPTION
this combination of methods fixes text indexing on windows. some code was assuming forward slashes for filename separators essentially