### PR TITLE
Fix random palette color generation

### DIFF
--- a/plugins/variants/src/util.ts
+++ b/plugins/variants/src/util.ts
@@ -44,7 +44,7 @@ export function randomColor(str: string) {
   for (let i = 0; i < str.length; i++) {
     sum += str.charCodeAt(i)
   }
-  return `hsl(${colorify(sum * 10)}, 50%, 50%)`
+  return colorify(sum * 10)
 }
 
 export function colorify(n: number) {


### PR DESCRIPTION
The current palettizer code uses a colorbrewer type scheme for the first 10 colors, and then makes random ones after that, but there was a bug in the random generation due to some last minute hacking that made it generate color strings like hsl(hsl(...),...) instead of just hsl(...)