### PR TITLE
v3.0.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v3.0.0.md
+++ b/website/release_announcement_drafts/v3.0.0.md
@@ -1,0 +1,11 @@
+Seasons greetings!
+
+We are marking a new major release of JBrowse, v3.0.0!
+
+This doesn't contain a lot blls and whistles, it is mostly to 'signal' a
+breaking change by upgrading to React v19 and generic-filehandle2 (similar to
+our v2.0.0 release which was mainly related to dependency version upgrades
+<https://jbrowse.org/jb2/blog/2022/07/07/v2.0.0-release/>)
+
+If you are a plugin developer or an embedded developer and you have trouble
+updating to this new latest version, please let us know!


### PR DESCRIPTION
This is a major version bump mainly as a signal of potential breakage due to the upgrades of some dependencies, notably:

- React 18-> React 19 in jbrowse web (and loss of support of React <=17 for embedded devs)
- generic-filehandle -> generic-filehandle2 (which has a slightly different API)

There are not a ton of other changes otherwise. This major version bump is similar to our decision to major version bump in our "v2.0.0" release https://jbrowse.org/jb2/blog/2022/07/07/v2.0.0-release/

This loses our "vanity version number" of v2 to correspond to JBrowse 2. We can continue calling it "JBrowse 2 v3.0.0" or we can just say "JBrowse v3.0.0" (https://paulrrogers.com/2014/09/vanity-versioning/)

if there is a particular branding that is preferable, we could discuss.

