### PR TITLE
Add `contig` to the default dontRedispatch list for Gff3TabixAdapter

### DIFF
--- a/plugins/gff3/src/Gff3TabixAdapter/configSchema.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/configSchema.ts
@@ -47,7 +47,7 @@ const Gff3TabixAdapter = ConfigurationSchema(
      */
     dontRedispatch: {
       type: 'stringArray',
-      defaultValue: ['chromosome', 'region'],
+      defaultValue: ['chromosome', 'region', 'contig'],
     },
   },
   { explicitlyTyped: true },


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse/issues/1649

By adding `contig` to the default dontRedispatch config, we will avoid large data downloads that end up secondarily overflowing the @gmod/gff "buffer size" (we should probably just remove this...) and then causing the error that there are "features reference other features that do not exist in the file" (which is likely false, it's just due to the buffer size being exceeded)