### PR TITLE
Include a raw version of function names in error message stack traces

### DIFF
--- a/packages/core/ui/ErrorMessageStackTraceDialog.tsx
+++ b/packages/core/ui/ErrorMessageStackTraceDialog.tsx
@@ -98,7 +98,7 @@ async function mapStackTrace(stack: string) {
     mappedStack.push(
       `${originalPosition.source}:${originalPosition.line}:${
         originalPosition.column + 1
-      }`,
+      } (${match[1]})`,
     )
   }
 


### PR DESCRIPTION
This adds a raw version of the function name to the stack traces. It could be a minified name in some cases, but it should make a little more readable stack traces

just for reference the match[1] refers to matching everything before http from lines like this

```
loadDataP@http://localhost:3001/static/js/plugins_gff3_src_Gff3Adapter_Gff3Adapter_ts.chunk.js:41:13

```

so in that case, match[1] would be loadDataP@

here is another example with a longer stack trace
with this PR:

```
Stack trace

Post a new issue at [GitHub](https://github.com/GMOD/jbrowse-components/issues/new?labels=bug&title=JBrowse+issue&body=I%20got%20this%20error%20from%20JBrowse%2C%20here%20is%20the%20stack%20trace%3A%0A%0A%60%60%60%0AError%3A%20test%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%3A64%3A1%20(..%2F..%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%2FLinearGenomeView%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2Fobserver.ts%3A107%3A1%20(..%2F..%2Fnode_modules%2Fmobx-react-lite%2Fes%2Fobserver.js%2Fobserver%2FobserverComponent%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2FuseObserver.ts%3A108%3A1%20(..%2F..%2Fnode_modules%2Fmobx-react-lite%2Fes%2FuseObserver.js%2FuseObserver%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx%2Fsrc%2Fcore%2Fderivation.ts%3A186%3A1%20(trackDerivedFunction%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx%2Fsrc%2Fcore%2Freaction.ts%3A138%3A1%20(track%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2FuseObserver.ts%3A106%3A1%20(useObserver%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2Fobserver.ts%3A107%3A1%20(observerComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A15486%3A1%20(renderWithHooks%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A19617%3A1%20(updateFunctionComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A19454%3A1%20(updateSimpleMemoComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A21717%3A1%20(beginWork%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A27465%3A1%20(beginWork%241%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26596%3A1%20(performUnitOfWork%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26505%3A1%20(workLoopSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26473%3A1%20(renderRootSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A25889%3A1%20(recoverFromConcurrentError%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26135%3A1%20(performSyncWorkOnRoot%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A12042%3A1%20(flushSyncCallbacks%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26240%3A1%20(flushSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A27834%3A1%20(scheduleRefresh%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%3A265%3A1%20(..%2F..%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%2FperformReactRefresh%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%3A254%3A1%20(performReactRefresh%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A100%3A1%20(..%2F..%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%2FcreateDebounceUpdate%2FenqueueUpdate%2FrefreshTimeout%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A98%3A1%20(setTimeout%20handler*enqueueUpdate%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A259%3A1%20(executeRuntime%40)%0A%24ReactRefreshModuleRuntime%24%40http%3A%2F%2Flocalhost%3A3001%2Fpackages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js%3A173%3A34%0A..%2F..%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%40http%3A%2F%2Flocalhost%3A3001%2Fpackages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js%3A186%3A29%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Freact%20refresh%3A6%3A1%20(options.factory%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fbootstrap%3A22%3A1%20(__webpack_require__%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A101%3A1%20(_requireSelf%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fjsonp%20chunk%20loading%3A444%3A1%20(apply%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A342%3A1%20(internalApply%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A340%3A1%20(internalApply%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A277%3A1%20(hotCheck%2F%3C%2F%3C%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A232%3A1%20(waitForBlockingPromises%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A275%3A1%20(hotCheck%2F%3C%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A274%3A1%20(promise%20callback*hotCheck%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A255%3A1%20(promise%20callback*hotCheck%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A246%3A1%20(promise%20callback*hotCheck%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%3A15%3A1%20(check%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%3A69%3A1%20(..%2F..%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fevents%2Fevents.js%3A153%3A1%20(emit%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Futils%2FreloadApp.js%3A38%3A1%20(reloadApp%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%3A226%3A1%20(ok%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%3A62%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%2FinitSocket%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%3A45%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%2FonMessage%2Fthis.client.onmessage%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%3A44%3A1%20(EventHandlerNonNull*onMessage%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%3A55%3A1%20(initSocket%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%3A311%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Freact%20refresh%3A6%3A1%20(options.factory%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fbootstrap%3A22%3A1%20(__webpack_require__%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fstartup%3A5%3A1%20(%40)%0A%40http%3A%2F%2Flocalhost%3A3001%2Fstatic%2Fjs%2Fbundle.js%3A51954%3A12%0A%0AJBrowse%202.11.1%0A%60%60%60%0A%0A) or send an email to [jbrowse2@berkeley.edu](mailto:jbrowse2@berkeley.edu?subject=JBrowse%202%20error&body=I%20got%20this%20error%20from%20JBrowse%2C%20here%20is%20the%20stack%20trace%3A%0A%0A%60%60%60%0AError%3A%20test%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%3A64%3A1%20(..%2F..%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%2FLinearGenomeView%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2Fobserver.ts%3A107%3A1%20(..%2F..%2Fnode_modules%2Fmobx-react-lite%2Fes%2Fobserver.js%2Fobserver%2FobserverComponent%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2FuseObserver.ts%3A108%3A1%20(..%2F..%2Fnode_modules%2Fmobx-react-lite%2Fes%2FuseObserver.js%2FuseObserver%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx%2Fsrc%2Fcore%2Fderivation.ts%3A186%3A1%20(trackDerivedFunction%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx%2Fsrc%2Fcore%2Freaction.ts%3A138%3A1%20(track%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2FuseObserver.ts%3A106%3A1%20(useObserver%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fmobx-react-lite%2Fsrc%2Fobserver.ts%3A107%3A1%20(observerComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A15486%3A1%20(renderWithHooks%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A19617%3A1%20(updateFunctionComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A19454%3A1%20(updateSimpleMemoComponent%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A21717%3A1%20(beginWork%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A27465%3A1%20(beginWork%241%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26596%3A1%20(performUnitOfWork%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26505%3A1%20(workLoopSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26473%3A1%20(renderRootSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A25889%3A1%20(recoverFromConcurrentError%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26135%3A1%20(performSyncWorkOnRoot%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A12042%3A1%20(flushSyncCallbacks%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A26240%3A1%20(flushSync%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js%3A27834%3A1%20(scheduleRefresh%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%3A265%3A1%20(..%2F..%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%2FperformReactRefresh%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Freact-refresh%2Fcjs%2Freact-refresh-runtime.development.js%3A254%3A1%20(performReactRefresh%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A100%3A1%20(..%2F..%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%2FcreateDebounceUpdate%2FenqueueUpdate%2FrefreshTimeout%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A98%3A1%20(setTimeout%20handler*enqueueUpdate%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2F%40pmmmwh%2Freact-refresh-webpack-plugin%2Flib%2Fruntime%2FRefreshUtils.js%3A259%3A1%20(executeRuntime%40)%0A%24ReactRefreshModuleRuntime%24%40http%3A%2F%2Flocalhost%3A3001%2Fpackages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js%3A173%3A34%0A..%2F..%2Fplugins%2Flinear-genome-view%2Fsrc%2FLinearGenomeView%2Fcomponents%2FLinearGenomeView.tsx%40http%3A%2F%2Flocalhost%3A3001%2Fpackages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js%3A186%3A29%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Freact%20refresh%3A6%3A1%20(options.factory%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fbootstrap%3A22%3A1%20(__webpack_require__%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A101%3A1%20(_requireSelf%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fjsonp%20chunk%20loading%3A444%3A1%20(apply%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A342%3A1%20(internalApply%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A340%3A1%20(internalApply%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A277%3A1%20(hotCheck%2F%3C%2F%3C%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A232%3A1%20(waitForBlockingPromises%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A275%3A1%20(hotCheck%2F%3C%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A274%3A1%20(promise%20callback*hotCheck%2F%3C%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A255%3A1%20(promise%20callback*hotCheck%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Fhot%20module%20replacement%3A246%3A1%20(promise%20callback*hotCheck%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%3A15%3A1%20(check%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%3A69%3A1%20(..%2F..%2Fnode_modules%2Fwebpack%2Fhot%2Fdev-server.js%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fevents%2Fevents.js%3A153%3A1%20(emit%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Futils%2FreloadApp.js%3A38%3A1%20(reloadApp%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%3A226%3A1%20(ok%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%3A62%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%2FinitSocket%2F%3C%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%3A45%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%2FonMessage%2Fthis.client.onmessage%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fclients%2FWebSocketClient.js%3A44%3A1%20(EventHandlerNonNull*onMessage%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Fsocket.js%3A55%3A1%20(initSocket%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%3A311%3A1%20(..%2F..%2Fnode_modules%2Fwebpack-dev-server%2Fclient%2Findex.js%3Fprotocol%3Dws%253A%26hostname%3D0.0.0.0%26port%3D3001%26pathname%3D%252Fws%26logging%3Dinfo%26overlay%3Dtrue%26reconnect%3D10%26hot%3Dtrue%26live-reload%3Dtrue%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fruntime%2Freact%20refresh%3A6%3A1%20(options.factory%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fbootstrap%3A22%3A1%20(__webpack_require__%40)%0A%2FUsers%2Fcolin%2Fsrc%2Fjbrowse-components%2Fproducts%2Fjbrowse-web%2Fwebpack%2Fstartup%3A5%3A1%20(%40)%0A%40http%3A%2F%2Flocalhost%3A3001%2Fstatic%2Fjs%2Fbundle.js%3A51954%3A12%0A%0AJBrowse%202.11.1%0A%60%60%60%0A%0A)

Error: test
/Users/colin/src/jbrowse-components/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx:64:1 (../../plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx/LinearGenomeView<@)
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/observer.ts:107:1 (../../node_modules/mobx-react-lite/es/observer.js/observer/observerComponent/<@)
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/useObserver.ts:108:1 (../../node_modules/mobx-react-lite/es/useObserver.js/useObserver/<@)
/Users/colin/src/jbrowse-components/node_modules/mobx/src/core/derivation.ts:186:1 (trackDerivedFunction@)
/Users/colin/src/jbrowse-components/node_modules/mobx/src/core/reaction.ts:138:1 (track@)
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/useObserver.ts:106:1 (useObserver@)
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/observer.ts:107:1 (observerComponent@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:15486:1 (renderWithHooks@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:19617:1 (updateFunctionComponent@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:19454:1 (updateSimpleMemoComponent@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:21717:1 (beginWork@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:27465:1 (beginWork$1@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26596:1 (performUnitOfWork@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26505:1 (workLoopSync@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26473:1 (renderRootSync@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:25889:1 (recoverFromConcurrentError@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26135:1 (performSyncWorkOnRoot@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:12042:1 (flushSyncCallbacks@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26240:1 (flushSync@)
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:27834:1 (scheduleRefresh@)
/Users/colin/src/jbrowse-components/node_modules/react-refresh/cjs/react-refresh-runtime.development.js:265:1 (../../node_modules/react-refresh/cjs/react-refresh-runtime.development.js/performReactRefresh/<@)
/Users/colin/src/jbrowse-components/node_modules/react-refresh/cjs/react-refresh-runtime.development.js:254:1 (performReactRefresh@)
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:100:1 (../../node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js/createDebounceUpdate/enqueueUpdate/refreshTimeout<@)
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:98:1 (setTimeout handler*enqueueUpdate@)
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:259:1 (executeRuntime@)
$ReactRefreshModuleRuntime$@http://localhost:3001/packages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js:173:34
../../plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx@http://localhost:3001/packages_core_PluginLoader_ts-packages_core_PluginManager_ts-src_corePlugins_ts.ba505d0a5d4134754ae6.hot-update.js:186:29
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/react refresh:6:1 (options.factory@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/bootstrap:22:1 (__webpack_require__@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:101:1 (_requireSelf@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/jsonp chunk loading:444:1 (apply@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:342:1 (internalApply/<@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:340:1 (internalApply@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:277:1 (hotCheck/</</</<@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:232:1 (waitForBlockingPromises@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:275:1 (hotCheck/</</<@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:274:1 (promise callback*hotCheck/</<@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:255:1 (promise callback*hotCheck/<@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:246:1 (promise callback*hotCheck@)
/Users/colin/src/jbrowse-components/node_modules/webpack/hot/dev-server.js:15:1 (check@)
/Users/colin/src/jbrowse-components/node_modules/webpack/hot/dev-server.js:69:1 (../../node_modules/webpack/hot/dev-server.js/<@)
/Users/colin/src/jbrowse-components/node_modules/events/events.js:153:1 (emit@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/utils/reloadApp.js:38:1 (reloadApp@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=3001&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true:226:1 (ok@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/socket.js:62:1 (../../node_modules/webpack-dev-server/client/socket.js/initSocket/<@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/clients/WebSocketClient.js:45:1 (../../node_modules/webpack-dev-server/client/clients/WebSocketClient.js/onMessage/this.client.onmessage@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/clients/WebSocketClient.js:44:1 (EventHandlerNonNull*onMessage@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/socket.js:55:1 (initSocket@)
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=3001&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true:311:1 (../../node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=3001&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/react refresh:6:1 (options.factory@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/bootstrap:22:1 (__webpack_require__@)
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/startup:5:1 (@)
@http://localhost:3001/static/js/bundle.js:51954:12
```

without this PR

```
Error: test
/Users/colin/src/jbrowse-components/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx:64:1
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/observer.ts:107:1
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/useObserver.ts:108:1
/Users/colin/src/jbrowse-components/node_modules/mobx/src/core/derivation.ts:186:1
/Users/colin/src/jbrowse-components/node_modules/mobx/src/core/reaction.ts:138:1
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/useObserver.ts:106:1
/Users/colin/src/jbrowse-components/node_modules/mobx-react-lite/src/observer.ts:107:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:15486:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:19617:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:19454:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:19303:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:20025:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:21632:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:27465:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26596:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26505:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26473:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:25889:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26135:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:12042:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:26240:1
/Users/colin/src/jbrowse-components/node_modules/react-dom/cjs/react-dom.development.js:27834:1
/Users/colin/src/jbrowse-components/node_modules/react-refresh/cjs/react-refresh-runtime.development.js:265:1
/Users/colin/src/jbrowse-components/node_modules/react-refresh/cjs/react-refresh-runtime.development.js:254:1
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:100:1
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:98:1
/Users/colin/src/jbrowse-components/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js:259:1
$ReactRefreshModuleRuntime$@http://localhost:3001/packages_core_ui_ErrorMessageStackTraceDialog_tsx.b71465666a206f739c55.hot-update.js:208:34
../../packages/core/ui/ErrorMessageStackTraceDialog.tsx@http://localhost:3001/packages_core_ui_ErrorMessageStackTraceDialog_tsx.b71465666a206f739c55.hot-update.js:221:29
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/react refresh:6:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/bootstrap:22:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:101:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/jsonp chunk loading:444:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:342:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:340:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:277:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:232:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:275:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:274:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:255:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/hot module replacement:246:1
/Users/colin/src/jbrowse-components/node_modules/webpack/hot/dev-server.js:15:1
/Users/colin/src/jbrowse-components/node_modules/webpack/hot/dev-server.js:69:1
/Users/colin/src/jbrowse-components/node_modules/events/events.js:153:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/utils/reloadApp.js:38:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=3001&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true:226:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/socket.js:62:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/clients/WebSocketClient.js:45:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/clients/WebSocketClient.js:44:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/socket.js:55:1
/Users/colin/src/jbrowse-components/node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=3001&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true:311:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/runtime/react refresh:6:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/bootstrap:22:1
/Users/colin/src/jbrowse-components/products/jbrowse-web/webpack/startup:5:1
@http://localhost:3001/static/js/bundle.js:51954:12

JBrowse 2.11.1
```