### PR TITLE
Add more support for putting html link in track names

### DIFF
--- a/packages/core/ui/Dialog.tsx
+++ b/packages/core/ui/Dialog.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundary } from 'react-error-boundary'
 import CloseIcon from '@mui/icons-material/Close'
 // locals
 import ErrorMessage from './ErrorMessage'
+import SanitizedHTML from './SanitizedHTML'
 
 const useStyles = makeStyles()(theme => ({
   closeButton: {
@@ -52,7 +53,7 @@ const Dialog = observer(function (props: Props) {
           header
         ) : (
           <DialogTitle>
-            {title}
+            <SanitizedHTML html={title || ''} />
             {onClose ? (
               <IconButton
                 className={classes.closeButton}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -30,10 +30,7 @@ const useStyles = makeStyles()(theme => ({
     },
   },
   trackName: {
-    margin: '0 auto',
-    width: '90%',
     fontSize: '0.8rem',
-    pointerEvents: 'none',
   },
   iconButton: {
     padding: theme.spacing(1),
@@ -111,6 +108,10 @@ const TrackLabel = observer(
           variant="body1"
           component="span"
           className={classes.trackName}
+          onMouseDown={event => {
+            // avoid becoming a click-and-drag action on the lgv
+            event.stopPropagation()
+          }}
         >
           <SanitizedHTML
             html={[trackName, minimized ? '(minimized)' : '']

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
@@ -45,33 +45,39 @@ const TrackRenderingContainer = observer(function ({
   const { classes } = useStyles()
   const display = track.displays[0]
   const { height, RenderingComponent, DisplayBlurb } = display
+  const { trackRefs, id, scaleFactor } = model
   const trackId = getConf(track, 'trackId')
   const ref = useRef<HTMLDivElement>(null)
   const minimized = track.minimized
 
   useEffect(() => {
     if (ref.current) {
-      model.trackRefs[trackId] = ref.current
+      trackRefs[trackId] = ref.current
     }
     return () => {
-      delete model.trackRefs[trackId]
+      delete trackRefs[trackId]
     }
-  }, [model.trackRefs, trackId])
+  }, [trackRefs, trackId])
 
   return (
     <div
       className={classes.trackRenderingContainer}
-      style={{ height: minimized ? 20 : height }}
+      style={{
+        height: minimized ? 20 : height,
+      }}
       onScroll={evt => display.setScrollTop(evt.currentTarget.scrollTop)}
       onDragEnter={onDragEnter}
-      data-testid={`trackRenderingContainer-${model.id}-${trackId}`}
+      data-testid={`trackRenderingContainer-${id}-${trackId}`}
     >
       {!minimized ? (
         <>
           <div
             ref={ref}
             className={classes.renderingComponentContainer}
-            style={{ transform: `scaleX(${model.scaleFactor})` }}
+            style={{
+              transform:
+                scaleFactor !== 1 ? `scaleX(${scaleFactor})` : undefined,
+            }}
           >
             <Suspense fallback={<LoadingEllipses />}>
               <RenderingComponent

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -478,7 +478,7 @@ exports[`renders one track, one region 1`] = `
             />
           </button>
           <span
-            class="MuiTypography-root MuiTypography-body1 css-877agm-MuiTypography-root-trackName"
+            class="MuiTypography-root MuiTypography-body1 css-ij4gik-MuiTypography-root-trackName"
           >
             <span>
               Foo Track
@@ -513,7 +513,6 @@ exports[`renders one track, one region 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
           >
             <div
               class="css-1y9lrrz-display"
@@ -1295,7 +1294,7 @@ exports[`renders two tracks, two regions 1`] = `
             />
           </button>
           <span
-            class="MuiTypography-root MuiTypography-body1 css-877agm-MuiTypography-root-trackName"
+            class="MuiTypography-root MuiTypography-body1 css-ij4gik-MuiTypography-root-trackName"
           >
             <span>
               Foo Track
@@ -1330,7 +1329,6 @@ exports[`renders two tracks, two regions 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
           >
             <div
               class="css-1y9lrrz-display"
@@ -1424,7 +1422,7 @@ exports[`renders two tracks, two regions 1`] = `
             />
           </button>
           <span
-            class="MuiTypography-root MuiTypography-body1 css-877agm-MuiTypography-root-trackName"
+            class="MuiTypography-root MuiTypography-body1 css-ij4gik-MuiTypography-root-trackName"
           >
             <span>
               Bar Track
@@ -1459,7 +1457,6 @@ exports[`renders two tracks, two regions 1`] = `
         >
           <div
             class="css-v11ioz-renderingComponentContainer"
-            style="transform: scaleX(1);"
           >
             <div
               class="css-1y9lrrz-display"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -969,7 +969,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     />
                   </button>
                   <span
-                    class="MuiTypography-root MuiTypography-body1 css-bpawrf-MuiTypography-root-trackName"
+                    class="MuiTypography-root MuiTypography-body1 css-1lqq4j2-MuiTypography-root-trackName"
                   >
                     <span>
                       Reference sequence (volvox)
@@ -1004,7 +1004,6 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 >
                   <div
                     class="css-v11ioz-renderingComponentContainer"
-                    style="transform: scaleX(1);"
                   >
                     <div
                       class="css-1y9lrrz-display"

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -581,7 +581,7 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
           "type": "LinearPairedArcDisplay",
         },
       ],
-      "name": "volvox structural variant test (<i>HTML italic</i>)",
+      "name": "volvox structural variant test (<a href="https://google.com"><i>HTML italic+link</i></a>)",
       "trackId": "volvox_sv_test",
       "type": "VariantTrack",
     },

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -265,7 +265,7 @@
       "type": "VariantTrack",
       "trackId": "volvox_sv_test",
       "description": "A uniquely interesting track",
-      "name": "volvox structural variant test (<i>HTML italic</i>)",
+      "name": "volvox structural variant test (<a href=\"https://google.com\"><i>HTML italic+link</i></a>)",
       "category": ["Variants"],
       "assemblyNames": ["volvox"],
       "adapter": {


### PR DESCRIPTION
Currently there are two funny things when storing an `<a href>` in a track label

1) dialog titles display the raw html in track title
2) unable to click links when they are activated tracks due to a pointerEvents:none

this removes the pointerEvents:none and instead just makes it so it doesn't trigger a click and drag side scroll. side benefit is you can copy the track names this way

