### PR TITLE
Fix "Add track" select box not going away after selecting element

### DIFF
--- a/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { observer } from 'mobx-react'
 import { FormControl, FormHelperText, Select, MenuItem } from '@mui/material'
 import { getEnv } from '@jbrowse/core/util'
@@ -14,12 +14,14 @@ const AddTrackSelector = observer(function ({
   model: AddTrackModel
 }) {
   const [val, setVal] = useState('Default add track workflow')
-  const { pluginManager } = getEnv(model)
-  const widgets = pluginManager.getAddTrackWorkflowElements()
   const ComponentMap = {
     'Default add track workflow': DefaultAddTrackWorkflow,
     'Add track JSON': PasteConfigWorkflow,
-    ...Object.fromEntries(widgets.map(w => [w.name, w.ReactComponent])),
+    ...Object.fromEntries(
+      getEnv(model)
+        .pluginManager.getAddTrackWorkflowElements()
+        .map(w => [w.name, w.ReactComponent]),
+    ),
   } as Record<string, React.FC<{ model: AddTrackModel }>>
 
   // make sure the selected value is in the list
@@ -43,8 +45,9 @@ const AddTrackSelector = observer(function ({
         <FormHelperText>Type of add track workflow</FormHelperText>
       </FormControl>
 
-      <br />
-      <Component model={model} />
+      <Suspense fallback={null}>
+        <Component model={model} />
+      </Suspense>
     </>
   )
 })

--- a/products/jbrowse-cli/src/commands/create.ts
+++ b/products/jbrowse-cli/src/commands/create.ts
@@ -40,7 +40,7 @@ export default class Create extends JBrowseCommand {
       description:
         'Overwrites existing JBrowse 2 installation if present in path',
     }),
-    // will need to account for pagenation once there is a lot of releases
+    // will need to account for pagination once there is a lot of releases
     listVersions: Flags.boolean({
       char: 'l',
       description: 'Lists out all versions of JBrowse 2',

--- a/products/jbrowse-cli/src/commands/upgrade.ts
+++ b/products/jbrowse-cli/src/commands/upgrade.ts
@@ -38,7 +38,7 @@ export default class Upgrade extends JBrowseCommand {
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    // will need to account for pagenation once there is a lot of releases
+    // will need to account for pagination once there is a lot of releases
     listVersions: Flags.boolean({
       char: 'l',
       description: 'Lists out all versions of JBrowse 2',


### PR DESCRIPTION
We have the concept of different types of track selectors. Currently, the select box is not dismissed properly though

This was a bit of a tricky one but it was due to not having a Suspense boundary properly wrapping the component.

Diagnosed by removing the rendering of `<Component/>`...confirmed that the behavior went away, realized it was related to rendering the `<Component/>` and that there could be a suspense boundary needed (could be interesting to dive deeper into this behavior for hobby purposes, probably it was going to a suspense boundary higher in the react tree and then the select state was sort of messed up by that somehow)