### PR TITLE
Bulk delete session tracks

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -41,8 +41,8 @@ export default function TrackLabel({ data }: { data: NodeData }) {
     id,
     trackId,
     name,
-    onChange,
     selected,
+    onChange,
   } = data
   const description = readConfObject(conf, 'description')
   return (
@@ -53,6 +53,15 @@ export default function TrackLabel({ data }: { data: NodeData }) {
       >
         <FormControlLabel
           className={classes.checkboxLabel}
+          onClick={event => {
+            if (event.ctrlKey) {
+              if (selected) {
+                model.removeFromSelection([conf])
+              } else {
+                model.addToSelection([conf])
+              }
+            }
+          }}
           control={
             <Checkbox
               className={classes.compactCheckbox}
@@ -70,7 +79,7 @@ export default function TrackLabel({ data }: { data: NodeData }) {
           label={
             <div
               data-testid={`htsTrackLabel-${id}`}
-              style={{ background: selected ? '#cccc' : undefined }}
+              className={selected ? classes.selected : undefined}
             >
               <SanitizedHTML html={name} />
             </div>

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackLabel.tsx
@@ -54,12 +54,13 @@ export default function TrackLabel({ data }: { data: NodeData }) {
         <FormControlLabel
           className={classes.checkboxLabel}
           onClick={event => {
-            if (event.ctrlKey) {
+            if (event.ctrlKey || event.metaKey) {
               if (selected) {
                 model.removeFromSelection([conf])
               } else {
                 model.addToSelection([conf])
               }
+              event.preventDefault()
             }
           }}
           control={


### PR DESCRIPTION
This PR adds the option to add a track to the "selection" (or remove it) using "ctrl+click" (cmd+click on mac) on a track label in the hierarchical selector

Then, it allows users to optionally bulk delete those selected tracks using the shopping cart if they are all session tracks or if they are admin