### PR TITLE
Smaller sequence track size

### DIFF
--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -95,6 +95,7 @@ function Translation(props: {
                 y={y + height / 2}
                 dominantBaseline="middle"
                 textAnchor="middle"
+                fontSize={height - 2}
               >
                 {letter}
               </text>
@@ -150,6 +151,7 @@ function DNA(props: {
                 y={y + height / 2}
                 dominantBaseline="middle"
                 textAnchor="middle"
+                fontSize={height - 2}
                 fill={
                   color ? theme.palette.getContrastText(color.main) : 'black'
                 }

--- a/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
+++ b/plugins/sequence/src/DivSequenceRenderer/components/__snapshots__/DivSequenceRendering.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19930"
       y="10"
@@ -32,6 +33,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19870"
       y="10"
@@ -46,6 +48,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19810"
       y="10"
@@ -60,6 +63,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19950"
       y="30"
@@ -74,6 +78,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19890"
       y="30"
@@ -88,6 +93,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19830"
       y="30"
@@ -102,6 +108,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19970"
       y="50"
@@ -116,6 +123,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19910"
       y="50"
@@ -130,6 +138,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19850"
       y="50"
@@ -145,6 +154,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="19970"
       y="70"
@@ -162,6 +172,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19950"
       y="70"
@@ -179,6 +190,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="19930"
       y="70"
@@ -196,6 +208,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19910"
       y="70"
@@ -213,6 +226,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19890"
       y="70"
@@ -230,6 +244,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19870"
       y="70"
@@ -247,6 +262,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="19850"
       y="70"
@@ -264,6 +280,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19830"
       y="70"
@@ -281,6 +298,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19810"
       y="70"
@@ -298,6 +316,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="19970"
       y="90"
@@ -315,6 +334,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19950"
       y="90"
@@ -332,6 +352,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="19930"
       y="90"
@@ -349,6 +370,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19910"
       y="90"
@@ -366,6 +388,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19890"
       y="90"
@@ -383,6 +406,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19870"
       y="90"
@@ -400,6 +424,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="19850"
       y="90"
@@ -417,6 +442,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19830"
       y="90"
@@ -434,6 +460,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="19810"
       y="90"
@@ -450,6 +477,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19970"
       y="110"
@@ -464,6 +492,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19910"
       y="110"
@@ -478,6 +507,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19850"
       y="110"
@@ -492,6 +522,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19930"
       y="130"
@@ -506,6 +537,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19870"
       y="130"
@@ -520,6 +552,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19810"
       y="130"
@@ -534,6 +567,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19950"
       y="150"
@@ -548,6 +582,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19890"
       y="150"
@@ -562,6 +597,7 @@ exports[`renders with one feature reversed with a correct seq, zoomed in, should
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="19830"
       y="150"
@@ -588,6 +624,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="10"
@@ -602,6 +639,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="130"
       y="10"
@@ -616,6 +654,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="190"
       y="10"
@@ -630,6 +669,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="30"
@@ -644,6 +684,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="110"
       y="30"
@@ -658,6 +699,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="170"
       y="30"
@@ -672,6 +714,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="50"
@@ -686,6 +729,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="90"
       y="50"
@@ -700,6 +744,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="150"
       y="50"
@@ -715,6 +760,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="70"
@@ -732,6 +778,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="70"
@@ -749,6 +796,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="70"
@@ -766,6 +814,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="90"
       y="70"
@@ -783,6 +832,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="110"
       y="70"
@@ -800,6 +850,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="130"
       y="70"
@@ -817,6 +868,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="150"
       y="70"
@@ -834,6 +886,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="170"
       y="70"
@@ -851,6 +904,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="190"
       y="70"
@@ -868,6 +922,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="90"
@@ -885,6 +940,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="90"
@@ -902,6 +958,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="90"
@@ -919,6 +976,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="90"
       y="90"
@@ -936,6 +994,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="110"
       y="90"
@@ -953,6 +1012,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="130"
       y="90"
@@ -970,6 +1030,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="150"
       y="90"
@@ -987,6 +1048,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="170"
       y="90"
@@ -1004,6 +1066,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="190"
       y="90"
@@ -1020,6 +1083,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="110"
@@ -1034,6 +1098,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="90"
       y="110"
@@ -1048,6 +1113,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="150"
       y="110"
@@ -1062,6 +1128,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="130"
@@ -1076,6 +1143,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="130"
       y="130"
@@ -1090,6 +1158,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="190"
       y="130"
@@ -1104,6 +1173,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="150"
@@ -1118,6 +1188,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="110"
       y="150"
@@ -1132,6 +1203,7 @@ exports[`renders with one feature with a correct seq, zoomed in, should render n
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="170"
       y="150"
@@ -1158,6 +1230,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="10"
@@ -1172,6 +1245,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="30"
@@ -1186,6 +1260,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="50"
@@ -1201,6 +1276,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="70"
@@ -1218,6 +1294,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="70"
@@ -1235,6 +1312,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="70"
@@ -1252,6 +1330,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="#fff"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="90"
@@ -1269,6 +1348,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="black"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="90"
@@ -1286,6 +1366,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     <text
       dominant-baseline="middle"
       fill="rgba(0, 0, 0, 0.87)"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="90"
@@ -1302,6 +1383,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="30"
       y="110"
@@ -1316,6 +1398,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="70"
       y="130"
@@ -1330,6 +1413,7 @@ exports[`renders with one feature with an incorrect seq, zoomed in, should throw
     />
     <text
       dominant-baseline="middle"
+      font-size="18"
       text-anchor="middle"
       x="50"
       y="150"

--- a/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
+++ b/plugins/sequence/src/LinearReferenceSequenceDisplay/model.ts
@@ -42,12 +42,14 @@ export function modelFactory(configSchema: AnyConfigurationSchemaType) {
          * #property
          */
         showTranslation: true,
-        /**
-         * #property
-         */
-        rowHeight: 20,
       }),
     )
+    .volatile(() => ({
+      /**
+       * #property
+       */
+      rowHeight: 15,
+    }))
     .views(self => ({
       /**
        * #getter


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/4229

Also moves rowHeight to a volatile, as if it's model, it will use the old size, so old sessions will not get updated