### PR TITLE
Allow plaintext GTF and VCF files greater than 512Mb

### DIFF
--- a/packages/app-core/src/ui/App/ViewsContainer.tsx
+++ b/packages/app-core/src/ui/App/ViewsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react'
+import React from 'react'
 import { makeStyles } from 'tss-react/mui'
 import { observer } from 'mobx-react'
 import { SessionWithFocusedViewAndDrawerWidgets } from '@jbrowse/core/util'

--- a/packages/core/data_adapters/CytobandAdapter/CytobandAdapter.ts
+++ b/packages/core/data_adapters/CytobandAdapter/CytobandAdapter.ts
@@ -1,13 +1,9 @@
 import { unzip } from '@gmod/bgzf-filehandle'
 
 // locals
-import { SimpleFeature } from '../../util'
+import { isGzip, SimpleFeature } from '../../util'
 import { openLocation } from '../../util/io'
 import { BaseAdapter } from '../BaseAdapter'
-
-export function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 
 export default class CytobandAdapter extends BaseAdapter {
   async getData() {

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1462,6 +1462,10 @@ export function renderToStaticMarkup(
   return div.innerHTML.replaceAll(/\brgba\((.+?),[^,]+?\)/g, 'rgb($1)')
 }
 
+export function isGzip(buf: Buffer) {
+  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
+}
+
 export {
   default as SimpleFeature,
   type Feature,

--- a/plugins/bed/src/BedAdapter/BedAdapter.ts
+++ b/plugins/bed/src/BedAdapter/BedAdapter.ts
@@ -5,16 +5,12 @@ import {
 } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
-import { Region, Feature } from '@jbrowse/core/util'
+import { Region, Feature, isGzip } from '@jbrowse/core/util'
 import IntervalTree from '@flatten-js/interval-tree'
 import { unzip } from '@gmod/bgzf-filehandle'
 
 // locals
 import { featureData } from '../util'
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 
 export default class BedAdapter extends BaseFeatureDataAdapter {
   protected bedFeatures?: Promise<{

--- a/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
+++ b/plugins/bed/src/BedpeAdapter/BedpeAdapter.ts
@@ -4,13 +4,9 @@ import {
 } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
-import { Region, Feature, SimpleFeature } from '@jbrowse/core/util'
+import { Region, Feature, SimpleFeature, isGzip } from '@jbrowse/core/util'
 import IntervalTree from '@flatten-js/interval-tree'
 import { unzip } from '@gmod/bgzf-filehandle'
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 
 export function featureData(
   line: string,

--- a/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
@@ -1,12 +1,9 @@
 import { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { openLocation } from '@jbrowse/core/util/io'
+import { isGzip } from '@jbrowse/core/util'
 import { unzip } from '@gmod/bgzf-filehandle'
 import PAFAdapter from '../PAFAdapter/PAFAdapter'
 import { paf_chain2paf } from './util'
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 
 export default class ChainAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {

--- a/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
@@ -3,10 +3,7 @@ import { openLocation } from '@jbrowse/core/util/io'
 import { unzip } from '@gmod/bgzf-filehandle'
 import PAFAdapter from '../PAFAdapter/PAFAdapter'
 import { paf_delta2paf } from './util'
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
+import { isGzip } from '@jbrowse/core/util'
 
 export default class DeltaAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {

--- a/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
@@ -1,12 +1,10 @@
 import { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { openLocation } from '@jbrowse/core/util/io'
 import { unzip } from '@gmod/bgzf-filehandle'
+import { isGzip } from '@jbrowse/core/util'
+
 import PAFAdapter from '../PAFAdapter/PAFAdapter'
 import { parseLineByLine } from '../util'
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 
 export default class MashMapAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -6,7 +6,7 @@ import { Region } from '@jbrowse/core/util/types'
 import { doesIntersect2 } from '@jbrowse/core/util/range'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
-import { Feature } from '@jbrowse/core/util'
+import { Feature, isGzip } from '@jbrowse/core/util'
 import {
   AnyConfigurationModel,
   readConfObject,
@@ -20,7 +20,6 @@ import {
   flipCigar,
   swapIndelCigar,
   parsePAFLine,
-  isGzip,
   parseLineByLine,
 } from '../util'
 import { getWeightedMeans, PAFRecord } from './util'

--- a/plugins/comparative-adapters/src/util.ts
+++ b/plugins/comparative-adapters/src/util.ts
@@ -1,11 +1,9 @@
 import { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 import { GenericFilehandle } from 'generic-filehandle'
 import { unzip } from '@gmod/bgzf-filehandle'
-import { PAFRecord } from './PAFAdapter/util'
+import { isGzip } from '@jbrowse/core/util'
 
-export function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
+import { PAFRecord } from './PAFAdapter/util'
 
 export function parseBed(text: string) {
   return new Map(

--- a/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
+++ b/plugins/gff3/src/Gff3Adapter/Gff3Adapter.ts
@@ -8,35 +8,36 @@ import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import IntervalTree from '@flatten-js/interval-tree'
 import SimpleFeature, { Feature } from '@jbrowse/core/util/simpleFeature'
 import { unzip } from '@gmod/bgzf-filehandle'
+import gff from '@gmod/gff'
+import { isGzip, updateStatus } from '@jbrowse/core/util'
 
-import gff, { GFF3FeatureLineWithRefs } from '@gmod/gff'
+import { featureData } from './featureData'
 
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
-
-const decoder =
-  typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined
+type StatusCallback = (arg: string) => void
 
 export default class Gff3Adapter extends BaseFeatureDataAdapter {
   calculatedIntervalTreeMap: Record<string, IntervalTree> = {}
 
-  protected gffFeatures?: Promise<{
+  gffFeatures?: Promise<{
     header: string
-    intervalTreeMap: Record<
-      string,
-      ((sc?: (arg: string) => void) => IntervalTree) | undefined
-    >
+    intervalTreeMap: Record<string, (sc?: StatusCallback) => IntervalTree>
   }>
 
   private async loadDataP(opts?: BaseOptions) {
     const { statusCallback = () => {} } = opts || {}
-    const pm = this.pluginManager
-    const buf = await openLocation(this.getConf('gffLocation'), pm).readFile()
-    const buffer = isGzip(buf) ? await unzip(buf) : buf
+    const buf = (await openLocation(
+      this.getConf('gffLocation'),
+      this.pluginManager,
+    ).readFile(opts)) as Buffer
+    const buffer = isGzip(buf)
+      ? await updateStatus('Unzipping', statusCallback, () => unzip(buf))
+      : buf
     const headerLines = []
     const featureMap = {} as Record<string, string>
     let blockStart = 0
+
+    const decoder =
+      typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined
 
     let i = 0
     while (blockStart < buffer.length) {
@@ -69,38 +70,36 @@ export default class Gff3Adapter extends BaseFeatureDataAdapter {
     }
 
     const intervalTreeMap = Object.fromEntries(
-      Object.entries(featureMap).map(([refName, lines]) => {
-        return [
-          refName,
-          (sc?: (arg: string) => void) => {
+      Object.entries(featureMap).map(([refName, lines]) => [
+        refName,
+        (sc?: (arg: string) => void) => {
+          if (!this.calculatedIntervalTreeMap[refName]) {
             sc?.('Parsing GFF data')
-            if (!this.calculatedIntervalTreeMap[refName]) {
-              const intervalTree = new IntervalTree()
-              gff
-                .parseStringSync(lines, {
-                  parseFeatures: true,
-                  parseComments: false,
-                  parseDirectives: false,
-                  parseSequences: false,
-                  disableDerivesFromReferences: true,
-                })
-                .flat()
-                .map(
-                  (f, i) =>
-                    new SimpleFeature({
-                      data: this.featureData(f),
-                      id: `${this.id}-${refName}-${i}`,
-                    }),
-                )
-                .forEach(obj =>
-                  intervalTree.insert([obj.get('start'), obj.get('end')], obj),
-                )
-              this.calculatedIntervalTreeMap[refName] = intervalTree
-            }
-            return this.calculatedIntervalTreeMap[refName]
-          },
-        ]
-      }),
+            const intervalTree = new IntervalTree()
+            gff
+              .parseStringSync(lines, {
+                parseFeatures: true,
+                parseComments: false,
+                parseDirectives: false,
+                parseSequences: false,
+                disableDerivesFromReferences: true,
+              })
+              .flat()
+              .map(
+                (f, i) =>
+                  new SimpleFeature({
+                    data: featureData(f),
+                    id: `${this.id}-${refName}-${i}`,
+                  }),
+              )
+              .forEach(obj =>
+                intervalTree.insert([obj.get('start'), obj.get('end')], obj),
+              )
+            this.calculatedIntervalTreeMap[refName] = intervalTree
+          }
+          return this.calculatedIntervalTreeMap[refName]
+        },
+      ]),
     )
 
     return {
@@ -145,71 +144,6 @@ export default class Gff3Adapter extends BaseFeatureDataAdapter {
         observer.error(e)
       }
     }, opts.signal)
-  }
-
-  private featureData(data: GFF3FeatureLineWithRefs) {
-    const f: Record<string, unknown> = { ...data }
-    ;(f.start as number) -= 1 // convert to interbase
-    if (data.strand === '+') {
-      f.strand = 1
-    } else if (data.strand === '-') {
-      f.strand = -1
-    } else if (data.strand === '.') {
-      f.strand = 0
-    } else {
-      f.strand = undefined
-    }
-    f.phase = Number(data.phase)
-    f.refName = data.seq_id
-    if (data.score === null) {
-      f.score = undefined
-    }
-    if (data.phase === null) {
-      f.score = undefined
-    }
-    const defaultFields = new Set([
-      'start',
-      'end',
-      'seq_id',
-      'score',
-      'type',
-      'source',
-      'phase',
-      'strand',
-    ])
-    const dataAttributes = data.attributes || {}
-    for (const a of Object.keys(dataAttributes)) {
-      let b = a.toLowerCase()
-      if (defaultFields.has(b)) {
-        // add "suffix" to tag name if it already exists
-        // reproduces behavior of NCList
-        b += '2'
-      }
-      if (dataAttributes[a]) {
-        let attr: string | string[] | undefined = dataAttributes[a]
-        if (Array.isArray(attr) && attr.length === 1) {
-          ;[attr] = attr
-        }
-        f[b] = attr
-      }
-    }
-    f.refName = f.seq_id
-
-    // the SimpleFeature constructor takes care of recursively inflating
-    // subfeatures
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (data.child_features && data.child_features.length > 0) {
-      f.subfeatures = data.child_features.flatMap(childLocs =>
-        childLocs.map(childLoc => this.featureData(childLoc)),
-      )
-    }
-
-    f.child_features = undefined
-    f.data = undefined
-    // delete f.derived_features
-    f.attributes = undefined
-    f.seq_id = undefined
-    return f
   }
 
   public freeResources(/* { region } */) {}

--- a/plugins/gff3/src/Gff3Adapter/featureData.ts
+++ b/plugins/gff3/src/Gff3Adapter/featureData.ts
@@ -1,0 +1,66 @@
+import { GFF3FeatureLineWithRefs } from '@gmod/gff'
+
+export function featureData(data: GFF3FeatureLineWithRefs) {
+  const f: Record<string, unknown> = { ...data }
+  ;(f.start as number) -= 1 // convert to interbase
+  if (data.strand === '+') {
+    f.strand = 1
+  } else if (data.strand === '-') {
+    f.strand = -1
+  } else if (data.strand === '.') {
+    f.strand = 0
+  } else {
+    f.strand = undefined
+  }
+  f.phase = Number(data.phase)
+  f.refName = data.seq_id
+  if (data.score === null) {
+    f.score = undefined
+  }
+  if (data.phase === null) {
+    f.score = undefined
+  }
+  const defaultFields = new Set([
+    'start',
+    'end',
+    'seq_id',
+    'score',
+    'type',
+    'source',
+    'phase',
+    'strand',
+  ])
+  const dataAttributes = data.attributes || {}
+  for (const a of Object.keys(dataAttributes)) {
+    let b = a.toLowerCase()
+    if (defaultFields.has(b)) {
+      // add "suffix" to tag name if it already exists
+      // reproduces behavior of NCList
+      b += '2'
+    }
+    if (dataAttributes[a]) {
+      let attr: string | string[] | undefined = dataAttributes[a]
+      if (Array.isArray(attr) && attr.length === 1) {
+        ;[attr] = attr
+      }
+      f[b] = attr
+    }
+  }
+  f.refName = f.seq_id
+
+  // the SimpleFeature constructor takes care of recursively inflating
+  // subfeatures
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (data.child_features && data.child_features.length > 0) {
+    f.subfeatures = data.child_features.flatMap(childLocs =>
+      childLocs.map(childLoc => featureData(childLoc)),
+    )
+  }
+
+  f.child_features = undefined
+  f.data = undefined
+  // delete f.derived_features
+  f.attributes = undefined
+  f.seq_id = undefined
+  return f
+}

--- a/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
+++ b/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
@@ -6,55 +6,107 @@ import { NoAssemblyRegion } from '@jbrowse/core/util/types'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import IntervalTree from '@flatten-js/interval-tree'
-import { SimpleFeature, Feature } from '@jbrowse/core/util'
+import { SimpleFeature, Feature, updateStatus } from '@jbrowse/core/util'
 import { unzip } from '@gmod/bgzf-filehandle'
 import gtf from '@gmod/gtf'
 
 // locals
 import { FeatureLoc, featureData } from '../util'
 
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
+const decoder =
+  typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined
+
+type StatusCallback = (arg: string) => void
 
 export default class GtfAdapter extends BaseFeatureDataAdapter {
-  protected gtfFeatures?: Promise<{
-    feats: Record<string, string[]>
+  calculatedIntervalTreeMap: Record<string, IntervalTree> = {}
+
+  gtfFeatures?: Promise<{
+    header: string
+    intervalTreeMap: Record<string, (sc?: StatusCallback) => IntervalTree>
   }>
 
-  protected intervalTrees: Record<
-    string,
-    Promise<IntervalTree | undefined> | undefined
-  > = {}
+  private async loadDataP(opts?: BaseOptions) {
+    const { statusCallback = () => {} } = opts || {}
+    const buf = (await openLocation(
+      this.getConf('gtfLocation'),
+      this.pluginManager,
+    ).readFile(opts)) as Buffer
 
-  private async loadDataP(opts: BaseOptions = {}) {
-    const gtfLoc = this.getConf('gtfLocation')
-    const buffer = await openLocation(gtfLoc, this.pluginManager).readFile(opts)
+    const buffer = isGzip(buf)
+      ? await updateStatus('Unzipping', statusCallback, () => unzip(buf))
+      : buf
+    const headerLines = []
+    const featureMap = {} as Record<string, string>
+    let blockStart = 0
 
-    const buf = isGzip(buffer) ? await unzip(buffer) : buffer
-    // 512MB  max chrome string length is 512MB
-    if (buf.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
-    const data = new TextDecoder('utf8', { fatal: true }).decode(buf)
-
-    const lines = data
-      .split(/\n|\r\n|\r/)
-      .filter(f => !!f && !f.startsWith('#'))
-    const feats = {} as Record<string, string[]>
-    for (const line of lines) {
-      if (line.startsWith('#')) {
-        continue
+    let i = 0
+    while (blockStart < buffer.length) {
+      const n = buffer.indexOf('\n', blockStart)
+      // could be a non-newline ended file, so slice to end of file if n===-1
+      const b =
+        n === -1 ? buffer.slice(blockStart) : buffer.slice(blockStart, n)
+      const line = (decoder?.decode(b) || b.toString()).trim()
+      if (line) {
+        if (line.startsWith('#')) {
+          headerLines.push(line)
+        } else if (line.startsWith('>')) {
+          break
+        } else {
+          const ret = line.indexOf('\t')
+          const refName = line.slice(0, ret)
+          if (!featureMap[refName]) {
+            featureMap[refName] = ''
+          }
+          featureMap[refName] += `${line}\n`
+        }
       }
-      const tab = line.indexOf('\t')
-      const refName = line.slice(0, tab)
-      if (!feats[refName]) {
-        feats[refName] = []
+      if (i++ % 10_000 === 0) {
+        statusCallback(
+          `Loading ${Math.floor(blockStart / 1_000_000).toLocaleString('en-US')}/${Math.floor(buffer.length / 1_000_000).toLocaleString('en-US')} MB`,
+        )
       }
-      feats[refName].push(line)
+
+      blockStart = n + 1
     }
 
-    return { feats }
+    const intervalTreeMap = Object.fromEntries(
+      Object.entries(featureMap).map(([refName, lines]) => [
+        refName,
+        (sc?: (arg: string) => void) => {
+          if (!this.calculatedIntervalTreeMap[refName]) {
+            sc?.('Parsing GTF data')
+            const intervalTree = new IntervalTree()
+            ;(
+              gtf.parseStringSync(lines, {
+                parseFeatures: true,
+                parseComments: false,
+                parseDirectives: false,
+                parseSequences: false,
+              }) as FeatureLoc[][]
+            )
+              .flat()
+              .map(
+                (f, i) =>
+                  new SimpleFeature({
+                    data: featureData(f),
+                    id: `${this.id}-${refName}-${i}`,
+                  }),
+              )
+              .forEach(obj =>
+                intervalTree.insert([obj.get('start'), obj.get('end')], obj),
+              )
+            this.calculatedIntervalTreeMap[refName] = intervalTree
+          }
+          return this.calculatedIntervalTreeMap[refName]
+        },
+      ]),
+    )
+
+    return {
+      header: headerLines.join('\n'),
+      intervalTreeMap,
+    }
   }
 
   private async loadData(opts: BaseOptions = {}) {
@@ -69,58 +121,25 @@ export default class GtfAdapter extends BaseFeatureDataAdapter {
   }
 
   public async getRefNames(opts: BaseOptions = {}) {
-    const { feats } = await this.loadData(opts)
-    return Object.keys(feats)
+    const { intervalTreeMap } = await this.loadData(opts)
+    return Object.keys(intervalTreeMap)
   }
 
-  private async loadFeatureIntervalTreeHelper(refName: string) {
-    const { feats } = await this.loadData()
-    const lines = feats[refName]
-    if (!lines) {
-      return undefined
-    }
-    const data = gtf.parseStringSync(lines.join('\n'), {
-      parseFeatures: true,
-      parseComments: false,
-      parseDirectives: false,
-      parseSequences: false,
-    }) as FeatureLoc[][]
-
-    const intervalTree = new IntervalTree()
-    const ret = data.flat().map(
-      (f, i) =>
-        new SimpleFeature({
-          data: featureData(f),
-          id: `${this.id}-${refName}-${i}`,
-        }),
-    )
-
-    for (const obj of ret) {
-      intervalTree.insert([obj.get('start'), obj.get('end')], obj)
-    }
-    return intervalTree
-  }
-
-  private async loadFeatureIntervalTree(refName: string) {
-    if (!this.intervalTrees[refName]) {
-      this.intervalTrees[refName] = this.loadFeatureIntervalTreeHelper(
-        refName,
-      ).catch((e: unknown) => {
-        this.intervalTrees[refName] = undefined
-        throw e
-      })
-    }
-    return this.intervalTrees[refName]
+  public async getHeader(opts: BaseOptions = {}) {
+    const { header } = await this.loadData(opts)
+    return header
   }
 
   public getFeatures(query: NoAssemblyRegion, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       try {
         const { start, end, refName } = query
-        const intervalTree = await this.loadFeatureIntervalTree(refName)
-        intervalTree?.search([start, end]).forEach(f => {
-          observer.next(f)
-        })
+        const { intervalTreeMap } = await this.loadData(opts)
+        intervalTreeMap[refName]?.(opts.statusCallback)
+          .search([start, end])
+          .forEach(f => {
+            observer.next(f)
+          })
         observer.complete()
       } catch (e) {
         observer.error(e)

--- a/plugins/variants/src/VcfAdapter/VcfAdapter.ts
+++ b/plugins/variants/src/VcfAdapter/VcfAdapter.ts
@@ -2,7 +2,7 @@ import {
   BaseFeatureDataAdapter,
   BaseOptions,
 } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { Region, Feature } from '@jbrowse/core/util'
+import { Region, Feature, updateStatus, isGzip } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import IntervalTree from '@flatten-js/interval-tree'
@@ -12,33 +12,17 @@ import VCF from '@gmod/vcf'
 // local
 import VcfFeature from '../VcfFeature'
 
-const readVcf = (f: string) => {
-  const header: string[] = []
-  const rest: string[] = []
-  f.split(/\n|\r\n|\r/)
-    .map(f => f.trim())
-    .filter(f => !!f)
-    .forEach(line => {
-      if (line.startsWith('#')) {
-        header.push(line)
-      } else if (line) {
-        rest.push(line)
-      }
-    })
-  return { header: header.join('\n'), lines: rest }
-}
-
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
+type StatusCallback = (arg: string) => void
 
 export default class VcfAdapter extends BaseFeatureDataAdapter {
-  public static capabilities = ['getFeatures', 'getRefNames']
+  calculatedIntervalTreeMap: Record<string, IntervalTree> = {}
 
-  protected vcfFeatures?: Promise<{
+  vcfFeatures?: Promise<{
     header: string
-    intervalTree: Record<string, IntervalTree<VcfFeature>>
+    intervalTreeMap: Record<string, (sc?: StatusCallback) => IntervalTree>
   }>
+
+  public static capabilities = ['getFeatures', 'getRefNames']
 
   public async getHeader() {
     const { header } = await this.setup()
@@ -47,43 +31,83 @@ export default class VcfAdapter extends BaseFeatureDataAdapter {
 
   async getMetadata() {
     const { header } = await this.setup()
-    const parser = new VCF({ header: header })
+    const parser = new VCF({ header })
     return parser.getMetadata()
   }
 
-  // converts lines into an interval tree
-  public async setupP() {
-    const pm = this.pluginManager
-    const buf = await openLocation(this.getConf('vcfLocation'), pm).readFile()
-    const buffer = isGzip(buf) ? await unzip(buf) : buf
+  public async setupP(opts?: BaseOptions) {
+    const { statusCallback = () => {} } = opts || {}
+    const buf = (await openLocation(
+      this.getConf('vcfLocation'),
+      this.pluginManager,
+    ).readFile(opts)) as Buffer
+    const buffer = isGzip(buf)
+      ? await updateStatus('Unzipping', statusCallback, () => unzip(buf))
+      : buf
+    const headerLines = []
+    const featureMap = {} as Record<string, string[]>
+    let blockStart = 0
 
-    // 512MB  max chrome string length is 512MB
-    if (buffer.length > 536_870_888) {
-      throw new Error('Data exceeds maximum string length (512MB)')
-    }
+    const decoder =
+      typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined
 
-    const str = new TextDecoder().decode(buffer)
-    const { header, lines } = readVcf(str)
-    const intervalTree = {} as Record<string, IntervalTree<VcfFeature>>
-
-    const parser = new VCF({ header })
-    let idx = 0
-    for (const line of lines) {
-      const f = new VcfFeature({
-        variant: parser.parseLine(line),
-        parser,
-        id: `${this.id}-${idx++}`,
-      })
-      const key = f.get('refName')
-      if (!intervalTree[key]) {
-        intervalTree[key] = new IntervalTree<VcfFeature>()
+    let i = 0
+    while (blockStart < buffer.length) {
+      const n = buffer.indexOf('\n', blockStart)
+      // could be a non-newline ended file, so slice to end of file if n===-1
+      const b =
+        n === -1 ? buffer.slice(blockStart) : buffer.slice(blockStart, n)
+      const line = (decoder?.decode(b) || b.toString()).trim()
+      if (line) {
+        if (line.startsWith('#')) {
+          headerLines.push(line)
+        } else {
+          const ret = line.indexOf('\t')
+          const refName = line.slice(0, ret)
+          if (!featureMap[refName]) {
+            featureMap[refName] = []
+          }
+          featureMap[refName].push(line)
+        }
       }
-      intervalTree[key].insert([f.get('start'), f.get('end')], f)
+      if (i++ % 10_000 === 0) {
+        statusCallback(
+          `Loading ${Math.floor(blockStart / 1_000_000).toLocaleString('en-US')}/${Math.floor(buffer.length / 1_000_000).toLocaleString('en-US')} MB`,
+        )
+      }
+
+      blockStart = n + 1
     }
+
+    const header = headerLines.join('\n')
+    const parser = new VCF({ header })
+
+    const intervalTreeMap = Object.fromEntries(
+      Object.entries(featureMap).map(([refName, lines]) => [
+        refName,
+        (sc?: (arg: string) => void) => {
+          if (!this.calculatedIntervalTreeMap[refName]) {
+            sc?.('Parsing VCF data')
+            let idx = 0
+            const intervalTree = new IntervalTree()
+            for (const line of lines) {
+              const f = new VcfFeature({
+                variant: parser.parseLine(line),
+                parser,
+                id: `${this.id}-${refName}-${idx++}`,
+              })
+              intervalTree.insert([f.get('start'), f.get('end')], f)
+            }
+            this.calculatedIntervalTreeMap[refName] = intervalTree
+          }
+          return this.calculatedIntervalTreeMap[refName]
+        },
+      ]),
+    )
 
     return {
       header,
-      intervalTree,
+      intervalTreeMap,
     }
   }
 
@@ -98,18 +122,20 @@ export default class VcfAdapter extends BaseFeatureDataAdapter {
   }
 
   public async getRefNames(_: BaseOptions = {}) {
-    const { intervalTree } = await this.setup()
-    return Object.keys(intervalTree)
+    const { intervalTreeMap } = await this.setup()
+    return Object.keys(intervalTreeMap)
   }
 
   public getFeatures(region: Region, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       try {
         const { start, end, refName } = region
-        const { intervalTree } = await this.setup()
-        intervalTree[refName]?.search([start, end]).forEach((f: VcfFeature) => {
-          observer.next(f)
-        })
+        const { intervalTreeMap } = await this.setup()
+        intervalTreeMap[refName]?.(opts.statusCallback)
+          .search([start, end])
+          .forEach(f => {
+            observer.next(f)
+          })
         observer.complete()
       } catch (e) {
         observer.error(e)


### PR DESCRIPTION
This uses the technique (line by line parsing instead of decoding entire buffer into a string, which breaks after >512Mb) adopted by the GFF3 parser to allow large plaintext GTF files