### PR TITLE
Allow inferring default values of adapter urls to simplify config.json

### DIFF
--- a/docs/generateConfigDocs.ts
+++ b/docs/generateConfigDocs.ts
@@ -93,6 +93,8 @@ function generateConfigDocs(files: string[]) {
       current.slots.push({ ...obj, name, docs, code })
     } else if (obj.type === 'config') {
       current.config = { ...obj, name, docs, id, category }
+    } else if (obj.type === 'preProcessSnapshot') {
+      current.config = { ...obj, name, docs, id, category }
     }
   })
   return contents

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -51,7 +51,6 @@ export interface ConfigurationSchemaOptions<
   explicitIdentifier?: EXPLICIT_IDENTIFIER
   implicitIdentifier?: string | boolean
   baseConfiguration?: BASE_SCHEMA
-  defaultValue?: Record<string, any>
 
   actions?: (self: unknown) => any
   views?: (self: unknown) => any
@@ -198,20 +197,14 @@ function makeConfigurationSchemaModel<
 
   const identifierDefault = identifier ? { [identifier]: 'placeholderId' } : {}
   const modelDefault = options.explicitlyTyped
-    ? {
-        type: modelName,
-        ...identifierDefault,
-        ...options.defaultValue,
-      }
-    : {
-        ...identifierDefault,
-        ...options.defaultValue,
-      }
+    ? { type: modelName, ...identifierDefault }
+    : identifierDefault
 
   const defaultSnap = getSnapshot(completeModel.create(modelDefault))
   completeModel = completeModel.postProcessSnapshot(snap => {
     const newSnap: SnapshotOut<typeof completeModel> = {}
     let matchesDefault = true
+    // let keyCount = 0
     for (const [key, value] of Object.entries(snap)) {
       if (matchesDefault) {
         if (typeof defaultSnap[key] === 'object' && typeof value === 'object') {

--- a/packages/core/configuration/configurationSchema.ts
+++ b/packages/core/configuration/configurationSchema.ts
@@ -51,6 +51,7 @@ export interface ConfigurationSchemaOptions<
   explicitIdentifier?: EXPLICIT_IDENTIFIER
   implicitIdentifier?: string | boolean
   baseConfiguration?: BASE_SCHEMA
+  defaultValue?: Record<string, any>
 
   actions?: (self: unknown) => any
   views?: (self: unknown) => any
@@ -197,14 +198,20 @@ function makeConfigurationSchemaModel<
 
   const identifierDefault = identifier ? { [identifier]: 'placeholderId' } : {}
   const modelDefault = options.explicitlyTyped
-    ? { type: modelName, ...identifierDefault }
-    : identifierDefault
+    ? {
+        type: modelName,
+        ...identifierDefault,
+        ...options.defaultValue,
+      }
+    : {
+        ...identifierDefault,
+        ...options.defaultValue,
+      }
 
   const defaultSnap = getSnapshot(completeModel.create(modelDefault))
   completeModel = completeModel.postProcessSnapshot(snap => {
     const newSnap: SnapshotOut<typeof completeModel> = {}
     let matchesDefault = true
-    // let keyCount = 0
     for (const [key, value] of Object.entries(snap)) {
       if (matchesDefault) {
         if (typeof defaultSnap[key] === 'object' && typeof value === 'object') {

--- a/plugins/alignments/src/BamAdapter/configSchema.ts
+++ b/plugins/alignments/src/BamAdapter/configSchema.ts
@@ -15,7 +15,10 @@ const configSchema = ConfigurationSchema(
      */
     bamLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bam', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bam',
+        locationType: 'UriLocation',
+      },
     },
 
     index: ConfigurationSchema('BamIndex', {
@@ -59,7 +62,28 @@ const configSchema = ConfigurationSchema(
       defaultValue: null,
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bamLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: `${snap.uri}.bai`,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default configSchema

--- a/plugins/alignments/src/BamAdapter/configSchema.ts
+++ b/plugins/alignments/src/BamAdapter/configSchema.ts
@@ -65,6 +65,11 @@ const configSchema = ConfigurationSchema(
   {
     explicitlyTyped: true,
 
+    /**
+     * #preProcessSnapshot
+     * if only uri is passed to snapshot, adds bamLocation and index.location
+     * with tbi index
+     */
     preProcessSnapshot: snap => {
       // populate from just snap.uri
       return snap.uri

--- a/plugins/alignments/src/CramAdapter/configSchema.ts
+++ b/plugins/alignments/src/CramAdapter/configSchema.ts
@@ -52,6 +52,24 @@ const configSchema = ConfigurationSchema(
       defaultValue: null,
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            cramLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            craiLocation: {
+              uri: `${snap.uri}.crai`,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default configSchema

--- a/plugins/bed/src/BedAdapter/configSchema.ts
+++ b/plugins/bed/src/BedAdapter/configSchema.ts
@@ -13,7 +13,10 @@ const BedAdapter = ConfigurationSchema(
      */
     bedLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bed.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bed.gz',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
@@ -64,6 +67,21 @@ const BedAdapter = ConfigurationSchema(
       defaultValue: 2,
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bedLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default BedAdapter

--- a/plugins/bed/src/BedGraphAdapter/configSchema.ts
+++ b/plugins/bed/src/BedGraphAdapter/configSchema.ts
@@ -27,6 +27,21 @@ const BedGraphAdapter = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bedGraphLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default BedGraphAdapter

--- a/plugins/bed/src/BedGraphTabixAdapter/configSchema.ts
+++ b/plugins/bed/src/BedGraphTabixAdapter/configSchema.ts
@@ -19,32 +19,26 @@ const BedGraphTabixAdapter = ConfigurationSchema(
         locationType: 'UriLocation',
       },
     },
-    index: ConfigurationSchema(
-      'VcfIndex',
-      {
-        /**
-         * #slot index.indexType
-         */
-        indexType: {
-          model: types.enumeration('IndexType', ['TBI', 'CSI']),
-          type: 'stringEnum',
-          defaultValue: 'TBI',
-        },
-        /**
-         * #slot index.location
-         */
-        location: {
-          type: 'fileLocation',
-          defaultValue: {
-            uri: '/path/to/my.vcf.gz.tbi',
-            locationType: 'UriLocation',
-          },
+    index: ConfigurationSchema('VcfIndex', {
+      /**
+       * #slot index.indexType
+       */
+      indexType: {
+        model: types.enumeration('IndexType', ['TBI', 'CSI']),
+        type: 'stringEnum',
+        defaultValue: 'TBI',
+      },
+      /**
+       * #slot index.location
+       */
+      location: {
+        type: 'fileLocation',
+        defaultValue: {
+          uri: '/path/to/my.vcf.gz.tbi',
+          locationType: 'UriLocation',
         },
       },
-      {
-        defaultValue: {},
-      },
-    ),
+    }),
     /**
      * #slot
      */

--- a/plugins/bed/src/BedGraphTabixAdapter/configSchema.ts
+++ b/plugins/bed/src/BedGraphTabixAdapter/configSchema.ts
@@ -19,26 +19,32 @@ const BedGraphTabixAdapter = ConfigurationSchema(
         locationType: 'UriLocation',
       },
     },
-    index: ConfigurationSchema('VcfIndex', {
-      /**
-       * #slot index.indexType
-       */
-      indexType: {
-        model: types.enumeration('IndexType', ['TBI', 'CSI']),
-        type: 'stringEnum',
-        defaultValue: 'TBI',
-      },
-      /**
-       * #slot index.location
-       */
-      location: {
-        type: 'fileLocation',
-        defaultValue: {
-          uri: '/path/to/my.vcf.gz.tbi',
-          locationType: 'UriLocation',
+    index: ConfigurationSchema(
+      'VcfIndex',
+      {
+        /**
+         * #slot index.indexType
+         */
+        indexType: {
+          model: types.enumeration('IndexType', ['TBI', 'CSI']),
+          type: 'stringEnum',
+          defaultValue: 'TBI',
+        },
+        /**
+         * #slot index.location
+         */
+        location: {
+          type: 'fileLocation',
+          defaultValue: {
+            uri: '/path/to/my.vcf.gz.tbi',
+            locationType: 'UriLocation',
+          },
         },
       },
-    }),
+      {
+        defaultValue: {},
+      },
+    ),
     /**
      * #slot
      */
@@ -48,6 +54,27 @@ const BedGraphTabixAdapter = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bedGraphGzLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: `${snap.uri}.tbi`,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 export default BedGraphTabixAdapter

--- a/plugins/bed/src/BedTabixAdapter/configSchema.ts
+++ b/plugins/bed/src/BedTabixAdapter/configSchema.ts
@@ -14,7 +14,10 @@ const BedTabixAdapter = ConfigurationSchema(
      */
     bedGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bed.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bed.gz',
+        locationType: 'UriLocation',
+      },
     },
 
     index: ConfigurationSchema('TabixIndex', {
@@ -65,7 +68,28 @@ const BedTabixAdapter = ConfigurationSchema(
       defaultValue: '',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bedGzLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: `${snap.uri}.tbi`,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default BedTabixAdapter

--- a/plugins/bed/src/BedpeAdapter/configSchema.ts
+++ b/plugins/bed/src/BedpeAdapter/configSchema.ts
@@ -30,6 +30,20 @@ const BedpeAdapter = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bedpeLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default BedpeAdapter

--- a/plugins/bed/src/BigBedAdapter/configSchema.ts
+++ b/plugins/bed/src/BigBedAdapter/configSchema.ts
@@ -13,7 +13,10 @@ const BigBedAdapter = ConfigurationSchema(
      */
     bigBedLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bb', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bb',
+        locationType: 'UriLocation',
+      },
     },
 
     /**
@@ -34,7 +37,21 @@ const BigBedAdapter = ConfigurationSchema(
       defaultValue: 'geneName2',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            bigBedLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default BigBedAdapter

--- a/plugins/comparative-adapters/src/PAFAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/configSchema.ts
@@ -44,7 +44,22 @@ const PAFAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            pafLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default PAFAdapter

--- a/plugins/gff3/src/Gff3Adapter/configSchema.ts
+++ b/plugins/gff3/src/Gff3Adapter/configSchema.ts
@@ -14,10 +14,28 @@ const Gff3Adapter = ConfigurationSchema(
      */
     gffLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gff', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gff',
+        locationType: 'UriLocation',
+      },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            gffLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default Gff3Adapter

--- a/plugins/gff3/src/Gff3TabixAdapter/configSchema.ts
+++ b/plugins/gff3/src/Gff3TabixAdapter/configSchema.ts
@@ -15,7 +15,10 @@ const Gff3TabixAdapter = ConfigurationSchema(
      */
     gffGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gff.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gff.gz',
+        locationType: 'UriLocation',
+      },
     },
 
     index: ConfigurationSchema('Gff3TabixIndex', {
@@ -50,7 +53,28 @@ const Gff3TabixAdapter = ConfigurationSchema(
       defaultValue: ['chromosome', 'region', 'contig'],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            gffGzLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: snap.uri,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default Gff3TabixAdapter

--- a/plugins/gtf/src/GtfAdapter/configSchema.ts
+++ b/plugins/gtf/src/GtfAdapter/configSchema.ts
@@ -14,7 +14,10 @@ const GtfAdapter = ConfigurationSchema(
      */
     gtfLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gtf', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gtf',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
@@ -24,7 +27,21 @@ const GtfAdapter = ConfigurationSchema(
       defaultValue: 'gene_name',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            gtfLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default GtfAdapter

--- a/plugins/hic/src/HicAdapter/configSchema.ts
+++ b/plugins/hic/src/HicAdapter/configSchema.ts
@@ -28,7 +28,22 @@ const HicAdapter = ConfigurationSchema(
       description: 'Initial resolution multiplier',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            hicLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default HicAdapter

--- a/plugins/variants/src/VcfAdapter/configSchema.ts
+++ b/plugins/variants/src/VcfAdapter/configSchema.ts
@@ -31,7 +31,22 @@ const VcfAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            vcfLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default VcfAdapter

--- a/plugins/variants/src/VcfTabixAdapter/configSchema.ts
+++ b/plugins/variants/src/VcfTabixAdapter/configSchema.ts
@@ -14,8 +14,12 @@ const VcfTabixAdapter = ConfigurationSchema(
      */
     vcfGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.vcf.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.vcf.gz',
+        locationType: 'UriLocation',
+      },
     },
+
     index: ConfigurationSchema('VcfIndex', {
       /**
        * #slot index.indexType
@@ -49,7 +53,32 @@ const VcfTabixAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    /**
+     * #preProcessSnapshot
+     * will populate the index field from vcfGzLocation
+     */
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            vcfGzLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: `${snap.uri}.tbi`,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default VcfTabixAdapter

--- a/plugins/wiggle/src/BigWigAdapter/configSchema.ts
+++ b/plugins/wiggle/src/BigWigAdapter/configSchema.ts
@@ -37,7 +37,21 @@ const BigWigAdapter = ConfigurationSchema(
       description: 'Initial resolution multiplier',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            bigWigLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default BigWigAdapter

--- a/products/jbrowse-cli/src/commands/text-index.ts
+++ b/products/jbrowse-cli/src/commands/text-index.ts
@@ -446,16 +446,16 @@ export default class TextIndex extends JBrowseCommand {
       let loc: UriLocation | LocalPathLocation
       if (type === 'Gff3TabixAdapter') {
         // @ts-expect-error
-        loc = adapter.gffGzLocation
+        loc = adapter.gffGzLocation || adapter
       } else if (type === 'Gff3Adapter') {
         // @ts-expect-error
-        loc = adapter.gffLocation
+        loc = adapter.gffLocation || adapter
       } else if (type === 'VcfAdapter') {
         // @ts-expect-error
-        loc = adapter.vcfLocation
+        loc = adapter.vcfLocation || adapter
       } else if (type === 'VcfTabixAdapter') {
         // @ts-expect-error
-        loc = adapter.vcfGzLocation
+        loc = adapter.vcfGzLocation || adapter
       } else {
         return
       }

--- a/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
+++ b/products/jbrowse-web/src/__snapshots__/jbrowseModel.test.ts.snap
@@ -904,12 +904,6 @@ exports[`JBrowse model creates with non-empty snapshot 1`] = `
           "locationType": "UriLocation",
           "uri": "volvox-sorted.bam",
         },
-        "index": {
-          "location": {
-            "locationType": "UriLocation",
-            "uri": "volvox-sorted.bam.bai",
-          },
-        },
         "type": "BamAdapter",
       },
       "assemblyNames": [

--- a/test_data/volvox/config.json
+++ b/test_data/volvox/config.json
@@ -290,16 +290,7 @@
       "assemblyNames": ["volvox"],
       "adapter": {
         "type": "VcfTabixAdapter",
-        "vcfGzLocation": {
-          "uri": "volvox.dup.renamed.vcf.gz",
-          "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "volvox.dup.renamed.vcf.gz.tbi",
-            "locationType": "UriLocation"
-          }
-        }
+        "uri": "volvox.dup.renamed.vcf.gz"
       }
     },
     {
@@ -310,14 +301,7 @@
       "assemblyNames": ["volvox"],
       "adapter": {
         "type": "CramAdapter",
-        "cramLocation": {
-          "uri": "volvox-sorted-altname.cram",
-          "locationType": "UriLocation"
-        },
-        "craiLocation": {
-          "uri": "volvox-sorted-altname.cram.crai",
-          "locationType": "UriLocation"
-        },
+        "uri": "volvox-sorted-altname.cram",
         "sequenceAdapter": {
           "type": "TwoBitAdapter",
           "twoBitLocation": {
@@ -500,12 +484,6 @@
         "bamLocation": {
           "uri": "volvox-sorted.bam",
           "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "volvox-sorted.bam.bai",
-            "locationType": "UriLocation"
-          }
         }
       },
       "displays": [
@@ -1445,10 +1423,7 @@
       "category": ["BigWig", "XYPlot"],
       "adapter": {
         "type": "BigWigAdapter",
-        "bigWigLocation": {
-          "uri": "volvox-sorted.bam.coverage.bw",
-          "locationType": "UriLocation"
-        }
+        "uri": "volvox-sorted.bam.coverage.bw"
       }
     },
     {
@@ -1459,10 +1434,7 @@
       "assemblyNames": ["volvox", "volvox"],
       "adapter": {
         "type": "PAFAdapter",
-        "pafLocation": {
-          "uri": "volvox_fake_synteny_alt.paf",
-          "locationType": "UriLocation"
-        },
+        "uri": "volvox_fake_synteny_alt.paf",
         "assemblyNames": ["volvox", "volvox"]
       }
     },

--- a/test_data/volvox/trix/volvox-rev-del_meta.json
+++ b/test_data/volvox/trix/volvox-rev-del_meta.json
@@ -1,5 +1,5 @@
 {
-  "dateCreated": "2025-01-24T16:05:19.959Z",
+  "dateCreated": "2025-03-13T01:08:37.917Z",
   "tracks": [
     {
       "trackId": "volvox-rev-del-annotations",

--- a/test_data/volvox/trix/volvox_meta.json
+++ b/test_data/volvox/trix/volvox_meta.json
@@ -1,5 +1,5 @@
 {
-  "dateCreated": "2025-01-24T16:05:19.939Z",
+  "dateCreated": "2025-03-13T01:08:37.901Z",
   "tracks": [
     {
       "trackId": "volvox_sv_test",
@@ -25,16 +25,7 @@
       "excludedTypes": ["CDS", "exon"],
       "adapterConf": {
         "type": "VcfTabixAdapter",
-        "vcfGzLocation": {
-          "uri": "volvox.dup.renamed.vcf.gz",
-          "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "volvox.dup.renamed.vcf.gz.tbi",
-            "locationType": "UriLocation"
-          }
-        }
+        "uri": "volvox.dup.renamed.vcf.gz"
       }
     },
     {

--- a/website/docs/config/BamAdapter.md
+++ b/website/docs/config/BamAdapter.md
@@ -27,7 +27,10 @@ used to configure BAM adapter
 ```js
 bamLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bam', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bam',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/BedAdapter.md
+++ b/website/docs/config/BedAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 bedLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bed.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bed.gz',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/BedTabixAdapter.md
+++ b/website/docs/config/BedTabixAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 bedGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bed.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bed.gz',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/BigBedAdapter.md
+++ b/website/docs/config/BigBedAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 bigBedLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.bb', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.bb',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/Gff3Adapter.md
+++ b/website/docs/config/Gff3Adapter.md
@@ -25,6 +25,9 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 gffLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gff', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gff',
+        locationType: 'UriLocation',
+      },
     }
 ```

--- a/website/docs/config/Gff3TabixAdapter.md
+++ b/website/docs/config/Gff3TabixAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 gffGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gff.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gff.gz',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/GtfAdapter.md
+++ b/website/docs/config/GtfAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 gtfLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.gtf', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.gtf',
+        locationType: 'UriLocation',
+      },
     }
 ```
 

--- a/website/docs/config/VcfTabixAdapter.md
+++ b/website/docs/config/VcfTabixAdapter.md
@@ -25,7 +25,10 @@ reference the markdown files in our repo of the checked out git tag
 ```js
 vcfGzLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.vcf.gz', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.vcf.gz',
+        locationType: 'UriLocation',
+      },
     }
 ```
 


### PR DESCRIPTION
This allows configurations to potentially specify a more minimal set of information


Normally you would have to specify all the info for an adapter e.g. like this

```json
{
  "type": "BedGraphTabixAdapter",
  "bedGraphGzLocation": {
    "uri": "https://jbrowse.org/genomes/GRCh38/1000g/kidd_lab_cnv/PUR/HG01414.qm2.CN.1k.simp.bed.gz"
  },
  "index": {
    "location": {
      "uri": "https://jbrowse.org/genomes/GRCh38/1000g/kidd_lab_cnv/PUR/HG01414.qm2.CN.1k.simp.bed.gz.tbi"
    }
  }
}
```


With this PR, a user can pass


```json
{
  "type": "BedGraphTabixAdapter",
  "uri": "file.bed.gz"
}
```


and it would infer that this is "bedGraphGzLocation":{"uri":"file.bed.gz"}


one possible downside is this can create a conflict between ingested config and exported config. for example, round tripping this through admin-server, would result in any of the 'simple' forms being removed most likely, unless bookkeeping was done about the simple form to also postProcessSnapshot

however, the upsides i think are significant: simple config is important
