### PR TITLE
Standardize modification colors between snpcov and pileup

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -96,7 +96,7 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
           if (!self.modificationTagMap.has(value)) {
             self.modificationTagMap.set(
               value,
-              modificationColors[value] || randomColor(),
+              modificationColors[value] || randomColor(value),
             )
           }
         })

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts
@@ -115,7 +115,7 @@ function stateModelFactory(
           if (!self.modificationTagMap.has(value)) {
             self.modificationTagMap.set(
               value,
-              modificationColors[value] || randomColor(),
+              modificationColors[value] || randomColor(value),
             )
           }
         })

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -127,7 +127,7 @@ export const modificationColors = {
   g: 'rgb(255, 160, 86)',
   e: 'rgb(141, 221, 208)',
   b: 'rgb(202, 71, 47)',
-  a: 'hsl(136.29398220333516, 50%, 50%)',
+  a: 'hsl(136, 50%, 50%)',
 } as Record<string, string>
 
 type DisplayModel = IAnyStateTreeNode & { setError: (arg: unknown) => void }
@@ -150,6 +150,13 @@ export function createAutorun(
     }, opts),
   )
 }
-export function randomColor() {
-  return `hsl(${Math.random() * 200}, 50%, 50%)`
+export function randomColor() {}
+
+function colorHash(str: string) {
+  let sum = 0
+
+  for (let i = 0; i < str.length; i++) {
+    sum += str.charCodeAt(i)
+  }
+  return `hsl(${Math.random() * sum * 100}, 50%, 50%)`
 }

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -150,13 +150,12 @@ export function createAutorun(
     }, opts),
   )
 }
-export function randomColor() {}
 
-function colorHash(str: string) {
+export function randomColor(str: string) {
   let sum = 0
 
   for (let i = 0; i < str.length; i++) {
     sum += str.charCodeAt(i)
   }
-  return `hsl(${Math.random() * sum * 100}, 50%, 50%)`
+  return `hsl(${sum * 10}, 20%, 50%)`
 }

--- a/plugins/alignments/src/util.ts
+++ b/plugins/alignments/src/util.ts
@@ -127,6 +127,7 @@ export const modificationColors = {
   g: 'rgb(255, 160, 86)',
   e: 'rgb(141, 221, 208)',
   b: 'rgb(202, 71, 47)',
+  a: 'hsl(136.29398220333516, 50%, 50%)',
 } as Record<string, string>
 
 type DisplayModel = IAnyStateTreeNode & { setError: (arg: unknown) => void }

--- a/products/jbrowse-web/src/tests/ReadVsRef.test.tsx
+++ b/products/jbrowse-web/src/tests/ReadVsRef.test.tsx
@@ -24,7 +24,7 @@ test('launch read vs ref panel', async () => {
   fireEvent.click(track[0]!, { clientX: 200, clientY: 40 })
   fireEvent.contextMenu(track[0]!, { clientX: 200, clientY: 20 })
   fireEvent.click(await findByText('Linear read vs ref', {}, delay))
-  const elt = await findByText('Submit')
+  const elt = await findByText('Submit', {}, delay)
 
   // https://stackoverflow.com/a/62443937/2129219
   await waitFor(() => {

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -4451,6 +4451,41 @@
         }
       },
       "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "AlignmentsTrack",
+      "trackId": "HG002_WGS_fiberseq.MAGEL2_2",
+      "name": "HG002_WGS_fiberseq.MAGEL2",
+      "adapter": {
+        "type": "BamAdapter",
+        "bamLocation": {
+          "uri": "https://jbrowse.org/genomes/GRCh38/HG002_WGS_fiberseq.MAGEL2.bam",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/HG002_WGS_fiberseq.MAGEL2.bam.bai",
+            "locationType": "UriLocation"
+          },
+          "indexType": "BAI"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz",
+            "locationType": "UriLocation"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai",
+            "locationType": "UriLocation"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi",
+            "locationType": "UriLocation"
+          }
+        }
+      },
+      "assemblyNames": ["hg38"]
     }
   ],
   "connections": [],


### PR DESCRIPTION
Currently 'unknown' modification types are given a random color, but it is different between top and bottom and between different runs of jbrowse

This changes it to be a deterministic random color based on the input "hash" of the string of the modification type