### PR TITLE
Fix usage of --assemblyNames in `jbrowse add-connection`

### DIFF
--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -464,10 +464,10 @@ Display help for jbrowse.
 
 ```
 USAGE
-  $ jbrowse help [COMMAND...] [-n]
+  $ jbrowse help [COMMAND] [-n]
 
 ARGUMENTS
-  COMMAND...  Command to show help for.
+  COMMAND  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.

--- a/products/jbrowse-cli/src/commands/add-connection.ts
+++ b/products/jbrowse-cli/src/commands/add-connection.ts
@@ -136,8 +136,9 @@ export default class AddConnection extends JBrowseCommand {
           }
         : {}),
       connectionId: id,
-      assemblyNames:
-        assemblyNames || type === 'JBrowse1Connection'
+      assemblyNames: assemblyNames
+        ? assemblyNames.split(',')
+        : type === 'JBrowse1Connection'
           ? [configContents.assemblies[0]?.name]
           : undefined,
       ...(config ? parseJSON(config) : {}),


### PR DESCRIPTION
Fixes #4264