### PR TITLE
Remove prop-types from re-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "npm-run-all": "^4.1.5",
     "oclif": "^4.0.0",
     "prettier": "^3.2.5",
-    "prop-types": "^15.0.0",
     "react": "^18.0.0",
     "react-dev-utils": "^12.0.1",
     "react-dom": "^18.0.0",

--- a/packages/core/ReExports/list.ts
+++ b/packages/core/ReExports/list.ts
@@ -16,7 +16,6 @@ export default [
   'tss-react/mui',
   '@material-ui/core',
   '@mui/material',
-  'prop-types',
 
   '@mui/material/styles',
   '@material-ui/core/styles',

--- a/packages/core/ReExports/modules.tsx
+++ b/packages/core/ReExports/modules.tsx
@@ -7,7 +7,6 @@ import * as mobx from 'mobx'
 import * as mst from 'mobx-state-tree'
 import * as mxreact from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
-import PropTypes from 'prop-types'
 
 import * as MUIStyles from '@mui/material/styles'
 import * as MUIUtils from '@mui/material/utils'
@@ -525,7 +524,6 @@ const libs = {
     alpha: MUIStyles.alpha,
     useTheme: MUIStyles.useTheme,
   },
-  'prop-types': PropTypes,
 
   // end special case
   // material-ui subcomponents, should get rid of these

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,6 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "prop-types": "^15.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",

--- a/packages/core/util/types/mst.ts
+++ b/packages/core/util/types/mst.ts
@@ -1,24 +1,7 @@
 import { types } from 'mobx-state-tree'
-import propTypes from 'prop-types'
-import { PropTypes as MxPropTypes } from 'mobx-react'
-
 import { nanoid } from '../nanoid'
 
 export const ElementId = types.optional(types.identifier, () => nanoid())
-
-// PropTypes that are useful when working with instances of these in react components
-export const PropTypes = {
-  Region: propTypes.shape({
-    refName: propTypes.string.isRequired,
-    start: propTypes.number.isRequired,
-    end: propTypes.number.isRequired,
-  }),
-  ConfigSchema: MxPropTypes.objectOrObservableObject,
-  Feature: propTypes.shape({
-    get: propTypes.func.isRequired,
-    id: propTypes.func.isRequired,
-  }),
-}
 
 export const NoAssemblyRegion = types
   .model('NoAssemblyRegion', {

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -48,7 +48,6 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "prop-types": "^15.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0"

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -42,7 +42,6 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "prop-types": "^15.0.0",
     "react": ">=16.8.0"
   },
   "distModule": "esm/index.js",

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -91,7 +91,6 @@
     "mobx-state-tree": "^5.0.0",
     "node-fetch": "^2.6.0",
     "prompts": "^2.4.2",
-    "prop-types": "^15.7.2",
     "react": "^18.0.0",
     "react-dev-utils": "^12.0.1",
     "react-dom": "^18.0.0",

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -91,7 +91,6 @@
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
     "pako": "^2.1.0",
-    "prop-types": "^15.0.0",
     "react-error-boundary": "^4.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.4.1",

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -57,7 +57,6 @@
     "mobx": "^6.6.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "prop-types": "^15.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.4.1"
   },

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -72,7 +72,6 @@
     "mobx": "^6.6.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "prop-types": "^15.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.4.1"
   },

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -60,7 +60,6 @@
     "mobx-state-tree": "^5.0.0",
     "pako": "^2.1.0",
     "prompts": "^2.4.2",
-    "prop-types": "^15.7.2",
     "react": "^18.0.0",
     "react-dev-utils": "^12.0.1",
     "react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13615,7 +13615,7 @@ promzard@^1.0.0:
   dependencies:
     read "^3.0.1"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
This proposes removing the prop-types package from our usage. The goal is to avoid a peerDependency warning from usage of @jbrowse/core when something that uses @jbrowse/core (like our plugins) doesn't also add the prop-types package. 
