### PR TITLE
Queue dialog for assemblymanager

### DIFF
--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -352,10 +352,6 @@ export interface AbstractRootModel {
 
 /** root model with more included for the heavier JBrowse web and desktop app */
 export interface AppRootModel extends AbstractRootModel {
-  isAssemblyEditing: boolean
-  isDefaultSessionEditing: boolean
-  setAssemblyEditing: (arg: boolean) => boolean
-  setDefaultSessionEditing: (arg: boolean) => boolean
   internetAccounts: BaseInternetAccountModel[]
   findAppropriateInternetAccount(
     location: UriLocation,
@@ -366,7 +362,6 @@ export function isAppRootModel(thing: unknown): thing is AppRootModel {
   return (
     typeof thing === 'object' &&
     thing !== null &&
-    'isAssemblyEditing' in thing &&
     'findAppropriateInternetAccount' in thing
   )
 }

--- a/packages/product-core/src/RootModel/BaseRootModel.ts
+++ b/packages/product-core/src/RootModel/BaseRootModel.ts
@@ -68,7 +68,6 @@ export function BaseRootModelFactory({
       ),
 
       adminMode: false,
-      isAssemblyEditing: false,
       error: undefined as unknown,
       textSearchManager: new TextSearchManager(pluginManager),
       pluginManager,
@@ -107,12 +106,6 @@ export function BaseRootModelFactory({
           snapshot.name = newName
           this.setSession(snapshot)
         }
-      },
-      /**
-       * #action
-       */
-      setAssemblyEditing(flag: boolean) {
-        self.isAssemblyEditing = flag
       },
     }))
 }

--- a/products/jbrowse-desktop/src/components/JBrowse.tsx
+++ b/products/jbrowse-desktop/src/components/JBrowse.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React from 'react'
 import { observer } from 'mobx-react'
 import { ThemeProvider } from '@mui/material/styles'
 import { CssBaseline } from '@mui/material'
@@ -6,7 +6,6 @@ import { CssBaseline } from '@mui/material'
 // jbrowse
 import { App } from '@jbrowse/app-core'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { AssemblyManager } from '@jbrowse/plugin-data-management'
 
 // locals
 import { DesktopRootModel } from '../rootModel'
@@ -16,35 +15,18 @@ const JBrowseNonNullRoot = observer(function ({
 }: {
   rootModel: DesktopRootModel
 }) {
-  const { session, error, isAssemblyEditing, setAssemblyEditing } = rootModel
+  const { session, error } = rootModel
 
   if (error) {
     throw error
   }
-  if (!session) {
-    return null
-  }
 
-  return (
+  return session ? (
     <ThemeProvider theme={session.theme}>
       <CssBaseline />
-      {session ? (
-        <>
-          <App session={session} />
-          <Suspense fallback={null}>
-            {isAssemblyEditing ? (
-              <AssemblyManager
-                rootModel={rootModel}
-                onClose={() => setAssemblyEditing(false)}
-              />
-            ) : null}
-          </Suspense>
-        </>
-      ) : (
-        <div>No session</div>
-      )}
+      <App session={session} />
     </ThemeProvider>
-  )
+  ) : null
 })
 
 const JBrowse = observer(function ({

--- a/products/jbrowse-desktop/src/rootModel/Menus.ts
+++ b/products/jbrowse-desktop/src/rootModel/Menus.ts
@@ -16,12 +16,13 @@ import type { MenuItem } from '@jbrowse/core/ui'
 import { Save, SaveAs, DNA, Cable } from '@jbrowse/core/ui/Icons'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { SessionWithDialogs } from '@jbrowse/product-core'
+import { AssemblyManager } from '@jbrowse/plugin-data-management'
 
 // locals
 import { getSaveSession } from './Sessions'
 import { DesktopRootModel } from '.'
 import OpenSequenceDialog from '../components/OpenSequenceDialog'
-
+import { AbstractSessionModel } from '@jbrowse/core/util'
 const PreferencesDialog = lazy(() => import('../components/PreferencesDialog'))
 const { ipcRenderer } = window.require('electron')
 
@@ -230,7 +231,12 @@ export function DesktopMenusMixin(_pluginManager: PluginManager) {
               label: 'Open assembly manager',
               icon: SettingsIcon,
               onClick: () => {
-                self.setAssemblyEditing(true)
+                ;(self.session as AbstractSessionModel).queueDialog(
+                  handleClose => [
+                    AssemblyManager,
+                    { rootModel: self, onClose: handleClose },
+                  ],
+                )
               },
             },
           ],


### PR DESCRIPTION
Instead of custom MST state management about whether the assembly manager is open, use the 'standard' queueDialog API to open the "assembly manager"