### PR TITLE
v2.11.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.11.0.md
+++ b/website/release_announcement_drafts/v2.11.0.md
@@ -1,0 +1,17 @@
+This release adds a new option "Color by CDS" to color the reference sequence
+track and CDS features in gene tracks by their reading frame
+
+![](https://github.com/GMOD/jbrowse-components/assets/6511937/beb6d534-ea0d-4b8e-b8fd-cdb130a60f45)
+
+Screenshot showing the "Color by CDS" setting on the linear genome view menu
+
+This release also adds new Hi-C coloring options, including a log-scale mode
+that enhances visible patterns
+
+![](https://github.com/GMOD/jbrowse-components/assets/6511937/cf848f37-56b2-4033-ab6f-f87260a1e0ae)
+
+There are also many other small fixes including the ability to highlight
+multiple regions from the URL bar &highlight= option, faster zooming with the
+zoom in/out buttons, and more
+
+See release notes for details


### PR DESCRIPTION
current changelog

## Unreleased (2024-04-16)

#### :rocket: Enhancement
* `core`
  * [#4341](https://github.com/GMOD/jbrowse-components/pull/4341) Improve error dialog stack trace display and fix usage on https sites ([@cmdcolin](https://github.com/cmdcolin))
  * [#4340](https://github.com/GMOD/jbrowse-components/pull/4340) Change email on error message dialog ([@cmdcolin](https://github.com/cmdcolin))
  * [#4288](https://github.com/GMOD/jbrowse-components/pull/4288) Create GCContentTrack type ([@cmdcolin](https://github.com/cmdcolin))
  * [#4312](https://github.com/GMOD/jbrowse-components/pull/4312) Update @mui/x-data-grid 6->7 ([@cmdcolin](https://github.com/cmdcolin))
  * [#4280](https://github.com/GMOD/jbrowse-components/pull/4280) Add JSON.parse utility to the "jexl function library" ([@cmdcolin](https://github.com/cmdcolin))
  * [#4276](https://github.com/GMOD/jbrowse-components/pull/4276) Add retry method to share link dialog in case of error ([@cmdcolin](https://github.com/cmdcolin))
  * [#4266](https://github.com/GMOD/jbrowse-components/pull/4266) Add bookmark highlight to overview scale bar ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
* Other
  * [#4335](https://github.com/GMOD/jbrowse-components/pull/4335) Add ability to create multiple highlights on the linear genome view ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
  * [#4287](https://github.com/GMOD/jbrowse-components/pull/4287) Fix snap package and also add deb package ([@cmdcolin](https://github.com/cmdcolin))
  * [#4034](https://github.com/GMOD/jbrowse-components/pull/4034) Subtler minicontrols focus ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `product-core`
  * [#4337](https://github.com/GMOD/jbrowse-components/pull/4337) Allow moving tracks and views up/down/to top/to bottom, and better click and drag track re-ordering ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`
  * [#4336](https://github.com/GMOD/jbrowse-components/pull/4336) Add new Hi-C color schemes with log scale mode ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `web-core`
  * [#4284](https://github.com/GMOD/jbrowse-components/pull/4284) Allow getting stack trace error dialog from session.notify errors ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* Other
  * [#4318](https://github.com/GMOD/jbrowse-components/pull/4318) Use node-fetch-native to fix warning from JBrowse CLI on node 21+ ([@cmdcolin](https://github.com/cmdcolin))
  * [#4319](https://github.com/GMOD/jbrowse-components/pull/4319) Fix Hi-C rendering for some high resolution files ([@cmdcolin](https://github.com/cmdcolin))
  * [#4314](https://github.com/GMOD/jbrowse-components/pull/4314) Fix loading of BED12 data from a plaintext BED with column headers ([@cmdcolin](https://github.com/cmdcolin))
  * [#4293](https://github.com/GMOD/jbrowse-components/pull/4293) Fix alignment curves showing up in inkscape for breakpoint svg ([@cmdcolin](https://github.com/cmdcolin))
  * [#4287](https://github.com/GMOD/jbrowse-components/pull/4287) Fix snap package and also add deb package ([@cmdcolin](https://github.com/cmdcolin))
  * [#4277](https://github.com/GMOD/jbrowse-components/pull/4277) Fix usage of --assemblyNames in `jbrowse add-connection` ([@cmdcolin](https://github.com/cmdcolin))
  * [#4275](https://github.com/GMOD/jbrowse-components/pull/4275) Fixes bug on URL highlight param in which refName aliases were not working ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
* `text-indexing`
  * [#4269](https://github.com/GMOD/jbrowse-components/pull/4269) Avoid crash on badly encoded GFF attributes ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 3
- Caroline Bridge ([@carolinebridge-oicr](https://github.com/carolinebridge-oicr))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 1.85s.

