### PR TITLE
Add ability to load refNameAliases from BigBed for UCSC trackhub compatibility

### DIFF
--- a/packages/core/data_adapters/CytobandAdapter/configSchema.ts
+++ b/packages/core/data_adapters/CytobandAdapter/configSchema.ts
@@ -13,10 +13,26 @@ const configSchema = ConfigurationSchema(
      */
     cytobandLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/cytoband.txt.gz' },
+      defaultValue: {
+        uri: '/path/to/cytoband.txt.gz',
+      },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            cytobandLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default configSchema

--- a/plugins/comparative-adapters/src/ChainAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/configSchema.ts
@@ -44,7 +44,21 @@ const ChainAdapter = ConfigurationSchema(
       defaultValue: { uri: '/path/to/file.chain', locationType: 'UriLocation' },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            chainLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default ChainAdapter

--- a/plugins/comparative-adapters/src/DeltaAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/configSchema.ts
@@ -47,7 +47,20 @@ const DeltaAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            deltaLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default DeltaAdapter

--- a/plugins/comparative-adapters/src/MCScanAnchorsAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/MCScanAnchorsAdapter/configSchema.ts
@@ -46,7 +46,28 @@ const MCScanAnchorsAdapter = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      return snap.uri && snap.bed1 && snap.bed2
+        ? {
+            ...snap,
+            mcscanAnchorsLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            bed1Location: {
+              uri: snap.bed1,
+              baseUri: snap.baseUri,
+            },
+            bed2Location: {
+              uri: snap.bed2,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default MCScanAnchorsAdapter

--- a/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/configSchema.ts
@@ -47,6 +47,27 @@ const MCScanSimpleAnchorsAdapter = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      return snap.uri && snap.bed1 && snap.bed2
+        ? {
+            ...snap,
+            mcscanSimpleAnchorsLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            bed1Location: {
+              uri: snap.bed1,
+              baseUri: snap.baseUri,
+            },
+            bed2Location: {
+              uri: snap.bed2,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default MCScanSimpleAnchorsAdapter

--- a/plugins/comparative-adapters/src/MashMapAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/configSchema.ts
@@ -45,7 +45,21 @@ const MashMapAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            outLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default MashMapAdapter

--- a/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/configSchema.ts
@@ -69,7 +69,27 @@ const PairwiseIndexedPAFAdapter = ConfigurationSchema(
       },
     }),
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            pifGzLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            index: {
+              location: {
+                uri: `${snap.uri}.tbi`,
+                baseUri: snap.baseUri,
+              },
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default PairwiseIndexedPAFAdapter

--- a/plugins/config/src/FromConfigSequenceAdapter/configSchema.ts
+++ b/plugins/config/src/FromConfigSequenceAdapter/configSchema.ts
@@ -15,7 +15,10 @@ const sequenceConfigSchema = ConfigurationSchema(
       defaultValue: [],
     },
   },
-  { explicitlyTyped: true, implicitIdentifier: 'adapterId' },
+  {
+    explicitlyTyped: true,
+    implicitIdentifier: 'adapterId',
+  },
 )
 
 export default sequenceConfigSchema

--- a/plugins/config/src/NcbiSequenceReportAliasAdapter/configSchema.ts
+++ b/plugins/config/src/NcbiSequenceReportAliasAdapter/configSchema.ts
@@ -27,7 +27,20 @@ const NcbiSequenceReportAliasAdapterConfigSchema = ConfigurationSchema(
         'forces usage of the UCSC names over the NCBI style names from a FASTA',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            location: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default NcbiSequenceReportAliasAdapterConfigSchema

--- a/plugins/config/src/RefNameAliasAdapter/configSchema.ts
+++ b/plugins/config/src/RefNameAliasAdapter/configSchema.ts
@@ -30,7 +30,21 @@ const RefNameAliasAdapter = ConfigurationSchema(
       defaultValue: 0,
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            location: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default RefNameAliasAdapter

--- a/plugins/data-management/src/UCSCTrackHub/configSchema.ts
+++ b/plugins/data-management/src/UCSCTrackHub/configSchema.ts
@@ -35,6 +35,17 @@ const UCSCTrackHubConnection = ConfigurationSchema(
      * #baseConfiguration
      */
     baseConfiguration: baseConnectionConfig,
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            hubTxtLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
   },
 )
 

--- a/plugins/data-management/src/UCSCTrackHub/doConnect.ts
+++ b/plugins/data-management/src/UCSCTrackHub/doConnect.ts
@@ -56,6 +56,16 @@ export async function doConnect(self: {
               },
             },
           },
+          ...(genome.data.chromAliasBb
+            ? {
+                refNameAliases: {
+                  adapter: {
+                    type: 'BigBedAdapter',
+                    uri: resolve(genome.data.chromAliasBb, hubUri),
+                  },
+                },
+              }
+            : {}),
         })
       }
       const asm2 = assemblyManager.get(genomeName)

--- a/plugins/sequence/src/BgzipFastaAdapter/configSchema.ts
+++ b/plugins/sequence/src/BgzipFastaAdapter/configSchema.ts
@@ -46,6 +46,28 @@ const BgzipFastaAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            fastaLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            faiLocation: {
+              uri: `${snap.uri}.fai`,
+              baseUri: snap.baseUri,
+            },
+            gziLocation: {
+              uri: `${snap.uri}.gzi`,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default BgzipFastaAdapter

--- a/plugins/sequence/src/ChromSizesAdapter/configSchema.ts
+++ b/plugins/sequence/src/ChromSizesAdapter/configSchema.ts
@@ -19,7 +19,21 @@ const ChromSizesAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            chromSizesLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default ChromSizesAdapter

--- a/plugins/sequence/src/IndexedFastaAdapter/configSchema.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/configSchema.ts
@@ -34,6 +34,24 @@ const IndexedFastaAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            fastaLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            faiLocation: {
+              uri: `${snap.uri}.fai`,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default IndexedFastaAdapter

--- a/plugins/sequence/src/TwoBitAdapter/configSchema.ts
+++ b/plugins/sequence/src/TwoBitAdapter/configSchema.ts
@@ -42,6 +42,14 @@ const TwoBitAdapter = ConfigurationSchema(
               uri: snap.uri,
               baseUri: snap.baseUri,
             },
+            ...(snap.chromSizes
+              ? {
+                  chromSizesLocation: {
+                    uri: snap.chromSizes,
+                    baseUri: snap.baseUri,
+                  },
+                }
+              : {}),
           }
         : snap
     },

--- a/plugins/sequence/src/TwoBitAdapter/configSchema.ts
+++ b/plugins/sequence/src/TwoBitAdapter/configSchema.ts
@@ -13,7 +13,10 @@ const TwoBitAdapter = ConfigurationSchema(
      */
     twoBitLocation: {
       type: 'fileLocation',
-      defaultValue: { uri: '/path/to/my.2bit', locationType: 'UriLocation' },
+      defaultValue: {
+        uri: '/path/to/my.2bit',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
@@ -28,7 +31,21 @@ const TwoBitAdapter = ConfigurationSchema(
         'An optional chrom.sizes file can be supplied to speed up loading since parsing the twobit file can take time',
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            twoBitLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 
 export default TwoBitAdapter

--- a/plugins/sequence/src/UnindexedFastaAdapter/configSchema.ts
+++ b/plugins/sequence/src/UnindexedFastaAdapter/configSchema.ts
@@ -38,6 +38,20 @@ const UnindexedFastaAdapter = ConfigurationSchema(
       },
     },
   },
-  { explicitlyTyped: true },
+  {
+    explicitlyTyped: true,
+    preProcessSnapshot: snap => {
+      // populate from just snap.uri
+      return snap.uri
+        ? {
+            ...snap,
+            fastaLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
 )
 export default UnindexedFastaAdapter

--- a/plugins/trix/src/TrixTextSearchAdapter/configSchema.ts
+++ b/plugins/trix/src/TrixTextSearchAdapter/configSchema.ts
@@ -13,24 +13,30 @@ const TrixTextSearchAdapter = ConfigurationSchema(
      */
     ixFilePath: {
       type: 'fileLocation',
-      defaultValue: { uri: 'out.ix', locationType: 'UriLocation' },
-      description: 'the location of the trix ix file',
+      defaultValue: {
+        uri: 'out.ix',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
      */
     ixxFilePath: {
       type: 'fileLocation',
-      defaultValue: { uri: 'out.ixx', locationType: 'UriLocation' },
-      description: 'the location of the trix ixx file',
+      defaultValue: {
+        uri: 'out.ixx',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
      */
     metaFilePath: {
       type: 'fileLocation',
-      defaultValue: { uri: 'meta.json', locationType: 'UriLocation' },
-      description: 'the location of the metadata json file for the trix index',
+      defaultValue: {
+        uri: 'meta.json',
+        locationType: 'UriLocation',
+      },
     },
     /**
      * #slot
@@ -55,6 +61,21 @@ const TrixTextSearchAdapter = ConfigurationSchema(
      * #identifier
      */
     explicitIdentifier: 'textSearchAdapterId',
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            ixFilePath: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+            ixxFilePath: {
+              uri: `${snap.uri}x`,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
   },
 )
 

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -18,35 +18,19 @@
         "trackId": "Pd8Wh30ei9R",
         "adapter": {
           "type": "BgzipFastaAdapter",
-          "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz",
-            "locationType": "UriLocation"
-          },
-          "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.fai",
-            "locationType": "UriLocation"
-          },
-          "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz.gzi",
-            "locationType": "UriLocation"
-          }
+          "uri": "https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz"
         }
       },
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",
-          "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt",
-            "locationType": "UriLocation"
-          }
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg19_aliases.txt"
         }
       },
       "cytobands": {
         "adapter": {
           "type": "CytobandAdapter",
-          "cytobandLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/cytoBand.txt"
-          }
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/cytoBand.txt"
         }
       }
     },
@@ -58,35 +42,19 @@
         "trackId": "P6R5xbRqRr",
         "adapter": {
           "type": "BgzipFastaAdapter",
-          "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz",
-            "locationType": "UriLocation"
-          },
-          "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai",
-            "locationType": "UriLocation"
-          },
-          "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi",
-            "locationType": "UriLocation"
-          }
+          "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
         }
       },
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",
-          "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt",
-            "locationType": "UriLocation"
-          }
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
         }
       },
       "cytobands": {
         "adapter": {
           "type": "CytobandAdapter",
-          "cytobandLocation": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/cytoBand.txt"
-          }
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/cytoBand.txt"
         }
       }
     },
@@ -97,10 +65,7 @@
         "trackId": "P6R5xbRqRr3",
         "adapter": {
           "type": "TwoBitAdapter",
-          "twoBitLocation": {
-            "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.2bit",
-            "locationType": "UriLocation"
-          },
+          "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.2bit",
           "chromSizesLocation": {
             "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.chrom.sizes"
           }
@@ -109,38 +74,7 @@
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",
-          "location": {
-            "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.chromAlias.txt",
-            "locationType": "UriLocation"
-          }
-        }
-      }
-    },
-    {
-      "name": "chm13v2.0",
-      "sequence": {
-        "type": "ReferenceSequenceTrack",
-        "trackId": "chm13v2.0-asm",
-        "adapter": {
-          "type": "BgzipFastaAdapter",
-          "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13v2.0.fa.gz"
-          },
-          "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13v2.0.fa.gz.fai"
-          },
-          "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/CHM13/fasta/chm13v2.0.fa.gz.gzi"
-          }
-        }
-      },
-      "refNameAliases": {
-        "adapter": {
-          "type": "RefNameAliasAdapter",
-          "location": {
-            "uri": "https://hgdownload.soe.ucsc.edu/goldenPath/hs1/bigZips/hs1.chromAlias.txt",
-            "locationType": "UriLocation"
-          }
+          "uri": "https://hgdownload.cse.ucsc.edu/goldenpath/hs1/bigZips/hs1.chromAlias.txt"
         }
       }
     }
@@ -3837,41 +3771,6 @@
       }
     },
     {
-      "type": "SyntenyTrack",
-      "category": ["Synteny"],
-      "trackId": "grch38-chm13v2.paf",
-      "name": "grch38-chm13v2.paf",
-      "adapter": {
-        "type": "PAFAdapter",
-        "pafLocation": {
-          "uri": "https://jbrowse.org/genomes/CHM13/synteny/grch38-chm13v2.paf.gz",
-          "locationType": "UriLocation"
-        },
-        "assemblyNames": ["chm13v2.0", "hg38"]
-      },
-      "assemblyNames": ["chm13v2.0", "hg38"]
-    },
-    {
-      "type": "FeatureTrack",
-      "trackId": "chm13v2.0.gff",
-      "name": "chm13v2.0.gff",
-      "adapter": {
-        "type": "Gff3TabixAdapter",
-        "gffGzLocation": {
-          "uri": "https://jbrowse.org/genomes/CHM13/gff/chm13v2.0.gff.gz",
-          "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "https://jbrowse.org/genomes/CHM13/gff/chm13v2.0.gff.gz.tbi",
-            "locationType": "UriLocation"
-          },
-          "indexType": "TBI"
-        }
-      },
-      "assemblyNames": ["chm13v2.0"]
-    },
-    {
       "type": "AlignmentsTrack",
       "trackId": "bonito_calls",
       "name": "Clive-ome 5mC",
@@ -4132,30 +4031,6 @@
         }
       },
       "assemblyNames": ["hg19"]
-    },
-    {
-      "type": "FeatureTrack",
-      "trackId": "ncbi_genes",
-      "name": "NCBI genes",
-      "metadata": {
-        "accessed_date": "2024/06/14",
-        "url": "https://www.ncbi.nlm.nih.gov/datasets/genome/GCF_009914755.1/"
-      },
-      "adapter": {
-        "type": "Gff3TabixAdapter",
-        "gffGzLocation": {
-          "uri": "https://jbrowse.org/genomes/CHM13/genes/ncbi_genes.gff.gz",
-          "locationType": "UriLocation"
-        },
-        "index": {
-          "location": {
-            "uri": "https://jbrowse.org/genomes/CHM13/genes/ncbi_genes.gff.gz.tbi",
-            "locationType": "UriLocation"
-          },
-          "indexType": "TBI"
-        }
-      },
-      "assemblyNames": ["chm13v2.0"]
     },
     {
       "type": "FeatureTrack",
@@ -4801,7 +4676,7 @@
           "locationType": "UriLocation"
         }
       },
-      "assemblyNames": ["hg1"]
+      "assemblyNames": ["hs1"]
     },
     {
       "type": "VariantTrack",
@@ -5275,10 +5150,7 @@
       "name": "MANE 1.4 (w/ ensembl IDs)",
       "adapter": {
         "type": "BigBedAdapter",
-        "bigBedLocation": {
-          "uri": "https://ftp.ncbi.nlm.nih.gov/refseq/MANE/trackhub/data/release_1.4/MANE.GRCh38.v1.4.ensembl.bb",
-          "locationType": "UriLocation"
-        }
+        "uri": "https://ftp.ncbi.nlm.nih.gov/refseq/MANE/trackhub/data/release_1.4/MANE.GRCh38.v1.4.ensembl.bb"
       },
       "category": ["Annotation", "MANE"],
       "assemblyNames": ["hg38"],
@@ -5302,10 +5174,7 @@
       "assemblyNames": ["hg38"],
       "adapter": {
         "type": "Gff3Adapter",
-        "gffLocation": {
-          "locationType": "UriLocation",
-          "uri": "https://ftp.ensembl.org/pub/release-113/regulation/homo_sapiens/homo_sapiens.GRCh38.Regulatory_Build.regulatory_features.20240230.gff.gz"
-        }
+        "uri": "https://ftp.ensembl.org/pub/release-113/regulation/homo_sapiens/homo_sapiens.GRCh38.Regulatory_Build.regulatory_features.20240230.gff.gz"
       }
     }
   ],
@@ -5322,35 +5191,13 @@
     {
       "type": "TrixTextSearchAdapter",
       "textSearchAdapterId": "hg19-index",
-      "ixFilePath": {
-        "uri": "https://jbrowse.org/genomes/hg19/trix/hg19.ix",
-        "locationType": "UriLocation"
-      },
-      "ixxFilePath": {
-        "uri": "https://jbrowse.org/genomes/hg19/trix/hg19.ixx",
-        "locationType": "UriLocation"
-      },
-      "metaFilePath": {
-        "uri": "https://jbrowse.org/genomes/hg19/trix/meta.json",
-        "locationType": "UriLocation"
-      },
+      "uri": "https://jbrowse.org/genomes/hg19/trix/hg19.ix",
       "assemblyNames": ["hg19"]
     },
     {
       "type": "TrixTextSearchAdapter",
       "textSearchAdapterId": "hg38-index",
-      "ixFilePath": {
-        "uri": "https://jbrowse.org/genomes/GRCh38/trix/hg38.ix",
-        "locationType": "UriLocation"
-      },
-      "ixxFilePath": {
-        "uri": "https://jbrowse.org/genomes/GRCh38/trix/hg38.ixx",
-        "locationType": "UriLocation"
-      },
-      "metaFilePath": {
-        "uri": "https://jbrowse.org/genomes/GRCh38/trix/meta.json",
-        "locationType": "UriLocation"
-      },
+      "uri": "https://jbrowse.org/genomes/GRCh38/trix/hg38.ix",
       "assemblyNames": ["hg38"]
     }
   ]


### PR DESCRIPTION
UCSC uses a file called chromAliases.bb

This loads this by default from hub.txt e.g. chromAliasBb GCF_000001735.4.chromAlias.bb

It also adds some more simplified config loading