### PR TITLE
Allow clustering multi-wiggle tracks on the fly

### DIFF
--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ClusterDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ClusterDialog.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useState } from 'react'
+
+import { Dialog, ErrorMessage, LoadingEllipses } from '@jbrowse/core/ui'
+import {
+  getContainingView,
+  getSession,
+  isAbortException,
+} from '@jbrowse/core/util'
+import { getRpcSessionId } from '@jbrowse/core/util/tracks'
+import {
+  Button,
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  FormControlLabel,
+  TextField,
+  Typography,
+} from '@mui/material'
+import copy from 'copy-to-clipboard'
+import { saveAs } from 'file-saver'
+import { isAlive } from 'mobx-state-tree'
+import { makeStyles } from 'tss-react/mui'
+
+import type { Source } from '../types'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+
+const useStyles = makeStyles()(theme => ({
+  textAreaFont: {
+    fontFamily: 'Courier New',
+  },
+  mgap: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(4),
+  },
+}))
+
+export default function ClusterDialog({
+  model,
+  handleClose,
+}: {
+  model: {
+    sources?: Source[]
+    minorAlleleFrequencyFilter?: number
+    adapterConfig: AnyConfigurationModel
+    setLayout: (arg: Source[]) => void
+  }
+  handleClose: () => void
+}) {
+  const { classes } = useStyles()
+  const [results, setResults] = useState<string>()
+  const [error, setError] = useState<unknown>()
+  const [paste, setPaste] = useState('')
+  const [useCompleteMethod, setUseCompleteMethod] = useState(false)
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    ;(async () => {
+      try {
+        setError(undefined)
+        const view = getContainingView(model) as LinearGenomeViewModel
+        if (!view.initialized) {
+          return
+        }
+        const { rpcManager } = getSession(model)
+        const { sources, minorAlleleFrequencyFilter, adapterConfig } = model
+        const sessionId = getRpcSessionId(model)
+        const { bpPerPx } = view
+        const ret = (await rpcManager.call(
+          sessionId,
+          'MultiWiggleGetScoreMatrix',
+          {
+            regions: view.dynamicBlocks.contentBlocks,
+            sources,
+            minorAlleleFrequencyFilter,
+            sessionId,
+            adapterConfig,
+            bpPerPx,
+          },
+        )) as Record<string, { scores: number[] }>
+
+        const entries = Object.values(ret)
+        const keys = Object.keys(ret)
+        const clusterMethod = useCompleteMethod ? 'complete' : 'single'
+        const text = `try(library(fastcluster), silent=TRUE)
+inputMatrix<-matrix(c(${entries.map(val => val.scores.join(',')).join(',\n')}
+),nrow=${entries.length},byrow=TRUE)
+rownames(inputMatrix)<-c(${keys.map(key => `'${key}'`).join(',')})
+resultClusters<-hclust(dist(inputMatrix), method='${clusterMethod}')
+cat(resultClusters$order,sep='\\n')`
+        setResults(text)
+      } catch (e) {
+        if (!isAbortException(e) && isAlive(model)) {
+          console.error(e)
+          setError(e)
+        }
+      }
+    })()
+  }, [model, useCompleteMethod])
+
+  return (
+    <Dialog open title="Cluster by score" onClose={handleClose}>
+      <DialogContent>
+        <div className={classes.mgap}>
+          <Typography>
+            This page will produce an R script that will perform hierarchical
+            clustering on the visible score data using `hclust`.
+          </Typography>
+          <Typography>
+            You can then paste the results in this form to specify the row
+            ordering.
+          </Typography>
+          {results ? (
+            <div>
+              <div>
+                Step 1:{' '}
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    saveAs(
+                      new Blob([results || ''], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      'cluster.R',
+                    )
+                  }}
+                >
+                  Download Rscript
+                </Button>{' '}
+                or{' '}
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    copy(results || '')
+                  }}
+                >
+                  Copy Rscript to clipboard
+                </Button>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={useCompleteMethod}
+                      onChange={e => {
+                        setUseCompleteMethod(e.target.checked)
+                      }}
+                    />
+                  }
+                  label="Use 'complete' linkage method instead of 'single'"
+                />
+                <div>
+                  <TextField
+                    multiline
+                    fullWidth
+                    variant="outlined"
+                    placeholder="Step 2. Paste results from Rscript here (sequence of numbers, one per line, specifying the new ordering)"
+                    rows={10}
+                    value={paste}
+                    onChange={event => {
+                      setPaste(event.target.value)
+                    }}
+                    slotProps={{
+                      input: {
+                        classes: {
+                          input: classes.textAreaFont,
+                        },
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <LoadingEllipses variant="h6" title="Generating score matrix" />
+          )}
+          {error ? <ErrorMessage error={error} /> : null}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!results}
+          variant="contained"
+          onClick={() => {
+            const { sources } = model
+            if (sources) {
+              try {
+                model.setLayout(
+                  paste
+                    .split('\n')
+                    .map(t => t.trim())
+                    .filter(f => !!f)
+                    .map(r => +r)
+                    .map(idx => {
+                      const ret = sources[idx - 1]
+                      if (!ret) {
+                        throw new Error(`out of bounds at ${idx}`)
+                      }
+                      return ret
+                    }),
+                )
+              } catch (e) {
+                console.error(e)
+                setError(e)
+              }
+            }
+            handleClose()
+          }}
+        >
+          Apply clustering
+        </Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            handleClose()
+          }}
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/model.ts
@@ -32,6 +32,7 @@ const randomColor = () =>
 // lazies
 const Tooltip = lazy(() => import('./components/Tooltip'))
 const SetColorDialog = lazy(() => import('./components/SetColorDialog'))
+const ClusterDialog = lazy(() => import('./components/ClusterDialog'))
 
 // using a map because it preserves order
 const rendererTypes = new Map([
@@ -471,13 +472,28 @@ export function stateModelFactory(
                   },
                 ]
               : []),
+            {
+              label: 'Cluster by score',
+              onClick: () => {
+                getSession(self).queueDialog(handleClose => [
+                  ClusterDialog,
+                  {
+                    model: self,
+                    handleClose,
+                  },
+                ])
+              },
+            },
 
             {
               label: 'Edit colors/arrangement...',
               onClick: () => {
                 getSession(self).queueDialog(handleClose => [
                   SetColorDialog,
-                  { model: self, handleClose },
+                  {
+                    model: self,
+                    handleClose,
+                  },
                 ])
               },
             },

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/types.ts
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/types.ts
@@ -1,0 +1,15 @@
+export interface Source {
+  baseUri?: string
+  name: string
+  label?: string
+  color?: string
+  group?: string
+  HP?: number
+  id?: string
+  [key: string]: unknown
+}
+
+export interface SampleInfo {
+  isPhased: boolean
+  maxPloidy: number
+}

--- a/plugins/wiggle/src/WiggleRPC/MultiWiggleGetScoreMatrix.ts
+++ b/plugins/wiggle/src/WiggleRPC/MultiWiggleGetScoreMatrix.ts
@@ -1,0 +1,67 @@
+import { getAdapter } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import RpcMethodTypeWithFiltersAndRenameRegions from '@jbrowse/core/pluggableElementTypes/RpcMethodTypeWithFiltersAndRenameRegions'
+import { type Region, groupBy } from '@jbrowse/core/util'
+import { firstValueFrom, toArray } from 'rxjs'
+
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
+
+export class MultiWiggleGetScoreMatrix extends RpcMethodTypeWithFiltersAndRenameRegions {
+  name = 'MultiWiggleGetScoreMatrix'
+
+  async execute(
+    args: {
+      adapterConfig: AnyConfigurationModel
+      stopToken?: string
+      sessionId: string
+      headers?: Record<string, string>
+      regions: Region[]
+      bpPerPx: number
+    },
+    rpcDriverClassName: string,
+  ) {
+    const pm = this.pluginManager
+    const deserializedArgs = await this.deserializeArguments(
+      args,
+      rpcDriverClassName,
+    )
+    const { sources, regions, adapterConfig, sessionId, bpPerPx } =
+      deserializedArgs
+    const adapter = await getAdapter(pm, sessionId, adapterConfig)
+    const dataAdapter = adapter.dataAdapter as BaseFeatureDataAdapter
+    const resolution = 2
+    const bpScale = bpPerPx / resolution
+
+    const r0 = regions[0]
+    const r0len = r0.end - r0.start
+    const w = Math.floor(r0len / bpScale)
+    const feats = await firstValueFrom(
+      dataAdapter.getFeatures(r0, deserializedArgs).pipe(toArray()),
+    )
+
+    const groups = groupBy(feats, f => f.get('source'))
+    const rows = {} as Record<string, { name: string; scores: string[] }>
+    for (const source of sources) {
+      const { name } = source
+      const features = groups[name] || []
+      for (const feat of features) {
+        if (!rows[name]) {
+          rows[name] = {
+            name,
+            scores: new Array(w),
+          }
+        }
+        const fstart = feat.get('start')
+        const fend = feat.get('end')
+        const score = feat.get('score')
+        for (let i = fstart; i < fend; i += bpScale) {
+          if (i > r0.start && i < r0.end) {
+            rows[name].scores[Math.floor((i - r0.start) / bpScale)] ||= score
+          }
+        }
+      }
+    }
+
+    return rows
+  }
+}

--- a/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
+++ b/plugins/wiggle/src/WiggleRPC/rpcMethods.ts
@@ -1,3 +1,4 @@
 export * from './MultiWiggleGetSources'
 export * from './WiggleGetMultiRegionQuantitativeStats'
 export * from './WiggleGetGlobalQuantitativeStats'
+export * from './MultiWiggleGetScoreMatrix'

--- a/plugins/wiggle/src/drawXY.ts
+++ b/plugins/wiggle/src/drawXY.ts
@@ -15,13 +15,19 @@ import type { Colord } from '@jbrowse/core/util/colord'
 function lighten(color: Colord, amount: number) {
   const hslColor = color.toHsl()
   const l = hslColor.l * (1 + amount)
-  return colord({ ...hslColor, l: clamp(l, 0, 100) })
+  return colord({
+    ...hslColor,
+    l: clamp(l, 0, 100),
+  })
 }
 
 function darken(color: Colord, amount: number) {
   const hslColor = color.toHsl()
   const l = hslColor.l * (1 - amount)
-  return colord({ ...hslColor, l: clamp(l, 0, 100) })
+  return colord({
+    ...hslColor,
+    l: clamp(l, 0, 100),
+  })
 }
 
 const fudgeFactor = 0.3

--- a/plugins/wiggle/src/index.ts
+++ b/plugins/wiggle/src/index.ts
@@ -21,6 +21,7 @@ import MultiXYPlotRendererF from './MultiXYPlotRenderer'
 import QuantitativeTrackF from './QuantitativeTrack'
 import WiggleBaseRenderer from './WiggleBaseRenderer'
 import {
+  MultiWiggleGetScoreMatrix,
   MultiWiggleGetSources,
   WiggleGetGlobalQuantitativeStats,
   WiggleGetMultiRegionQuantitativeStats,
@@ -59,6 +60,7 @@ export default class WigglePlugin extends Plugin {
     pm.addRpcMethod(() => new WiggleGetGlobalQuantitativeStats(pm))
     pm.addRpcMethod(() => new WiggleGetMultiRegionQuantitativeStats(pm))
     pm.addRpcMethod(() => new MultiWiggleGetSources(pm))
+    pm.addRpcMethod(() => new MultiWiggleGetScoreMatrix(pm))
   }
 
   exports = {


### PR DESCRIPTION
The multi-variant track has the abiity to cluster variants on the fly via export to an R script, running it on the users computer, and then re-importing the result


This extends this concept for multi-wiggle tracks

An example of this is CNV data from 1000 genomes, we can cluster all the rows and see patterns in CNV across different populations


The procedure is a little different from how variants work where each variant is entered into the clustering algorithm...instead this samples the data file's score at essentially 1 value per visible pixel on the screen

This is done because there is no reliable "column of scores" like there is a "column of genotypes" for each variant. We could sample at as fine of a grain as 1 score per base pair, but the choice of 1 score per pixel will provide basically good clustering that corresponds essentially with what the user is viewing

Before clustering
![image](https://github.com/user-attachments/assets/a8c64fb8-7bb4-44a1-8ea0-b54a0d88e988)



After clustering
![Screenshot From 2025-03-11 00-25-06](https://github.com/user-attachments/assets/ff026b8a-e46e-4f66-afd1-314841b4d586)

Note: CNV calculations performed by Quick-kmer https://github.com/KiddLab/kmer_1KG


ENCODE example

Before clustering
![image](https://github.com/user-attachments/assets/f4182f9f-d8fe-465f-a8b0-a6f7434374ca)


After clustering
![image](https://github.com/user-attachments/assets/3fa72980-7920-4668-9bd5-76ddd0aa8a20)



