### PR TITLE
Update @gmod/cram for fixed decoding of some CRAM files

### DIFF
--- a/packages/sv-core/package.json
+++ b/packages/sv-core/package.json
@@ -41,7 +41,7 @@
     "useSrc": "node ../../scripts/useSrc.js"
   },
   "dependencies": {
-    "@gmod/vcf": "^6.0.0",
+    "@gmod/vcf": "^6.0.8",
     "@jbrowse/core": "^3.0.1",
     "@jbrowse/plugin-linear-genome-view": "^3.0.1",
     "@mui/icons-material": "^6.0.0",

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf dist esm *.tsbuildinfo"
   },
   "dependencies": {
-    "@gmod/vcf": "^6.0.0",
+    "@gmod/vcf": "^6.0.8",
     "@jbrowse/core": "^3.0.1",
     "@jbrowse/plugin-linear-genome-view": "^3.0.1",
     "@mui/icons-material": "^6.0.0",

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@gmod/bgzf-filehandle": "^2.0.1",
-    "@gmod/vcf": "^6.0.0",
+    "@gmod/vcf": "^6.0.8",
     "@jbrowse/core": "^3.0.1",
     "@jbrowse/plugin-linear-genome-view": "^3.0.1",
     "@jbrowse/plugin-variants": "^3.0.1",

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -39,7 +39,7 @@
     "@flatten-js/interval-tree": "^1.0.15",
     "@gmod/bgzf-filehandle": "^2.0.1",
     "@gmod/tabix": "^2.0.0",
-    "@gmod/vcf": "^6.0.7",
+    "@gmod/vcf": "^6.0.8",
     "@jbrowse/core": "^3.0.1",
     "@jbrowse/plugin-circular-view": "^3.0.1",
     "@jbrowse/plugin-linear-genome-view": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,11 +2141,10 @@
     pako "^1.0.11"
 
 "@gmod/cram@^4.0.1":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-4.0.7.tgz#76c194d5071cbae17e71bdd671e51bfff6ba479e"
-  integrity sha512-N0VsoDCb+HhTxRLImveXy5lC6dTVIw2D9fsag2oQboFZg+hFRQw4WdAN9MdyKMCulLM+1O0QMuMUER4BhnOFGA==
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@gmod/cram/-/cram-4.0.10.tgz#382ac3b8cdfb1fd4b886efb7c0cf87c9d398a1f2"
+  integrity sha512-kYN24I7AT61cBUIl/jdZxt3MATi1wa0w+DIkteNGGA70F7pkhlHHtHm6lOBIq8mOQCWNlhXu+ia7HI+ck8LKzg==
   dependencies:
-    bzip2 "^0.1.1"
     crc "^4.3.2"
     generic-filehandle2 "^1.0.0"
     md5 "^2.2.1"
@@ -6241,11 +6240,6 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-bzip2@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/bzip2/-/bzip2-0.1.1.tgz#b0d232bd0f0f750d2023306d40a886ee51b901f4"
-  integrity sha512-wMvOIQ5jX3ikcCxWO1HjYVOAB+sjKzMTYLQmFPi4d6GBF01cYpnIwQ4RaDX4F3QSJeiB6gFqt5hh9fbebCSspw==
-
 cacache@^15.2.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
@@ -8006,9 +8000,9 @@ electron-publish@25.1.7:
     mime "^2.5.2"
 
 electron-to-chromium@^1.5.73:
-  version "1.5.97"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz#5c4a4744c79e7c85b187adf5160264ac130c776f"
-  integrity sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==
+  version "1.5.98"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.98.tgz#bdd59c95042fa8f6483893602b1530c8752baebc"
+  integrity sha512-bI/LbtRBxU2GzK7KK5xxFd2y9Lf9XguHooPYbcXWy6wUoT8NMnffsvRhPmSeUHLSDKAEtKuTaEtK4Ms15zkIEA==
 
 electron-updater@^6.1.1:
   version "6.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,10 +2212,10 @@
   resolved "https://registry.yarnpkg.com/@gmod/ucsc-hub/-/ucsc-hub-1.0.0.tgz#2fd6251d5ad040b8658e3d4c17987f89bc741322"
   integrity sha512-BTMPPUS667K2eGQ6ASc69908l3hDWF2sV/ZoTuMqIz1AfiHuaDMpcdELNf61bVeTWvUUFG5qkOQApcWMvlIvjw==
 
-"@gmod/vcf@^6.0.0", "@gmod/vcf@^6.0.7":
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-6.0.7.tgz#15fb42ccb23f1fe094be3412ef799ebbcb2e4abf"
-  integrity sha512-Sn3bEhLBXTu1StofTMeqcwmSxinvThvdst+na/3s6CbUPtkM/AYerMIOrztKvHP6z7CnYgxQ3MQEAuH0BqVeOA==
+"@gmod/vcf@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-6.0.8.tgz#540f14e14f88f8997fc7bee25c993acd4871f756"
+  integrity sha512-hUMXeeduB7Fby2TiG+3rtnaiD+K2aPy65JqTOGv6wXk1TN6eq8PCciucC6zQDz8DaTHcfkvLDuZlhrHZOPS50A==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"


### PR DESCRIPTION
swapped out bzip2 decoder in @gmod/cram in https://github.com/GMOD/cram-js/pull/152