### PR TITLE
Add mate.name to LGVSyntenyDisplay feature mouseovers

### DIFF
--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
@@ -11,7 +11,13 @@ import type PluginManager from '@jbrowse/core/PluginManager'
 function configSchemaF(pluginManager: PluginManager) {
   return ConfigurationSchema(
     'LGVSyntenyDisplay',
-    {},
+    {
+      mouseover: {
+        type: 'string',
+        defaultValue:
+          'jexl:(get(feature,"name")||"")+ "<br/>" + (get(feature,"mate").name||"")',
+      },
+    },
     {
       /**
        * #baseConfiguration


### PR DESCRIPTION
Example



![image](https://github.com/user-attachments/assets/69cf5cdf-473b-4c6c-80cc-239cb7b6acde)


More info like chr name could be added if interest also, but hopefully this helps

cc @srobb1

Can try this branch with

`jbrowse create --branch mouseover_name` if interested

fixes #4677