### PR TITLE
v2.18.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v2.18.0.md
+++ b/website/release_announcement_drafts/v2.18.0.md
@@ -1,0 +1,19 @@
+This release marks a number of improvements including
+
+- Ability to display multi-sample VCF in a 'matrix' or 'stacked' style view
+- Major improvements to the spreadsheet and SV inspector views, including:
+  - Let's you open tracks from in the spreadsheet and SV inspector
+  - Let's you re-navigate the breakpoint split view instead of launching a new
+    one each time
+  - Uses @mui/x-data-grid for display of the spreadsheet
+  - Makes separate columns for VCF INFO fields
+  - Ability to open much larger files
+- Auto-saves user sessions to a local IndexedDB, so you won't lose your sessions
+  anymore if your web browser closes (!!)
+  - Users can easily create "favorite" sessions to revisit for later, and admins
+    can create pre-configured sessions for their instancse for users
+- Improved 'aborting' behavior, still an ongoing process
+
+![image](https://github.com/user-attachments/assets/c1d2f66b-dfd6-446e-af3d-fd66b8750301)
+
+Screenshot of the multi-variant viewer


### PR DESCRIPTION
current changelog

## Unreleased (2024-11-27)

#### :rocket: Enhancement
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `text-indexing`, `web-core`
  * [#4682](https://github.com/GMOD/jbrowse-components/pull/4682) Quality of life improvements for SV inspector ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`
  * [#4178](https://github.com/GMOD/jbrowse-components/pull/4178) Add ability to use colorBy and filterBy for alignments track configs, and group by strand ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#4672](https://github.com/GMOD/jbrowse-components/pull/4672) Add BedGraphAdapter and BedGraphTabixAdapter ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`, `text-indexing`
  * [#4663](https://github.com/GMOD/jbrowse-components/pull/4663) Replace AbortSignal with "stop token" to rescue some aborting behavior ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* [#4676](https://github.com/GMOD/jbrowse-components/pull/4676) Fix MCScanAnchorsAdapter rendering in linear genome view ([@cmdcolin](https://github.com/cmdcolin))
* [#4670](https://github.com/GMOD/jbrowse-components/pull/4670) Fix GC-content track regression in v2.17.0 ([@cmdcolin](https://github.com/cmdcolin))
* [#4667](https://github.com/GMOD/jbrowse-components/pull/4667) Reduce self-pairing for some paired-end read data in breakpoint split view ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 1
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 1.05s.
