### PR TITLE
Add resolutionMultiplier config slot to BigWigAdapter

### DIFF
--- a/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
+++ b/plugins/wiggle/src/BigWigAdapter/BigWigAdapter.ts
@@ -78,10 +78,11 @@ export default class BigWigAdapter extends BaseFeatureDataAdapter {
     return ObservableCreate<Feature>(async observer => {
       statusCallback('Downloading bigwig data')
       const source = this.getConf('source')
+      const resolutionMultiplier = this.getConf('resolutionMultiplier')
       const { bigwig } = await this.setup(opts)
       const feats = await bigwig.getFeatures(refName, start, end, {
         ...opts,
-        basesPerSpan: bpPerPx / resolution,
+        basesPerSpan: (bpPerPx / resolution) * resolutionMultiplier,
       })
 
       for (const data of feats) {

--- a/plugins/wiggle/src/BigWigAdapter/configSchema.ts
+++ b/plugins/wiggle/src/BigWigAdapter/configSchema.ts
@@ -27,6 +27,12 @@ const BigWigAdapter = ConfigurationSchema(
       defaultValue: '',
       description: 'Used for multiwiggle',
     },
+
+    resolutionMultiplier: {
+      type: 'number',
+      defaultValue: 1,
+      description: 'Initial resolution multiplier',
+    },
   },
   { explicitlyTyped: true },
 )

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -901,6 +901,7 @@
       "category": ["SKBR3"],
       "adapter": {
         "type": "BigWigAdapter",
+        "resolutionMultiplier": 10,
         "bigWigLocation": {
           "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/reads_lr_skbr3.fa_ngmlr-0.2.3_mapped.bam.regions.bw",
           "locationType": "UriLocation"


### PR DESCRIPTION
Allows a default multiplier to adjust the initially shown resolution in bigwig files

So e.g. setting it to 10 makes it quite low resolution on a whole genome coverage bigwig file

http://jbrowse.org/code/jb2/resolution_multiplier/?config=test_data%2Fconfig_demo.json&session=share-8ItYciPZqJ&password=LsY0O


the example config
```json
    {
      "type": "QuantitativeTrack",
      "trackId": "ngmlr_cov",
      "name": "SKBR3 pacbio coverage (NGMLR)",
      "assemblyNames": ["hg19"],
      "adapter": {
        "type": "BigWigAdapter",
        "resolutionMultiplier": 10,
        "bigWigLocation": {
          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/reads_lr_skbr3.fa_ngmlr-0.2.3_mapped.bam.regions.bw"
        }
      }
    },
```

