### PR TITLE
Adds genomic coordinates back into the sequence panel accounting for strand direction

### DIFF
--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.test.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.test.tsx
@@ -30,11 +30,12 @@ test('test using the sequence feature panel', () => {
 
   // http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-zMPjiv36k0&password=ddxCy
   const feature = DLGAP3
+  const model = SequenceFeatureDetailsF().create()
+  model.setMode('protein')
   const { getByTestId } = render(
     <SequencePanel
-      model={SequenceFeatureDetailsF().create()}
+      model={model}
       sequence={{ seq: dna }}
-      mode="protein"
       feature={feature.subfeatures[0]}
     />,
   )
@@ -65,11 +66,11 @@ test('test using the sequence feature panel with show coords', () => {
   const model = SequenceFeatureDetailsF().create()
   const feature = DLGAP3
   model.setShowCoordinates('genomic')
+  model.setMode('protein')
   const { getByTestId } = render(
     <SequencePanel
       model={model}
       sequence={{ seq: dna }}
-      mode="protein"
       feature={feature.subfeatures[0]}
     />,
   )
@@ -91,11 +92,12 @@ test('NCDN collapsed intron', () => {
 
   // http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-zMPjiv36k0&password=ddxCy
   const feature = NCDN
+  const model = SequenceFeatureDetailsF().create()
+  model.setMode('gene_collapsed_intron')
   const { getByTestId } = render(
     <SequencePanel
-      model={SequenceFeatureDetailsF().create()}
+      model={model}
       sequence={{ seq: dna }}
-      mode="gene_collapsed_intron"
       feature={feature.subfeatures[0]}
     />,
   )
@@ -116,11 +118,12 @@ test('NCDN updownstream', () => {
 
   // http://localhost:3000/?config=test_data%2Fconfig_demo.json&session=share-zMPjiv36k0&password=ddxCy
   const feature = NCDN
+  const model = SequenceFeatureDetailsF().create()
+  model.setMode('gene_updownstream')
   const { getByTestId } = render(
     <SequencePanel
-      model={SequenceFeatureDetailsF().create()}
+      model={model}
       sequence={{ seq, upstream }}
-      mode="gene_updownstream"
       feature={feature.subfeatures[0]}
     />,
   )
@@ -142,11 +145,12 @@ test('NCDN updownstream', () => {
 
 test('single exon cDNA should not have duplicate sequences', () => {
   const seq = readFasta('./test_data/volvox.fa')
+  const model = SequenceFeatureDetailsF().create()
+  model.setMode('cdna')
   const { getByTestId } = render(
     <SequencePanel
-      model={SequenceFeatureDetailsF().create()}
+      model={model}
       sequence={{ seq }}
-      mode="cdna"
       feature={{
         start: 1200,
         end: 1500,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
@@ -37,14 +37,10 @@ const SequenceFeatureDetails = observer(function ({
     force,
   )
 
-  const [mode, setMode] = useState('cds')
-
   return (
     <>
       <div>
         <SequenceTypeSelector
-          mode={mode}
-          setMode={setMode}
           feature={feature}
           model={sequenceFeatureDetails}
         />
@@ -92,7 +88,6 @@ const SequenceFeatureDetails = observer(function ({
               <SequencePanel
                 ref={seqPanelRef}
                 feature={feature}
-                mode={mode}
                 sequence={sequence}
                 model={sequenceFeatureDetails}
               />

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequencePanel.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequencePanel.tsx
@@ -23,7 +23,6 @@ import { observer } from 'mobx-react'
 interface SequencePanelProps {
   sequence: SeqState
   feature: SimpleFeatureSerialized
-  mode: string
   model: SequenceFeatureDetailsModel
 }
 
@@ -73,8 +72,8 @@ function NoWordWrap({ children }: { children: React.ReactNode }) {
 const SequencePanel = observer(
   React.forwardRef<HTMLDivElement, SequencePanelProps>(
     function SequencePanel2(props, ref) {
-      const { model, feature, mode } = props
-      const { showCoordinates } = model
+      const { model, feature } = props
+      const { showCoordinates, mode } = model
       let {
         sequence: { seq, upstream = '', downstream = '' },
       } = props
@@ -161,6 +160,7 @@ const SequencePanel = observer(
               <CDNASequence
                 model={model}
                 exons={exons}
+                feature={feature}
                 cds={cds}
                 utr={utr}
                 sequence={seq}
@@ -176,6 +176,7 @@ const SequencePanel = observer(
               <CDNASequence
                 model={model}
                 exons={exons}
+                feature={feature}
                 cds={cds}
                 utr={utr}
                 sequence={seq}
@@ -185,6 +186,7 @@ const SequencePanel = observer(
               <CDNASequence
                 model={model}
                 exons={exons}
+                feature={feature}
                 cds={cds}
                 sequence={seq}
                 utr={utr}
@@ -195,6 +197,7 @@ const SequencePanel = observer(
               <CDNASequence
                 model={model}
                 exons={exons}
+                feature={feature}
                 cds={cds}
                 sequence={seq}
                 utr={utr}
@@ -206,6 +209,7 @@ const SequencePanel = observer(
               <CDNASequence
                 model={model}
                 exons={exons}
+                feature={feature}
                 cds={cds}
                 sequence={seq}
                 utr={utr}

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
@@ -43,7 +43,6 @@ const SequenceDialog = observer(function ({
     force,
   )
 
-  const [mode, setMode] = useState('cds')
   return (
     <Dialog
       maxWidth="xl"
@@ -54,8 +53,6 @@ const SequenceDialog = observer(function ({
       <DialogContent className={classes.dialogContent}>
         <div>
           <SequenceTypeSelector
-            mode={mode}
-            setMode={setMode}
             feature={feature}
             model={sequenceFeatureDetails}
           />
@@ -92,7 +89,6 @@ const SequenceDialog = observer(function ({
                 <SequencePanel
                   ref={seqPanelRef}
                   feature={feature}
-                  mode={mode}
                   sequence={sequence}
                   model={sequenceFeatureDetails}
                 />

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceFeatureMenu.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceFeatureMenu.tsx
@@ -28,7 +28,7 @@ const SequenceFeatureMenu = observer(
       throw new Error('needs a non function ref')
     }
     const [showSettings, setShowSettings] = useState(false)
-    const { showCoordinates2 } = model
+    const { showCoordinatesSetting, showGenomicCoordsOption } = model
 
     return (
       <>
@@ -90,15 +90,26 @@ const SequenceFeatureMenu = observer(
                 {
                   label: 'No coordinates',
                   type: 'radio',
-                  checked: showCoordinates2 === 'none',
+                  checked: showCoordinatesSetting === 'none',
                   onClick: () => model.setShowCoordinates('none'),
                 },
                 {
                   label: 'Coordinates relative to feature start',
                   type: 'radio',
-                  checked: showCoordinates2 === 'relative',
+                  checked: showCoordinatesSetting === 'relative',
                   onClick: () => model.setShowCoordinates('relative'),
                 },
+                ...(showGenomicCoordsOption
+                  ? [
+                      {
+                        label:
+                          'Coordinates relative to genome (only available for continuous genome based sequence types)',
+                        type: 'radio' as const,
+                        checked: showCoordinatesSetting === 'genomic',
+                        onClick: () => model.setShowCoordinates('genomic'),
+                      },
+                    ]
+                  : []),
               ],
             },
             {

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceTypeSelector.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceTypeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FormControl, MenuItem, Select } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
@@ -14,33 +14,33 @@ const useStyles = makeStyles()({
 })
 
 const SequenceTypeSelector = observer(function ({
-  mode,
-  setMode,
   feature,
   model,
 }: {
-  mode: string
-  setMode: (arg: string) => void
   feature: SimpleFeatureSerialized
   model: SequenceFeatureDetailsModel
 }) {
   const { classes } = useStyles()
-  const { intronBp, upDownBp } = model
+  const { intronBp, upDownBp, setMode } = model
 
   const hasCDS = feature.subfeatures?.some(sub => sub.type === 'CDS')
   const hasExon = feature.subfeatures?.some(sub => sub.type === 'exon')
   const hasExonOrCDS = hasExon || hasCDS
 
+  const [selectMode, setSelectMode] = useState(
+    hasCDS ? 'cds' : hasExon ? 'cdna' : 'genomic',
+  )
+
   useEffect(() => {
-    setMode(hasCDS ? 'cds' : hasExon ? 'cdna' : 'genomic')
-  }, [setMode, hasCDS, hasExon])
+    setMode(selectMode)
+  }, [setMode, hasCDS, hasExon, selectMode])
 
   return (
     <FormControl className={classes.formControl}>
       <Select
         size="small"
-        value={mode}
-        onChange={event => setMode(event.target.value)}
+        value={selectMode}
+        onChange={event => setSelectMode(event.target.value)}
       >
         {Object.entries({
           ...(hasCDS
@@ -78,7 +78,6 @@ const SequenceTypeSelector = observer(function ({
                 gene_updownstream_collapsed_intron: `Genomic w/ ${intronBp}bp intron +/- ${upDownBp}bp up+down stream `,
               }
             : {}),
-
           ...(!hasExonOrCDS
             ? {
                 genomic: 'Genomic',

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/model.ts
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/model.ts
@@ -12,8 +12,8 @@ export function SequenceFeatureDetailsF() {
   return types
     .model('SequenceFeatureDetails')
     .volatile(() => ({
-      showCoordinates2:
-        localStorageGetItem('sequenceFeatureDetails-showCoordinates2') ||
+      showCoordinatesSetting:
+        localStorageGetItem('sequenceFeatureDetails-showCoordinatesSetting') ||
         'none',
       intronBp: localStorageGetNumber('sequenceFeatureDetails-intronBp', 10),
       upDownBp: localStorageGetNumber('sequenceFeatureDetails-upDownBp', 100),
@@ -23,10 +23,14 @@ export function SequenceFeatureDetailsF() {
         ),
       ),
       width: 100,
+      mode: '',
     }))
     .views(self => ({
       get showCoordinates() {
-        return self.showCoordinates2 !== 'none'
+        return self.showCoordinatesSetting !== 'none'
+      },
+      get showGenomicCoordsOption() {
+        return self.mode === 'gene' || self.mode === 'gene_updownstream'
       },
     }))
     .actions(self => ({
@@ -39,8 +43,11 @@ export function SequenceFeatureDetailsF() {
       setUpperCaseCDS(f: boolean) {
         self.upperCaseCDS = f
       },
-      setShowCoordinates(f: string) {
-        self.showCoordinates2 = f
+      setShowCoordinates(f: 'none' | 'relative' | 'genomic') {
+        self.showCoordinatesSetting = f
+      },
+      setMode(mode: string) {
+        self.mode = mode
       },
     }))
     .actions(self => ({
@@ -61,8 +68,8 @@ export function SequenceFeatureDetailsF() {
               JSON.stringify(self.upperCaseCDS),
             )
             localStorageSetItem(
-              'sequenceFeatureDetails-showCoordinates2',
-              self.showCoordinates2,
+              'sequenceFeatureDetails-showCoordinatesSetting',
+              self.showCoordinatesSetting,
             )
           }),
         )

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/SequenceDisplay.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/SequenceDisplay.tsx
@@ -6,23 +6,24 @@ const SequenceDisplay = observer(function ({
   chunks,
   start,
   color,
+  strand = 1,
   coordStart = start,
-  coordMultiplier = 1,
   model,
 }: {
   chunks: string[]
   start: number
   coordStart?: number
-  coordMultiplier?: number
+  strand?: number
   color?: string
   model: SequenceFeatureDetailsModel
 }) {
   const { width, showCoordinates } = model
+
   return chunks.map((chunk, idx) => {
     const f = coordStart - (start % 100)
     const prefix =
       (idx == 0 && start % width == 0) || idx > 0
-        ? `${f + idx * width * coordMultiplier}`.padStart(4) + '   '
+        ? `${f + idx * strand * width}`.padStart(4) + '   '
         : ''
     const postfix =
       idx === chunks.length - 1 &&

--- a/packages/core/stories/examples/WithSequencePanel.tsx
+++ b/packages/core/stories/examples/WithSequencePanel.tsx
@@ -6,64 +6,34 @@ import { sequence, feature } from './util'
 function GeneCollapsedIntronCoords() {
   const model = SequenceFeatureDetailsF().create()
   model.setShowCoordinates('relative')
-  return (
-    <SequencePanel
-      model={model}
-      mode="gene_collapsed_intron"
-      sequence={sequence}
-      feature={feature}
-    />
-  )
+  model.setMode('gene_collapsed_intron')
+  return <SequencePanel model={model} sequence={sequence} feature={feature} />
 }
 
 function GeneCollapsedIntronNoCoords() {
   const model = SequenceFeatureDetailsF().create()
-  return (
-    <SequencePanel
-      model={model}
-      mode="gene_collapsed_intron"
-      sequence={sequence}
-      feature={feature}
-    />
-  )
+  model.setMode('gene_collapsed_intron')
+  return <SequencePanel model={model} sequence={sequence} feature={feature} />
 }
 
 function CDSCoords() {
   const model = SequenceFeatureDetailsF().create()
   model.setShowCoordinates('relative')
-  return (
-    <SequencePanel
-      model={model}
-      mode="cds"
-      sequence={sequence}
-      feature={feature}
-    />
-  )
+  model.setMode('cds')
+  return <SequencePanel model={model} sequence={sequence} feature={feature} />
 }
 
 function GeneCoordsGenomic() {
   const model = SequenceFeatureDetailsF().create()
   model.setShowCoordinates('genomic')
-  return (
-    <SequencePanel
-      model={model}
-      mode="gene"
-      sequence={sequence}
-      feature={feature}
-    />
-  )
+  model.setMode('gene')
+  return <SequencePanel model={model} sequence={sequence} feature={feature} />
 }
 
 function CDSNoCoords() {
   const model = SequenceFeatureDetailsF().create()
-  return (
-    <SequencePanel
-      model={model}
-      mode="cds"
-      sequence={sequence}
-      feature={feature}
-    />
-  )
+  model.setMode('cds')
+  return <SequencePanel model={model} sequence={sequence} feature={feature} />
 }
 
 export {


### PR DESCRIPTION
Adds genomic coordinates back into the sequence panel accounting for strand direction

https://github.com/GMOD/jbrowse-components/issues/3873