### PR TITLE
Fix repeat masker track BED interpretation

### DIFF
--- a/plugins/bed/src/generateRepeatMaskerFeature.ts
+++ b/plugins/bed/src/generateRepeatMaskerFeature.ts
@@ -60,8 +60,9 @@ export function generateRepeatMaskerFeature({
   description: string
   [key: string]: unknown
 }) {
+  const { subfeatures, ...rest2 } = rest
   return {
-    ...rest,
+    ...rest2,
     ...makeRepeatTrackDescription(description),
     uniqueId,
     refName,

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -1169,7 +1169,6 @@
         }
       }
     },
-
     {
       "type": "AlignmentsTrack",
       "trackId": "nanopore_ultralong",
@@ -1826,7 +1825,6 @@
         }
       }
     },
-
     {
       "type": "QuantitativeTrack",
       "category": ["Mappability"],
@@ -4722,6 +4720,19 @@
         }
       },
       "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "chm13v2.0_rmsk",
+      "name": "chm13v2.0_rmsk",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hs1/t2tRepeatMasker/chm13v2.0_rmsk.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg1"]
     }
   ],
   "connections": [],


### PR DESCRIPTION
This fixes by avoiding loading sub-features from repeatmasker tracks

We might be able to restore sub-feature loading but it is a complex schema where subfeatures have "negative offsets" to the start that vary depending on forward or reverse strand features

See the description of repStart and repEnd here https://genome.ucsc.edu/cgi-bin/hgTables?db=hg38&hgta_group=rep&hgta_track=rmsk&hgta_table=rmsk&hgta_doSchema=describe+table+schema


repStart "Start (if strand is +) or -#bases after match (if strand is -) in repeat sequence"
repLeft "-#bases after match (if strand is +) or start (if strand is -) in repeat sequence"


these are atypical with typical bed12 parsing  and causes negative length features if passed as bed12 through the bed parser

