### PR TITLE
v3.0.0 release announcement

### DIFF
--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -4469,6 +4469,39 @@
     },
     {
       "type": "AlignmentsTrack",
+      "trackId": "hg002_cram",
+      "name": "HG002 CRAM nanopore+whatshap",
+      "assemblyNames": ["hg19"],
+      "category": ["GIAB"],
+      "adapter": {
+        "type": "CramAdapter",
+        "cramLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg002/HG002_ONTrel2_16x_RG_HP10xtrioRTG.cram",
+          "locationType": "UriLocation"
+        },
+        "craiLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg002/HG002_ONTrel2_16x_RG_HP10xtrioRTG.cram.crai",
+          "locationType": "UriLocation"
+        },
+        "sequenceAdapter": {
+          "type": "BgzipFastaAdapter",
+          "fastaLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz",
+            "locationType": "UriLocation"
+          },
+          "faiLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai",
+            "locationType": "UriLocation"
+          },
+          "gziLocation": {
+            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi",
+            "locationType": "UriLocation"
+          }
+        }
+      }
+    },
+    {
+      "type": "AlignmentsTrack",
       "trackId": "Pairend_StrandSpecific_51mer_Human_hg19.chr1.TS.bam",
       "name": "Paired-end stranded RNA-seq (BAM,TS)",
       "category": ["RNA-seq"],
@@ -4739,6 +4772,26 @@
         }
       },
       "assemblyNames": ["hg1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf",
+      "name": "NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://jbrowse.org/genomes/hg38/NA12878/NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/genomes/hg38/NA12878/NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hg38"]
     }
   ],
   "connections": [],

--- a/website/release_announcement_drafts/v3.0.0.md
+++ b/website/release_announcement_drafts/v3.0.0.md
@@ -1,0 +1,122 @@
+Hello all!
+
+This release announces v3.0.0 of JBrowse 2. Is not a dramatic change like the
+jbrowse 1 -> jbrowse 2 transition, it's much more incremental, and in fact, you
+can go on calling it JBrowse 2...as a point of comparison, ggplot2 is on v3.5.1
+right now :)
+
+We decided to make a major bump due to some small "breaking" changes that could
+affect plugin and embedded library users in particular.
+
+But for most users, this release should have nothing but the usual bugfixes and
+improvements! And there are a lot of these!
+
+Without further ado, here are some highlights!
+
+## Improved rendering of phased VCF in multi-variant view
+
+Phased variants offer a unique opportunity to see "which parent" particular
+parents came from
+
+![Screenshot From 2025-01-25 15-03-21](https://github.com/user-attachments/assets/a9308a40-ab74-48c0-9ab6-035b50a1ae0b)
+Screenshot showing the "phased mode" for the multi-variant matrix display, here
+showing a "trio VCF" with child and parents. You can visually see which blocks
+the child inherited from which parents. This inspection can also be useful for
+plant breeders to ensure regions that their crosses inherited particular gnomic
+regions from a particular parent line
+
+We can also render "phased sets" if the VCF is not completely phased (detects PS
+tag in genotypes)
+
+![image](https://github.com/user-attachments/assets/63fa9f59-d54b-4f66-852d-4d8592ff95ec)
+
+Screenshot showing phase set rendering of a phased VCF. This is nearly
+completely phased so just showing green, but each phase set would get a unique
+color. The black entries are unphased variants (which could be filtered out, but
+this is not done currently)
+
+## Improved rendering of polyploid VCF in multi-variant view
+
+![image](https://github.com/user-attachments/assets/58138b02-4d20-487b-af77-68b2d038dedc)
+
+Screenshot showing the "polyploid" rendering of the multi-variant display.
+
+Polyploid variant calls can look like `0/2/./1` indicating one match to the
+reference (0), two alts (1,2), and one missing call (.).
+
+- Yellow indicates missingness
+- Grey indicates reference
+- Blue indicates the ALT===1
+- Red is ALT!==1
+
+Each of these is a spectrum that increases in darkness, so darker blue indicates
+more ALT===1, darker red indicates more ALT!==1, darker yellow is more uncalled,
+etc.
+
+## Adding VCF sample metadata from TSV
+
+![image](https://github.com/user-attachments/assets/ba7b99ab-53eb-4719-a6de-1cf9ff16511a)
+
+Screnshot showing multi-sample matrix display, with the population colors coming
+from a "sample TSV" file
+
+Config
+
+```json
+{
+  "type": "VariantTrack",
+  "trackId": "1kGP_high_coverage_Illumina.chr1.filtered.SNV_INDEL_SV_phased_panel.vcf",
+  "name": "1kGP_high_coverage_Illumina.chr1.filtered.SNV_INDEL_SV_phased_panel.vcf",
+  "assemblyNames": ["hg19"],
+  "adapter": {
+    "type": "VcfTabixAdapter",
+    "vcfGzLocation": {
+      "uri": "https://ftp-trace.ncbi.nlm.nih.gov/1000genomes/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
+    },
+    "index": {
+      "location": {
+        "uri": "https://ftp-trace.ncbi.nlm.nih.gov/1000genomes/ftp/release/20130502/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi"
+      }
+    },
+    "samplesTsvLocation": {
+      "uri": "https://jbrowse.org/genomes/hg19/1000g.sorted.csv.gz"
+    }
+  }
+}
+```
+
+## Improved UI for opening synteny tracks
+
+It has always been a little tricky to open synteny tracks
+
+We now allow support adding synteny tracks via the default "Add track" workflow,
+and make it easier to specify the query and target assembly names
+
+![image](https://github.com/user-attachments/assets/913fd8b9-9d4e-4d44-88d7-ba3e70fd54f4)
+
+Screnshot showing the default add track workflow with new UI for choosing target
+and query assemblies for PAF tracks
+
+![image](https://github.com/user-attachments/assets/75da5058-50cc-413e-aee9-e57362d2d0c0)
+
+Screenshot showing the add track workflow in the Linear synteny view import
+form, also showing new UI for choosing query and target assmblies
+
+## New "turbo zoom" buttons
+
+In working with users, we noticed people having to click the zoom buttons or
+fiddle with the slider a lot. To aid this, we added a small dropdown for quickly
+doing 10x, 50x, and 100x zooms
+
+![image](https://github.com/user-attachments/assets/2ee0305e-d617-4ec3-8957-8ec1d906feff)
+
+## For developers: some "breaking" changes
+
+1. We changed the "filehandle" type used in data adapters. We now use
+   generic-filehandle2 which is simpler and does not require a node.js polyfill
+   on the web
+2. Upgrading React 18 -> React 19 in our main webapp. This drops support for
+   React 17, and may have some other implications
+
+If you are a plugin or embedded user, and experience problems with upgrading,
+let us know!

--- a/website/src/pages/demos.mdx
+++ b/website/src/pages/demos.mdx
@@ -58,6 +58,9 @@ desktop.
 - <Link extra="?config=https%3A%2F%2Fjbrowse.org%2Fdemos%2Fplant_synteny_demo%2Fconfig2.json&session=share-pARmvLazem&password=ZPOwE">
     {'Multi-way synteny demo (grape vs peach vs cacao)'}
   </Link>
+- <Link extra="?config=/genomes/potato/config.json">
+    {'Tetraploid potato multi-sample VCF rendering'}
+  </Link>
 
 **Conference and other guided demos**
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,14 +100,14 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-cloudfront@^3.726.1":
-  version "3.734.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudfront/-/client-cloudfront-3.734.0.tgz#d9e16cf6c4acae88db6803222c68d92c2d204961"
-  integrity sha512-j0R5arpRRBHRBKrnRmwXECCKFNOYdjGAmkpVS27GNuE6hJ2h2CBGJvb+XRzqZiEhna40+VeBn0/39yroMb157g==
+  version "3.738.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudfront/-/client-cloudfront-3.738.0.tgz#8492886fd9cc81a49047960d17d2c8967f2bae92"
+  integrity sha512-T2bAcJrNpZsPHfh+YJR9yYg8rxRAAWvwYlvJgwtPz0kn3TiNdOwcbgiQkcWuWTKxirshOpn6sWBoRcAarMYVZg==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
     "@aws-sdk/core" "3.734.0"
-    "@aws-sdk/credential-provider-node" "3.734.0"
+    "@aws-sdk/credential-provider-node" "3.738.0"
     "@aws-sdk/middleware-host-header" "3.734.0"
     "@aws-sdk/middleware-logger" "3.734.0"
     "@aws-sdk/middleware-recursion-detection" "3.734.0"
@@ -148,15 +148,15 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-s3@^3.735.0":
-  version "3.735.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.735.0.tgz#c8b8c8303530982a82ae83b763f1941cb6c60c08"
-  integrity sha512-6NcxX06c4tnnu6FTFiyS8shoYLy+8TvIDkYjJ5r9tvbaysOptUKQdolOuh7+Lz95QyaqiznpCsNTxsfywLXcqw==
+  version "3.738.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.738.0.tgz#0bb71fa46d234c0bd7f86f61c4075453bdf61a8e"
+  integrity sha512-1Im/p5yfoV15ydVY+QlffsWQkQm7iGVI+3V9tCHEUT6SdmukYEpN3G8Y+lWofRBidxzUE2Xd+MbChCXfzLAoAg==
   dependencies:
     "@aws-crypto/sha1-browser" "5.2.0"
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
     "@aws-sdk/core" "3.734.0"
-    "@aws-sdk/credential-provider-node" "3.734.0"
+    "@aws-sdk/credential-provider-node" "3.738.0"
     "@aws-sdk/middleware-bucket-endpoint" "3.734.0"
     "@aws-sdk/middleware-expect-continue" "3.734.0"
     "@aws-sdk/middleware-flexible-checksums" "3.735.0"
@@ -316,10 +316,10 @@
     "@smithy/types" "^4.1.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-node@3.734.0":
-  version "3.734.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.734.0.tgz#86d54171c11cab5b64bfa55ab0def5e807440ad2"
-  integrity sha512-9NOSNbkPVb91JwaXOhyfahkzAwWdMsbWHL6fh5/PHlXYpsDjfIfT23I++toepNF2nODAJNLnOEHGYIxgNgf6jQ==
+"@aws-sdk/credential-provider-node@3.738.0":
+  version "3.738.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.738.0.tgz#0a470fc4d2e791c26da57261b8b14f07de43cd74"
+  integrity sha512-3MuREsazwBxghKb2sQQHvie+uuK4dX4/ckFYiSoffzJQd0YHxaGxf8cr4NOSCQCUesWu8D3Y0SzlnHGboVSkpA==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.734.0"
     "@aws-sdk/credential-provider-http" "3.734.0"
@@ -2205,9 +2205,9 @@
   integrity sha512-BTMPPUS667K2eGQ6ASc69908l3hDWF2sV/ZoTuMqIz1AfiHuaDMpcdELNf61bVeTWvUUFG5qkOQApcWMvlIvjw==
 
 "@gmod/vcf@^6.0.0":
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-6.0.6.tgz#8b82c0d6c6c3badead814ca9fc39b78cad2ce1f7"
-  integrity sha512-pgNGVbglMrNZKUiRgxCxOEZUsF9LyGTOHxu6DJvbLU7ZJEiLo6uAHIJYTmk6Z8pdT9lLCqNd9mJCc/g0TbmpnA==
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-6.0.7.tgz#15fb42ccb23f1fe094be3412ef799ebbcb2e4abf"
+  integrity sha512-Sn3bEhLBXTu1StofTMeqcwmSxinvThvdst+na/3s6CbUPtkM/AYerMIOrztKvHP6z7CnYgxQ3MQEAuH0BqVeOA==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -2242,14 +2242,14 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inquirer/checkbox@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-4.0.6.tgz#e71401a7e1900332f17ed68c172a89fe20225f49"
-  integrity sha512-PgP35JfmGjHU0LSXOyRew0zHuA9N6OJwOlos1fZ20b7j8ISeAdib3L+n0jIxBtX958UeEpte6xhG/gxJ5iUqMw==
+"@inquirer/checkbox@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-4.0.7.tgz#4c11322ab932765cace50d163eea73002dd76432"
+  integrity sha512-lyoF4uYdBBTnqeB1gjPdYkiQ++fz/iYKaP9DON1ZGlldkvAEJsjaOBRdbl5UW1pOSslBRd701jxhAG0MlhHd2w==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/figures" "^1.0.9"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/figures" "^1.0.10"
+    "@inquirer/type" "^3.0.3"
     ansi-escapes "^4.3.2"
     yoctocolors-cjs "^2.1.2"
 
@@ -2261,26 +2261,25 @@
     "@inquirer/core" "^9.1.0"
     "@inquirer/type" "^1.5.3"
 
-"@inquirer/confirm@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.3.tgz#c1ad57663f54758981811ccb86f823072ddf5c1a"
-  integrity sha512-fuF9laMmHoOgWapF9h9hv6opA5WvmGFHsTYGCmuFxcghIhEhb3dN0CdQR4BUMqa2H506NCj8cGX4jwMsE4t6dA==
+"@inquirer/confirm@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.4.tgz#3e2c9bfdf80331676196d8dbb2261103a67d0e9d"
+  integrity sha512-EsiT7K4beM5fN5Mz6j866EFA9+v9d5o9VUra3hrg8zY4GHmCS8b616FErbdo5eyKoVotBQkHzMIeeKYsKDStDw==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
 
-"@inquirer/core@^10.1.4":
-  version "10.1.4"
-  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-10.1.4.tgz#02394e68d894021935caca0d10fc68fd4f3a3ead"
-  integrity sha512-5y4/PUJVnRb4bwWY67KLdebWOhOc7xj5IP2J80oWXa64mVag24rwQ1VAdnj7/eDY/odhguW0zQ1Mp1pj6fO/2w==
+"@inquirer/core@^10.1.5":
+  version "10.1.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-10.1.5.tgz#7271c177340f77c2e231704227704d8cdf497747"
+  integrity sha512-/vyCWhET0ktav/mUeBqJRYTwmjFPIKPRYb3COAw7qORULgipGSUO2vL32lQKki3UxDKJ8BvuEbokaoyCA6YlWw==
   dependencies:
-    "@inquirer/figures" "^1.0.9"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/figures" "^1.0.10"
+    "@inquirer/type" "^3.0.3"
     ansi-escapes "^4.3.2"
     cli-width "^4.1.0"
     mute-stream "^2.0.0"
     signal-exit "^4.1.0"
-    strip-ansi "^6.0.1"
     wrap-ansi "^6.2.0"
     yoctocolors-cjs "^2.1.2"
 
@@ -2302,28 +2301,28 @@
     wrap-ansi "^6.2.0"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/editor@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-4.2.3.tgz#0858adcd07d9607b0614778eaa5ce8a83871c367"
-  integrity sha512-S9KnIOJuTZpb9upeRSBBhoDZv7aSV3pG9TECrBj0f+ZsFwccz886hzKBrChGrXMJwd4NKY+pOA9Vy72uqnd6Eg==
+"@inquirer/editor@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-4.2.4.tgz#1b2b6c0088c80375df1d7d2de89c30088b2bfe29"
+  integrity sha512-S8b6+K9PLzxiFGGc02m4syhEu5JsH0BukzRsuZ+tpjJ5aDsDX1WfNfOil2fmsO36Y1RMcpJGxlfQ1yh4WfU28Q==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
     external-editor "^3.1.0"
 
-"@inquirer/expand@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-4.0.6.tgz#8676e6049c6114fb306df23358375bd84fa1c92c"
-  integrity sha512-TRTfi1mv1GeIZGyi9PQmvAaH65ZlG4/FACq6wSzs7Vvf1z5dnNWsAAXBjWMHt76l+1hUY8teIqJFrWBk5N6gsg==
+"@inquirer/expand@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-4.0.7.tgz#352e05407e72e2f079e5affe032cc77c93ff7501"
+  integrity sha512-PsUQ5t7r+DPjW0VVEHzssOTBM2UPHnvBNse7hzuki7f6ekRL94drjjfBLrGEDe7cgj3pguufy/cuFwMeWUWHXw==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/figures@^1.0.5", "@inquirer/figures@^1.0.6", "@inquirer/figures@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.9.tgz#9d8128f8274cde4ca009ca8547337cab3f37a4a3"
-  integrity sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==
+"@inquirer/figures@^1.0.10", "@inquirer/figures@^1.0.5", "@inquirer/figures@^1.0.6":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.10.tgz#e3676a51c9c51aaabcd6ba18a28e82b98417db37"
+  integrity sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==
 
 "@inquirer/input@^2.2.4":
   version "2.3.0"
@@ -2333,64 +2332,64 @@
     "@inquirer/core" "^9.1.0"
     "@inquirer/type" "^1.5.3"
 
-"@inquirer/input@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-4.1.3.tgz#fa0ea9a392b2ec4ddd763c504d0b0c8839a48fe2"
-  integrity sha512-zeo++6f7hxaEe7OjtMzdGZPHiawsfmCZxWB9X1NpmYgbeoyerIbWemvlBxxl+sQIlHC0WuSAG19ibMq3gbhaqQ==
+"@inquirer/input@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-4.1.4.tgz#10080f9a4b258c3d3a066488804bfb4caf5529fc"
+  integrity sha512-CKKF8otRBdIaVnRxkFLs00VNA9HWlEh3x4SqUfC3A8819TeOZpTYG/p+4Nqu3hh97G+A0lxkOZNYE7KISgU8BA==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
 
-"@inquirer/number@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-3.0.6.tgz#19bba46725df194bdd907762cf432a37e053b300"
-  integrity sha512-xO07lftUHk1rs1gR0KbqB+LJPhkUNkyzV/KhH+937hdkMazmAYHLm1OIrNKpPelppeV1FgWrgFDjdUD8mM+XUg==
+"@inquirer/number@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-3.0.7.tgz#50bc394cda68205025e098b0cdec716f6d100e56"
+  integrity sha512-uU2nmXGC0kD8+BLgwZqcgBD1jcw2XFww2GmtP6b4504DkOp+fFAhydt7JzRR1TAI2dmj175p4SZB0lxVssNreA==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
 
-"@inquirer/password@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-4.0.6.tgz#4bbee12fe7cd1d37435401098c296ddc4586861b"
-  integrity sha512-QLF0HmMpHZPPMp10WGXh6F+ZPvzWE7LX6rNoccdktv/Rov0B+0f+eyXkAcgqy5cH9V+WSpbLxu2lo3ysEVK91w==
+"@inquirer/password@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-4.0.7.tgz#28a908185da7d65cf24b0e8e44c7ecc73b703889"
+  integrity sha512-DFpqWLx+C5GV5zeFWuxwDYaeYnTWYphO07pQ2VnP403RIqRIpwBG0ATWf7pF+3IDbaXEtWatCJWxyDrJ+rkj2A==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
     ansi-escapes "^4.3.2"
 
 "@inquirer/prompts@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-7.2.3.tgz#8a0d7cb5310d429bf815d25bbff108375fc6315b"
-  integrity sha512-hzfnm3uOoDySDXfDNOm9usOuYIaQvTgKp/13l1uJoe6UNY+Zpcn2RYt0jXz3yA+yemGHvDOxVzqWl3S5sQq53Q==
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-7.2.4.tgz#115f3a8ed1f9c6726e18cd797aecec8ca32629ec"
+  integrity sha512-Zn2XZL2VZl76pllUjeDnS6Poz2Oiv9kmAZdSZw1oFya985+/JXZ3GZ2JUWDokAPDhvuhkv9qz0Z7z/U80G8ztA==
   dependencies:
-    "@inquirer/checkbox" "^4.0.6"
-    "@inquirer/confirm" "^5.1.3"
-    "@inquirer/editor" "^4.2.3"
-    "@inquirer/expand" "^4.0.6"
-    "@inquirer/input" "^4.1.3"
-    "@inquirer/number" "^3.0.6"
-    "@inquirer/password" "^4.0.6"
-    "@inquirer/rawlist" "^4.0.6"
-    "@inquirer/search" "^3.0.6"
-    "@inquirer/select" "^4.0.6"
+    "@inquirer/checkbox" "^4.0.7"
+    "@inquirer/confirm" "^5.1.4"
+    "@inquirer/editor" "^4.2.4"
+    "@inquirer/expand" "^4.0.7"
+    "@inquirer/input" "^4.1.4"
+    "@inquirer/number" "^3.0.7"
+    "@inquirer/password" "^4.0.7"
+    "@inquirer/rawlist" "^4.0.7"
+    "@inquirer/search" "^3.0.7"
+    "@inquirer/select" "^4.0.7"
 
-"@inquirer/rawlist@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-4.0.6.tgz#b55d5828d850f07bc6792bbce3b2a963e33b3ef5"
-  integrity sha512-QoE4s1SsIPx27FO4L1b1mUjVcoHm1pWE/oCmm4z/Hl+V1Aw5IXl8FYYzGmfXaBT0l/sWr49XmNSiq7kg3Kd/Lg==
+"@inquirer/rawlist@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-4.0.7.tgz#b6c710a6a1c3dc8891b313d1b901367b4fc0df31"
+  integrity sha512-ZeBca+JCCtEIwQMvhuROT6rgFQWWvAImdQmIIP3XoyDFjrp2E0gZlEn65sWIoR6pP2EatYK96pvx0887OATWQQ==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/type" "^3.0.3"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/search@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-3.0.6.tgz#5537e3f46b7d31ab65ca22b831cf546f88db1d5b"
-  integrity sha512-eFZ2hiAq0bZcFPuFFBmZEtXU1EarHLigE+ENCtpO+37NHCl4+Yokq1P/d09kUblObaikwfo97w+0FtG/EXl5Ng==
+"@inquirer/search@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-3.0.7.tgz#78ec82bc0597fb27ac6bf306e4602e607a06a0b3"
+  integrity sha512-Krq925SDoLh9AWSNee8mbSIysgyWtcPnSAp5YtPBGCQ+OCO+5KGC8FwLpyxl8wZ2YAov/8Tp21stTRK/fw5SGg==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/figures" "^1.0.9"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/figures" "^1.0.10"
+    "@inquirer/type" "^3.0.3"
     yoctocolors-cjs "^2.1.2"
 
 "@inquirer/select@^2.5.0":
@@ -2404,14 +2403,14 @@
     ansi-escapes "^4.3.2"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/select@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-4.0.6.tgz#3062c02c82f7bbe238972672def6d8394732bb2b"
-  integrity sha512-yANzIiNZ8fhMm4NORm+a74+KFYHmf7BZphSOBovIzYPVLquseTGEkU5l2UTnBOf5k0VLmTgPighNDLE9QtbViQ==
+"@inquirer/select@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-4.0.7.tgz#cea50dc7a00e749386d23ac42487dd62f7379d84"
+  integrity sha512-ejGBMDSD+Iqk60u5t0Zf2UQhGlJWDM78Ep70XpNufIfc+f4VOTeybYKXu9pDjz87FkRzLiVsGpQG2SzuGlhaJw==
   dependencies:
-    "@inquirer/core" "^10.1.4"
-    "@inquirer/figures" "^1.0.9"
-    "@inquirer/type" "^3.0.2"
+    "@inquirer/core" "^10.1.5"
+    "@inquirer/figures" "^1.0.10"
+    "@inquirer/type" "^3.0.3"
     ansi-escapes "^4.3.2"
     yoctocolors-cjs "^2.1.2"
 
@@ -2429,10 +2428,10 @@
   dependencies:
     mute-stream "^1.0.0"
 
-"@inquirer/type@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.2.tgz#baff9f8d70947181deb36772cd9a5b6876d3e60c"
-  integrity sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==
+"@inquirer/type@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.3.tgz#aa9cb38568f23f772b417c972f6a2d906647a6af"
+  integrity sha512-I4VIHFxUuY1bshGbXZTxCmhwaaEst9s/lll3ekok+o1Z26/ZUKdx8y1b7lsoG6rtsBDwEGfiBJ2SfirjoISLpg==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -2833,28 +2832,28 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@mui/core-downloads-tracker@^6.4.1":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.1.tgz#5f9b31768c5be562522c5e5816f3c4f8bada1202"
-  integrity sha512-SfDLWMV5b5oXgDf3NTa2hCTPC1d2defhDH2WgFKmAiejC4mSfXYbyi+AFCLzpizauXhgBm8OaZy9BHKnrSpahQ==
+"@mui/core-downloads-tracker@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.2.tgz#a516b3f678add06e08978b327761622841326e39"
+  integrity sha512-Qmod9fHsFWrtLxdSkZ4iDLRz2AUKt3C2ZEimuY+qKlQGVKJDNS5DuSlNOAgqfHFDq8mzB17ATN6HFcThwJlvUw==
 
 "@mui/icons-material@^6.0.0":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-6.4.1.tgz#e12f2a93bd5226aa65258533b7161f156b515b8d"
-  integrity sha512-wsxFcUTQxt4s+7Bg4GgobqRjyaHLmZGNOs+HJpbwrwmLbT6mhIJxhpqsKzzWq9aDY8xIe7HCjhpH7XI5UD6teA==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-6.4.2.tgz#21fc2a944b83cb3901e966ad32ee35e548d54c11"
+  integrity sha512-uwsH1KRmxkJwK3NZyo1xL9pEduL16ftCnzYBYjd6nPNtm05QAoIc0aqedS9tqDV+Ab3q5C04HHOVsMDDv1EBpg==
   dependencies:
     "@babel/runtime" "^7.26.0"
 
 "@mui/material@^6.0.0":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-6.4.1.tgz#8f5d027b99928a632654f4161292a6f62ae69257"
-  integrity sha512-MFBfia6UiKxyoLeGkAh8M15bkeDmfnsUTMRJd/vTQue6YQ8AQ6lw9HqDthyYghzDEWIvZO/lQQzLrZE8XwNJLA==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-6.4.2.tgz#480ecc683584d598efafd703655ecaac16335995"
+  integrity sha512-9jKr53KbAJyyBRx8LRmX7ATXHlGtxVQdPgm1uyXMoEPMVkSJW1yO3vFgfYoDbGx4ZHcCNuWa4FkFIPWVt9fghA==
   dependencies:
     "@babel/runtime" "^7.26.0"
-    "@mui/core-downloads-tracker" "^6.4.1"
-    "@mui/system" "^6.4.1"
+    "@mui/core-downloads-tracker" "^6.4.2"
+    "@mui/system" "^6.4.2"
     "@mui/types" "^7.2.21"
-    "@mui/utils" "^6.4.1"
+    "@mui/utils" "^6.4.2"
     "@popperjs/core" "^2.11.8"
     "@types/react-transition-group" "^4.4.12"
     clsx "^2.1.1"
@@ -2863,19 +2862,19 @@
     react-is "^19.0.0"
     react-transition-group "^4.4.5"
 
-"@mui/private-theming@^6.4.1":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-6.4.1.tgz#b4085e456edabc5b3fe2d1f777397a907404ad48"
-  integrity sha512-DcT7mwK89owwgcEuiE7w458te4CIjHbYWW6Kn6PiR6eLtxBsoBYphA968uqsQAOBQDpbYxvkuFLwhgk4bxoN/Q==
+"@mui/private-theming@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-6.4.2.tgz#25b2fbfb89632ed684900bee35d8f0eb664e9173"
+  integrity sha512-2CkQT0gNlogM50qGTBJgWA7hPPx4AeH8RE2xJa+PHtIOowiVPX52ZsQ0e7Ho18DAqEbkngQ6Uju037ER+TCY5A==
   dependencies:
     "@babel/runtime" "^7.26.0"
-    "@mui/utils" "^6.4.1"
+    "@mui/utils" "^6.4.2"
     prop-types "^15.8.1"
 
-"@mui/styled-engine@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-6.4.0.tgz#1f01a5218964f0e3bd8eb13170e12b5f55c4f159"
-  integrity sha512-ek/ZrDujrger12P6o4luQIfRd2IziH7jQod2WMbLqGE03Iy0zUwYmckRTVhRQTLPNccpD8KXGcALJF+uaUQlbg==
+"@mui/styled-engine@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-6.4.2.tgz#6d2c734dc5cde2bf0ddf33d8f14b361fe5c7fe08"
+  integrity sha512-cgjQK2bkllSYoWUBv93ALhCPJ0NhfO3NctsBf13/b4XSeQVfKPBAnR+P9mNpdFMa5a5RWwtWuBD3cZ5vktsN+g==
   dependencies:
     "@babel/runtime" "^7.26.0"
     "@emotion/cache" "^11.13.5"
@@ -2884,16 +2883,16 @@
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/system@^6.0.0", "@mui/system@^6.4.1":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-6.4.1.tgz#6491bbeae8b10d4f1e38afbec27f586445e05b6e"
-  integrity sha512-rgQzgcsHCTtzF9MZ+sL0tOhf2ZBLazpjrujClcb4Siju5lTrK0xX4PsiropActzCemNfM+mOu+0jezAVnfRK8g==
+"@mui/system@^6.0.0", "@mui/system@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-6.4.2.tgz#856a999140a1d15329b5c9726cf2a55abbe9311f"
+  integrity sha512-wQbaPCtsxNsM5nR+NZpkFJBKVKH03GQnAjlkKENM8JQqGdWcRyM3f4fJZgzzNdIFpSQw4wpAQKnhfHkjf3d6yQ==
   dependencies:
     "@babel/runtime" "^7.26.0"
-    "@mui/private-theming" "^6.4.1"
-    "@mui/styled-engine" "^6.4.0"
+    "@mui/private-theming" "^6.4.2"
+    "@mui/styled-engine" "^6.4.2"
     "@mui/types" "^7.2.21"
-    "@mui/utils" "^6.4.1"
+    "@mui/utils" "^6.4.2"
     clsx "^2.1.1"
     csstype "^3.1.3"
     prop-types "^15.8.1"
@@ -2903,10 +2902,10 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.21.tgz#63f50874eda8e4a021a69aaa8ba9597369befda2"
   integrity sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==
 
-"@mui/utils@^5.16.6 || ^6.0.0", "@mui/utils@^6.4.1":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.4.1.tgz#19e71af7f94a35fe6f43023a4badafc5807ab429"
-  integrity sha512-iQUDUeYh87SvR4lVojaRaYnQix8BbRV51MxaV6MBmqthecQoxwSbS5e2wnbDJUeFxY2ppV505CiqPLtd0OWkqw==
+"@mui/utils@^5.16.6 || ^6.0.0", "@mui/utils@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.4.2.tgz#eeba878bf55fbe0a72bd6adb361f5737a489ec52"
+  integrity sha512-5NkhzlJkmR5+5RSs/Irqin1GPy2Z8vbLk/UzQrH9FEAnm6OA9SvuXjzgklxUs7N65VwEkGpKK1jMZ5K84hRdzQ==
   dependencies:
     "@babel/runtime" "^7.26.0"
     "@mui/types" "^7.2.21"
@@ -3274,9 +3273,9 @@
   integrity sha512-IUeCeLdehVocLML6Wub7OZVM96Sk97AshiWmeNnozI6/OYdS34hQ2+thH7ETUZas9nkC2nNkJ5jLwuAHm+5/vw==
 
 "@oclif/core@^4", "@oclif/core@^4.0.19", "@oclif/core@^4.0.37", "@oclif/core@^4.2.3":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.2.4.tgz#0737063beb35e3d421135cd07983bc5306fb17bf"
-  integrity sha512-JDqdhX6fBbijY3ouubfmX7yFBXy95YSpiAVk0TAaXXCoSqoo/2WMcV2Ufv2V+8zriafPU/rvKgI+ZE07/7HwfQ==
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.2.5.tgz#6b51e1db17272204b2431fee3eba93a21d59ebbe"
+  integrity sha512-bdXOojq8GaPnWnDgVOw030JlUROJEiDLXiV3XUUGUQDEp6YpVQvEYLIrUsEvyfASU3z3FGg3DC9k0kprcOYdhw==
   dependencies:
     ansi-escapes "^4.3.2"
     ansis "^3.9.0"
@@ -6404,9 +6403,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001688:
-  version "1.0.30001695"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz#39dfedd8f94851132795fdf9b79d29659ad9c4d4"
-  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
+  version "1.0.30001696"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz#00c30a2fc11e3c98c25e5125418752af3ae2f49f"
+  integrity sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==
 
 canvas-sequencer@^3.1.0:
   version "3.1.0"
@@ -14465,9 +14464,9 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.0.tgz#9c6fe61d0c6f9fa9e26575162ee5a9180361b09c"
+  integrity sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==
 
 send@0.19.0:
   version "0.19.0"
@@ -15784,9 +15783,9 @@ typescript-eslint@^8.0.1:
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 typescript@^5.8.0-dev.20241213:
-  version "5.8.0-dev.20250128"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-dev.20250128.tgz#c59b177fa5dbc9a492268f44e857354c59c55c71"
-  integrity sha512-zxnu5BSmL1qbW+jJyVvkdvIHog6eBy84HKlTJQDV97fqrbPKlS5WJVGj/1xKlbBMA9lyqYsp/ijkuJbaq4mt2g==
+  version "5.8.0-dev.20250129"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-dev.20250129.tgz#73473644db6599f8e3caa4a2450e1430d0520230"
+  integrity sha512-02x0dvITiMrpFF7O55RqWGvOgeuv7HOUkUiObmiI0j+MuO7EJq++6wkRGRZW23FxZYB7vV6xlC+UC65nvYvmbQ==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION

## Unreleased (2025-01-29)

#### :boom: Breaking Change
* `core`
  * [#4716](https://github.com/GMOD/jbrowse-components/pull/4716) Update to generic-filehandle2 ([@cmdcolin](https://github.com/cmdcolin))
* `__mocks__`, `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`
  * [#4702](https://github.com/GMOD/jbrowse-components/pull/4702) Update to react 19 ([@cmdcolin](https://github.com/cmdcolin))

#### :rocket: Enhancement
* `core`, `web-core`
  * [#4799](https://github.com/GMOD/jbrowse-components/pull/4799) Add genotype to multi-variant mouseover  ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`
  * [#4798](https://github.com/GMOD/jbrowse-components/pull/4798) Add more track metadata to UCSC assembly hub loading ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#4796](https://github.com/GMOD/jbrowse-components/pull/4796) Make any bigType track open as BigBedAdapter in ucsc connections ([@cmdcolin](https://github.com/cmdcolin))
  * [#4782](https://github.com/GMOD/jbrowse-components/pull/4782) Add track filetype guesser for BedGraph ([@cmdcolin](https://github.com/cmdcolin))
  * [#4774](https://github.com/GMOD/jbrowse-components/pull/4774) Restore concept of linking synteny views ([@cmdcolin](https://github.com/cmdcolin))
  * [#4770](https://github.com/GMOD/jbrowse-components/pull/4770) Add turbo-zoom buttons ([@cmdcolin](https://github.com/cmdcolin))
  * [#4756](https://github.com/GMOD/jbrowse-components/pull/4756) Improved mouseover on alignment squiggles in breakpoint split view ([@cmdcolin](https://github.com/cmdcolin))
  * [#4736](https://github.com/GMOD/jbrowse-components/pull/4736) Bulk delete session tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#4733](https://github.com/GMOD/jbrowse-components/pull/4733) Add option to 'Hide small indels (<10bp)' ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4795](https://github.com/GMOD/jbrowse-components/pull/4795) Improved rendering of phased VCF and polyploid VCF in multi-variant view ([@cmdcolin](https://github.com/cmdcolin))
  * [#4792](https://github.com/GMOD/jbrowse-components/pull/4792) Allow uploading a sampleTsv file with per-sample metadata for VCF files ([@cmdcolin](https://github.com/cmdcolin))
  * [#4786](https://github.com/GMOD/jbrowse-components/pull/4786) Allow opening "synteny tracks" from the default Add track workflow ([@cmdcolin](https://github.com/cmdcolin))
  * [#4785](https://github.com/GMOD/jbrowse-components/pull/4785) Allow opening BedGraph et al in the default Add track workflow ([@cmdcolin](https://github.com/cmdcolin))
  * [#4784](https://github.com/GMOD/jbrowse-components/pull/4784) Improve UI for choosing query and target assemblies in the "New track" workflow for synteny tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#4767](https://github.com/GMOD/jbrowse-components/pull/4767) Improve load time when multiple tracks use same data file ([@cmdcolin](https://github.com/cmdcolin))
  * [#4750](https://github.com/GMOD/jbrowse-components/pull/4750) Add some more lazy loading for smaller bundle size ([@cmdcolin](https://github.com/cmdcolin))
* `sv-core`
  * [#4753](https://github.com/GMOD/jbrowse-components/pull/4753) Allow launching a single level breakpoint split view focused on the breakends ([@cmdcolin](https://github.com/cmdcolin))
* `web-core`
  * [#4745](https://github.com/GMOD/jbrowse-components/pull/4745) Add ability to load a ?hubURL= from URL bar ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`
  * [#4729](https://github.com/GMOD/jbrowse-components/pull/4729) Update cram-js to avoid requesting file size for more CORS compatibility ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* Other
  * [#4778](https://github.com/GMOD/jbrowse-components/pull/4778) Fix GC content calculation consistency across blocks ([@cmdcolin](https://github.com/cmdcolin))
  * [#4773](https://github.com/GMOD/jbrowse-components/pull/4773) Fix "Color by CDS" for BED12 features ([@cmdcolin](https://github.com/cmdcolin))
  * [#4771](https://github.com/GMOD/jbrowse-components/pull/4771) Fix generating categories for composite tracks in UCSC hubs ([@cmdcolin](https://github.com/cmdcolin))
  * [#4769](https://github.com/GMOD/jbrowse-components/pull/4769) Fix facet filter crash ([@cmdcolin](https://github.com/cmdcolin))
  * [#4765](https://github.com/GMOD/jbrowse-components/pull/4765) Fix repeat masker track BED interpretation ([@cmdcolin](https://github.com/cmdcolin))
  * [#4764](https://github.com/GMOD/jbrowse-components/pull/4764) Fix modifications coverage calculations ([@cmdcolin](https://github.com/cmdcolin))
  * [#4731](https://github.com/GMOD/jbrowse-components/pull/4731) Fix naming of subtracks produced by "group by tag" operation ([@cmdcolin](https://github.com/cmdcolin))
  * [#4732](https://github.com/GMOD/jbrowse-components/pull/4732) Fix persisting alignments "color by" and "filter by" settings in snapshots/session shares/page reloads ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4776](https://github.com/GMOD/jbrowse-components/pull/4776) Fix maximum recursion error in linear synteny view import form ([@cmdcolin](https://github.com/cmdcolin))
  * [#4768](https://github.com/GMOD/jbrowse-components/pull/4768) Fix navigation via CIGAR string alignment in synteny view ([@cmdcolin](https://github.com/cmdcolin))
  * [#4766](https://github.com/GMOD/jbrowse-components/pull/4766) Fix some bed12 transcripts displaying as bedMethyl features ([@cmdcolin](https://github.com/cmdcolin))
  * [#4727](https://github.com/GMOD/jbrowse-components/pull/4727) Fix type confusion where sequence feature details crashes for empty subfeatures ([@cmdcolin](https://github.com/cmdcolin))
  * [#4725](https://github.com/GMOD/jbrowse-components/pull/4725) Avoid error on closing draggable dialog and a couple more refactors ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* Other
  * [#4791](https://github.com/GMOD/jbrowse-components/pull/4791) Fix storybook vcf failing to load in dev server ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4777](https://github.com/GMOD/jbrowse-components/pull/4777) Remove margin:'dense' in default theme ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 2
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Kim Rutherford ([@kimrutherford](https://github.com/kimrutherford))
Done in 2.65s.
