### PR TITLE
v2.11.2 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.11.2.md
+++ b/website/release_announcement_drafts/v2.11.2.md
@@ -1,0 +1,12 @@
+This adds the ability for users and admins to configure filters to tracks. Users
+can edit the filters interactively with a "Edit filters" dialog box in the track
+menu, allowing them to only show features above a certain score, or of a certain
+type, etc.
+
+![](https://github.com/GMOD/jbrowse-components/assets/6511937/0b403ef3-ee74-4938-b4fe-7fe3e992070a)
+
+Screenshot showing the "Edit filters" dialog, making only a single feature type
+visible
+
+There is also an important bugfix for the "Show soft clipping" feature of
+alignments tracks


### PR DESCRIPTION
Current changelog
## Unreleased (2024-06-03)

#### :rocket: Enhancement
* Other
  * [#4406](https://github.com/GMOD/jbrowse-components/pull/4406) Allow loading plaintext GFF3 files larger than 512Mb ([@cmdcolin](https://github.com/cmdcolin))
  * [#4398](https://github.com/GMOD/jbrowse-components/pull/4398) Adds a context menu option to zoom to a feature ([@carolinebridge](https://github.com/carolinebridge))
* `core`
  * [#4405](https://github.com/GMOD/jbrowse-components/pull/4405) Include a raw version of function names in error message stack traces ([@cmdcolin](https://github.com/cmdcolin))
  * [#4393](https://github.com/GMOD/jbrowse-components/pull/4393) Allow users to configure filters and set them at runtime via a editable dialog ([@cmdcolin](https://github.com/cmdcolin))
  * [#4395](https://github.com/GMOD/jbrowse-components/pull/4395) Remove x-data-grid resize bar workaround ([@cmdcolin](https://github.com/cmdcolin))
  * [#4389](https://github.com/GMOD/jbrowse-components/pull/4389) Improve return type of `intersection2` ([@garrettjstevens](https://github.com/garrettjstevens))

#### :bug: Bug Fix
* [#4407](https://github.com/GMOD/jbrowse-components/pull/4407) Fix custom theme being applied in renderings in desktop ([@cmdcolin](https://github.com/cmdcolin))
* [#4402](https://github.com/GMOD/jbrowse-components/pull/4402) Fix for rendering of softclipping when there are insertions in the sequence ([@cmdcolin](https://github.com/cmdcolin))
* [#4385](https://github.com/GMOD/jbrowse-components/pull/4385) Fix ability to choose line plot bigwig coloring ([@cmdcolin](https://github.com/cmdcolin))
* [#4386](https://github.com/GMOD/jbrowse-components/pull/4386) Fix ability to add custom frame colors ([@garrettjstevens](https://github.com/garrettjstevens))

#### Committers: 3
- Caroline Bridge ([@carolinebridge](https://github.com/carolinebridge))
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 1.18s.

