### PR TITLE
Fix Fab positioning on @jbrowse/react-app

### DIFF
--- a/packages/app-core/src/ui/App/Drawer.tsx
+++ b/packages/app-core/src/ui/App/Drawer.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles()(theme => ({
   paper: {
     overflowY: 'auto',
     height: '100%',
+    position: 'relative',
     zIndex: theme.zIndex.drawer,
     outline: 'none',
     background: theme.palette.background.default,


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/4272

Adds a position:relative to the drawer container

Without this it uses position:absolute relative to the body of the page