### PR TITLE
Change some peerDeps into deps

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -45,16 +45,16 @@
     "@jbrowse/product-core": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
     "@mui/material": "^6.0.0",
-    "copy-to-clipboard": "^3.3.1"
-  },
-  "peerDependencies": {
+    "copy-to-clipboard": "^3.3.1",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,17 +53,17 @@
     "rbush": "^3.0.1",
     "react-draggable": "^4.4.5",
     "serialize-error": "^8.0.0",
-    "source-map-js": "^1.0.2"
-  },
-  "peerDependencies": {
+    "source-map-js": "^1.0.2",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/embedded-core/package.json
+++ b/packages/embedded-core/package.json
@@ -46,16 +46,16 @@
     "@jbrowse/product-core": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
     "@mui/material": "^6.0.0",
-    "copy-to-clipboard": "^3.3.1"
-  },
-  "peerDependencies": {
+    "copy-to-clipboard": "^3.3.1",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/product-core/package.json
+++ b/packages/product-core/package.json
@@ -48,16 +48,16 @@
     "@mui/material": "^6.0.0",
     "copy-to-clipboard": "^3.3.1",
     "librpc-web-mod": "^1.0.0",
-    "serialize-error": "^8.0.0"
-  },
-  "peerDependencies": {
+    "serialize-error": "^8.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sv-core/package.json
+++ b/packages/sv-core/package.json
@@ -45,16 +45,16 @@
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
-    "@mui/material": "^6.0.0"
-  },
-  "peerDependencies": {
+    "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/text-indexing/package.json
+++ b/packages/text-indexing/package.json
@@ -45,15 +45,15 @@
     "@jbrowse/core": "^3.0.0",
     "ixixx": "^2.0.1",
     "node-fetch": "^2.6.0",
-    "sanitize-filename": "^1.6.3"
-  },
-  "peerDependencies": {
+    "sanitize-filename": "^1.6.3",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -46,16 +46,16 @@
     "@jbrowse/product-core": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
     "@mui/material": "^6.0.0",
-    "copy-to-clipboard": "^3.3.1"
-  },
-  "peerDependencies": {
+    "copy-to-clipboard": "^3.3.1",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugin-development-tools/package.json
+++ b/plugin-development-tools/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "regenerator-runtime": "^0.13.0",
     "rollup": "^2.0.0",
     "tslib": "^2.0.0",

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -43,9 +43,7 @@
     "canvas2svg": "^1.0.16",
     "copy-to-clipboard": "^3.3.1",
     "fast-deep-equal": "^3.1.3",
-    "generic-filehandle2": "^1.0.0"
-  },
-  "peerDependencies": {
+    "generic-filehandle2": "^1.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@jbrowse/plugin-wiggle": "^3.0.0",
@@ -53,9 +51,11 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "rxjs": "^7.0.0",
-    "tss-react": "^4.0.0"
+    "tss-react": "^4.0.0",
+    "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -46,9 +46,9 @@
     "generic-filehandle2": "^1.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
-    "@jbrowse/plugin-wiggle": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
+    "@jbrowse/plugin-wiggle": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/arc/package.json
+++ b/plugins/arc/package.json
@@ -35,7 +35,7 @@
     "build:commonjs": "tsc --build tsconfig.build.commonjs.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@jbrowse/plugin-wiggle": "^3.0.0",
@@ -43,9 +43,11 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/arc/package.json
+++ b/plugins/arc/package.json
@@ -36,9 +36,9 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
-    "@jbrowse/plugin-wiggle": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
+    "@jbrowse/plugin-wiggle": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -37,17 +37,17 @@
   },
   "dependencies": {
     "crypto-js": "^4.2.0",
-    "generic-filehandle2": "^1.0.0"
-  },
-  "peerDependencies": {
+    "generic-filehandle2": "^1.0.0",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -40,7 +40,7 @@
     "generic-filehandle2": "^1.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -43,7 +43,7 @@
     "@gmod/tabix": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -40,9 +40,7 @@
     "@gmod/bbi": "^6.0.0",
     "@gmod/bed": "^2.1.2",
     "@gmod/bgzf-filehandle": "^2.0.1",
-    "@gmod/tabix": "^2.0.0"
-  },
-  "peerDependencies": {
+    "@gmod/tabix": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -42,8 +42,8 @@
     "file-saver": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -39,18 +39,18 @@
     "@gmod/vcf": "^6.0.0",
     "@mui/icons-material": "^6.0.0",
     "@types/file-saver": "^2.0.1",
-    "file-saver": "^2.0.0"
-  },
-  "peerDependencies": {
+    "file-saver": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.4",
-    "react-dom": ">=16.8.4",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.4",
+    "react-dom": ">=16.8.4"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -41,7 +41,7 @@
     "file-saver": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -38,17 +38,17 @@
   "dependencies": {
     "@mui/icons-material": "^6.0.0",
     "@types/file-saver": "^2.0.0",
-    "file-saver": "^2.0.0"
-  },
-  "peerDependencies": {
+    "file-saver": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -38,9 +38,7 @@
   "dependencies": {
     "@gmod/bgzf-filehandle": "^2.0.1",
     "@gmod/tabix": "^2.0.0",
-    "generic-filehandle2": "^1.0.0"
-  },
-  "peerDependencies": {
+    "generic-filehandle2": "^1.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-alignments": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
@@ -48,9 +46,11 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -41,9 +41,9 @@
     "generic-filehandle2": "^1.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-alignments": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-alignments": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -37,18 +37,18 @@
   },
   "dependencies": {
     "@mui/icons-material": "^6.0.0",
-    "pluralize": "^8.0.0"
-  },
-  "peerDependencies": {
+    "pluralize": "^8.0.0",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -40,7 +40,7 @@
     "pluralize": "^8.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -45,9 +45,9 @@
     "react-window": "^1.8.6"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-config": "^2.0.0",
-    "@jbrowse/product-core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-config": "^3.0.0",
+    "@jbrowse/product-core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -42,9 +42,7 @@
     "deepmerge": "^4.3.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-vtree": "^3.0.0-beta.1",
-    "react-window": "^1.8.6"
-  },
-  "peerDependencies": {
+    "react-window": "^1.8.6",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-config": "^3.0.0",
     "@jbrowse/product-core": "^3.0.0",
@@ -52,8 +50,10 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -42,8 +42,8 @@
     "file-saver": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-alignments": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-alignments": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -39,19 +39,19 @@
     "@mui/icons-material": "^6.0.0",
     "@mui/x-data-grid": "^7.0.0",
     "@types/file-saver": "^2.0.1",
-    "file-saver": "^2.0.0"
-  },
-  "peerDependencies": {
+    "file-saver": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-alignments": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/gccontent/package.json
+++ b/plugins/gccontent/package.json
@@ -36,10 +36,10 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
-    "@jbrowse/plugin-sequence": "^2.0.0",
-    "@jbrowse/plugin-wiggle": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
+    "@jbrowse/plugin-sequence": "^3.0.0",
+    "@jbrowse/plugin-wiggle": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/gccontent/package.json
+++ b/plugins/gccontent/package.json
@@ -35,7 +35,7 @@
     "build:commonjs": "tsc --build tsconfig.build.commonjs.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@jbrowse/plugin-sequence": "^3.0.0",
@@ -44,8 +44,10 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -42,8 +42,8 @@
     "gff-nostream": "^1.3.3"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -39,9 +39,7 @@
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^2.0.1",
     "@gmod/tabix": "^2.0.0",
-    "gff-nostream": "^1.3.3"
-  },
-  "peerDependencies": {
+    "gff-nostream": "^1.3.3",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",

--- a/plugins/grid-bookmark/package.json
+++ b/plugins/grid-bookmark/package.json
@@ -42,9 +42,9 @@
     "file-saver": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-config": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-config": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "@mui/x-data-grid": "^7.0.0",
     "mobx": "^6.0.0",

--- a/plugins/grid-bookmark/package.json
+++ b/plugins/grid-bookmark/package.json
@@ -39,9 +39,7 @@
     "@mui/icons-material": "^6.0.0",
     "@types/file-saver": "^2.0.1",
     "copy-to-clipboard": "^3.3.1",
-    "file-saver": "^2.0.0"
-  },
-  "peerDependencies": {
+    "file-saver": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-config": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
@@ -50,8 +48,10 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -41,8 +41,8 @@
     "gtf-nostream": "^1.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -38,17 +38,17 @@
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^2.0.1",
-    "gtf-nostream": "^1.0.0"
-  },
-  "peerDependencies": {
+    "gtf-nostream": "^1.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -37,17 +37,17 @@
   },
   "dependencies": {
     "@mui/x-charts-vendor": "^7.12.0",
-    "hic-straw": "^2.0.3"
-  },
-  "peerDependencies": {
+    "hic-straw": "^2.0.3",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -40,8 +40,8 @@
     "hic-straw": "^2.0.3"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -37,16 +37,16 @@
   },
   "dependencies": {
     "@jbrowse/text-indexing": "^3.0.0",
-    "@mui/icons-material": "^6.0.0"
-  },
-  "peerDependencies": {
+    "@mui/icons-material": "^6.0.0",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/jobs-management/package.json
+++ b/plugins/jobs-management/package.json
@@ -40,7 +40,7 @@
     "@mui/icons-material": "^6.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/legacy-jbrowse/package.json
+++ b/plugins/legacy-jbrowse/package.json
@@ -40,9 +40,7 @@
     "crc": "^4.0.0",
     "generic-filehandle2": "^1.0.0",
     "get-value": "^3.0.0",
-    "set-value": "^4.0.1"
-  },
-  "peerDependencies": {
+    "set-value": "^4.0.1",
     "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/legacy-jbrowse/package.json
+++ b/plugins/legacy-jbrowse/package.json
@@ -43,7 +43,7 @@
     "set-value": "^4.0.1"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -41,9 +41,9 @@
     "file-saver": "^2.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-alignments": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-alignments": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -38,9 +38,7 @@
   "dependencies": {
     "@mui/icons-material": "^6.0.0",
     "copy-to-clipboard": "^3.3.1",
-    "file-saver": "^2.0.0"
-  },
-  "peerDependencies": {
+    "file-saver": "^2.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-alignments": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
@@ -48,10 +46,12 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -38,21 +38,21 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
+    "@jbrowse/core": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
     "@types/file-saver": "^2.0.1",
     "copy-to-clipboard": "^3.3.1",
     "file-saver": "^2.0.0",
-    "material-ui-popup-state": "^5.0.0"
-  },
-  "peerDependencies": {
-    "@jbrowse/core": "^3.0.0",
+    "material-ui-popup-state": "^5.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/linear-genome-view/package.json
+++ b/plugins/linear-genome-view/package.json
@@ -45,7 +45,7 @@
     "material-ui-popup-state": "^5.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -36,8 +36,8 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -35,14 +35,16 @@
     "build:commonjs": "tsc --build tsconfig.build.commonjs.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
-    "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0"
+    "mobx-state-tree": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/menus/package.json
+++ b/plugins/menus/package.json
@@ -42,7 +42,7 @@
     "react-dropzone": "^14.2.1"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/menus/package.json
+++ b/plugins/menus/package.json
@@ -39,17 +39,17 @@
     "@mui/icons-material": "^6.0.0",
     "date-fns": "^4.1.0",
     "pluralize": "^8.0.0",
-    "react-dropzone": "^14.2.1"
-  },
-  "peerDependencies": {
+    "react-dropzone": "^14.2.1",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -36,9 +36,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "string-template": "^1.0.0"
-  },
-  "peerDependencies": {
+    "string-template": "^1.0.0",
     "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -39,7 +39,7 @@
     "string-template": "^1.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -41,9 +41,9 @@
     "@gmod/twobit": "^4.0.1"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
-    "@jbrowse/plugin-wiggle": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
+    "@jbrowse/plugin-wiggle": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -38,9 +38,7 @@
   "dependencies": {
     "@gmod/abortable-promise-cache": "^2.0.0",
     "@gmod/indexedfasta": "^3.0.0",
-    "@gmod/twobit": "^4.0.1"
-  },
-  "peerDependencies": {
+    "@gmod/twobit": "^4.0.1",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@jbrowse/plugin-wiggle": "^3.0.0",
@@ -48,8 +46,10 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -42,8 +42,8 @@
     "@mui/icons-material": "^6.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "@mui/x-data-grid": "^7.0.0",
     "mobx": "^6.0.0",

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -39,9 +39,7 @@
     "@gmod/bgzf-filehandle": "^2.0.1",
     "@gmod/vcf": "^6.0.0",
     "@jbrowse/plugin-variants": "^3.0.0",
-    "@mui/icons-material": "^6.0.0"
-  },
-  "peerDependencies": {
+    "@mui/icons-material": "^6.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
@@ -49,10 +47,12 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -37,19 +37,19 @@
   },
   "dependencies": {
     "@jbrowse/sv-core": "^3.0.0",
-    "@mui/icons-material": "^6.0.0"
-  },
-  "peerDependencies": {
+    "@mui/icons-material": "^6.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-circular-view": "^3.0.0",
-    "@jbrowse/plugin-spradsheet-view": "^3.0.0",
+    "@jbrowse/plugin-spreadsheet-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -40,9 +40,9 @@
     "@mui/icons-material": "^6.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-circular-view": "^2.0.0",
-    "@jbrowse/plugin-spreadsheet-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-circular-view": "^3.0.0",
+    "@jbrowse/plugin-spradsheet-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/svg/package.json
+++ b/plugins/svg/package.json
@@ -35,13 +35,15 @@
     "build:commonjs": "tsc --build tsconfig.build.commonjs.json",
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
-    "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0"
+    "mobx-state-tree": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/svg/package.json
+++ b/plugins/svg/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -39,7 +39,7 @@
     "@jbrowse/text-indexing": "^3.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",

--- a/plugins/text-indexing/package.json
+++ b/plugins/text-indexing/package.json
@@ -36,14 +36,14 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@jbrowse/text-indexing": "^3.0.0"
-  },
-  "peerDependencies": {
+    "@jbrowse/text-indexing": "^3.0.0",
     "@jbrowse/core": "^3.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
-    "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0"
+    "mobx-state-tree": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "distModule": "esm/index.js",
   "srcModule": "src/index.ts",

--- a/plugins/trix/package.json
+++ b/plugins/trix/package.json
@@ -36,15 +36,15 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
+    "react": ">=18.0.0"
+  },
+  "dependencies": {
+    "@gmod/trix": "^3.0.0",
     "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
-    "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0"
-  },
-  "dependencies": {
-    "@gmod/trix": "^3.0.0"
+    "mobx-state-tree": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/trix/package.json
+++ b/plugins/trix/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -45,9 +45,9 @@
     "@mui/x-data-grid": "^7.0.0"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-circular-view": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-circular-view": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -42,9 +42,7 @@
     "@gmod/vcf": "^6.0.0",
     "@jbrowse/sv-core": "^3.0.0",
     "@mui/icons-material": "^6.0.0",
-    "@mui/x-data-grid": "^7.0.0"
-  },
-  "peerDependencies": {
+    "@mui/x-data-grid": "^7.0.0",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-circular-view": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
@@ -52,9 +50,11 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -42,9 +42,7 @@
     "@mui/x-data-grid": "^7.0.0",
     "fast-deep-equal": "^3.1.3",
     "react-d3-axis-mod": "^0.1.9",
-    "react-draggable": "^4.4.5"
-  },
-  "peerDependencies": {
+    "react-draggable": "^4.4.5",
     "@jbrowse/core": "^3.0.0",
     "@jbrowse/plugin-data-management": "^3.0.0",
     "@jbrowse/plugin-linear-genome-view": "^3.0.0",
@@ -52,9 +50,11 @@
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
     "mobx-state-tree": "^5.0.0",
-    "react": ">=16.8.0",
     "rxjs": "^7.0.0",
     "tss-react": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -45,9 +45,9 @@
     "react-draggable": "^4.4.5"
   },
   "peerDependencies": {
-    "@jbrowse/core": "^2.0.0",
-    "@jbrowse/plugin-data-management": "^2.0.0",
-    "@jbrowse/plugin-linear-genome-view": "^2.0.0",
+    "@jbrowse/core": "^3.0.0",
+    "@jbrowse/plugin-data-management": "^3.0.0",
+    "@jbrowse/plugin-linear-genome-view": "^3.0.0",
     "@mui/material": "^6.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -96,7 +96,7 @@
     "webpack": "^5.72.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -61,7 +61,7 @@
     "tss-react": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -76,7 +76,7 @@
     "tss-react": "^4.4.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The peer deps in the repo were not updated to v3.0.0

Not too critical of an issue, but NPM package manager is picky about this so makes warnings and actually can cause issues. current npm install -g @jbrowse/img retrives @jbrowse/core@2.18.0 because of the broken peerdeps presumably

This changes peerdeps to deps. Only react and react-dom are left as peerdeps, as the user installs react and can vary it themselves.

