### PR TITLE
Avoid clearing hubURL to allow it to survive page refresh

### DIFF
--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -71,21 +71,21 @@ export function Loader({
   useEffect(() => {
     setLoc(undefined, 'replaceIn')
     setTracks(undefined, 'replaceIn')
-    setHubURL(undefined, 'replaceIn')
     setAssembly(undefined, 'replaceIn')
     setPassword(undefined, 'replaceIn')
     setSessionTracks(undefined, 'replaceIn')
+    setHubURL(undefined, 'replaceIn')
     setTrackList(undefined, 'replaceIn')
     setNav(undefined, 'replaceIn')
     setHighlight(undefined, 'replaceIn')
   }, [
     setAssembly,
     setHighlight,
-    setHubURL,
     setLoc,
     setNav,
     setPassword,
     setSessionTracks,
+    setHubURL,
     setTrackList,
     setTracks,
   ])

--- a/products/jbrowse-web/src/createPluginManager.ts
+++ b/products/jbrowse-web/src/createPluginManager.ts
@@ -35,69 +35,73 @@ export function createPluginManager(model: SessionLoaderModel) {
         url: definition.url,
       },
     })),
-  ])
-  pluginManager.createPluggableElements()
+  ]).createPluggableElements()
+
   const RootModel = JBrowseRootModelFactory({
     pluginManager,
     sessionModelFactory,
     adminMode: !!model.adminKey,
   })
 
-  if (!model.configSnapshot) {
+  if (model.configSnapshot) {
+    const rootModel = RootModel.create(
+      {
+        jbrowse: model.configSnapshot,
+        configPath: model.configPath,
+      },
+      { pluginManager },
+    )
+
+    // @ts-expect-error
+    if (!model.configSnapshot.configuration?.rpc?.defaultDriver) {
+      rootModel.jbrowse.configuration.rpc.defaultDriver.set(
+        'WebWorkerRpcDriver',
+      )
+    }
+
+    let afterInitializedCb = () => {}
+
+    // in order: saves the previous autosave for recovery, tries to load the
+    // local session if session in query, or loads the default session
+    try {
+      const { sessionError, sessionSpec, sessionSnapshot, hubSpec } = model
+      if (sessionError) {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw sessionError
+      } else if (sessionSnapshot) {
+        rootModel.setSession(sessionSnapshot)
+      } else if (hubSpec) {
+        // @ts-expect-error
+        afterInitializedCb = () => loadHubSpec(hubSpec, pluginManager)
+      } else if (sessionSpec) {
+        // @ts-expect-error
+        afterInitializedCb = () => loadSessionSpec(sessionSpec, pluginManager)
+      } else if (rootModel.jbrowse.defaultSession?.views?.length) {
+        rootModel.setDefaultSession()
+      }
+    } catch (e) {
+      rootModel.setDefaultSession()
+      const str = `${e}`
+      const m = str.replace('[mobx-state-tree] ', '').replace(/\(.+/, '')
+      const r =
+        m.length > 1000 ? `${m.slice(0, 1000)}...see more in console` : m
+      const s = r.startsWith('Error:') ? r : `Error: ${r}`
+      rootModel.session?.notifyError(
+        `${s}. If you received this URL from another user, request that they send you a session generated with the "Share" button instead of copying and pasting their URL`,
+        model.sessionError,
+        model.sessionSnapshot,
+      )
+      console.error(e)
+    }
+
+    // send analytics
+    doAnalytics(rootModel, model.initialTimestamp, model.sessionQuery)
+
+    pluginManager.setRootModel(rootModel)
+    pluginManager.configure()
+    afterInitializedCb()
+    return pluginManager
+  } else {
     return undefined
   }
-  const rootModel = RootModel.create(
-    {
-      jbrowse: model.configSnapshot,
-      configPath: model.configPath,
-    },
-    { pluginManager },
-  )
-
-  // @ts-expect-error
-  if (!model.configSnapshot.configuration?.rpc?.defaultDriver) {
-    rootModel.jbrowse.configuration.rpc.defaultDriver.set('WebWorkerRpcDriver')
-  }
-
-  let afterInitializedCb = () => {}
-
-  // in order: saves the previous autosave for recovery, tries to load the
-  // local session if session in query, or loads the default session
-  try {
-    const { sessionError, sessionSpec, sessionSnapshot, hubSpec } = model
-    if (sessionError) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
-      throw sessionError
-    } else if (sessionSnapshot) {
-      rootModel.setSession(sessionSnapshot)
-    } else if (hubSpec) {
-      // @ts-expect-error
-      afterInitializedCb = () => loadHubSpec(hubSpec, pluginManager)
-    } else if (sessionSpec) {
-      // @ts-expect-error
-      afterInitializedCb = () => loadSessionSpec(sessionSpec, pluginManager)
-    } else if (rootModel.jbrowse.defaultSession?.views?.length) {
-      rootModel.setDefaultSession()
-    }
-  } catch (e) {
-    rootModel.setDefaultSession()
-    const str = `${e}`
-    const m = str.replace('[mobx-state-tree] ', '').replace(/\(.+/, '')
-    const r = m.length > 1000 ? `${m.slice(0, 1000)}...see more in console` : m
-    const s = r.startsWith('Error:') ? r : `Error: ${r}`
-    rootModel.session?.notifyError(
-      `${s}. If you received this URL from another user, request that they send you a session generated with the "Share" button instead of copying and pasting their URL`,
-      model.sessionError,
-      model.sessionSnapshot,
-    )
-    console.error(e)
-  }
-
-  // send analytics
-  doAnalytics(rootModel, model.initialTimestamp, model.sessionQuery)
-
-  pluginManager.setRootModel(rootModel)
-  pluginManager.configure()
-  afterInitializedCb()
-  return pluginManager
 }


### PR DESCRIPTION
This adds a couple of special cases to hubURL loading

a) makes it so that specifically a hubURL can be loaded without a config if ?config=none is in the URL
b) otherwise if ?config=none is not in the URL, it will load the config and the hub. this allows plugins define in the config be combined with hubURL for example. it will load all the assemblies and tracks from config also

the above two things combined allow hubURL to survive page refresh better, particularly in the case where there is no default config.json file (for example, our development environment) because the following chain of behavior otherwise occurs

1. visit URL with ?hubURL, goes through custom path in session loader that skips config.json loading
2. the ?hubURL is cleared from URL via the session loader
3. then you refresh, the session loader doesn't find config, so then it doesn't load the hub anymore


by making a special ?config=none explicit, then the app can still clear the &hubURL param from the URL, and continue on as needed setting a blank config snapshot if no config loading is desired


the alternative is NOT clearing the &hubURL param, and treating like a config=none, but i think config=none might be better