### PR TITLE
Refactor add track adapter hinting

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -110,28 +110,32 @@ export function storeBlobLocation(location: PreFileLocation) {
 }
 
 /**
- * creates a new location from the provided location including the appropriate suffix and location type
+ * creates a new location from the provided location including the appropriate
+ * suffix and location type
+ *
  * @param location - the FileLocation
  * @param suffix - the file suffix (e.g. .bam)
  * @returns the constructed location object from the provided parameters
  */
 export function makeIndex(location: FileLocation, suffix: string) {
   if ('uri' in location) {
-    return { uri: location.uri + suffix, locationType: 'UriLocation' }
-  }
-
-  if ('localPath' in location) {
+    return {
+      uri: location.uri + suffix,
+      locationType: 'UriLocation',
+    }
+  } else if ('localPath' in location) {
     return {
       localPath: location.localPath + suffix,
       locationType: 'LocalPathLocation',
     }
+  } else {
+    return location
   }
-
-  return location
 }
 
 /**
  * constructs a potential index file (with suffix) from the provided file name
+ *
  * @param name - the name of the index file
  * @param typeA - one option of a potential two file suffix (e.g. CSI, BAI)
  * @param typeB - the second option of a potential two file suffix (e.g. CSI, BAI)
@@ -190,7 +194,6 @@ export function guessAdapter(
     ) as AdapterGuesser
 
     const adapter = adapterGuesser(file, index, adapterHint)
-
     if (adapter) {
       return adapter
     }
@@ -218,7 +221,6 @@ export function guessTrackType(
     ) as TrackTypeGuesser
 
     const trackType = trackTypeGuesser(adapterType)
-
     if (trackType) {
       return trackType
     }

--- a/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.test.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.test.tsx
@@ -91,28 +91,28 @@ function getSession() {
   return { session, model }
 }
 
-describe('<AddTrackWidget />', () => {
-  it('adds a track', async () => {
-    const { session, model } = getSession()
-    const { getByTestId, getAllByTestId, findByText, findAllByText } = render(
-      <AddTrackWidget model={model} />,
-    )
-    expect(session.sessionTracks.length).toBe(1)
-    fireEvent.change(getAllByTestId('urlInput')[0]!, {
-      target: { value: 'test.txt' },
-    })
-    fireEvent.click(getAllByTestId('addTrackNextButton')[0]!)
-    fireEvent.mouseDown(getByTestId('adapterTypeSelect'))
-    const bamAdapter = await findByText('BAM adapter')
-    fireEvent.click(bamAdapter)
-    fireEvent.change(getByTestId('trackNameInput'), {
-      target: { value: 'Test track name' },
-    })
-    fireEvent.mouseDown(getByTestId('trackTypeSelect'))
-    fireEvent.click(await findByText('Feature track'))
-    fireEvent.mouseDown(getByTestId('assemblyNameSelect'))
-    fireEvent.click((await findAllByText('volMyt1'))[1]!)
-    fireEvent.click(getAllByTestId('addTrackNextButton')[0]!)
-    expect(session.sessionTracks.length).toBe(2)
+test('adds a track', async () => {
+  const { session, model } = getSession()
+  const { getByTestId, getAllByTestId, findByText, findAllByText } = render(
+    <AddTrackWidget model={model} />,
+  )
+  expect(session.sessionTracks.length).toBe(1)
+  fireEvent.change(getAllByTestId('urlInput')[0]!, {
+    target: { value: 'test.txt' },
   })
+  fireEvent.click(getAllByTestId('addTrackNextButton')[0]!)
+  fireEvent.mouseDown(getByTestId('adapterTypeSelect'))
+  const bamAdapter = await findByText('BAM adapter')
+  fireEvent.click(bamAdapter)
+  fireEvent.change(getByTestId('trackNameInput'), {
+    target: {
+      value: 'Test track name',
+    },
+  })
+  fireEvent.mouseDown(getByTestId('trackTypeSelect'))
+  fireEvent.click(await findByText('Feature track'))
+  fireEvent.mouseDown(getByTestId('assemblyNameSelect'))
+  fireEvent.click((await findAllByText('volMyt1'))[1]!)
+  fireEvent.click(getAllByTestId('addTrackNextButton')[0]!)
+  expect(session.sessionTracks.length).toBe(2)
 })

--- a/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
@@ -7,6 +7,7 @@ import {
   isSessionWithAddTracks,
 } from '@jbrowse/core/util'
 import { Button, TextField } from '@mui/material'
+import { transaction } from 'mobx'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -39,14 +40,12 @@ const PasteConfigAddTrackWorkflow = observer(function ({
         multiline
         rows={10}
         value={val}
+        placeholder="Paste track config or array of track configs in JSON format"
+        variant="outlined"
+        className={classes.textbox}
         onChange={event => {
           setVal(event.target.value)
         }}
-        placeholder={
-          'Paste track config or array of track configs in JSON format'
-        }
-        variant="outlined"
-        className={classes.textbox}
       />
       <Button
         variant="contained"
@@ -61,11 +60,16 @@ const PasteConfigAddTrackWorkflow = observer(function ({
               isSessionWithAddTracks(session) &&
               isSessionModelWithWidgets(session)
             ) {
-              confs.forEach(c => {
-                session.addTrackConf(c)
+              transaction(() => {
+                confs.forEach(c => {
+                  session.addTrackConf(c)
+                })
+                confs.forEach(c => {
+                  model.view.showTrack(c.trackId)
+                })
+                model.clearData()
               })
-              confs.forEach(c => model.view.showTrack(c.trackId))
-              model.clearData()
+
               session.hideWidget(model)
             }
           } catch (e) {

--- a/plugins/data-management/src/AddTrackWidget/components/TrackAdapterSelector.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackAdapterSelector.tsx
@@ -31,6 +31,7 @@ const TrackAdapterSelector = observer(({ model }: { model: AddTrackModel }) => {
   const { classes } = useStyles()
   const { trackAdapter } = model
   const { pluginManager } = getEnv(model)
+
   return (
     <TextField
       className={classes.spacing}
@@ -45,8 +46,10 @@ const TrackAdapterSelector = observer(({ model }: { model: AddTrackModel }) => {
       }}
       slotProps={{
         select: {
-          // @ts-expect-error
-          SelectDisplayProps: { 'data-testid': 'adapterTypeSelect' },
+          SelectDisplayProps: {
+            // @ts-expect-error
+            'data-testid': 'adapterTypeSelect',
+          },
         },
       }}
     >
@@ -56,18 +59,16 @@ const TrackAdapterSelector = observer(({ model }: { model: AddTrackModel }) => {
             .getAdapterElements()
             .filter(e => !e.adapterMetadata?.hiddenFromGUI),
         ),
-      ).map(([key, val]) => {
+      ).map(([key, val]) => [
         // returning array avoids needing to use a react fragment which
         // Select/TextField sub-elements disagree with
-        return [
-          <ListSubheader key={key}>{key}</ListSubheader>,
-          val.map(elt => (
-            <MenuItem key={elt.name} value={elt.name}>
-              {elt.displayName}
-            </MenuItem>
-          )),
-        ]
-      })}
+        <ListSubheader key={key}>{key}</ListSubheader>,
+        val.map(elt => (
+          <MenuItem key={elt.name} value={elt.name}>
+            {elt.displayName}
+          </MenuItem>
+        )),
+      ])}
     </TextField>
   )
 })

--- a/plugins/data-management/src/AddTrackWidget/components/TrackTypeSelector.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackTypeSelector.tsx
@@ -11,7 +11,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const TrackTypeSelector = observer(({ model }: { model: AddTrackModel }) => {
+const TrackTypeSelector = observer(function ({
+  model,
+}: {
+  model: AddTrackModel
+}) {
   const { classes } = useStyles()
   const { pluginManager } = getEnv(model)
   const { trackType } = model
@@ -31,8 +35,10 @@ const TrackTypeSelector = observer(({ model }: { model: AddTrackModel }) => {
       }}
       slotProps={{
         select: {
-          // @ts-expect-error
-          SelectDisplayProps: { 'data-testid': 'trackTypeSelect' },
+          SelectDisplayProps: {
+            // @ts-expect-error
+            'data-testid': 'trackTypeSelect',
+          },
         },
       }}
     >

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -252,8 +252,9 @@ export default function f(pluginManager: PluginManager) {
           resources from JBrowse when it is running on https. Please use an
           https URL for your track, or access the JBrowse app from the http
           protocol`
+        } else {
+          return ''
         }
-        return ''
       },
     }))
 }

--- a/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
@@ -28,15 +28,13 @@ const AssemblyTable = observer(function ({
             rowHeight={25}
             columnHeaderHeight={35}
             hideFooter={session.assemblies.length < 25}
-            rows={session.assemblies.map(assembly => {
-              return {
-                id: readConfObject(assembly, 'name'),
-                name: readConfObject(assembly, 'name'),
-                displayName: readConfObject(assembly, 'displayName'),
-                aliases: readConfObject(assembly, 'aliases'),
-                assembly,
-              }
-            })}
+            rows={session.assemblies.map(assembly => ({
+              id: readConfObject(assembly, 'name'),
+              name: readConfObject(assembly, 'name'),
+              displayName: readConfObject(assembly, 'displayName'),
+              aliases: readConfObject(assembly, 'aliases'),
+              assembly,
+            }))}
             columns={[
               { field: 'name' },
               { field: 'displayName' },

--- a/plugins/data-management/src/PluginStoreWidget/components/DeletePluginDialog.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/DeletePluginDialog.tsx
@@ -11,10 +11,10 @@ export default function DeletePluginDialog({
   return (
     <Dialog
       open
+      title={`Remove ${plugin}`}
       onClose={() => {
         onClose()
       }}
-      title={`Remove ${plugin}`}
     >
       <DialogContent>
         <Typography>

--- a/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.tsx
@@ -57,6 +57,7 @@ const PluginStoreWidget = observer(function ({
 }) {
   const { classes } = useStyles()
   const { plugins, error } = useFetchPlugins()
+  const { filterText } = model
   const session = getSession(model)
   const { adminMode } = session
   const { pluginManager } = getEnv(model)
@@ -94,7 +95,7 @@ const PluginStoreWidget = observer(function ({
       )}
       <TextField
         label="Filter plugins"
-        value={model.filterText}
+        value={filterText}
         onChange={event => {
           model.setFilterText(event.target.value)
         }}
@@ -135,15 +136,12 @@ const PluginStoreWidget = observer(function ({
           <Typography color="error">{`${error}`}</Typography>
         ) : plugins ? (
           plugins
-            .filter(plugin => {
-              // If plugin only has cjsUrl, don't display outside desktop
-              return (
+            .filter(
+              plugin =>
+                // If plugin only has cjsUrl, don't display outside desktop
                 !(isElectron && plugin.cjsUrl) &&
-                plugin.name
-                  .toLowerCase()
-                  .includes(model.filterText.toLowerCase())
-              )
-            })
+                plugin.name.toLowerCase().includes(filterText.toLowerCase()),
+            )
             .map(plugin => (
               <PluginCard key={plugin.name} plugin={plugin} model={model} />
             ))

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyTrackSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyTrackSelector.tsx
@@ -39,14 +39,15 @@ const ImportSyntenyTrackSelector = observer(function ({
   const resetTrack = filteredTracks[0]?.trackId || ''
   const [value, setValue] = useState(resetTrack)
   useEffect(() => {
-    // if assembly1/assembly2 changes, then we will want to use this effect to change
-    // the state of the useState because it otherwise gets locked to a stale value
+    // if assembly1/assembly2 changes, then we will want to use this effect to
+    // change the state of the useState because it otherwise gets locked to a
+    // stale value
     setValue(resetTrack)
   }, [resetTrack])
 
   useEffect(() => {
-    // sets track data in a useEffect because the initial load is needed as well as
-    // onChange's to the select box
+    // sets track data in a useEffect because the initial load is needed as
+    // well as onChange's to the select box
     model.setImportFormSyntenyTrack(0, {
       type: 'preConfigured',
       value,

--- a/plugins/gff3/src/GuessGff3/index.ts
+++ b/plugins/gff3/src/GuessGff3/index.ts
@@ -17,13 +17,14 @@ export default function GuessGff3F(pluginManager: PluginManager) {
         index?: FileLocation,
         adapterHint?: string,
       ) => {
-        const regexGuess = /\.gff3?\.b?gz$/i
-        const adapterName = 'Gff3TabixAdapter'
         const fileName = getFileName(file)
         const indexName = index && getFileName(index)
-        if (regexGuess.test(fileName) || adapterHint === adapterName) {
+        if (
+          (!adapterHint && /\.gff3?\.b?gz$/i.test(fileName)) ||
+          adapterHint === 'Gff3TabixAdapter'
+        ) {
           return {
-            type: adapterName,
+            type: 'Gff3TabixAdapter',
             bamLocation: file,
             gffGzLocation: file,
             index: {
@@ -31,34 +32,17 @@ export default function GuessGff3F(pluginManager: PluginManager) {
               indexType: makeIndexType(indexName, 'CSI', 'TBI'),
             },
           }
+        } else if (
+          (!adapterHint && /\.gff3?$/i.test(fileName)) ||
+          adapterHint === 'Gff3Adapter'
+        ) {
+          return {
+            type: 'Gff3Adapter',
+            gffLocation: file,
+          }
+        } else {
+          return adapterGuesser(file, index, adapterHint)
         }
-        return adapterGuesser(file, index, adapterHint)
-      }
-    },
-  )
-
-  pluginManager.addToExtensionPoint(
-    'Core-guessAdapterForLocation',
-    (adapterGuesser: AdapterGuesser) => {
-      return (
-        file: FileLocation,
-        index?: FileLocation,
-        adapterHint?: string,
-      ) => {
-        const regexGuess = /\.gff3?$/i
-        const adapterName = 'Gff3Adapter'
-        const fileName = getFileName(file)
-        const obj = {
-          type: adapterName,
-          gffLocation: file,
-        }
-        if (regexGuess.test(fileName) && !adapterHint) {
-          return obj
-        }
-        if (adapterHint === adapterName) {
-          return obj
-        }
-        return adapterGuesser(file, index, adapterHint)
       }
     },
   )

--- a/plugins/hic/src/index.ts
+++ b/plugins/hic/src/index.ts
@@ -32,21 +32,14 @@ export default class HicPlugin extends Plugin {
           index?: FileLocation,
           adapterHint?: string,
         ) => {
-          const regexGuess = /\.hic/i
-          const adapterName = 'HicAdapter'
           const fileName = getFileName(file)
-          const obj = {
-            type: adapterName,
-            hicLocation: file,
-          }
-
-          if (regexGuess.test(fileName) && !adapterHint) {
-            return obj
-          } else if (adapterHint === adapterName) {
-            return obj
-          } else {
-            return adapterGuesser(file, index, adapterHint)
-          }
+          return (/\.hic$/i.test(fileName) && !adapterHint) ||
+            adapterHint === 'HicAdapter'
+            ? {
+                type: 'HicAdapter',
+                hicLocation: file,
+              }
+            : adapterGuesser(file, index, adapterHint)
         }
       },
     )

--- a/plugins/legacy-jbrowse/src/GuessNCList/index.ts
+++ b/plugins/legacy-jbrowse/src/GuessNCList/index.ts
@@ -13,16 +13,14 @@ export default function GuessNCListF(pluginManager: PluginManager) {
         index?: FileLocation,
         adapterHint?: string,
       ) => {
-        const regexGuess = /trackData.jsonz?$/i
-        const adapterName = 'NCListAdapter'
         const fileName = getFileName(file)
-        if (regexGuess.test(fileName) || adapterHint === adapterName) {
-          return {
-            type: adapterName,
-            rootUrlTemplate: file,
-          }
-        }
-        return adapterGuesser(file, index, adapterHint)
+        return (/trackData.jsonz?$/i.test(fileName) && !adapterHint) ||
+          adapterHint === 'NCListAdapter'
+          ? {
+              type: 'NCListAdapter',
+              rootUrlTemplate: file,
+            }
+          : adapterGuesser(file, index, adapterHint)
       }
     },
   )

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -63,23 +63,19 @@ export default class WigglePlugin extends Plugin {
     pm.addToExtensionPoint(
       'Core-guessAdapterForLocation',
       (cb: AdapterGuesser) => {
-        return (file: FileLocation, index?: FileLocation, hint?: string) => {
-          const regexGuess = /\.(bw|bigwig)$/i
-          const adapterName = 'BigWigAdapter'
+        return (
+          file: FileLocation,
+          index?: FileLocation,
+          adapterHint?: string,
+        ) => {
           const fileName = getFileName(file)
-          const obj = {
-            type: adapterName,
-            bigWigLocation: file,
-          }
-
-          if (regexGuess.test(fileName) && !hint) {
-            return obj
-          }
-          if (hint === adapterName) {
-            return obj
-          }
-
-          return cb(file, index, hint)
+          return (/\.(bw|bigwig)$/i.test(fileName) && !adapterHint) ||
+            adapterHint === 'BigWigAdapter'
+            ? {
+                type: 'BigWigAdapter',
+                bigWigLocation: file,
+              }
+            : cb(file, index, adapterHint)
         }
       },
     )
@@ -87,10 +83,9 @@ export default class WigglePlugin extends Plugin {
       'Core-guessTrackTypeForLocation',
       (trackTypeGuesser: TrackTypeGuesser) => {
         return (adapterName: string) => {
-          if (adapterName === 'BigWigAdapter') {
-            return 'QuantitativeTrack'
-          }
-          return trackTypeGuesser(adapterName)
+          return adapterName === 'BigWigAdapter'
+            ? 'QuantitativeTrack'
+            : trackTypeGuesser(adapterName)
         }
       },
     )


### PR DESCRIPTION
It is noticed that somtimes manually choosing an adapter type in the select box has no effect in the add track workflow

It is perhaps odd, but this is because it is because it has to go through all the Core-guessAdapterType callbacks, then get a full adapter config from one of them, and then only then, will it update the adapter type. So if those callbacks are misbehaving, it will fail

and, as it turns out, you have to specifically respond to adapterHint (which is the select box selection) in order to handle this properly. if the gussAdapterType only looks at filename, it misses the "hint" that the user selected something from the select box, and the select box value will not update

Most of the guess routines had the right logic (checking for !adapterHint&&filnameCheck instead of just filenameCheck) but this fixes bedgraph and bedpe