### PR TITLE
Add slot.type to configuration editor elements

### DIFF
--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.test.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.test.tsx
@@ -8,88 +8,86 @@ import SVG from '@jbrowse/plugin-svg'
 import { linearBasicDisplayConfigSchemaFactory } from '@jbrowse/plugin-linear-genome-view'
 import ConfigurationEditor from './ConfigurationEditor'
 
-describe('ConfigurationEditor widget', () => {
-  it('renders with just the required model elements', () => {
-    const TestSchema = ConfigurationSchema('TestThing', {
-      foo: {
-        type: 'string',
-        defaultValue: 'bar',
-      },
-    })
-
-    const { container } = render(
-      <ConfigurationEditor model={{ target: TestSchema.create() }} />,
-    )
-    expect(container).toMatchSnapshot()
+test('renders with just the required model elements', () => {
+  const TestSchema = ConfigurationSchema('TestThing', {
+    foo: {
+      type: 'string',
+      defaultValue: 'bar',
+    },
   })
 
-  it('renders all the different types of built-in slots', () => {
-    const TestSchema = ConfigurationSchema('TestThing', {
-      stringTest: {
-        name: 'stringTest',
-        description: 'stringTest',
-        type: 'string',
-        defaultValue: 'string1',
-      },
-      fileLocationTest: {
-        name: 'fileLocationTest',
-        description: 'fileLocationTest',
-        type: 'fileLocation',
-        defaultValue: { uri: '/path/to/my.file', locationType: 'UriLocation' },
-      },
-      stringArrayTest: {
-        name: 'stringArrayTest',
-        description: 'stringArrayTest',
-        type: 'stringArray',
-        defaultValue: ['string1', 'string2'],
-      },
-      stringArrayMapTest: {
-        name: 'stringArrayMapTest',
-        description: 'stringArrayMapTest',
-        type: 'stringArrayMap',
-        defaultValue: { key1: ['string1', 'string2'] },
-      },
-      numberTest: {
-        name: 'numberTest',
-        description: 'numberTest',
-        type: 'number',
-        defaultValue: 88.5,
-      },
-      integerTest: {
-        name: 'integerTest',
-        description: 'integerTest',
-        type: 'integer',
-        defaultValue: 42,
-      },
-      colorTest: {
-        name: 'colorTest',
-        description: 'colorTest',
-        type: 'color',
-        defaultValue: '#396494',
-      },
-      booleanTest: {
-        name: 'booleanTest',
-        description: 'booleanTest',
-        type: 'boolean',
-        defaultValue: true,
-      },
-    })
+  const { container } = render(
+    <ConfigurationEditor model={{ target: TestSchema.create() }} />,
+  )
+  expect(container).toMatchSnapshot()
+})
 
-    const { container } = render(
-      <ConfigurationEditor model={{ target: TestSchema.create() }} />,
-    )
-    expect(container).toMatchSnapshot()
+test('renders all the different types of built-in slots', () => {
+  const TestSchema = ConfigurationSchema('TestThing', {
+    stringTest: {
+      name: 'stringTest',
+      description: 'stringTest',
+      type: 'string',
+      defaultValue: 'string1',
+    },
+    fileLocationTest: {
+      name: 'fileLocationTest',
+      description: 'fileLocationTest',
+      type: 'fileLocation',
+      defaultValue: { uri: '/path/to/my.file', locationType: 'UriLocation' },
+    },
+    stringArrayTest: {
+      name: 'stringArrayTest',
+      description: 'stringArrayTest',
+      type: 'stringArray',
+      defaultValue: ['string1', 'string2'],
+    },
+    stringArrayMapTest: {
+      name: 'stringArrayMapTest',
+      description: 'stringArrayMapTest',
+      type: 'stringArrayMap',
+      defaultValue: { key1: ['string1', 'string2'] },
+    },
+    numberTest: {
+      name: 'numberTest',
+      description: 'numberTest',
+      type: 'number',
+      defaultValue: 88.5,
+    },
+    integerTest: {
+      name: 'integerTest',
+      description: 'integerTest',
+      type: 'integer',
+      defaultValue: 42,
+    },
+    colorTest: {
+      name: 'colorTest',
+      description: 'colorTest',
+      type: 'color',
+      defaultValue: '#396494',
+    },
+    booleanTest: {
+      name: 'booleanTest',
+      description: 'booleanTest',
+      type: 'boolean',
+      defaultValue: true,
+    },
   })
 
-  it('renders with defaults of the PileupTrack schema', () => {
-    const pluginManager = new PluginManager([new Alignments(), new SVG()])
-    pluginManager.createPluggableElements()
-    pluginManager.configure()
-    const PileupDisplaySchema =
-      linearBasicDisplayConfigSchemaFactory(pluginManager)
-    const { container } = render(
-      <ConfigurationEditor model={{ target: PileupDisplaySchema.create() }} />,
-    )
-    expect(container).toMatchSnapshot()
-  })
+  const { container } = render(
+    <ConfigurationEditor model={{ target: TestSchema.create() }} />,
+  )
+  expect(container).toMatchSnapshot()
+})
+
+test('renders with defaults of the PileupTrack schema', () => {
+  const pluginManager = new PluginManager([new Alignments(), new SVG()])
+  pluginManager.createPluggableElements()
+  pluginManager.configure()
+  const PileupDisplaySchema =
+    linearBasicDisplayConfigSchemaFactory(pluginManager)
+  const { container } = render(
+    <ConfigurationEditor model={{ target: PileupDisplaySchema.create() }} />,
+  )
+  expect(container).toMatchSnapshot()
 })

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
@@ -1,11 +1,5 @@
 import React from 'react'
-import {
-  readConfObject,
-  getTypeNamesFromExplicitlyTypedUnion,
-  isConfigurationSchemaType,
-  isConfigurationSlotType,
-  AnyConfigurationModel,
-} from '@jbrowse/core/configuration'
+
 import {
   FormGroup,
   Accordion,
@@ -17,8 +11,17 @@ import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { getMembers, IAnyType } from 'mobx-state-tree'
 import { singular } from 'pluralize'
+
+// jbrowse
 import { AbstractSessionModel } from '@jbrowse/core/util'
 import SanitizedHTML from '@jbrowse/core/ui/SanitizedHTML'
+import {
+  readConfObject,
+  getTypeNamesFromExplicitlyTypedUnion,
+  isConfigurationSchemaType,
+  isConfigurationSlotType,
+  AnyConfigurationModel,
+} from '@jbrowse/core/configuration'
 
 // icons
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -28,11 +31,8 @@ import SlotEditor from './SlotEditor'
 import TypeSelector from './TypeSelector'
 
 const useStyles = makeStyles()(theme => ({
-  expandIcon: {
+  icon: {
     color: theme.palette.tertiary?.contrastText || '#fff',
-  },
-  root: {
-    padding: theme.spacing(1, 3, 1, 1),
   },
   expansionPanelDetails: {
     display: 'block',
@@ -77,7 +77,7 @@ const Member = observer(function (props: {
     return (
       <Accordion defaultExpanded className={classes.accordion}>
         <AccordionSummary
-          expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+          expandIcon={<ExpandMoreIcon className={classes.icon} />}
         >
           <Typography>{[...path, slotName].join('➔')}</Typography>
         </AccordionSummary>
@@ -101,7 +101,6 @@ const Member = observer(function (props: {
       </Accordion>
     )
   } else if (isConfigurationSlotType(slotSchema)) {
-    // this is a regular config slot
     return <SlotEditor key={slotName} slot={slot} slotSchema={slotSchema} />
   } else {
     return null
@@ -147,7 +146,7 @@ const ConfigurationEditor = observer(function ({
   return (
     <Accordion key={key} defaultExpanded className={classes.accordion}>
       <AccordionSummary
-        expandIcon={<ExpandMoreIcon className={classes.expandIcon} />}
+        expandIcon={<ExpandMoreIcon className={classes.icon} />}
       >
         <Typography>
           <SanitizedHTML html={name ?? 'Configuration'} />

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConfigurationEditor widget renders all the different types of built-in slots 1`] = `
+exports[`renders all the different types of built-in slots 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters css-cczqch-MuiPaper-root-MuiAccordion-root-accordion"
@@ -25,7 +25,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ymsoo8-MuiSvgIcon-root-expandIcon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nfyztd-MuiSvgIcon-root-icon"
           data-testid="ExpandMoreIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -862,7 +862,7 @@ exports[`ConfigurationEditor widget renders all the different types of built-in 
 </div>
 `;
 
-exports[`ConfigurationEditor widget renders with defaults of the PileupTrack schema 1`] = `
+exports[`renders with defaults of the PileupTrack schema 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters css-cczqch-MuiPaper-root-MuiAccordion-root-accordion"
@@ -887,7 +887,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ymsoo8-MuiSvgIcon-root-expandIcon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nfyztd-MuiSvgIcon-root-icon"
           data-testid="ExpandMoreIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1237,7 +1237,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ymsoo8-MuiSvgIcon-root-expandIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nfyztd-MuiSvgIcon-root-icon"
                       data-testid="ExpandMoreIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -2005,7 +2005,7 @@ exports[`ConfigurationEditor widget renders with defaults of the PileupTrack sch
 </div>
 `;
 
-exports[`ConfigurationEditor widget renders with just the required model elements 1`] = `
+exports[`renders with just the required model elements 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters css-cczqch-MuiPaper-root-MuiAccordion-root-accordion"
@@ -2030,7 +2030,7 @@ exports[`ConfigurationEditor widget renders with just the required model element
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ymsoo8-MuiSvgIcon-root-expandIcon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nfyztd-MuiSvgIcon-root-icon"
           data-testid="ExpandMoreIcon"
           focusable="false"
           viewBox="0 0 24 24"


### PR DESCRIPTION
In the configuration editor, the "array of displays" is listed as e.g. display 1, display 2, display 3...and there is no indication of what they are

This changes it to list the slot.type

main
![image](https://github.com/GMOD/jbrowse-components/assets/6511937/4a2a032e-f3a6-4a6a-8c6c-d429c75682d8)

this branch
![Screenshot from 2024-06-18 14-35-50](https://github.com/GMOD/jbrowse-components/assets/6511937/424bcee7-87f9-4090-babc-5d9a0f412a7e)

fixes #3398
