### PR TITLE
Fix custom theme being applied in renderings in desktop

### DIFF
--- a/products/jbrowse-desktop/src/sessionModel/index.ts
+++ b/products/jbrowse-desktop/src/sessionModel/index.ts
@@ -142,7 +142,7 @@ export default function sessionModelFactory({
        */
       renderProps() {
         return {
-          theme: getConf(self, 'theme'),
+          theme: self.theme,
           highResolutionScaling: getConf(self, 'highResolutionScaling'),
         }
       },


### PR DESCRIPTION
the theme is passed in via renderProps on the session model, which gets applied to e.g. the display's renderProps function via getParentRenderProps

the fix is to use the "currently active theme" (state variable) rather than just the pre-configured theme (via getConf, which is what it was on main)