### PR TITLE
Fix config description of assembly name ordering for synteny data adapters

### DIFF
--- a/plugins/comparative-adapters/src/ChainAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/configSchema.ts
@@ -16,7 +16,7 @@ const ChainAdapter = ConfigurationSchema(
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Target is the first value in the array, query is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     },
     /**
      * #slot

--- a/plugins/comparative-adapters/src/DeltaAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/configSchema.ts
@@ -16,7 +16,7 @@ const DeltaAdapter = ConfigurationSchema(
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     },
     /**
      * #slot
@@ -41,7 +41,10 @@ const DeltaAdapter = ConfigurationSchema(
      */
     deltaLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/file.delta', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/file.delta',
+        locationType: 'UriLocation',
+      },
     },
   },
   { explicitlyTyped: true },

--- a/plugins/comparative-adapters/src/MashMapAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/configSchema.ts
@@ -15,7 +15,7 @@ const MashMapAdapter = ConfigurationSchema(
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Target is the first value in the array, query is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     },
 
     /**

--- a/plugins/comparative-adapters/src/PAFAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/configSchema.ts
@@ -15,7 +15,7 @@ const PAFAdapter = ConfigurationSchema(
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     },
     /**
      * #slot

--- a/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/configSchema.ts
@@ -16,7 +16,7 @@ const PairwiseIndexedPAFAdapter = ConfigurationSchema(
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     },
     /**
      * #slot


### PR DESCRIPTION
Noted by @garrettjstevens 

