### PR TITLE
Handle case insensitive UTR

### DIFF
--- a/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
+++ b/plugins/gtf/src/GtfAdapter/GtfAdapter.ts
@@ -212,7 +212,7 @@ export default class GtfAdapter extends BaseFeatureDataAdapter {
         }
       }
 
-      Object.entries(parentAggregation).map(([name, subfeatures]) => {
+      for (const [name, subfeatures] of Object.entries(parentAggregation)) {
         const s = min(subfeatures.map(f => f.start))
         const e = max(subfeatures.map(f => f.end))
         if (doesIntersect2(s, e, originalQuery.start, originalQuery.end)) {
@@ -232,7 +232,7 @@ export default class GtfAdapter extends BaseFeatureDataAdapter {
             }),
           )
         }
-      })
+      }
     }
     observer.complete()
   }

--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
@@ -3,7 +3,7 @@ import { SimpleFeature } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 
 import Segments from './Segments'
-import { layOutFeature, layOutSubfeatures } from './util'
+import { isUTR, layOutFeature, layOutSubfeatures } from './util'
 
 import type { ExtraGlyphValidator } from './util'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
@@ -27,12 +27,6 @@ function makeSubpartsFilter(
 
 function filterSubpart(feature: Feature, config: AnyConfigurationModel) {
   return makeSubpartsFilter('subParts', config)(feature)
-}
-
-function isUTR(feature: Feature) {
-  return /(\bUTR|_UTR|untranslated[_\s]region)\b/.test(
-    feature.get('type') || '',
-  )
 }
 
 function makeUTRs(parent: Feature, subs: Feature[]) {

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -172,7 +172,7 @@ export function layOutSubfeatures(args: SubfeatureLayOutArgs) {
 }
 
 export function isUTR(feature: Feature) {
-  return /(\bUTR|_UTR|untranslated[_\s]region)\b/.test(
+  return /(\bUTR|_UTR|untranslated[_\s]region)\b/i.test(
     feature.get('type') || '',
   )
 }


### PR DESCRIPTION
The gene rendering misbehaves if the user has five_prime_utr instead of five_prime_UTR

This makes it case insensitive