### PR TITLE
Fix cursor:pointer style on an alignments feature detail clickable link

### DIFF
--- a/plugins/alignments/src/AlignmentsFeatureDetail/LaunchBreakpointSplitViewPanel.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/LaunchBreakpointSplitViewPanel.tsx
@@ -6,7 +6,6 @@ import {
   getSession,
   toLocale,
 } from '@jbrowse/core/util'
-import { makeStyles } from 'tss-react/mui'
 import { ErrorMessage } from '@jbrowse/core/ui'
 import { ViewType } from '@jbrowse/core/pluggableElementTypes'
 
@@ -17,11 +16,6 @@ import { ReducedFeature, getSAFeatures } from './getSAFeatures'
 // lazies
 const BreakendOptionDialog = lazy(() => import('./BreakendOptionDialog'))
 
-const useStyles = makeStyles()({
-  cursor: {
-    cursor: 'pointer',
-  },
-})
 export default function LaunchBreakpointSplitViewPanel({
   model,
   feature,
@@ -31,7 +25,6 @@ export default function LaunchBreakpointSplitViewPanel({
   feature: SimpleFeatureSerialized
   viewType: ViewType
 }) {
-  const { classes } = useStyles()
   const session = getSession(model)
   const { view } = model
   const [res, setRes] = useState<ReducedFeature[]>()
@@ -72,7 +65,6 @@ export default function LaunchBreakpointSplitViewPanel({
               <Tooltip title="Top panel->Bottom panel">
                 <Link
                   href="#"
-                  className={classes.cursor}
                   onClick={event => {
                     event.preventDefault()
                     session.queueDialog(handleClose => [

--- a/plugins/alignments/src/AlignmentsFeatureDetail/SuppAlignmentsLocStrings.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/SuppAlignmentsLocStrings.tsx
@@ -34,6 +34,7 @@ export default function SuppAlignmentsLocStrings({
             return (
               <li key={`${locString}-${index}`}>
                 <Link
+                  href="#"
                   onClick={async event => {
                     event.preventDefault()
 

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
@@ -20,9 +20,6 @@ const EditBookmarkLabelDialog = lazy(
 )
 
 const useStyles = makeStyles()(() => ({
-  link: {
-    cursor: 'pointer',
-  },
   cell: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -35,7 +32,7 @@ const BookmarkGrid = observer(function ({
 }: {
   model: GridBookmarkModel
 }) {
-  const { classes, cx } = useStyles()
+  const { classes } = useStyles()
   const {
     bookmarks,
     bookmarksWithValidAssemblies,
@@ -91,7 +88,7 @@ const BookmarkGrid = observer(function ({
           width: widths[1],
           renderCell: ({ value, row }) => (
             <Link
-              className={cx(classes.link, classes.cell)}
+              className={classes.cell}
               href="#"
               onClick={async event => {
                 event.preventDefault()

--- a/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
@@ -13,9 +13,6 @@ import { loadPluginManager, RecentSessionData } from './util'
 import { measureGridWidth } from '@jbrowse/core/util'
 
 const useStyles = makeStyles()({
-  pointer: {
-    cursor: 'pointer',
-  },
   cell: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -53,7 +50,7 @@ export default function RecentSessionsList({
   setSelectedSessions: (arg: RecentSessionData[]) => void
   sessions: RecentSessionData[]
 }) {
-  const { classes, cx } = useStyles()
+  const { classes } = useStyles()
 
   const now = Date.now()
   const oneDayLength = 24 * 60 * 60 * 1000
@@ -135,8 +132,10 @@ export default function RecentSessionsList({
               const { value } = params
               return (
                 <Link
-                  className={cx(classes.pointer, classes.cell)}
-                  onClick={async () => {
+                  href="#"
+                  className={classes.cell}
+                  onClick={async event => {
+                    event.preventDefault()
                     try {
                       setPluginManager(await loadPluginManager(params.row.path))
                     } catch (e) {


### PR DESCRIPTION
I noticed that code in the alignment details widget (plugins/alignments/src/AlignmentsFeatureDetail/SuppAlignmentsLocStrings.tsx) had links with mouseover where the cursor did not use the pointer style, which turns out to be due to missing href prop on the Link element. For Link elements without a true href (e.g. they are more link link buttons), we can use href="#" and then event.preventDefault in the handler. 

The alternative is not having any href and then using the makeStyles to restore the cursor:pointer style, but i think the href="#" is a bit more idiomatic. Just gotta remember to event.preventDefault in those cases.