### PR TITLE
Fix cascading sub menus bug in embedded components in v2.14.0

### DIFF
--- a/packages/embedded-core/src/ui/ViewMenu.tsx
+++ b/packages/embedded-core/src/ui/ViewMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import {
   IconButton,
   IconButtonProps as IconButtonPropsType,
@@ -7,7 +7,12 @@ import {
 import MenuIcon from '@mui/icons-material/Menu'
 import { observer } from 'mobx-react'
 import { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
-import { Menu } from '@jbrowse/core/ui'
+import { CascadingMenu } from '@jbrowse/core/ui'
+import {
+  bindTrigger,
+  bindPopover,
+  usePopupState,
+} from 'material-ui-popup-state/hooks'
 
 const ViewMenu = observer(function ({
   model,
@@ -18,32 +23,26 @@ const ViewMenu = observer(function ({
   IconButtonProps: IconButtonPropsType
   IconProps: SvgIconProps
 }) {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement>()
+  const popupState = usePopupState({
+    popupId: 'viewMenu',
+    variant: 'popover',
+  })
   return (
     <>
       <IconButton
         {...IconButtonProps}
-        aria-label="more"
-        aria-controls="view-menu"
-        aria-haspopup="true"
-        onClick={event => {
-          setAnchorEl(event.currentTarget)
-        }}
+        {...bindTrigger(popupState)}
         data-testid="view_menu_icon"
       >
         <MenuIcon {...IconProps} />
       </IconButton>
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onMenuItemClick={(_, callback) => {
+      <CascadingMenu
+        {...bindPopover(popupState)}
+        onMenuItemClick={(_event: unknown, callback: () => void) => {
           callback()
-          setAnchorEl(undefined)
-        }}
-        onClose={() => {
-          setAnchorEl(undefined)
         }}
         menuItems={model.menuItems()}
+        popupState={popupState}
       />
     </>
   )

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/__snapshots__/JBrowseCircularGenomeView.test.tsx.snap
@@ -16,9 +16,7 @@ exports[`<JBrowseCircularGenomeView /> 1`] = `
           class="css-10rokvf-container"
         >
           <button
-            aria-controls="view-menu"
             aria-haspopup="true"
-            aria-label="more"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-pcgapu-MuiButtonBase-root-MuiIconButton-root-iconRoot"
             data-testid="view_menu_icon"
             tabindex="0"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -16,9 +16,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
           class="css-10rokvf-container"
         >
           <button
-            aria-controls="view-menu"
             aria-haspopup="true"
-            aria-label="more"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeStart MuiIconButton-sizeSmall css-pcgapu-MuiButtonBase-root-MuiIconButton-root-iconRoot"
             data-testid="view_menu_icon"
             tabindex="0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,9 +8551,9 @@ eslint-plugin-react-refresh@^0.4.3:
   integrity sha512-wrAKxMbVr8qhXTtIKfXqAn5SAtRZt0aXxe5P23Fh4pUAdC6XEsybGLB8P0PI4j1yYqOgUEUlzKAGDfo7rJOjcw==
 
 eslint-plugin-react@^7.33.2:
-  version "7.35.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.1.tgz#afc80387031aa99dd6e0a14437c77d02e5700b47"
-  integrity sha512-B5ok2JgbaaWn/zXbKCGgKDNL2tsID3Pd/c/yvjcpsd9HQDwyYc/TQv3AZMmOvrJgCs3AnYNUHRCQEMMQAYJ7Yg==
+  version "7.35.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.2.tgz#d32500d3ec268656d5071918bfec78cfd8b070ed"
+  integrity sha512-Rbj2R9zwP2GYNcIak4xoAMV57hrBh3hTaR0k7hVjwCQgryE/pw5px4b13EYjduOI0hfXyZhwBxaGpOTbWSGzKQ==
   dependencies:
     array-includes "^3.1.8"
     array.prototype.findlast "^1.2.5"
@@ -9147,9 +9147,9 @@ flow-parser@0.*:
   integrity sha512-xUBkkpIDfDZHAebnDEX65FCVitJUctab82KFmtP5SY4cGly1vbuYNe6Muyp0NLXrgmBChVdoC2T+3/RUHi4Mww==
 
 follow-redirects@^1.0.0, follow-redirects@^1.15.6:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.7.tgz#87248a048fc4eeebfb2389d6aef79028da179690"
+  integrity sha512-aAW9al/NMw4COcZnwgUaG8kAjBUXq/El+1R11e9RDHAIlxa1fb1b5SP0K6BbMoNgWdmJ/kXAwoTlVDlUN3OTDw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
The embedded-core ViewMenu (e.g. where there are view level options like Export SVG) ended up diverging slightly from the app-core ViewMenu, where it did not use CascadingMenu, and then a bug introduced during refactoring (removal of Grow component from the @jbrowse/core/ui/Menu) resulted in the cascading effect not working, instead putting all cascading menus on the screen at once

screenshot
![image](https://github.com/user-attachments/assets/50147fe6-8364-4394-838b-7c950b51697d)


This fixes it by both
a) Adding the Grow back to @jbrowse/core/ui/Menu
b) Converting the embedded-core ViewMenu to use CascadingMenu, just because there are benefits to the CascadingMenu (it avoids offscreen behavior)

