### PR TITLE
Fix regression performance since v2.14.0 in assembly loading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,15 +213,3 @@ particular notes include
    subpaths like '@jbrowse/core/util'
 2. The use of tsconfig.build.json to generate types in the final release
 3. The use of referring to the src directory at development time
-
-## Notes about yarn
-
-Using `yarn upgrade` or `yarn upgrade-interactive --latest` can produce errors
-with the latest version of yarn. This is commonly cited around the web, but
-using npx to one-off run an older version of yarn can fix this issues
-
-Example:
-
-```
-npx yarn@1.19.1 upgrade-interactive --latest
-```

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "cross-env": "^7.0.2",
     "cross-spawn": "^7.0.1",
     "crypto-js": "^4.2.0",
-    "css-loader": "^6.5.1",
     "dependency-graph": "^1.0.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^11.0.3",

--- a/packages/core/assemblyManager/assembly.ts
+++ b/packages/core/assemblyManager/assembly.ts
@@ -165,22 +165,8 @@ export default function assemblyFactory(
       loadingP: undefined as Promise<void> | undefined,
       volatileRegions: undefined as BasicRegion[] | undefined,
       refNameAliases: undefined as RefNameAliases | undefined,
+      lowerCaseRefNameAliases: undefined as RefNameAliases | undefined,
       cytobands: undefined as Feature[] | undefined,
-    }))
-    .views(self => ({
-      /**
-       * #getter
-       */
-      get lowerCaseRefNameAliases() {
-        return self.refNameAliases
-          ? Object.fromEntries(
-              Object.entries(self.refNameAliases).map(([key, val]) => [
-                key.toLowerCase(),
-                val,
-              ]),
-            )
-          : undefined
-      },
     }))
     .views(self => ({
       /**
@@ -339,14 +325,16 @@ export default function assemblyFactory(
       setLoaded({
         regions,
         refNameAliases,
+        lowerCaseRefNameAliases,
         cytobands,
       }: {
         regions: Region[]
         refNameAliases: RefNameAliases
+        lowerCaseRefNameAliases: RefNameAliases
         cytobands: Feature[]
       }) {
         this.setRegions(regions)
-        this.setRefNameAliases(refNameAliases)
+        this.setRefNameAliases(refNameAliases, lowerCaseRefNameAliases)
         this.setCytobands(cytobands)
       },
       /**
@@ -364,8 +352,12 @@ export default function assemblyFactory(
       /**
        * #action
        */
-      setRefNameAliases(aliases: RefNameAliases) {
+      setRefNameAliases(
+        aliases: RefNameAliases,
+        lowerCaseAliases: RefNameAliases,
+      ) {
         self.refNameAliases = aliases
+        self.lowerCaseRefNameAliases = lowerCaseAliases
       },
       /**
        * #action
@@ -435,6 +427,12 @@ export default function assemblyFactory(
           // mapping for the primary region to be an alias
           refNameAliases[region.refName] ||= region.refName
         }
+        const lowerCaseRefNameAliases = Object.fromEntries(
+          Object.entries(refNameAliases).map(([key, val]) => [
+            key.toLowerCase(),
+            val,
+          ]),
+        )
 
         this.setLoaded({
           refNameAliases,
@@ -442,6 +440,7 @@ export default function assemblyFactory(
             ...r,
             refName: refNameAliases[r.refName] || r.refName,
           })),
+          lowerCaseRefNameAliases,
           cytobands: await getCytobands({
             config: cytobandAdapterConf,
             pluginManager,

--- a/products/jbrowse-react-app/stories/JBrowseReactApp.stories.tsx
+++ b/products/jbrowse-react-app/stories/JBrowseReactApp.stories.tsx
@@ -1,5 +1,6 @@
 export {
   BasicExample,
+  HumanDemo,
   WithWebWorker,
   WithFetchConfigJson,
   WithImportConfigJson,

--- a/products/jbrowse-react-app/stories/examples/HumanDemo.tsx
+++ b/products/jbrowse-react-app/stories/examples/HumanDemo.tsx
@@ -1,0 +1,307 @@
+import React, { useState, useEffect } from 'react'
+
+// replace with this in your code:
+// import {createViewState,JBrowseApp} from '@jbrowse/react-app'
+import { createViewState, JBrowseApp } from '../../src'
+
+const config = {
+  assemblies: [
+    {
+      name: 'GRCh38',
+      aliases: ['hg38'],
+      sequence: {
+        type: 'ReferenceSequenceTrack',
+        trackId: 'GRCh38-ReferenceSequenceTrack',
+        adapter: {
+          type: 'BgzipFastaAdapter',
+          fastaLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz',
+          },
+          faiLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai',
+          },
+          gziLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi',
+          },
+        },
+      },
+      refNameAliases: {
+        adapter: {
+          type: 'RefNameAliasAdapter',
+          location: {
+            uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt',
+          },
+        },
+      },
+    },
+  ],
+  tracks: [
+    {
+      type: 'FeatureTrack',
+      trackId: 'genes',
+      name: 'NCBI RefSeq Genes',
+      assemblyNames: ['GRCh38'],
+      category: ['Genes'],
+      adapter: {
+        type: 'Gff3TabixAdapter',
+        gffGzLocation: {
+          uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/ncbi_refseq/GCA_000001405.15_GRCh38_full_analysis_set.refseq_annotation.sorted.gff.gz',
+        },
+        index: {
+          location: {
+            uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/ncbi_refseq/GCA_000001405.15_GRCh38_full_analysis_set.refseq_annotation.sorted.gff.gz.tbi',
+          },
+        },
+      },
+      textSearching: {
+        textSearchAdapter: {
+          type: 'TrixTextSearchAdapter',
+          textSearchAdapterId: 'gff3tabix_genes-index',
+          ixFilePath: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/ncbi_refseq/trix/GCA_000001405.15_GRCh38_full_analysis_set.refseq_annotation.sorted.gff.gz.ix',
+          },
+          ixxFilePath: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/ncbi_refseq/trix/GCA_000001405.15_GRCh38_full_analysis_set.refseq_annotation.sorted.gff.gz.ixx',
+          },
+          metaFilePath: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/ncbi_refseq/trix/GCA_000001405.15_GRCh38_full_analysis_set.refseq_annotation.sorted.gff.gz_meta.json',
+          },
+          assemblyNames: ['GRCh38'],
+        },
+      },
+    },
+    {
+      type: 'FeatureTrack',
+      trackId: 'repeats_hg38',
+      name: 'Repeats',
+      assemblyNames: ['hg38'],
+      category: ['Annotation'],
+      adapter: {
+        type: 'BigBedAdapter',
+        bigBedLocation: {
+          uri: 'https://jbrowse.org/genomes/GRCh38/repeats.bb',
+          locationType: 'UriLocation',
+        },
+      },
+    },
+    {
+      type: 'AlignmentsTrack',
+      trackId: 'NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome',
+      name: 'NA12878 Exome',
+      assemblyNames: ['GRCh38'],
+      category: ['1000 Genomes', 'Alignments'],
+      adapter: {
+        type: 'CramAdapter',
+        cramLocation: {
+          uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/alignments/NA12878/NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome.cram',
+        },
+        craiLocation: {
+          uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/alignments/NA12878/NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome.cram.crai',
+        },
+        sequenceAdapter: {
+          type: 'BgzipFastaAdapter',
+          fastaLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz',
+          },
+          faiLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai',
+          },
+          gziLocation: {
+            uri: 'https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi',
+          },
+        },
+      },
+    },
+    {
+      type: 'VariantTrack',
+      trackId:
+        'ALL.wgs.shapeit2_integrated_snvindels_v2a.GRCh38.27022019.sites.vcf',
+      name: '1000 Genomes Variant Calls',
+      assemblyNames: ['GRCh38'],
+      category: ['1000 Genomes', 'Variants'],
+      adapter: {
+        type: 'VcfTabixAdapter',
+        vcfGzLocation: {
+          uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/variants/ALL.wgs.shapeit2_integrated_snvindels_v2a.GRCh38.27022019.sites.vcf.gz',
+        },
+        index: {
+          location: {
+            uri: 'https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/variants/ALL.wgs.shapeit2_integrated_snvindels_v2a.GRCh38.27022019.sites.vcf.gz.tbi',
+          },
+        },
+      },
+    },
+    {
+      type: 'QuantitativeTrack',
+      trackId: 'hg38.100way.phyloP100way',
+      name: 'hg38.100way.phyloP100way',
+      category: ['Conservation'],
+      assemblyNames: ['hg38'],
+      adapter: {
+        type: 'BigWigAdapter',
+        bigWigLocation: {
+          uri: 'https://hgdownload.cse.ucsc.edu/goldenpath/hg38/phyloP100way/hg38.phyloP100way.bw',
+          locationType: 'UriLocation',
+        },
+      },
+    },
+  ],
+  defaultSession: {
+    name: 'this session',
+    margin: 0,
+    views: [
+      {
+        id: 'linearGenomeView',
+        minimized: false,
+        type: 'LinearGenomeView',
+        offsetPx: 191980240,
+        bpPerPx: 0.1554251851851852,
+        displayedRegions: [
+          {
+            refName: '10',
+            start: 0,
+            end: 133797422,
+            reversed: false,
+            assemblyName: 'GRCh38',
+          },
+        ],
+        tracks: [
+          {
+            id: '4aZAiE-A3',
+            type: 'ReferenceSequenceTrack',
+            configuration: 'GRCh38-ReferenceSequenceTrack',
+            minimized: false,
+            displays: [
+              {
+                id: 'AD3gqvG0_6',
+                type: 'LinearReferenceSequenceDisplay',
+                height: 180,
+                configuration:
+                  'GRCh38-ReferenceSequenceTrack-LinearReferenceSequenceDisplay',
+                showForward: true,
+                showReverse: true,
+                showTranslation: true,
+              },
+            ],
+          },
+          {
+            id: 'T6uhrtY40O',
+            type: 'AlignmentsTrack',
+            configuration: 'NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome',
+            minimized: false,
+            displays: [
+              {
+                id: 'FinKswChSr',
+                type: 'LinearAlignmentsDisplay',
+                PileupDisplay: {
+                  id: 'YAAaF494z',
+                  type: 'LinearPileupDisplay',
+                  height: 134,
+                  configuration: {
+                    type: 'LinearPileupDisplay',
+                    displayId:
+                      'NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome-LinearAlignmentsDisplay_LinearPileupDisplay_xyz',
+                  },
+                  showSoftClipping: false,
+                  filterBy: {
+                    flagInclude: 0,
+                    flagExclude: 1540,
+                  },
+                },
+                SNPCoverageDisplay: {
+                  id: 'VTQ_VGbAVJ',
+                  type: 'LinearSNPCoverageDisplay',
+                  height: 45,
+                  configuration: {
+                    type: 'LinearSNPCoverageDisplay',
+                    displayId:
+                      'NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome-LinearAlignmentsDisplay_snpcoverage_xyz',
+                  },
+                  selectedRendering: '',
+                  resolution: 1,
+                  constraints: {},
+                  filterBy: {
+                    flagInclude: 0,
+                    flagExclude: 1540,
+                  },
+                },
+                snpCovHeight: 45,
+                configuration:
+                  'NA12878.alt_bwamem_GRCh38DH.20150826.CEU.exome-LinearAlignmentsDisplay',
+                height: 179,
+                lowerPanelType: 'LinearPileupDisplay',
+              },
+            ],
+          },
+          {
+            id: 'EUnTnpVI6',
+            type: 'QuantitativeTrack',
+            configuration: 'hg38.100way.phyloP100way',
+            minimized: false,
+            displays: [
+              {
+                id: 'mrlawr9Wtg',
+                type: 'LinearWiggleDisplay',
+                height: 100,
+                configuration: 'hg38.100way.phyloP100way-LinearWiggleDisplay',
+                selectedRendering: '',
+                resolution: 1,
+                constraints: {},
+              },
+            ],
+          },
+          {
+            id: 'Cbnwl72EX',
+            type: 'VariantTrack',
+            configuration:
+              'ALL.wgs.shapeit2_integrated_snvindels_v2a.GRCh38.27022019.sites.vcf',
+            minimized: false,
+            displays: [
+              {
+                id: 'dvXz01Wf6w',
+                type: 'LinearVariantDisplay',
+                height: 100,
+                configuration:
+                  'ALL.wgs.shapeit2_integrated_snvindels_v2a.GRCh38.27022019.sites.vcf-LinearVariantDisplay',
+              },
+            ],
+          },
+        ],
+        hideHeader: false,
+        hideHeaderOverview: false,
+        hideNoTracksActive: false,
+        trackSelectorType: 'hierarchical',
+        trackLabels: 'overlapping',
+        showCenterLine: false,
+        showCytobandsSetting: true,
+        showGridlines: true,
+      },
+    ],
+  },
+}
+
+type ViewModel = ReturnType<typeof createViewState>
+
+export const HumanDemo = () => {
+  const [viewState, setViewState] = useState<ViewModel>()
+
+  useEffect(() => {
+    const state = createViewState({
+      config,
+    })
+    setViewState(state)
+  }, [])
+
+  if (!viewState) {
+    return null
+  }
+
+  return (
+    <>
+      <JBrowseApp viewState={viewState} />
+      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/HumanDemo.tsx">
+        Source code
+      </a>
+    </>
+  )
+}

--- a/products/jbrowse-react-app/stories/examples/index.ts
+++ b/products/jbrowse-react-app/stories/examples/index.ts
@@ -1,4 +1,5 @@
 export * from './BasicExample'
+export * from './HumanDemo'
 export * from './WithWebWorker'
 export * from './WithImportConfigJson'
 export * from './WithFetchConfigJson'

--- a/products/jbrowse-web/src/components/NoConfigMessage.tsx
+++ b/products/jbrowse-web/src/components/NoConfigMessage.tsx
@@ -7,6 +7,7 @@ export default function NoConfigMessage() {
     ['test_data/config_demo.json', 'Human sample data'],
     ['test_data/sars-cov2/config.json', 'SARS-CoV2'],
     ['test_data/tomato/config.json', 'Tomato SVs'],
+    ['test_data/cfam2/config.json', 'Dog (NCBI sequence aliases adapter)'],
     ['test_data/breakpoint/config.json', 'Breakpoint'],
     ['test_data/config_dotplot.json', 'Grape/Peach dotplot'],
     ['test_data/config_synteny_grape_peach.json', 'Grape/Peach synteny'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,7 +88,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/client-cloudfront@^3.637.0":
+"@aws-sdk/client-cloudfront@^3.645.0":
   version "3.645.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudfront/-/client-cloudfront-3.645.0.tgz#4dd0d20d9dccce902d6872c7f2f97215424dd027"
   integrity sha512-buXVTKi3b+B6LqhTxoTELfszRviNI6Cg9eoctKaR4UcKs1VlB4D/rX2Mt1ShQ0QBnC5pboOT0nbDWFkAn/LcBQ==
@@ -138,7 +138,7 @@
     "@smithy/util-waiter" "^3.1.2"
     tslib "^2.6.2"
 
-"@aws-sdk/client-s3@^3.633.0":
+"@aws-sdk/client-s3@^3.645.0":
   version "3.645.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.645.0.tgz#a0d201248ee711e79f3e515d870b02547a652102"
   integrity sha512-RjT/mfNv4yr1uv/+aEXgSIxC5EB+yHPSU7hH0KZOZrvZEFASLl0i4FeoHzbMEOH5KdKGAi0uu3zRP3D1y45sKg==
@@ -2226,15 +2226,22 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.9.1":
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.9.1.tgz#4a97e85e982099d6c7ee8410aacb55adaa576f06"
-  integrity sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==
+"@eslint/js@9.10.0":
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.10.0.tgz#eaa3cb0baec497970bb29e43a153d0d5650143c6"
+  integrity sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==
 
 "@eslint/object-schema@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.4.tgz#9e69f8bb4031e11df79e03db09f9dbbae1740843"
   integrity sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==
+
+"@eslint/plugin-kit@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz#809b95a0227ee79c3195adfb562eb94352e77974"
+  integrity sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==
+  dependencies:
+    levn "^0.4.1"
 
 "@flatten-js/interval-tree@^1.0.15":
   version "1.1.3"
@@ -2278,9 +2285,9 @@
   integrity sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==
 
 "@fontsource/roboto@^5.0.2":
-  version "5.0.14"
-  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.14.tgz#a3f67e47116309233ff3bba2c3613d2cf0302529"
-  integrity sha512-zHAxlTTm9RuRn9/StwclFJChf3z9+fBrOxC3fw71htjHP1BgXNISwRjdJtAKAmMe5S2BzgpnjkQR93P9EZYI/Q==
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.15.tgz#781811e4ef40adbdff22c92ebe17760beac62059"
+  integrity sha512-352XiID9jfwmYaHpdmS3ocGJi3PA+vOm4HzJIRfSyPEyLP6dZN8iiEKUbdAfB5YXQO3YxO2KZpR+R28q2zMiYw==
 
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -2425,7 +2432,7 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inquirer/confirm@^3.1.22":
+"@inquirer/confirm@^3.1.22", "@inquirer/confirm@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-3.2.0.tgz#6af1284670ea7c7d95e3f1253684cfbd7228ad6a"
   integrity sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==
@@ -3422,15 +3429,15 @@
     wrap-ansi "^7.0.0"
 
 "@oclif/core@^4":
-  version "4.0.20"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.0.20.tgz#0c7fd743720c39b33b194b5b335c7ffa3a4fffee"
-  integrity sha512-N1RKI/nteiEbd/ilyv/W1tz82SEAeXeQ5oZpdU/WgLrDilHH7cicrT/NBLextJJhH3QTC+1oan0Z5vNzkX6lGA==
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.0.21.tgz#fda25b950572ae7762248a808f141e3e32fb2a57"
+  integrity sha512-SvLTSclf104IVX8BY7nWqess1pBmeNl9qRFTWjOXg7B1/ESemfEtZYBDRAXAp1ILvazDng5IF/7YSbTxDVbwNg==
   dependencies:
     ansi-escapes "^4.3.2"
     ansis "^3.3.2"
     clean-stack "^3.0.1"
     cli-spinners "^2.9.2"
-    debug "^4.3.5"
+    debug "^4.3.7"
     ejs "^3.1.10"
     get-package-type "^0.1.0"
     globby "^11.1.0"
@@ -3445,26 +3452,26 @@
     wrap-ansi "^7.0.0"
 
 "@oclif/plugin-help@^6.0.15", "@oclif/plugin-help@^6.2.10":
-  version "6.2.10"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-6.2.10.tgz#d6e8140efa89ae624ae9f25b7fdb8d112c62715f"
-  integrity sha512-Gm5/l/upTtj34StLIjZzhmO3AngqGx20rsbfOqDQ3SrsEnjfujtKgUm+MxXTjl4XfkkWREUN0CwuqLcuftnsOw==
+  version "6.2.11"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-6.2.11.tgz#4477cf02778c6051b91cf21add5593fea9c8418c"
+  integrity sha512-Vo854dALtNhA34g6m4T9uWIrYfm/JFM82LWa5gLrsJGwpUGgeBwBX4P64HLo5ro59LF3YO2xPWViLaoK6gkm3g==
   dependencies:
     "@oclif/core" "^4"
 
 "@oclif/plugin-not-found@^3.2.16":
-  version "3.2.18"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-not-found/-/plugin-not-found-3.2.18.tgz#6ed73f1c2e3022723c588295131bb2b4f06468f3"
-  integrity sha512-595+i3eG+K4jM+BjWLAuWzBb2wqrXpKqF9IianroSCxeZEC4Ujg6HWvLSYT//afJzeXWpsNyqGCqeoGF7kXE/w==
+  version "3.2.20"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-not-found/-/plugin-not-found-3.2.20.tgz#13545eb2db365e92b9d242663b1fc0fedfbdfdfe"
+  integrity sha512-Le/+9TpXn7HQu4hU7bi6oBDu7aRHNtqBm+JvNlRAcv9tsw3IySOq9DWhsQI3ZN6w6ou1524gx+0DObxKwciZFA==
   dependencies:
-    "@inquirer/confirm" "^3.1.22"
+    "@inquirer/confirm" "^3.2.0"
     "@oclif/core" "^4"
     ansis "^3.3.1"
     fast-levenshtein "^3.0.0"
 
 "@oclif/plugin-warn-if-update-available@^3.1.11":
-  version "3.1.14"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-3.1.14.tgz#43ae026329b571a3eec99bb44bb42c5103244e22"
-  integrity sha512-v0moOf9GnzY2q/9TdP1g6nwPFKK732kvrUOB13oWLEsFh8QEKZ783874EnGIs1WPpExiuLvuejJO9ILW4bF3uQ==
+  version "3.1.15"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-3.1.15.tgz#855f4655aecba588cfd1743f366d0c55927a9cfb"
+  integrity sha512-VzKbjzKiJssh7bDG9vTsZ9r6g7WuCL1Q7/Njqw7t33f17rGAn6w31S7eCZiWJBBjCEqxKF2JmhkfZ4YSA8Xt2g==
   dependencies:
     "@oclif/core" "^4"
     ansis "^3.3.1"
@@ -5727,9 +5734,9 @@ acorn-walk@^7.2.0:
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
 acorn-walk@^8.0.0, acorn-walk@^8.0.2, acorn-walk@^8.1.1:
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
-  integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
   dependencies:
     acorn "^8.11.0"
 
@@ -6677,9 +6684,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001616, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001655:
-  version "1.0.30001658"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001658.tgz#b5f7be8ac748a049ab06aa1cf7a1408d83f074ec"
-  integrity sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==
+  version "1.0.30001659"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001659.tgz#f370c311ffbc19c4965d8ec0064a3625c8aaa7af"
+  integrity sha512-Qxxyfv3RdHAfJcXelgf0hU4DFUVXBGTjqrBUZLUh8AtlGnsDo+CnncYtTd95+ZKfnANUOzxyIQCuU/UeBZBYoA==
 
 canvas-sequencer@^3.1.0:
   version "3.1.0"
@@ -6828,9 +6835,9 @@ citty@^0.1.6:
     consola "^3.2.3"
 
 cjs-module-lexer@^1.0.0, cjs-module-lexer@^1.2.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.0.tgz#677de7ed7efff67cc40c9bf1897fea79d41b5215"
-  integrity sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz#707413784dbb3a72aa11c2f2b042a0bef4004170"
+  integrity sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==
 
 classnames@^2.2.6:
   version "2.5.1"
@@ -7432,7 +7439,7 @@ crypto-random-string@^4.0.0:
   dependencies:
     type-fest "^1.0.1"
 
-css-loader@^6.5.1, css-loader@^6.7.1:
+css-loader@^6.7.1:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.11.0.tgz#33bae3bf6363d0a7c2cf9031c96c744ff54d85ba"
   integrity sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==
@@ -7474,11 +7481,11 @@ cssstyle@^2.3.0:
     cssom "~0.3.6"
 
 cssstyle@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.0.1.tgz#ef29c598a1e90125c870525490ea4f354db0660a"
-  integrity sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.1.0.tgz#161faee382af1bafadb6d3867a92a19bcb4aea70"
+  integrity sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==
   dependencies:
-    rrweb-cssom "^0.6.0"
+    rrweb-cssom "^0.7.1"
 
 csstype@^3.0.2, csstype@^3.1.3:
   version "3.1.3"
@@ -7628,7 +7635,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -8104,9 +8111,9 @@ electron-publish@25.0.3:
     mime "^2.5.2"
 
 electron-to-chromium@^1.5.4:
-  version "1.5.17"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.17.tgz#292da718d3d96961d022e49bb843e0c4ea10be70"
-  integrity sha512-Q6Q+04tjC2KJ8qsSOSgovvhWcv5t+SmpH6/YfAWmhpE5/r+zw6KQy1/yWVFFNyEBvy68twTTXr2d5eLfCq7QIw==
+  version "1.5.18"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz#5fe62b9d21efbcfa26571066502d94f3ed97e495"
+  integrity sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==
 
 electron-updater@^6.1.1:
   version "6.3.4"
@@ -8560,15 +8567,16 @@ eslint-visitor-keys@^4.0.0:
   integrity sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==
 
 eslint@^9.0.0:
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.9.1.tgz#147ac9305d56696fb84cf5bdecafd6517ddc77ec"
-  integrity sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.10.0.tgz#0bd74d7fe4db77565d0e7f57c7df6d2b04756806"
+  integrity sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.11.0"
     "@eslint/config-array" "^0.18.0"
     "@eslint/eslintrc" "^3.1.0"
-    "@eslint/js" "9.9.1"
+    "@eslint/js" "9.10.0"
+    "@eslint/plugin-kit" "^0.1.0"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@humanwhocodes/retry" "^0.3.0"
     "@nodelib/fs.walk" "^1.2.8"
@@ -8591,7 +8599,6 @@ eslint@^9.0.0:
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
     lodash.merge "^4.6.2"
     minimatch "^3.1.2"
     natural-compare "^1.4.0"
@@ -12177,9 +12184,9 @@ mobx-state-tree@^5.0.0, mobx-state-tree@^5.1.7:
   integrity sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==
 
 mobx@^6.0.0, mobx@^6.6.0:
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.13.1.tgz#76c41aa675199f75b84a257e4bec8ff839e33259"
-  integrity sha512-ekLRxgjWJr8hVxj9ZKuClPwM/iHckx3euIJ3Np7zLVNtqJvfbbq7l370W/98C8EabdQ1pB5Jd3BbDWxJPNnaOg==
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.13.2.tgz#e4514c983c41611d7008ac4cd21c7f3d1be3180d"
+  integrity sha512-GIubI2qf+P6lG6rSEG0T2pg3jV9/0+O0ncF09+0umRe75+Cbnh1KNLM1GvbTY9RSc7QuU+LcPNZfxDY8B+3XRg==
 
 modify-values@^1.0.1:
   version "1.0.1"
@@ -12706,12 +12713,12 @@ obuf@^1.0.0, obuf@^1.1.2:
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 oclif@^4.0.0:
-  version "4.14.29"
-  resolved "https://registry.yarnpkg.com/oclif/-/oclif-4.14.29.tgz#e8c057543da164638f280c69828df2690be80f66"
-  integrity sha512-/wt4bKamN0eMpIYFHFeChR6mmEQpdoIAskOVN0uihuwit1fkDUxvT2usOC9oIgugEs0mzuB3POdowBWNyGJQnw==
+  version "4.14.31"
+  resolved "https://registry.yarnpkg.com/oclif/-/oclif-4.14.31.tgz#9cff05d97cea5da9a37d1530c37203f906ce4f16"
+  integrity sha512-AbeRAftNTRFNO7Q3++7QIbcx7+RXRHLfWLaVBgusEJcelUDH6wIdktVTKmVM2Mxda/JoNNf8KsUbP/PfsprrOA==
   dependencies:
-    "@aws-sdk/client-cloudfront" "^3.637.0"
-    "@aws-sdk/client-s3" "^3.633.0"
+    "@aws-sdk/client-cloudfront" "^3.645.0"
+    "@aws-sdk/client-s3" "^3.645.0"
     "@inquirer/confirm" "^3.1.22"
     "@inquirer/input" "^2.2.4"
     "@inquirer/select" "^2.3.10"
@@ -13428,9 +13435,9 @@ promise-all-reject-late@^1.0.0:
   integrity sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==
 
 promise-call-limit@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/promise-call-limit/-/promise-call-limit-3.0.1.tgz#3570f7a3f2aaaf8e703623a552cd74749688cf19"
-  integrity sha512-utl+0x8gIDasV5X+PI5qWEPqH6fJS0pFtQ/4gZ95xfEFb/89dmh+/b895TbFDBLiafBvxD/PGTKfvxl4kH/pQg==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/promise-call-limit/-/promise-call-limit-3.0.2.tgz#524b7f4b97729ff70417d93d24f46f0265efa4f9"
+  integrity sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -14159,11 +14166,6 @@ robust-predicates@^3.0.2:
   resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
   integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
-rrweb-cssom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
-  integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
-
 rrweb-cssom@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
@@ -14658,9 +14660,9 @@ sort-package-json@^2.10.1:
     sort-object-keys "^1.1.3"
 
 source-map-js@^1.0.2, source-map-js@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
-  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -15264,9 +15266,9 @@ terser-webpack-plugin@^5.3.10:
     terser "^5.26.0"
 
 terser@^5.15.1, terser@^5.26.0:
-  version "5.31.6"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.6.tgz#c63858a0f0703988d0266a82fcbf2d7ba76422b1"
-  integrity sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.32.0.tgz#ee811c0d2d6b741c1cc34a2bc5bcbfc1b5b1f96c"
+  integrity sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
v2.14.0 introduced the NCBI sequence report adapter (xref https://github.com/GMOD/jbrowse-components/pull/4516/files) which allows e.g. NC_000001.11 to be displayed as chr1 in the UI)

Unfortunately there was an unexpected performance regression, due to accessing a mst observable outside of an observable context, causing it to be re-calculated for every invocation which was once per refname so it was a big slowdown

can see that loading a human FASTA takes:

before, 8000milliseconds (8s):
![image](https://github.com/user-attachments/assets/6160840d-1653-4ad7-b0f8-8a4dffa5ea3a)

after, 10ms:
![image](https://github.com/user-attachments/assets/81729b33-0292-45dc-8ec8-fdc14b389d2b)
