### PR TITLE
Add more track metadata to UCSC assembly hub loading

### DIFF
--- a/packages/core/util/tracks.ts
+++ b/packages/core/util/tracks.ts
@@ -247,7 +247,7 @@ export function generateUnsupportedTrackConf(
 export function generateUnknownTrackConf(
   trackName: string,
   trackUrl: string,
-  categories: string[] | undefined,
+  categories?: string[],
 ) {
   const conf = {
     type: 'FeatureTrack',

--- a/packages/product-core/src/ui/AboutDialogContents.tsx
+++ b/packages/product-core/src/ui/AboutDialogContents.tsx
@@ -61,7 +61,9 @@ const AboutDialogContents = observer(function ({
       },
     },
     { session, config },
-  ) as Record<string, unknown>
+  ) as {
+    config: { metadata?: Record<string, unknown>; [key: string]: unknown }
+  }
 
   const ExtraPanel = pluginManager.evaluateExtensionPoint(
     'Core-extraAboutPanel',
@@ -99,11 +101,20 @@ const AboutDialogContents = observer(function ({
           </span>
         ) : null}
         <Attributes
-          attributes={confPostExt}
-          omit={['displays', 'baseUri', 'refNames', 'formatAbout']}
+          attributes={confPostExt.config}
+          omit={['displays', 'baseUri', 'refNames', 'formatAbout', 'metadata']}
           hideUris={hideUris}
         />
       </BaseCard>
+      {confPostExt.config.metadata ? (
+        <BaseCard title="Metadata">
+          <Attributes
+            attributes={confPostExt.config.metadata}
+            omit={['displays', 'baseUri', 'refNames', 'formatAbout']}
+            hideUris={hideUris}
+          />
+        </BaseCard>
+      ) : null}
       {ExtraPanel ? (
         <BaseCard title={ExtraPanel.name}>
           <ExtraPanel.Component config={config} />

--- a/plugins/data-management/src/UCSCTrackHub/doConnect.ts
+++ b/plugins/data-management/src/UCSCTrackHub/doConnect.ts
@@ -5,14 +5,10 @@ import { openLocation } from '@jbrowse/core/util/io'
 import { nanoid } from '@jbrowse/core/util/nanoid'
 
 import { generateTracks } from './ucscTrackHub'
-import { fetchGenomesFile, fetchTrackDbFile } from './util'
+import { fetchGenomesFile, fetchTrackDbFile, resolve } from './util'
 
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { FileLocation } from '@jbrowse/core/util'
-
-function resolve(uri: string, baseUri: string) {
-  return new URL(uri, baseUri).href
-}
 
 export async function doConnect(self: {
   configuration: AnyConfigurationModel
@@ -38,6 +34,15 @@ export async function doConnect(self: {
           name: genomeName,
           sequence: {
             type: 'ReferenceSequenceTrack',
+            metadata: {
+              // eslint-disable-next-line @typescript-eslint/no-misused-spread
+              ...genome,
+              ...(genome.data.htmlPath
+                ? {
+                    htmlPath: `<a href="${resolve(genome.data.htmlPath, hubUri)}">${genome.data.htmlPath}</a>`,
+                  }
+                : {}),
+            },
             trackId: `${genomeName}-${nanoid()}`,
             adapter: {
               type: 'TwoBitAdapter',
@@ -58,6 +63,7 @@ export async function doConnect(self: {
         trackDbLoc: hubFileLocation,
         assemblyName: genomeName,
         sequenceAdapter,
+        baseUrl: hubUri,
       })
       self.addTrackConfs(tracksNew)
     } else {
@@ -113,6 +119,7 @@ export async function doConnect(self: {
           trackDbLoc: loc,
           assemblyName: genomeName,
           sequenceAdapter,
+          baseUrl: hubUri,
         })
         self.addTrackConfs(tracks)
         map[genomeName] = tracks.length

--- a/plugins/data-management/src/UCSCTrackHub/util.ts
+++ b/plugins/data-management/src/UCSCTrackHub/util.ts
@@ -38,3 +38,7 @@ export function makeLoc2(first: string, alt?: string) {
         locationType: 'UriLocation',
       }
 }
+
+export function resolve(uri: string, baseUri: string) {
+  return new URL(uri, baseUri).href
+}


### PR DESCRIPTION
- Uses the 'group' attribute to categorize tracks

![image](https://github.com/user-attachments/assets/c7e35661-90fc-4b44-994d-5f47bc50986a)


These are short labels like varRep, gene, rna, map. A bit obscure, but better than nothing for track grouping

- Renders track metadata in a custom card in About track dialog
- Adds UCSC track as track metadata
- Adds functional links to the track and assembly "description html" pages in about track dialog

![image](https://github.com/user-attachments/assets/1ff8a7f3-e2db-49af-8d83-f10567d88c08)

looks like this at link

![image](https://github.com/user-attachments/assets/3c1afe73-0a8c-41fa-8a90-f8ad15e6cf4d)


it could alternatively be fetched via ajax and displayed in the dialog, but this is somewhat ok for now
