### PR TITLE
Handle multiple jobs with the same name

### DIFF
--- a/plugins/jobs-management/src/JobsListWidget/model.ts
+++ b/plugins/jobs-management/src/JobsListWidget/model.ts
@@ -62,9 +62,11 @@ export function stateModelFactory(_pluginManager: PluginManager) {
        */
       removeJob(jobName: string) {
         const indx = self.jobs.findIndex(job => job.name === jobName)
-        const removed = self.jobs[indx]
-        self.jobs.splice(indx, 1)
-        return removed
+        if (indx === -1) {
+          return undefined
+        }
+        const removed = self.jobs.splice(indx, 1)
+        return removed[0]
       },
       /**
        * #action
@@ -110,9 +112,11 @@ export function stateModelFactory(_pluginManager: PluginManager) {
        */
       removeQueuedJob(jobName: string) {
         const indx = self.queued.findIndex(job => job.name === jobName)
-        const removed = self.queued[indx]
-        self.queued.splice(indx, 1)
-        return removed
+        if (indx === -1) {
+          return undefined
+        }
+        const removed = self.queued.splice(indx, 1)
+        return removed[0]
       },
       /**
        * #action

--- a/plugins/jobs-management/src/JobsListWidget/model.ts
+++ b/plugins/jobs-management/src/JobsListWidget/model.ts
@@ -47,7 +47,11 @@ export function stateModelFactory(_pluginManager: PluginManager) {
        * #action
        */
       addJob(job: NewJob) {
-        const { cancelCallback } = job
+        const { cancelCallback, name } = job
+        const existing = self.jobs.find(job => job.name === name)
+        if (existing) {
+          return existing
+        }
         const length = self.jobs.push(job)
         const addedJob = self.jobs[length - 1]!
         addedJob.setCancelCallback(cancelCallback)
@@ -66,22 +70,40 @@ export function stateModelFactory(_pluginManager: PluginManager) {
        * #action
        */
       addFinishedJob(job: NewJob) {
-        self.finished.push(job)
-        return self.finished
+        const existing = self.finished.find(
+          finishedJob => finishedJob.name === job.name,
+        )
+        if (existing) {
+          return existing
+        }
+        const length = self.finished.push(job)
+        return self.finished[length - 1]
       },
       /**
        * #action
        */
       addQueuedJob(job: NewJob) {
-        self.queued.push(job)
-        return self.finished
+        const existing = self.queued.find(
+          queuedJob => queuedJob.name === job.name,
+        )
+        if (existing) {
+          return existing
+        }
+        const length = self.queued.push(job)
+        return self.queued[length - 1]
       },
       /**
        * #action
        */
       addAbortedJob(job: NewJob) {
-        self.aborted.push(job)
-        return self.aborted
+        const existing = self.aborted.find(
+          abortedJob => abortedJob.name === job.name,
+        )
+        if (existing) {
+          return existing
+        }
+        const length = self.aborted.push(job)
+        return self.aborted[length - 1]
       },
       /**
        * #action


### PR DESCRIPTION
The JobsListWidget treats the name of a job as an identifier, but also allowed multiple jobs with the same name. This changes the behavior so that if a job is added with the same name as an existing job, it skips adding the job and returns the existing one. There are other ways this could be addressed (e.g. assigning generated ids to jobs), but this seemed the least disruptive.

It also fixes a bug where if a job name that didn't exist was provided to `removeJob` or `removedQueuedJob`, it would remove the last job in the list. Now it doesn't remove any jobs and returns `undefined`.