### PR TITLE
Add bookmark highlight to overview scale bar

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/OverviewHighlight.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/OverviewHighlight.tsx
@@ -2,11 +2,8 @@ import React, { useEffect, useRef } from 'react'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 import { SessionWithWidgets, getSession, notEmpty } from '@jbrowse/core/util'
-import { colord } from '@jbrowse/core/util/colord'
+import { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 import { Tooltip } from '@mui/material'
-
-// icons
-import BookmarkIcon from '@mui/icons-material/Bookmark'
 
 // locals
 import { GridBookmarkModel } from '../../model'
@@ -18,14 +15,20 @@ const useStyles = makeStyles()({
   highlight: {
     height: '100%',
     position: 'absolute',
-    overflow: 'hidden',
   },
 })
 
-const Highlight = observer(function Highlight({ model }: { model: LGV }) {
+const OverviewHighlight = observer(function OverviewHighlight({
+  model,
+  overview,
+}: {
+  model: LGV
+  overview: Base1DViewModel
+}) {
   const { classes } = useStyles()
-
+  const { cytobandOffset } = model
   const session = getSession(model) as SessionWithWidgets
+
   const { showBookmarkHighlights, showBookmarkLabels } = model
   const assemblyNames = new Set(session.assemblyNames)
 
@@ -51,18 +54,18 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
         ? bookmarks.current
             .filter(value => assemblyNames.has(value.assemblyName))
             .map(r => {
-              const s = model.bpToPx({
-                refName: r.refName,
-                coord: r.start,
+              const s = overview.bpToPx({
+                ...r,
+                coord: r.reversed ? r.end : r.start,
               })
-              const e = model.bpToPx({
-                refName: r.refName,
-                coord: r.end,
+              const e = overview.bpToPx({
+                ...r,
+                coord: r.reversed ? r.start : r.end,
               })
-              return s && e
+              return s !== undefined && e !== undefined
                 ? {
-                    width: Math.max(Math.abs(e.offsetPx - s.offsetPx), 3),
-                    left: Math.min(s.offsetPx, e.offsetPx) - model.offsetPx,
+                    width: Math.abs(e - s),
+                    left: s + cytobandOffset,
                     highlight: r.highlight,
                     label: r.label,
                   }
@@ -70,34 +73,35 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
             })
             .filter(notEmpty)
             .map(({ left, width, highlight, label }, idx) => (
-              <div
-                key={`${left}_${width}_${idx}`}
-                className={classes.highlight}
-                style={{
-                  left,
-                  width,
-                  background: highlight,
-                }}
-              >
+              <>
                 {showBookmarkLabels ? (
                   <Tooltip title={label} arrow>
-                    <BookmarkIcon
-                      fontSize="small"
-                      sx={{
-                        color: `${
-                          colord(highlight).alpha() !== 0
-                            ? colord(highlight).alpha(0.8).toRgbString()
-                            : colord(highlight).alpha(0).toRgbString()
-                        }`,
+                    <div
+                      key={`${left}_${width}_${idx}`}
+                      className={classes.highlight}
+                      style={{
+                        left,
+                        width,
+                        background: highlight,
                       }}
                     />
                   </Tooltip>
-                ) : null}
-              </div>
+                ) : (
+                  <div
+                    key={`${left}_${width}_${idx}`}
+                    className={classes.highlight}
+                    style={{
+                      left,
+                      width,
+                      background: highlight,
+                    }}
+                  />
+                )}
+              </>
             ))
         : null}
     </>
   )
 })
 
-export default Highlight
+export default OverviewHighlight

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/index.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import PluginManager from '@jbrowse/core/PluginManager'
+import { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 
 // locals
 import Highlight from './Highlight'
+import OverviewHighlight from './OverviewHighlight'
 import { IExtendedLGV } from '../../model'
 
 export default function AddHighlightModelF(pluginManager: PluginManager) {
@@ -13,6 +15,23 @@ export default function AddHighlightModelF(pluginManager: PluginManager) {
       return [
         ...rest,
         <Highlight key={`highlight_grid_bookmark`} model={model} />,
+      ]
+    },
+  )
+  pluginManager.addToExtensionPoint(
+    'LinearGenomeView-OverviewScalebarComponent',
+    // @ts-expect-error
+    (
+      rest: React.ReactNode[] = [],
+      { model, overview }: { model: IExtendedLGV; overview: Base1DViewModel },
+    ) => {
+      return [
+        ...rest,
+        <OverviewHighlight
+          key={`overview_highlight_grid_bookmark`}
+          model={model}
+          overview={overview}
+        />,
       ]
     },
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
@@ -25,11 +25,10 @@ const useStyles = makeStyles()(theme => ({
   highlight: {
     height: '100%',
     position: 'absolute',
+    overflow: 'hidden',
     background: `${colord(theme.palette.quaternary?.main ?? 'goldenrod')
       .alpha(0.35)
       .toRgbString()}`,
-    borderLeft: `1px solid ${theme.palette.quaternary?.main ?? 'goldenrod'}`,
-    borderRight: `1px solid ${theme.palette.quaternary?.main ?? 'goldenrod'}`,
   },
 }))
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
@@ -17,8 +17,6 @@ const useStyles = makeStyles()(theme => ({
     background: `${colord(theme.palette.quaternary?.main ?? 'goldenrod')
       .alpha(0.35)
       .toRgbString()}`,
-    borderLeft: `1px solid ${theme.palette.quaternary?.main ?? 'goldenrod'}`,
-    borderRight: `1px solid ${theme.palette.quaternary?.main ?? 'goldenrod'}`,
   },
 }))
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react'
 
 // core
 import Base1DView, { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
-import { getSession, getTickDisplayStr } from '@jbrowse/core/util'
+import { getEnv, getSession, getTickDisplayStr } from '@jbrowse/core/util'
 import { ContentBlock } from '@jbrowse/core/util/blockTypes'
 
 // locals
@@ -201,6 +201,7 @@ const Scalebar = observer(function ({
   const { classes } = useStyles()
   const theme = useTheme()
   const { dynamicBlocks, showCytobands, cytobandOffset } = model
+  const { pluginManager } = getEnv(model)
   const visibleRegions = dynamicBlocks.contentBlocks
   const overviewVisibleRegions = overview.dynamicBlocks
 
@@ -228,6 +229,12 @@ const Scalebar = observer(function ({
 
   const color = showCytobands ? '#f00' : scalebarColor
   const transparency = showCytobands ? 0.1 : 0.3
+
+  const additional = pluginManager.evaluateExtensionPoint(
+    'LinearGenomeView-OverviewScalebarComponent',
+    undefined,
+    { model, overview },
+  ) as React.ReactNode
 
   return (
     <div className={classes.scalebar}>
@@ -265,6 +272,7 @@ const Scalebar = observer(function ({
         )
       })}
       <OverviewHighlight model={model} overview={overview} />
+      {additional}
     </div>
   )
 })


### PR DESCRIPTION
- adds highlights to overview scale bar for bookmarks
- adds new extension point `OverviewScalebarComponent` to accomplish this
- aligns styling between bookmark highlights and url param highlights

![Screenshot 2024-03-06 at 3 55 47 PM](https://github.com/GMOD/jbrowse-components/assets/83305007/d9eaa2cb-cfa6-46e6-a8e1-269d4cc3b5b1)
![Screenshot 2024-03-06 at 3 55 08 PM](https://github.com/GMOD/jbrowse-components/assets/83305007/6d31f47f-be63-4915-90a4-52a91862f2be)

Outlines for comparison (I think they might make the regions more visible in the overview scale bar):
![Screenshot 2024-03-06 at 11 41 00 AM](https://github.com/GMOD/jbrowse-components/assets/83305007/cd724e3b-4840-4849-8062-cdb6419f9f8e)

Resolves https://github.com/GMOD/jbrowse-components/issues/4246
