### PR TITLE
Create random color for rendering phase sets in phased variant rendering

### DIFF
--- a/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/importAdapters/__snapshots__/VcfImport.test.ts.snap
@@ -173,6 +173,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion A -> AGTGT",
           "end": 156845492,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs144271100",
           "refName": "1",
           "samples": {
@@ -332,6 +333,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 156848995,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs6337",
           "refName": "1",
           "samples": {
@@ -499,6 +501,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 47601106,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1126497",
           "refName": "2",
           "samples": {
@@ -658,6 +661,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 47630550,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2303426",
           "refName": "2",
           "samples": {
@@ -758,6 +762,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion TAAAAA -> T,TAA",
           "end": 47641564,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs768805063",
           "refName": "2",
           "samples": {
@@ -929,6 +934,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 47693959,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs3732183",
           "refName": "2",
           "samples": {
@@ -1096,6 +1102,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> A",
           "end": 48010558,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1042820",
           "refName": "2",
           "samples": {
@@ -1255,6 +1262,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 48010654,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs55927047",
           "refName": "2",
           "samples": {
@@ -1414,6 +1422,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 48018030,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800931",
           "refName": "2",
           "samples": {
@@ -1581,6 +1590,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 48018081,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800932",
           "refName": "2",
           "samples": {
@@ -1748,6 +1758,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 48023115,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800935",
           "refName": "2",
           "samples": {
@@ -1899,6 +1910,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> T",
           "end": 48030838,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2020911",
           "refName": "2",
           "samples": {
@@ -2061,6 +2073,7 @@ exports[`vcf file import 1`] = `
           ],
           "description": "deletion ACTAT -> A",
           "end": 48032878,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2234731,rs767177736",
           "refName": "2",
           "samples": {
@@ -2204,6 +2217,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 48033551,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs3136367",
           "refName": "2",
           "samples": {
@@ -2303,6 +2317,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion C -> CT",
           "end": 48033890,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs771393147",
           "refName": "2",
           "samples": {
@@ -2454,6 +2469,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 215632256,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2070093",
           "refName": "2",
           "samples": {
@@ -2613,6 +2629,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 215645545,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2070096",
           "refName": "2",
           "samples": {
@@ -2712,6 +2729,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion TA -> T",
           "end": 215657183,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs56130510",
           "refName": "2",
           "samples": {
@@ -2863,6 +2881,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> G",
           "end": 215674090,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs35933323",
           "refName": "2",
           "samples": {
@@ -3014,6 +3033,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 215674323,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1129804",
           "refName": "2",
           "samples": {
@@ -3165,6 +3185,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 215674341,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs17489363",
           "refName": "2",
           "samples": {
@@ -3262,6 +3283,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> G",
           "end": 10191523,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": undefined,
           "refName": "3",
           "samples": {
@@ -3421,6 +3443,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 37083740,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs9876116",
           "refName": "3",
           "samples": {
@@ -3568,6 +3591,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 112103135,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": undefined,
           "refName": "5",
           "samples": {
@@ -3727,6 +3751,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 112162854,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2229992",
           "refName": "5",
           "samples": {
@@ -3886,6 +3911,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 112164561,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs351771",
           "refName": "5",
           "samples": {
@@ -4045,6 +4071,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 112175770,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs41115",
           "refName": "5",
           "samples": {
@@ -4204,6 +4231,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 112176325,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs42427",
           "refName": "5",
           "samples": {
@@ -4363,6 +4391,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> G",
           "end": 112176559,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs866006",
           "refName": "5",
           "samples": {
@@ -4538,6 +4567,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> A",
           "end": 112176756,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs459552",
           "refName": "5",
           "samples": {
@@ -4705,6 +4735,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 112177171,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs465899",
           "refName": "5",
           "samples": {
@@ -4880,6 +4911,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 112178795,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2229995",
           "refName": "5",
           "samples": {
@@ -5023,6 +5055,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 131892979,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4526098",
           "refName": "5",
           "samples": {
@@ -5184,6 +5217,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 6022626,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1805326",
           "refName": "7",
           "samples": {
@@ -5351,6 +5385,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 6026775,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2228006",
           "refName": "7",
           "samples": {
@@ -5518,6 +5553,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 6026988,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1805321",
           "refName": "7",
           "samples": {
@@ -5677,6 +5713,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 6036980,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1805319",
           "refName": "7",
           "samples": {
@@ -5776,6 +5813,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion GA -> G",
           "end": 6037058,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs60794673",
           "refName": "7",
           "samples": {
@@ -5935,6 +5973,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 6038722,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs62456182",
           "refName": "7",
           "samples": {
@@ -6034,6 +6073,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion GT -> G",
           "end": 116381122,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs112241458",
           "refName": "7",
           "samples": {
@@ -6134,6 +6174,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion CTT -> C,CT",
           "end": 116409677,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs753027677",
           "refName": "7",
           "samples": {
@@ -6289,6 +6330,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 21968199,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs11515",
           "refName": "9",
           "samples": {
@@ -6440,6 +6482,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 97873957,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4647534",
           "refName": "9",
           "samples": {
@@ -6591,6 +6634,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 98221861,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2236406",
           "refName": "9",
           "samples": {
@@ -6742,6 +6786,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 98229389,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2066829",
           "refName": "9",
           "samples": {
@@ -6901,6 +6946,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 98238358,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2066836",
           "refName": "9",
           "samples": {
@@ -7008,6 +7054,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion T -> TGCC",
           "end": 98270646,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs587780530",
           "refName": "9",
           "samples": {
@@ -7175,6 +7222,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 43595968,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800858",
           "refName": "10",
           "samples": {
@@ -7350,6 +7398,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 43606687,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800860",
           "refName": "10",
           "samples": {
@@ -7509,6 +7558,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 43612226,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs760466",
           "refName": "10",
           "samples": {
@@ -7684,6 +7734,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> T",
           "end": 43613843,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1800861",
           "refName": "10",
           "samples": {
@@ -7851,6 +7902,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 43622217,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2075912",
           "refName": "10",
           "samples": {
@@ -7950,6 +8002,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion CT -> C",
           "end": 89720634,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs771859047",
           "refName": "10",
           "samples": {
@@ -8109,6 +8162,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> G",
           "end": 89720907,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs555895",
           "refName": "10",
           "samples": {
@@ -8276,6 +8330,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 64572018,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2959656",
           "refName": "11",
           "samples": {
@@ -8435,6 +8490,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 64572557,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs540012",
           "refName": "11",
           "samples": {
@@ -8602,6 +8658,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 64572602,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2071313",
           "refName": "11",
           "samples": {
@@ -8753,6 +8810,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 64577620,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs509606",
           "refName": "11",
           "samples": {
@@ -8912,6 +8970,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 94197260,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs641936",
           "refName": "11",
           "samples": {
@@ -9063,6 +9122,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 94225920,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs497763",
           "refName": "11",
           "samples": {
@@ -9209,6 +9269,7 @@ exports[`vcf file import 1`] = `
           ],
           "description": "deletion TAA -> T",
           "end": 108098461,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2066734,rs766396464",
           "refName": "11",
           "samples": {
@@ -9308,6 +9369,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion AT -> A",
           "end": 108114662,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs779838075",
           "refName": "11",
           "samples": {
@@ -9407,6 +9469,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion C -> CT",
           "end": 108121410,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs34325032",
           "refName": "11",
           "samples": {
@@ -9506,6 +9569,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion CT -> C",
           "end": 108141956,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs373881770",
           "refName": "11",
           "samples": {
@@ -9597,6 +9661,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion T -> TA",
           "end": 108151707,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs3218681",
           "refName": "11",
           "samples": {
@@ -9748,6 +9813,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 108183167,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs659243",
           "refName": "11",
           "samples": {
@@ -9899,6 +9965,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 58144665,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2069502",
           "refName": "12",
           "samples": {
@@ -10058,6 +10125,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 32890572,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1799943",
           "refName": "13",
           "samples": {
@@ -10233,6 +10301,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> C",
           "end": 32906729,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs144848",
           "refName": "13",
           "samples": {
@@ -10400,6 +10469,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 32911888,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1801406",
           "refName": "13",
           "samples": {
@@ -10559,6 +10629,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 32913055,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs206075",
           "refName": "13",
           "samples": {
@@ -10710,6 +10781,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 32915005,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs206076",
           "refName": "13",
           "samples": {
@@ -10877,6 +10949,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 32929387,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs169547",
           "refName": "13",
           "samples": {
@@ -11028,6 +11101,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 68771372,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs3743674",
           "refName": "16",
           "samples": {
@@ -11195,6 +11269,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 68855966,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs35187787",
           "refName": "16",
           "samples": {
@@ -11354,6 +11429,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 7579472,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1042522",
           "refName": "17",
           "samples": {
@@ -11521,6 +11597,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 7579801,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1642785",
           "refName": "17",
           "samples": {
@@ -11620,6 +11697,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "deletion AT -> A",
           "end": 29508820,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs765008499",
           "refName": "17",
           "samples": {
@@ -11771,6 +11849,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 29553485,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2285892",
           "refName": "17",
           "samples": {
@@ -11914,6 +11993,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> A",
           "end": 29559932,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2066736",
           "refName": "17",
           "samples": {
@@ -12057,6 +12137,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion T -> TG",
           "end": 29563076,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs59745739",
           "refName": "17",
           "samples": {
@@ -12203,6 +12284,7 @@ exports[`vcf file import 1`] = `
           ],
           "description": "insertion T -> TG",
           "end": 29563085,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs56874702,rs72813695",
           "refName": "17",
           "samples": {
@@ -12349,6 +12431,7 @@ exports[`vcf file import 1`] = `
           ],
           "description": "insertion T -> TA",
           "end": 29663625,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs553817239,rs7406039",
           "refName": "17",
           "samples": {
@@ -12492,6 +12575,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 29670190,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs7405740",
           "refName": "17",
           "samples": {
@@ -12667,6 +12751,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 41223094,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1799966",
           "refName": "17",
           "samples": {
@@ -12834,6 +12919,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 41234470,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1060915",
           "refName": "17",
           "samples": {
@@ -13009,6 +13095,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 41244000,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs16942",
           "refName": "17",
           "samples": {
@@ -13184,6 +13271,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 41244435,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs16941",
           "refName": "17",
           "samples": {
@@ -13359,6 +13447,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 41244936,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs799917",
           "refName": "17",
           "samples": {
@@ -13526,6 +13615,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 41245237,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs16940",
           "refName": "17",
           "samples": {
@@ -13693,6 +13783,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 41245466,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs1799949",
           "refName": "17",
           "samples": {
@@ -13868,6 +13959,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> T",
           "end": 41245471,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4986850",
           "refName": "17",
           "samples": {
@@ -13967,6 +14059,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "14bp DEL",
           "end": 41256103,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs373413425",
           "refName": "17",
           "samples": {
@@ -14118,6 +14211,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 56798207,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs28363318",
           "refName": "17",
           "samples": {
@@ -14269,6 +14363,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 59760996,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4986763",
           "refName": "17",
           "samples": {
@@ -14428,6 +14523,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV A -> G",
           "end": 59763347,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4986764",
           "refName": "17",
           "samples": {
@@ -14579,6 +14675,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV T -> C",
           "end": 59763465,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4986765",
           "refName": "17",
           "samples": {
@@ -14730,6 +14827,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV C -> G",
           "end": 59857809,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs4988351",
           "refName": "17",
           "samples": {
@@ -14829,6 +14927,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "insertion A -> ATT",
           "end": 48584855,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs760402978",
           "refName": "18",
           "samples": {
@@ -14988,6 +15087,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> A",
           "end": 1219274,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs34928889",
           "refName": "19",
           "samples": {
@@ -15147,6 +15247,7 @@ exports[`vcf file import 1`] = `
           "aliases": undefined,
           "description": "SNV G -> C",
           "end": 1222012,
+          "format": "GT:AD:DP:GQ:PL:SB",
           "name": "rs2075607",
           "refName": "19",
           "samples": {

--- a/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/LinesConnectingMatrixToGenomicPosition.tsx
+++ b/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/LinesConnectingMatrixToGenomicPosition.tsx
@@ -43,7 +43,7 @@ const LinesConnectingMatrixToGenomicPosition = observer(function ({
 }) {
   const { assemblyManager } = getSession(model)
   const view = getContainingView(model) as LinearGenomeViewModel
-  const { featuresVolatile } = model
+  const { lineZoneHeight, featuresVolatile } = model
   const { offsetPx, assemblyNames, dynamicBlocks } = view
   const assembly = assemblyManager.get(assemblyNames[0]!)
   const b0 = dynamicBlocks.contentBlocks[0]?.widthPx || 0
@@ -60,11 +60,11 @@ const LinesConnectingMatrixToGenomicPosition = observer(function ({
           })?.offsetPx || 0) - l
         return (
           <line
-            stroke="#0006"
+            stroke="#0004"
             key={f.id()}
             x1={i * w + w / 2}
             x2={c}
-            y1={20}
+            y1={lineZoneHeight}
             y2={0}
           />
         )

--- a/plugins/variants/src/VcfAdapter/__snapshots__/VcfAdapter.test.ts.snap
+++ b/plugins/variants/src/VcfAdapter/__snapshots__/VcfAdapter.test.ts.snap
@@ -48,6 +48,7 @@ exports[`adapter can fetch variants from volvox.vcf 2`] = `
     "aliases": undefined,
     "description": "SNV T -> C",
     "end": 277,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -115,6 +116,7 @@ exports[`adapter can fetch variants from volvox.vcf 2`] = `
     "aliases": undefined,
     "description": "SNV T -> C",
     "end": 1694,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -182,6 +184,7 @@ exports[`adapter can fetch variants from volvox.vcf 2`] = `
     "aliases": undefined,
     "description": "SNV T -> G",
     "end": 2644,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -243,6 +246,7 @@ exports[`adapter can fetch variants from volvox.vcf 2`] = `
     "aliases": undefined,
     "description": "SNV T -> A",
     "end": 3213,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -305,6 +309,7 @@ exports[`adapter can fetch variants from volvox.vcf 2`] = `
     "aliases": undefined,
     "description": "deletion ctt -> ct",
     "end": 3860,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {

--- a/plugins/variants/src/VcfFeature/__snapshots__/index.test.ts.snap
+++ b/plugins/variants/src/VcfFeature/__snapshots__/index.test.ts.snap
@@ -20,6 +20,7 @@ exports[`null ALT 1`] = `
   "aliases": undefined,
   "description": "no alternative alleles",
   "end": 100,
+  "format": undefined,
   "name": "rs123",
   "refName": "chr1",
   "samples": {},

--- a/plugins/variants/src/VcfFeature/index.ts
+++ b/plugins/variants/src/VcfFeature/index.ts
@@ -7,7 +7,7 @@ import type { Feature } from '@jbrowse/core/util'
 type FeatureData = ReturnType<typeof dataFromVariant>
 
 function dataFromVariant(variant: Variant, parser: VCFParser) {
-  const { REF = '', ALT, POS, CHROM, ID } = variant
+  const { FORMAT, REF = '', ALT, POS, CHROM, ID } = variant
   const start = POS - 1
   const [type, description] = getSOTermAndDescription(REF, ALT, parser)
 
@@ -19,6 +19,7 @@ function dataFromVariant(variant: Variant, parser: VCFParser) {
     type,
     name: ID?.join(','),
     aliases: ID && ID.length > 1 ? ID.slice(1) : undefined,
+    format: FORMAT,
   }
 }
 function getEnd(variant: Variant) {

--- a/plugins/variants/src/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
+++ b/plugins/variants/src/VcfTabixAdapter/__snapshots__/VcfTabixAdapter.test.ts.snap
@@ -48,6 +48,7 @@ exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
     "aliases": undefined,
     "description": "SNV T -> C",
     "end": 277,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -115,6 +116,7 @@ exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
     "aliases": undefined,
     "description": "SNV T -> C",
     "end": 1694,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -182,6 +184,7 @@ exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
     "aliases": undefined,
     "description": "SNV T -> G",
     "end": 2644,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -243,6 +246,7 @@ exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
     "aliases": undefined,
     "description": "SNV T -> A",
     "end": 3213,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {
@@ -305,6 +309,7 @@ exports[`adapter can fetch variants from volvox.vcf.gz 2`] = `
     "aliases": undefined,
     "description": "deletion ctt -> ct",
     "end": 3860,
+    "format": "GT:PL:GQ",
     "name": undefined,
     "refName": "ctgA",
     "samples": {

--- a/plugins/variants/src/shared/MultiVariantBaseModel.tsx
+++ b/plugins/variants/src/shared/MultiVariantBaseModel.tsx
@@ -6,7 +6,7 @@ import { stopStopToken } from '@jbrowse/core/util/stopToken'
 import { linearBareDisplayStateModelFactory } from '@jbrowse/plugin-linear-genome-view'
 import FilterListIcon from '@mui/icons-material/FilterList'
 import HeightIcon from '@mui/icons-material/Height'
-import PaletteIcon from '@mui/icons-material/Palette'
+import SplitscreenIcon from '@mui/icons-material/Splitscreen'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import deepEqual from 'fast-deep-equal'
 import { types } from 'mobx-state-tree'
@@ -314,29 +314,30 @@ export default function MultiVariantBaseModelF(
               ],
             },
             {
-              label: 'Color by',
-              icon: PaletteIcon,
+              label: 'Rendering mode',
+              icon: SplitscreenIcon,
               subMenu: [
-                ...(self.hasPhased
-                  ? [
-                      {
-                        label: 'Allele count',
-                        type: 'radio',
-                        checked: self.renderingMode === 'alleleCount',
-                        onClick: () => {
-                          self.setPhasedMode('alleleCount')
-                        },
-                      },
-                      {
-                        label: 'Phased',
-                        checked: self.renderingMode === 'phased',
-                        type: 'radio',
-                        onClick: () => {
-                          self.setPhasedMode('phased')
-                        },
-                      },
-                    ]
-                  : []),
+                {
+                  label: 'Allele count',
+                  type: 'radio',
+                  checked: self.renderingMode === 'alleleCount',
+                  onClick: () => {
+                    self.setPhasedMode('alleleCount')
+                  },
+                },
+                {
+                  label:
+                    'Phased' +
+                    (self.hasPhased
+                      ? ' (disabled, no phased variants found)'
+                      : ''),
+                  disabled: self.hasPhased,
+                  checked: self.renderingMode === 'phased',
+                  type: 'radio',
+                  onClick: () => {
+                    self.setPhasedMode('phased')
+                  },
+                },
               ],
             },
             {

--- a/plugins/variants/src/shared/multiVariantColor.ts
+++ b/plugins/variants/src/shared/multiVariantColor.ts
@@ -1,6 +1,8 @@
 import { set1 } from '@jbrowse/core/ui/colors'
 import { colord } from '@jbrowse/core/util/colord'
 
+import { colorify } from '../util'
+
 export function getColorAlleleCount(alleles: string[]) {
   const total = alleles.length
   let alt = 0
@@ -38,4 +40,13 @@ export function getColorAlleleCount(alleles: string[]) {
 export function getColorPhased(alleles: string[], HP: number) {
   const c = +alleles[HP]!
   return c ? set1[c - 1] || 'black' : '#ccc'
+}
+
+export function getColorPhasedWithPhaseSet(
+  alleles: string[],
+  HP: number,
+  PS: string,
+) {
+  const c = +alleles[HP]!
+  return c ? colorify(+PS) || 'black' : '#ccc'
 }

--- a/plugins/variants/src/util.ts
+++ b/plugins/variants/src/util.ts
@@ -44,9 +44,12 @@ export function randomColor(str: string) {
   for (let i = 0; i < str.length; i++) {
     sum += str.charCodeAt(i)
   }
-  return `hsl(${sum * 10}, 50%, 50%)`
+  return `hsl(${colorify(sum * 10)}, 50%, 50%)`
 }
 
+export function colorify(n: number) {
+  return `hsl(${n % 255}, 50%, 50%)`
+}
 // used for calculating minor allele
 export function findSecondLargest(arr: Iterable<number>) {
   let firstMax = 0
@@ -91,7 +94,7 @@ export function getFeaturesThatPassMinorAlleleFrequencyFilter(
 ) {
   const mafs = [] as Feature[]
   for (const feat of feats) {
-    if (calculateMinorAlleleFrequency(feat) > minorAlleleFrequencyFilter) {
+    if (calculateMinorAlleleFrequency(feat) >= minorAlleleFrequencyFilter) {
       mafs.push(feat)
     }
   }


### PR DESCRIPTION
phased variants can be "completely phased" or come in sets which are a random 32 bit number indicating a block of shared variants

this colors variants randomly based on the PS value if it exists, and I added a test file with PS values from GIAB to the test data