### PR TITLE
Convert displayedRegions from MST array of Region[] into a types.frozen<IRegion[]> to speed up large displayedRegions sets

### DIFF
--- a/packages/core/util/Base1DUtils.ts
+++ b/packages/core/util/Base1DUtils.ts
@@ -1,4 +1,3 @@
-import { getSnapshot } from 'mobx-state-tree'
 import { Region, ViewSnap } from './index'
 
 export interface BpOffset {
@@ -100,7 +99,7 @@ export function pxToBp(
   offset: number
   start: number
   end: number
-  reversed: boolean
+  reversed?: boolean
 } {
   let bpSoFar = 0
   const {
@@ -114,8 +113,7 @@ export function pxToBp(
   const bp = (offsetPx + px) * bpPerPx
   if (bp < 0) {
     const r = displayedRegions[0]
-    const snap = getSnapshot(r)
-    // @ts-expect-error
+    const snap = r
     return {
       // xref https://github.com/mobxjs/mobx-state-tree/issues/1524 for Omit
       ...(snap as Omit<typeof snap, symbol>),
@@ -133,8 +131,7 @@ export function pxToBp(
     const len = r.end - r.start
     const offset = bp - bpSoFar
     if (len + bpSoFar > bp && bpSoFar <= bp) {
-      const snap = getSnapshot(r)
-      // @ts-expect-error
+      const snap = r
       return {
         // xref https://github.com/mobxjs/mobx-state-tree/issues/1524 for Omit
         ...(snap as Omit<typeof snap, symbol>),
@@ -160,8 +157,7 @@ export function pxToBp(
     const len = r.end - r.start
     const offset = bp - bpSoFar + len
 
-    const snap = getSnapshot(r)
-    // @ts-expect-error
+    const snap = r
     return {
       // xref https://github.com/mobxjs/mobx-state-tree/issues/1524 for Omit
       ...(snap as Omit<typeof snap, symbol>),

--- a/packages/core/util/Base1DViewModel.ts
+++ b/packages/core/util/Base1DViewModel.ts
@@ -1,7 +1,7 @@
 import { types, cast, Instance } from 'mobx-state-tree'
-import { clamp } from './index'
+import { clamp, sum } from './index'
 import { Feature } from './simpleFeature'
-import { Region, ElementId } from './types/mst'
+import { ElementId } from './types/mst'
 import { Region as IRegion } from './types'
 import calculateDynamicBlocks from './calculateDynamicBlocks'
 import calculateStaticBlocks from './calculateStaticBlocks'
@@ -23,7 +23,7 @@ const Base1DView = types
     /**
      * #property
      */
-    displayedRegions: types.array(Region),
+    displayedRegions: types.optional(types.frozen<IRegion[]>(), []),
     /**
      * #property
      */
@@ -76,9 +76,7 @@ const Base1DView = types
      * #getter
      */
     get assemblyNames() {
-      return [
-        ...new Set(self.displayedRegions.map(region => region.assemblyName)),
-      ]
+      return [...new Set(self.displayedRegions.map(r => r.assemblyName))]
     },
     /**
      * #getter
@@ -109,9 +107,7 @@ const Base1DView = types
      * #getter
      */
     get totalBp() {
-      return self.displayedRegions
-        .map(a => a.end - a.start)
-        .reduce((a, b) => a + b, 0)
+      return sum(self.displayedRegions.map(a => a.end - a.start))
     },
   }))
   .views(self => ({
@@ -133,9 +129,7 @@ const Base1DView = types
      * #getter
      */
     get currBp() {
-      return this.dynamicBlocks
-        .map(a => a.end - a.start)
-        .reduce((a, b) => a + b, 0)
+      return sum(this.dynamicBlocks.map(a => a.end - a.start))
     },
   }))
   .views(self => ({
@@ -265,8 +259,8 @@ const Base1DView = types
   .actions(self => ({
     /**
      * #action
-     * offset is the base-pair-offset in the displayed region, index is the index of the
-     * displayed region in the linear genome view
+     * offset is the base-pair-offset in the displayed region, index is the
+     * index of the displayed region in the linear genome view
      *
      * @param start - object as `{start, end, offset, index}`
      * @param end - object as `{start, end, offset, index}`

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1126,7 +1126,7 @@ export interface ViewSnap {
     start: number
     end: number
     refName: string
-    reversed: boolean
+    reversed?: boolean
     assemblyName: string
   })[]
 }

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -416,7 +416,10 @@ export function isAbstractMenuManager(
 export interface NoAssemblyRegion
   extends SnapshotIn<typeof MUNoAssemblyRegion> {}
 
-/** a description of a specific genomic region. assemblyName, refName, start, end, and reversed */
+/**
+ * a description of a specific genomic region. assemblyName, refName, start,
+ * end, and reversed
+ */
 export interface Region extends SnapshotIn<typeof MUIRegion> {}
 
 export interface AugmentedRegion extends Region {

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -2,7 +2,8 @@ import React, { lazy } from 'react'
 import { getConf, AnyConfigurationModel } from '@jbrowse/core/configuration'
 import { BaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import { Region } from '@jbrowse/core/util/types'
-import { ElementId, Region as MUIRegion } from '@jbrowse/core/util/types/mst'
+import { ElementId } from '@jbrowse/core/util/types/mst'
+import { Region as IRegion } from '@jbrowse/core/util/types'
 import { MenuItem } from '@jbrowse/core/ui'
 import {
   assembleLocString,
@@ -175,7 +176,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
          * advised to use the entire set of chromosomes if your assembly is very
          * fragmented
          */
-        displayedRegions: types.array(MUIRegion),
+        displayedRegions: types.optional(types.frozen<IRegion[]>(), []),
 
         /**
          * #property
@@ -421,7 +422,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * #getter
        */
       get totalBp() {
-        return self.displayedRegions.reduce((a, b) => a + b.end - b.start, 0)
+        return sum(self.displayedRegions.map(r => r.end - r.start))
       },
 
       /**


### PR DESCRIPTION
Pros: 
- can handle very large sets of displayedRegions, which can occur from "show all regions" operations from a linear genome view, or showing entire genome in synteny view

Cons: 
- changes the 'type spec' of the linear genome view, so calling getSnapshot on the displayedRegions object (or individual regions) is a thrown error (kind of annoying)
- can't directly "push" or mutate the self.displayedRegions array since it is not an observable after this
- there are problems with creating gigantic displayedRegions sets anyways because it causes the sessions to be too large to share, but that is sort of an aside

You can see benefit by performing a show all regions on our 'many_contigs' test dataset

main
https://jbrowse.org/code/jb2/main/?config=test_data%2Fmany_contigs%2Fconfig.json

this branch
https://jbrowse.org/code/jb2/large_displayed_regions_set/?config=test_data%2Fmany_contigs%2Fconfig.json