### PR TITLE
Allow getting stack trace from track errors

### DIFF
--- a/packages/core/ui/ErrorMessageStackTraceDialog.tsx
+++ b/packages/core/ui/ErrorMessageStackTraceDialog.tsx
@@ -88,6 +88,42 @@ function stripMessage(trace: string, error: unknown) {
   }
 }
 
+function Contents({ text }: { text: string }) {
+  const err = encodeURIComponent(
+    'I got this error from JBrowse, here is the stack trace:\n\n```\n' +
+      text +
+      '\n```\n',
+  )
+  const githubLink = `https://github.com/GMOD/jbrowse-components/issues/new?labels=bug&title=JBrowse+issue&body=${err}`
+  const emailLink = `mailto:jbrowse2dev@gmail.com?subject=JBrowse%202%20error&body=${err}`
+
+  return (
+    <>
+      <Typography>
+        Post a new issue at{' '}
+        <Link href={githubLink} target="_blank">
+          GitHub
+        </Link>{' '}
+        or send an email to{' '}
+        <Link href={emailLink} target="_blank">
+          jbrowse2dev@gmail.com
+        </Link>{' '}
+      </Typography>
+      <pre
+        style={{
+          background: 'lightgrey',
+          border: '1px solid black',
+          overflow: 'auto',
+          margin: 20,
+          maxHeight: 300,
+        }}
+      >
+        {text}
+      </pre>
+    </>
+  )
+}
+
 export default function ErrorMessageStackTraceDialog({
   error,
   onClose,
@@ -128,42 +164,13 @@ export default function ErrorMessageStackTraceDialog({
     window.JBrowseSession ? `JBrowse ${window.JBrowseSession.version}` : '',
   ].join('\n')
 
-  const err = encodeURIComponent(
-    'I got this error from JBrowse, here is the stack trace:\n\n```\n' +
-      errorBoxText +
-      '\n```\n',
-  )
-  const githubLink = `https://github.com/GMOD/jbrowse-components/issues/new?labels=bug&title=JBrowse+issue&body=${err}`
-  const emailLink = `mailto:jbrowse2dev@gmail.com?subject=JBrowse%202%20error&body=${err}`
   return (
     <Dialog open onClose={onClose} title="Stack trace" maxWidth="xl">
       <DialogContent>
         {mappedStackTrace === undefined ? (
           <LoadingEllipses variant="h6" />
         ) : (
-          <>
-            <Typography>
-              Post a new issue at{' '}
-              <Link href={githubLink} target="_blank">
-                GitHub
-              </Link>{' '}
-              or send an email to{' '}
-              <Link href={emailLink} target="_blank">
-                jbrowse2dev@gmail.com
-              </Link>{' '}
-            </Typography>
-            <pre
-              style={{
-                background: 'lightgrey',
-                border: '1px solid black',
-                overflow: 'auto',
-                margin: 20,
-                maxHeight: 300,
-              }}
-            >
-              {errorBoxText}
-            </pre>
-          </>
+          <Contents text={errorBoxText} />
         )}
       </DialogContent>
       <DialogActions>

--- a/packages/product-core/src/ui/FileInfoPanel.tsx
+++ b/packages/product-core/src/ui/FileInfoPanel.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from 'react'
-import { Typography } from '@mui/material'
 import {
   readConfObject,
   AnyConfigurationModel,
 } from '@jbrowse/core/configuration'
-import LoadingEllipses from '@jbrowse/core/ui/LoadingEllipses'
 import { getSession } from '@jbrowse/core/util'
 import {
   BaseCard,
   Attributes,
 } from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'
+import { ErrorMessage, LoadingEllipses } from '@jbrowse/core/ui'
 
 type FileInfo = Record<string, unknown> | string
 
@@ -24,32 +23,19 @@ export default function FileInfoPanel({
   const { rpcManager } = session
 
   useEffect(() => {
-    const aborter = new AbortController()
-    const { signal } = aborter
-    let cancelled = false
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ;(async () => {
       try {
         const adapterConfig = readConfObject(config, 'adapter')
         const result = await rpcManager.call(config.trackId, 'CoreGetInfo', {
           adapterConfig,
-          signal,
         })
-        if (!cancelled) {
-          setInfo(result as FileInfo)
-        }
+        setInfo(result as FileInfo)
       } catch (e) {
-        if (!cancelled) {
-          console.error(e)
-          setError(e)
-        }
+        console.error(e)
+        setError(e)
       }
     })()
-
-    return () => {
-      aborter.abort()
-      cancelled = true
-    }
   }, [config, rpcManager])
 
   const details =
@@ -64,7 +50,7 @@ export default function FileInfoPanel({
   return info !== null ? (
     <BaseCard title="File info">
       {error ? (
-        <Typography color="error">{`${error}`}</Typography>
+        <ErrorMessage error={error} />
       ) : info === undefined ? (
         <LoadingEllipses message="Loading file data" />
       ) : (

--- a/plugins/alignments/src/shared/BaseDisplayComponent.tsx
+++ b/plugins/alignments/src/shared/BaseDisplayComponent.tsx
@@ -6,11 +6,12 @@ import {
 } from '@jbrowse/plugin-linear-genome-view'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
+import { getContainingView } from '@jbrowse/core/util'
+import { Button, Tooltip } from '@mui/material'
 
 // local
 import { LinearReadCloudDisplayModel } from '../LinearReadCloudDisplay/model'
 import { LinearReadArcsDisplayModel } from '../LinearReadArcsDisplay/model'
-import { getContainingView } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()(theme => ({
   loading: {
@@ -38,8 +39,13 @@ const BaseDisplayComponent = observer(function ({
     <BlockMsg
       message={`${error}`}
       severity="error"
-      buttonText="Reload"
-      action={model.reload}
+      action={
+        <Tooltip title="Reload">
+          <Button data-testid="reload_button" onClick={() => model.reload()}>
+            Reload
+          </Button>
+        </Tooltip>
+      }
     />
   ) : regionTooLarge ? (
     model.regionCannotBeRendered()

--- a/plugins/arc/src/LinearPairedArcDisplay/components/BaseDisplayComponent.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/BaseDisplayComponent.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { lazy } from 'react'
+import { IconButton, Tooltip } from '@mui/material'
 import { LoadingEllipses } from '@jbrowse/core/ui'
 import { BlockMsg } from '@jbrowse/plugin-linear-genome-view'
 import { makeStyles } from 'tss-react/mui'
@@ -6,6 +7,16 @@ import { observer } from 'mobx-react'
 
 // local
 import { LinearArcDisplayModel } from '../model'
+
+// icons
+import RefreshIcon from '@mui/icons-material/Refresh'
+import ReportIcon from '@mui/icons-material/Report'
+
+import { getSession } from '@jbrowse/core/util'
+
+const ErrorMessageStackTraceDialog = lazy(
+  () => import('@jbrowse/core/ui/ErrorMessageStackTraceDialog'),
+)
 
 const useStyles = makeStyles()(theme => ({
   loading: {
@@ -33,8 +44,30 @@ const BaseDisplayComponent = observer(function ({
     <BlockMsg
       message={`${error}`}
       severity="error"
-      buttonText="Reload"
-      action={model.reload}
+      action={
+        <>
+          <Tooltip title="Reload">
+            <IconButton
+              data-testid="reload_button"
+              onClick={() => model.reload()}
+            >
+              <RefreshIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Show stack trace">
+            <IconButton
+              onClick={() => {
+                getSession(model).queueDialog(onClose => [
+                  ErrorMessageStackTraceDialog,
+                  { onClose, error: model.error as Error },
+                ])
+              }}
+            >
+              <ReportIcon />
+            </IconButton>
+          </Tooltip>
+        </>
+      }
     />
   ) : regionTooLarge ? (
     model.regionCannotBeRendered()

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ManageConnectionsDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ManageConnectionsDialog.tsx
@@ -26,6 +26,16 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
+function DisabledButton() {
+  return (
+    <Tooltip title="Unable to delete connection in config file as non-admin user">
+      <IconButton>
+        <CloseIcon color="disabled" />
+      </IconButton>
+    </Tooltip>
+  )
+}
+
 const ManageConnectionsDialog = observer(function ({
   session,
   handleClose,
@@ -53,11 +63,7 @@ const ManageConnectionsDialog = observer(function ({
                     <CloseIcon color="error" />
                   </IconButton>
                 ) : (
-                  <Tooltip title="Unable to delete connection in config file as non-admin user">
-                    <IconButton>
-                      <CloseIcon color="disabled" />
-                    </IconButton>
-                  </Tooltip>
+                  <DisabledButton />
                 )}
                 {name}
               </Typography>

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BlockMsg.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BlockMsg.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Tooltip, Button, Alert, AlertColor } from '@mui/material'
+import { Tooltip, Alert, AlertColor } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 
 const useStyles = makeStyles()({
@@ -12,26 +12,17 @@ const useStyles = makeStyles()({
 export default function BlockMsg({
   message,
   severity,
-  buttonText,
-  icon,
   action,
 }: {
   message: string
   severity?: AlertColor
-  buttonText?: string
-  icon?: React.ReactNode
-  action?: () => void
+  action?: React.ReactNode
 }) {
   const { classes } = useStyles()
-  const button = action ? (
-    <Button data-testid="reload_button" onClick={action} startIcon={icon}>
-      {buttonText}
-    </Button>
-  ) : null
   return (
     <Alert
       severity={severity}
-      action={button}
+      action={action}
       classes={{ message: classes.ellipses }}
     >
       <Tooltip title={message}>

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -58,10 +58,10 @@ const RenderedBlocks = observer(function ({
               block={block}
               key={`${model.id}-${block.key}`}
             >
-              {state && state.ReactComponent ? (
+              {state?.ReactComponent ? (
                 <state.ReactComponent model={state} />
               ) : null}
-              {state && state.maxHeightReached ? (
+              {state?.maxHeightReached ? (
                 <div
                   className={classes.heightOverflowed}
                   style={{

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState } from 'react'
+import React, { lazy } from 'react'
 import { Tooltip, IconButton } from '@mui/material'
 
 import { makeStyles } from 'tss-react/mui'
@@ -50,7 +50,6 @@ const ServerSideRenderedBlockContent = observer(function ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   model: any
 }) {
-  const [showStack, setShowStack] = useState(false)
   if (model.error) {
     return (
       <BlockMsg

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -1,10 +1,10 @@
 import React, { lazy } from 'react'
 import { Tooltip, IconButton } from '@mui/material'
-
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { getParent } from 'mobx-state-tree'
 import { LoadingEllipses } from '@jbrowse/core/ui'
+import { getSession } from '@jbrowse/core/util'
 
 // icons
 import RefreshIcon from '@mui/icons-material/Refresh'
@@ -12,7 +12,6 @@ import ReportIcon from '@mui/icons-material/Report'
 
 // locals
 import BlockMsg from './BlockMsg'
-import { getSession } from '@jbrowse/core/util'
 
 const ErrorMessageStackTraceDialog = lazy(
   () => import('@jbrowse/core/ui/ErrorMessageStackTraceDialog'),
@@ -30,12 +29,10 @@ const useStyles = makeStyles()(theme => {
   }
 })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LoadingMessage = observer(({ model }: { model: any }) => {
+const LoadingMessage = observer(({ model }: { model: { status?: string } }) => {
   const { classes } = useStyles()
   const { status: blockStatus } = model
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { message: displayStatus } = getParent<any>(model, 2)
+  const { message: displayStatus } = getParent<{ message?: string }>(model, 2)
   const status = displayStatus || blockStatus
   return (
     <div className={classes.loading}>
@@ -47,8 +44,14 @@ const LoadingMessage = observer(({ model }: { model: any }) => {
 const ServerSideRenderedBlockContent = observer(function ({
   model,
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  model: any
+  model: {
+    error?: unknown
+    reload: () => void
+    message: React.ReactNode
+    filled?: boolean
+    status?: string
+    reactElement?: React.ReactElement
+  }
 }) {
   if (model.error) {
     return (
@@ -57,7 +60,7 @@ const ServerSideRenderedBlockContent = observer(function ({
         severity="error"
         action={
           <>
-            <Tooltip title="Reload">
+            <Tooltip title="Reload track">
               <IconButton
                 data-testid="reload_button"
                 onClick={() => model.reload()}
@@ -70,7 +73,7 @@ const ServerSideRenderedBlockContent = observer(function ({
                 onClick={() => {
                   getSession(model).queueDialog(onClose => [
                     ErrorMessageStackTraceDialog,
-                    { onClose, error: model.error },
+                    { onClose, error: model.error as Error },
                   ])
                 }}
               >

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/TooLargeMessage.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/TooLargeMessage.tsx
@@ -3,6 +3,7 @@ import { FeatureDensityStats } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 // locals
 import BlockMsg from '../components/BlockMsg'
+import { Button } from '@mui/material'
 
 function TooLargeMessage({
   model,
@@ -18,11 +19,16 @@ function TooLargeMessage({
   return (
     <BlockMsg
       severity="warning"
-      action={() => {
-        model.setFeatureDensityStatsLimit(model.featureDensityStats)
-        model.reload()
-      }}
-      buttonText="Force load"
+      action={
+        <Button
+          onClick={() => {
+            model.setFeatureDensityStatsLimit(model.featureDensityStats)
+            model.reload()
+          }}
+        >
+          Force load
+        </Button>
+      }
       message={[
         regionTooLargeReason,
         'Zoom in to see features or force load (may be slow)',


### PR DESCRIPTION
The track errors do not use the "ErrorMessage" component with the built-in stack trace button so PR adds a the stack trace button to track errors


![image](https://github.com/GMOD/jbrowse-components/assets/6511937/d04ec5c8-48d2-45df-aa98-69e385093e26)


it works for web worker errors

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/d30bf6bc-c1f7-4616-b920-8f1431efedda)

I replaced the "API" of the BlockMsg component to make "action" a React.ReactNode instead of just a function, therefore any amount of stuff can be placed, and I just use IconButton instead of the "Reload" text
