### PR TITLE
Fixes crash after importing bookmarks via TSV

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ExportBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ExportBookmarksDialog.tsx
@@ -1,15 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { observer } from 'mobx-react'
 
-import {
-  Button,
-  DialogContent,
-  DialogActions,
-  MenuItem,
-  Select,
-  Typography,
-  Alert,
-} from '@mui/material'
+import { Button, DialogContent, DialogActions, Alert } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { Dialog } from '@jbrowse/core/ui'
 
@@ -21,9 +13,6 @@ import { GridBookmarkModel } from '../../model'
 import { downloadBookmarkFile } from '../../utils'
 
 const useStyles = makeStyles()({
-  flexItem: {
-    margin: 5,
-  },
   container: {
     display: 'flex',
     flexFlow: 'column',
@@ -39,7 +28,6 @@ const ExportBookmarksDialog = observer(function ExportBookmarksDialog({
   onClose: (arg: boolean) => void
 }) {
   const { classes } = useStyles()
-  const [fileType, setFileType] = useState('BED')
   const { selectedBookmarks } = model
   const exportAll = selectedBookmarks.length === 0
   return (
@@ -57,20 +45,11 @@ const ExportBookmarksDialog = observer(function ExportBookmarksDialog({
           ) : (
             'Only selected bookmarks will be exported.'
           )}
+          <br />
+          <span>
+            The file will be in <strong>BED</strong> format.
+          </span>
         </Alert>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <Typography>Format to download:</Typography>
-          <Select
-            size="small"
-            className={classes.flexItem}
-            data-testid="selectFileType"
-            value={fileType}
-            onChange={event => setFileType(event.target.value)}
-          >
-            <MenuItem value="BED">BED</MenuItem>
-            <MenuItem value="TSV">TSV</MenuItem>
-          </Select>
-        </div>
       </DialogContent>
       <DialogActions>
         <Button
@@ -78,7 +57,7 @@ const ExportBookmarksDialog = observer(function ExportBookmarksDialog({
           color="primary"
           startIcon={<GetAppIcon />}
           onClick={() => {
-            downloadBookmarkFile(fileType, model)
+            downloadBookmarkFile(model)
             onClose(false)
           }}
         >

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
@@ -66,6 +66,7 @@ async function getBookmarksFromFile(
       f =>
         !f.startsWith('#') &&
         !f.startsWith('track') &&
+        !f.startsWith('chrom') &&
         !f.startsWith('browser'),
     )
     .map(line => {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
@@ -140,11 +140,11 @@ const ImportBookmarksDialog = observer(function ({
               location={location}
               setLocation={setLocation}
               name="File"
-              description="Choose a BED or TSV format file to import."
+              description="Choose a BED file to import."
             />
             <AssemblySelector
               onChange={val => setSelectedAsm(val)}
-              helperText={`Select the assembly your bookmarks belong to (BED or TSV without assembly column).`}
+              helperText={`Select the assembly your bookmarks belong to (BED format).`}
               session={session}
               selected={selectedAsm}
             />

--- a/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
+++ b/products/jbrowse-web/src/tests/BookmarkWidget.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, fireEvent, within } from '@testing-library/react'
+import { waitFor, fireEvent } from '@testing-library/react'
 import { saveAs } from 'file-saver'
 import userEvent from '@testing-library/user-event'
 import { createView, setup, doBeforeEach } from './util'
@@ -287,34 +287,3 @@ test('Downloads a BED file correctly', async () => {
 
   expect(saveAs).toHaveBeenCalledWith(blob, 'jbrowse_bookmarks_volvox.bed')
 }, 20000)
-
-test('Downloads a TSV file correctly', async () => {
-  const { session, findByText, findByTestId, getByRole } = await createView()
-
-  // @ts-expect-error
-  const bookmarkWidget = session.addWidget(
-    'GridBookmarkWidget',
-    'gridBookmarkWidget',
-  )
-  // @ts-expect-error
-  session.showWidget('gridBookmarkWidget')
-
-  bookmarkWidget.addBookmark({
-    refName: 'ctgA',
-    start: 0,
-    end: 8,
-    assemblyName: 'volvox',
-  })
-  fireEvent.click(await findByTestId('grid_bookmark_menu'))
-  fireEvent.click(await findByText('Export'))
-  fireEvent.mouseDown(await findByText('BED'))
-  const listbox = within(getByRole('listbox'))
-  fireEvent.click(listbox.getByText('TSV'))
-  fireEvent.click(await findByText(/Download/))
-
-  const blob = new Blob([''], {
-    type: 'text/tab-separated-values;charset=utf-8',
-  })
-
-  expect(saveAs).toHaveBeenCalledWith(blob, 'jbrowse_bookmarks.tsv')
-})

--- a/website/docs/user_guides/bookmark_widget.md
+++ b/website/docs/user_guides/bookmark_widget.md
@@ -89,13 +89,11 @@ be pasted within the appropriate filed in the "Import" form
 
 ### Exporting bookmarks
 
-You can export bookmarks into a list of regions as a BED or TSV file.
-
-<Figure caption="Exporting a list of regions to a TSV file." src="/img/bookmark_widget_export_dialog.png"/>
+You can export bookmarks into a list of regions as a BED file.
 
 ### Importing bookmarks
 
-You can import bookmarks from a list of regions in a BED or TSV file.
+You can import bookmarks from a list of regions in a BED file.
 
 <Figure caption="Importing a list of regions from a BED file." src="/img/bookmark_widget_import_dialog.png"/>
 


### PR DESCRIPTION
Fixes crash after importing bookmarks via TSV by filtering out the header in the import operation; addresses https://github.com/GMOD/jbrowse-components/issues/4359