### PR TITLE
Improve return type of `intersection2`

### DIFF
--- a/packages/core/util/calculateDynamicBlocks.ts
+++ b/packages/core/util/calculateDynamicBlocks.ts
@@ -68,17 +68,14 @@ export default function calculateDynamicBlocks(
     const regionWidthPx = (regionEnd - regionStart) / bpPerPx
     const parentRegion = isStateTreeNode(region) ? getSnapshot(region) : region
 
-    if (
-      displayedRegionLeftPx < windowRightPx &&
-      displayedRegionRightPx > windowLeftPx
-    ) {
+    const [leftPx, rightPx] = intersection2(
+      windowLeftPx,
+      windowRightPx,
+      displayedRegionLeftPx,
+      displayedRegionRightPx,
+    )
+    if (leftPx !== undefined && rightPx !== undefined) {
       // this displayed region overlaps the view, so make a record for it
-      const [leftPx, rightPx] = intersection2(
-        windowLeftPx,
-        windowRightPx,
-        displayedRegionLeftPx,
-        displayedRegionRightPx,
-      )
       let start: number
       let end: number
       let isLeftEndOfDisplayedRegion: boolean

--- a/packages/core/util/range.ts
+++ b/packages/core/util/range.ts
@@ -10,7 +10,7 @@ export function intersection2(
   right1: number,
   left2: number,
   right2: number,
-) {
+): [number, number] | [] {
   // this code is verbose because "if" statements are faster than Math.min and Math.max
   if (right1 > left2 && left1 < right2 && right2 - left2 && right1 - left1) {
     if (left1 > left2) {


### PR DESCRIPTION
I was using the `intersection2` function in Apollo and realized the return type could be narrowed to `[number, number] | []` instead of the inferred `number[]`.