### PR TITLE
Allow loading plaintext GFF3 files larger than 512Mb

### DIFF
--- a/plugins/gff3/src/Gff3Adapter/__snapshots__/Gff3Adapter.test.ts.snap
+++ b/plugins/gff3/src/Gff3Adapter/__snapshots__/Gff3Adapter.test.ts.snap
@@ -12,7 +12,7 @@ exports[`adapter can fetch features from volvox.gff3 test getfeatures on gff pla
     "start": 0,
     "strand": undefined,
     "type": "contig",
-    "uniqueId": "test-offset-187",
+    "uniqueId": "test-ctgB-0",
   },
   {
     "derived_features": [],
@@ -25,7 +25,7 @@ exports[`adapter can fetch features from volvox.gff3 test getfeatures on gff pla
     "start": 1658,
     "strand": 1,
     "type": "remark",
-    "uniqueId": "test-offset-188",
+    "uniqueId": "test-ctgB-1",
   },
   {
     "derived_features": [],
@@ -38,7 +38,7 @@ exports[`adapter can fetch features from volvox.gff3 test getfeatures on gff pla
     "start": 3013,
     "strand": 1,
     "type": "remark",
-    "uniqueId": "test-offset-189",
+    "uniqueId": "test-ctgB-2",
   },
   {
     "derived_features": [],
@@ -51,7 +51,7 @@ exports[`adapter can fetch features from volvox.gff3 test getfeatures on gff pla
     "start": 4714,
     "strand": -1,
     "type": "remark",
-    "uniqueId": "test-offset-190",
+    "uniqueId": "test-ctgB-3",
   },
 ]
 `;


### PR DESCRIPTION
Uses line-by-line parsing of the Buffer object instead of upfront conversion to the string to avoid the 512Mb string limitation (Buffer can be longer than 512Mb). It also reports the progress with statusCallback which gives some indication of what is happening during possibly long (e.g. 30+ second) loading of larger files

fixes #4403