### PR TITLE
Z-index of breakpoint split view overlay

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
     // pointerEvents:'auto' to retoggle it back on for a single e.g. svg line
     pointerEvents: 'none',
     width: '100%',
-    zIndex: 10,
+    zIndex: 1001, // above the 1000 z-index of the floating view header
   },
 })
 


### PR DESCRIPTION
Raises the z-index from 10->1001 to go over the view header

Fixes #4891 

For an alternative, it seems like one potential approach would be for the normal linear-genome-view header to not have a high z-index when it is embedded in the breakpoint split view