### PR TITLE
Remove mouseover pixelation

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/LinearSyntenyRendering.tsx
@@ -26,7 +26,6 @@ const useStyles = makeStyles()({
     position: 'relative',
   },
   mouseoverCanvas: {
-    imageRendering: 'pixelated',
     position: 'absolute',
     pointEvents: 'none',
   },


### PR DESCRIPTION
Currently the mouseover canvas is pixelated due to css style for pixelated being set on it accidentally. The pixelated setting actually is intended for the 'mouseover detection' canvas, not the canvas that displays the mouseover