### PR TITLE
Add assembly name to scalebar in synteny views

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -39,6 +39,8 @@ const ReturnToImportFormDialog = lazy(
  * - [BaseViewModel](../baseviewmodel)
  */
 function stateModelFactory(pluginManager: PluginManager) {
+  const model = pluginManager.getViewType('LinearGenomeView')
+    .stateModel as LinearGenomeViewStateModel
   return types
     .compose(
       'LinearComparativeView',
@@ -79,8 +81,11 @@ function stateModelFactory(pluginManager: PluginManager) {
          * currently this is limited to an array of two
          */
         views: types.array(
-          pluginManager.getViewType('LinearGenomeView')
-            .stateModel as LinearGenomeViewStateModel,
+          model.views(self => ({
+            scaleBarDisplayPrefix() {
+              return self.assemblyNames[0]
+            },
+          })),
         ),
 
         /**

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -71,7 +71,7 @@ const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
   const val = scaleBarDisplayPrefix()
   return (
     <>
-      {staticBlocks.blocks[0].type !== 'ContentBlock' ? (
+      {staticBlocks.blocks[0].type !== 'ContentBlock' && val ? (
         <Typography
           style={{ left: 0, zIndex: 100 }}
           className={classes.refLabel}
@@ -136,7 +136,7 @@ const RenderedBlockTicks = function ({
   )
 }
 
-const RenderedScalebarLabels = observer(({ model }: { model: LGV }) => {
+const RenderedScalebarLabels = observer(function ({ model }: { model: LGV }) {
   const { staticBlocks, bpPerPx } = model
 
   return (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -3,6 +3,9 @@ import { makeStyles } from 'tss-react/mui'
 import { ContentBlock } from '@jbrowse/core/util/blockTypes'
 import { observer } from 'mobx-react'
 import React from 'react'
+import { getTickDisplayStr } from '@jbrowse/core/util'
+
+// locals
 import { LinearGenomeViewModel } from '..'
 import {
   ContentBlock as ContentBlockComponent,
@@ -10,7 +13,6 @@ import {
   InterRegionPaddingBlock as InterRegionPaddingBlockComponent,
 } from '../../BaseLinearDisplay/components/Block'
 import { makeTicks } from '../util'
-import { getTickDisplayStr } from '@jbrowse/core/util'
 
 type LGV = LinearGenomeViewModel
 
@@ -57,7 +59,7 @@ const useStyles = makeStyles()(theme => ({
 
 const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
   const { classes } = useStyles()
-  const { staticBlocks, offsetPx, assemblyNames } = model
+  const { staticBlocks, offsetPx, scaleBarDisplayPrefix } = model
 
   // find the block that needs pinning to the left side for context
   let lastLeftBlock = 0
@@ -66,6 +68,7 @@ const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
       lastLeftBlock = i
     }
   })
+  const val = scaleBarDisplayPrefix()
   return (
     <>
       {staticBlocks.blocks[0].type !== 'ContentBlock' ? (
@@ -73,7 +76,7 @@ const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
           style={{ left: 0, zIndex: 100 }}
           className={classes.refLabel}
         >
-          {assemblyNames[0]}
+          {val}
         </Typography>
       ) : null}
       {staticBlocks.map((block, index) => {
@@ -91,7 +94,7 @@ const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
             className={classes.refLabel}
             data-testid={`refLabel-${block.refName}`}
           >
-            {index === lastLeftBlock ? assemblyNames[0] + ':' : ''}
+            {index === lastLeftBlock && val ? `${val}:` : ''}
             {block.refName}
           </Typography>
         ) : null

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -55,19 +55,28 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
+const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
   const { classes } = useStyles()
+  const { staticBlocks, offsetPx, assemblyNames } = model
 
   // find the block that needs pinning to the left side for context
   let lastLeftBlock = 0
-  model.staticBlocks.forEach((block, i) => {
-    if (block.offsetPx - model.offsetPx < 0) {
+  staticBlocks.forEach((block, i) => {
+    if (block.offsetPx - offsetPx < 0) {
       lastLeftBlock = i
     }
   })
   return (
     <>
-      {model.staticBlocks.map((block, index) => {
+      {staticBlocks.blocks[0].type !== 'ContentBlock' ? (
+        <Typography
+          style={{ left: 0, zIndex: 100 }}
+          className={classes.refLabel}
+        >
+          {assemblyNames[0]}
+        </Typography>
+      ) : null}
+      {staticBlocks.map((block, index) => {
         return block.type === 'ContentBlock' &&
           (block.isLeftEndOfDisplayedRegion || index === lastLeftBlock) ? (
           <Typography
@@ -75,13 +84,14 @@ const RenderedRefNameLabels = observer(({ model }: { model: LGV }) => {
             style={{
               left:
                 index === lastLeftBlock
-                  ? Math.max(0, -model.offsetPx)
-                  : block.offsetPx - model.offsetPx - 1,
+                  ? Math.max(0, -offsetPx)
+                  : block.offsetPx - offsetPx - 1,
               paddingLeft: index === lastLeftBlock ? 0 : 1,
             }}
             className={classes.refLabel}
             data-testid={`refLabel-${block.refName}`}
           >
+            {index === lastLeftBlock ? assemblyNames[0] + ':' : ''}
             {block.refName}
           </Typography>
         ) : null

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -283,6 +283,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
       rightOffset: undefined as undefined | BpOffset,
     }))
     .views(self => ({
+      scaleBarDisplayPrefix() {
+        return ''
+      },
       /**
        * #getter
        * this is the effective value of the track labels setting, incorporating


### PR DESCRIPTION
Adds the concept of a scalebar display "prefix" so that the synteny display can show the assembly name in each row

The prefix is "combined with the refname" if a leftmost block is a content block, or otherwise just put at position absolute leftPx:0

![image](https://github.com/user-attachments/assets/cb86ecc7-befc-4456-916d-26bf89bdaff7)


with a show all regions the leftmost block is a padding block, so you can see the assemblyname gets detached from the chromosome names

![image](https://github.com/user-attachments/assets/c5f7e1ab-0279-48ae-b1d3-d196f2e178f7)

this approach is similar but a little different from the approach mentioned here https://github.com/GMOD/jbrowse-components/issues/3414 which had a always floating leftmost paper, but this would cover up the leftmost refname

It is also a little different from pairing discussion with garrett who proposed adding it to minicontrols (on right side of screen). it just felt a bit off :)

fixes https://github.com/GMOD/jbrowse-components/issues/3414


