### PR TITLE
Support UCSC repeatmasker BigBed and BED files

### DIFF
--- a/packages/core/data_adapters/CytobandAdapter/CytobandAdapter.ts
+++ b/packages/core/data_adapters/CytobandAdapter/CytobandAdapter.ts
@@ -25,8 +25,9 @@ export default class CytobandAdapter extends BaseAdapter {
           refName: refName!,
           start: +start!,
           end: +end!,
-          name: name!,
-          type: type!,
+          name,
+          type,
+          gieStain: type || name,
         })
       })
   }

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1469,10 +1469,11 @@ export function isGzip(buf: Buffer) {
 }
 
 export {
+  isFeature,
   default as SimpleFeature,
   type Feature,
   type SimpleFeatureSerialized,
-  isFeature,
+  type SimpleFeatureSerializedNoId,
 } from './simpleFeature'
 
 export { blobToDataURL } from './blobToDataURL'

--- a/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
+++ b/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`adapter can fetch bed with header 1`] = `
 [
   {
+    "description": undefined,
     "end": 3009,
     "refName": "contigA",
     "score": undefined,
@@ -13,6 +14,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-0",
   },
   {
+    "description": undefined,
     "end": 3114,
     "refName": "contigA",
     "score": undefined,
@@ -23,6 +25,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-1",
   },
   {
+    "description": undefined,
     "end": 3161,
     "refName": "contigA",
     "score": undefined,
@@ -33,6 +36,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-2",
   },
   {
+    "description": undefined,
     "end": 3180,
     "refName": "contigA",
     "score": undefined,
@@ -43,6 +47,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-3",
   },
   {
+    "description": undefined,
     "end": 3183,
     "refName": "contigA",
     "score": undefined,
@@ -53,6 +58,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-4",
   },
   {
+    "description": undefined,
     "end": 3222,
     "refName": "contigA",
     "score": undefined,
@@ -63,6 +69,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-5",
   },
   {
+    "description": undefined,
     "end": 3474,
     "refName": "contigA",
     "score": undefined,
@@ -73,6 +80,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-6",
   },
   {
+    "description": undefined,
     "end": 3804,
     "refName": "contigA",
     "score": undefined,
@@ -83,6 +91,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-7",
   },
   {
+    "description": undefined,
     "end": 4044,
     "refName": "contigA",
     "score": undefined,
@@ -93,6 +102,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-contigA-8",
   },
   {
+    "description": undefined,
     "end": 4082,
     "refName": "contigA",
     "score": undefined,
@@ -125,6 +135,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
     "days_to_death": "--",
     "dbSNP_RS": "novel",
     "dbSNP_Val_Status": "",
+    "description": undefined,
     "end": 10,
     "ethnicity": "not hispanic or latino",
     "freq": "0.0108695652174",
@@ -160,6 +171,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
 exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
 [
   {
+    "description": undefined,
     "end": 3009,
     "refName": "contigA",
     "score": undefined,
@@ -170,6 +182,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-0",
   },
   {
+    "description": undefined,
     "end": 3114,
     "refName": "contigA",
     "score": undefined,
@@ -180,6 +193,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-1",
   },
   {
+    "description": undefined,
     "end": 3161,
     "refName": "contigA",
     "score": undefined,
@@ -190,6 +204,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-2",
   },
   {
+    "description": undefined,
     "end": 3180,
     "refName": "contigA",
     "score": undefined,
@@ -200,6 +215,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-3",
   },
   {
+    "description": undefined,
     "end": 3183,
     "refName": "contigA",
     "score": undefined,
@@ -210,6 +226,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-4",
   },
   {
+    "description": undefined,
     "end": 3222,
     "refName": "contigA",
     "score": undefined,
@@ -220,6 +237,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-5",
   },
   {
+    "description": undefined,
     "end": 3474,
     "refName": "contigA",
     "score": undefined,
@@ -230,6 +248,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-6",
   },
   {
+    "description": undefined,
     "end": 3804,
     "refName": "contigA",
     "score": undefined,
@@ -240,6 +259,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-7",
   },
   {
+    "description": undefined,
     "end": 4044,
     "refName": "contigA",
     "score": undefined,
@@ -250,6 +270,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
     "uniqueId": "test-contigA-8",
   },
   {
+    "description": undefined,
     "end": 4082,
     "refName": "contigA",
     "score": undefined,
@@ -265,6 +286,7 @@ exports[`adapter can fetch features from volvox.sort.bed simple bed3 1`] = `
 exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
 [
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.1",
@@ -332,6 +354,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
     "uniqueId": "test-ctgA-0",
   },
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.2",
@@ -390,6 +413,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
     "uniqueId": "test-ctgA-1",
   },
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.3",
@@ -457,6 +481,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
     "uniqueId": "test-ctgA-2",
   },
   {
+    "description": undefined,
     "end": 23000,
     "itemRgb": "0,0,0",
     "name": "rna-Apple3",

--- a/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
+++ b/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`adapter can fetch bed with header 1`] = `
 [
   {
+    "description": undefined,
     "end": 3009,
     "refName": "contigA",
     "score": undefined,
@@ -13,6 +14,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163099",
   },
   {
+    "description": undefined,
     "end": 3114,
     "refName": "contigA",
     "score": undefined,
@@ -23,6 +25,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163117",
   },
   {
+    "description": undefined,
     "end": 3161,
     "refName": "contigA",
     "score": undefined,
@@ -33,6 +36,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163135",
   },
   {
+    "description": undefined,
     "end": 3180,
     "refName": "contigA",
     "score": undefined,
@@ -43,6 +47,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163153",
   },
   {
+    "description": undefined,
     "end": 3183,
     "refName": "contigA",
     "score": undefined,
@@ -53,6 +58,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163171",
   },
   {
+    "description": undefined,
     "end": 3222,
     "refName": "contigA",
     "score": undefined,
@@ -63,6 +69,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163189",
   },
   {
+    "description": undefined,
     "end": 3474,
     "refName": "contigA",
     "score": undefined,
@@ -73,6 +80,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163207",
   },
   {
+    "description": undefined,
     "end": 3804,
     "refName": "contigA",
     "score": undefined,
@@ -83,6 +91,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163225",
   },
   {
+    "description": undefined,
     "end": 4044,
     "refName": "contigA",
     "score": undefined,
@@ -93,6 +102,7 @@ exports[`adapter can fetch bed with header 1`] = `
     "uniqueId": "test-163243",
   },
   {
+    "description": undefined,
     "end": 4082,
     "refName": "contigA",
     "score": undefined,
@@ -125,6 +135,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
     "days_to_death": "--",
     "dbSNP_RS": "novel",
     "dbSNP_Val_Status": "",
+    "description": undefined,
     "end": 10,
     "ethnicity": "not hispanic or latino",
     "freq": "0.0108695652174",
@@ -160,6 +171,7 @@ exports[`adapter can fetch features bed with autosql 1`] = `
 exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
 [
   {
+    "description": undefined,
     "end": 3009,
     "refName": "contigA",
     "score": undefined,
@@ -170,6 +182,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155163",
   },
   {
+    "description": undefined,
     "end": 3114,
     "refName": "contigA",
     "score": undefined,
@@ -180,6 +193,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155181",
   },
   {
+    "description": undefined,
     "end": 3161,
     "refName": "contigA",
     "score": undefined,
@@ -190,6 +204,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155199",
   },
   {
+    "description": undefined,
     "end": 3180,
     "refName": "contigA",
     "score": undefined,
@@ -200,6 +215,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155217",
   },
   {
+    "description": undefined,
     "end": 3183,
     "refName": "contigA",
     "score": undefined,
@@ -210,6 +226,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155235",
   },
   {
+    "description": undefined,
     "end": 3222,
     "refName": "contigA",
     "score": undefined,
@@ -220,6 +237,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155253",
   },
   {
+    "description": undefined,
     "end": 3474,
     "refName": "contigA",
     "score": undefined,
@@ -230,6 +248,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155271",
   },
   {
+    "description": undefined,
     "end": 3804,
     "refName": "contigA",
     "score": undefined,
@@ -240,6 +259,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155289",
   },
   {
+    "description": undefined,
     "end": 4044,
     "refName": "contigA",
     "score": undefined,
@@ -250,6 +270,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
     "uniqueId": "test-155307",
   },
   {
+    "description": undefined,
     "end": 4082,
     "refName": "contigA",
     "score": undefined,
@@ -265,6 +286,7 @@ exports[`adapter can fetch features from volvox.sort.bed.gz simple bed3 1`] = `
 exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
 [
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.1",
@@ -332,6 +354,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
     "uniqueId": "test-45690",
   },
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.2",
@@ -390,6 +413,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
     "uniqueId": "test-45787",
   },
   {
+    "description": undefined,
     "end": 9000,
     "itemRgb": "0,0,0",
     "name": "EDEN.3",
@@ -457,6 +481,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
     "uniqueId": "test-45875",
   },
   {
+    "description": undefined,
     "end": 23000,
     "itemRgb": "0,0,0",
     "name": "rna-Apple3",

--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -21,6 +21,7 @@ import { Observer } from 'rxjs'
 import {
   isUcscProcessedTranscript,
   ucscProcessedTranscript,
+  makeRepeatTrackDescription,
   makeBlocks,
   arrayify,
 } from '../util'
@@ -154,6 +155,7 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
         chrom,
         chromStart,
         chromEnd,
+        description,
         chromStarts: chromStarts2,
         blockStarts: blockStarts2,
         blockSizes: blockSizes2,
@@ -184,6 +186,7 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
           strand,
           blockCount,
           thickStart,
+          description,
         })
       ) {
         const f = ucscProcessedTranscript({
@@ -195,6 +198,7 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
           end: feat.end,
           refName: query.refName,
           score,
+          description,
           chromStarts: chromStarts!,
           blockSizes: blockSizes!,
           blockCount,
@@ -214,7 +218,10 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
             )
           ) {
             observer.next(
-              new SimpleFeature({ id: `${this.id}-${uniqueId}`, data: f }),
+              new SimpleFeature({
+                id: `${this.id}-${uniqueId}`,
+                data: f,
+              }),
             )
           }
         }
@@ -232,6 +239,7 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
               id: `${this.id}-${uniqueId}`,
               data: {
                 ...rest,
+                ...makeRepeatTrackDescription(description),
                 start: feat.start,
                 end: feat.end,
                 strand,

--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -13,19 +13,20 @@ import {
   min,
   Feature,
   SimpleFeature,
+  SimpleFeatureSerializedNoId,
 } from '@jbrowse/core/util'
 import { Observer } from 'rxjs'
-import { SimpleFeatureSerializedNoId } from '@jbrowse/core/util/simpleFeature'
 
 // locals
 import {
   isUcscProcessedTranscript,
-  makeBlocks,
   ucscProcessedTranscript,
+  makeBlocks,
+  arrayify,
 } from '../util'
 
 export default class BigBedAdapter extends BaseFeatureDataAdapter {
-  private cached?: Promise<{
+  private cachedP?: Promise<{
     bigbed: BigBed
     header: Awaited<ReturnType<BigBed['getHeader']>>
     parser: BED
@@ -37,18 +38,24 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
       filehandle: openLocation(this.getConf('bigBedLocation'), pm),
     })
     const header = await bigbed.getHeader(opts)
-    const parser = new BED({ autoSql: header.autoSql })
-    return { bigbed, header, parser }
+    const parser = new BED({
+      autoSql: header.autoSql,
+    })
+    return {
+      bigbed,
+      header,
+      parser,
+    }
   }
 
   public async configure(opts?: BaseOptions) {
-    if (!this.cached) {
-      this.cached = this.configurePre(opts).catch((e: unknown) => {
-        this.cached = undefined
+    if (!this.cachedP) {
+      this.cachedP = this.configurePre(opts).catch((e: unknown) => {
+        this.cachedP = undefined
         throw e
       })
     }
-    return this.cached
+    return this.cachedP
   }
 
   public async getRefNames(opts?: BaseOptions) {
@@ -70,13 +77,19 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
     }
   }
 
-  public async getFeaturesHelper(
-    query: Region,
-    opts: BaseOptions,
-    observer: Observer<Feature>,
-    allowRedispatch: boolean,
+  public async getFeaturesHelper({
+    query,
+    opts,
+    observer,
+    allowRedispatch,
     originalQuery = query,
-  ) {
+  }: {
+    query: Region
+    opts: BaseOptions
+    observer: Observer<Feature>
+    allowRedispatch: boolean
+    originalQuery?: Region
+  }) {
     const { signal } = opts
     const scoreColumn = this.getConf('scoreColumn')
     const aggregateField = this.getConf('aggregateField')
@@ -102,13 +115,17 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
         }
       }
       if (maxEnd > query.end || minStart < query.start) {
-        await this.getFeaturesHelper(
-          { ...query, start: minStart, end: maxEnd },
+        await this.getFeaturesHelper({
+          query: {
+            ...query,
+            start: minStart,
+            end: maxEnd,
+          },
           opts,
           observer,
-          false,
-          query,
-        )
+          allowRedispatch: false,
+          originalQuery: query,
+        })
         return
       }
     }
@@ -134,43 +151,53 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
       const {
         uniqueId,
         type,
+        chrom,
         chromStart,
-        chromStarts,
-        blockStarts,
-        blockCount,
-        blockSizes,
         chromEnd,
+        chromStarts: chromStarts2,
+        blockStarts: blockStarts2,
+        blockSizes: blockSizes2,
+        score: score2,
+        blockCount,
         thickStart,
         thickEnd,
-        chrom,
-        score,
+        strand,
         ...rest
       } = data
+      const chromStarts = arrayify(chromStarts2)
+      const blockStarts = arrayify(blockStarts2)
+      const blockSizes = arrayify(blockSizes2)
+      const score = scoreColumn ? +data[scoreColumn] : +score2
 
-      const subfeatures = blockCount
-        ? makeBlocks({
-            chromStarts,
-            blockStarts,
-            blockCount,
-            blockSizes,
-            uniqueId,
-            refName: query.refName,
-            start: feat.start,
-          })
-        : []
+      const subfeatures = makeBlocks({
+        chromStarts,
+        blockStarts,
+        blockSizes,
+        blockCount,
+        uniqueId,
+        refName: query.refName,
+        start: feat.start,
+      })
 
-      if (isUcscProcessedTranscript(data)) {
+      if (
+        isUcscProcessedTranscript({
+          strand,
+          blockCount,
+          thickStart,
+        })
+      ) {
         const f = ucscProcessedTranscript({
           ...rest,
+          strand,
           uniqueId,
           type,
           start: feat.start,
           end: feat.end,
           refName: query.refName,
-          score: scoreColumn ? +data[scoreColumn] : score,
-          chromStarts,
+          score,
+          chromStarts: chromStarts!,
+          blockSizes: blockSizes!,
           blockCount,
-          blockSizes,
           thickStart,
           thickEnd,
           subfeatures,
@@ -205,11 +232,12 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
               id: `${this.id}-${uniqueId}`,
               data: {
                 ...rest,
+                start: feat.start,
+                end: feat.end,
+                strand,
                 uniqueId,
                 type,
-                start: feat.start,
-                score: scoreColumn ? +data[scoreColumn] : score,
-                end: feat.end,
+                score,
                 refName: query.refName,
                 subfeatures,
               },
@@ -245,7 +273,12 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
   public getFeatures(query: Region, opts: BaseOptions = {}) {
     return ObservableCreate<Feature>(async observer => {
       try {
-        await this.getFeaturesHelper(query, opts, observer, true)
+        await this.getFeaturesHelper({
+          query,
+          opts,
+          observer,
+          allowRedispatch: true,
+        })
       } catch (e) {
         observer.error(e)
       }

--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -15,7 +15,7 @@ import {
   SimpleFeature,
   SimpleFeatureSerializedNoId,
 } from '@jbrowse/core/util'
-import { Observer } from 'rxjs'
+import { firstValueFrom, Observer, toArray } from 'rxjs'
 
 // locals
 import {
@@ -62,6 +62,23 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
   public async getRefNames(opts?: BaseOptions) {
     const { header } = await this.configure(opts)
     return Object.keys(header.refsByName)
+  }
+
+  public async getData() {
+    const refNames = await this.getRefNames()
+    const features = []
+    for (const refName of refNames) {
+      const f = await firstValueFrom(
+        this.getFeatures({
+          assemblyName: 'unknown',
+          refName,
+          start: 0,
+          end: Number.MAX_SAFE_INTEGER,
+        }).pipe(toArray()),
+      )
+      features.push(f)
+    }
+    return features.flat()
   }
 
   async getHeader(opts?: BaseOptions) {

--- a/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
+++ b/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
@@ -10,6 +10,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
     "strand": 1,
     "subfeatures": [
       {
+        "description": undefined,
         "end": 9000,
         "geneBioType": "-",
         "geneId": "EDEN",
@@ -83,6 +84,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
         "uniqueId": "bb-358912",
       },
       {
+        "description": undefined,
         "end": 9000,
         "geneBioType": "-",
         "geneId": "EDEN",
@@ -147,6 +149,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
         "uniqueId": "bb-359006",
       },
       {
+        "description": undefined,
         "end": 9000,
         "geneBioType": "-",
         "geneId": "EDEN",
@@ -231,6 +234,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
     "strand": 1,
     "subfeatures": [
       {
+        "description": undefined,
         "end": 23000,
         "geneBioType": "-",
         "geneId": "rna-Apple3",

--- a/plugins/bed/src/util.ts
+++ b/plugins/bed/src/util.ts
@@ -232,7 +232,7 @@ export function featureData(
   const start = +l[colStart]!
   const colSame = colStart === colEnd ? 1 : 0
   const end = +l[colEnd]! + colSame
-  const score = scoreColumn ? +data[scoreColumn] : +score2
+  const score = scoreColumn ? +data[scoreColumn] : score2 ? +score2 : undefined
   const strand =
     typeof strand2 === 'string'
       ? strand2 === '-'

--- a/plugins/bed/src/util.ts
+++ b/plugins/bed/src/util.ts
@@ -19,8 +19,6 @@ export interface TranscriptFeat extends MinimalFeature {
   subfeatures: MinimalFeature[]
 }
 
-const SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS = 15
-
 export function ucscProcessedTranscript(feature: TranscriptFeat) {
   const {
     subfeatures: oldSubfeatures,
@@ -299,8 +297,7 @@ export function isUcscProcessedTranscript({
     thickStart &&
     blockCount &&
     strand !== 0 &&
-    description?.trim().split(' ').length !==
-      SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS
+    !isRepeatMaskerDescriptionField(description)
   )
 }
 
@@ -312,11 +309,16 @@ export function arrayify(f?: string | number[]) {
     : undefined
 }
 
+function isRepeatMaskerDescriptionField(
+  description?: string,
+): description is string {
+  const ret = description?.trim().split(' ')
+  return [0, 1, 2, 3, 5, 6].every(s =>
+    ret?.[s] !== undefined ? !Number.isNaN(+ret[s]) : false,
+  )
+}
 export function makeRepeatTrackDescription(description?: string) {
-  if (
-    description?.trim().split(' ').length ===
-    SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS
-  ) {
+  if (isRepeatMaskerDescriptionField(description)) {
     const [
       bitsw_score,
       percent_div,

--- a/plugins/bed/src/util.ts
+++ b/plugins/bed/src/util.ts
@@ -19,6 +19,8 @@ export interface TranscriptFeat extends MinimalFeature {
   subfeatures: MinimalFeature[]
 }
 
+const SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS = 15
+
 export function ucscProcessedTranscript(feature: TranscriptFeat) {
   const {
     subfeatures: oldSubfeatures,
@@ -219,6 +221,7 @@ export function featureData(
     thickStart,
     thickEnd,
     type,
+    description,
     strand: strand2,
     score: score2,
     chrom: _1,
@@ -243,6 +246,7 @@ export function featureData(
 
   const f = {
     ...rest,
+    ...makeRepeatTrackDescription(description),
     type,
     score,
     start,
@@ -266,6 +270,7 @@ export function featureData(
       strand,
       blockCount,
       thickStart,
+      description,
     })
       ? ucscProcessedTranscript({
           thickStart: thickStart!,
@@ -283,12 +288,20 @@ export function isUcscProcessedTranscript({
   thickStart,
   blockCount,
   strand,
+  description,
 }: {
   thickStart?: number
   blockCount?: number
   strand?: number
+  description?: string
 }) {
-  return thickStart && blockCount && strand !== 0
+  return (
+    thickStart &&
+    blockCount &&
+    strand !== 0 &&
+    description?.trim().split(' ').length !==
+      SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS
+  )
 }
 
 export function arrayify(f?: string | number[]) {
@@ -297,4 +310,47 @@ export function arrayify(f?: string | number[]) {
       ? f.split(',').map(f => +f)
       : f
     : undefined
+}
+
+export function makeRepeatTrackDescription(description?: string) {
+  if (
+    description?.trim().split(' ').length ===
+    SPECIFIC_LENGTH_OF_REPEAT_MASKER_DESCRIPTION_FIELDS
+  ) {
+    const [
+      bitsw_score,
+      percent_div,
+      percent_del,
+      percent_ins,
+      query_chr,
+      query_begin,
+      query_end,
+      query_remaining,
+      orientation,
+      matching_repeat_name,
+      matching_repeat_class,
+      matching_repeat_begin,
+      matching_repeat_end,
+      matching_repeat_remaining,
+      repeat_id,
+    ] = description.trim().split(' ')
+    return {
+      bitsw_score,
+      percent_div,
+      percent_del,
+      percent_ins,
+      query_chr,
+      query_begin,
+      query_end,
+      query_remaining,
+      orientation,
+      matching_repeat_name,
+      matching_repeat_class,
+      matching_repeat_begin,
+      matching_repeat_end,
+      matching_repeat_remaining,
+      repeat_id,
+    }
+  }
+  return { description }
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -70,7 +70,7 @@ export function getCytobands(assembly: Assembly | undefined, refName: string) {
           assembly.getCanonicalRefName(f.get('refName')) || f.get('refName'),
         start: f.get('start'),
         end: f.get('end'),
-        type: f.get('type') as string,
+        type: f.get('gieStain') as string,
       }))
       .filter(f => f.refName === refName) || []
   )

--- a/products/jbrowse-cli/README.md
+++ b/products/jbrowse-cli/README.md
@@ -57,6 +57,7 @@ It is likely preferable in most cases to install the tools globally with
 - [`jbrowse make-pif FILE`](#jbrowse-make-pif-file)
 - [`jbrowse remove-track TRACK`](#jbrowse-remove-track-track)
 - [`jbrowse set-default-session`](#jbrowse-set-default-session)
+- [`jbrowse sort-bed FILE`](#jbrowse-sort-bed-file)
 - [`jbrowse sort-gff FILE`](#jbrowse-sort-gff-file)
 - [`jbrowse text-index`](#jbrowse-text-index)
 - [`jbrowse upgrade [LOCALPATH]`](#jbrowse-upgrade-localpath)
@@ -578,6 +579,37 @@ EXAMPLES
 
 _See code:
 [src/commands/set-default-session.ts](https://github.com/GMOD/jbrowse-components/blob/v2.16.1/products/jbrowse-cli/src/commands/set-default-session.ts)_
+
+## `jbrowse sort-bed FILE`
+
+Helper utility to sort GFF files for tabix. Moves all lines starting with # to
+the top of the file, and sort by refname and start position using unix utilities
+sort and grep
+
+```
+USAGE
+  $ jbrowse sort-bed FILE [-h]
+
+ARGUMENTS
+  FILE  GFF file
+
+FLAGS
+  -h, --help  Show CLI help.
+
+DESCRIPTION
+  Helper utility to sort GFF files for tabix. Moves all lines starting with # to the top of the file, and sort by
+  refname and start position using unix utilities sort and grep
+
+EXAMPLES
+  # sort gff and pipe to bgzip
+
+  $ jbrowse sort-gff input.gff | bgzip > sorted.gff.gz
+
+  $ tabix sorted.gff.gz
+```
+
+_See code:
+[src/commands/sort-bed.ts](https://github.com/GMOD/jbrowse-components/blob/v2.16.1/products/jbrowse-cli/src/commands/sort-bed.ts)_
 
 ## `jbrowse sort-gff FILE`
 

--- a/products/jbrowse-cli/src/commands/sort-bed.ts
+++ b/products/jbrowse-cli/src/commands/sort-bed.ts
@@ -1,0 +1,56 @@
+import { Args, Flags } from '@oclif/core'
+import { sync as commandExistsSync } from 'command-exists'
+
+import { spawn } from 'child_process'
+import JBrowseCommand from '../base'
+
+export default class SortGff extends JBrowseCommand {
+  static description =
+    'Helper utility to sort GFF files for tabix. Moves all lines starting with # to the top of the file, and sort by refname and start position using unix utilities sort and grep'
+
+  static examples = [
+    '# sort gff and pipe to bgzip',
+    '$ jbrowse sort-gff input.gff | bgzip > sorted.gff.gz',
+    '$ tabix sorted.gff.gz',
+  ]
+
+  static args = {
+    file: Args.string({
+      required: true,
+      description: 'GFF file',
+    }),
+  }
+
+  static flags = {
+    help: Flags.help({ char: 'h' }),
+  }
+
+  async run() {
+    const {
+      args: { file },
+    } = await this.parse(SortGff)
+
+    if (
+      commandExistsSync('sh') &&
+      commandExistsSync('sort') &&
+      commandExistsSync('grep')
+    ) {
+      // this command comes from the tabix docs http://www.htslib.org/doc/tabix.html
+      spawn(
+        'sh',
+        [
+          '-c',
+          `(grep "^#" "${file}"; grep -v "^#" "${file}" | sort -t"\`printf '\t'\`" -k1,1 -k2,2n)`,
+        ],
+        {
+          env: { ...process.env, LC_ALL: 'C' },
+          stdio: 'inherit',
+        },
+      )
+    } else {
+      throw new Error(
+        'Unable to sort, requires unix type environment with sort, grep',
+      )
+    }
+  }
+}

--- a/test_data/hs1.json
+++ b/test_data/hs1.json
@@ -1,0 +1,62 @@
+{
+  "assemblies": [
+    {
+      "name": "hs1",
+      "displayName": "Homo sapiens (hs1/T2T-CHM13v2.0)",
+      "sequence": {
+        "type": "ReferenceSequenceTrack",
+        "trackId": "hs1-reference",
+        "adapter": {
+          "type": "TwoBitAdapter",
+          "twoBitLocation": {
+            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hs1/bigZips/hs1.2bit",
+            "locationType": "UriLocation"
+          },
+          "chromSizesLocation": {
+            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hs1/bigZips/hs1.chrom.sizes.txt",
+            "locationType": "UriLocation"
+          }
+        }
+      },
+      "refNameAliases": {
+        "adapter": {
+          "type": "RefNameAliasAdapter",
+          "location": {
+            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hs1/bigZips/hs1.chromAlias.txt",
+            "locationType": "UriLocation"
+          }
+        }
+      },
+      "cytobands": {
+        "adapter": {
+          "type": "BigBedAdapter",
+          "bigBedLocation": {
+            "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hs1/cytoBandMapped/cytoBandMapped.bb"
+          }
+        }
+      }
+    }
+  ],
+  "tracks": [
+    {
+      "type": "FeatureTrack",
+      "trackId": "RepeatMasker.sorted.bed",
+      "name": "RepeatMasker.sorted.bed",
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "RepeatMasker.sorted.bed.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "RepeatMasker.sorted.bed.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    }
+  ]
+}

--- a/test_data/hs1.json
+++ b/test_data/hs1.json
@@ -45,12 +45,12 @@
       "adapter": {
         "type": "BedTabixAdapter",
         "bedGzLocation": {
-          "uri": "RepeatMasker.sorted.bed.gz",
+          "uri": "https://jbrowse.org/genomes/hs1/RepeatMasker.sorted.bed.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "RepeatMasker.sorted.bed.gz.tbi",
+            "uri": "https://jbrowse.org/genomes/hs1/RepeatMasker.sorted.bed.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"


### PR DESCRIPTION
UCSC RepeatMasker BED files have extended fields which are somewhat complicated

This PR fixes the rendering of repeatmasker BED, BEDTabix, and BigBed files from UCSC with full fields

Example here https://hgdownload.soe.ucsc.edu/gbdb/hs1/t2tRepeatMasker/


See the "Full mode visualization" which shows, at least from the UCSC UI perspective, how complex these data are...https://genome.ucsc.edu/cgi-bin/hgTrackUi?hgsid=2372603109_AcR4Yt0XayFS0KE6hJ1sksSrAkTv&db=hub_3671779_hs1&c=chr1&g=hub_3671779_t2tRepeatMasker


In the data format, they re-use UCSC specific BED fields and specifically troublesome is they make negative valued blockSizes to indicate unaligned regions. This caused JBrowse to create negative length SimpleFeature's which crashes the track (we just don't allow negative size features, probably best to not change that)

This fixes it by filtering out the negative size features, and also does some heuristics to check if the track is a repeatmasker track to avoid it being inferred to be a "ProcessedTranscript" (it is hard to exactly tell since RepeatMasker uses thickStart,thickEnd, blockSizes, etc. this new heuristic is that description.split(' ').length == 15. hacky, but it is otherwise hard to tell)

