### PR TITLE
Remove snap package 

### DIFF
--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -130,12 +130,6 @@
       "target": [
         {
           "target": "AppImage"
-        },
-        {
-          "target": "snap"
-        },
-        {
-          "target": "deb"
         }
       ],
       "executableName": "jbrowse-desktop",


### PR DESCRIPTION
This removes snap from our linux options. 

Closes https://github.com/GMOD/jbrowse-components/issues/4260
Closes https://github.com/GMOD/jbrowse-components/issues/3777

Could reconsider in the future if there is interest but snap is just causing problems at release time right now

The deb package i tried out seemed to have trouble too