### PR TITLE
Fix 'no tracks active' button show and hide

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -1,12 +1,8 @@
-import React, { lazy, useEffect, useRef } from 'react'
-import { Button, Paper, Typography } from '@mui/material'
+import React, { lazy, Suspense, useEffect, useRef } from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { LoadingEllipses } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
-
-// icons
-import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
 
 // locals
 import { LinearGenomeViewModel } from '..'
@@ -14,6 +10,7 @@ import TrackContainer from './TrackContainer'
 import TracksContainer from './TracksContainer'
 
 const ImportForm = lazy(() => import('./ImportForm'))
+const NoTracksActiveButton = lazy(() => import('./NoTracksActiveButton'))
 
 type LGV = LinearGenomeViewModel
 
@@ -30,31 +27,6 @@ const useStyles = makeStyles()(theme => ({
     zIndex: 1000,
   },
 }))
-
-function NoTracksActive({ model }: { model: LinearGenomeViewModel }) {
-  const { classes } = useStyles()
-  const { hideNoTracksActive } = model
-  return (
-    <Paper className={classes.note}>
-      {!hideNoTracksActive ? (
-        <>
-          <Typography>No tracks active.</Typography>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={() => model.activateTrackSelector()}
-            className={classes.top}
-            startIcon={<TrackSelectorIcon />}
-          >
-            Open track selector
-          </Button>
-        </>
-      ) : (
-        <div style={{ height: '48px' }}></div>
-      )}
-    </Paper>
-  )
-}
 
 const LinearGenomeView = observer(({ model }: { model: LGV }) => {
   const { tracks, error, initialized, hasDisplayedRegions } = model
@@ -109,7 +81,9 @@ const LinearGenomeView = observer(({ model }: { model: LGV }) => {
       <MiniControlsComponent model={model} />
       <TracksContainer model={model}>
         {!tracks.length ? (
-          <NoTracksActive model={model} />
+          <Suspense fallback={<React.Fragment />}>
+            <NoTracksActiveButton model={model} />
+          </Suspense>
         ) : (
           tracks.map(track => (
             <TrackContainer key={track.id} model={model} track={track} />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/NoTracksActiveButton.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/NoTracksActiveButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Button, Paper, Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+import { observer } from 'mobx-react'
+
+// icons
+import { TrackSelector as TrackSelectorIcon } from '@jbrowse/core/ui/Icons'
+
+// locals
+import { LinearGenomeViewModel } from '..'
+
+const useStyles = makeStyles()(theme => ({
+  note: {
+    textAlign: 'center',
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+  top: {
+    zIndex: 1000,
+  },
+}))
+
+const NoTracksActiveButton = observer(function ({
+  model,
+}: {
+  model: LinearGenomeViewModel
+}) {
+  const { classes } = useStyles()
+  const { hideNoTracksActive } = model
+  return (
+    <Paper className={classes.note}>
+      {!hideNoTracksActive ? (
+        <>
+          <Typography>No tracks active.</Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => model.activateTrackSelector()}
+            className={classes.top}
+            startIcon={<TrackSelectorIcon />}
+          >
+            Open track selector
+          </Button>
+        </>
+      ) : (
+        <div style={{ height: '48px' }}></div>
+      )}
+    </Paper>
+  )
+})
+
+export default NoTracksActiveButton


### PR DESCRIPTION
Currently it was not wrapped in an observer, meaning it did not react to changes in the show/hide state

This just wraps it in an observer and moves to a separate file