### PR TITLE
Fix for regex sequence search

### DIFF
--- a/plugins/sequence/src/SequenceSearchAdapter/SequenceSearchAdapter.ts
+++ b/plugins/sequence/src/SequenceSearchAdapter/SequenceSearchAdapter.ts
@@ -30,10 +30,9 @@ export default class SequenceSearchAdapter extends BaseFeatureDataAdapter {
   public getFeatures(query: Region, opts: BaseOptions) {
     return ObservableCreate<Feature>(async observer => {
       const sequenceAdapter = await this.configure()
-      const hw = 1000
-      let { start: queryStart, end: queryEnd } = query
-      queryStart = Math.max(0, queryStart - hw)
-      queryEnd += hw
+      const hw = 10000
+      const queryEnd = query.end + hw
+      const queryStart = Math.max(0, query.start - hw)
 
       if (queryEnd < 0 || queryStart > queryEnd) {
         observer.complete()
@@ -60,15 +59,15 @@ export default class SequenceSearchAdapter extends BaseFeatureDataAdapter {
         if (searchForward) {
           const matches = residues.matchAll(re)
           for (const match of matches) {
-            const s = queryStart + (match.index || 0)
-
-            if (doesIntersect2(s, s + search.length, query.start, query.end)) {
+            const s = queryStart + match.index
+            const e = queryStart + match.index + match[0].length
+            if (doesIntersect2(s, e, query.start, query.end)) {
               observer.next(
                 new SimpleFeature({
-                  uniqueId: `${this.id}-match-${s}-p`,
+                  uniqueId: `${this.id}-${s}-${match[0]}-pos`,
                   refName: query.refName,
                   start: s,
-                  end: s + match[0].length,
+                  end: e,
                   name: match[0],
                   strand: 1,
                 }),
@@ -79,15 +78,16 @@ export default class SequenceSearchAdapter extends BaseFeatureDataAdapter {
         if (searchReverse) {
           const matches = revcom(residues).matchAll(re)
           for (const match of matches) {
-            const s = queryEnd - (match.index || 0)
-            if (doesIntersect2(s, s + search.length, query.start, query.end)) {
+            const e = queryEnd - match.index
+            const s = queryEnd - match.index - match[0].length
+            if (doesIntersect2(s, e, query.start, query.end)) {
               observer.next(
                 new SimpleFeature({
-                  uniqueId: `${this.id}-match-${s}-n`,
+                  uniqueId: `${this.id}-${s}-${match[0]}-neg`,
                   refName: query.refName,
-                  start: s - match[0].length,
+                  start: s,
+                  end: e,
                   name: match[0],
-                  end: s,
                   strand: -1,
                 }),
               )


### PR DESCRIPTION
Fixes issue raised in the gitter chat about reverse strand sequence searches failing. The start and end coordinates were not correctly calculated, leading to inconsistencies across blocks and thus broken features. This fixes it by using the match.length instead of the search.length, and fixing how that was applied to (a) coordinates to doesIntersect2, (b) the feature coordinates, (c) the feature id.