### PR TITLE
Fix Hi-C rendering for some high resolution files

### DIFF
--- a/plugins/hic/src/HicAdapter/HicAdapter.ts
+++ b/plugins/hic/src/HicAdapter/HicAdapter.ts
@@ -36,21 +36,23 @@ interface HicOptions extends BaseOptions {
   bpPerPx?: number
 }
 
-// wraps generic-filehandle so the read function only takes a position and length
-// in some ways, generic-filehandle wishes it was just this but it has
+// wraps generic-filehandle so the read function only takes a position and
+// length in some ways, generic-filehandle wishes it was just this but it has
 // to adapt to the node.js fs promises API
 class GenericFilehandleWrapper {
   constructor(private filehandle: GenericFilehandle) {}
 
   async read(position: number, length: number) {
-    const { buffer: b, bytesRead } = await this.filehandle.read(
-      Buffer.allocUnsafe(length),
+    const { buffer } = await this.filehandle.read(
+      Buffer.alloc(length),
       0,
       length,
       position,
     )
-    // xref https://stackoverflow.com/a/31394257/2129219
-    return b.buffer.slice(b.byteOffset, b.byteOffset + bytesRead)
+    return buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength,
+    )
   }
 }
 export function openFilehandleWrapper(

--- a/plugins/hic/src/HicRenderer/HicRenderer.tsx
+++ b/plugins/hic/src/HicRenderer/HicRenderer.tsx
@@ -81,8 +81,8 @@ export default class HicRenderer extends ServerSideRendererType {
 
     const w = res / (bpPerPx * Math.sqrt(2))
     const baseColor = colord(readConfObject(config, 'baseColor'))
+    const offset = region.start
     if (features.length) {
-      const offset = features[0].bin1
       let maxScore = 0
       let minBin = 0
       let maxBin = 0


### PR DESCRIPTION
assumed that it should shift the offset by the bp coordinate of the "first data line in the file" but this is actually wrong when it is sparse...I believe the correct shift is just the region start bp coordinate