### PR TITLE
Delay cascading menu closing after mouseout

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -24,6 +24,7 @@ import TrackLabelDragHandle from './TrackLabelDragHandle'
 
 const useStyles = makeStyles()(theme => ({
   root: {
+    zIndex: 1000,
     background: alpha(theme.palette.background.paper, 0.8),
     '&:hover': {
       background: theme.palette.background.paper,
@@ -51,66 +52,7 @@ const TrackLabel = observer(
   ) {
     const { classes, cx } = useStyles()
     const view = getContainingView(track) as LGV
-    const session = getSession(track)
-    const trackConf = track.configuration
-    const minimized = track.minimized
     const trackId = getConf(track, 'trackId')
-    const trackName = getTrackName(trackConf, session)
-    const items = [
-      {
-        label: 'Track order',
-        type: 'subMenu',
-        priority: 2000,
-        subMenu: [
-          {
-            label: minimized ? 'Restore track' : 'Minimize track',
-            icon: minimized ? AddIcon : MinimizeIcon,
-            onClick: () => {
-              track.setMinimized(!minimized)
-            },
-          },
-          ...(view.tracks.length > 2
-            ? [
-                {
-                  label: 'Move track to top',
-                  icon: KeyboardDoubleArrowUpIcon,
-                  onClick: () => {
-                    view.moveTrackToTop(track.id)
-                  },
-                },
-              ]
-            : []),
-
-          {
-            label: 'Move track up',
-            icon: KeyboardArrowUpIcon,
-            onClick: () => {
-              view.moveTrackUp(track.id)
-            },
-          },
-          {
-            label: 'Move track down',
-            icon: KeyboardArrowDownIcon,
-            onClick: () => {
-              view.moveTrackDown(track.id)
-            },
-          },
-          ...(view.tracks.length > 2
-            ? [
-                {
-                  label: 'Move track to bottom',
-                  icon: KeyboardDoubleArrowDownIcon,
-                  onClick: () => {
-                    view.moveTrackToBottom(track.id)
-                  },
-                },
-              ]
-            : []),
-        ],
-      },
-      ...(session.getTrackActionMenuItems?.(trackConf) || []),
-      ...track.trackMenuItems(),
-    ].sort((a, b) => (b?.priority || 0) - (a?.priority || 0))
 
     return (
       <Paper ref={ref} className={cx(className, classes.root)}>
@@ -122,29 +64,113 @@ const TrackLabel = observer(
         >
           <CloseIcon fontSize="small" />
         </IconButton>
-
-        <Typography
-          variant="body1"
-          component="span"
-          className={classes.trackName}
-          onMouseDown={event => {
-            // avoid becoming a click-and-drag action on the lgv
-            event.stopPropagation()
-          }}
-        >
-          <SanitizedHTML
-            html={[trackName, minimized ? '(minimized)' : '']
-              .filter(f => !!f)
-              .join(' ')}
-          />
-        </Typography>
-
-        <CascadingMenuButton menuItems={items} data-testid="track_menu_icon">
-          <MoreVertIcon fontSize="small" />
-        </CascadingMenuButton>
+        <TrackLabelTypography track={track} />
+        <TrackLabelMenu track={track} />
       </Paper>
     )
   }),
 )
+
+const TrackLabelTypography = observer(function ({
+  track,
+}: {
+  track: BaseTrackModel
+}) {
+  const { classes } = useStyles()
+  const session = getSession(track)
+  const trackConf = track.configuration
+  const minimized = track.minimized
+  const trackName = getTrackName(trackConf, session)
+  return (
+    <Typography
+      variant="body1"
+      component="span"
+      className={classes.trackName}
+      onMouseDown={event => {
+        // avoid becoming a click-and-drag action on the lgv
+        event.stopPropagation()
+      }}
+    >
+      <SanitizedHTML
+        html={[trackName, minimized ? '(minimized)' : '']
+          .filter(f => !!f)
+          .join(' ')}
+      />
+    </Typography>
+  )
+})
+
+const TrackLabelMenu = observer(function ({
+  track,
+}: {
+  track: BaseTrackModel
+}) {
+  const view = getContainingView(track) as LGV
+  const session = getSession(track)
+  const minimized = track.minimized
+  const trackConf = track.configuration
+  return (
+    <CascadingMenuButton
+      menuItems={[
+        {
+          label: 'Track order',
+          type: 'subMenu',
+          priority: 2000,
+          subMenu: [
+            {
+              label: minimized ? 'Restore track' : 'Minimize track',
+              icon: minimized ? AddIcon : MinimizeIcon,
+              onClick: () => {
+                track.setMinimized(!minimized)
+              },
+            },
+            ...(view.tracks.length > 2
+              ? [
+                  {
+                    label: 'Move track to top',
+                    icon: KeyboardDoubleArrowUpIcon,
+                    onClick: () => {
+                      view.moveTrackToTop(track.id)
+                    },
+                  },
+                ]
+              : []),
+
+            {
+              label: 'Move track up',
+              icon: KeyboardArrowUpIcon,
+              onClick: () => {
+                view.moveTrackUp(track.id)
+              },
+            },
+            {
+              label: 'Move track down',
+              icon: KeyboardArrowDownIcon,
+              onClick: () => {
+                view.moveTrackDown(track.id)
+              },
+            },
+            ...(view.tracks.length > 2
+              ? [
+                  {
+                    label: 'Move track to bottom',
+                    icon: KeyboardDoubleArrowDownIcon,
+                    onClick: () => {
+                      view.moveTrackToBottom(track.id)
+                    },
+                  },
+                ]
+              : []),
+          ],
+        },
+        ...(session.getTrackActionMenuItems?.(trackConf) || []),
+        ...track.trackMenuItems(),
+      ].sort((a, b) => (b?.priority || 0) - (a?.priority || 0))}
+      data-testid="track_menu_icon"
+    >
+      <MoreVertIcon fontSize="small" />
+    </CascadingMenuButton>
+  )
+})
 
 export default TrackLabel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -422,7 +422,7 @@ exports[`renders one track, one region 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-8osoox-MuiPaper-root-root"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-166mc98-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-9obt5s-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span
@@ -1215,7 +1215,7 @@ exports[`renders two tracks, two regions 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-8osoox-MuiPaper-root-root"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-166mc98-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-9obt5s-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span
@@ -1338,7 +1338,7 @@ exports[`renders two tracks, two regions 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-8osoox-MuiPaper-root-root"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-166mc98-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-9obt5s-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -904,7 +904,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-8osoox-MuiPaper-root-root"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1eqvr2m-MuiPaper-root-trackLabel-trackLabelOffset-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-15kbsoo-MuiPaper-root-trackLabel-trackLabelOffset-root"
                   style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
                 >
                   <span


### PR DESCRIPTION
Currently, while opening a cascading menu (e.g. a popover menu with multiple sub-menus), if they mouseover for even a split second the whole menu closes. 

This PR debounces the menu "isOpen" state so if their mouse strays outside the boundaries of the menu, it doesn't immediately close