### PR TITLE
Use ref instead of deprecated findDOMNode for draggable dialog

### DIFF
--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/DraggableDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/DraggableDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -6,8 +6,8 @@ import {
   Divider,
   DialogProps,
   Paper,
-  PaperProps,
   ScopedCssBaseline,
+  PaperProps,
 } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
@@ -25,14 +25,16 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-// draggable dialog demo https://mui.com/material-ui/react-dialog/#draggable-dialog
 function PaperComponent(props: PaperProps) {
+  const ref = useRef<HTMLDivElement>(null)
   return (
     <Draggable
-      handle="#draggable-dialog-title"
+      nodeRef={ref}
       cancel={'[class*="MuiDialogContent-root"]'}
+      // @ts-expect-error
+      onStart={arg => arg.target?.className?.includes('MuiDialogTitle')}
     >
-      <Paper {...props} />
+      <Paper ref={ref} {...props} />
     </Draggable>
   )
 }
@@ -44,13 +46,9 @@ const DraggableDialog = observer(function DraggableDialog(
   const { title, children, onClose } = props
 
   return (
-    <Dialog
-      {...props}
-      PaperComponent={PaperComponent}
-      aria-labelledby="draggable-dialog-title" // this area is important for the draggable functionality
-    >
+    <Dialog {...props} PaperComponent={PaperComponent}>
       <ScopedCssBaseline>
-        <DialogTitle style={{ cursor: 'move' }} id="draggable-dialog-title">
+        <DialogTitle style={{ cursor: 'move' }}>
           {title}
           {onClose ? (
             <IconButton

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react'
 import { Button } from '@mui/material'
 import { getStr, measureGridWidth } from '@jbrowse/core/util'
-import { DataGrid, GridCellParams, GridColDef } from '@mui/x-data-grid'
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
 import { makeStyles } from 'tss-react/mui'
+import ColorPicker, { ColorPopover } from '@jbrowse/core/ui/ColorPicker'
+import { SanitizedHTML } from '@jbrowse/core/ui'
 
 // locals
-import ColorPicker, { ColorPopover } from '@jbrowse/core/ui/ColorPicker'
 import { moveUp, moveDown } from './util'
 import { Source } from '../../util'
 
@@ -14,7 +15,6 @@ import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp
 import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
-import { SanitizedHTML } from '@jbrowse/core/ui'
 
 const useStyles = makeStyles()({
   cell: {


### PR DESCRIPTION
This changes the "DraggableDialog" component to use refs instead of findDOMNode which is deprecated