### PR TITLE
Fix navigating to a refname result that is also indexed in search track index

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchResultsTable.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchResultsTable.tsx
@@ -92,13 +92,13 @@ export default function SearchResultsTable({
                 <Button
                   onClick={async () => {
                     try {
-                      const location = result.getLocation()
-                      if (location) {
-                        await handleClick(location)
-                        const resultTrackId = result.getTrackId()
-                        if (resultTrackId) {
-                          model.showTrack(resultTrackId)
-                        }
+                      await handleClick(
+                        // label is used if it is a refName, it has no location
+                        result.getLocation() || result.getLabel(),
+                      )
+                      const resultTrackId = result.getTrackId()
+                      if (resultTrackId) {
+                        model.showTrack(resultTrackId)
                       }
                     } catch (e) {
                       console.error(e)


### PR DESCRIPTION
Currently if you query the search box for a refname, you can get a situation where manually clicking on the returned search results does nothing

This PR fixes that

Fixes https://github.com/GMOD/jbrowse-components/issues/4452

Note: i'm not even attempting to document the exact data flow and reason why this PR fixes the issue at this time. This is a bit of a stop gap solution. The behavior of the search box is complex and i admittedly do not actually know the exact sequence of steps that leads to this scenario happening, a more thorough analysis could be useful, as well as for potentially refactoring the data flow of the search box