### PR TITLE
Avoid full length sequence fetch on SNP coverage calculation

### DIFF
--- a/plugins/alignments/src/SNPCoverageAdapter/generateCoverageBins.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/generateCoverageBins.ts
@@ -27,12 +27,7 @@ export async function generateCoverageBins({
   const bins = [] as PreBaseCoverageBin[]
   const start2 = Math.max(0, region.start - 1)
   const diff = region.start - start2
-  const regionSequence =
-    (await fetchSequence({
-      ...region,
-      start: start2,
-      end: region.end + 1,
-    })) || ''
+
   let start = performance.now()
   for (const feature of features) {
     if (performance.now() - start > 400) {
@@ -43,10 +38,15 @@ export async function generateCoverageBins({
       feature,
       bins,
       region,
-      regionSequence: regionSequence.slice(diff),
     })
 
     if (colorBy?.type === 'modifications') {
+      const regionSequence =
+        (await fetchSequence({
+          ...region,
+          start: start2,
+          end: region.end + 1,
+        })) || ''
       processModifications({
         feature,
         colorBy,
@@ -55,6 +55,12 @@ export async function generateCoverageBins({
         regionSequence: regionSequence.slice(diff),
       })
     } else if (colorBy?.type === 'methylation') {
+      const regionSequence =
+        (await fetchSequence({
+          ...region,
+          start: start2,
+          end: region.end + 1,
+        })) || ''
       processReferenceCpGs({
         feature,
         bins,

--- a/plugins/alignments/src/SNPCoverageAdapter/processDepth.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/processDepth.ts
@@ -1,17 +1,15 @@
 import type { PreBaseCoverageBin } from '../shared/types'
 import type { Feature } from '@jbrowse/core/util'
-import type { AugmentedRegion as Region } from '@jbrowse/core/util/types'
+import type { AugmentedRegion } from '@jbrowse/core/util/types'
 
 export function processDepth({
   feature,
   bins,
   region,
-  regionSequence,
 }: {
   feature: Feature
   bins: PreBaseCoverageBin[]
-  region: Region
-  regionSequence: string
+  region: AugmentedRegion
 }) {
   const fstart = feature.get('start')
   const fend = feature.get('end')
@@ -24,7 +22,6 @@ export function processDepth({
         bins[i] = {
           depth: 0,
           readsCounted: 0,
-          refbase: regionSequence[i],
           ref: {
             probabilities: [],
             entryDepth: 0,

--- a/plugins/alignments/src/SNPCoverageAdapter/processMismatches.ts
+++ b/plugins/alignments/src/SNPCoverageAdapter/processMismatches.ts
@@ -2,7 +2,7 @@ import { inc, isInterbase, mismatchLen } from './util'
 
 import type { Mismatch, PreBaseCoverageBin, SkipMap } from '../shared/types'
 import type { Feature } from '@jbrowse/core/util'
-import type { AugmentedRegion as Region } from '@jbrowse/core/util/types'
+import type { AugmentedRegion } from '@jbrowse/core/util/types'
 
 export function processMismatches({
   feature,
@@ -10,7 +10,7 @@ export function processMismatches({
   bins,
   skipmap,
 }: {
-  region: Region
+  region: AugmentedRegion
   bins: PreBaseCoverageBin[]
   feature: Feature
   skipmap: SkipMap
@@ -28,7 +28,7 @@ export function processMismatches({
       const epos = j - region.start
       if (epos >= 0 && epos < bins.length) {
         const bin = bins[epos]!
-        const { base, type } = mismatch
+        const { base, altbase, type } = mismatch
         const interbase = isInterbase(type)
 
         if (type === 'deletion' || type === 'skip') {
@@ -38,6 +38,7 @@ export function processMismatches({
           inc(bin, fstrand, 'snps', base)
           bin.ref.entryDepth--
           bin.ref[fstrand]--
+          bin.refbase = altbase
         } else {
           inc(bin, fstrand, 'noncov', type)
         }


### PR DESCRIPTION
This PR https://github.com/GMOD/jbrowse-components/pull/4647 which addressed primarily rendering modifications made a large number of refactors to make rendering modifications and methylation improved

In the process it introduced a change that fetched the entire sequence. However, there are some cases where


a) jbrowse will decide to render when you are zoomed out super far (for e.g. targetted sequencing)
b) then it will fetch an entire chromosomes worth of data

there is an additional thing where maybe there is something else combining the requests because the indexedfastaadapter is designed to break up requests into smaller chunks, but a user was observing that it was making a single(?) huge HTTP Range request and this was rejected by google cloud servers