### PR TITLE
Fix name indexing failure on jbrowse desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "ts-node": "^10.4.0",
     "tslib": "^2.0.1",
     "tss-react": "^4.0.0",
-    "typescript": "^5.8.0-dev.20241213",
+    "typescript": "^5.8.0",
     "typescript-eslint": "^8.0.1",
     "webpack": "^5.64.4",
     "webpack-cli": "^6.0.1",

--- a/packages/core/util/types/index.ts
+++ b/packages/core/util/types/index.ts
@@ -51,7 +51,7 @@ export function isViewContainer(
 
 export type NotificationLevel = 'error' | 'info' | 'warning' | 'success'
 export interface SnackAction {
-  name: React.ReactElement
+  name: React.ReactElement | string
   onClick: () => void
 }
 

--- a/plugins/data-management/src/AddTrackWidget/model.ts
+++ b/plugins/data-management/src/AddTrackWidget/model.ts
@@ -254,7 +254,7 @@ export default function f(pluginManager: PluginManager) {
       /**
        * #getter
        */
-      get trackConfig() {
+      getTrackConfig(timestamp: number) {
         const session = getSession(self)
         const assemblyInstance = session.assemblyManager.get(self.assembly)
 
@@ -264,7 +264,7 @@ export default function f(pluginManager: PluginManager) {
           ? deepmerge(
               {
                 trackId: [
-                  `${self.trackName.toLowerCase().replaceAll(' ', '_')}-${Date.now()}`,
+                  `${self.trackName.toLowerCase().replaceAll(' ', '_')}-${timestamp}`,
                   session.adminMode ? '' : '-sessionTrack',
                 ].join(''),
                 type: self.trackType,

--- a/products/jbrowse-desktop/src/components/OpenSequenceDialog.tsx
+++ b/products/jbrowse-desktop/src/components/OpenSequenceDialog.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react'
 
-import { Dialog, ErrorMessage, FileSelector } from '@jbrowse/core/ui'
+import {
+  Dialog,
+  ErrorMessage,
+  FileSelector,
+  LoadingEllipses,
+} from '@jbrowse/core/ui'
 import {
   Button,
   DialogActions,
@@ -189,7 +194,9 @@ const OpenSequenceDialog = ({
         ) : null}
 
         {loading ? (
-          <Typography className={classes.message}>{loading}</Typography>
+          <LoadingEllipses className={classes.message}>
+            {loading}
+          </LoadingEllipses>
         ) : null}
 
         {error ? <ErrorMessage error={error} /> : null}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,10 +4074,10 @@
     "@smithy/types" "^4.1.0"
     tslib "^2.6.2"
 
-"@storybook/addon-actions@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-8.6.2.tgz#abb13aa13d539bfb9fb0e3a9b2b6c4d10ae3aa96"
-  integrity sha512-grIRReMObwwt/VZemFnaKDbeaiK257egN+/knuqMbT3eUA6aitlzTr5UynBZnsVYbJFdD6PYyIZMKoGWEdFJlQ==
+"@storybook/addon-actions@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-8.6.3.tgz#fd5e60b4e78fc0d1eb762a0646195ced8dc9cf0f"
+  integrity sha512-0UrVqRoZFRFCqjtR8ODacpJNqi47qDUnsnB5F7e93U9ihSrH2edOBBX6frl11XKYA23rzq7jtnviFTVOpWpG7Q==
   dependencies:
     "@storybook/global" "^5.0.0"
     "@types/uuid" "^9.0.1"
@@ -4085,102 +4085,102 @@
     polished "^4.2.2"
     uuid "^9.0.0"
 
-"@storybook/addon-backgrounds@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.2.tgz#ced4fc0de3bd3a7fbeed922ba6a1d5107b1b306a"
-  integrity sha512-xysLkeHCdwh1xcLIrarRnJipl2ccoR1Oy6hHYcPtFiUB89gd6DsTe2WC8zsqrO16ogPYovCTP4UiBzApo+yoYA==
+"@storybook/addon-backgrounds@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.3.tgz#8e81148df3227fa77f43595c9bd85ea3dc83a196"
+  integrity sha512-2mmMpMyUsS8rti2guMR4rk4h5YBLNHidxUqTm+U4nITZFfCXNP76To9hfTczpLTvUEpPxSbPG0sCIeHFaw4NRQ==
   dependencies:
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-controls@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-8.6.2.tgz#67147eab1a1d75c5699feffd4ea9375bcaaab2ff"
-  integrity sha512-MOTzQTZ64Wfc/hWBflnrOsw8qdNSu37VFzvcXtQa1npEJUO6KU822KvvuKGtdDZJhwcVrGDM5yL9gy4Nw5/M5g==
+"@storybook/addon-controls@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-8.6.3.tgz#3db390b8f06064834115fab0f064e6775aaa0a49"
+  integrity sha512-j4Oof3nwjyiO6oNP1bJ98Sz1iZlYhdcgHX284yd0wBO91Q5B2GoCeqyCE+yRCh752ZnnYG1gazJrHmiG6gKxVg==
   dependencies:
     "@storybook/global" "^5.0.0"
     dequal "^2.0.2"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-8.6.2.tgz#b37754617891402b7d91c8be9d22fcb5ffb11dc6"
-  integrity sha512-urc6GCKZRV2Mhh2V0fzhkqOdKYvJ1E45dCeCZ7hNrz0Yfe72NG8rTz5U/+u7ESUMTjE4Q5sAgplW7hnELt4vLg==
+"@storybook/addon-docs@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-8.6.3.tgz#1eae8f04397a5606f46ceeffa3a9380aa60c1a94"
+  integrity sha512-FRABH+r2huMpAK8iUQiFlYZtYenbqtudX3fNKFK9b38eV1R14kWggVG02lsa6upXbzxWVbMLUdOqaZJHxNbO/A==
   dependencies:
     "@mdx-js/react" "^3.0.0"
-    "@storybook/blocks" "8.6.2"
-    "@storybook/csf-plugin" "8.6.2"
-    "@storybook/react-dom-shim" "8.6.2"
+    "@storybook/blocks" "8.6.3"
+    "@storybook/csf-plugin" "8.6.3"
+    "@storybook/react-dom-shim" "8.6.3"
     react "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     react-dom "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     ts-dedent "^2.0.0"
 
 "@storybook/addon-essentials@^8.5.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-8.6.2.tgz#a78d4bfed4f42e58bd361ec63025c358c5afb7ec"
-  integrity sha512-nJvtVVcB8847Olsd5vbnW34SVQpboXdSGPRuUNTeRXOAIQQc5heWwRXjgBQgqF2kD5GaPaHfKTfec37cVyJFfA==
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-8.6.3.tgz#3d91dd097aafd0d86052456c72ba4c8a12dd649f"
+  integrity sha512-tH+MwkZ6UwRWyhGdq8izVZAZHGWdeiBY1wpIwdceP1Rl2j9s11Gbddb/JlmiXrC+f/Oiylxghaf7EIksVVqLQQ==
   dependencies:
-    "@storybook/addon-actions" "8.6.2"
-    "@storybook/addon-backgrounds" "8.6.2"
-    "@storybook/addon-controls" "8.6.2"
-    "@storybook/addon-docs" "8.6.2"
-    "@storybook/addon-highlight" "8.6.2"
-    "@storybook/addon-measure" "8.6.2"
-    "@storybook/addon-outline" "8.6.2"
-    "@storybook/addon-toolbars" "8.6.2"
-    "@storybook/addon-viewport" "8.6.2"
+    "@storybook/addon-actions" "8.6.3"
+    "@storybook/addon-backgrounds" "8.6.3"
+    "@storybook/addon-controls" "8.6.3"
+    "@storybook/addon-docs" "8.6.3"
+    "@storybook/addon-highlight" "8.6.3"
+    "@storybook/addon-measure" "8.6.3"
+    "@storybook/addon-outline" "8.6.3"
+    "@storybook/addon-toolbars" "8.6.3"
+    "@storybook/addon-viewport" "8.6.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-highlight@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-8.6.2.tgz#361f4dae514832cd5aa455d7e11698cf8e5dccb7"
-  integrity sha512-TtRW+JK1NNuRI6zEXQAHImqVW7x+wkFGddhE6ikWX6eXJER+dgXaPd1pGBNlEQp2kzdWbzOEvXbrIKU1cy1A7Q==
+"@storybook/addon-highlight@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-8.6.3.tgz#3fd975e5fca2d3925ecf7910b93e6c42a2a47829"
+  integrity sha512-LYZsgZt5q3EZBkZjUEELh/5+TDnUP0njuQ5g6skyKil6vj9+2RI4/Vjodp+ni5+xct5aDhXavRyUnPRfclX/Cg==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/addon-measure@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-8.6.2.tgz#35ea45dd7915e589cbeaf5666906a8430196710e"
-  integrity sha512-qNzR8yj/g2FRRLBwTreGqeUR5ZcXpkhcdndWlf5rnxp97BDbPnGNCvaI9vhHS3GbjZ+C1FE+yG3o70O5Rhh7Ag==
+"@storybook/addon-measure@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-8.6.3.tgz#f7fd39d0c78bada393e91c8d1d415f3978f6e2d8"
+  integrity sha512-FC/3pqM2adSnwyPOd9AxEoZD5XWCMKAk16urQFQ0M4+IzRUdf2OV8cc7aM/oZiBX36+q/UCcUWm2SbQ5nzNJpg==
   dependencies:
     "@storybook/global" "^5.0.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/addon-outline@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-8.6.2.tgz#a337b14b418965c994d333f760baa617fa1e2aad"
-  integrity sha512-lgDCOkOLoehat4APUbKpAA7CBwXtxrRRK91hNBI3prUUBex6ML9jXWcuTDsGTrkilRkLOT7kN6H0DGj5rH/H9Q==
+"@storybook/addon-outline@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-8.6.3.tgz#4ac86a6dcc899ab8cd71861f5dca883a9a630a93"
+  integrity sha512-YklKHRkoDLSWawIIBrEI69RAWEdvhkYCOv+fMLu9zBeVPnkwbtIjXN/I+UJwPCm6jlxeEwEUAvbPWZMMf+BkPQ==
   dependencies:
     "@storybook/global" "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-8.6.2.tgz#ecbc7b045e7544e243098c2f0260e3848d9f5b19"
-  integrity sha512-rfUSMacIfGwPoYYeVro+3I5C3qNy0MgB+qJ16ejuTLTlx4ji0icAOckILmPmhIT577KqIQBo1R2sB+oMVzK9+w==
+"@storybook/addon-toolbars@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-8.6.3.tgz#166cb5db172798f4ab93fd41dcc0c128b1b511d2"
+  integrity sha512-GTC1GPrFNfWvvBaQQnGuL7ZfGK5Q+3ZovwQA9tnPu7QZEwea/4CXvUyQh1u0NwqrFZkrabOad1XvYfpRuCPGSA==
 
-"@storybook/addon-viewport@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-8.6.2.tgz#492f51a39b3d291048f04003f396d708e69d4769"
-  integrity sha512-znUIG808UEEfF5Gg+T478ixblBwEebeOYaKLD7yfxKwL2TMTmaIq4DXPESqV9M1lBcy3UrBWrPG9mzvq4PKMxA==
+"@storybook/addon-viewport@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-8.6.3.tgz#09cb8fce7068dad71bb8094bf86a7d4421a5d659"
+  integrity sha512-AixZKiQdBVs7ePj5iV0U1IY2jvH0G7wQJwBRTOq4qC1FKiOsZEYmrwc3wLUBUlVqyenXFKN+H40r4VhPzzSfLw==
   dependencies:
     memoizerific "^1.11.3"
 
-"@storybook/blocks@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-8.6.2.tgz#16924c652336e61eea5f1b0148be9de92ed4e2a7"
-  integrity sha512-yYskHxUDJcBcRRSTZ95agqO3gZ4gLK9/1QZvANa6+Hb23Z5tGpNDHzLFGZePUJGRBqPPaNraay+SCI1LBY3/yw==
+"@storybook/blocks@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-8.6.3.tgz#1df08fb3acffa3d8fc389a9d61ad72ab40e1ad84"
+  integrity sha512-Ieu6kwqdeAcrLzcX2QIqnCd0XWZi46i4eem8W54JRiOMQMYUpZ7onbciRAP58qxEWrZWqgxPS+tiCTaJe48VVQ==
   dependencies:
     "@storybook/icons" "^1.2.12"
     ts-dedent "^2.0.0"
 
-"@storybook/builder-webpack5@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-8.6.2.tgz#f0c5f7885bc3d3d103e564f1a0ef584e7ec5d86f"
-  integrity sha512-yDb2n/VSB5fCK4S0K23pGpdgmln1BKtO1jP/Ywf/Yr83s+RtjyAev3V+pOLiL5Sb6e7qz3vG+ZKWleFme4/jKQ==
+"@storybook/builder-webpack5@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-8.6.3.tgz#80c2ebcf6ba0e37b51c2d95775a12bb1a26b5d0d"
+  integrity sha512-+Er6wFbi6O1xAqSsCZwqMcOfKM90n2jYDgSixYTsgqhjEcKLvCX9sn5akyRB1pPl5cGq4zBDIG4l9aLzZLLC3Q==
   dependencies:
-    "@storybook/core-webpack" "8.6.2"
+    "@storybook/core-webpack" "8.6.3"
     "@types/semver" "^7.3.4"
     browser-assert "^1.2.1"
     case-sensitive-paths-webpack-plugin "^2.4.0"
@@ -4205,24 +4205,24 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.6.0"
 
-"@storybook/components@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-8.6.2.tgz#2ebf0ba71e37ff3c6f033dc1842b080870144900"
-  integrity sha512-tPEgj40YMkIE8KfElh5gf3s/B/KOcFKBpf6k7Nn3wZAu+dSifrGNyU33lecHjfkRHO/ZK1QYF7kIkCkPu/SKQA==
+"@storybook/components@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-8.6.3.tgz#155c33adfd908cd756c2a0d52a65fd7e0fee0a24"
+  integrity sha512-q5DQkV+E/j0KfF818RywgqEHjaZTg71q5YY4z0UO8CRSzDQ/VYF6L76oc69corbkJtYAk/GqaYJllzrWykS4sg==
 
-"@storybook/core-webpack@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-8.6.2.tgz#a64bd45b0f4ba4e3fd692c9bb166f1e26c632acc"
-  integrity sha512-qJpBtojqrfIONR6ixpsqLDj4Xv8pFCG4GcvD+ZylLicFm1ZToHcOwhFUjGAdO9/HbJReqqhI9D5qZMTHs4B0Qg==
+"@storybook/core-webpack@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-8.6.3.tgz#48db1158092808a19d2bbc249ecfb86442164c77"
+  integrity sha512-JYrHPwgyiXa4BgfkrUIDyl5Dp1I7xZG+GV7z0m/2wCn1PcDrDJ8iRl2HHbVbHZXYRK3zSp84iRjdBK4DF94HGQ==
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-8.6.2.tgz#d5c3f86c093c8aabfb8f662d9bb380eec3b883c1"
-  integrity sha512-i8a/nUuzzH5RLKjPn8DM7l8xxuTdLZ6xbI4hgpruas3JY8lQq72I7qmH6pmI7ByjGangDWK1iPh+tghdKkS6KQ==
+"@storybook/core@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-8.6.3.tgz#a64aea869d3df0d4101ad14e000348b1cc19d849"
+  integrity sha512-0iMTfmo3UFCa1hFJLtThnRIppkIpGPyTL3MElhORP1t5l9lCUq5am0ymbi/TeCbsJPjE86FjeO0NinokL9iQiw==
   dependencies:
-    "@storybook/theming" "8.6.2"
+    "@storybook/theming" "8.6.3"
     better-opn "^3.0.2"
     browser-assert "^1.2.1"
     esbuild "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0"
@@ -4234,10 +4234,10 @@
     util "^0.12.5"
     ws "^8.2.3"
 
-"@storybook/csf-plugin@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-8.6.2.tgz#b3c8ee6efdf90555264cce5cd0dcfb7d166cc181"
-  integrity sha512-YqvtCTzAn4EJ+Da+QcY6oeGxrybeHohRiPwYN6gjGQOgRj0acp5CJakH9Nz/0/U3BaXrf+5YtfTEM+SWhlRROw==
+"@storybook/csf-plugin@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-8.6.3.tgz#3cbaca9562627df9e1aee22138ac606b92e57070"
+  integrity sha512-0QDLBcMOxSEt1yH28cvIsoiaIokIxDDShMnxVJHWk/7+KZ3xe4lZBfKCWZspZoJmrxgz10gLRifj1b3ysIFlyA==
   dependencies:
     unplugin "^1.3.1"
 
@@ -4251,23 +4251,23 @@
   resolved "https://registry.yarnpkg.com/@storybook/icons/-/icons-1.3.2.tgz#e9b92c35ca789ff79f9d0b3848829dd6490ca628"
   integrity sha512-t3xcbCKkPvqyef8urBM0j/nP6sKtnlRkVgC+8JTbTAZQjaTmOjes3byEgzs89p4B/K6cJsg9wLW2k3SknLtYJw==
 
-"@storybook/manager-api@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-8.6.2.tgz#695d21b5ee247433f3e3e8ea50f00d8a13970da4"
-  integrity sha512-75yx3xSDRU1B4dsf2OSJev7VAvR+6SjWUExENmMGXa0PpoO0MBZqMKdIufKMPsRtw77ugKGfS04MWt4yc5lgRQ==
+"@storybook/manager-api@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-8.6.3.tgz#b50f2263d2bcae139adb7f3c571a2f60b5bd3453"
+  integrity sha512-7m9MQELc6XpuKIuliqMiQWzl8yVWpUDwTcpr+rTT7l3OfRzw7Y00UFct2tI03YG6EXsxsykw8EmueMQhe0lG5Q==
 
 "@storybook/node-logger@^8.3.0":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-8.6.2.tgz#3e51690b43afde5368d7cc7bd4f9ad4763f42849"
-  integrity sha512-3oJzgwoWed88pxKy0EGuef8UPToT8s3ro8L0GhSXBaYb+8WxF6pz/E2QKhyBtduYm8oeI6csu0vBtfjRambf3A==
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-8.6.3.tgz#4ca96f2e1ef16c975b470456ce5ab64de6af0fc9"
+  integrity sha512-rIq2mWv1lDmBpPNCf4FcBe4D8Ik458GIPxSUZHoOxLmEElOzncixiGWpRKUCycOXpD8f3lZaxgZjYZqVmdeW7A==
 
-"@storybook/preset-react-webpack@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-8.6.2.tgz#53826c536f201e657f2abe6965cea04e195fe4be"
-  integrity sha512-Q/LmW7PNDKCzIusSQZO4qOFk6pvw9xYbYH5T5SL0K3Wo6rUb0G/tlH1TLMr0v8SaQGpSAdfKQjNwShB+gGRHIw==
+"@storybook/preset-react-webpack@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-8.6.3.tgz#abcda70e6341524e247a0788a1d9f1a22f6c09da"
+  integrity sha512-ROZdvtRm0jtApA21DQa4q5FkG3EPiHdYEWp01DxtGQrenl8YV4JBF3va9sYcPFki2gW+lx/iVpAcHfIAR7PS2Q==
   dependencies:
-    "@storybook/core-webpack" "8.6.2"
-    "@storybook/react" "8.6.2"
+    "@storybook/core-webpack" "8.6.3"
+    "@storybook/react" "8.6.3"
     "@storybook/react-docgen-typescript-plugin" "1.0.6--canary.9.0c3f3b7.0"
     "@types/semver" "^7.3.4"
     find-up "^5.0.0"
@@ -4278,10 +4278,10 @@
     tsconfig-paths "^4.2.0"
     webpack "5"
 
-"@storybook/preview-api@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-8.6.2.tgz#95a2f5702c667cca78a04432eaa039f60f5e0b59"
-  integrity sha512-hkKmQ9OWlCpS2mHYsuWTbXMfeLx90fiWdUblTBIUQnj8VLhSbNtmeBZdZRkz33uYHFkAqZ3F2nQ9I2iTv8AmwA==
+"@storybook/preview-api@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-8.6.3.tgz#e2da8e5139ae0645e583237b6a675fcc0cd78c89"
+  integrity sha512-y2Ic6eHBQD/AwaCHctKOJ4tOM1r7/mPXfhGh0I+Qf8kZPlDTgQcJ6Z7/Ruma1L+ijXPBWouDaPw51gipcX+t9Q==
 
 "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0":
   version "1.0.6--canary.9.0c3f3b7.0"
@@ -4296,36 +4296,36 @@
     react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
-"@storybook/react-dom-shim@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-8.6.2.tgz#18827af84a541c30d4ec89a337c71680c74b8ec6"
-  integrity sha512-8VTAaYtvtP3dx9AXk2lMTQ/o/hTBpL/a6C48JYWhfbU1UO6O0B4PUGADFJ8XWzobXRkTm7CR3RGLzA2oYgWxdA==
+"@storybook/react-dom-shim@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-8.6.3.tgz#aed690e9f2c4d659754aafa6dc90e635ec7a598c"
+  integrity sha512-vE3LA2TxbzDF1Fso2IgvUtoHc+8a6laKhuJdx8frP5A8M1KGOBfuEPFCCcE49Q90HUlDgwb/zQl1GNq/QjLgWQ==
 
 "@storybook/react-webpack5@^8.5.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-8.6.2.tgz#f4bc092af70f964cddf300a95c45127b6d01b993"
-  integrity sha512-opA7AYh0DvGH1KRIR+NuMTuZ90sIhcrrVTKBWT6Rmpg3piapNTorRhQykafPvb5C/Gl+KuC4cUYB/QxHyGI1qg==
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-8.6.3.tgz#e772f35aa21514e90378f7577107a1ee9773ec18"
+  integrity sha512-T4dpvXUMiG7zMLZcFuJNshMr9rUulowl2AyqLd2LjQtN32COAzhn6uKJkFycTHkOMM8qC03WNefc55MNJVtr/w==
   dependencies:
-    "@storybook/builder-webpack5" "8.6.2"
-    "@storybook/preset-react-webpack" "8.6.2"
-    "@storybook/react" "8.6.2"
+    "@storybook/builder-webpack5" "8.6.3"
+    "@storybook/preset-react-webpack" "8.6.3"
+    "@storybook/react" "8.6.3"
 
-"@storybook/react@8.6.2", "@storybook/react@^8.3.0":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-8.6.2.tgz#753090bca03169dccbfb3ae3da462f6f4faabec1"
-  integrity sha512-f6mS9nydU2KGY3nIvu4WVUFmJNEjzmFLj86iznO9CK/pELH53e4RjuzXgIqfWIGxBpR0QyFMdwyWjaOB5ZKr7Q==
+"@storybook/react@8.6.3", "@storybook/react@^8.3.0":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-8.6.3.tgz#5c4b16d8d8751c870c87db1f6098cf4ce7f2441c"
+  integrity sha512-B4WYRWU2Y71UWl4CG3+mcB7duNln9finJyDB8Y1o2CYWUxgEo+3Bnp3k7NUr++tYVkZI1H+28UWeX0rpCkvReQ==
   dependencies:
-    "@storybook/components" "8.6.2"
+    "@storybook/components" "8.6.3"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "8.6.2"
-    "@storybook/preview-api" "8.6.2"
-    "@storybook/react-dom-shim" "8.6.2"
-    "@storybook/theming" "8.6.2"
+    "@storybook/manager-api" "8.6.3"
+    "@storybook/preview-api" "8.6.3"
+    "@storybook/react-dom-shim" "8.6.3"
+    "@storybook/theming" "8.6.3"
 
-"@storybook/theming@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-8.6.2.tgz#e4bfd25ef19a38cebe96786d8c60ada889f02419"
-  integrity sha512-NF7tMZBbmh6rNf+uw5wVUpsVIwnbhLgauhQJONuQ8i+cI6cJEBaKjIC2uMWUBABqnj1LqGrHSEWVeeYwuAeUYg==
+"@storybook/theming@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-8.6.3.tgz#f35fd55aa1c50e1b768fd71ac5b93547d2ba05ba"
+  integrity sha512-sDcWnnko73KOCIc9stQyec9KvTmGOuMswqeKtWh0ha/wsgYB6G2/2j1xOheFmWKPitOsbwgvqtjCP7bRE68uIA==
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -4819,9 +4819,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.15.tgz#12d4af0ed17cc7600ce1f9980cec48fc17ad1e89"
-  integrity sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==
+  version "4.17.16"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
+  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
 
 "@types/mdx@^2.0.0":
   version "2.0.13"
@@ -4871,16 +4871,16 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^22.5.5":
-  version "22.13.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.5.tgz#23add1d71acddab2c6a4d31db89c0f98d330b511"
-  integrity sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==
+  version "22.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.8.tgz#57e2450295b33a6518d6fd4f65f47236d3e41d8d"
+  integrity sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==
   dependencies:
     undici-types "~6.20.0"
 
 "@types/node@^20.0.0", "@types/node@^20.9.0":
-  version "20.17.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.19.tgz#0f2869555719bef266ca6e1827fcdca903c1a697"
-  integrity sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==
+  version "20.17.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.22.tgz#18e463b500af6e6d407d2a0084dfc244ef3c8d06"
+  integrity sha512-9RV2zST+0s3EhfrMZIhrz2bhuhBwxgkbHEwP2gtGWPjBzVQjifMzJ9exw7aDZhR1wbpj8zBrfp3bo8oJcGiUUw==
   dependencies:
     undici-types "~6.19.2"
 
@@ -8385,9 +8385,9 @@ eslint-plugin-react-compiler@^19.0.0-beta-6fc168f-20241025:
     zod-validation-error "^3.0.3"
 
 eslint-plugin-react-hooks@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz#3d34e37d5770866c34b87d5b499f5f0b53bf0854"
-  integrity sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz#1be0080901e6ac31ce7971beed3d3ec0a423d9e3"
+  integrity sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==
 
 eslint-plugin-react-refresh@^0.4.3:
   version "0.4.19"
@@ -8885,9 +8885,9 @@ find-root@^1.1.0:
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up-simple@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/find-up-simple/-/find-up-simple-1.0.0.tgz#21d035fde9fdbd56c8f4d2f63f32fd93a1cfc368"
-  integrity sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/find-up-simple/-/find-up-simple-1.0.1.tgz#18fb90ad49e45252c4d7fca56baade04fa3fca1e"
+  integrity sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==
 
 find-up@^2.0.0:
   version "2.1.0"
@@ -14813,9 +14813,9 @@ sort-object-keys@^1.1.3:
   integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
 sort-package-json@^2.14.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-2.15.0.tgz#82b975a50aec2a4b78a0899db8a570c724e360b3"
-  integrity sha512-wpKu3DvFuymcRvPqJR7VN5J6wnqR+SYZ4SZmnJa9ckpV+BuoE0XYHZYsoWaJbt6oz8OwOXb4eoMjlEBM6hwhBw==
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-2.15.1.tgz#e5a035fad7da277b1947b9eecc93ea09c1c2526e"
+  integrity sha512-9x9+o8krTT2saA9liI4BljNjwAbvUnWf11Wq+i/iZt8nl2UGYnf3TH5uBydE7VALmP7AGwlfszuEeL8BDyb0YA==
   dependencies:
     detect-indent "^7.0.1"
     detect-newline "^4.0.0"
@@ -15007,11 +15007,11 @@ statuses@2.0.1:
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 storybook@^8.5.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-8.6.2.tgz#6161494b9a974fdcdff60a57d9b285bce73b7e37"
-  integrity sha512-IkQGRNImyN14+tx/9KLg9k5xKBgrkWaPFhfwTCxUZUzLNClbVrxkkXyjFaks9kPVQIEUVPGQCiGFqypUiwoM6g==
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-8.6.3.tgz#519166a7f64b67ed86b092ab530d278cbbe05e27"
+  integrity sha512-Vbmd8/FXp6X0AOMak6arcg3WdkHj+2AYJTNHbCPVHsCEbnREyRZIG+Eq5/Ffmy6byiz+4OAX5HwsHGSMR6Xmow==
   dependencies:
-    "@storybook/core" "8.6.2"
+    "@storybook/core" "8.6.3"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -15465,17 +15465,17 @@ tinyglobby@^0.2.9:
     fdir "^6.4.3"
     picomatch "^4.0.2"
 
-tldts-core@^6.1.79:
-  version "6.1.79"
-  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.79.tgz#2d98689a161fbafe38a6640a54f5d4c88bd941a1"
-  integrity sha512-HM+Ud/2oQuHt4I43Nvjc213Zji/z25NSH5OkJskJwHXNtYh9DTRlHMDFhms9dFMP7qyve/yVaXFIxmcJ7TdOjw==
+tldts-core@^6.1.80:
+  version "6.1.80"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.80.tgz#81c4a8cd7011de977520b8c521caddd8ca12a14c"
+  integrity sha512-g8knP0P5sq4DAEVZa+yaMFAeJdVgvrMKou/Esjm79gJqdsYGLWxF+tDTrAeg1aKQbcWKXKMdtf2xmyrl84ScQA==
 
 tldts@^6.1.32:
-  version "6.1.79"
-  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.79.tgz#1804eddc48f8ae22a0e20937c9d92634ace7580b"
-  integrity sha512-wjlYwK8lC/WcywLWf3A7qbK07SexezXjTRVwuPWXHvcjD7MnpPS2RXY5rLO3g12a8CNc7Y7jQRQsV7XyuBZjig==
+  version "6.1.80"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.80.tgz#4e0c98660103b076e01b850f0f2d7c4d50ac7411"
+  integrity sha512-K1PQBCX0TmCI3oE2qXjYqlIU3qogPyn12XxRhkZigJeVa3qRpsP59fvstryGv5wqCUGJ95qYIpFB7yMNHMdSig==
   dependencies:
-    tldts-core "^6.1.79"
+    tldts-core "^6.1.80"
 
 tmp-promise@^3.0.2:
   version "3.0.3"
@@ -15534,9 +15534,9 @@ tough-cookie@^4.1.2:
     url-parse "^1.5.3"
 
 tough-cookie@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.1.tgz#4641c1fdbf024927e29c5532edb7b6e5377ea1f2"
-  integrity sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
     tldts "^6.1.32"
 
@@ -15707,9 +15707,9 @@ type-fest@^0.8.1:
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-fest@^4.6.0, type-fest@^4.7.1:
-  version "4.35.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.35.0.tgz#007ed74d65c2ca0fb3b564b3dc8170d5c872d665"
-  integrity sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==
+  version "4.36.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.36.0.tgz#e656de02aa880aa01b4d3a71188bb6adb18668a2"
+  integrity sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==
 
 type-is@1.6.18, type-is@~1.6.18:
   version "1.6.18"
@@ -15778,15 +15778,10 @@ typescript-eslint@^8.0.1:
     "@typescript-eslint/parser" "8.25.0"
     "@typescript-eslint/utils" "8.25.0"
 
-"typescript@>=3 < 6", typescript@^5.1.3, typescript@^5.4.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
-
-typescript@^5.8.0-dev.20241213:
-  version "5.8.0-dev.20250218"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-dev.20250218.tgz#4fd98cc5524a9ce0d09a557d97905657a909f6fa"
-  integrity sha512-ug24uoLMp4xZWUZOYi900L8VM9Tjpvm7+clJYYDY9OYOlveZf7en8ndF/kfZZ7QoODkFC/z6mvDdaD0ePD2fmQ==
+"typescript@>=3 < 6", typescript@^5.1.3, typescript@^5.4.3, typescript@^5.8.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
The PR https://github.com/GMOD/jbrowse-components/pull/4786 introduced a regression error in indexing tracks

It made the track config a 'getter' on the model, which includes running Date.now for the trackId

I erroneously thought the getter would be stable and not need re-running after initial creation

Turns out the getter is re-evaluated so if it is evaluated multiple times, the Date.now returns different values between runs, and it fails. probably a bad idea to make that assumption

This is somewhat intermittent but happens most times you try to index

Reported to jbrowse2dev email by user

This fixes it by changing it from a 'getter' to a 'method' to guarantee we invoke the method once to get the config
