### PR TITLE
Fix dark redraw on selected features after vertical resize of the synteny canvas

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/util.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/util.ts
@@ -128,7 +128,6 @@ export function drawBox(
   ctx.lineTo(x3, y2)
   ctx.lineTo(x4, y2)
   ctx.closePath()
-  ctx.fill()
 }
 
 export function drawBezierBox(
@@ -159,7 +158,6 @@ export function drawBezierBox(
   ctx.lineTo(x4, y2)
   ctx.bezierCurveTo(x4, mid, x1, mid, x1, y1)
   ctx.closePath()
-  ctx.fill()
 }
 
 export function onSynClick(

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
@@ -179,15 +179,18 @@ export function drawRef(
               continuingFlag = false
 
               draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
+              ctx1.fill()
               if (ctx3) {
                 ctx3.fillStyle = makeColor(idx)
                 draw(ctx3, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
+                ctx3.fill()
               }
             }
           }
         }
       } else {
         draw(ctx1, x11, x12, y1, x22, x21, y2, mid, drawCurves)
+        ctx1.fill()
       }
     }
   }

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
@@ -240,9 +240,10 @@ export function drawMouseoverSynteny(model: LinearSyntenyDisplayModel) {
   ctx.resetTransform()
   ctx.scale(highResolutionScaling, highResolutionScaling)
   ctx.clearRect(0, 0, width, height)
+  ctx.strokeStyle = 'rgba(0, 0, 0, 0.9)'
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.1)'
   const feature1 = model.featMap[mouseoverId || '']
   if (feature1) {
-    ctx.fillStyle = 'rgb(0,0,0,0.1)'
     drawMatchSimple({
       cb: ctx => {
         ctx.fill()
@@ -259,8 +260,6 @@ export function drawMouseoverSynteny(model: LinearSyntenyDisplayModel) {
   }
   const feature2 = model.featMap[clickId || '']
   if (feature2) {
-    ctx.strokeStyle = 'rgb(0, 0, 0, 0.9)'
-
     drawMatchSimple({
       cb: ctx => {
         ctx.stroke()


### PR DESCRIPTION
Fixes #4625 

the cause of the issue was the the code assumed that the "callback" ctx=>ctx.stroke() or ctx=>ctx.fill() would be the execution of the drawing operation that was performed by the drawMatchSimple, however, it internally would call drawBox or drawBeizierBox which would force a ctx.fill()

this would cause trouble when the canvas had not yet initialized a fillStyle

this PR fixes a number of things
1) restores the assumption that the drawMatchSimple execution of the drawing operation is done by the callback
2) makes sure that fillStyle is set, unneeded but this improves clarity
3) renames some variables in the rendering process, unneeded but this improves clarity