### PR TITLE
Add JSON.parse utility to the "jexl function library"

### DIFF
--- a/packages/core/util/jexl.ts
+++ b/packages/core/util/jexl.ts
@@ -75,6 +75,7 @@ export default function (/* config?: any*/): JexlNonBuildable {
   )
   j.addFunction('toLowerCase', (s: string) => s.toLowerCase())
   j.addFunction('toUpperCase', (s: string) => s.toUpperCase())
+  j.addFunction('jsonParse', (s: string) => JSON.parse(s))
   j.addFunction('trim', (s: string) => s.trim())
   j.addFunction('trimEnd', (s: string) => s.trimEnd())
   j.addFunction('trimStart', (s: string) => s.trimStart())

--- a/test_data/volvox/volvox.sort.gff3
+++ b/test_data/volvox/volvox.sort.gff3
@@ -2,7 +2,7 @@
 # multi-exon gene - several linked CDSs
 # single exon gene - one CDS only
 ##gff-version 3
-ctgA	example	contig	1	50001	.	.	.	Name=ctgA;multivalue=val1,val2,val3
+ctgA	example	contig	1	50001	.	.	.	Name=ctgA;multivalue=val1,val2,val3;table=%5B%7B%22name%22%3A%22hello1%22%2C%22value%22%3A1%7D%2C%7B%22name%22%3A%22hello2%22%2C%22value%22%3A2%7D%2C%7B%22name%22%3A%22hello3%22%2C%22value%22%3A3%7D%2C%7B%22name%22%3A%22hello4%22%2C%22value%22%3A4%7D%2C%7B%22name%22%3A%22hello5%22%2C%22value%22%3A5%7D%5D
 ctgA	example	BAC	1000	20000	.	.	.	ID=b101.2;Name=b101.2;Note=Fingerprinted BAC with end reads
 ctgA	example	SNP	1000	1000	0.987	.	.	ID=FakeSNP1;Name=FakeSNP;Note=This is a fake SNP that should appear at 1000 with length 1
 ctgA	example	clone_start	1000	1500	.	+	.	Parent=b101.2


### PR DESCRIPTION
This adds a JSON.parse utility to the jexl functions. It is a little specialized but this can enable a sort of (office hours) use case where a table of data can be stored in a GFF3 attribute as a json "array of objects". A volvox track showing this use case is added in this PR too

The alternative is that this isn't a built in utility but doesn't seem too bad to add it

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/ba5d7c0d-4a78-4005-9b00-36e06a6019af)
