### PR TITLE
Optimistically fix snap package and also add deb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "dependency-graph": "^0.11.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^11.0.3",
-    "electron": "29.1.0",
+    "electron": "29.1.2",
     "electron-builder": "^24.9.0",
     "electron-mock-ipc": "^0.3.8",
     "eslint": "^8.0.0",

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -104,32 +104,19 @@
     "use-query-params": "^2.0.0"
   },
   "devDependencies": {
-    "electron": "29.1.0"
+    "electron": "29.1.2"
   },
   "browserslist": [
     "last 1 chrome version"
   ],
   "build": {
-    "electronVersion": "29.1.0",
+    "electronVersion": "29.1.2",
     "extraMetadata": {
       "main": "build/electron.js"
     },
     "appId": "org.jbrowse2.app",
     "productName": "JBrowse 2",
     "copyright": "Copyright © 2019",
-    "snap": {
-      "confinement": "strict",
-      "plugs": [
-        "default",
-        "removable-media"
-      ],
-      "publish": [
-        "github"
-      ],
-      "slots": [
-        "default"
-      ]
-    },
     "win": {
       "publish": [
         "github"
@@ -139,6 +126,14 @@
     "linux": {
       "publish": [
         "github"
+      ],
+      "target": [
+        {
+          "target": "AppImage"
+        },
+        {
+          "target": "snap"
+        }
       ],
       "executableName": "jbrowse-desktop",
       "artifactName": "jbrowse-desktop-v${version}-linux.${ext}"

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -133,10 +133,26 @@
         },
         {
           "target": "snap"
+        },
+        {
+          "target": "deb"
         }
       ],
       "executableName": "jbrowse-desktop",
       "artifactName": "jbrowse-desktop-v${version}-linux.${ext}"
+    },
+    "deb": {
+      "maintainer": "colin.diesh@gmail.com"
+    },
+    "snap": {
+      "confinement": "strict",
+      "plugs": [
+        "default",
+        "removable-media"
+      ],
+      "slots": [
+        "default"
+      ]
     },
     "mac": {
       "mergeASARs": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9079,10 +9079,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@29.1.0:
-  version "29.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.0.tgz#37f0e4915226db3c87bc54b187795272bf61fc39"
-  integrity sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==
+electron@29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.2.tgz#b9a5f97b77c0fb3336f381405037770703c4955d"
+  integrity sha512-f1JZpUeeTH+UESdYOxnnfyf4hUUVlAFFRsaawIgYIlibEOiZOxJ0UILm7htv+yrQ51+V86yJRi8miyP7vjIULw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
This takes influence from how the mac "multiple targets" config is defined (as an array of objects with "target" key within an array of targets within the OS specific grouping)

this was made from studying https://www.electron.build/configuration/linux

it is allowed for there to be a top level snap key, as before, but this changes it to be inside the linux grouping

more linux builds (.tar.gz, deb, etc) could be added also
