### PR TITLE
Allow looking up header column by name for RefNameAliases

### DIFF
--- a/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
+++ b/plugins/config/src/RefNameAliasAdapter/RefNameAliasAdapter.ts
@@ -14,13 +14,21 @@ export default class RefNameAliasAdapter
     }
     const results = await openLocation(loc, this.pluginManager).readFile('utf8')
     const refColumn = this.getConf('refNameColumn')
-    return results
+    const refColumnHeaderName = this.getConf('refNameColumnHeaderName')
+    const lines = results
       .trim()
       .split(/\n|\r\n|\r/)
-      .filter(f => !!f && !f.startsWith('#'))
+      .filter(f => !!f)
+    const header = lines.filter(f => f.startsWith('#'))
+    const headerCol =
+      refColumnHeaderName && header.length
+        ? header.at(-1)!.split('\t').indexOf(refColumnHeaderName)
+        : refColumn
+    return lines
+      .filter(f => !f.startsWith('#'))
       .map(row => {
         const aliases = row.split('\t')
-        const refName = aliases[refColumn]
+        const refName = aliases[headerCol]
         return {
           refName: refName!,
           aliases: aliases.filter(f => !!f.trim()),

--- a/plugins/config/src/RefNameAliasAdapter/configSchema.ts
+++ b/plugins/config/src/RefNameAliasAdapter/configSchema.ts
@@ -29,6 +29,17 @@ const RefNameAliasAdapter = ConfigurationSchema(
       type: 'number',
       defaultValue: 0,
     },
+
+    /**
+     * #slot
+     * refNameColumnHeaderName
+     */
+    refNameColumnHeaderName: {
+      type: 'string',
+      description:
+        'alternative to refNameColumn, instead looks at header (starts with # and finds column name)',
+      defaultValue: '',
+    },
   },
   {
     explicitlyTyped: true,


### PR DESCRIPTION
This adds the ability to look for a specific column in a RefNameAliasAdapter

This enables it to reliably get the 'UCSC name' which can change column number


Sort of similar to this PR that was for the NCBI sequence_report alias adapter
https://github.com/GMOD/jbrowse-components/pull/4851

