### PR TITLE
Fix code signing on the windows for jbrowse desktop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,15 +73,11 @@ jobs:
           cd products/jbrowse-desktop/code_signer
           wget  https://www.ssl.com/download/codesigntool-for-linux-and-macos -O out.zip
           unzip out.zip
+          chmod +x CodeSignTool.sh
           cd ../../../
 
       - name: Build app
         env:
-          # NOTE: must explicitly pass in even the parameters that
-          # esigner-codesign says are optional since we're not using the action
-          # directly, but rather passing the params in as env vars:
-          # xref https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-1994110062
-          CODE_SIGN_SCRIPT_PATH: 'code_signer'
           WINDOWS_SIGN_USER_NAME: ${{ secrets.WINDOWS_SIGN_USER_NAME }}
           WINDOWS_SIGN_USER_PASSWORD: ${{ secrets.WINDOWS_SIGN_USER_PASSWORD }}
           WINDOWS_SIGN_CREDENTIAL_ID: ${{ secrets.WINDOWS_SIGN_CREDENTIAL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,33 @@ jobs:
       - name: Install build deps
         run: |
           apt install --yes python3 make gcc libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      # We are just cloning the esigner repo instead of calling their github
+      # action directly https://github.com/SSLcom/esigner-codesign
+      - name: Get ssl.com esigner zip file and unzip
+        run: |
+          mkdir products/jbrowse-desktop/code_signer
+          cd products/jbrowse-desktop/code_signer
+          wget  https://www.ssl.com/download/codesigntool-for-linux-and-macos -O out.zip
+          unzip out.zip
+          cd ../../../
+
       - name: Build app
         env:
-          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          # NOTE: must explicitly pass in even the parameters that
+          # esigner-codesign says are optional since we're not using the action
+          # directly, but rather passing the params in as env vars:
+          # xref https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-1994110062
+          CODE_SIGN_SCRIPT_PATH: 'code_signer'
+          WINDOWS_SIGN_USER_NAME: ${{ secrets.WINDOWS_SIGN_USER_NAME }}
+          WINDOWS_SIGN_USER_PASSWORD: ${{ secrets.WINDOWS_SIGN_USER_PASSWORD }}
+          WINDOWS_SIGN_CREDENTIAL_ID: ${{ secrets.WINDOWS_SIGN_CREDENTIAL_ID }}
+          WINDOWS_SIGN_USER_TOTP: ${{ secrets.WINDOWS_SIGN_USER_TOTP }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chown --recursive root:root /github/home
           yarn build-electron:win --publish always
         working-directory: products/jbrowse-desktop
+
   buildmac:
     needs: createrelease
     name: Build Mac desktop app

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,6 +169,7 @@ export default tseslint.config(
       'products/jbrowse-img/**/*',
       'products/jbrowse-web/scripts/*',
       'products/jbrowse-desktop/scripts/*',
+      'products/jbrowse-desktop/sign.js',
       'products/jbrowse-desktop/linux-sandbox-fix.js',
       'products/jbrowse-aws-lambda-functions/**/*.js',
       'plugins/data-management/scripts/*.js',

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -117,6 +117,7 @@
     "productName": "JBrowse 2",
     "copyright": "Copyright © 2019",
     "win": {
+      "sign": "./sign.js",
       "publish": [
         "github"
       ],

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -118,6 +118,9 @@
     "copyright": "Copyright © 2019",
     "win": {
       "sign": "./sign.js",
+      "signingHashAlgorithms": [
+        "sha256"
+      ],
       "publish": [
         "github"
       ],

--- a/products/jbrowse-desktop/sign.js
+++ b/products/jbrowse-desktop/sign.js
@@ -1,6 +1,5 @@
-// this script taken from
+// this script adapted from
 // https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-899798533
-// see our shared google drive -> developer folder for more info on this
 const path = require('path')
 const fs = require('fs')
 const childProcess = require('child_process')
@@ -13,22 +12,35 @@ if (!fs.existsSync(TEMP_DIR)) {
 
 function sign(configuration) {
   console.log(`Signing ${configuration.path}`)
-  const { name, dir } = path.parse(configuration.path)
-  // CodeSignTool can't sign in place without verifying the overwrite with a
-  // y/m interaction so we are creating a new file in a temp directory and
-  // then replacing the original file with the signed file.
-  const signFile = [
-    'codesigner/CodeSignTool.sh sign',
-    `-input_file_path="${configuration.path}"`,
-    `-output_dir_path="${TEMP_DIR}"`,
-    `-credential_id="${process.env.WINDOWS_SIGN_CREDENTIAL_ID}"`,
-    `-username="${process.env.WINDOWS_SIGN_USER_NAME}"`,
-    `-password="${process.env.WINDOWS_SIGN_USER_PASSWORD}"`,
-    `-totp_secret="${process.env.WINDOWS_SIGN_USER_TOTP}"`,
-  ].join(' ')
+  // we move signed files to a file named tmp.exe because our product name
+  // contains a space, meaning our .exe contains a space, which CodeSignTool
+  // balks at even with attempted backslash escaping, so we rename to tmp.exe
+  const tmpExe = `tmp-${Math.random()}.exe`
 
-  const moveFile = `mv "${path.join(TEMP_DIR, name)}" "${dir}"`
-  childProcess.execSync(`${setDir} && ${signFile} && ${moveFile}`, {
+  // note: CodeSignTool can't sign in place without verifying the overwrite
+  // with a y/m interaction so we are creating a new file in a temp directory
+  // and then replacing the original file with the signed file.
+  const signFile = [
+    // code_signer is directory containing the CodeSignTool script in
+    // products/jbrowse-desktop that is created by .github/workflows/release.sh
+    // on windows
+    'CODE_SIGN_TOOL_PATH=code_signer bash code_signer/CodeSignTool.sh sign',
+    `-input_file_path='${tmpExe}'`,
+    `-output_dir_path='${TEMP_DIR}'`,
+    `-credential_id='${process.env.WINDOWS_SIGN_CREDENTIAL_ID}'`,
+    `-username='${process.env.WINDOWS_SIGN_USER_NAME}'`,
+    `-password='${process.env.WINDOWS_SIGN_USER_PASSWORD}'`,
+    `-totp_secret='${process.env.WINDOWS_SIGN_USER_TOTP}'`,
+  ].join(' ')
+  const preMoveFile = `cp "${configuration.path}" "${tmpExe}"`
+  const postMoveFile = `cp "${path.join(TEMP_DIR, tmpExe)}" "${configuration.path}"`
+  childProcess.execSync(`${preMoveFile}`, {
+    stdio: 'inherit',
+  })
+  childProcess.execSync(`${signFile}`, {
+    stdio: 'inherit',
+  })
+  childProcess.execSync(`${postMoveFile}`, {
     stdio: 'inherit',
   })
 }

--- a/products/jbrowse-desktop/sign.js
+++ b/products/jbrowse-desktop/sign.js
@@ -1,0 +1,36 @@
+// this script taken from
+// https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-899798533
+// see our shared google drive -> developer folder for more info on this
+const path = require('path')
+const fs = require('fs')
+const childProcess = require('child_process')
+
+const TEMP_DIR = path.join(__dirname, 'release', 'temp')
+
+if (!fs.existsSync(TEMP_DIR)) {
+  fs.mkdirSync(TEMP_DIR, { recursive: true })
+}
+
+function sign(configuration) {
+  console.log(`Signing ${configuration.path}`)
+  const { name, dir } = path.parse(configuration.path)
+  // CodeSignTool can't sign in place without verifying the overwrite with a
+  // y/m interaction so we are creating a new file in a temp directory and
+  // then replacing the original file with the signed file.
+  const signFile = [
+    'codesigner/CodeSignTool.sh sign',
+    `-input_file_path="${configuration.path}"`,
+    `-output_dir_path="${TEMP_DIR}"`,
+    `-credential_id="${process.env.WINDOWS_SIGN_CREDENTIAL_ID}"`,
+    `-username="${process.env.WINDOWS_SIGN_USER_NAME}"`,
+    `-password="${process.env.WINDOWS_SIGN_USER_PASSWORD}"`,
+    `-totp_secret="${process.env.WINDOWS_SIGN_USER_TOTP}"`,
+  ].join(' ')
+
+  const moveFile = `mv "${path.join(TEMP_DIR, name)}" "${dir}"`
+  childProcess.execSync(`${setDir} && ${signFile} && ${moveFile}`, {
+    stdio: 'inherit',
+  })
+}
+
+exports.default = sign

--- a/products/jbrowse-desktop/sign.js
+++ b/products/jbrowse-desktop/sign.js
@@ -34,13 +34,13 @@ function sign(configuration) {
   ].join(' ')
   const preMoveFile = `cp "${configuration.path}" "${tmpExe}"`
   const postMoveFile = `cp "${path.join(TEMP_DIR, tmpExe)}" "${configuration.path}"`
-  childProcess.execSync(`${preMoveFile}`, {
+  childProcess.execSync(preMoveFile, {
     stdio: 'inherit',
   })
-  childProcess.execSync(`${signFile}`, {
+  childProcess.execSync(signFile, {
     stdio: 'inherit',
   })
-  childProcess.execSync(`${postMoveFile}`, {
+  childProcess.execSync(postMoveFile, {
     stdio: 'inherit',
   })
 }


### PR DESCRIPTION
this is an attempt to get our SSL code signing back into action for our windows app

it had been apparently broken for awhile i believe our certificate was expired since mid-2023, and even attempting to fix it would not work because at that same time in mid-2023 they disabled the method we were using (downloading the p12/pfx file to the WIN_CSC_LINK env variable)

this PR's new solution closely follows https://github.com/electron-userland/electron-builder/issues/6158


