### PR TITLE
Change office hours link to new berkeley google account and remove community meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@ Homepage https://jbrowse.org/jb2
 Docs http://jbrowse.org/jb2/docs/
 
 Fall 2023: New outreach! We created an "office hours" Google Calendar for anyone
-to schedule 1-on-1 meetings with the development team. We also are starting a
-new community meeting that anyone can join via a public Google Meet link.
-Details below:
+to schedule 1-on-1 meetings with the development team. Details below:
 
-- [Schedule 1-on-1 appointment](https://calendar.app.google/E9i5fyZN4UcZawuNA)
-- [Community call - Monthly on the third Thursday, 10am EST (North America, Europe friendly)](https://meet.google.com/uti-xsjf-xbu)
-- [Community call - Monthly on the last Tuesday, 8pm EST (Asia Pacific friendly)](https://meet.google.com/rnq-exdt-tuz)
-- [Add both events to your Google calendar](https://calendar.google.com/calendar/u/2?cid=ZDgxZmE0Yjk3YjdiZTAxYThjMDAzYzNkOThkMjUyOGQ1ZWM4YzNkMzRjNjgwMmQ3YjZhOWEwYmU4NDYxZDBiM0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [Schedule 1-on-1 appointment](https://calendar.app.google/1AYZkNCQNmwdY2R26)
 
 ## Pre-requisites
 

--- a/website/src/pages/contact.mdx
+++ b/website/src/pages/contact.mdx
@@ -9,7 +9,7 @@ import GoogleCalendarScheduleFunction from './util'
 We **really** love talking to our users. Please reach out with any thoughts you
 have on what we are building!
 
-## Office hours and community meetings
+## Office hours
 
 <GoogleCalendarScheduleFunction />
 

--- a/website/src/pages/util.tsx
+++ b/website/src/pages/util.tsx
@@ -7,9 +7,7 @@ import Alert from '@mui/material/Alert'
 export default function GoogleCalendarScheduleFunction() {
   return (
     <Alert severity="info" style={{ margin: 10 }}>
-      <Typography variant="h6">
-        New: JBrowse 2 office hours and community meetings!
-      </Typography>
+      <Typography variant="h6">New: JBrowse 2 office hours!</Typography>
       <Typography>
         Starting Fall 2023, we are offering 1-on-1 appointments with members of
         our team via Google Calendar
@@ -17,33 +15,11 @@ export default function GoogleCalendarScheduleFunction() {
           variant="contained"
           style={{ margin: 10 }}
           size="small"
-          href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2WIB6bwPtShkYDn49c-ADXvpxfa6iyaEP453Uvy-e-RDZPZF5rsbTRbRlXrWelVpSicZJQsdn5"
+          href="https://calendar.app.google/1AYZkNCQNmwdY2R26"
         >
           Schedule appointment
         </Button>
       </Typography>
-      <Typography>
-        We will also have community meetings where anyone can join a public
-        Google Meet
-      </Typography>
-      <ul>
-        <li>
-          <a href="https://meet.google.com/uti-xsjf-xbu">
-            Monthly on the third Thursday, 10am EST (North America, Europe
-            friendly)
-          </a>
-        </li>
-        <li>
-          <a href="https://meet.google.com/rnq-exdt-tuz">
-            Monthly on the last Tuesday, 8pm EST (Asia Pacific friendly)
-          </a>
-        </li>
-        <li>
-          <a href="https://calendar.google.com/calendar/u/2?cid=ZDgxZmE0Yjk3YjdiZTAxYThjMDAzYzNkOThkMjUyOGQ1ZWM4YzNkMzRjNjgwMmQ3YjZhOWEwYmU4NDYxZDBiM0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t">
-            Add both events to your Google calendar
-          </a>
-        </li>
-      </ul>
     </Alert>
   )
 }


### PR DESCRIPTION
Had a hard time sharing the account settings with the jbrowse2dev@gmail.com so now it is a true shared account with jbrowse2@berkeley.edu that garrett and i can respond to

This PR also removes the community meetings. They ended up basically being kind of one-on-one discussions with maybe 1 or two other people joining, so it might just be better as the office hours system anyways.

I think there has been a reasonable amount of feedback from people from the community meetings but I think the office hours is probably the best going forward

if there are any objections to removing community meetings lemme know :) 
