### PR TITLE
Fix persisting alignments "color by" and "filter by" settings in snapshots/session shares/page reloads

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
@@ -676,11 +676,12 @@ export function SharedLinearPileupDisplayMixin(
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (snap) {
         // @ts-expect-error
-        const { colorBy, filterBy, ...rest } = snap
+        const { colorBy, colorBySetting, filterBySetting, filterBy, ...rest } =
+          snap
         return {
           ...rest,
-          filterBySetting: filterBy,
-          colorBySetting: colorBy,
+          filterBySetting: filterBySetting || filterBy,
+          colorBySetting: colorBySetting || colorBy,
         }
       }
       return snap


### PR DESCRIPTION
Another regression from https://github.com/GMOD/jbrowse-components/pull/4178

There was an attempt at backwards compatibility after the model schema changed slightly after this PR, but this ended up clearing the new style snapshot values with undefined values while trying to load old style snapshots


This PR prioritizes new style snapshot values over old style snapshot values