### PR TITLE
Remove concept of adapterId from FromConfigAdapters

### DIFF
--- a/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
+++ b/plugins/config/src/FromConfigAdapter/FromConfigAdapter.ts
@@ -45,8 +45,9 @@ export default class FromConfigAdapter extends BaseFeatureDataAdapter {
     pluginManager?: PluginManager,
   ) {
     super(conf, getSubAdapter, pluginManager)
-    const feats = readConfObject(conf, 'features') as SimpleFeatureSerialized[]
-    this.features = makeFeatures(feats || [])
+    this.features = makeFeatures(
+      (readConfObject(conf, 'features') || []) as SimpleFeatureSerialized[],
+    )
   }
 
   async getRefNames() {

--- a/plugins/config/src/FromConfigAdapter/configSchema.ts
+++ b/plugins/config/src/FromConfigAdapter/configSchema.ts
@@ -13,10 +13,10 @@ const configSchema = ConfigurationSchema(
      */
     features: {
       type: 'frozen',
-      defaultValue: [],
+      defaultValue: null,
     },
   },
-  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
+  { explicitlyTyped: true },
 )
 
 export default configSchema

--- a/plugins/config/src/FromConfigRegionsAdapter/FromConfigRegionsAdapter.ts
+++ b/plugins/config/src/FromConfigRegionsAdapter/FromConfigRegionsAdapter.ts
@@ -31,8 +31,9 @@ export default class FromConfigRegionsAdapter
     pluginManager?: PluginManager,
   ) {
     super(config, getSubAdapter, pluginManager)
-    const f = readConfObject(config, 'features') as SimpleFeatureSerialized[]
-    this.features = makeFeatures(f || [])
+    this.features = makeFeatures(
+      (readConfObject(config, 'features') || []) as SimpleFeatureSerialized[],
+    )
   }
 
   /**

--- a/plugins/config/src/FromConfigRegionsAdapter/configSchema.ts
+++ b/plugins/config/src/FromConfigRegionsAdapter/configSchema.ts
@@ -13,12 +13,11 @@ const regionsConfigSchema = ConfigurationSchema(
      */
     features: {
       type: 'frozen',
-      defaultValue: [],
+      defaultValue: null,
     },
   },
   {
     explicitlyTyped: true,
-    implicitIdentifier: 'adapterId',
   },
 )
 export default regionsConfigSchema

--- a/plugins/config/src/FromConfigSequenceAdapter/FromConfigSequenceAdapter.ts
+++ b/plugins/config/src/FromConfigSequenceAdapter/FromConfigSequenceAdapter.ts
@@ -78,9 +78,8 @@ export default class FromConfigSequenceAdapter
   }
 
   /**
-   * called to provide a hint that data tied to a certain region
-   * will not be needed for the foreseeable future and can be purged
-   * from caches, etc
+   * called to provide a hint that data tied to a certain region will not be
+   * needed for the foreseeable future and can be purged from caches, etc
    */
   freeResources(/* { region } */): void {}
 }

--- a/plugins/config/src/FromConfigSequenceAdapter/configSchema.ts
+++ b/plugins/config/src/FromConfigSequenceAdapter/configSchema.ts
@@ -12,10 +12,10 @@ const sequenceConfigSchema = ConfigurationSchema(
      */
     features: {
       type: 'frozen',
-      defaultValue: [],
+      defaultValue: null,
     },
   },
-  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
+  { explicitlyTyped: true },
 )
 
 export default sequenceConfigSchema

--- a/plugins/config/src/__snapshots__/index.test.ts.snap
+++ b/plugins/config/src/__snapshots__/index.test.ts.snap
@@ -2,9 +2,4 @@
 
 exports[`Config editing adds config editor widget 1`] = `{}`;
 
-exports[`Config editing creates proper FromConfigAdapter 1`] = `
-{
-  "adapterId": "testFromConfigAdapterId",
-  "type": "FromConfigAdapter",
-}
-`;
+exports[`Config editing creates proper FromConfigAdapter 1`] = `{}`;


### PR DESCRIPTION
Note: this PR might be more trouble than it is worth for small change


the FromConfigAdapter's are the only adapters that use a concept of adapterId. the usage is not really actually to supply an ID but  to prevent the snapshot from collapsing to an empty object (because config objets with default values, in this case, empty array of features, are eliminated at snapshot time) if a fromconfigadapter with no features is supplied. This "no feature" is used in a couple tests.

We can fix that by
- making FromConfigAdapter default to null for the types.frozen of features instead of empty array, so that empty array is not collapsed to empty object (which is done in this PR)
- fix the logic for collapsing to empty object better
- ignore this PR and go on without any change

this PR was made because the random ID of fromconfigadapters was tricky to snapshot properly (since you'd need to mock the id generator), but i just removed the snapshot tests instead