### PR TITLE
Fix MCScanAnchorsAdapter rendering in linear genome view

### DIFF
--- a/plugins/alignments/src/PileupRenderer/renderAlignmentShape.ts
+++ b/plugins/alignments/src/PileupRenderer/renderAlignmentShape.ts
@@ -17,11 +17,11 @@ export function renderAlignmentShape({
   const region = regions[0]!
   const s = feature.get('start')
   const e = feature.get('end')
-  const CIGAR = feature.get('CIGAR')
+  const CIGAR = feature.get('CIGAR') as string | undefined
   const flip = region.reversed ? -1 : 1
   const strand = feature.get('strand') * flip
   const renderChevrons = bpPerPx < 10 && heightPx > 5
-  if (CIGAR.includes('N')) {
+  if (CIGAR?.includes('N')) {
     const cigarOps = parseCigar(CIGAR)
     if (strand === 1) {
       let drawLen = 0


### PR DESCRIPTION
A regression between v2.16.1 and v2.17.0 resulted in 'mcscan' type features not being rendered on the LGV

It assumed that CIGAR strings would always be present but this is not the case (no CIGAR for MCScan type features)

