### PR TITLE
Allow using Cmd key for alternative click and drag behavior on Mac for dotplot

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
@@ -66,14 +66,16 @@ const DotplotControls = observer(function ({
             subMenu: [
               {
                 onClick: () => model.setCursorMode('move'),
-                label: 'Pan by default, select region when ctrl key is held',
+                label:
+                  'Pan by default, select region when ctrl/cmd key is held',
                 icon: CursorMove,
                 type: 'radio',
                 checked: model.cursorMode === 'move',
               },
               {
                 onClick: () => model.setCursorMode('crosshair'),
-                label: 'Select region by default, pan when ctrl key is held',
+                label:
+                  'Select region by default, pan when ctrl/cmd key is held',
                 icon: CursorMouse,
                 type: 'radio',
                 checked: model.cursorMode === 'crosshair',

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -105,6 +105,7 @@ const DotplotViewInternal = observer(function ({
   const distanceY = useRef(0)
   const scheduled = useRef(false)
   const [ctrlKeyWasUsed, setCtrlKeyWasUsed] = useState(false)
+  const [ctrlKeyDown, setCtrlKeyDown] = useState(false)
   const svg = ref.current?.getBoundingClientRect() || blank
   const rootRect = ref.current?.getBoundingClientRect() || blank
   const mousedown = getOffset(mousedownClient, svg)
@@ -190,6 +191,24 @@ const DotplotViewInternal = observer(function ({
     hview,
     vview,
   ])
+  useEffect(() => {
+    function globalCtrlKeyDown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey) {
+        setCtrlKeyDown(true)
+      }
+    }
+    function globalCtrlKeyUp(event: KeyboardEvent) {
+      if (!event.metaKey && !event.ctrlKey) {
+        setCtrlKeyDown(false)
+      }
+    }
+    window.addEventListener('keydown', globalCtrlKeyDown)
+    window.addEventListener('keyup', globalCtrlKeyUp)
+    return () => {
+      window.removeEventListener('keydown', globalCtrlKeyDown)
+      window.addEventListener('keyup', globalCtrlKeyUp)
+    }
+  }, [])
 
   // detect a mouseup after a mousedown was submitted, autoremoves mouseup once
   // that single mouseup is set
@@ -261,13 +280,13 @@ const DotplotViewInternal = observer(function ({
               />
             ) : null}
             <div
-              style={{ cursor: ctrlKeyWasUsed ? 'pointer' : cursorMode }}
+              style={{ cursor: ctrlKeyDown ? 'pointer' : cursorMode }}
               onMouseDown={event => {
                 if (event.button === 0) {
                   const { clientX, clientY } = event
                   setMouseDownClient([clientX, clientY])
                   setMouseCurrClient([clientX, clientY])
-                  setCtrlKeyWasUsed(event.ctrlKey)
+                  setCtrlKeyWasUsed(ctrlKeyDown)
                 }
               }}
             >


### PR DESCRIPTION
The current behavior to use "ctrl+key" for the alt click and drag behavior doesn't work on Mac because it is a right click without any recourse to disable this. Therefore, this handles using the cmd key as an alternative. 

This is just a small UI think but this PR also changes the pointer cursor style immediately after the ctrl/cmd key press instead of only triggering the cursor style after the keypress+click