### PR TITLE
Update electron-builder to fix broken desktop builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "dotenv": "^16.3.1",
     "dotenv-expand": "^11.0.3",
     "electron": "32.1.0",
-    "electron-builder": "^25.0.5",
+    "electron-builder": "next",
     "electron-mock-ipc": "^0.3.8",
     "eslint": "^9.0.0",
     "eslint-plugin-react": "^7.33.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,16 +1731,7 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/notarize@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@electron/notarize/-/notarize-2.3.2.tgz#20a52a961747be8542a35003380988a0d3fe15e6"
-  integrity sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==
-  dependencies:
-    debug "^4.1.1"
-    fs-extra "^9.0.1"
-    promise-retry "^2.0.1"
-
-"@electron/notarize@^2.0.0":
+"@electron/notarize@2.5.0", "@electron/notarize@^2.0.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@electron/notarize/-/notarize-2.5.0.tgz#d4d25356adfa29df4a76bd64a8bd347237cd251e"
   integrity sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==
@@ -5656,18 +5647,18 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-app-builder-bin@5.0.0-alpha.7:
-  version "5.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-5.0.0-alpha.7.tgz#8c835ad083b18fb5d434bc4e4d99cca1fb46c19f"
-  integrity sha512-ww2mK4ITUvqisnqOuUWAeHzokpPidyZ7a0ZkwW+V7sF5/Pdi2OldkRjAWqEzn6Xtmj3SLVT84as4wB59A6jJ4g==
+app-builder-bin@5.0.0-alpha.9:
+  version "5.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-5.0.0-alpha.9.tgz#e2669314d0a667bf4332328da1602d7aebfcaad0"
+  integrity sha512-c/wOXdITW80MGUV2PECWuxB49MIm44latbuoWGjq0i89lmA9ZB8jcvuF1pStu3wrxStYVjYpPD3/NgQDWSHohA==
 
-app-builder-lib@25.0.5:
-  version "25.0.5"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-25.0.5.tgz#4886ee77030576cbd36fab92633347d3cc554f87"
-  integrity sha512-rxgxMx1f7I4ZAP0jA5+5iB7X6x6MJvGF7GauRzQBnIVihwXX2HOiAE7yenyY9Ry5YAiH47MnCxdq413Wq6XOcQ==
+app-builder-lib@25.1.5:
+  version "25.1.5"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-25.1.5.tgz#dca627d97b761743714c7e64238907c762ae8a51"
+  integrity sha512-0m44K6wTPlcstFp+U+znCCDmrJoCUN03AzqpuHFbo02OIGctCg8DggJ91GZ58eBajAU50JNOQ7G6QRkhA7wB/w==
   dependencies:
     "@develar/schema-utils" "~2.6.5"
-    "@electron/notarize" "2.3.2"
+    "@electron/notarize" "2.5.0"
     "@electron/osx-sign" "1.3.1"
     "@electron/rebuild" "3.6.0"
     "@electron/universal" "2.0.1"
@@ -5675,21 +5666,24 @@ app-builder-lib@25.0.5:
     "@types/fs-extra" "9.0.13"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.9"
-    builder-util "25.0.3"
-    builder-util-runtime "9.2.5"
+    builder-util "25.1.5"
+    builder-util-runtime "9.2.9"
     chromium-pickle-js "^0.2.0"
+    config-file-ts "0.2.8-rc1"
     debug "^4.3.4"
+    dotenv "^16.4.5"
+    dotenv-expand "^11.0.6"
     ejs "^3.1.8"
-    electron-publish "25.0.3"
+    electron-publish "25.1.5"
     form-data "^4.0.0"
     fs-extra "^10.1.0"
     hosted-git-info "^4.1.0"
     is-ci "^3.0.0"
     isbinaryfile "^5.0.0"
     js-yaml "^4.1.0"
+    json5 "^2.2.3"
     lazy-val "^1.0.5"
     minimatch "^10.0.0"
-    read-config-file "6.4.0"
     resedit "^1.7.0"
     sanitize-filename "^1.6.3"
     semver "^7.3.8"
@@ -6256,22 +6250,30 @@ builder-util-runtime@9.2.5:
     debug "^4.3.4"
     sax "^1.2.4"
 
-builder-util@25.0.3:
-  version "25.0.3"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-25.0.3.tgz#bd00d8e8abbe6ea56974a2adbbc39578eab0134b"
-  integrity sha512-eH5c1ukdY2xjtFQWQ6jlzEuXuqcuAVc3UQ6V6fdYu9Kg3CkDbCR82Mox42uaJDmee9WXSbP/88cOworFdOHPhw==
+builder-util-runtime@9.2.9:
+  version "9.2.9"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.2.9.tgz#e7d5dcb3a7caa9575406edea28940f6088d7cbb3"
+  integrity sha512-DWeHdrRFVvNnVyD4+vMztRpXegOGaQHodsAjyhstTbUNBIjebxM1ahxokQL+T1v8vpW8SY7aJ5is/zILH82lAw==
+  dependencies:
+    debug "^4.3.4"
+    sax "^1.2.4"
+
+builder-util@25.1.5:
+  version "25.1.5"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-25.1.5.tgz#9c20c35e636535025ab986a3e1fbeccb879eff8c"
+  integrity sha512-NR/RroiugrM+HN+DHIuTfaIby+xKB2ukSZpTIIRfPbDpSnn4ByPQd0DZdyrupsbcndadMYf7R21i3GZy8DENaQ==
   dependencies:
     "7zip-bin" "~5.2.0"
     "@types/debug" "^4.1.6"
-    app-builder-bin "5.0.0-alpha.7"
+    app-builder-bin "5.0.0-alpha.9"
     bluebird-lst "^1.0.9"
-    builder-util-runtime "9.2.5"
+    builder-util-runtime "9.2.9"
     chalk "^4.1.2"
     cross-spawn "^7.0.3"
     debug "^4.3.4"
     fs-extra "^10.1.0"
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.1"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.0"
     is-ci "^3.0.0"
     js-yaml "^4.1.0"
     source-map-support "^0.5.19"
@@ -7795,14 +7797,14 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dmg-builder@25.0.5:
-  version "25.0.5"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-25.0.5.tgz#e7e2731b65cf1ed43c14f2ca672e7d9a2e0234f0"
-  integrity sha512-ocnZV44ZqInoSFaY54fF7BlCtw+WtbrjyPrkBhaB+Ztn7GPKjmFgRbIKytifJ8h9Cib8jdFRMgjCUtkU45Y6DA==
+dmg-builder@25.1.5:
+  version "25.1.5"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-25.1.5.tgz#826f0c5563b0cbd47137dd0d9e6ceccf4e47f0c9"
+  integrity sha512-kPvdGQVVztIu9xiosBCQaXLhTwal2gX7qf79CgZwPyAlY3XsClaG+6Bt2fMGQ63Q/ZTojUEi8yrf0QMsZMabvA==
   dependencies:
-    app-builder-lib "25.0.5"
-    builder-util "25.0.3"
-    builder-util-runtime "9.2.5"
+    app-builder-lib "25.1.5"
+    builder-util "25.1.5"
+    builder-util-runtime "9.2.9"
     fs-extra "^10.1.0"
     iconv-lite "^0.6.2"
     js-yaml "^4.1.0"
@@ -7985,20 +7987,19 @@ ejs@^3.1.10, ejs@^3.1.7, ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@^25.0.5:
-  version "25.0.5"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-25.0.5.tgz#fed2432016618fd5ff81dc9dad7ec47889ffe0f1"
-  integrity sha512-Uj5LFRbUqNiVajsgqcwlKe+CHtwubK3hcoJsW5C2YiWodej2mmxM+LrTqga0rrWWHVMNmrcmGcS/WHpKwy6KEw==
+electron-builder@next:
+  version "25.1.5"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-25.1.5.tgz#1cb66173d39b6d07bfba33ae23db587a3f6a3549"
+  integrity sha512-XZJ/AIiFwes2XGJkewnHtOk0M19bjT8GSgeI3tyWVvI+8hdkST5JlPRYbI+5/OcYRV5EfdUowRqBxojdxwosEQ==
   dependencies:
-    app-builder-lib "25.0.5"
-    builder-util "25.0.3"
-    builder-util-runtime "9.2.5"
+    app-builder-lib "25.1.5"
+    builder-util "25.1.5"
+    builder-util-runtime "9.2.9"
     chalk "^4.1.2"
-    dmg-builder "25.0.5"
+    dmg-builder "25.1.5"
     fs-extra "^10.1.0"
     is-ci "^3.0.0"
     lazy-val "^1.0.5"
-    read-config-file "6.4.0"
     simple-update-notifier "2.0.0"
     yargs "^17.6.2"
 
@@ -8035,14 +8036,14 @@ electron-mock-ipc@^0.3.8:
   resolved "https://registry.yarnpkg.com/electron-mock-ipc/-/electron-mock-ipc-0.3.12.tgz#f9a7dca9a23a95dbe5a62f27cca12768d4cb88c0"
   integrity sha512-/uwZRpbX+k4E+GesmREg6XcQiTLNhi35M/cw8Czr+ij9k+EYTYY3UPkILnsTr5KTEeAx5/uypf/KwjZDQFDyjA==
 
-electron-publish@25.0.3:
-  version "25.0.3"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-25.0.3.tgz#63509992a5ae31bb2b0d8863b26a2f7c35e303cc"
-  integrity sha512-wSGm+TFK2lArswIFBPLuIRHbo945s3MCvG5y1xVC57zL/PsrElUkaGH2ERtRrcKNpaDNq77rDA9JnMJhAFJjUg==
+electron-publish@25.1.5:
+  version "25.1.5"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-25.1.5.tgz#b7c03f6e87568bccd17a85bfad43bd4f75ddb00d"
+  integrity sha512-P3hrxzY5ETTCn/YtepOdulAbkLdb/PD/uMMpjU9No3q8Yic5YZ3fd/fpbNGC7SV7TsQNqufNwFWGn2kLaoycJQ==
   dependencies:
     "@types/fs-extra" "^9.0.11"
-    builder-util "25.0.3"
-    builder-util-runtime "9.2.5"
+    builder-util "25.1.5"
+    builder-util-runtime "9.2.9"
     chalk "^4.1.2"
     fs-extra "^10.1.0"
     lazy-val "^1.0.5"
@@ -9896,7 +9897,7 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.5:
+https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz#9e8b5013873299e11fab6fd548405da2d6c602b2"
   integrity sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==
@@ -13896,18 +13897,6 @@ read-cmd-shim@4.0.0, read-cmd-shim@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-4.0.0.tgz#640a08b473a49043e394ae0c7a34dd822c73b9bb"
   integrity sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==
-
-read-config-file@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.4.0.tgz#970542833216cccff6b1d83320495003dcf85a45"
-  integrity sha512-uB5QOBeF84PT61GlV11OTV4jUGHAO3iDEOP6v9ygxhG6Bs9PLg7WsjNT6mtIX2G+x8lJTr4ZWNeG6LDTKkNf2Q==
-  dependencies:
-    config-file-ts "0.2.8-rc1"
-    dotenv "^16.4.5"
-    dotenv-expand "^11.0.6"
-    js-yaml "^4.1.0"
-    json5 "^2.2.3"
-    lazy-val "^1.0.5"
 
 read-package-json-fast@^3.0.0, read-package-json-fast@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Uses the electron-builder@next to fix issue like this https://github.com/electron-userland/electron-builder/issues/8503  (which produced crash on startup) which were observed in both windows and appimage installs now