### PR TITLE
Reduce re-rendering on quantitative and snpcoverage track height adjustments (pt. 2)

### DIFF
--- a/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
+++ b/packages/core/pluggableElementTypes/models/BaseDisplayModel.tsx
@@ -17,14 +17,17 @@ function stateModelFactory() {
     .model('BaseDisplay', {
       /**
        * #property
+       * corresponds to a displayId
        */
       id: ElementId,
       /**
        * #property
+       * display type
        */
       type: types.string,
       /**
        * #property
+       * RPC driver
        */
       rpcDriverName: types.maybe(types.string),
     })
@@ -36,6 +39,7 @@ function stateModelFactory() {
     .views(self => ({
       /**
        * #getter
+       * the component that contains the rendered content
        */
       get RenderingComponent(): React.FC<{
         model: typeof self
@@ -53,8 +57,10 @@ function stateModelFactory() {
 
       /**
        * #getter
+       * a component to display a 'blurb' of information (docked bottom left of
+       * track)
        */
-      get DisplayBlurb(): React.FC<{ model: typeof self }> | null {
+      get DisplayBlurb(): React.FC<any> | null {
         return null
       },
 

--- a/packages/core/util/stats.ts
+++ b/packages/core/util/stats.ts
@@ -14,6 +14,7 @@ export interface UnrectifiedQuantitativeStats {
   basesCovered: number
 }
 export interface QuantitativeStats extends UnrectifiedQuantitativeStats {
+  currStatsRegions: string
   currStatsBpPerPx: number
   featureDensity: number
   scoreMean: number

--- a/packages/core/util/stats.ts
+++ b/packages/core/util/stats.ts
@@ -15,7 +15,6 @@ export interface UnrectifiedQuantitativeStats {
 }
 export interface QuantitativeStats extends UnrectifiedQuantitativeStats {
   currStatsRegions: string
-  currStatsBpPerPx: number
   featureDensity: number
   scoreMean: number
   scoreStdDev: number

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -75,20 +75,25 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
     .volatile(() => ({
       /**
        * #volatile
+       * check if the sorting is complete before rendering
        */
       sortReady: false,
       /**
        * #volatile
+       * the sort is relative to a current zoom level due to the layout being
+       * linked to a certain zoom level
        */
       currSortBpPerPx: 0,
       /**
        * #volatile
+       * visible MM tag type modifications in current region
        */
       visibleModifications: observable.map<string, ModificationTypeWithColor>(
         {},
       ),
       /**
        * #volatile
+       * whether we have checked for mods at least once
        */
       modificationsReady: false,
     }))

--- a/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
@@ -6,7 +6,6 @@ import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 // local
 import { LinearReadArcsDisplayModel } from '../model'
 import BaseDisplayComponent from '../../shared/components/BaseDisplayComponent'
-import { isAlive } from 'mobx-state-tree'
 
 type LGV = LinearGenomeViewModel
 
@@ -21,9 +20,7 @@ const Arcs = observer(function ({
   // biome-ignore lint/correctness/useExhaustiveDependencies:
   const cb = useCallback(
     (ref: HTMLCanvasElement) => {
-      if (isAlive(model)) {
-        model.setRef(ref)
-      }
+      model.setRef(ref)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [model, width, height],

--- a/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/components/ReactComponent.tsx
@@ -6,6 +6,7 @@ import { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 // local
 import { LinearReadArcsDisplayModel } from '../model'
 import BaseDisplayComponent from '../../shared/components/BaseDisplayComponent'
+import { isAlive } from 'mobx-state-tree'
 
 type LGV = LinearGenomeViewModel
 
@@ -20,7 +21,9 @@ const Arcs = observer(function ({
   // biome-ignore lint/correctness/useExhaustiveDependencies:
   const cb = useCallback(
     (ref: HTMLCanvasElement) => {
-      model.setRef(ref)
+      if (isAlive(model)) {
+        model.setRef(ref)
+      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [model, width, height],

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/BaseLinearDisplayModel.tsx
@@ -77,12 +77,19 @@ function stateModelFactory() {
         blockState: types.map(BlockState),
         /**
          * #property
+         * configuration
          */
         configuration: ConfigurationReference(configSchema),
       }),
     )
     .volatile(() => ({
+      /**
+       * #volatile
+       */
       featureIdUnderMouse: undefined as undefined | string,
+      /**
+       * #volatile
+       */
       contextMenuFeature: undefined as undefined | Feature,
     }))
     .views(self => ({

--- a/plugins/wiggle/src/LinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/model.ts
@@ -75,9 +75,13 @@ function stateModelFactory(
        * #getter
        * unused currently
        */
-      get quantitativeStatsRelevantToCurrentZoom() {
+      get quantitativeStatsUpToDate() {
         const view = getContainingView(self) as LinearGenomeViewModel
-        return self.stats?.currStatsBpPerPx === view.bpPerPx
+        const statsRegions = JSON.stringify(view.dynamicBlocks)
+        return (
+          self.stats?.currStatsBpPerPx === view.bpPerPx ||
+          self.stats?.currStatsRegions === statsRegions
+        )
       },
     }))
 
@@ -140,7 +144,7 @@ function stateModelFactory(
         const superProps = self.adapterProps()
         return {
           ...self.adapterProps(),
-          notReady: superProps.notReady || !self.stats,
+          notReady: superProps.notReady || !self.quantitativeStatsUpToDate,
           height,
           ticks,
         }
@@ -150,8 +154,10 @@ function stateModelFactory(
        * #getter
        */
       get needsScalebar() {
-        const { rendererTypeName: type } = self
-        return type === 'XYPlotRenderer' || type === 'LinePlotRenderer'
+        return (
+          self.rendererTypeName === 'XYPlotRenderer' ||
+          self.rendererTypeName === 'LinePlotRenderer'
+        )
       },
       /**
        * #getter

--- a/plugins/wiggle/src/LinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/model.ts
@@ -77,10 +77,7 @@ function stateModelFactory(
       get quantitativeStatsUpToDate() {
         const view = getContainingView(self) as LinearGenomeViewModel
         const statsRegions = JSON.stringify(view.dynamicBlocks)
-        return (
-          self.stats?.currStatsBpPerPx === view.bpPerPx ||
-          self.stats?.currStatsRegions === statsRegions
-        )
+        return self.stats?.currStatsRegions === statsRegions
       },
     }))
 

--- a/plugins/wiggle/src/LinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/LinearWiggleDisplay/model.ts
@@ -73,7 +73,6 @@ function stateModelFactory(
       },
       /**
        * #getter
-       * unused currently
        */
       get quantitativeStatsUpToDate() {
         const view = getContainingView(self) as LinearGenomeViewModel

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
@@ -326,10 +326,7 @@ export function stateModelFactory(
         get quantitativeStatsUpToDate() {
           const view = getContainingView(self) as LinearGenomeViewModel
           const statsRegions = JSON.stringify(view.dynamicBlocks)
-          return (
-            self.stats?.currStatsBpPerPx === view.bpPerPx ||
-            self.stats?.currStatsRegions === statsRegions
-          )
+          return self.stats?.currStatsRegions === statsRegions
         },
       }
     })

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
@@ -322,11 +322,14 @@ export function stateModelFactory(
         },
         /**
          * #getter
-         * unused currently
          */
-        get quantitativeStatsRelevantToCurrentZoom() {
+        get quantitativeStatsUpToDate() {
           const view = getContainingView(self) as LinearGenomeViewModel
-          return self.stats?.currStatsBpPerPx === view.bpPerPx
+          const statsRegions = JSON.stringify(view.dynamicBlocks)
+          return (
+            self.stats?.currStatsBpPerPx === view.bpPerPx ||
+            self.stats?.currStatsRegions === statsRegions
+          )
         },
       }
     })
@@ -338,7 +341,10 @@ export function stateModelFactory(
         const superProps = self.adapterProps()
         return {
           ...superProps,
-          notReady: superProps.notReady || !self.sources || !self.stats,
+          notReady:
+            superProps.notReady ||
+            !self.sources ||
+            !self.quantitativeStatsUpToDate,
           displayModel: self,
           rpcDriverName: self.rpcDriverName,
           displayCrossHatches: self.displayCrossHatches,

--- a/plugins/wiggle/src/getQuantitativeStats.ts
+++ b/plugins/wiggle/src/getQuantitativeStats.ts
@@ -19,7 +19,6 @@ export async function getQuantitativeStats(
     headers?: Record<string, string>
     signal?: AbortSignal
     filters: string[]
-    currStatsBpPerPx: number
     currStatsRegions: string
   },
 ): Promise<QuantitativeStats> {
@@ -27,7 +26,7 @@ export async function getQuantitativeStats(
   const sessionId = getRpcSessionId(self)
   const { rpcManager } = getSession(self)
   const { adapterConfig, autoscaleType } = self
-  const { currStatsRegions, currStatsBpPerPx } = opts
+  const { currStatsRegions } = opts
   const params = {
     sessionId,
     adapterConfig,
@@ -55,12 +54,10 @@ export async function getQuantitativeStats(
           ...results,
           scoreMin: scoreMin >= 0 ? 0 : scoreMean - numStdDev * scoreStdDev,
           scoreMax: scoreMean + numStdDev * scoreStdDev,
-          currStatsBpPerPx,
           currStatsRegions,
         }
       : {
           ...results,
-          currStatsBpPerPx,
           currStatsRegions,
         }
   }
@@ -92,12 +89,10 @@ export async function getQuantitativeStats(
           ...results,
           scoreMin: scoreMin >= 0 ? 0 : scoreMean - numStdDev * scoreStdDev,
           scoreMax: scoreMean + numStdDev * scoreStdDev,
-          currStatsBpPerPx,
           currStatsRegions,
         }
       : {
           ...results,
-          currStatsBpPerPx,
           currStatsRegions,
         }
   }

--- a/plugins/wiggle/src/getQuantitativeStats.ts
+++ b/plugins/wiggle/src/getQuantitativeStats.ts
@@ -20,13 +20,14 @@ export async function getQuantitativeStats(
     signal?: AbortSignal
     filters: string[]
     currStatsBpPerPx: number
+    currStatsRegions: string
   },
 ): Promise<QuantitativeStats> {
-  const { rpcManager } = getSession(self)
   const numStdDev = getConf(self, 'numStdDev') || 3
-  const { adapterConfig, autoscaleType } = self
   const sessionId = getRpcSessionId(self)
-  const { currStatsBpPerPx } = opts
+  const { rpcManager } = getSession(self)
+  const { adapterConfig, autoscaleType } = self
+  const { currStatsRegions, currStatsBpPerPx } = opts
   const params = {
     sessionId,
     adapterConfig,
@@ -55,10 +56,12 @@ export async function getQuantitativeStats(
           scoreMin: scoreMin >= 0 ? 0 : scoreMean - numStdDev * scoreStdDev,
           scoreMax: scoreMean + numStdDev * scoreStdDev,
           currStatsBpPerPx,
+          currStatsRegions,
         }
       : {
           ...results,
           currStatsBpPerPx,
+          currStatsRegions,
         }
   }
   if (autoscaleType === 'local' || autoscaleType === 'localsd') {
@@ -90,10 +93,12 @@ export async function getQuantitativeStats(
           scoreMin: scoreMin >= 0 ? 0 : scoreMean - numStdDev * scoreStdDev,
           scoreMax: scoreMean + numStdDev * scoreStdDev,
           currStatsBpPerPx,
+          currStatsRegions,
         }
       : {
           ...results,
           currStatsBpPerPx,
+          currStatsRegions,
         }
   }
   if (autoscaleType === 'zscale') {

--- a/plugins/wiggle/src/getQuantitativeStatsAutorun.ts
+++ b/plugins/wiggle/src/getQuantitativeStatsAutorun.ts
@@ -12,6 +12,7 @@ type LGV = LinearGenomeViewModel
 
 export function getQuantitativeStatsAutorun(self: {
   quantitativeStatsReady: boolean
+  quantitativeStatsUpToDate: boolean
   configuration: AnyConfigurationModel
   adapterConfig: AnyConfigurationModel
   autoscaleType: string
@@ -29,21 +30,24 @@ export function getQuantitativeStatsAutorun(self: {
           const view = getContainingView(self) as LGV
           const aborter = new AbortController()
           self.setStatsLoading(aborter)
-
           if (!self.quantitativeStatsReady) {
             return
           }
+          if (self.quantitativeStatsUpToDate) {
+            return
+          }
 
-          const statsRegion = JSON.stringify(view.dynamicBlocks)
+          const statsRegions = JSON.stringify(view.dynamicBlocks)
           const wiggleStats = await getQuantitativeStats(self, {
             signal: aborter.signal,
             filters: [],
             currStatsBpPerPx: view.bpPerPx,
+            currStatsRegions: statsRegions,
             ...self.adapterProps(),
           })
 
           if (isAlive(self)) {
-            self.updateQuantitativeStats(wiggleStats, statsRegion)
+            self.updateQuantitativeStats(wiggleStats, statsRegions)
           }
         } catch (e) {
           console.error(e)

--- a/plugins/wiggle/src/getQuantitativeStatsAutorun.ts
+++ b/plugins/wiggle/src/getQuantitativeStatsAutorun.ts
@@ -41,7 +41,6 @@ export function getQuantitativeStatsAutorun(self: {
           const wiggleStats = await getQuantitativeStats(self, {
             signal: aborter.signal,
             filters: [],
-            currStatsBpPerPx: view.bpPerPx,
             currStatsRegions: statsRegions,
             ...self.adapterProps(),
           })

--- a/plugins/wiggle/src/shared/SharedWiggleMixin.ts
+++ b/plugins/wiggle/src/shared/SharedWiggleMixin.ts
@@ -22,7 +22,6 @@ const SetMinMaxDialog = lazy(() => import('./SetMinMaxDialog'))
 
 export interface QuantitativeStats {
   currStatsRegions: string
-  currStatsBpPerPx: number
   scoreMin: number
   scoreMax: number
 }

--- a/plugins/wiggle/src/shared/SharedWiggleMixin.ts
+++ b/plugins/wiggle/src/shared/SharedWiggleMixin.ts
@@ -120,20 +120,7 @@ export default function SharedWiggleMixin(
        * #action
        */
       updateQuantitativeStats(stats: QuantitativeStats) {
-        const { currStatsRegions, currStatsBpPerPx, scoreMin, scoreMax } = stats
-        const EPSILON = 0.000001
-        if (
-          !self.stats ||
-          Math.abs(self.stats.scoreMax - scoreMax) > EPSILON ||
-          Math.abs(self.stats.scoreMin - scoreMin) > EPSILON
-        ) {
-          self.stats = {
-            currStatsRegions,
-            currStatsBpPerPx,
-            scoreMin,
-            scoreMax,
-          }
-        }
+        self.stats = stats
       },
       /**
        * #action

--- a/plugins/wiggle/src/shared/SharedWiggleMixin.ts
+++ b/plugins/wiggle/src/shared/SharedWiggleMixin.ts
@@ -20,6 +20,13 @@ import { lazy } from 'react'
 // lazies
 const SetMinMaxDialog = lazy(() => import('./SetMinMaxDialog'))
 
+export interface QuantitativeStats {
+  currStatsRegions: string
+  currStatsBpPerPx: number
+  scoreMin: number
+  scoreMax: number
+}
+
 /**
  * #stateModel SharedWiggleMixin
  */
@@ -102,9 +109,7 @@ export default function SharedWiggleMixin(
       /**
        * #volatile
        */
-      stats: undefined as
-        | { currStatsBpPerPx: number; scoreMin: number; scoreMax: number }
-        | undefined,
+      stats: undefined as QuantitativeStats | undefined,
       /**
        * #volatile
        */
@@ -114,12 +119,8 @@ export default function SharedWiggleMixin(
       /**
        * #action
        */
-      updateQuantitativeStats(stats: {
-        currStatsBpPerPx: number
-        scoreMin: number
-        scoreMax: number
-      }) {
-        const { currStatsBpPerPx, scoreMin, scoreMax } = stats
+      updateQuantitativeStats(stats: QuantitativeStats) {
+        const { currStatsRegions, currStatsBpPerPx, scoreMin, scoreMax } = stats
         const EPSILON = 0.000001
         if (
           !self.stats ||
@@ -127,6 +128,7 @@ export default function SharedWiggleMixin(
           Math.abs(self.stats.scoreMin - scoreMin) > EPSILON
         ) {
           self.stats = {
+            currStatsRegions,
             currStatsBpPerPx,
             scoreMin,
             scoreMax,
@@ -518,7 +520,10 @@ export default function SharedWiggleMixin(
             onClick: () => {
               getSession(self).queueDialog(handleClose => [
                 SetMinMaxDialog,
-                { model: self, handleClose },
+                {
+                  model: self,
+                  handleClose,
+                },
               ])
             },
           },

--- a/website/docs/config/BigWigAdapter.md
+++ b/website/docs/config/BigWigAdapter.md
@@ -33,3 +33,13 @@ source: {
       description: 'Used for multiwiggle',
     }
 ```
+
+#### slot: resolutionMultiplier
+
+```js
+resolutionMultiplier: {
+      type: 'number',
+      defaultValue: 1,
+      description: 'Initial resolution multiplier',
+    }
+```

--- a/website/docs/config/BlastTabularAdapter.md
+++ b/website/docs/config/BlastTabularAdapter.md
@@ -1,0 +1,68 @@
+---
+id: blasttabularadapter
+title: BlastTabularAdapter
+---
+
+Note: this document is automatically generated from configuration objects in our
+source code. See [Config guide](/docs/config_guide) for more info
+
+### Source file
+
+[plugins/comparative-adapters/src/BlastTabularAdapter/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/comparative-adapters/src/BlastTabularAdapter/configSchema.ts)
+
+### BlastTabularAdapter - Slots
+
+#### slot: assemblyNames
+
+```js
+assemblyNames: {
+      type: 'stringArray',
+      defaultValue: [],
+      description:
+        'Query assembly is the first value in the array, target assembly is the second',
+    }
+```
+
+#### slot: targetAssembly
+
+```js
+targetAssembly: {
+      type: 'string',
+      defaultValue: '',
+      description: 'Alternative to assemblyNames array: the target assembly',
+    }
+```
+
+#### slot: queryAssembly
+
+```js
+queryAssembly: {
+      type: 'string',
+      defaultValue: '',
+      description: 'Alternative to assemblyNames array: the query assembly',
+    }
+```
+
+#### slot: blastTableLocation
+
+```js
+blastTableLocation: {
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '/path/to/blastTable.tsv',
+        locationType: 'UriLocation',
+      },
+    }
+```
+
+#### slot: columns
+
+```js
+columns: {
+      type: 'string',
+      description:
+        'Optional space-separated column name list. If custom columns were used in outfmt, enter them here exactly as specified in the command. At least qseqid, sseqid, qstart, qend, sstart, and send are required',
+      defaultValue:
+        'qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore',
+    }
+```

--- a/website/docs/config/ChainAdapter.md
+++ b/website/docs/config/ChainAdapter.md
@@ -19,7 +19,7 @@ assemblyNames: {
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Target is the first value in the array, query is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     }
 ```
 

--- a/website/docs/config/DeltaAdapter.md
+++ b/website/docs/config/DeltaAdapter.md
@@ -19,7 +19,7 @@ assemblyNames: {
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     }
 ```
 
@@ -52,6 +52,9 @@ queryAssembly: {
 ```js
 deltaLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/file.delta', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/file.delta',
+        locationType: 'UriLocation',
+      },
     }
 ```

--- a/website/docs/config/HicAdapter.md
+++ b/website/docs/config/HicAdapter.md
@@ -23,3 +23,13 @@ hicLocation: {
       },
     }
 ```
+
+#### slot: resolutionMultiplier
+
+```js
+resolutionMultiplier: {
+      type: 'number',
+      defaultValue: 1,
+      description: 'Initial resolution multiplier',
+    }
+```

--- a/website/docs/config/LinearAlignmentsDisplay.md
+++ b/website/docs/config/LinearAlignmentsDisplay.md
@@ -8,7 +8,7 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 ### Source file
 
-[plugins/alignments/src/LinearAlignmentsDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/models/configSchema.ts)
+[plugins/alignments/src/LinearAlignmentsDisplay/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/configSchema.ts)
 
 has a "pileup" sub-display, where you can see individual reads and a
 quantitative "snpcoverage" sub-display track showing SNP frequencies

--- a/website/docs/config/LinearSNPCoverageDisplay.md
+++ b/website/docs/config/LinearSNPCoverageDisplay.md
@@ -8,7 +8,7 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 ### Source file
 
-[plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/models/configSchema.ts)
+[plugins/alignments/src/LinearSNPCoverageDisplay/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/configSchema.ts)
 
 extends
 

--- a/website/docs/config/LinearWiggleDisplay.md
+++ b/website/docs/config/LinearWiggleDisplay.md
@@ -8,7 +8,7 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 ### Source file
 
-[plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/models/configSchema.ts)
+[plugins/wiggle/src/LinearWiggleDisplay/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/configSchema.ts)
 
 extends
 

--- a/website/docs/config/MashMapAdapter.md
+++ b/website/docs/config/MashMapAdapter.md
@@ -19,7 +19,7 @@ assemblyNames: {
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Target is the first value in the array, query is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     }
 ```
 

--- a/website/docs/config/MultiLinearWiggleDisplay.md
+++ b/website/docs/config/MultiLinearWiggleDisplay.md
@@ -8,7 +8,7 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 ### Source file
 
-[plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/models/configSchema.ts)
+[plugins/wiggle/src/MultiLinearWiggleDisplay/configSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/configSchema.ts)
 
 extends
 

--- a/website/docs/config/PAFAdapter.md
+++ b/website/docs/config/PAFAdapter.md
@@ -19,7 +19,7 @@ assemblyNames: {
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     }
 ```
 

--- a/website/docs/config/PairwiseIndexedPAFAdapter.md
+++ b/website/docs/config/PairwiseIndexedPAFAdapter.md
@@ -19,7 +19,7 @@ assemblyNames: {
       type: 'stringArray',
       defaultValue: [],
       description:
-        'Array of assembly names to use for this file. The target assembly name is the first value in the array, query assembly name is the second',
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
     }
 ```
 

--- a/website/docs/config/SharedWiggleDisplay.md
+++ b/website/docs/config/SharedWiggleDisplay.md
@@ -8,7 +8,7 @@ source code. See [Config guide](/docs/config_guide) for more info
 
 ### Source file
 
-[plugins/wiggle/src/shared/configShared.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/shared/configShared.ts)
+[plugins/wiggle/src/shared/SharedWiggleConfigSchema.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/shared/SharedWiggleConfigSchema.ts)
 
 extends
 

--- a/website/docs/models/BaseDisplay.md
+++ b/website/docs/models/BaseDisplay.md
@@ -16,6 +16,8 @@ info
 
 #### property: id
 
+corresponds to a displayId
+
 ```js
 // type signature
 IOptionalIType<ISimpleType<string>, [undefined]>
@@ -25,6 +27,8 @@ id: ElementId
 
 #### property: type
 
+display type
+
 ```js
 // type signature
 ISimpleType<string>
@@ -33,6 +37,8 @@ type: types.string
 ```
 
 #### property: rpcDriverName
+
+RPC driver
 
 ```js
 // type signature

--- a/website/docs/models/BreakpointSplitView.md
+++ b/website/docs/models/BreakpointSplitView.md
@@ -155,7 +155,7 @@ getTrackFeatures: (trackConfigId: string) => Map<string, Feature>
 
 ```js
 // type signature
-getMatchedFeaturesInLayout: (trackConfigId: string, features: Feature[][]) => { feature: Feature; layout: LayoutRecord; level: any; }[][]
+getMatchedFeaturesInLayout: (trackConfigId: string, features: Feature[][]) => { feature: Feature; layout: LayoutRecord; level: any; clipPos: number; }[][]
 ```
 
 #### method: menuItems

--- a/website/docs/models/LGVSyntenyDisplay.md
+++ b/website/docs/models/LGVSyntenyDisplay.md
@@ -54,3 +54,12 @@ contextMenuItems: () => MenuItem[]
 // type signature
 trackMenuItems: () => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; })[]
 ```
+
+### LGVSyntenyDisplay - Actions
+
+#### action: selectFeature
+
+```js
+// type signature
+selectFeature: (feature: Feature) => void
+```

--- a/website/docs/models/LinearAlignmentsDisplay.md
+++ b/website/docs/models/LinearAlignmentsDisplay.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/models/model.tsx)
+[plugins/alignments/src/LinearAlignmentsDisplay/model.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/model.tsx)
 
 extends
 
@@ -139,7 +139,7 @@ setHeight: (n: number) => number
 
 ```js
 // type signature
-setFilterBy: (filter: IFilter) => void
+setFilterBy: (filter: FilterBy) => void
 ```
 
 #### action: setLowerPanelType

--- a/website/docs/models/LinearAlignmentsDisplayMixin.md
+++ b/website/docs/models/LinearAlignmentsDisplayMixin.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/models/alignmentsModel.tsx)
+[plugins/alignments/src/LinearAlignmentsDisplay/alignmentsModel.tsx](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearAlignmentsDisplay/alignmentsModel.tsx)
 
 ### LinearAlignmentsDisplayMixin - Properties
 

--- a/website/docs/models/LinearComparativeDisplay.md
+++ b/website/docs/models/LinearComparativeDisplay.md
@@ -38,6 +38,20 @@ configuration: ConfigurationReference(configSchema)
 
 ### LinearComparativeDisplay - Getters
 
+#### getter: level
+
+```js
+// type
+number
+```
+
+#### getter: height
+
+```js
+// type
+number
+```
+
 #### getter: renderProps
 
 ```js

--- a/website/docs/models/LinearHicDisplay.md
+++ b/website/docs/models/LinearHicDisplay.md
@@ -61,6 +61,15 @@ IMaybe<ISimpleType<string>>
 colorScheme: types.maybe(types.string)
 ```
 
+#### property: activeNormalization
+
+```js
+// type signature
+string
+// code
+activeNormalization: 'KR'
+```
+
 ### LinearHicDisplay - Getters
 
 #### getter: blockType
@@ -81,7 +90,7 @@ string
 
 ```js
 // type
-() => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; } | { ...; })[]
+() => (MenuDivider | MenuSubHeader | NormalMenuItem | CheckboxMenuItem | RadioMenuItem | SubMenuItem | { ...; } | { ...; } | { ...; })[]
 ```
 
 ### LinearHicDisplay - Methods
@@ -114,4 +123,18 @@ setUseLogScale: (f: boolean) => void
 ```js
 // type signature
 setColorScheme: (f?: string) => void
+```
+
+#### action: setActiveNormalization
+
+```js
+// type signature
+setActiveNormalization: (f: string) => void
+```
+
+#### action: setAvailableNormalizations
+
+```js
+// type signature
+setAvailableNormalizations: (f: string[]) => void
 ```

--- a/website/docs/models/LinearPileupDisplay.md
+++ b/website/docs/models/LinearPileupDisplay.md
@@ -58,20 +58,19 @@ mismatchAlpha: types.maybe(types.boolean)
 
 ```js
 // type signature
-IMaybe<IModelType<{ type: ISimpleType<string>; pos: ISimpleType<number>; tag: IMaybe<ISimpleType<string>>; refName: ISimpleType<string>; assemblyName: ISimpleType<...>; }, {}, _NotCustomized, _NotCustomized>>
+IType<SortedBy, SortedBy, SortedBy>
 // code
-sortedBy: types.maybe(
-          types.model({
-            type: types.string,
-            pos: types.number,
-            tag: types.maybe(types.string),
-            refName: types.string,
-            assemblyName: types.string,
-          }),
-        )
+sortedBy: types.frozen<SortedBy | undefined>()
 ```
 
 ### LinearPileupDisplay - Getters
+
+#### getter: visibleModificationTypes
+
+```js
+// type
+any[]
+```
 
 #### getter: rendererConfig
 
@@ -126,11 +125,11 @@ trackMenuItems: () => readonly [...MenuItem[], { readonly label: "Sort by..."; r
 setCurrSortBpPerPx: (n: number) => void
 ```
 
-#### action: updateModificationColorMap
+#### action: updateVisibleModifications
 
 ```js
 // type signature
-updateModificationColorMap: (uniqueModifications: string[]) => void
+updateVisibleModifications: (uniqueModifications: ModificationType[]) => void
 ```
 
 #### action: setModificationsReady

--- a/website/docs/models/LinearReadArcsDisplay.md
+++ b/website/docs/models/LinearReadArcsDisplay.md
@@ -43,9 +43,9 @@ configuration: ConfigurationReference(configSchema)
 
 ```js
 // type signature
-IOptionalIType<IModelType<{ flagInclude: IOptionalIType<ISimpleType<number>, [undefined]>; flagExclude: IOptionalIType<ISimpleType<number>, [undefined]>; readName: IMaybe<...>; tagFilter: IMaybe<...>; }, {}, _NotCustomized, _NotCustomized>, [...]>
+IOptionalIType<IType<FilterBy, FilterBy, FilterBy>, [undefined]>
 // code
-filterBy: types.optional(FilterModel, {})
+filterBy: types.optional(types.frozen<FilterBy>(), defaultFilterFlags)
 ```
 
 #### property: lineWidth
@@ -70,15 +70,9 @@ jitter: types.maybe(types.number)
 
 ```js
 // type signature
-IMaybe<IModelType<{ type: ISimpleType<string>; tag: IMaybe<ISimpleType<string>>; extra: IType<any, any, any>; }, {}, _NotCustomized, _NotCustomized>>
+IType<ColorBy, ColorBy, ColorBy>
 // code
-colorBy: types.maybe(
-          types.model({
-            type: types.string,
-            tag: types.maybe(types.string),
-            extra: types.frozen(),
-          }),
-        )
+colorBy: types.frozen<ColorBy | undefined>()
 ```
 
 #### property: drawInter
@@ -191,7 +185,7 @@ setRef: (ref: HTMLCanvasElement) => void
 
 ```js
 // type signature
-setColorScheme: (s: { type: string; }) => void
+setColorScheme: (colorBy: { type: string; }) => void
 ```
 
 #### action: setChainData
@@ -219,7 +213,7 @@ setDrawLongRange: (f: boolean) => void
 
 ```js
 // type signature
-setFilterBy: (filter: IFilter) => void
+setFilterBy: (filter: FilterBy) => void
 ```
 
 #### action: setLineWidth

--- a/website/docs/models/LinearReadCloudDisplay.md
+++ b/website/docs/models/LinearReadCloudDisplay.md
@@ -42,24 +42,18 @@ configuration: ConfigurationReference(configSchema)
 
 ```js
 // type signature
-IOptionalIType<IModelType<{ flagInclude: IOptionalIType<ISimpleType<number>, [undefined]>; flagExclude: IOptionalIType<ISimpleType<number>, [undefined]>; readName: IMaybe<...>; tagFilter: IMaybe<...>; }, {}, _NotCustomized, _NotCustomized>, [...]>
+IOptionalIType<IType<FilterBy, FilterBy, FilterBy>, [undefined]>
 // code
-filterBy: types.optional(FilterModel, {})
+filterBy: types.optional(types.frozen<FilterBy>(), defaultFilterFlags)
 ```
 
 #### property: colorBy
 
 ```js
 // type signature
-IMaybe<IModelType<{ type: ISimpleType<string>; tag: IMaybe<ISimpleType<string>>; extra: IType<any, any, any>; }, {}, _NotCustomized, _NotCustomized>>
+IType<ColorBy, ColorBy, ColorBy>
 // code
-colorBy: types.maybe(
-          types.model({
-            type: types.string,
-            tag: types.maybe(types.string),
-            extra: types.frozen(),
-          }),
-        )
+colorBy: types.frozen<ColorBy | undefined>()
 ```
 
 #### property: drawSingletons
@@ -145,5 +139,5 @@ setChainData: (args: ChainData) => void
 
 ```js
 // type signature
-setFilterBy: (filter: IFilter) => void
+setFilterBy: (filter: FilterBy) => void
 ```

--- a/website/docs/models/LinearSNPCoverageDisplay.md
+++ b/website/docs/models/LinearSNPCoverageDisplay.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/models/model.ts)
+[plugins/alignments/src/LinearSNPCoverageDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/alignments/src/LinearSNPCoverageDisplay/model.ts)
 
 extends
 
@@ -58,23 +58,21 @@ drawArcs: types.maybe(types.boolean)
 
 ```js
 // type signature
-IOptionalIType<IModelType<{ flagInclude: IOptionalIType<ISimpleType<number>, [undefined]>; flagExclude: IOptionalIType<ISimpleType<number>, [undefined]>; readName: IMaybe<...>; tagFilter: IMaybe<...>; }, {}, _NotCustomized, _NotCustomized>, [...]>
+IOptionalIType<IType<FilterBy, FilterBy, FilterBy>, [undefined]>
 // code
-filterBy: types.optional(FilterModel, {})
+filterBy: types.optional(types.frozen<FilterBy>(), {
+          flagInclude: 0,
+          flagExclude: 1540,
+        })
 ```
 
 #### property: colorBy
 
 ```js
 // type signature
-IMaybe<IModelType<{ type: ISimpleType<string>; tag: IMaybe<ISimpleType<string>>; }, {}, _NotCustomized, _NotCustomized>>
+IType<ColorBy, ColorBy, ColorBy>
 // code
-colorBy: types.maybe(
-          types.model({
-            type: types.string,
-            tag: types.maybe(types.string),
-          }),
-        )
+colorBy: types.frozen<ColorBy | undefined>()
 ```
 
 #### property: jexlFilters
@@ -123,6 +121,20 @@ any
 boolean
 ```
 
+#### getter: renderReady
+
+```js
+// type
+boolean
+```
+
+#### getter: ready
+
+```js
+// type
+any
+```
+
 #### getter: TooltipComponent
 
 ```js
@@ -163,6 +175,13 @@ SerializableFilterChain
 
 ### LinearSNPCoverageDisplay - Methods
 
+#### method: adapterProps
+
+```js
+// type signature
+adapterProps: () => any
+```
+
 #### method: renderProps
 
 ```js
@@ -197,14 +216,14 @@ setConfig: (configuration: { [x: string]: any; } & NonEmptyObject & { setSubsche
 
 ```js
 // type signature
-setFilterBy: (filter: IFilter) => void
+setFilterBy: (filter: FilterBy) => void
 ```
 
-#### action: setColorBy
+#### action: setColorScheme
 
 ```js
 // type signature
-setColorBy: (colorBy?: { type: string; tag?: string; }) => void
+setColorScheme: (colorBy?: ColorBy) => void
 ```
 
 #### action: setJexlFilters
@@ -214,11 +233,11 @@ setColorBy: (colorBy?: { type: string; tag?: string; }) => void
 setJexlFilters: (filters: string[]) => void
 ```
 
-#### action: updateModificationColorMap
+#### action: updateVisibleModifications
 
 ```js
 // type signature
-updateModificationColorMap: (uniqueModifications: string[]) => void
+updateVisibleModifications: (uniqueModifications: ModificationType[]) => void
 ```
 
 #### action: setModificationsReady

--- a/website/docs/models/LinearSyntenyDisplay.md
+++ b/website/docs/models/LinearSyntenyDisplay.md
@@ -52,13 +52,6 @@ any
 string[]
 ```
 
-#### getter: height
-
-```js
-// type
-number
-```
-
 #### getter: numFeats
 
 ```js

--- a/website/docs/models/LinearWiggleDisplay.md
+++ b/website/docs/models/LinearWiggleDisplay.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/wiggle/src/LinearWiggleDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/models/model.ts)
+[plugins/wiggle/src/LinearWiggleDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/LinearWiggleDisplay/model.ts)
 
 extends
 
@@ -43,6 +43,13 @@ React.ComponentType<any>
 string
 ```
 
+#### getter: quantitativeStatsUpToDate
+
+```js
+// type
+boolean
+```
+
 #### getter: ticks
 
 ```js
@@ -64,7 +71,21 @@ boolean
 ;1 | 0 | 2
 ```
 
+#### getter: quantitativeStatsReady
+
+```js
+// type
+boolean
+```
+
 ### LinearWiggleDisplay - Methods
+
+#### method: adapterProps
+
+```js
+// type signature
+adapterProps: () => any
+```
 
 #### method: renderProps
 

--- a/website/docs/models/MultiLinearWiggleDisplay.md
+++ b/website/docs/models/MultiLinearWiggleDisplay.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/models/model.ts)
+[plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts)
 
 extends
 
@@ -90,6 +90,13 @@ this yet but flag can be used for this
 boolean
 ```
 
+#### getter: canHaveFill
+
+```js
+// type
+boolean
+```
+
 #### getter: renderColorBoxes
 
 the multirowxy and multiline don't need to use colors on the legend boxes since
@@ -115,6 +122,13 @@ any
 ```js
 // type
 { color: string; name: string; group?: string; }[]
+```
+
+#### getter: quantitativeStatsReady
+
+```js
+// type
+boolean
 ```
 
 #### getter: rowHeight
@@ -152,6 +166,13 @@ any
 string[]
 ```
 
+#### getter: quantitativeStatsUpToDate
+
+```js
+// type
+boolean
+```
+
 #### getter: hasResolution
 
 ```js
@@ -174,6 +195,13 @@ boolean
 ```
 
 ### MultiLinearWiggleDisplay - Methods
+
+#### method: adapterProps
+
+```js
+// type signature
+adapterProps: () => any
+```
 
 #### method: renderProps
 

--- a/website/docs/models/SharedLinearPileupDisplayMixin.md
+++ b/website/docs/models/SharedLinearPileupDisplayMixin.md
@@ -65,18 +65,18 @@ trackMaxHeight: types.maybe(types.number)
 
 ```js
 // type signature
-IMaybe<IModelType<{ type: ISimpleType<string>; tag: IMaybe<ISimpleType<string>>; extra: IType<any, any, any>; }, {}, _NotCustomized, _NotCustomized>>
+IType<ColorBy, ColorBy, ColorBy>
 // code
-colorBy: ColorByModel
+colorBy: types.frozen<ColorBy | undefined>()
 ```
 
 #### property: filterBy
 
 ```js
 // type signature
-IOptionalIType<IModelType<{ flagInclude: IOptionalIType<ISimpleType<number>, [undefined]>; flagExclude: IOptionalIType<ISimpleType<number>, [undefined]>; readName: IMaybe<...>; tagFilter: IMaybe<...>; }, {}, _NotCustomized, _NotCustomized>, [...]>
+IOptionalIType<IType<FilterBy, FilterBy, FilterBy>, [undefined]>
 // code
-filterBy: types.optional(FilterModel, {})
+filterBy: types.optional(types.frozen<FilterBy>(), defaultFilterFlags)
 ```
 
 #### property: jexlFilters
@@ -210,7 +210,7 @@ setNoSpacing: (flag?: boolean) => void
 
 ```js
 // type signature
-setColorScheme: (colorScheme: { type: string; tag?: string; extra?: ExtraColorBy; }) => void
+setColorScheme: (colorScheme: ColorBy) => void
 ```
 
 #### action: updateColorTagMap
@@ -254,7 +254,7 @@ setConfig: (conf: { [x: string]: any; } & NonEmptyObject & { setSubschema(slotNa
 
 ```js
 // type signature
-setFilterBy: (filter: IFilter) => void
+setFilterBy: (filter: FilterBy) => void
 ```
 
 #### action: setJexlFilters

--- a/website/docs/models/SharedWiggleMixin.md
+++ b/website/docs/models/SharedWiggleMixin.md
@@ -10,7 +10,7 @@ info
 
 ### Source file
 
-[plugins/wiggle/src/shared/modelShared.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/shared/modelShared.ts)
+[plugins/wiggle/src/shared/SharedWiggleMixin.ts](https://github.com/GMOD/jbrowse-components/blob/main/plugins/wiggle/src/shared/SharedWiggleMixin.ts)
 
 ### SharedWiggleMixin - Properties
 
@@ -238,7 +238,7 @@ string
 
 ```js
 // type
-{ domain: number[]; stats: { scoreMin: number; scoreMax: number; }; autoscaleType: any; scaleType: any; inverted: any; }
+{ domain: number[]; stats: QuantitativeStats; autoscaleType: any; scaleType: any; inverted: any; }
 ```
 
 #### getter: canHaveFill
@@ -284,7 +284,7 @@ scoreTrackMenuItems: () => ({ label: string; subMenu: { label: string; onClick: 
 
 ```js
 // type signature
-updateQuantitativeStats: (stats: { scoreMin: number; scoreMax: number; }) => void
+updateQuantitativeStats: (stats: QuantitativeStats) => void
 ```
 
 #### action: setColor
@@ -308,11 +308,11 @@ setPosColor: (color?: string) => void
 setNegColor: (color?: string) => void
 ```
 
-#### action: setLoading
+#### action: setStatsLoading
 
 ```js
 // type signature
-setLoading: (aborter: AbortController) => void
+setStatsLoading: (aborter: AbortController) => void
 ```
 
 #### action: selectFeature

--- a/website/docs/models/TrackHeightMixin.md
+++ b/website/docs/models/TrackHeightMixin.md
@@ -29,15 +29,6 @@ heightPreConfig: types.maybe(
       )
 ```
 
-#### property: scrollTop
-
-```js
-// type signature
-number
-// code
-scrollTop: 0
-```
-
 ### TrackHeightMixin - Actions
 
 #### action: setScrollTop


### PR DESCRIPTION
Part of https://github.com/GMOD/jbrowse-components/pull/4652 had to be reverted due to hanging the track

This restores the functionality

Previously, what we would see a lot with quantitative tracks when you e.g. zoom in is

a) you have track rendered
b) you hit zoom in button
c) it would render the track using the stats that are preexisting (e.g. from the zoomed out state)
d) the stats would update for the new zoom in level
e) then it would re-render again

for the user, this would appear sort of like weird flash where the track would render, blank, and then rerender with the new stats

this PR makes it so that it gets the stats for the visible region before rendering

one risk is that the user gets a slightly 'slower' response because instead of rendering with the old stats 'instantly' it has to 'wait for the new stats before rendering'

loading states do make you lose focus a little

however, by removing the render_with_old_stats->blank_screen->rerender_with_new_stats effect, I think users can focus better on the result, and this is especially true for wiggle renderings which take a substantial time (e.g. large BAM/CRAM SNPCov) since it only renders once instead of twice

In order to accomplish this PR, I make a getter called "quantitativeStatsUpToDate" that decides whether the stats are up to date if current view.dynamicBlocks exactly matches a stringified version of the dynamicBlocks stored on the stats. Note that this string could get long if there are many regions being displayed,