### PR TITLE
De-duplicate snackbar messages

### DIFF
--- a/packages/core/ui/SnackbarModel.tsx
+++ b/packages/core/ui/SnackbarModel.tsx
@@ -9,7 +9,6 @@ import { NotificationLevel, SnackAction } from '../util/types'
 import Report from '@mui/icons-material/Report'
 
 // lazies
-
 const ErrorMessageStackTraceDialog = lazy(
   () => import('@jbrowse/core/ui/ErrorMessageStackTraceDialog'),
 )
@@ -28,7 +27,18 @@ export default function SnackbarModel() {
   return types
     .model({})
     .volatile(() => ({
+      /**
+       * #volatile
+       */
       snackbarMessages: observable.array<SnackbarMessage>(),
+    }))
+    .views(self => ({
+      /**
+       * #getter
+       */
+      get snackbarMessageSet() {
+        return new Map(self.snackbarMessages.map(s => [s.message, s]))
+      },
     }))
     .actions(self => ({
       /**
@@ -42,6 +52,10 @@ export default function SnackbarModel() {
           }, 5000)
         }
       },
+
+      /**
+       * #action
+       */
       notifyError(errorMessage: string, error?: unknown, extra?: unknown) {
         this.notify(errorMessage, 'error', {
           name: <Report />,
@@ -66,7 +80,9 @@ export default function SnackbarModel() {
         level?: NotificationLevel,
         action?: SnackAction,
       ) {
-        return self.snackbarMessages.push({ message, level, action })
+        if (action || !self.snackbarMessageSet.has(message)) {
+          self.snackbarMessages.push({ message, level, action })
+        }
       },
       /**
        * #action
@@ -78,8 +94,8 @@ export default function SnackbarModel() {
        * #action
        */
       removeSnackbarMessage(message: string) {
-        const element = self.snackbarMessages.find(f => f.message === message)
-        if (element) {
+        const element = self.snackbarMessageSet.get(message)
+        if (element !== undefined) {
           self.snackbarMessages.remove(element)
         }
       },


### PR DESCRIPTION
sometimes a (admittedly buggy...) user interface action can create a 'storm' of snackbar events. similar to putting alert('stuff') in a loop. this proposes to de-duplicate these messages

alternative systems that could be considered: a 'dismiss all' button on the snackbar