### PR TITLE
Fix ability to add custom frame colors

### DIFF
--- a/products/jbrowse-web/src/util.ts
+++ b/products/jbrowse-web/src/util.ts
@@ -131,7 +131,7 @@ export function filterSessionInPlace(node: IAnyStateTreeNode, type: IAnyType) {
 type Config = SnapshotOut<AnyConfigurationModel>
 
 export function addRelativeUris(config: Config, base: URL) {
-  if (typeof config === 'object') {
+  if (typeof config === 'object' && config !== null) {
     for (const key of Object.keys(config)) {
       if (typeof config[key] === 'object') {
         addRelativeUris(config[key], base)


### PR DESCRIPTION
If you add a custom frame theme to your config.json like this:

```json
{
  "configuration": {
    "theme": {
      "palette": {
        "frames": [
          null,
          { "main": "#FF8080" },
          { "main": "#80FF80" },
          { "main": "#8080FF" },
          { "main": "#8080FF" },
          { "main": "#80FF80" },
          { "main": "#FF8080" }
        ]
      }
    }
  }
}
```

you get an error:

```
TypeError: Cannot convert undefined or null to object
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
/path/to/jbrowse-components/products/jbrowse-web/src/util.ts:135:1
```

This is because there's a `null` in the config, which I don't think we have anywhere else, and the `addRelativeUris` function was missing a null check. This PR adds the null check.