### PR TITLE
Fix crash after navToLocString in some cases

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -71,7 +71,7 @@ const RenderedRefNameLabels = observer(function ({ model }: { model: LGV }) {
   const val = scaleBarDisplayPrefix()
   return (
     <>
-      {staticBlocks.blocks[0]!.type !== 'ContentBlock' && val ? (
+      {staticBlocks.blocks[0]?.type !== 'ContentBlock' && val ? (
         <Typography
           style={{ left: 0, zIndex: 100 }}
           className={classes.refLabel}


### PR DESCRIPTION
during office hours, saw an issue where there was a crash after a navToLocString

the code assumed that contentBlocks[0] was not undefined, but there may be situations where it is undefined for some amount of time (during loading or if bpPerPx/offsetPx is temporarily way off screen for example)



this code that causes the crash was introduced in v2.13.0 (recently)

