### PR TITLE
Add ?data= parameter

### DIFF
--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -16,6 +16,10 @@ const SessionLoader = types
     /**
      * #property
      */
+    dataDir: types.maybe(types.string),
+    /**
+     * #property
+     */
     configPath: types.maybe(types.string),
     /**
      * #property
@@ -324,8 +328,10 @@ const SessionLoader = types
      */
     async fetchConfig() {
       // @ts-expect-error
-      const path = window.__jbrowseConfigPath
-      const { configPath = path || 'config.json' } = self
+      const path = window.__jbrowseConfigPath || 'config.json'
+      const { configPath: configPathPre, dataDir } = self
+      const configPath =
+        configPathPre || (dataDir ? `${dataDir}/config.json` : '') || path
       const shouldFetchConfig = configPath !== 'none'
 
       // if ?config=none then we will not load the config, which is useful for

--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -40,6 +40,7 @@ export function Loader({
   const Str = StringParam
 
   const [config] = useQueryParam('config', Str)
+  const [data] = useQueryParam('data', Str)
   const [session] = useQueryParam('session', Str)
   const [adminKey] = useQueryParam('adminKey', Str)
   const [password, setPassword] = useQueryParam('password', Str)
@@ -54,6 +55,7 @@ export function Loader({
 
   const loader = SessionLoader.create({
     configPath: normalize(config),
+    dataDir: normalize(data),
     sessionQuery: normalize(session),
     password: normalize(password),
     adminKey: normalize(adminKey),


### PR DESCRIPTION
This allows users to specify ?data=test_data to load test_data/config.json

This was proposed previously but stopped to let perfect be the enemy of good...maybe just let a little imperfect in https://github.com/GMOD/jbrowse-components/pull/3192