### PR TITLE
Move session options from the appbar File menu into a submenu

### DIFF
--- a/products/jbrowse-desktop/src/rootModel/rootModel.ts
+++ b/products/jbrowse-desktop/src/rootModel/rootModel.ts
@@ -7,7 +7,7 @@ import {
 } from '@jbrowse/app-core'
 import assemblyConfigSchemaF from '@jbrowse/core/assemblyManager/assemblyConfigSchema'
 import RpcManager from '@jbrowse/core/rpc/RpcManager'
-import { Cable, DNA, Save, SaveAs } from '@jbrowse/core/ui/Icons'
+import { Cable, DNA, SaveAs } from '@jbrowse/core/ui/Icons'
 import { AssemblyManager } from '@jbrowse/plugin-data-management'
 import {
   BaseRootModelFactory,
@@ -149,7 +149,7 @@ export default function rootModelFactory({
               label: 'File',
               menuItems: [
                 {
-                  label: 'Open',
+                  label: 'Open session...',
                   icon: OpenIcon,
                   onClick: async () => {
                     try {
@@ -164,21 +164,7 @@ export default function rootModelFactory({
                   },
                 },
                 {
-                  label: 'Save',
-                  icon: Save,
-                  onClick: async () => {
-                    if (self.session) {
-                      try {
-                        await self.saveSession(getSaveSession(self))
-                      } catch (e) {
-                        console.error(e)
-                        self.session?.notifyError(`${e}`, e)
-                      }
-                    }
-                  },
-                },
-                {
-                  label: 'Save as...',
+                  label: 'Save session as...',
                   icon: SaveAs,
                   onClick: async () => {
                     try {


### PR DESCRIPTION
Sometimes users have a hard to locating the "Open track" option. I see this a lot in office hours.


They especially mistake the "Open" menu item in jbrowse desktop because it just says "Open"

This moves all session related options to a subMenu. The session options are fairly specialized


## jbrowse-web

Here is how it looks on jbrowse-web with this PR

![image](https://github.com/user-attachments/assets/c1ba0ba9-5074-46aa-a296-42a8f499c075)

The web re-organization here might not be super 'aesthetic' because there are so few other options for web in the File menu, but i think it reduces confusion from session options. Adding an option to open assembly in web (session assemblies) might round it out...

## jbrowse-desktop

![image](https://github.com/user-attachments/assets/c15a73ec-dd5b-4fd5-a2fc-08550589d2c9)






