### PR TITLE
Use a "no throw" version of decodeURIComponent for text indexing

### DIFF
--- a/packages/text-indexing/src/types/gff3Adapter.ts
+++ b/packages/text-indexing/src/types/gff3Adapter.ts
@@ -1,6 +1,6 @@
 import { createGunzip } from 'zlib'
 import readline from 'readline'
-import { Track } from '../util'
+import { Track, decodeURIComponentNoThrow } from '../util'
 import { getLocalOrRemoteStream } from './common'
 import { checkAbortSignal } from '@jbrowse/core/util'
 
@@ -51,7 +51,7 @@ export async function* indexGff3(
           .map(f => f.split('='))
           .map(([key, val]) => [
             key.trim(),
-            decodeURIComponent(val).trim().split(',').join(' '),
+            decodeURIComponentNoThrow(val).trim().split(',').join(' '),
           ]),
       )
       const attrs = attributes

--- a/packages/text-indexing/src/types/vcfAdapter.ts
+++ b/packages/text-indexing/src/types/vcfAdapter.ts
@@ -1,6 +1,6 @@
 import { createGunzip } from 'zlib'
 import readline from 'readline'
-import { Track } from '../util'
+import { Track, decodeURIComponentNoThrow } from '../util'
 import { getLocalOrRemoteStream } from './common'
 import { checkAbortSignal } from '@jbrowse/core/util'
 
@@ -52,7 +52,9 @@ export async function* indexVcf(
         .map(f => f.split('='))
         .map(([key, val]) => [
           key.trim(),
-          val ? decodeURIComponent(val).trim().split(',').join(' ') : undefined,
+          val
+            ? decodeURIComponentNoThrow(val).trim().split(',').join(' ')
+            : undefined,
         ]),
     )
 

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -165,3 +165,12 @@ export function findTrackConfigsToIndex(
     )
     .filter(track => isSupportedIndexingAdapter(track.adapter?.type))
 }
+
+export function decodeURIComponentNoThrow(uri: string) {
+  try {
+    return decodeURIComponent(uri)
+  } catch (e) {
+    // avoid throwing exception on a failure to decode URI component
+    return uri
+  }
+}

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -53,7 +53,7 @@ It is likely preferable in most cases to install the tools globally with
 - [`jbrowse add-track-json TRACK`](#jbrowse-add-track-json-track)
 - [`jbrowse admin-server`](#jbrowse-admin-server)
 - [`jbrowse create LOCALPATH`](#jbrowse-create-localpath)
-- [`jbrowse help [COMMANDS]`](#jbrowse-help-commands)
+- [`jbrowse help [COMMAND]`](#jbrowse-help-command)
 - [`jbrowse make-pif FILE`](#jbrowse-make-pif-file)
 - [`jbrowse remove-track TRACK`](#jbrowse-remove-track-track)
 - [`jbrowse set-default-session`](#jbrowse-set-default-session)
@@ -458,16 +458,16 @@ EXAMPLES
 _See code:
 [src/commands/create.ts](https://github.com/GMOD/jbrowse-components/blob/v2.10.3/products/jbrowse-cli/src/commands/create.ts)_
 
-## `jbrowse help [COMMANDS]`
+## `jbrowse help [COMMAND]`
 
 Display help for jbrowse.
 
 ```
 USAGE
-  $ jbrowse help [COMMANDS] [-n]
+  $ jbrowse help [COMMAND] [-n]
 
 ARGUMENTS
-  COMMANDS  Command to show help for.
+  COMMAND  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.
@@ -477,7 +477,7 @@ DESCRIPTION
 ```
 
 _See code:
-[@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.0.15/src/commands/help.ts)_
+[@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.0.17/src/commands/help.ts)_
 
 ## `jbrowse make-pif FILE`
 

--- a/products/jbrowse-cli/src/types/gff3Adapter.ts
+++ b/products/jbrowse-cli/src/types/gff3Adapter.ts
@@ -4,7 +4,7 @@ import readline from 'readline'
 
 // locals
 import { Track } from '../base'
-import { getLocalOrRemoteStream } from '../util'
+import { decodeURIComponentNoThrow, getLocalOrRemoteStream } from '../util'
 
 export async function* indexGff3({
   config,
@@ -75,7 +75,7 @@ export async function* indexGff3({
           .map(f => f.split('='))
           .map(([key, val]) => [
             key.trim(),
-            decodeURIComponent(val).trim().split(',').join(' '),
+            decodeURIComponentNoThrow(val).trim().split(',').join(' '),
           ]),
       )
       const attrs = attributesToIndex

--- a/products/jbrowse-cli/src/types/vcfAdapter.ts
+++ b/products/jbrowse-cli/src/types/vcfAdapter.ts
@@ -4,7 +4,7 @@ import readline from 'readline'
 
 // locals
 import { Track } from '../base'
-import { getLocalOrRemoteStream } from '../util'
+import { decodeURIComponentNoThrow, getLocalOrRemoteStream } from '../util'
 
 export async function* indexVcf({
   config,
@@ -73,7 +73,9 @@ export async function* indexVcf({
         .map(f => f.split('='))
         .map(([key, val]) => [
           key.trim(),
-          val ? decodeURIComponent(val).trim().split(',').join(' ') : undefined,
+          val
+            ? decodeURIComponentNoThrow(val).trim().split(',').join(' ')
+            : undefined,
         ]),
     )
 

--- a/products/jbrowse-cli/src/util.ts
+++ b/products/jbrowse-cli/src/util.ts
@@ -16,3 +16,12 @@ export async function getLocalOrRemoteStream(uri: string, out: string) {
   }
   return { totalBytes, stream }
 }
+
+export function decodeURIComponentNoThrow(uri: string) {
+  try {
+    return decodeURIComponent(uri)
+  } catch (e) {
+    // avoid throwing exception on a failure to decode URI component
+    return uri
+  }
+}


### PR DESCRIPTION
Some files are badly encoded (not following e.g. GFF3 spec) and cause decodeURIComponent to throw. This is not a good user experience. This PR just proposes passing the string along

addresses https://github.com/GMOD/jbrowse-components/discussions/4268