### PR TITLE
Less gappyness at SVG features block boundaries

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
@@ -33,7 +33,7 @@ const Box = observer(function Box(props: {
     topLevel,
   } = props
   const { start, end } = region
-  const screenWidth = (end - start) / bpPerPx
+  const screenWidth = Math.ceil((end - start) / bpPerPx)
   const featureStart = feature.get('start')
   const featureEnd = feature.get('end')
   const featureType: string | undefined = feature.get('type')


### PR DESCRIPTION
In an effort to not render very large SVG elements, they are "mathematically cropped" to fit in the visible region. For whatever reason, the math doesn't line up quite right and can lead to ~1px emptyness being rendered. I fixed this by Math.ceil'ing the "screen width" calculation

Possible hypothesis could be...got the math wrong and this is a fudge factor, or lossy large floating points from bpPerPx, and again, fudge factor

Before (can see small gap in orange blocks)
![image](https://github.com/user-attachments/assets/09c53971-240d-4509-8e93-4753e7bf4a9e)


After
![image](https://github.com/user-attachments/assets/403f5601-290d-4ad7-9aec-5e6046bc37d1)
