### PR TITLE
Add persist_credentials:false to github actions workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -31,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -61,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -143,6 +149,8 @@ jobs:
     steps:
       - run: sudo apt-get -y install tabix
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           draft: true
           prerelease: false
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
@@ -54,6 +56,8 @@ jobs:
       image: docker://node:20-bullseye
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Setup java
@@ -100,6 +104,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
@@ -125,6 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -11,6 +11,8 @@ jobs:
     if: "contains(github.event.head_commit.message, 'update docs')"
     steps:
       - uses: actions/checkout@v4
+        with:
+          - persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
These were identified as 'low severity' by the zizmor (a github actions auditor)

these were identified by the following message

"warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /home/cdiesh/src/jbrowse-components/.github/workflows/release.yml:102:9
    |
102 |       - uses: actions/checkout@v4
    |         ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low
"

the good news is we do not have any medium or high entries, or any use of pull_request_target which was identified  "is almost always used insecurely" ..https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection

i think it's worth looking into a bit more because we do e.g. deploy to jbrowse.org from our gh actions but these, to my knowledge, do not run from external contributions