### PR TITLE
Fix highlight button causing issues clicking underlying track features

### DIFF
--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/Highlight.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/Highlight/Highlight.tsx
@@ -16,18 +16,15 @@ import { IExtendedLGV } from '../../model'
 type LGV = IExtendedLGV
 
 const useStyles = makeStyles()({
+  bookmarkButton: {
+    overflow: 'hidden',
+    position: 'absolute',
+    zIndex: 1000,
+  },
   highlight: {
-    // when the highlight is small, overflow:hidden makes the icon/indicators
-    // invisible
     overflow: 'hidden',
     height: '100%',
     position: 'absolute',
-    zIndex: 100,
-    pointerEvents: 'none',
-  },
-  highlightButton: {
-    // re-enable pointerEvents on the button
-    pointerEvents: 'auto',
   },
 })
 
@@ -69,18 +66,19 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
         })
         .filter(notEmpty)
         .map(({ left, width, highlight, label, bookmark }, idx) => (
-          <div
-            /* biome-ignore lint/suspicious/noArrayIndexKey: */
-            key={`${left}_${width}_${idx}`}
-            className={classes.highlight}
-            style={{
-              left,
-              width,
-              background: highlight,
-            }}
-          >
-            {showBookmarkLabels ? (
-              <div className={classes.highlightButton}>
+          /* biome-ignore lint/suspicious/noArrayIndexKey: */
+          <React.Fragment key={`${left}_${width}_${idx}`}>
+            <div
+              className={classes.highlight}
+              id="highlight"
+              style={{
+                left,
+                width,
+                background: highlight,
+              }}
+            />
+            {showBookmarkLabels && width > 20 ? (
+              <div className={classes.bookmarkButton} style={{ left }}>
                 <CascadingMenuButton
                   menuItems={[
                     {
@@ -111,7 +109,7 @@ const Highlight = observer(function Highlight({ model }: { model: LGV }) {
                 </CascadingMenuButton>
               </div>
             ) : null}
-          </div>
+          </React.Fragment>
         ))
     : null
 })


### PR DESCRIPTION
The bookmark highlights added a clickable button to "show bookmark widget" or "remove bookmark" recently (#4556), but it caused some minor issues interacting with the track surrounding the highlight. 

The possible cause was creating a pointerEvents:auto inside of a pointerEvents:none div. This seemed to work ok but maybe caused the weird behavior.

This PR tries to fix it by making the click button a separate div from the highlight div, so there is less reliance on this "stacking" of pointerEvents contexts.

Fixes https://github.com/GMOD/jbrowse-components/issues/4579