### PR TITLE
Change python to python3 for Ubuntu apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On macOS with homebrew:
 
 On Ubuntu, with apt:
 
-    sudo apt install -y python make gcc libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+    sudo apt install -y python3 make gcc libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
 ## Install (Linux/Mac)
 


### PR DESCRIPTION
The python package isn't available in Ubuntu 24.10:

```
Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  2to3  python-is-python3

Error: Package 'python' has no installation candidate
```