### PR TITLE
Remove animated zoom

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -997,35 +997,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
       return { slide }
     })
     .actions(self => {
-      let cancelLastAnimation = () => {}
-
       /**
        * #action
-       * perform animated zoom
+       * perform zoom
        */
       function zoom(targetBpPerPx: number) {
-        self.zoomTo(self.bpPerPx)
-        if (
-          // already zoomed all the way in
-          (targetBpPerPx < self.bpPerPx && self.bpPerPx === self.minBpPerPx) ||
-          // already zoomed all the way out
-          (targetBpPerPx > self.bpPerPx && self.bpPerPx === self.maxBpPerPx)
-        ) {
-          return
-        }
-        const factor = self.bpPerPx / targetBpPerPx
-        const [animate, cancelAnimation] = springAnimate(
-          1,
-          factor,
-          self.setScaleFactor,
-          () => {
-            self.zoomTo(targetBpPerPx)
-            self.setScaleFactor(1)
-          },
-        )
-        cancelLastAnimation()
-        cancelLastAnimation = cancelAnimation
-        animate()
+        self.zoomTo(targetBpPerPx)
       }
 
       return { zoom }


### PR DESCRIPTION
This PR proposes removing the animated zoom

It is motivated by my experience at PAG watching users trying to use the zoom in button multiple times, but having to wait at each stage, and it being quite slow

By removing the animation, they can hit it multiple times and the UI updates instantly

An alternative would be to allow the zoom to be clicked multiple times and continue the animation all the way through this process, but I think the animation is not necessary for continuity of the UI. 