### PR TITLE
Fix bug parsing GFF3 data on chromosomes where data is empty

### DIFF
--- a/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
+++ b/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
@@ -25,7 +25,7 @@ export default class Gff3Adapter extends BaseFeatureDataAdapter {
     header: string
     intervalTreeMap: Record<
       string,
-      (sc?: (arg: string) => void) => IntervalTree
+      ((sc?: (arg: string) => void) => IntervalTree) | undefined
     >
   }>
 
@@ -132,7 +132,7 @@ export default class Gff3Adapter extends BaseFeatureDataAdapter {
       try {
         const { start, end, refName } = query
         const { intervalTreeMap } = await this.loadData(opts)
-        intervalTreeMap[refName](opts.statusCallback)
+        intervalTreeMap[refName]?.(opts.statusCallback)
           ?.search([start, end])
           .forEach(f => observer.next(f))
         observer.complete()


### PR DESCRIPTION
Small typescript issue related to undefined result of record data access

related to my typescript rant/blogpost https://cmdcolin.github.io/posts/2023-09-27-areyousure

We could consider turning on noUncheckedIndexedAccess tsc setting to try to help this more or less globally...but this just targets the smaller fix

Regression after #4406 