### PR TITLE
Changes default height for SVG rendering to maxHeight to fix blank track effect on slow CPU

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -241,10 +241,11 @@ const SvgFeatureRendering = observer(function SvgFeatureRendering(props: {
   const [region] = regions
   const width = (region.end - region.start) / bpPerPx
   const displayMode = readConfObject(config, 'displayMode') as string
+  const maxConfHeight = readConfObject(config, 'maxHeight') as number
 
   const ref = useRef<SVGSVGElement>(null)
   const [mouseIsDown, setMouseIsDown] = useState(false)
-  const [height, setHeight] = useState(0)
+  const [height, setHeight] = useState(maxConfHeight)
   const [movedDuringLastMouseDown, setMovedDuringLastMouseDown] =
     useState(false)
 


### PR DESCRIPTION
Super minor adjustment to the SVG renderer as an interim fix to how scrolling SSR block tracks appears when CPU/Network throttling occurs.

Instead of the SVG height defaulting to 0 (effectively 100 with the `svgHeightPadding` const) and thus cutting off everything below it while waiting for the client to finish rendering, it defaults to the track's maxHeight, showing everything until the client updates the height with the layout.getTotalHeight().

Note that labels are still delayed by the client as rendering is happening -- some "loading" UI was attempted but felt cluttered / wrong.

Main vs. branch:
![image](https://github.com/GMOD/jbrowse-components/assets/83305007/cde05d62-83a0-4565-8b91-8b2f786e98d1)

Main (left) branch (right)
https://github.com/GMOD/jbrowse-components/assets/83305007/87b03dfa-1652-41d5-b230-6cb661727b61

