### PR TITLE
Facet filter crash

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
@@ -40,16 +40,18 @@ const FacetFilters = observer(function ({
 
   let currentRows = rows
   for (const facet of ret) {
-    const elt = uniqs.get(facet)!
-    for (const row of currentRows) {
-      const key = getRowStr(facet, row)
-      const val = elt.get(key)
-      // we don't allow filtering on empty yet
-      if (key) {
-        if (val === undefined) {
-          elt.set(key, 1)
-        } else {
-          elt.set(key, val + 1)
+    const elt = uniqs.get(facet)
+    if (elt) {
+      for (const row of currentRows) {
+        const key = getRowStr(facet, row)
+        const val = elt.get(key)
+        // we don't allow filtering on empty yet
+        if (key) {
+          if (val === undefined) {
+            elt.set(key, 1)
+          } else {
+            elt.set(key, val + 1)
+          }
         }
       }
     }


### PR DESCRIPTION
Avoids crash where a user filters on a facet, and then performs a search

Fixes #4760 


There might be a more principalled way of doing this because this PR ultimately hides all the facet filters entirely in this case, but it is better than a crash
