### PR TITLE
v3.1.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v3.1.0.md
+++ b/website/release_announcement_drafts/v3.1.0.md
@@ -1,0 +1,67 @@
+This release adds several interesting features including
+
+## Sticky view headers and pinned tracks
+
+We created a new UI where the "view header" stays visible even when scrolling
+the page.
+
+We also added the ability to "pin" tracks in the linear genome view, which also
+stay visible when scrolling the page.
+
+## Cluster multi-quantitative tracks
+
+Motivated by the clustering workflow in the Multi-variant viewer, a similar
+feature was added to the multi-quantitative track
+
+To do this, we sample the data according to the current zoom level (otherwise,
+it would create very large matrices at per-base resolution) and then provide an
+R script the user can run to cluster the data
+
+Before clustering
+![image](https://github.com/user-attachments/assets/a8c64fb8-7bb4-44a1-8ea0-b54a0d88e988)
+
+After clustering
+![Screenshot From 2025-03-11 00-25-06](https://github.com/user-attachments/assets/ff026b8a-e46e-4f66-afd1-314841b4d586)
+
+## Simplify some adapter configuration
+
+The configuration system has a lot of complex substructure, but in this release
+we created the ability to supply a simplified config, and the results will be
+auto-determined
+
+For example
+
+```json
+{
+  "type": "AlignmentsTrack",
+  "trackId": "volvox_alignments",
+  "name": "volvox-sorted.bam",
+  "assemblyNames": ["volvox"],
+  "adapter": {
+    "type": "BedGraphTabixAdapter",
+    "bedGraphGzLocation": {
+      "uri": "file.bed.gz"
+    },
+    "index": {
+      "location": {
+        "uri": "file.bed.gz.tbi"
+      }
+    }
+  }
+}
+```
+
+after
+
+```json
+{
+  "type": "AlignmentsTrack",
+  "trackId": "volvox_alignments",
+  "name": "volvox-sorted.bam",
+  "assemblyNames": ["volvox"],
+  "adapter": {
+    "type": "BedGraphTabixAdapter",
+    "uri": "file.bed.gz"
+  }
+}
+```

--- a/website/release_announcement_drafts/v3.1.0.md
+++ b/website/release_announcement_drafts/v3.1.0.md
@@ -65,3 +65,7 @@ after
   }
 }
 ```
+
+The CLI tools and other systems will continue to output the verbose version for
+the time being, but this simplified system will be handy to anyone who does
+hand-coding of the configuration


### PR DESCRIPTION

## Unreleased (2025-03-13)

#### :rocket: Enhancement
* Other
  * [#4876](https://github.com/GMOD/jbrowse-components/pull/4876) Allow inferring default values of adapter urls to simplify config.json ([@cmdcolin](https://github.com/cmdcolin))
  * [#4875](https://github.com/GMOD/jbrowse-components/pull/4875) Add sample data from HGSVCv3 to 1000 genomes demo and config_demo ([@cmdcolin](https://github.com/cmdcolin))
  * [#4880](https://github.com/GMOD/jbrowse-components/pull/4880) Allow selecting track error messages with click and drag ([@cmdcolin](https://github.com/cmdcolin))
  * [#4882](https://github.com/GMOD/jbrowse-components/pull/4882) Allow clustering multi-wiggle tracks on the fly ([@cmdcolin](https://github.com/cmdcolin))
  * [#4874](https://github.com/GMOD/jbrowse-components/pull/4874) Use a '012' matrix to improve clustering of genotypes ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4871](https://github.com/GMOD/jbrowse-components/pull/4871) Add deletion, insertion, skip, softclip, hardclip to theme ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `product-core`
  * [#4237](https://github.com/GMOD/jbrowse-components/pull/4237) Add ability for views to pin elements, such as headers and tracks ([@garrettjstevens](https://github.com/garrettjstevens))

#### :bug: Bug Fix
* `core`
  * [#4867](https://github.com/GMOD/jbrowse-components/pull/4867) Fix web worker usage of lollipop renderer ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#4883](https://github.com/GMOD/jbrowse-components/pull/4883) Bump @gmod/bam for CSI index fix ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 2
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
- Garrett Stevens ([@garrettjstevens](https://github.com/garrettjstevens))
Done in 1.39s.
