### PR TITLE
Fix Color by CDS for BED12 features

### DIFF
--- a/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
+++ b/plugins/bed/src/BedAdapter/__snapshots__/BedAdapter.test.ts.snap
@@ -274,6 +274,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1500,
         "parentId": "test-ctgA-0",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -283,6 +284,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 3902,
         "parentId": "test-ctgA-0",
+        "phase": 0,
         "refName": "ctgA",
         "start": 2999,
         "strand": 1,
@@ -292,6 +294,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-0",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -301,6 +304,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7608,
         "parentId": "test-ctgA-0",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -342,6 +346,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 1500,
         "parentId": "test-ctgA-1",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -351,6 +356,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-1",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -360,6 +366,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7608,
         "parentId": "test-ctgA-1",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -410,6 +417,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 3902,
         "parentId": "test-ctgA-2",
+        "phase": 0,
         "refName": "ctgA",
         "start": 3300,
         "strand": 1,
@@ -419,6 +427,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 5500,
         "parentId": "test-ctgA-2",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -428,6 +437,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 7600,
         "parentId": "test-ctgA-2",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -469,6 +479,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 18800,
         "parentId": "test-ctgA-3",
+        "phase": 0,
         "refName": "ctgA",
         "start": 17999,
         "strand": 1,
@@ -478,6 +489,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 19500,
         "parentId": "test-ctgA-3",
+        "phase": 0,
         "refName": "ctgA",
         "start": 18999,
         "strand": 1,
@@ -487,6 +499,7 @@ exports[`adapter can fetch features from volvox-bed12.bed 1`] = `
       {
         "end": 21200,
         "parentId": "test-ctgA-3",
+        "phase": 0,
         "refName": "ctgA",
         "start": 20999,
         "strand": 1,

--- a/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
+++ b/plugins/bed/src/BedTabixAdapter/__snapshots__/BedTabixAdapter.test.ts.snap
@@ -274,6 +274,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1500,
         "parentId": "test-45690",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -283,6 +284,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 3902,
         "parentId": "test-45690",
+        "phase": 0,
         "refName": "ctgA",
         "start": 2999,
         "strand": 1,
@@ -292,6 +294,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45690",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -301,6 +304,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7608,
         "parentId": "test-45690",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -342,6 +346,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 1500,
         "parentId": "test-45787",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -351,6 +356,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45787",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -360,6 +366,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7608,
         "parentId": "test-45787",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -410,6 +417,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 3902,
         "parentId": "test-45875",
+        "phase": 0,
         "refName": "ctgA",
         "start": 3300,
         "strand": 1,
@@ -419,6 +427,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 5500,
         "parentId": "test-45875",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -428,6 +437,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 7600,
         "parentId": "test-45875",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -469,6 +479,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 18800,
         "parentId": "test-45972",
+        "phase": 0,
         "refName": "ctgA",
         "start": 17999,
         "strand": 1,
@@ -478,6 +489,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 19500,
         "parentId": "test-45972",
+        "phase": 0,
         "refName": "ctgA",
         "start": 18999,
         "strand": 1,
@@ -487,6 +499,7 @@ exports[`adapter can fetch features from volvox-bed12.bed.gz 1`] = `
       {
         "end": 21200,
         "parentId": "test-45972",
+        "phase": 0,
         "refName": "ctgA",
         "start": 20999,
         "strand": 1,

--- a/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
+++ b/plugins/bed/src/BigBedAdapter/__snapshots__/BigBedAdapter.test.ts.snap
@@ -28,6 +28,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1500,
         "parentId": "test-bb-358912",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -37,6 +38,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 3902,
         "parentId": "test-bb-358912",
+        "phase": 0,
         "refName": "ctgA",
         "start": 2999,
         "strand": 1,
@@ -46,6 +48,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-358912",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -55,6 +58,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7608,
         "parentId": "test-bb-358912",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -101,6 +105,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 1500,
         "parentId": "test-bb-359006",
+        "phase": 0,
         "refName": "ctgA",
         "start": 1200,
         "strand": 1,
@@ -110,6 +115,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-359006",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -119,6 +125,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7608,
         "parentId": "test-bb-359006",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -174,6 +181,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 3902,
         "parentId": "test-bb-359091",
+        "phase": 0,
         "refName": "ctgA",
         "start": 3300,
         "strand": 1,
@@ -183,6 +191,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 5500,
         "parentId": "test-bb-359091",
+        "phase": 0,
         "refName": "ctgA",
         "start": 4999,
         "strand": 1,
@@ -192,6 +201,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 7600,
         "parentId": "test-bb-359091",
+        "phase": 0,
         "refName": "ctgA",
         "start": 6999,
         "strand": 1,
@@ -238,6 +248,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 18800,
         "parentId": "test-bb-359185",
+        "phase": 0,
         "refName": "ctgA",
         "start": 17999,
         "strand": 1,
@@ -247,6 +258,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 19500,
         "parentId": "test-bb-359185",
+        "phase": 0,
         "refName": "ctgA",
         "start": 18999,
         "strand": 1,
@@ -256,6 +268,7 @@ exports[`adapter can fetch features from volvox.bb 1`] = `
       {
         "end": 21200,
         "parentId": "test-bb-359185",
+        "phase": 0,
         "refName": "ctgA",
         "start": 20999,
         "strand": 1,

--- a/plugins/bed/src/generateUcscTranscript.ts
+++ b/plugins/bed/src/generateUcscTranscript.ts
@@ -60,6 +60,7 @@ export function generateUcscTranscript(data: TranscriptFeat) {
         },
         {
           type: 'CDS',
+          phase: 0,
           start: thickStart,
           end,
           refName,
@@ -69,6 +70,7 @@ export function generateUcscTranscript(data: TranscriptFeat) {
       // CDS
       subfeatures.push({
         type: 'CDS',
+        phase: 0,
         start,
         end,
         refName,
@@ -84,6 +86,7 @@ export function generateUcscTranscript(data: TranscriptFeat) {
         },
         {
           type: 'CDS',
+          phase: 0,
           start: thickStart,
           end: thickEnd,
           refName,
@@ -100,6 +103,7 @@ export function generateUcscTranscript(data: TranscriptFeat) {
       subfeatures.push(
         {
           type: 'CDS',
+          phase: 0,
           start,
           end: thickEnd,
           refName,


### PR DESCRIPTION
Fixes #4772

This adds a phase field to features generated in BED12

The SVG Box renderer uses the existence of the "phase" field to determine whether to color by CDS

Specifically this check https://github.com/GMOD/jbrowse-components/blob/ce9fb70030bfd2dd89c02063bb1968d4e1f4c125/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx#L62-L67