### PR TITLE
Fix generating categories for composite tracks in UCSC hubs

### DIFF
--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@gmod/ucsc-hub": "^0.3.0",
+    "@gmod/ucsc-hub": "^1.0.0",
     "@mui/icons-material": "^6.0.0",
     "@mui/x-data-grid": "^7.0.0",
     "react-virtualized-auto-sizer": "^1.0.2",

--- a/plugins/data-management/src/UCSCTrackHub/doConnect.ts
+++ b/plugins/data-management/src/UCSCTrackHub/doConnect.ts
@@ -95,7 +95,6 @@ export async function doConnect(self: {
           continue
         }
 
-        // @ts-expect-error
         const db = genome.data.trackDb
         if (!db) {
           throw new Error('genomesFile not found on hub')

--- a/plugins/data-management/src/UCSCTrackHub/ucscTrackHub.ts
+++ b/plugins/data-management/src/UCSCTrackHub/ucscTrackHub.ts
@@ -53,42 +53,43 @@ export function generateTracks({
   assemblyName: string
   sequenceAdapter: any
 }) {
+  const parentTrackKeys = new Set([
+    'superTrack',
+    'compositeTrack',
+    'container',
+    'view',
+  ])
   return Object.entries(trackDb.data)
     .map(([trackName, track]) => {
-      const trackKeys = Object.keys(track!)
-      const parentTrackKeys = new Set([
-        'superTrack',
-        'compositeTrack',
-        'container',
-        'view',
-      ])
-      if (trackKeys.some(key => parentTrackKeys.has(key))) {
+      const { data } = track
+      if (Object.keys(data).some(key => parentTrackKeys.has(key))) {
         return undefined
-      }
-      const parentTracks = []
-      let currentTrackName = trackName
-      do {
-        currentTrackName = trackDb.data[currentTrackName]?.data.parent || ''
-        if (currentTrackName) {
-          currentTrackName = currentTrackName.split(' ')[0]!
-          parentTracks.push(trackDb.data[currentTrackName])
+      } else {
+        const parentTracks = []
+        let currentTrackName = trackName
+        do {
+          currentTrackName = trackDb.data[currentTrackName]?.data.parent || ''
+          if (currentTrackName) {
+            currentTrackName = currentTrackName.split(' ')[0]!
+            parentTracks.push(trackDb.data[currentTrackName])
+          }
+        } while (currentTrackName)
+        parentTracks.reverse()
+        const categories = parentTracks
+          .map(p => p?.data.shortLabel)
+          .filter((f): f is string => !!f)
+        const res = makeTrackConfig({
+          track,
+          categories,
+          trackDbLoc,
+          trackDb,
+          sequenceAdapter,
+        })
+        return {
+          ...res,
+          trackId: `ucsc-trackhub-${objectHash(res)}`,
+          assemblyNames: [assemblyName],
         }
-      } while (currentTrackName)
-      parentTracks.reverse()
-      const categories = parentTracks
-        .map(p => p?.data.shortLabel)
-        .filter((f): f is string => !!f)
-      const res = makeTrackConfig({
-        track: track!,
-        categories,
-        trackDbLoc,
-        trackDb,
-        sequenceAdapter,
-      })
-      return {
-        ...res,
-        trackId: `ucsc-trackhub-${objectHash(res)}`,
-        assemblyNames: [assemblyName],
       }
     })
     .filter(notEmpty)
@@ -107,11 +108,15 @@ function makeTrackConfig({
   trackDb: TrackDbFile
   sequenceAdapter: any
 }) {
-  const trackType =
-    track.data.type || trackDb.data[track.data.parent || '']?.data.type || ''
-  const name = track.data.shortLabel || ''
-  const bigDataUrl = track.data.bigDataUrl || ''
-  const bigDataIdx = track.data.bigDataIndex || ''
+  const { data } = track
+
+  const parent = data.parent || ''
+  const bigDataUrl = data.bigDataUrl || ''
+  const bigDataIdx = data.bigDataIndex || ''
+  const trackType = data.type || trackDb.data[parent]?.data.type || ''
+  const name =
+    (data.shortLabel || '') + (bigDataUrl.includes('xeno') ? ' (xeno)' : '')
+
   const isUri = isUriLocation(trackDbLoc)
   let baseTrackType = trackType.split(' ')[0] || ''
   if (baseTrackType === 'bam' && bigDataUrl.toLowerCase().endsWith('cram')) {
@@ -125,8 +130,8 @@ function makeTrackConfig({
     case 'bam':
       return {
         type: 'AlignmentsTrack',
-        name: track.data.longLabel,
-        description: track.data.longLabel,
+        name,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'BamAdapter',
@@ -143,7 +148,7 @@ function makeTrackConfig({
       return {
         type: 'AlignmentsTrack',
         name,
-        description: track.data.longLabel,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'CramAdapter',
@@ -165,7 +170,7 @@ function makeTrackConfig({
       return {
         type: 'FeatureTrack',
         name,
-        description: track.data.longLabel,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'BigBedAdapter',
@@ -176,7 +181,7 @@ function makeTrackConfig({
       return {
         type: 'QuantitativeTrack',
         name,
-        description: track.data.longLabel,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'BigWigAdapter',
@@ -188,7 +193,7 @@ function makeTrackConfig({
       return {
         type: 'VariantTrack',
         name,
-        description: track.data.longLabel,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'VcfTabixAdapter',
@@ -205,7 +210,7 @@ function makeTrackConfig({
       return {
         type: 'HicTrack',
         name,
-        description: track.data.longLabel,
+        description: data.longLabel,
         category: categories,
         adapter: {
           type: 'HicAdapter',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2367,10 +2367,10 @@
   dependencies:
     generic-filehandle2 "^1.0.0"
 
-"@gmod/ucsc-hub@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@gmod/ucsc-hub/-/ucsc-hub-0.3.0.tgz#375eeab1c515605510c706f6e2d76d6b42454f8c"
-  integrity sha512-M8r1rpmNOVH6UHwUTSOR5Z86upWEhvI3BKbyYVq8imTS+nZAq8Gr9RJTBsGlL0sgX7fmLSXms8/pTyp7e3YAQA==
+"@gmod/ucsc-hub@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@gmod/ucsc-hub/-/ucsc-hub-1.0.0.tgz#2fd6251d5ad040b8658e3d4c17987f89bc741322"
+  integrity sha512-BTMPPUS667K2eGQ6ASc69908l3hDWF2sV/ZoTuMqIz1AfiHuaDMpcdELNf61bVeTWvUUFG5qkOQApcWMvlIvjw==
 
 "@gmod/vcf@^6.0.0":
   version "6.0.2"


### PR DESCRIPTION
The ucschub-js package changed from directly storing all info on an object into storing the info on a subkey named "data"

However, the code was not inspecting this data object to detect composite tracks

This fixes that, properly reconstructing UCSC trackhub categories in the track selector


It also appends the label (xeno) to tracks with xeno in their URL, as it's otherwise hard to tell what the cross-species (xeno) alignments are, and the current UCSC trackhubs don't by default add this

Fixes https://github.com/GMOD/jbrowse-components/issues/4762