### PR TITLE
Add description config slot to reference sequence track

### DIFF
--- a/plugins/sequence/src/ReferenceSequenceTrack/configSchema.ts
+++ b/plugins/sequence/src/ReferenceSequenceTrack/configSchema.ts
@@ -37,6 +37,14 @@ export function createReferenceSeqTrackConfig(pluginManager: PluginManager) {
           'optional track name, otherwise uses the "Reference sequence (assemblyName)"',
         defaultValue: '',
       },
+      /**
+       * #slot
+       */
+      description: {
+        description: 'a description of the track',
+        type: 'string',
+        defaultValue: '',
+      },
 
       /**
        * #slot


### PR DESCRIPTION
this is probably uncommonly used but it was displaying the string 'undefined' in the tooltip since there was no configslot/defaultvalue empty string for this