### PR TITLE
Fix the viewport calculations for when URL params includes &tracklist=true

### DIFF
--- a/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
@@ -54,15 +54,6 @@ export default (pluginManager: PluginManager) => {
           )
         }
 
-        await handleSelectedRegion({ input: loc, model: view, assembly: asm })
-
-        const idsNotFound = [] as string[]
-        tracks.forEach(track => tryTrack(view, track, idsNotFound))
-        if (idsNotFound.length) {
-          throw new Error(
-            `Could not resolve identifiers: ${idsNotFound.join(',')}`,
-          )
-        }
         if (tracklist) {
           view.activateTrackSelector()
         }
@@ -77,6 +68,16 @@ export default (pluginManager: PluginManager) => {
             location.assemblyName = assembly
             view.setHighlight(location)
           }
+        }
+
+        await handleSelectedRegion({ input: loc, model: view, assembly: asm })
+
+        const idsNotFound = [] as string[]
+        tracks.forEach(track => tryTrack(view, track, idsNotFound))
+        if (idsNotFound.length) {
+          throw new Error(
+            `Could not resolve identifiers: ${idsNotFound.join(',')}`,
+          )
         }
       } catch (e) {
         session.notify(`${e}`, 'error')


### PR DESCRIPTION
can compare the viewport when visiting these links

https://jbrowse.org/code/jb2/order_of_operations/?loc=BRCA1&assembly=hg19&tracklist=true
https://jbrowse.org/code/jb2/main/?loc=BRCA1&assembly=hg19&tracklist=true

this PR branch includes the gene full width in the view
the main branch has the gene partially hidden

i'm not sure if this is 100% reliable as this code doesn't "wait for the viewport width to include that tracklist" but it could help

the source of this problem is that the state of the view is driven primarily by a combination of variables (bpPerPx and offsetPx and displayedRegions) instead of the desired loc string

This has some odd consequences including the fact that a share link from a screen that is e.g. 800px does not get stretched when shared with a screen that has width 3000px, the 3000px actually views extra data if it loads that share link. This similarly is the case here where the tracklist is subtly changing the width of the viewport, and it isn't stretching the content of the view, it just 'hides it'

fixes #4249