### PR TITLE
Add UnindexedFastaAdapter for fetching small plaintext FASTA files

### DIFF
--- a/plugins/sequence/src/UnindexedFastaAdapter/UnindexedFastaAdapter.ts
+++ b/plugins/sequence/src/UnindexedFastaAdapter/UnindexedFastaAdapter.ts
@@ -1,0 +1,109 @@
+import {
+  BaseSequenceAdapter,
+  BaseOptions,
+} from '@jbrowse/core/data_adapters/BaseAdapter'
+import { FileLocation, NoAssemblyRegion } from '@jbrowse/core/util/types'
+import { openLocation } from '@jbrowse/core/util/io'
+import { ObservableCreate } from '@jbrowse/core/util/rxjs'
+import { SimpleFeature, Feature } from '@jbrowse/core/util'
+import { readConfObject } from '@jbrowse/core/configuration'
+
+function parseSmallFasta(text: string) {
+  return new Map(
+    text
+      .split('>')
+      .filter(t => /\S/.test(t))
+      .map(entryText => {
+        const [defLine, ...seqLines] = entryText.split('\n')
+        const [id, ...description] = defLine!.split(' ')
+        const sequence = seqLines.join('').replace(/\s/g, '')
+        return [
+          id!,
+          {
+            description: description.join(' '),
+            sequence,
+          },
+        ] as const
+      }),
+  )
+}
+
+export default class UnindexedFastaAdapter extends BaseSequenceAdapter {
+  protected setupP?: Promise<{
+    fasta: ReturnType<typeof parseSmallFasta>
+  }>
+
+  public async getRefNames(opts?: BaseOptions) {
+    const { fasta } = await this.setup(opts)
+    return [...fasta.keys()]
+  }
+
+  public async getRegions(opts?: BaseOptions) {
+    const { fasta } = await this.setup(opts)
+    return [...fasta.entries()].map(([refName, data]) => ({
+      refName,
+      start: 0,
+      end: data.sequence.length,
+    }))
+  }
+
+  public async setupPre(_opts?: BaseOptions) {
+    const fastaLocation = this.getConf('fastaLocation') as FileLocation
+    const res = parseSmallFasta(
+      await openLocation(fastaLocation, this.pluginManager).readFile('utf8'),
+    )
+
+    return {
+      fasta: new Map(
+        [...res.entries()].map(([refName, val]) => {
+          return [
+            readConfObject(this.config, 'rewriteRefNames', { refName }) ||
+              refName,
+            val,
+          ]
+        }),
+      ),
+    }
+  }
+
+  public async getHeader() {
+    const loc = this.getConf('metadataLocation')
+    return loc.uri === '' || loc.uri === '/path/to/fa.metadata.yaml'
+      ? null
+      : openLocation(loc, this.pluginManager).readFile('utf8')
+  }
+
+  public async setup(opts?: BaseOptions) {
+    if (!this.setupP) {
+      this.setupP = this.setupPre(opts).catch((e: unknown) => {
+        this.setupP = undefined
+        throw e
+      })
+    }
+    return this.setupP
+  }
+
+  public getFeatures(region: NoAssemblyRegion, opts?: BaseOptions) {
+    const { refName, start, end } = region
+    return ObservableCreate<Feature>(async observer => {
+      const { fasta } = await this.setup(opts)
+      const entry = fasta.get(refName)
+      if (entry) {
+        observer.next(
+          new SimpleFeature({
+            id: `${refName}-${start}-${end}`,
+            data: {
+              refName,
+              start,
+              end,
+              seq: entry.sequence.slice(start, end),
+            },
+          }),
+        )
+      }
+      observer.complete()
+    })
+  }
+
+  public freeResources(/* { region } */): void {}
+}

--- a/plugins/sequence/src/UnindexedFastaAdapter/configSchema.ts
+++ b/plugins/sequence/src/UnindexedFastaAdapter/configSchema.ts
@@ -1,0 +1,40 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+/**
+ * #config UnindexedFastaAdapter
+ */
+function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
+
+const UnindexedFastaAdapter = ConfigurationSchema(
+  'UnindexedFastaAdapter',
+  {
+    rewriteRefNames: {
+      type: 'string',
+      defaultValue: '',
+      contextVariable: ['refName'],
+    },
+    /**
+     * #slot
+     */
+    fastaLocation: {
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '/path/to/seq.fa',
+        locationType: 'UriLocation',
+      },
+    },
+    /**
+     * #slot
+     */
+    metadataLocation: {
+      description: 'Optional metadata file',
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '/path/to/fa.metadata.yaml',
+        locationType: 'UriLocation',
+      },
+    },
+  },
+  { explicitlyTyped: true },
+)
+export default UnindexedFastaAdapter

--- a/plugins/sequence/src/UnindexedFastaAdapter/index.ts
+++ b/plugins/sequence/src/UnindexedFastaAdapter/index.ts
@@ -1,0 +1,20 @@
+import PluginManager from '@jbrowse/core/PluginManager'
+import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
+
+import configSchema from './configSchema'
+
+export default function UnindexedFastaAdapterF(pluginManager: PluginManager) {
+  pluginManager.addAdapterType(
+    () =>
+      new AdapterType({
+        name: 'UnindexedFastaAdapter',
+        displayName: 'Unindexed FASTA adapter',
+        configSchema,
+        adapterMetadata: {
+          hiddenFromGUI: true,
+        },
+        getAdapterClass: () =>
+          import('./UnindexedFastaAdapter').then(r => r.default),
+      }),
+  )
+}

--- a/plugins/sequence/src/index.ts
+++ b/plugins/sequence/src/index.ts
@@ -6,6 +6,7 @@ import DivSequenceRendererF from './DivSequenceRenderer'
 import BgzipFastaAdapterF from './BgzipFastaAdapter'
 import ChromSizesAdapterF from './ChromSizesAdapter'
 import IndexedFastaAdapterF from './IndexedFastaAdapter'
+import UnindexedFastaAdapterF from './UnindexedFastaAdapter'
 import SequenceSearchAdapterF from './SequenceSearchAdapter'
 import ReferenceSequenceTrackF from './ReferenceSequenceTrack'
 import LinearReferenceSequenceDisplayF from './LinearReferenceSequenceDisplay'
@@ -20,6 +21,7 @@ export default class SequencePlugin extends Plugin {
     BgzipFastaAdapterF(pluginManager)
     ChromSizesAdapterF(pluginManager)
     IndexedFastaAdapterF(pluginManager)
+    UnindexedFastaAdapterF(pluginManager)
     SequenceSearchAdapterF(pluginManager)
     ReferenceSequenceTrackF(pluginManager)
     LinearReferenceSequenceDisplayF(pluginManager)


### PR DESCRIPTION
this allows fetching plaintext FASTA files from remote resources. this allows e.g. fetching a .fasta file without a .fai file from a remote resource

an example of this is for a protein FASTA browser from UniProt

the below screenshot can be generated by fetching  https://rest.uniprot.org/uniprotkb/P05067.fasta and https://rest.uniprot.org/uniprotkb/P05067.gff on the fly with no indexing (different tracks are the same gff, with repeated jexlFilters applied)

![image](https://github.com/user-attachments/assets/de7cc733-a8b3-4006-987b-878178cc0702)
