### PR TITLE
Add mobx transaction to multi-level synteny zoom

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Menu } from '@jbrowse/core/ui'
 import { stringify } from '@jbrowse/core/util'
 import { Popover, Typography, alpha } from '@mui/material'
+import { transaction } from 'mobx'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -103,12 +104,14 @@ const LinearComparativeRubberband = observer(function Rubberband({
           clientX,
           clientY,
         })
-        model.views.forEach(view => {
-          const args = computeOffsets(offsetX, view)
-          if (args) {
-            const { leftOffset, rightOffset } = args
-            view.setOffsets(leftOffset, rightOffset)
-          }
+        transaction(() => {
+          model.views.forEach(view => {
+            const args = computeOffsets(offsetX, view)
+            if (args) {
+              const { leftOffset, rightOffset } = args
+              view.setOffsets(leftOffset, rightOffset)
+            }
+          })
         })
         setGuideX(undefined)
       }
@@ -152,8 +155,10 @@ const LinearComparativeRubberband = observer(function Rubberband({
 
   function mouseOut() {
     setGuideX(undefined)
-    model.views.forEach(view => {
-      view.setOffsets(undefined, undefined)
+    transaction(() => {
+      model.views.forEach(view => {
+        view.setOffsets(undefined, undefined)
+      })
     })
   }
 


### PR DESCRIPTION
This might not fix anything but I had a rare issue where zooming in on multiple levels on a linear synteny view produced the wrong offsets and zoomed into a very tiny region when that wasn't what I selected. It is a hard-to-reproduce issue though so i can't necessarily tell whether this PR will fix it entirely, but this PR changes the code to use a 'mobx transaction' to make sure all zoom level changes are committed at the same time. It doesn't seem like this change would fix the issue