### PR TITLE
Fix sandbox error on AppImage startup on certain linux systems

### DIFF
--- a/products/jbrowse-desktop/linux-sandbox-fix.js
+++ b/products/jbrowse-desktop/linux-sandbox-fix.js
@@ -1,4 +1,4 @@
-// from https://github.com/d3473r/jitsi-meet-electron/blob/master/LICENSE
+// from https://github.com/d3473r/jitsi-meet-electron/commit/11b9348f117a87349917c252cbae203cf92062a
 //
 const fs = require('fs').promises
 const path = require('path')

--- a/products/jbrowse-desktop/linux-sandbox-fix.js
+++ b/products/jbrowse-desktop/linux-sandbox-fix.js
@@ -1,0 +1,25 @@
+// from https://github.com/d3473r/jitsi-meet-electron/blob/master/LICENSE
+//
+const fs = require('fs').promises
+const path = require('path')
+
+/**
+ * Workaround for https://github.com/electron-userland/electron-builder/issues/5371
+ *
+ * use as "afterPack": "./linux-sandbox-fix.js" in build section of package.json
+ */
+async function afterPack({ appOutDir, electronPlatformName, packager }) {
+  if (electronPlatformName !== 'linux') {
+    return
+  }
+
+  const appName = packager.appInfo.productFilename
+  const script = `#!/bin/bash\n"\${BASH_SOURCE%/*}"/${appName}.bin --no-sandbox "$@"`
+  const scriptPath = path.join(appOutDir, appName)
+
+  await fs.rename(scriptPath, `${scriptPath}.bin`)
+  await fs.writeFile(scriptPath, script)
+  await fs.chmod(scriptPath, 0o755)
+}
+
+module.exports = afterPack

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -180,7 +180,8 @@
     "directories": {
       "buildResources": "assets/"
     },
-    "afterSign": "scripts/notarize.js"
+    "afterSign": "scripts/notarize.js",
+    "afterPack": "./linux-sandbox-fix.js"
   },
   "private": true
 }

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/GMOD/jbrowse-components.git",
   "scripts": {
     "start": "cross-env BROWSER=none node scripts/start.js",
-    "electron": "electron .",
+    "electron": "electron . --no-sandbox",
     "electron-ts": "tsc --strict --esModuleInterop --skipLibCheck public/electron.ts",
     "preelectron": "npm run electron-ts",
     "prebuild": "npm run electron-ts",


### PR DESCRIPTION
Fixes #4457

This is adapted from a script I found that replaces the AppImage launcher script with a bash one-liner that adds the no-sandbox flag

https://github.com/d3473r/jitsi-meet-electron/commit/11b9348f117a87349917c252cbae203cf92062a8

there were other things that discussed adding the no-sandbox flag via the 'main' process with app.appendSwitch('--no-sandbox') but this did not work for me

I also add --no-sandbox to the devmode script. This is a little 'heavy handed' but it only affects dev mode