### PR TITLE
Show all regions in synteny view after submitting import form

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/index.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/index.tsx
@@ -144,6 +144,7 @@ const LinearSyntenyViewImportForm = observer(function ({
         ),
       )
       model.views.forEach(view => view.setWidth(model.width))
+      model.views.forEach(view => view.showAllRegions())
       if (sessionTrackData) {
         session.addTrackConf(sessionTrackData)
         model.toggleTrack(sessionTrackData.trackId)


### PR DESCRIPTION
fixes https://github.com/GMOD/jbrowse-components/issues/4372

alternative approaches or add-ons to this PR could be taken include

a) allowing user to use a refname autocomplete on the import form before submitting
b) allow user to tailor the set of chromosomes displayed in some way (similar to https://github.com/GMOD/jbrowse-components/issues/2063) which could help for very fragmented e.g. hundreds of thousands of scaffolds scenarios

the default output comparing hg19 vs hg38 looks like so after this PR

![image](https://github.com/GMOD/jbrowse-components/assets/6511937/6d55af3d-51d6-4100-88cd-340e94d249af)
