### PR TITLE
Fix type confusion where sequence feature details crashes for empty subfeatures

### DIFF
--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceContents.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceContents.tsx
@@ -23,21 +23,19 @@ const SequenceContents = observer(function ({
   model: SequenceFeatureDetailsModel
 }) {
   let { seq, upstream = '', downstream = '' } = sequence
+  const children =
+    feature.subfeatures
+      ?.sort((a, b) => a.start - b.start)
+      .map(sub => ({
+        ...sub,
+        start: sub.start - feature.start,
+        end: sub.end - feature.start,
+      })) || []
 
-  const { subfeatures = [] } = feature
-
-  const children = subfeatures
-    .sort((a, b) => a.start - b.start)
-    .map(sub => ({
-      ...sub,
-      start: sub.start - feature.start,
-      end: sub.end - feature.start,
-    }))
-
-  // we filter duplicate entries in cds and exon lists duplicate entries
-  // may be rare but was seen in Gencode v36 track NCList, likely a bug
-  // on GFF3 or probably worth ignoring here (produces broken protein
-  // translations if included)
+  // we filter duplicate entries in cds and exon lists duplicate entries may be
+  // rare but was seen in Gencode v36 track NCList, likely a bug on GFF3 or
+  // probably worth ignoring here (produces broken protein translations if
+  // included)
   //
   // position 1:224,800,006..225,203,064 gene ENSG00000185842.15 first
   // transcript ENST00000445597.6


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/4726

The root cause was that

a) feature.subfeatures was null instead of undefined
b) our type system did not include null in the type signature
c) we used a default assignment, which does not apply to null
d) we use a system that remaps undefined to null in snapshots. this is sort of a questionable thing to do, but it prevents the values from being removed completely from the snapshot. the code comments surrounding this are pretty hard to decipher though, so it could be worth revisiting


This PR fixes it by using "nullish coalescing" which handles both null and undefined. A more extensive fix would probably add null to the type signature, or remove null from being possible
