### PR TITLE
Fix bug where applying clustering twice produces randomness

### DIFF
--- a/plugins/variants/src/shared/MultiVariantBaseModel.tsx
+++ b/plugins/variants/src/shared/MultiVariantBaseModel.tsx
@@ -202,6 +202,25 @@ export default function MultiVariantBaseModelF(
       get preSources() {
         return self.layout.length ? self.layout : self.sourcesVolatile
       },
+
+      get nonLayoutSources() {
+        if (self.sourcesVolatile) {
+          const rows = []
+          const sources = Object.fromEntries(
+            self.sourcesVolatile.map(s => [s.name, s]),
+          )
+          for (const row of self.sourcesVolatile) {
+            rows.push({
+              ...sources[row.name],
+              ...row,
+              label: row.name,
+              id: row.name,
+            })
+          }
+          return rows
+        }
+        return undefined
+      },
       /**
        * #getter
        */

--- a/plugins/variants/src/shared/components/ClusterDialog.tsx
+++ b/plugins/variants/src/shared/components/ClusterDialog.tsx
@@ -44,10 +44,11 @@ const ClusterDialog = observer(function ({
   handleClose,
 }: {
   model: {
-    sources?: Source[]
+    nonLayoutSources?: Source[]
     minorAlleleFrequencyFilter?: number
     adapterConfig: AnyConfigurationModel
     setLayout: (arg: Source[]) => void
+    clearLayout: () => void
   }
   handleClose: () => void
 }) {
@@ -73,14 +74,15 @@ const ClusterDialog = observer(function ({
           return
         }
         const { rpcManager } = getSession(model)
-        const { sources, minorAlleleFrequencyFilter, adapterConfig } = model
+        const { nonLayoutSources, minorAlleleFrequencyFilter, adapterConfig } =
+          model
         const sessionId = getRpcSessionId(model)
         const ret = (await rpcManager.call(
           sessionId,
           'MultiVariantGetGenotypeMatrix',
           {
             regions: view.dynamicBlocks.contentBlocks,
-            sources,
+            sources: nonLayoutSources,
             minorAlleleFrequencyFilter,
             sessionId,
             adapterConfig,
@@ -231,8 +233,8 @@ cat(resultClusters$order,sep='\\n')`
           disabled={!results}
           variant="contained"
           onClick={() => {
-            const { sources } = model
-            if (sources) {
+            const { nonLayoutSources } = model
+            if (nonLayoutSources) {
               try {
                 model.setLayout(
                   paste
@@ -241,7 +243,7 @@ cat(resultClusters$order,sep='\\n')`
                     .filter(f => !!f)
                     .map(r => +r)
                     .map(idx => {
-                      const ret = sources[idx - 1]
+                      const ret = nonLayoutSources[idx - 1]
                       if (!ret) {
                         throw new Error(`out of bounds at ${idx}`)
                       }


### PR DESCRIPTION
The VCF genotype clustering rows were re-ordered according to the last state instead of the original state, effectively producing randomness when clustering was applied twice