### PR TITLE
LTR repeat glyph example

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Box.tsx
@@ -21,6 +21,8 @@ const Box = observer(function Box(props: {
   selected?: boolean
   topLevel?: boolean
   colorByCDS: boolean
+  color?: string
+  shorten?: boolean
 }) {
   const theme = useTheme()
   const {
@@ -31,6 +33,8 @@ const Box = observer(function Box(props: {
     featureLayout,
     bpPerPx,
     topLevel,
+    shorten,
+    color,
   } = props
   const { start, end } = region
   const screenWidth = Math.ceil((end - start) / bpPerPx)
@@ -47,7 +51,7 @@ const Box = observer(function Box(props: {
     return null
   }
 
-  if (isUTR(feature)) {
+  if (shorten || isUTR(feature)) {
     top += ((1 - utrHeightFraction) / 2) * height
     height *= utrHeightFraction
   }
@@ -55,9 +59,11 @@ const Box = observer(function Box(props: {
   const diff = leftWithinBlock - left
   const widthWithinBlock = Math.max(2, Math.min(width - diff, screenWidth))
 
-  let fill: string = isUTR(feature)
-    ? readConfObject(config, 'color3', { feature })
-    : readConfObject(config, 'color1', { feature })
+  let fill: string =
+    color ??
+    (isUTR(feature)
+      ? readConfObject(config, 'color3', { feature })
+      : readConfObject(config, 'color1', { feature }))
   if (
     colorByCDS &&
     featureType === 'CDS' &&

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 
 import FeatureLabel from './FeatureLabel'
 
-import type { DisplayModel } from './util'
+import type { DisplayModel, ViewParams } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature, Region } from '@jbrowse/core/util'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'
@@ -25,12 +25,7 @@ const FeatureGlyph = observer(function (props: {
   reversed?: boolean
   topLevel?: boolean
   region: Region
-  viewParams: {
-    end: number
-    start: number
-    offsetPx: number
-    offsetPx1: number
-  }
+  viewParams: ViewParams
   bpPerPx: number
 }) {
   const {

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material'
 import { observer } from 'mobx-react'
 import { isAlive, isStateTreeNode } from 'mobx-state-tree'
 
-import type { DisplayModel } from './util'
+import type { DisplayModel } from './types'
 import type { Feature, Region } from '@jbrowse/core/util'
 
 interface ViewParams {

--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react'
 import Segments from './Segments'
 import { isUTR, layOutFeature, layOutSubfeatures } from './util'
 
-import type { ExtraGlyphValidator } from './util'
+import type { ExtraGlyphValidator } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature, Region } from '@jbrowse/core/util'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'

--- a/plugins/svg/src/SvgFeatureRenderer/components/RenderedFeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/RenderedFeatureGlyph.tsx
@@ -1,0 +1,144 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+import { bpToPx, measureText } from '@jbrowse/core/util'
+import { SceneGraph } from '@jbrowse/core/util/layouts'
+
+import FeatureGlyph from './FeatureGlyph'
+import { chooseGlyphComponent } from './chooseGlyphComponent'
+import { layOut } from './util'
+
+import type { DisplayModel, ExtraGlyphValidator, ViewParams } from './types'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { Feature, Region } from '@jbrowse/core/util'
+import type { BaseLayout } from '@jbrowse/core/util/layouts'
+
+// used to make features have a little padding for their labels
+const xPadding = 3
+const yPadding = 5
+
+export default function RenderedFeatureGlyph(props: {
+  feature: Feature
+  bpPerPx: number
+  region: Region
+  config: AnyConfigurationModel
+  colorByCDS: boolean
+  layout: BaseLayout<unknown>
+  extraGlyphs?: ExtraGlyphValidator[]
+  displayMode: string
+  exportSVG?: unknown
+  displayModel?: DisplayModel
+  detectRerender?: () => void
+  viewParams: ViewParams
+  [key: string]: unknown
+}) {
+  const {
+    feature,
+    detectRerender,
+    bpPerPx,
+    region,
+    config,
+    displayMode,
+    layout,
+    extraGlyphs,
+  } = props
+
+  // used for unit testing, difficult to mock out so it is in actual source code
+  detectRerender?.()
+
+  const { reversed } = region
+  const start = feature.get(reversed ? 'end' : 'start')
+  const startPx = bpToPx(start, region, bpPerPx)
+  const labelAllowed = displayMode !== 'collapsed'
+
+  const rootLayout = new SceneGraph('root', 0, 0, 0, 0)
+  const GlyphComponent = chooseGlyphComponent({
+    config,
+    feature,
+    extraGlyphs,
+  })
+  const featureLayout = (GlyphComponent.layOut || layOut)({
+    layout: rootLayout,
+    feature,
+    bpPerPx,
+    reversed,
+    config,
+    extraGlyphs,
+  })
+  let shouldShowName = false
+  let shouldShowDescription = false
+  let name = ''
+  let description = ''
+  let fontHeight = 0
+  let expansion = 0
+  if (labelAllowed) {
+    const showLabels = readConfObject(config, 'showLabels')
+    const showDescriptions = readConfObject(config, 'showDescriptions')
+    fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature })
+    expansion = readConfObject(config, 'maxFeatureGlyphExpansion') || 0
+    name = String(readConfObject(config, ['labels', 'name'], { feature }) || '')
+    shouldShowName = /\S/.test(name) && showLabels
+
+    const getWidth = (text: string) => {
+      const glyphWidth = rootLayout.width + expansion
+      const textWidth = measureText(text, fontHeight)
+      return Math.round(Math.min(textWidth, glyphWidth))
+    }
+
+    description = String(
+      readConfObject(config, ['labels', 'description'], { feature }) || '',
+    )
+    shouldShowDescription = /\S/.test(description) && showDescriptions
+
+    if (shouldShowName) {
+      rootLayout.addChild(
+        'nameLabel',
+        0,
+        featureLayout.bottom,
+        getWidth(name),
+        fontHeight,
+      )
+    }
+
+    if (shouldShowDescription) {
+      const aboveLayout = shouldShowName
+        ? rootLayout.getSubRecord('nameLabel')
+        : featureLayout
+      if (!aboveLayout) {
+        throw new Error('failed to layout nameLabel')
+      }
+
+      rootLayout.addChild(
+        'descriptionLabel',
+        0,
+        aboveLayout.bottom,
+        getWidth(description),
+        fontHeight,
+      )
+    }
+  }
+
+  const topPx = layout.addRect(
+    feature.id(),
+    feature.get('start'),
+    feature.get('start') + rootLayout.width * bpPerPx + xPadding * bpPerPx,
+    rootLayout.height + yPadding,
+  )
+  if (topPx === null) {
+    return null
+  }
+  rootLayout.move(startPx, topPx)
+
+  return (
+    <FeatureGlyph
+      rootLayout={rootLayout}
+      name={name}
+      shouldShowName={shouldShowName}
+      description={description}
+      shouldShowDescription={shouldShowDescription}
+      fontHeight={fontHeight}
+      allowedWidthExpansion={expansion}
+      reversed={region.reversed}
+      topLevel={true}
+      {...props}
+    />
+  )
+}

--- a/plugins/svg/src/SvgFeatureRenderer/components/RenderedFeatures.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/RenderedFeatures.tsx
@@ -1,0 +1,43 @@
+import { observer } from 'mobx-react'
+
+import RenderedFeatureGlyph from './RenderedFeatureGlyph'
+
+import type { DisplayModel, ExtraGlyphValidator, ViewParams } from './types'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { Feature, Region } from '@jbrowse/core/util'
+import type { BaseLayout } from '@jbrowse/core/util/layouts'
+
+const RenderedFeatures = observer(function RenderedFeatures(props: {
+  features?: Map<string, Feature>
+  isFeatureDisplayed?: (f: Feature) => boolean
+  bpPerPx: number
+  config: AnyConfigurationModel
+  displayMode: string
+  colorByCDS: boolean
+  displayModel?: DisplayModel
+  region: Region
+  exportSVG?: unknown
+  extraGlyphs?: ExtraGlyphValidator[]
+  layout: BaseLayout<unknown>
+  viewParams: ViewParams
+  [key: string]: unknown
+}) {
+  const { features = new Map(), isFeatureDisplayed } = props
+  return (
+    <>
+      {[...features.values()]
+        .filter(feature =>
+          isFeatureDisplayed ? isFeatureDisplayed(feature) : true,
+        )
+        .map(feature => (
+          <RenderedFeatureGlyph
+            key={feature.id()}
+            feature={feature}
+            {...props}
+          />
+        ))}
+    </>
+  )
+})
+
+export default RenderedFeatures

--- a/plugins/svg/src/SvgFeatureRenderer/components/RepeatRegion.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/RepeatRegion.tsx
@@ -1,0 +1,112 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+import { stripAlpha } from '@jbrowse/core/util'
+import { useTheme } from '@mui/material'
+import { observer } from 'mobx-react'
+
+import Arrow from './Arrow'
+import Box from './Box'
+
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { Feature, Region } from '@jbrowse/core/util'
+import type { SceneGraph } from '@jbrowse/core/util/layouts'
+
+const map = {
+  CACTA_TIR_transposon: '#e6194b',
+  centromeric_repeat: '#3cb44b',
+  Copia_LTR_retrotransposon: '#118119',
+  Gypsy_LTR_retrotransposon: '#4363d8',
+  hAT_TIR_transposon: '#f58231',
+  helitron: '#911eb4',
+  knob: '#46f0f0',
+  L1_LINE_retrotransposon: '#f032e6',
+  LINE_element: '#bcf60c',
+  long_terminal_repeat: '#fb0',
+  low_complexity: '#008080',
+  LTR_retrotransposon: '#e6beff',
+  Mutator_TIR_transposon: '#9a6324',
+  PIF_Harbinger_TIR_transposon: '#fffac8',
+  rDNA_intergenic_spacer_element: '#800000',
+  repeat_region: '#aaffc3',
+  RTE_LINE_retrotransposon: '#808000',
+  subtelomere: '#ffd8b1',
+  target_site_duplication: '#000075',
+  Tc1_Mariner_TIR_transposon: '#808080',
+}
+
+const Segments = observer(function Segments(props: {
+  region: Region
+  feature: Feature
+  featureLayout: SceneGraph
+  config: AnyConfigurationModel
+  selected?: boolean
+  reversed?: boolean
+  subfeatures?: Feature[]
+  children?: React.ReactNode
+  bpPerPx: number
+  colorByCDS: boolean
+}) {
+  const {
+    feature,
+    featureLayout,
+    selected,
+    config,
+    // some subfeatures may be computed e.g. makeUTRs,
+    // so these are passed as a prop, or feature.get('subfeatures') by default
+    subfeatures = feature.get('subfeatures'),
+  } = props
+
+  const theme = useTheme()
+  const c = readConfObject(config, 'color2', { feature })
+  const color2 = c === '#f0f' ? stripAlpha(theme.palette.text.secondary) : c
+
+  const { left = 0, top = 0, width = 0, height = 0 } = featureLayout.absolute
+
+  const y = top + height / 2
+  return (
+    <>
+      <line
+        data-testid={feature.id()}
+        x1={left}
+        y1={y}
+        y2={y}
+        x2={left + width}
+        stroke={color2}
+      />
+      {subfeatures
+        ?.sort((a, b) => {
+          if (a.get('type').endsWith('_retrotransposon')) {
+            return -1
+          } else if (b.get('type').endsWith('_retrotransposon')) {
+            return 1
+          } else {
+            return 0
+          }
+        })
+        .map(subfeature => {
+          const subfeatureId = String(subfeature.id())
+          const subfeatureLayout = featureLayout.getSubRecord(subfeatureId)
+          // This subfeature got filtered out
+          if (!subfeatureLayout) {
+            return null
+          }
+          const type = subfeature.get('type')
+          const color = map[type as keyof typeof map] || '#000'
+          return (
+            <Box
+              key={`glyph-${subfeatureId}`}
+              {...props}
+              feature={subfeature}
+              topLevel={false}
+              color={color}
+              featureLayout={subfeatureLayout}
+              selected={selected}
+              shorten={type.endsWith('_retrotransposon')}
+            />
+          )
+        })}
+      <Arrow {...props} />
+    </>
+  )
+})
+
+export default Segments

--- a/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.tsx
@@ -1,9 +1,10 @@
 import { readConfObject } from '@jbrowse/core/configuration'
 import { observer } from 'mobx-react'
 
-import { chooseGlyphComponent, layOut, layOutFeature } from './util'
+import { chooseGlyphComponent } from './chooseGlyphComponent'
+import { layOut, layOutFeature } from './util'
 
-import type { ExtraGlyphValidator } from './util'
+import type { ExtraGlyphValidator } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'
 import type { Feature } from '@jbrowse/core/util/simpleFeature'

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -1,193 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { readConfObject } from '@jbrowse/core/configuration'
-import { bpToPx, measureText } from '@jbrowse/core/util'
-import { SceneGraph } from '@jbrowse/core/util/layouts'
 import { observer } from 'mobx-react'
 
-import FeatureGlyph from './FeatureGlyph'
+import RenderedFeatures from './RenderedFeatures'
 import SvgOverlay from './SvgOverlay'
-import { chooseGlyphComponent, layOut } from './util'
 
-import type { DisplayModel, ExtraGlyphValidator } from './util'
+import type { DisplayModel, ExtraGlyphValidator, ViewParams } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature, Region } from '@jbrowse/core/util'
 import type { BaseLayout } from '@jbrowse/core/util/layouts'
 
-// used to make features have a little padding for their labels
-const xPadding = 3
-const yPadding = 5
-
 // used so that user can click-away-from-feature below the laid out features
 // (issue #1248)
 const svgHeightPadding = 100
-
-function RenderedFeatureGlyph(props: {
-  feature: Feature
-  bpPerPx: number
-  region: Region
-  config: AnyConfigurationModel
-  colorByCDS: boolean
-  layout: BaseLayout<unknown>
-  extraGlyphs?: ExtraGlyphValidator[]
-  displayMode: string
-  exportSVG?: unknown
-  displayModel?: DisplayModel
-  detectRerender?: () => void
-  viewParams: {
-    start: number
-    end: number
-    offsetPx: number
-    offsetPx1: number
-  }
-  [key: string]: unknown
-}) {
-  const {
-    feature,
-    detectRerender,
-    bpPerPx,
-    region,
-    config,
-    displayMode,
-    layout,
-    extraGlyphs,
-  } = props
-
-  // used for unit testing, difficult to mock out so it is in actual source code
-  detectRerender?.()
-
-  const { reversed } = region
-  const start = feature.get(reversed ? 'end' : 'start')
-  const startPx = bpToPx(start, region, bpPerPx)
-  const labelAllowed = displayMode !== 'collapsed'
-
-  const rootLayout = new SceneGraph('root', 0, 0, 0, 0)
-  const GlyphComponent = chooseGlyphComponent({ config, feature, extraGlyphs })
-  const featureLayout = (GlyphComponent.layOut || layOut)({
-    layout: rootLayout,
-    feature,
-    bpPerPx,
-    reversed,
-    config,
-    extraGlyphs,
-  })
-  let shouldShowName = false
-  let shouldShowDescription = false
-  let name = ''
-  let description = ''
-  let fontHeight = 0
-  let expansion = 0
-  if (labelAllowed) {
-    const showLabels = readConfObject(config, 'showLabels')
-    const showDescriptions = readConfObject(config, 'showDescriptions')
-    fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature })
-    expansion = readConfObject(config, 'maxFeatureGlyphExpansion') || 0
-    name = String(readConfObject(config, ['labels', 'name'], { feature }) || '')
-    shouldShowName = /\S/.test(name) && showLabels
-
-    const getWidth = (text: string) => {
-      const glyphWidth = rootLayout.width + expansion
-      const textWidth = measureText(text, fontHeight)
-      return Math.round(Math.min(textWidth, glyphWidth))
-    }
-
-    description = String(
-      readConfObject(config, ['labels', 'description'], { feature }) || '',
-    )
-    shouldShowDescription = /\S/.test(description) && showDescriptions
-
-    if (shouldShowName) {
-      rootLayout.addChild(
-        'nameLabel',
-        0,
-        featureLayout.bottom,
-        getWidth(name),
-        fontHeight,
-      )
-    }
-
-    if (shouldShowDescription) {
-      const aboveLayout = shouldShowName
-        ? rootLayout.getSubRecord('nameLabel')
-        : featureLayout
-      if (!aboveLayout) {
-        throw new Error('failed to layout nameLabel')
-      }
-
-      rootLayout.addChild(
-        'descriptionLabel',
-        0,
-        aboveLayout.bottom,
-        getWidth(description),
-        fontHeight,
-      )
-    }
-  }
-
-  const topPx = layout.addRect(
-    feature.id(),
-    feature.get('start'),
-    feature.get('start') + rootLayout.width * bpPerPx + xPadding * bpPerPx,
-    rootLayout.height + yPadding,
-  )
-  if (topPx === null) {
-    return null
-  }
-  rootLayout.move(startPx, topPx)
-
-  return (
-    <FeatureGlyph
-      rootLayout={rootLayout}
-      name={name}
-      shouldShowName={shouldShowName}
-      description={description}
-      shouldShowDescription={shouldShowDescription}
-      fontHeight={fontHeight}
-      allowedWidthExpansion={expansion}
-      reversed={region.reversed}
-      topLevel={true}
-      {...props}
-    />
-  )
-}
-
-const RenderedFeatures = observer(function RenderedFeatures(props: {
-  features?: Map<string, Feature>
-  isFeatureDisplayed?: (f: Feature) => boolean
-  bpPerPx: number
-  config: AnyConfigurationModel
-  displayMode: string
-  colorByCDS: boolean
-  displayModel?: DisplayModel
-  region: Region
-  exportSVG?: unknown
-  extraGlyphs?: ExtraGlyphValidator[]
-  layout: BaseLayout<unknown>
-  viewParams: {
-    start: number
-    end: number
-    offsetPx: number
-    offsetPx1: number
-  }
-  [key: string]: unknown
-}) {
-  const { features = new Map(), isFeatureDisplayed } = props
-  return (
-    <>
-      {[...features.values()]
-        .filter(feature =>
-          isFeatureDisplayed ? isFeatureDisplayed(feature) : true,
-        )
-        .map(feature => (
-          <RenderedFeatureGlyph
-            key={feature.id()}
-            feature={feature}
-            {...props}
-          />
-        ))}
-    </>
-  )
-})
 
 const SvgFeatureRendering = observer(function SvgFeatureRendering(props: {
   layout: BaseLayout<unknown>
@@ -200,12 +26,7 @@ const SvgFeatureRendering = observer(function SvgFeatureRendering(props: {
   features: Map<string, Feature>
   displayModel?: DisplayModel
   exportSVG?: boolean
-  viewParams: {
-    start: number
-    end: number
-    offsetPx: number
-    offsetPx1: number
-  }
+  viewParams: ViewParams
   featureDisplayHandler?: (f: Feature) => boolean
   extraGlyphs?: ExtraGlyphValidator[]
   onMouseOut?: React.MouseEventHandler

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
@@ -3,9 +3,8 @@ import { useEffect, useState } from 'react'
 import { bpSpanPx } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 
+import type { LayoutRecord } from './types'
 import type { Feature, Region } from '@jbrowse/core/util'
-
-type LayoutRecord = [number, number, number, number]
 
 interface OverlayRectProps extends React.SVGProps<SVGRectElement> {
   rect?: LayoutRecord

--- a/plugins/svg/src/SvgFeatureRenderer/components/chooseGlyphComponent.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/chooseGlyphComponent.ts
@@ -1,0 +1,45 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+
+import Box from './Box'
+import ProcessedTranscript from './ProcessedTranscript'
+import RepeatRegion from './RepeatRegion'
+import Segments from './Segments'
+import Subfeatures from './Subfeatures'
+
+import type { ExtraGlyphValidator, Glyph } from './types'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { Feature } from '@jbrowse/core/util'
+
+export function chooseGlyphComponent({
+  feature,
+  extraGlyphs,
+  config,
+}: {
+  feature: Feature
+  config: AnyConfigurationModel
+  extraGlyphs?: ExtraGlyphValidator[]
+}): Glyph {
+  const type = feature.get('type')
+  const subfeatures = feature.get('subfeatures')
+  const transcriptTypes = readConfObject(config, 'transcriptTypes')
+  const containerTypes = readConfObject(config, 'containerTypes')
+
+  if (type === 'repeat_region' && subfeatures?.length) {
+    return RepeatRegion
+  } else if (subfeatures?.length && type !== 'CDS') {
+    const hasSubSub = subfeatures.some(f => f.get('subfeatures')?.length)
+    const hasCDS = subfeatures.some(f => f.get('type') === 'CDS')
+    if (transcriptTypes.includes(type) && hasCDS) {
+      return ProcessedTranscript
+    } else if (
+      (!feature.parent() && hasSubSub) ||
+      containerTypes.includes(type)
+    ) {
+      return Subfeatures
+    } else {
+      return Segments
+    }
+  } else {
+    return extraGlyphs?.find(f => f.validator(feature))?.glyph || Box
+  }
+}

--- a/plugins/svg/src/SvgFeatureRenderer/components/types.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/types.ts
@@ -1,0 +1,61 @@
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { Feature, Region } from '@jbrowse/core/util'
+import type SceneGraph from '@jbrowse/core/util/layouts/SceneGraph'
+
+export interface ExtraGlyphValidator {
+  glyph: Glyph
+  validator: (feature: Feature) => boolean
+}
+
+export interface Glyph
+  extends React.FC<{
+    colorByCDS: boolean
+    feature: Feature
+    featureLayout: SceneGraph
+    selected?: boolean
+    config: AnyConfigurationModel
+    region: Region
+    bpPerPx: number
+    topLevel?: boolean
+    [key: string]: unknown
+  }> {
+  layOut?: (arg: FeatureLayOutArgs) => SceneGraph
+}
+
+export type LayoutRecord = [number, number, number, number]
+
+export interface DisplayModel {
+  getFeatureByID?: (arg0: string, arg1: string) => LayoutRecord
+  getFeatureOverlapping?: (
+    blockKey: string,
+    bp: number,
+    y: number,
+  ) => string | undefined
+  selectedFeatureId?: string
+  featureIdUnderMouse?: string
+  contextMenuFeature?: Feature
+}
+
+export interface BaseLayOutArgs {
+  layout: SceneGraph
+  bpPerPx: number
+  reversed?: boolean
+  config: AnyConfigurationModel
+}
+
+export interface FeatureLayOutArgs extends BaseLayOutArgs {
+  feature: Feature
+  extraGlyphs?: ExtraGlyphValidator[]
+}
+
+export interface SubfeatureLayOutArgs extends BaseLayOutArgs {
+  subfeatures: Feature[]
+  extraGlyphs?: ExtraGlyphValidator[]
+}
+
+export interface ViewParams {
+  start: number
+  end: number
+  offsetPx: number
+  offsetPx1: number
+}

--- a/plugins/svg/src/SvgFeatureRenderer/components/util.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/components/util.ts
@@ -1,98 +1,11 @@
-import type React from 'react'
-
 import { readConfObject } from '@jbrowse/core/configuration'
 
 import Box from './Box'
-import ProcessedTranscript from './ProcessedTranscript'
-import Segments from './Segments'
-import Subfeatures from './Subfeatures'
+import { chooseGlyphComponent } from './chooseGlyphComponent'
 
-import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
-import type { Feature, Region } from '@jbrowse/core/util'
+import type { FeatureLayOutArgs, SubfeatureLayOutArgs } from './types'
+import type { Feature } from '@jbrowse/core/util'
 import type SceneGraph from '@jbrowse/core/util/layouts/SceneGraph'
-
-export interface Glyph
-  extends React.FC<{
-    colorByCDS: boolean
-    feature: Feature
-    featureLayout: SceneGraph
-    selected?: boolean
-    config: AnyConfigurationModel
-    region: Region
-    bpPerPx: number
-    topLevel?: boolean
-    [key: string]: unknown
-  }> {
-  layOut?: (arg: FeatureLayOutArgs) => SceneGraph
-}
-
-type LayoutRecord = [number, number, number, number]
-
-export interface DisplayModel {
-  getFeatureByID?: (arg0: string, arg1: string) => LayoutRecord
-  getFeatureOverlapping?: (
-    blockKey: string,
-    bp: number,
-    y: number,
-  ) => string | undefined
-  selectedFeatureId?: string
-  featureIdUnderMouse?: string
-  contextMenuFeature?: Feature
-}
-
-export interface ExtraGlyphValidator {
-  glyph: Glyph
-  validator: (feature: Feature) => boolean
-}
-
-export function chooseGlyphComponent({
-  feature,
-  extraGlyphs,
-  config,
-}: {
-  feature: Feature
-  config: AnyConfigurationModel
-  extraGlyphs?: ExtraGlyphValidator[]
-}): Glyph {
-  const type = feature.get('type')
-  const subfeatures = feature.get('subfeatures')
-  const transcriptTypes = readConfObject(config, 'transcriptTypes')
-  const containerTypes = readConfObject(config, 'containerTypes')
-
-  if (subfeatures?.length && type !== 'CDS') {
-    const hasSubSub = subfeatures.some(f => f.get('subfeatures')?.length)
-    const hasCDS = subfeatures.some(f => f.get('type') === 'CDS')
-    if (transcriptTypes.includes(type) && hasCDS) {
-      return ProcessedTranscript
-    } else if (
-      (!feature.parent() && hasSubSub) ||
-      containerTypes.includes(type)
-    ) {
-      return Subfeatures
-    } else {
-      return Segments
-    }
-  } else {
-    return extraGlyphs?.find(f => f.validator(feature))?.glyph || Box
-  }
-}
-
-interface BaseLayOutArgs {
-  layout: SceneGraph
-  bpPerPx: number
-  reversed?: boolean
-  config: AnyConfigurationModel
-}
-
-interface FeatureLayOutArgs extends BaseLayOutArgs {
-  feature: Feature
-  extraGlyphs?: ExtraGlyphValidator[]
-}
-
-interface SubfeatureLayOutArgs extends BaseLayOutArgs {
-  subfeatures: Feature[]
-  extraGlyphs?: ExtraGlyphValidator[]
-}
 
 export function layOut({
   layout,


### PR DESCRIPTION
You can get some of the way towards this by using just the existing examples, but there are weaknesses


1) There is a "repeat_region" element that is full length of feature
2) There is a "Copia_ltr_retrotransposon" (for example) that is a child of repeat_region, that is ALSO the full length of feature
3) Then there are other elements, that are also child of repeat_region

By making a specialized repeat glyph, we can render it a bit better, particularly the fact of of (2)


This is a demo quality PR, but could be improved potentially