### PR TITLE
Allow refNameColumn in RefNameAliasAdapter to override the default displayed refnames

### DIFF
--- a/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
+++ b/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
@@ -20,7 +20,7 @@ export default class RefNameAliasAdapter
       .filter(f => !!f && !f.startsWith('#'))
       .map(row => {
         const aliases = row.split('\t')
-        const [refName] = aliases.splice(refColumn, 1)
+        const refName = aliases[refColumn]
         return {
           refName: refName!,
           aliases: aliases.filter(f => !!f.trim()),


### PR DESCRIPTION
This is basically expected behavior if your refNameColumn doesn't match the fasta/2bit refnames, with the change, you can force the default displayed refNames to be from refNameColumn in the aliases file

A demo of this was added for NcbiSequenceReportAdapter but now we add it here so that we can load GenArk UCSC assemblies

This way, you can load a FASTA file with names like NC_000001.10 and it will display as chr1