### PR TITLE
Add turbo-zoom buttons

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -35,6 +35,16 @@ const ZoomControls = observer(function ({
   return (
     <div className={classes.container}>
       <IconButton
+        data-testid="zoom_out_more"
+        onClick={() => {
+          model.zoom(bpPerPx * 15)
+        }}
+        disabled={bpPerPx >= maxBpPerPx - 0.0001}
+        size="large"
+      >
+        <ZoomOut fontSize="large" />
+      </IconButton>
+      <IconButton
         data-testid="zoom_out"
         onClick={() => {
           model.zoom(bpPerPx * 2)
@@ -65,6 +75,16 @@ const ZoomControls = observer(function ({
         size="large"
       >
         <ZoomIn />
+      </IconButton>
+      <IconButton
+        data-testid="zoom_in"
+        onClick={() => {
+          model.zoom(model.bpPerPx / 15)
+        }}
+        disabled={bpPerPx <= minBpPerPx + 0.0001}
+        size="large"
+      >
+        <ZoomIn fontSize="large" />
       </IconButton>
     </div>
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 import ZoomIn from '@mui/icons-material/ZoomIn'
 import ZoomOut from '@mui/icons-material/ZoomOut'
-import { IconButton, Slider } from '@mui/material'
+import { IconButton, Slider, Tooltip } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -15,7 +15,7 @@ const useStyles = makeStyles()(theme => ({
     alignItems: 'center',
   },
   slider: {
-    width: 70,
+    width: 100,
     color: theme.palette.text.secondary,
   },
 }))
@@ -31,29 +31,32 @@ const ZoomControls = observer(function ({
   useEffect(() => {
     setValue(-Math.log2(bpPerPx) * 100)
   }, [bpPerPx])
-
+  const zoomInDisabled = bpPerPx <= minBpPerPx + 0.0001
+  const zoomOutDisabled = bpPerPx >= maxBpPerPx - 0.0001
   return (
     <div className={classes.container}>
-      <IconButton
-        data-testid="zoom_out_more"
-        onClick={() => {
-          model.zoom(bpPerPx * 15)
-        }}
-        disabled={bpPerPx >= maxBpPerPx - 0.0001}
-        size="large"
-      >
-        <ZoomOut fontSize="large" />
-      </IconButton>
-      <IconButton
-        data-testid="zoom_out"
-        onClick={() => {
-          model.zoom(bpPerPx * 2)
-        }}
-        disabled={bpPerPx >= maxBpPerPx - 0.0001}
-        size="large"
-      >
-        <ZoomOut />
-      </IconButton>
+      <Tooltip title="Zoom out 15x">
+        <IconButton
+          data-testid="zoom_out_more"
+          disabled={zoomOutDisabled}
+          onClick={() => {
+            model.zoom(bpPerPx * 15)
+          }}
+        >
+          <ZoomOut fontSize="large" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Zoom out 2x">
+        <IconButton
+          data-testid="zoom_out"
+          disabled={zoomOutDisabled}
+          onClick={() => {
+            model.zoom(bpPerPx * 2)
+          }}
+        >
+          <ZoomOut />
+        </IconButton>
+      </Tooltip>
 
       <Slider
         size="small"
@@ -61,31 +64,33 @@ const ZoomControls = observer(function ({
         value={value}
         min={-Math.log2(maxBpPerPx) * 100}
         max={-Math.log2(minBpPerPx) * 100}
+        onChangeCommitted={() => model.zoomTo(2 ** (-value / 100))}
         onChange={(_, val) => {
           setValue(val as number)
         }}
-        onChangeCommitted={() => model.zoomTo(2 ** (-value / 100))}
       />
-      <IconButton
-        data-testid="zoom_in"
-        onClick={() => {
-          model.zoom(model.bpPerPx / 2)
-        }}
-        disabled={bpPerPx <= minBpPerPx + 0.0001}
-        size="large"
-      >
-        <ZoomIn />
-      </IconButton>
-      <IconButton
-        data-testid="zoom_in"
-        onClick={() => {
-          model.zoom(model.bpPerPx / 15)
-        }}
-        disabled={bpPerPx <= minBpPerPx + 0.0001}
-        size="large"
-      >
-        <ZoomIn fontSize="large" />
-      </IconButton>
+      <Tooltip title="Zoom in 2x">
+        <IconButton
+          data-testid="zoom_in"
+          disabled={zoomInDisabled}
+          onClick={() => {
+            model.zoom(model.bpPerPx / 2)
+          }}
+        >
+          <ZoomIn />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Zoom in 15x">
+        <IconButton
+          data-testid="zoom_in_more"
+          disabled={zoomInDisabled}
+          onClick={() => {
+            model.zoom(model.bpPerPx / 15)
+          }}
+        >
+          <ZoomIn fontSize="large" />
+        </IconButton>
+      </Tooltip>
     </div>
   )
 })

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ZoomControls.tsx
@@ -36,26 +36,30 @@ const ZoomControls = observer(function ({
   return (
     <div className={classes.container}>
       <Tooltip title="Zoom out 15x">
-        <IconButton
-          data-testid="zoom_out_more"
-          disabled={zoomOutDisabled}
-          onClick={() => {
-            model.zoom(bpPerPx * 15)
-          }}
-        >
-          <ZoomOut fontSize="large" />
-        </IconButton>
+        <span>
+          <IconButton
+            data-testid="zoom_out_more"
+            disabled={zoomOutDisabled}
+            onClick={() => {
+              model.zoom(bpPerPx * 15)
+            }}
+          >
+            <ZoomOut fontSize="large" />
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Zoom out 2x">
-        <IconButton
-          data-testid="zoom_out"
-          disabled={zoomOutDisabled}
-          onClick={() => {
-            model.zoom(bpPerPx * 2)
-          }}
-        >
-          <ZoomOut />
-        </IconButton>
+        <span>
+          <IconButton
+            data-testid="zoom_out"
+            disabled={zoomOutDisabled}
+            onClick={() => {
+              model.zoom(bpPerPx * 2)
+            }}
+          >
+            <ZoomOut />
+          </IconButton>
+        </span>
       </Tooltip>
 
       <Slider
@@ -70,26 +74,30 @@ const ZoomControls = observer(function ({
         }}
       />
       <Tooltip title="Zoom in 2x">
-        <IconButton
-          data-testid="zoom_in"
-          disabled={zoomInDisabled}
-          onClick={() => {
-            model.zoom(model.bpPerPx / 2)
-          }}
-        >
-          <ZoomIn />
-        </IconButton>
+        <span>
+          <IconButton
+            data-testid="zoom_in"
+            disabled={zoomInDisabled}
+            onClick={() => {
+              model.zoom(model.bpPerPx / 2)
+            }}
+          >
+            <ZoomIn />
+          </IconButton>
+        </span>
       </Tooltip>
       <Tooltip title="Zoom in 15x">
-        <IconButton
-          data-testid="zoom_in_more"
-          disabled={zoomInDisabled}
-          onClick={() => {
-            model.zoom(model.bpPerPx / 15)
-          }}
-        >
-          <ZoomIn fontSize="large" />
-        </IconButton>
+        <span>
+          <IconButton
+            data-testid="zoom_in_more"
+            disabled={zoomInDisabled}
+            onClick={() => {
+              model.zoom(model.bpPerPx / 15)
+            }}
+          >
+            <ZoomIn fontSize="large" />
+          </IconButton>
+        </span>
       </Tooltip>
     </div>
   )

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -246,56 +246,64 @@ exports[`renders one track, one region 1`] = `
           <div
             class="css-z84q6m-container"
           >
-            <button
+            <span
               aria-label="Zoom out 15x"
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_out_more"
-              disabled=""
-              id=":r15:"
-              tabindex="-1"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                data-testid="ZoomOutIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_out_more"
+                disabled=""
+                id=":r15:"
+                tabindex="-1"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-              </svg>
-            </button>
-            <button
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                  data-testid="ZoomOutIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                  />
+                </svg>
+              </button>
+            </span>
+            <span
               aria-label="Zoom out 2x"
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_out"
-              disabled=""
-              id=":r17:"
-              tabindex="-1"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                data-testid="ZoomOutIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_out"
+                disabled=""
+                id=":r17:"
+                tabindex="-1"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                  data-testid="ZoomOutIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                  />
+                </svg>
+              </button>
+            </span>
             <span
               class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
             >
@@ -326,60 +334,68 @@ exports[`renders one track, one region 1`] = `
                 />
               </span>
             </span>
-            <button
+            <span
               aria-label="Zoom in 2x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_in"
-              id=":r19:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                data-testid="ZoomInIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_in"
+                id=":r19:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                />
-              </svg>
-            </button>
-            <button
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                  data-testid="ZoomInIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                  />
+                </svg>
+              </button>
+            </span>
+            <span
               aria-label="Zoom in 15x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_in_more"
-              id=":r1b:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                data-testid="ZoomInIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_in_more"
+                id=":r1b:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                  data-testid="ZoomInIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                  />
+                </svg>
+              </button>
+            </span>
           </div>
           <div
             class="css-1n1xfjh-spacer"
@@ -880,54 +896,62 @@ exports[`renders two tracks, two regions 1`] = `
           <div
             class="css-z84q6m-container"
           >
-            <button
+            <span
               aria-label="Zoom out 15x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_out_more"
-              id=":r1p:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                data-testid="ZoomOutIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_out_more"
+                id=":r1p:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-              </svg>
-            </button>
-            <button
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                  data-testid="ZoomOutIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                  />
+                </svg>
+              </button>
+            </span>
+            <span
               aria-label="Zoom out 2x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_out"
-              id=":r1r:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                data-testid="ZoomOutIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_out"
+                id=":r1r:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                  data-testid="ZoomOutIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                  />
+                </svg>
+              </button>
+            </span>
             <span
               class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
             >
@@ -958,60 +982,68 @@ exports[`renders two tracks, two regions 1`] = `
                 />
               </span>
             </span>
-            <button
+            <span
               aria-label="Zoom in 2x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_in"
-              id=":r1t:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                data-testid="ZoomInIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_in"
+                id=":r1t:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                />
-              </svg>
-            </button>
-            <button
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                  data-testid="ZoomInIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                  />
+                </svg>
+              </button>
+            </span>
+            <span
               aria-label="Zoom in 15x"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              class=""
               data-mui-internal-clone-element="true"
-              data-testid="zoom_in_more"
-              id=":r1v:"
-              tabindex="0"
-              type="button"
             >
-              <span
-                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                data-testid="ZoomInIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <button
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                data-testid="zoom_in_more"
+                id=":r1v:"
+                tabindex="0"
+                type="button"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                <span
+                  class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                 />
-                <path
-                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                  data-testid="ZoomInIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                  />
+                  <path
+                    d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                  />
+                </svg>
+              </button>
+            </span>
           </div>
           <div
             class="css-1n1xfjh-spacer"

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`renders one track, one region 1`] = `
         >
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1hf3bf0-MuiButtonBase-root-MuiIconButton-root-toggleButton"
-            id=":ro:"
+            id=":ru:"
             tabindex="0"
             title="Open track selector"
             type="button"
@@ -121,7 +121,7 @@ exports[`renders one track, one region 1`] = `
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-71atz7-MuiButtonBase-root-MuiButton-root-panButton"
-              id=":rp:"
+              id=":rv:"
               tabindex="0"
               type="button"
             >
@@ -139,7 +139,7 @@ exports[`renders one track, one region 1`] = `
             </button>
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-71atz7-MuiButtonBase-root-MuiButton-root-panButton"
-              id=":rq:"
+              id=":r10:"
               tabindex="0"
               type="button"
             >
@@ -175,7 +175,7 @@ exports[`renders one track, one region 1`] = `
                     autocapitalize="none"
                     autocomplete="off"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
-                    id=":rr:"
+                    id=":r11:"
                     placeholder="Search for location"
                     role="combobox"
                     spellcheck="false"
@@ -199,7 +199,7 @@ exports[`renders one track, one region 1`] = `
                     </svg>
                     <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
-                      id=":rt:"
+                      id=":r13:"
                       tabindex="0"
                       type="button"
                     >
@@ -247,10 +247,37 @@ exports[`renders one track, one region 1`] = `
             class="css-z84q6m-container"
           >
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+              aria-label="Zoom out 15x"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              data-testid="zoom_out_more"
+              disabled=""
+              id=":r15:"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                data-testid="ZoomOutIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Zoom out 2x"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
               data-testid="zoom_out"
               disabled=""
-              id=":ru:"
+              id=":r17:"
               tabindex="-1"
               type="button"
             >
@@ -270,7 +297,7 @@ exports[`renders one track, one region 1`] = `
               </svg>
             </button>
             <span
-              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-webx07-MuiSlider-root-slider"
+              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
             >
               <span
                 class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -300,9 +327,11 @@ exports[`renders one track, one region 1`] = `
               </span>
             </span>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+              aria-label="Zoom in 2x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
               data-testid="zoom_in"
-              id=":rv:"
+              id=":r19:"
               tabindex="0"
               type="button"
             >
@@ -312,6 +341,33 @@ exports[`renders one track, one region 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                data-testid="ZoomInIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+                <path
+                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Zoom in 15x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              data-testid="zoom_in_more"
+              id=":r1b:"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
                 data-testid="ZoomInIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -463,7 +519,7 @@ exports[`renders one track, one region 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1qdvzjn-MuiButtonBase-root-MuiIconButton-root-iconButton"
-            id=":r10:"
+            id=":r1c:"
             tabindex="0"
             title="close this track"
             type="button"
@@ -493,7 +549,7 @@ exports[`renders one track, one region 1`] = `
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
             data-testid="track_menu_icon"
-            id=":r11:"
+            id=":r1d:"
             tabindex="0"
             type="button"
           >
@@ -671,7 +727,7 @@ exports[`renders two tracks, two regions 1`] = `
         >
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1hf3bf0-MuiButtonBase-root-MuiIconButton-root-toggleButton"
-            id=":r16:"
+            id=":r1i:"
             tabindex="0"
             title="Open track selector"
             type="button"
@@ -699,7 +755,7 @@ exports[`renders two tracks, two regions 1`] = `
           >
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-71atz7-MuiButtonBase-root-MuiButton-root-panButton"
-              id=":r17:"
+              id=":r1j:"
               tabindex="0"
               type="button"
             >
@@ -717,7 +773,7 @@ exports[`renders two tracks, two regions 1`] = `
             </button>
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-71atz7-MuiButtonBase-root-MuiButton-root-panButton"
-              id=":r18:"
+              id=":r1k:"
               tabindex="0"
               type="button"
             >
@@ -753,7 +809,7 @@ exports[`renders two tracks, two regions 1`] = `
                     autocapitalize="none"
                     autocomplete="off"
                     class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
-                    id=":r19:"
+                    id=":r1l:"
                     placeholder="Search for location"
                     role="combobox"
                     spellcheck="false"
@@ -777,7 +833,7 @@ exports[`renders two tracks, two regions 1`] = `
                     </svg>
                     <button
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
-                      id=":r1b:"
+                      id=":r1n:"
                       tabindex="0"
                       type="button"
                     >
@@ -825,9 +881,35 @@ exports[`renders two tracks, two regions 1`] = `
             class="css-z84q6m-container"
           >
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+              aria-label="Zoom out 15x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              data-testid="zoom_out_more"
+              id=":r1p:"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                data-testid="ZoomOutIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Zoom out 2x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
               data-testid="zoom_out"
-              id=":r1c:"
+              id=":r1r:"
               tabindex="0"
               type="button"
             >
@@ -847,7 +929,7 @@ exports[`renders two tracks, two regions 1`] = `
               </svg>
             </button>
             <span
-              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-webx07-MuiSlider-root-slider"
+              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
             >
               <span
                 class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -877,9 +959,11 @@ exports[`renders two tracks, two regions 1`] = `
               </span>
             </span>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+              aria-label="Zoom in 2x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
               data-testid="zoom_in"
-              id=":r1d:"
+              id=":r1t:"
               tabindex="0"
               type="button"
             >
@@ -889,6 +973,33 @@ exports[`renders two tracks, two regions 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                data-testid="ZoomInIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+                <path
+                  d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Zoom in 15x"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              data-testid="zoom_in_more"
+              id=":r1v:"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
                 data-testid="ZoomInIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1283,7 +1394,7 @@ exports[`renders two tracks, two regions 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1qdvzjn-MuiButtonBase-root-MuiIconButton-root-iconButton"
-            id=":r1e:"
+            id=":r20:"
             tabindex="0"
             title="close this track"
             type="button"
@@ -1313,7 +1424,7 @@ exports[`renders two tracks, two regions 1`] = `
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
             data-testid="track_menu_icon"
-            id=":r1f:"
+            id=":r21:"
             tabindex="0"
             type="button"
           >
@@ -1414,7 +1525,7 @@ exports[`renders two tracks, two regions 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1qdvzjn-MuiButtonBase-root-MuiIconButton-root-iconButton"
-            id=":r1g:"
+            id=":r22:"
             tabindex="0"
             title="close this track"
             type="button"
@@ -1444,7 +1555,7 @@ exports[`renders two tracks, two regions 1`] = `
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
             data-testid="track_menu_icon"
-            id=":r1h:"
+            id=":r23:"
             tabindex="0"
             type="button"
           >

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -337,54 +337,62 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   <div
                     class="css-z84q6m-container"
                   >
-                    <button
+                    <span
                       aria-label="Zoom out 15x"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      class=""
                       data-mui-internal-clone-element="true"
-                      data-testid="zoom_out_more"
-                      id=":r9:"
-                      tabindex="0"
-                      type="button"
                     >
-                      <span
-                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                        data-testid="ZoomOutIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="zoom_out_more"
+                        id=":r9:"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                        <span
+                          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                         />
-                      </svg>
-                    </button>
-                    <button
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                          data-testid="ZoomOutIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <span
                       aria-label="Zoom out 2x"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      class=""
                       data-mui-internal-clone-element="true"
-                      data-testid="zoom_out"
-                      id=":rb:"
-                      tabindex="0"
-                      type="button"
                     >
-                      <span
-                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                        data-testid="ZoomOutIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="zoom_out"
+                        id=":rb:"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                        <span
+                          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                         />
-                      </svg>
-                    </button>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="ZoomOutIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <span
                       class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
                     >
@@ -415,60 +423,68 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         />
                       </span>
                     </span>
-                    <button
+                    <span
                       aria-label="Zoom in 2x"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      class=""
                       data-mui-internal-clone-element="true"
-                      data-testid="zoom_in"
-                      id=":rd:"
-                      tabindex="0"
-                      type="button"
                     >
-                      <span
-                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
-                        data-testid="ZoomInIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="zoom_in"
+                        id=":rd:"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                        <span
+                          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                         />
-                        <path
-                          d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                        />
-                      </svg>
-                    </button>
-                    <button
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="ZoomInIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                          <path
+                            d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <span
                       aria-label="Zoom in 15x"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      class=""
                       data-mui-internal-clone-element="true"
-                      data-testid="zoom_in_more"
-                      id=":rf:"
-                      tabindex="0"
-                      type="button"
                     >
-                      <span
-                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
-                        data-testid="ZoomInIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="zoom_in_more"
+                        id=":rf:"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                        <span
+                          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
                         />
-                        <path
-                          d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
-                        />
-                      </svg>
-                    </button>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                          data-testid="ZoomInIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                          <path
+                            d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                   </div>
                   <div
                     class="css-1n1xfjh-spacer"

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -338,9 +338,35 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="css-z84q6m-container"
                   >
                     <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+                      aria-label="Zoom out 15x"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="zoom_out_more"
+                      id=":r9:"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
+                        data-testid="ZoomOutIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14M7 9h5v1H7z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-label="Zoom out 2x"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       data-testid="zoom_out"
-                      id=":r8:"
+                      id=":rb:"
                       tabindex="0"
                       type="button"
                     >
@@ -360,7 +386,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       </svg>
                     </button>
                     <span
-                      class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-webx07-MuiSlider-root-slider"
+                      class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-1fayfxi-MuiSlider-root-slider"
                     >
                       <span
                         class="MuiSlider-rail css-r64h58-MuiSlider-rail"
@@ -390,9 +416,11 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       </span>
                     </span>
                     <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-ktsoci-MuiButtonBase-root-MuiIconButton-root"
+                      aria-label="Zoom in 2x"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
                       data-testid="zoom_in"
-                      id=":r9:"
+                      id=":rd:"
                       tabindex="0"
                       type="button"
                     >
@@ -402,6 +430,33 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                        data-testid="ZoomInIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                        />
+                        <path
+                          d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-label="Zoom in 15x"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="zoom_in_more"
+                      id=":rf:"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-1ivw8v3-MuiSvgIcon-root"
                         data-testid="ZoomInIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -953,7 +1008,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   </span>
                   <button
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1qdvzjn-MuiButtonBase-root-MuiIconButton-root-iconButton"
-                    id=":ra:"
+                    id=":rg:"
                     tabindex="0"
                     title="close this track"
                     type="button"
@@ -983,7 +1038,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   <button
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
                     data-testid="track_menu_icon"
-                    id=":rb:"
+                    id=":rh:"
                     tabindex="0"
                     type="button"
                   >


### PR DESCRIPTION
Currently to zoom in far and close, you have to click the zoom in or out button multiple times

This adds a 'turbo zoom' button that uses 15x instead of 2x in each direction

This goes from 50kb to 3kb in one click for example

Otherwise you have to click it about 7 times for the same behavior

Motivated by UCSC having zoom in 10x. They also have 100x but that might overload UI