### PR TITLE
Add sample data from HGSVCv3

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -19,3 +19,4 @@ website/docs/models/
 plugins/spreadsheet-view/src/SpreadsheetView/test_data/1801160099-N32519_26611_S51_56704.hard-filtered.vcf
 test_data/sars-cov2/ncbi_original.gff3
 plugins/data-management/src/UCSCTrackHub/ucscAssemblies.ts
+test_data/config_demo.json

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -154,7 +154,7 @@
         "subfeatures": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>'}"
       },
       "assemblyNames": ["hg19"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "metadata": {
         "source": "https://www.ncbi.nlm.nih.gov/genome/guide/human/",
         "dateaccessed": "12/03/2020"
@@ -179,7 +179,7 @@
         "feature": "jexl:{name:'<a href=https://google.com/?q='+feature.name+'>'+feature.name+'</a>'}"
       },
       "assemblyNames": ["hg19"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "metadata": {
         "source": "https://www.ncbi.nlm.nih.gov/genome/guide/human/",
         "dateaccessed": "12/03/2020"
@@ -217,7 +217,7 @@
       "trackId": "nclist_genes_hg19",
       "name": "Gencode v19",
       "assemblyNames": ["hg19"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "Gencode"],
       "adapter": {
         "type": "NCListAdapter",
         "rootUrlTemplate": {
@@ -354,7 +354,7 @@
       "trackId": "clinvar_hg19",
       "name": "ClinVar variants (UCSC)",
       "assemblyNames": ["hg19"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "ClinVar"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -368,7 +368,7 @@
       "trackId": "clinvar_ncbi",
       "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg19"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "ClinVar"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -402,7 +402,7 @@
       "trackId": "clinvar_ncbi_hg38",
       "name": "ClinVar variants (NCBI)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "ClinVar"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -450,7 +450,7 @@
       "trackId": "gencode_nclist_hg38",
       "name": "Gencode v32",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "Gencode"],
       "adapter": {
         "type": "NCListAdapter",
         "rootUrlTemplate": {
@@ -504,7 +504,7 @@
       "trackId": "clinvar_cnv_hg38",
       "name": "ClinVar CNV (UCSC)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "ClinVar"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -518,7 +518,7 @@
       "trackId": "clinvar_hg38",
       "name": "ClinVar variants (UCSC)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "ClinVar"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -532,7 +532,7 @@
       "trackId": "mane_hg38",
       "name": "MANE 1.0",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "MANE"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -586,7 +586,7 @@
       "trackId": "ncbi_refseq_109_hg38",
       "name": "NCBI RefSeq analysis set (GFF3Tabix)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
@@ -606,7 +606,7 @@
       "trackId": "ncbi_refseq_109_hg38_latest",
       "name": "NCBI RefSeq (GFF3Tabix)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
@@ -626,7 +626,7 @@
       "trackId": "ncbi_refseq_analysis_set",
       "name": "NCBI RefSeq (NCList)",
       "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "adapter": {
         "type": "NCListAdapter",
         "rootUrlTemplate": {
@@ -1968,7 +1968,7 @@
       "trackId": "clinGenGeneDisease",
       "name": "ClinGen Gene-Disease mapping",
       "assemblyNames": ["hg38"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -1982,7 +1982,7 @@
       "trackId": "clinGenHaplo",
       "name": "ClinGen haplosensitivity",
       "assemblyNames": ["hg38"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -1996,7 +1996,7 @@
       "trackId": "clinGenTriplo",
       "name": "ClinGen triplosensitivity",
       "assemblyNames": ["hg38"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -2010,7 +2010,7 @@
       "trackId": "clinGenDiesease_hg19",
       "name": "ClinGen Gene-Disease mapping",
       "assemblyNames": ["hg19"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -2024,7 +2024,7 @@
       "trackId": "clinGenHaplo_hg19",
       "name": "ClinGen haplosensitivity",
       "assemblyNames": ["hg19"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -2038,7 +2038,7 @@
       "trackId": "clinGenTriplo_hg19",
       "name": "ClinGen triplosensitivity",
       "assemblyNames": ["hg19"],
-      "category": ["ClinGen"],
+      "category": ["Annotation", "ClinGen"],
       "adapter": {
         "type": "BigBedAdapter",
         "bigBedLocation": {
@@ -2709,7 +2709,7 @@
       "type": "FeatureTrack",
       "trackId": "gencode.v36lift37.annotation.sort.gff3",
       "name": "Gencode v36 (GRCh37 liftover)",
-      "category": ["Annotation"],
+      "category": ["Annotation", "Gencode"],
       "assemblyNames": ["hg19"],
       "adapter": {
         "type": "Gff3TabixAdapter",
@@ -2742,7 +2742,7 @@
       "type": "FeatureTrack",
       "trackId": "gencode.v36.annotation.sort.gff3",
       "name": "Gencode v36",
-      "category": ["Annotation"],
+      "category": ["Annotation", "Gencode"],
       "assemblyNames": ["hg38"],
       "adapter": {
         "type": "Gff3TabixAdapter",
@@ -3808,6 +3808,7 @@
     },
     {
       "type": "SyntenyTrack",
+      "category": ["Synteny"],
       "trackId": "hg19ToHg38.over.chain.gz-1645073157673",
       "name": "hg19ToHg38.over.chain.gz",
       "assemblyNames": ["hg38", "hg19"],
@@ -3822,6 +3823,7 @@
     },
     {
       "type": "SyntenyTrack",
+      "category": ["Synteny"],
       "trackId": "hg38ToHs1.over.chain.gz-1645073157673",
       "name": "hg38ToHs1.over.chain.gz",
       "assemblyNames": ["hg38", "hs1"],
@@ -3836,6 +3838,7 @@
     },
     {
       "type": "SyntenyTrack",
+      "category": ["Synteny"],
       "trackId": "grch38-chm13v2.paf",
       "name": "grch38-chm13v2.paf",
       "adapter": {
@@ -4240,7 +4243,7 @@
       "type": "FeatureTrack",
       "trackId": "gencode_47",
       "name": "Gencode v47",
-      "category": ["Annotation"],
+      "category": ["Annotation", "Gencode"],
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
@@ -4261,7 +4264,7 @@
       "type": "FeatureTrack",
       "trackId": "ncbi_08_24",
       "name": "NCBI RefSeq (Aug 2024)",
-      "category": ["Annotation"],
+      "category": ["Annotation", "NCBI RefSeq"],
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
@@ -4282,6 +4285,7 @@
       "type": "AlignmentsTrack",
       "trackId": "HG002_WGS_fiberseq.MAGEL2_2",
       "name": "HG002_WGS_fiberseq.MAGEL2",
+      "category": ["GIAB"],
       "adapter": {
         "type": "BamAdapter",
         "bamLocation": {
@@ -4823,6 +4827,7 @@
       "type": "VariantTrack",
       "trackId": "NA12878.vcf",
       "name": "NA12878.vcf",
+      "category": ["NA12878"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -5004,6 +5009,7 @@
       "type": "FeatureTrack",
       "trackId": "hs1.ncbiRefSeq",
       "name": "NCBI RefSeq genes",
+      "category": ["Annotation", "NCBI RefSeq"],
       "adapter": {
         "type": "GtfAdapter",
         "gtfLocation": {
@@ -5187,6 +5193,107 @@
       },
       "category": ["1000 Genomes", "Integrated SV Map"],
       "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "sgdp_memstrs_1.release.sorted.vcf",
+      "name": "sgdp_memstrs_1.release.sorted.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/data/Homo_sapiens/by_study/genotype/nstd128/sgdp_memstrs_1.release.sorted.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/data/Homo_sapiens/by_study/genotype/nstd128/sgdp_memstrs_1.release.sorted.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "STRs"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinvar_non_pathogenic",
+      "category": ["Annotation", "ClinVar"],
+      "name": "ClinVar Non-pathogenic SVs",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg38/clinvar_non_pathogenic.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "clinvar_pathogenic",
+      "category": ["Annotation", "ClinVar"],
+      "name": "ClinVar Pathogenic SVs",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg38/clinvar_pathogenic.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "MANE.GRCh38.v1.4.refseq",
+      "name": "MANE 1.4 (w/ RefSeq IDs)",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/refseq/MANE/trackhub/data/release_1.4/MANE.GRCh38.v1.4.refseq.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "category": ["Annotation", "MANE"],
+      "assemblyNames": ["hg38"],
+      "displays": [
+        {
+          "type": "LinearBasicDisplay",
+          "displayId": "MANE.GRCh38.v1.4.refseq-LinearBasicDisplay",
+          "renderer": {
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "description": "jexl:get(feature,'geneSymbol')"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "MANE.GRCh38.v1.4.ensembl",
+      "name": "MANE 1.4 (w/ ensembl IDs)",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://ftp.ncbi.nlm.nih.gov/refseq/MANE/trackhub/data/release_1.4/MANE.GRCh38.v1.4.ensembl.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "category": ["Annotation", "MANE"],
+      "assemblyNames": ["hg38"],
+      "displays": [
+        {
+          "type": "LinearBasicDisplay",
+          "displayId": "MANE.GRCh38.v1.4.ensembl-LinearBasicDisplay",
+          "renderer": {
+            "type": "SvgFeatureRenderer",
+            "labels": {
+              "description": "jexl:get(feature,'geneSymbol')"
+            }
+          }
+        }
+      ]
     }
   ],
   "connections": [],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -5010,6 +5010,76 @@
         }
       },
       "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "category": ["1000 Genomes", "HGSVC"],
+      "trackId": "Ortho_MEI_GRCh38.ALL.20241211",
+      "name": "Ortho_MEI_GRCh38.ALL.20241211",
+      "adapter": {
+        "type": "VcfAdapter",
+        "vcfLocation": {
+          "uri": "Ortho_MEI_GRCh38.ALL.20241211.vcf",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "category": ["1000 Genomes", "HGSVC"],
+      "trackId": "MEI_Callset_GRCh38.ALL.20241211",
+      "name": "MEI_Callset_GRCh38.ALL.20241211",
+      "adapter": {
+        "type": "VcfAdapter",
+        "vcfLocation": {
+          "uri": "MEI_Callset_GRCh38.ALL.20241211.vcf",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38-vcfbub.a100k.wave.norm.vcf",
+      "name": "hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38-vcfbub.a100k.wave.norm.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Graph_Genomes/1.0/2024_02_23_minigraph_cactus_hgsvc3_hprc/hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38-vcfbub.a100k.wave.norm.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Graph_Genomes/1.0/2024_02_23_minigraph_cactus_hgsvc3_hprc/hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38-vcfbub.a100k.wave.norm.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "HGSVC"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38.raw.vcf",
+      "name": "hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38.raw.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Graph_Genomes/1.0/2024_02_23_minigraph_cactus_hgsvc3_hprc/hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38.raw.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Graph_Genomes/1.0/2024_02_23_minigraph_cactus_hgsvc3_hprc/hgsvc3-hprc-2024-02-23-mc-chm13.GRCh38.raw.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "HGSVC"],
+      "assemblyNames": ["hg38"]
     }
   ],
   "connections": [],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -4722,6 +4722,7 @@
       "type": "VariantTrack",
       "trackId": "1KGP_3202.Illumina_ensemble_callset.freeze_V1.vcf",
       "name": "1KGP_3202.Illumina_ensemble_callset.freeze_V1.vcf",
+      "category": ["1000 Genomes"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4768,6 +4769,7 @@
       "type": "VariantTrack",
       "trackId": "HG02024_VN049_KHVTrio.chr1.vcf",
       "name": "HG02024_VN049_KHVTrio.chr1.vcf",
+      "category": ["1000 Genomes"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4801,6 +4803,7 @@
       "type": "VariantTrack",
       "trackId": "NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf",
       "name": "NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf",
+      "category": ["NA12878"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4811,8 +4814,7 @@
           "location": {
             "uri": "https://jbrowse.org/genomes/hg38/NA12878/NA12878.whatshap.strandseq-pacbio-phasing.2017-07-19.vcf.gz.tbi",
             "locationType": "UriLocation"
-          },
-          "indexType": "TBI"
+          }
         }
       },
       "assemblyNames": ["hg38"]
@@ -5019,7 +5021,7 @@
       "adapter": {
         "type": "VcfAdapter",
         "vcfLocation": {
-          "uri": "https://jbrowse.org/genomes/GRCh38/Ortho_MEI_GRCh38.ALL.20241211.vcf.gz",
+          "uri": "https://jbrowse.org/genomes/GRCh38/1000g/Ortho_MEI_GRCh38.ALL.20241211.vcf.gz",
           "locationType": "UriLocation"
         }
       },
@@ -5033,7 +5035,7 @@
       "adapter": {
         "type": "VcfAdapter",
         "vcfLocation": {
-          "uri": "https://jbrowse.org/genomes/GRCh38/MEI_Callset_GRCh38.ALL.20241211.vcf.gz",
+          "uri": "https://jbrowse.org/genomes/GRCh38/1000g/MEI_Callset_GRCh38.ALL.20241211.vcf.gz",
           "locationType": "UriLocation"
         }
       },
@@ -5079,6 +5081,111 @@
         }
       },
       "category": ["1000 Genomes", "HGSVC"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_GRCh38_indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "name": "variants_GRCh38_indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/GRCh38/variants_GRCh38_indel_insdel_alt_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/GRCh38/variants_GRCh38_indel_insdel_alt_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "HGSVC"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_GRCh38_sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "name": "variants_GRCh38_sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/GRCh38/variants_GRCh38_sv_insdel_sym_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/GRCh38/variants_GRCh38_sv_insdel_sym_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "HGSVC"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "ALL.wgs.integrated_sv_map_v1_GRCh38.20130502.svs.genotypes.vcf",
+      "name": "ALL.wgs.integrated_sv_map_v1_GRCh38.20130502.svs.genotypes.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.integrated_sv_map_v1_GRCh38.20130502.svs.genotypes.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.integrated_sv_map_v1_GRCh38.20130502.svs.genotypes.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "Integrated SV Map"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "ALL.wgs.integrated_sv_map_v2_GRCh38.20130502.svs.genotypes.vcf",
+      "name": "ALL.wgs.integrated_sv_map_v2_GRCh38.20130502.svs.genotypes.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.integrated_sv_map_v2_GRCh38.20130502.svs.genotypes.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.integrated_sv_map_v2_GRCh38.20130502.svs.genotypes.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "Integrated SV Map"],
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "ALL.wgs.mergedSV.v8.20130502.svs.genotypes.GRCh38.vcf",
+      "name": "ALL.wgs.mergedSV.v8.20130502.svs.genotypes.GRCh38.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.mergedSV.v8.20130502.svs.genotypes.GRCh38.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/supporting/GRCh38_positions/ALL.wgs.mergedSV.v8.20130502.svs.genotypes.GRCh38.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "category": ["1000 Genomes", "Integrated SV Map"],
       "assemblyNames": ["hg38"]
     }
   ],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -100,6 +100,9 @@
           "twoBitLocation": {
             "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.2bit",
             "locationType": "UriLocation"
+          },
+          "chromSizesLocation": {
+            "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.chrom.sizes"
           }
         }
       },
@@ -4833,6 +4836,179 @@
         }
       },
       "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf",
+      "name": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "name": "variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf",
+      "name": "variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "name": "variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf",
+      "name": "variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Variant_Calls/1.0/T2T-CHM13/variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "complex_variants_T2T-CHM13_HGSVC2024v1.0.bed",
+      "name": "complex_variants_T2T-CHM13_HGSVC2024v1.0.bed",
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "https://jbrowse.org/demos/hs1/1000g/complex_variants_T2T-CHM13_HGSVC2024v1.0.bed.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://jbrowse.org/demos/hs1/1000g/complex_variants_T2T-CHM13_HGSVC2024v1.0.bed.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "vamos.VNTR.q-0.1.CHM13_anotations.vcf",
+      "name": "vamos.VNTR.q-0.1.CHM13_anotations.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/working/20240829_vamos_vntr/vamos.VNTR.q-0.1.CHM13_anotations.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/working/20240829_vamos_vntr/vamos.VNTR.q-0.1.CHM13_anotations.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "shapeit-pangenie_chm13_all.vcf",
+      "name": "shapeit-pangenie_chm13_all.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Genotyping_1kGP/shapeit-phasing/1.0/shapeit-pangenie_chm13_all.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Genotyping_1kGP/shapeit-phasing/1.0/shapeit-pangenie_chm13_all.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "MEI_Callset_T2T-CHM13.ALL.20241211",
+      "name": "MEI_Callset_T2T-CHM13.ALL.20241211",
+      "adapter": {
+        "type": "VcfAdapter",
+        "vcfLocation": {
+          "uri": "https://jbrowse.org/genomes/hs1/1000g/MEI_Callset_T2T-CHM13.ALL.20241211.vcf",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hs1"]
     }
   ],
   "connections": [],

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -5019,7 +5019,7 @@
       "adapter": {
         "type": "VcfAdapter",
         "vcfLocation": {
-          "uri": "Ortho_MEI_GRCh38.ALL.20241211.vcf",
+          "uri": "https://jbrowse.org/genomes/GRCh38/Ortho_MEI_GRCh38.ALL.20241211.vcf.gz",
           "locationType": "UriLocation"
         }
       },
@@ -5033,7 +5033,7 @@
       "adapter": {
         "type": "VcfAdapter",
         "vcfLocation": {
-          "uri": "MEI_Callset_GRCh38.ALL.20241211.vcf",
+          "uri": "https://jbrowse.org/genomes/GRCh38/MEI_Callset_GRCh38.ALL.20241211.vcf.gz",
           "locationType": "UriLocation"
         }
       },

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -4839,28 +4839,9 @@
     },
     {
       "type": "VariantTrack",
-      "trackId": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf",
-      "name": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf",
-      "adapter": {
-        "type": "VcfTabixAdapter",
-        "vcfGzLocation": {
-          "uri": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf.gz",
-          "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "1KGP_3202.Illumina_ensemble_callset.freeze_V1_MEI_SVA.vcf.gz.tbi",
-            "locationType": "UriLocation"
-          },
-          "indexType": "TBI"
-        }
-      },
-      "assemblyNames": ["hg38"]
-    },
-    {
-      "type": "VariantTrack",
       "trackId": "variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf",
-      "name": "variants_T2T-CHM13_indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "name": "indel_insdel_alt_HGSVC2024v1.0.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4880,7 +4861,8 @@
     {
       "type": "VariantTrack",
       "trackId": "variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf",
-      "name": "variants_T2T-CHM13_snv_snv_alt_HGSVC2024v1.0.vcf",
+      "name": "snv_snv_alt_HGSVC2024v1.0.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4900,7 +4882,8 @@
     {
       "type": "VariantTrack",
       "trackId": "variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf",
-      "name": "variants_T2T-CHM13_sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "name": "sv_insdel_sym_HGSVC2024v1.0.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4920,7 +4903,8 @@
     {
       "type": "VariantTrack",
       "trackId": "variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf",
-      "name": "variants_T2T-CHM13_sv_inv_sym_HGSVC2024v1.0.vcf",
+      "name": "sv_inv_sym_HGSVC2024v1.0.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4940,7 +4924,8 @@
     {
       "type": "FeatureTrack",
       "trackId": "complex_variants_T2T-CHM13_HGSVC2024v1.0.bed",
-      "name": "complex_variants_T2T-CHM13_HGSVC2024v1.0.bed",
+      "name": "complex_HGSVC2024v1.0.bed",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "BedTabixAdapter",
         "bedGzLocation": {
@@ -4961,6 +4946,7 @@
       "type": "VariantTrack",
       "trackId": "vamos.VNTR.q-0.1.CHM13_anotations.vcf",
       "name": "vamos.VNTR.q-0.1.CHM13_anotations.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4981,6 +4967,7 @@
       "type": "VariantTrack",
       "trackId": "shapeit-pangenie_chm13_all.vcf",
       "name": "shapeit-pangenie_chm13_all.vcf",
+      "category": ["1000 Genomes", "HGSVC"],
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
@@ -4999,12 +4986,26 @@
     },
     {
       "type": "VariantTrack",
+      "category": ["1000 Genomes", "HGSVC"],
       "trackId": "MEI_Callset_T2T-CHM13.ALL.20241211",
       "name": "MEI_Callset_T2T-CHM13.ALL.20241211",
       "adapter": {
         "type": "VcfAdapter",
         "vcfLocation": {
           "uri": "https://jbrowse.org/genomes/hs1/1000g/MEI_Callset_T2T-CHM13.ALL.20241211.vcf",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hs1"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "hs1.ncbiRefSeq",
+      "name": "NCBI RefSeq genes",
+      "adapter": {
+        "type": "GtfAdapter",
+        "gtfLocation": {
+          "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/genes/hs1.ncbiRefSeq.gtf.gz",
           "locationType": "UriLocation"
         }
       },


### PR DESCRIPTION
Adds some sample data from the human genome structural variant consortium, including genotyped mobile element insertions across 1000 genomes. I had to convert their MEI csv to VCF to load into jbrowse (https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release/Mobile_Elements/1.0/)

https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC3/release