### PR TITLE
Adds ability to highlight multiple locations using URL query API

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/Highlight.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/Highlight.tsx
@@ -27,6 +27,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
 
   const session = getSession(model) as SessionWithWidgets
   const { showBookmarkHighlights, showBookmarkLabels } = model
+  const { assemblyManager } = session
   const assemblyNames = new Set(session.assemblyNames)
 
   const bookmarkWidget = session.widgets.get(
@@ -49,12 +50,14 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
     ? bookmarks.current
         .filter(value => assemblyNames.has(value.assemblyName))
         .map(r => {
+          const asm = assemblyManager.get(r.assemblyName)
+          const refName = asm?.getCanonicalRefName(r.refName) ?? r.refName
           const s = model.bpToPx({
-            refName: r.refName,
+            refName: refName,
             coord: r.start,
           })
           const e = model.bpToPx({
-            refName: r.refName,
+            refName: refName,
             coord: r.end,
           })
           return s && e

--- a/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
@@ -76,7 +76,7 @@ export default (pluginManager: PluginManager) => {
                 location?.start !== undefined &&
                 location?.end !== undefined
               ) {
-                view.setHighlight(location)
+                view.addToHighlights(location)
               }
             }
           })

--- a/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
+++ b/plugins/linear-genome-view/src/LaunchLinearGenomeView/index.ts
@@ -30,7 +30,7 @@ export default (pluginManager: PluginManager) => {
       tracks?: string[]
       tracklist?: boolean
       nav?: boolean
-      highlight?: string
+      highlight?: string[]
     }) => {
       try {
         const { assemblyManager } = session
@@ -61,18 +61,25 @@ export default (pluginManager: PluginManager) => {
           view.setHideHeader(!nav)
         }
         if (highlight !== undefined) {
-          const parsedLocString = parseLocString(highlight, refName =>
-            isValidRefName(refName, assembly),
-          ) as Required<ParsedLocString>
+          highlight.forEach(async h => {
+            if (h) {
+              const parsedLocString = parseLocString(h, refName =>
+                isValidRefName(refName, assembly),
+              ) as Required<ParsedLocString>
 
-          const location = {
-            ...parsedLocString,
-            assemblyName: assembly,
-          }
+              const location = {
+                ...parsedLocString,
+                assemblyName: assembly,
+              }
 
-          if (location?.start !== undefined && location?.end !== undefined) {
-            view.setHighlight(location)
-          }
+              if (
+                location?.start !== undefined &&
+                location?.end !== undefined
+              ) {
+                view.setHighlight(location)
+              }
+            }
+          })
         }
 
         await handleSelectedRegion({ input: loc, model: view, assembly: asm })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
@@ -32,7 +32,13 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Highlight = observer(function Highlight({ model }: { model: LGV }) {
+const Highlight = observer(function Highlight({
+  model,
+  highlight,
+}: {
+  model: LGV
+  highlight: Required<ParsedLocString>
+}) {
   const { classes } = useStyles()
   const [open, setOpen] = useState(false)
   const anchorEl = useRef(null)
@@ -42,7 +48,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
   const { assemblyManager } = session
 
   const dismissHighlight = () => {
-    model.setHighlight(undefined)
+    model.removeHighlight(highlight)
   }
 
   const menuItems = [
@@ -63,7 +69,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
           )
         }
         // @ts-ignore
-        bookmarkWidget.addBookmark(model.highlight as Region)
+        bookmarkWidget.addBookmark(highlight as Region)
         dismissHighlight()
       },
     },
@@ -73,7 +79,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
     setOpen(false)
   }
 
-  if (!model.highlight) {
+  if (!highlight) {
     return null
   }
 
@@ -95,13 +101,11 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
       : undefined
   }
 
-  const asm = assemblyManager.get(model.highlight?.assemblyName)
+  const asm = assemblyManager.get(highlight?.assemblyName)
 
   const h = mapCoords({
-    ...model.highlight,
-    refName:
-      asm?.getCanonicalRefName(model.highlight.refName) ??
-      model.highlight.refName,
+    ...highlight,
+    refName: asm?.getCanonicalRefName(highlight.refName) ?? highlight.refName,
   })
 
   return h ? (
@@ -116,7 +120,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
         <IconButton
           ref={anchorEl}
           onClick={() => setOpen(true)}
-          style={{ zIndex: 4 }}
+          style={{ zIndex: 3 }}
         >
           <LinkIcon
             fontSize="small"
@@ -140,4 +144,20 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
   ) : null
 })
 
-export default Highlight
+const HighlightGroup = observer(function HighlightGroup({
+  model,
+}: {
+  model: LGV
+}) {
+  if (!model.highlight) {
+    return null
+  }
+
+  return model.highlight
+    ? model.highlight.map((h, idx) => {
+        return <Highlight key={idx} model={model} highlight={h} />
+      })
+    : null
+})
+
+export default HighlightGroup

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
@@ -145,15 +145,13 @@ const HighlightGroup = observer(function HighlightGroup({
 }: {
   model: LGV
 }) {
-  if (!model.highlight) {
-    return null
-  }
-
-  return model.highlight
-    ? model.highlight.map(h => {
-        return <Highlight key={JSON.stringify(h)} model={model} highlight={h} />
-      })
-    : null
+  return model.highlight.map((highlight, idx) => (
+    <Highlight
+      key={JSON.stringify(highlight) + '-' + idx}
+      model={model}
+      highlight={highlight}
+    />
+  ))
 })
 
 export default HighlightGroup

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
@@ -79,10 +79,6 @@ const Highlight = observer(function Highlight({
     setOpen(false)
   }
 
-  if (!highlight) {
-    return null
-  }
-
   // coords
   const mapCoords = (r: Required<ParsedLocString>) => {
     const s = model.bpToPx({
@@ -154,8 +150,8 @@ const HighlightGroup = observer(function HighlightGroup({
   }
 
   return model.highlight
-    ? model.highlight.map((h, idx) => {
-        return <Highlight key={idx} model={model} highlight={h} />
+    ? model.highlight.map(h => {
+        return <Highlight key={JSON.stringify(h)} model={model} highlight={h} />
       })
     : null
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
@@ -6,6 +6,7 @@ import {
   ParsedLocString,
   SessionWithWidgets,
   getSession,
+  notEmpty,
 } from '@jbrowse/core/util'
 import { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 
@@ -63,24 +64,28 @@ const OverviewHighlight = observer(function OverviewHighlight({
     return null
   }
 
-  const asm = assemblyManager.get(model.highlight?.assemblyName)
+  return model.highlight
+    ? model.highlight
+        .map(h => {
+          const asm = assemblyManager.get(h?.assemblyName)
 
-  const h = mapCoords({
-    ...model.highlight,
-    refName:
-      asm?.getCanonicalRefName(model.highlight.refName) ??
-      model.highlight.refName,
-  })
-
-  return h ? (
-    <div
-      className={classes.highlight}
-      style={{
-        width: h.width,
-        left: h.left,
-      }}
-    />
-  ) : null
+          return mapCoords({
+            ...h,
+            refName: asm?.getCanonicalRefName(h.refName) ?? h.refName,
+          })
+        })
+        .filter(notEmpty)
+        .map(({ left, width }, idx) => (
+          <div
+            key={`${left}_${width}_${idx}`}
+            className={classes.highlight}
+            style={{
+              width: width,
+              left: left,
+            }}
+          />
+        ))
+    : null
 })
 
 export default OverviewHighlight

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewHighlight.tsx
@@ -60,32 +60,26 @@ const OverviewHighlight = observer(function OverviewHighlight({
       : undefined
   }
 
-  if (!model.highlight) {
-    return null
-  }
-
   return model.highlight
-    ? model.highlight
-        .map(h => {
-          const asm = assemblyManager.get(h?.assemblyName)
+    .map(h => {
+      const asm = assemblyManager.get(h?.assemblyName)
 
-          return mapCoords({
-            ...h,
-            refName: asm?.getCanonicalRefName(h.refName) ?? h.refName,
-          })
-        })
-        .filter(notEmpty)
-        .map(({ left, width }, idx) => (
-          <div
-            key={`${left}_${width}_${idx}`}
-            className={classes.highlight}
-            style={{
-              width: width,
-              left: left,
-            }}
-          />
-        ))
-    : null
+      return mapCoords({
+        ...h,
+        refName: asm?.getCanonicalRefName(h.refName) ?? h.refName,
+      })
+    })
+    .filter(notEmpty)
+    .map(({ left, width }, idx) => (
+      <div
+        key={`${left}_${width}_${idx}`}
+        className={classes.highlight}
+        style={{
+          width: width,
+          left: left,
+        }}
+      />
+    ))
 })
 
 export default OverviewHighlight

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -15,7 +15,7 @@ import Gridlines from './Gridlines'
 import CenterLine from './CenterLine'
 import VerticalGuide from './VerticalGuide'
 import RubberbandSpan from './RubberbandSpan'
-import Highlight from './Highlight'
+import HighlightGroup from './Highlight'
 
 const useStyles = makeStyles()({
   tracksContainer: {
@@ -108,7 +108,7 @@ const TracksContainer = observer(function TracksContainer({
           />
         }
       />
-      <Highlight model={model} />
+      <HighlightGroup model={model} />
       {additional}
       {children}
     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -250,7 +250,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
          * #property
          * highlights on the LGV from the URL parameters
          */
-        highlight: types.maybe(types.frozen<Required<ParsedLocString>>()),
+        highlight: types.optional(
+          types.array(types.frozen<Required<ParsedLocString>>()),
+          [],
+        ),
 
         /**
          * #property
@@ -603,8 +606,14 @@ export function stateModelFactory(pluginManager: PluginManager) {
       /**
        * #action
        */
-      setHighlight(highlight: Required<ParsedLocString> | undefined) {
-        self.highlight = highlight
+      setHighlight(highlight: Required<ParsedLocString>) {
+        self.highlight?.push(highlight)
+      },
+      /**
+       * #action
+       */
+      removeHighlight(highlight: Required<ParsedLocString>) {
+        self.highlight.splice(self.highlight.indexOf(highlight), 1)
       },
       /**
        * #action

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -606,14 +606,20 @@ export function stateModelFactory(pluginManager: PluginManager) {
       /**
        * #action
        */
-      setHighlight(highlight: Required<ParsedLocString>) {
+      addToHighlights(highlight: Required<ParsedLocString>) {
         self.highlight?.push(highlight)
       },
       /**
        * #action
        */
+      setHighlight(highlight: Required<ParsedLocString>[] | undefined) {
+        self.highlight = cast(highlight)
+      },
+      /**
+       * #action
+       */
       removeHighlight(highlight: Required<ParsedLocString>) {
-        self.highlight.splice(self.highlight.indexOf(highlight), 1)
+        self.highlight.remove(highlight)
       },
       /**
        * #action
@@ -1626,6 +1632,13 @@ export function stateModelFactory(pluginManager: PluginManager) {
         })
       },
     }))
+    .preProcessSnapshot(snap => {
+      const { highlight, ...rest } = snap
+      return {
+        highlight: highlight ? [...highlight] : [],
+        ...rest,
+      }
+    })
 }
 
 export type LinearGenomeViewStateModel = ReturnType<typeof stateModelFactory>

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1633,9 +1633,15 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .preProcessSnapshot(snap => {
+      if (!snap) {
+        return snap
+      }
       const { highlight, ...rest } = snap
       return {
-        highlight: highlight ? [...highlight] : [],
+        highlight:
+          Array.isArray(highlight) || highlight === undefined
+            ? highlight
+            : [...highlight],
         ...rest,
       }
     })

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1641,7 +1641,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
         highlight:
           Array.isArray(highlight) || highlight === undefined
             ? highlight
-            : [...highlight],
+            : [highlight],
         ...rest,
       }
     })

--- a/products/jbrowse-react-linear-genome-view/src/createViewState.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createViewState.ts
@@ -135,7 +135,7 @@ export default function createViewState(opts: ViewStateOptions) {
                 location?.start !== undefined &&
                 location?.end !== undefined
               ) {
-                session.view.setHighlight(location)
+                session.view.addToHighlights(location)
               }
             }
           })

--- a/products/jbrowse-react-linear-genome-view/src/createViewState.ts
+++ b/products/jbrowse-react-linear-genome-view/src/createViewState.ts
@@ -120,10 +120,10 @@ export default function createViewState(opts: ViewStateOptions) {
           assembly.name,
         )
         if (highlight) {
-          highlight.forEach(async h => {
+          highlight.forEach(h => {
             if (h) {
               const parsedLocString = parseLocString(h, refName =>
-                isValidRefName(refName, assembly),
+                isValidRefName(refName, assembly.name),
               ) as Required<ParsedLocString>
 
               const location = {

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -301,7 +301,7 @@ const SessionLoader = types
               assembly,
               tracklist,
               nav,
-              highlight,
+              highlight: highlight?.split(';'),
             },
           ],
         }

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -301,7 +301,7 @@ const SessionLoader = types
               assembly,
               tracklist,
               nav,
-              highlight: highlight?.split(';'),
+              highlight: highlight?.split(' '),
             },
           ],
         }

--- a/website/docs/urlparams.md
+++ b/website/docs/urlparams.md
@@ -80,6 +80,11 @@ Example
 This will create a highlight over the specified region when combined with
 [&assembly=](#assembly) and [&loc=](#loc).
 
+Multiple highlight locations can be specified by delimiting locations with a
+semi-colon:
+
+`&highlight=chr1:6000-7000;chr1:7100-7200`
+
 ### &tracklist=
 
 Example

--- a/website/docs/urlparams.md
+++ b/website/docs/urlparams.md
@@ -81,9 +81,9 @@ This will create a highlight over the specified region when combined with
 [&assembly=](#assembly) and [&loc=](#loc).
 
 Multiple highlight locations can be specified by delimiting locations with a
-semi-colon:
+space:
 
-`&highlight=chr1:6000-7000;chr1:7100-7200`
+`&highlight=chr1:6000-7000 chr1:7100-7200`
 
 ### &tracklist=
 
@@ -97,9 +97,9 @@ This opens the track selector by default. Default false
 
 Example
 
-`&nav=`
+`&nav=false`
 
-Turns of the navigation bar of the linear genome view
+Turns off the navigation bar of the linear genome view
 
 ### &tracks=
 


### PR DESCRIPTION
Some QOL improvements on this small feature:
- adds ability to highlight multiple locations using URL query API
**example:** [&highlight=7:140,636,065..140,680,172;7:140,609,755..140,624,677](https://s3.amazonaws.com/jbrowse.org/code/jb2/improve-url-quer-highlight/index.html?config=test_data/config_demo.json&loc=7:140,307,327..140,730,530&assembly=hg19&tracks=mygene_hg19,nclist_genes_hg19&highlight=7:140,636,065..140,680,172;7:140,609,755..140,624,677)
NOTE: must delimit highlights with a semi-colon to avoid collision with the location string parsing
- adds ability to highlight locations using createViewState
**example:**
```
  const state = createViewState({
    assembly,
    tracks,
    location: 'ctgA:1105..1221',
    highlight: ['ctgA:1,117..1,135', 'ctgA:1,155..1,174'],
    onChange: patch => {
      console.log('patch', patch)
    },
  })
```
- fixes bug that prevented the menu button for the highlight from being clicked when track menus were "overlapping"

responds to commentary from https://github.com/GMOD/jbrowse-components/issues/599 and resolves https://github.com/GMOD/jbrowse-components/issues/4309