### PR TITLE
Remove the concept of linking the views in the synteny view

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -5,7 +5,6 @@ import {
   getParent,
   getPath,
   getRoot,
-  onAction,
   resolveIdentifier,
   types,
   Instance,
@@ -61,10 +60,6 @@ function stateModelFactory(pluginManager: PluginManager) {
          * #property
          */
         showIntraviewLinks: true,
-        /**
-         * #property
-         */
-        linkViews: false,
         /**
          * #property
          */
@@ -137,24 +132,6 @@ function stateModelFactory(pluginManager: PluginManager) {
       },
     }))
     .actions(self => ({
-      afterAttach() {
-        addDisposer(
-          self,
-          onAction(self, param => {
-            if (self.linkViews) {
-              const { name, path, args } = param
-
-              // doesn't link showTrack/hideTrack, doesn't make sense in
-              // synteny views most time
-              const actions = ['horizontalScroll', 'zoomTo', 'setScaleFactor']
-              if (actions.includes(name) && path) {
-                this.onSubviewAction(name, path, args)
-              }
-            }
-          }),
-        )
-      },
-
       // automatically removes session assemblies associated with this view
       // e.g. read vs ref
       beforeDestroy() {
@@ -211,13 +188,6 @@ function stateModelFactory(pluginManager: PluginManager) {
       setMiddleComparativeHeight(n: number) {
         self.middleComparativeHeight = n
         return self.middleComparativeHeight
-      },
-
-      /**
-       * #action
-       */
-      toggleLinkViews() {
-        self.linkViews = !self.linkViews
       },
 
       /**

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
@@ -7,7 +7,6 @@ import { saveAs } from 'file-saver'
 
 // icons
 import CropFreeIcon from '@mui/icons-material/CropFree'
-import LinkIcon from '@mui/icons-material/Link'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
 import { Curves } from './components/Icons'
@@ -124,13 +123,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               checked: self.drawCIGAR,
               type: 'checkbox',
               description: 'Draws per-base CIGAR level alignments',
-            },
-            {
-              label: 'Link views',
-              type: 'checkbox',
-              checked: self.linkViews,
-              onClick: self.toggleLinkViews,
-              icon: LinkIcon,
             },
             {
               label: 'Use curved lines',


### PR DESCRIPTION
The concept is somewhat cumbersome to toggle, and now the middle panel of the synteny view can be used instead

A similar thing could be done for breakpoint split view, but it does not have the same idea of a middle area which does challenge it a bit

Would fix #4375 as a round about