### PR TITLE
Fix log scale for some types of signal tracks

### DIFF
--- a/plugins/wiggle/src/util.ts
+++ b/plugins/wiggle/src/util.ts
@@ -130,11 +130,10 @@ export function getNiceDomain({
     }
   }
   if (scaleType === 'log') {
-    // if the min is 0, assume that it's just something
-    // with no read coverage and that we should ignore it in calculations
-    // if it's greater than 1 pin to 1 for the full range also
-    // otherwise, we may see bigwigs with fractional values
-    if (min === 0 || min > 1) {
+    // for min>0 and max>1, set log min to 1, which works for most coverage
+    // types tracks. if max is not >1, might be like raw p-values so then it'll
+    // display negative values
+    if (min >= 0 && max > 1) {
       min = 1
     }
   }


### PR DESCRIPTION
When we apply the log scale, we change the minimum value to 1 in some cases

This helps avoid performing log(0) which is undefined (or...-Infinity in javascript)

The current check applies well to "count data" but less well for "fractional data"

I found that there are ENCODE bigwigs return fractional values between 0-maxval so there are things like 0.02 and 34.8 and 24.5 etc.

The 0.02 causes the log scale to go negative though, in a way that is not super informative. Therefore, we try to make the logscale again snap to 1 with this PR

The caveat is that if the min and max are just between 0-1 then we do not perform this operation, because in that case, the values might be raw p-values, and then just not transforming it gives someone something similar to -log(p), a common unit for graphing, but just without the negative.






