### PR TITLE
Fix issue where multi-level linear synteny view would show a blank tracklist

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles()(theme => {
       height: '100%',
       background: alpha(theme.palette.tertiary.main, 0.7),
       position: 'absolute',
-      zIndex: 10,
+      zIndex: 900,
       textAlign: 'center',
       overflow: 'hidden',
     },

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
@@ -1,5 +1,5 @@
 import { stringify } from '@jbrowse/core/util'
-import { Tooltip, Typography } from '@mui/material'
+import { Tooltip } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -13,10 +13,8 @@ const useStyles = makeStyles()({
     height: '100%',
     width: 1,
     position: 'absolute',
+    background: 'red',
     zIndex: 1001,
-  },
-  sm: {
-    fontSize: 10,
   },
 })
 
@@ -35,12 +33,9 @@ const VerticalGuide = observer(function ({
       title={model.views
         .map(view => view.pxToBp(coordX))
         .map((elt, idx) => (
-          <Typography
-            className={classes.sm}
-            key={[JSON.stringify(elt), idx].join('-')}
-          >
+          <div key={[JSON.stringify(elt), idx].join('-')}>
             {stringify(elt, true)}
-          </Typography>
+          </div>
         ))}
       arrow
     >
@@ -48,7 +43,6 @@ const VerticalGuide = observer(function ({
         className={classes.guide}
         style={{
           left: coordX,
-          background: 'red',
         }}
       />
     </Tooltip>

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles()({
     height: '100%',
     width: 1,
     position: 'absolute',
-    zIndex: 10,
+    zIndex: 1001,
   },
   sm: {
     fontSize: 10,

--- a/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/model.ts
@@ -171,6 +171,11 @@ function stateModelFactory(pluginManager: PluginManager) {
        */
       setViews(views: SnapshotIn<LinearGenomeViewModel>[]) {
         self.views = cast(views)
+        const levels = []
+        for (let i = 0; i < views.length - 1; i++) {
+          levels.push({ level: i })
+        }
+        self.levels = cast(levels)
       },
 
       /**
@@ -221,6 +226,7 @@ function stateModelFactory(pluginManager: PluginManager) {
       toggleTrack(trackId: string, level = 0) {
         self.levels[level]?.toggleTrack(trackId)
       },
+
       /**
        * #action
        */

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/AssemblyRows.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/AssemblyRows.tsx
@@ -1,0 +1,89 @@
+import { AssemblySelector } from '@jbrowse/core/ui'
+import { getSession, notEmpty } from '@jbrowse/core/util'
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
+import CloseIcon from '@mui/icons-material/Close'
+import { IconButton } from '@mui/material'
+import { observer } from 'mobx-react'
+import { makeStyles } from 'tss-react/mui'
+
+import type { LinearSyntenyViewModel } from '../../model'
+
+const useStyles = makeStyles()(theme => ({
+  rel: {
+    position: 'relative',
+  },
+  synbutton: {
+    position: 'absolute',
+    top: 30,
+  },
+  bg: {
+    background: theme.palette.divider,
+  },
+}))
+
+const AssemblyRow = observer(function ({
+  selectedRow,
+  selectedAssemblyNames,
+  setSelectedRow,
+  setSelectedAssemblyNames,
+  model,
+}: {
+  selectedRow: number
+  selectedAssemblyNames: string[]
+  setSelectedRow: (idx: number) => void
+  setSelectedAssemblyNames: (assemblies: string[]) => void
+  model: LinearSyntenyViewModel
+}) {
+  const { classes, cx } = useStyles()
+  const session = getSession(model)
+  return selectedAssemblyNames.map((assemblyName, idx) => (
+    <div key={`${assemblyName}-${idx}`} className={classes.rel}>
+      <span>Row {idx + 1}: </span>
+
+      <IconButton
+        disabled={selectedAssemblyNames.length <= 2}
+        onClick={() => {
+          model.importFormRemoveRow(idx)
+          setSelectedAssemblyNames(
+            selectedAssemblyNames
+              .map((asm, idx2) => (idx2 === idx ? undefined : asm))
+              .filter(notEmpty),
+          )
+          if (selectedRow >= selectedAssemblyNames.length - 2) {
+            setSelectedRow(0)
+          }
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+      <AssemblySelector
+        helperText=""
+        selected={assemblyName}
+        onChange={newAssembly => {
+          setSelectedAssemblyNames(
+            selectedAssemblyNames.map((asm, idx2) =>
+              idx2 === idx ? newAssembly : asm,
+            ),
+          )
+        }}
+        session={session}
+      />
+      {idx !== selectedAssemblyNames.length - 1 ? (
+        <IconButton
+          data-testid="synbutton"
+          className={cx(
+            classes.synbutton,
+            idx === selectedRow ? classes.bg : undefined,
+          )}
+          onClick={() => {
+            setSelectedRow(idx)
+          }}
+        >
+          <ArrowForwardIosIcon />
+        </IconButton>
+      ) : null}
+    </div>
+  ))
+})
+
+export default AssemblyRow

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LeftPanel.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LeftPanel.tsx
@@ -2,13 +2,19 @@ import { AssemblySelector } from '@jbrowse/core/ui'
 import { getSession, notEmpty } from '@jbrowse/core/util'
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
 import CloseIcon from '@mui/icons-material/Close'
-import { IconButton } from '@mui/material'
+import { Button, IconButton } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
 import type { LinearSyntenyViewModel } from '../../model'
 
 const useStyles = makeStyles()(theme => ({
+  mb: {
+    marginBottom: 10,
+  },
+  button: {
+    margin: theme.spacing(2),
+  },
   rel: {
     position: 'relative',
   },
@@ -21,7 +27,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const AssemblyRow = observer(function ({
+const AssemblyRows = observer(function ({
   selectedRow,
   selectedAssemblyNames,
   setSelectedRow,
@@ -86,4 +92,63 @@ const AssemblyRow = observer(function ({
   ))
 })
 
-export default AssemblyRow
+const LeftPanel = observer(function ({
+  model,
+  selectedAssemblyNames,
+  setSelectedAssemblyNames,
+  selectedRow,
+  setSelectedRow,
+  defaultAssemblyName,
+  onLaunch,
+}: {
+  model: LinearSyntenyViewModel
+  selectedAssemblyNames: string[]
+  setSelectedAssemblyNames: (names: string[]) => void
+  selectedRow: number
+  setSelectedRow: (row: number) => void
+  defaultAssemblyName: string
+  onLaunch: () => void
+}) {
+  const { classes } = useStyles()
+
+  return (
+    <>
+      <div className={classes.mb}>
+        Select assemblies for linear synteny view
+      </div>
+      <AssemblyRows
+        model={model}
+        selectedAssemblyNames={selectedAssemblyNames}
+        setSelectedAssemblyNames={setSelectedAssemblyNames}
+        selectedRow={selectedRow}
+        setSelectedRow={setSelectedRow}
+      />
+
+      <div>
+        <Button
+          className={classes.button}
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            setSelectedAssemblyNames([
+              ...selectedAssemblyNames,
+              defaultAssemblyName,
+            ])
+          }}
+        >
+          Add row
+        </Button>
+        <Button
+          className={classes.button}
+          onClick={onLaunch}
+          variant="contained"
+          color="primary"
+        >
+          Launch
+        </Button>
+      </div>
+    </>
+  )
+})
+
+export default LeftPanel

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
@@ -1,13 +1,12 @@
 import { useState } from 'react'
 
-import { AssemblySelector, ErrorMessage } from '@jbrowse/core/ui'
-import { getSession, notEmpty } from '@jbrowse/core/util'
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
-import CloseIcon from '@mui/icons-material/Close'
-import { Button, Container, IconButton } from '@mui/material'
+import { ErrorMessage } from '@jbrowse/core/ui'
+import { getSession } from '@jbrowse/core/util'
+import { Button, Container } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
+import AssemblyRows from './AssemblyRows'
 import ImportSyntenyTrackSelector from './ImportSyntenyTrackSelectorArea'
 import { doSubmit } from './doSubmit'
 
@@ -20,13 +19,6 @@ const useStyles = makeStyles()(theme => ({
   button: {
     margin: theme.spacing(2),
   },
-  rel: {
-    position: 'relative',
-  },
-  synbutton: {
-    position: 'absolute',
-    top: 30,
-  },
 
   flex: {
     display: 'flex',
@@ -34,9 +26,6 @@ const useStyles = makeStyles()(theme => ({
   },
   mb: {
     marginBottom: 10,
-  },
-  bg: {
-    background: theme.palette.divider,
   },
   rightPanel: {
     flexGrow: 11,
@@ -55,7 +44,7 @@ const LinearSyntenyViewImportForm = observer(function ({
 }: {
   model: LinearSyntenyViewModel
 }) {
-  const { classes, cx } = useStyles()
+  const { classes } = useStyles()
   const session = getSession(model)
   const { assemblyNames } = session
   const defaultAssemblyName = assemblyNames[0] || ''
@@ -74,54 +63,14 @@ const LinearSyntenyViewImportForm = observer(function ({
           <div className={classes.mb}>
             Select assemblies for linear synteny view
           </div>
-          {selectedAssemblyNames.map((assemblyName, idx) => (
-            <div key={`${assemblyName}-${idx}`} className={classes.rel}>
-              <span>Row {idx + 1}: </span>
+          <AssemblyRows
+            model={model}
+            selectedAssemblyNames={selectedAssemblyNames}
+            setSelectedAssemblyNames={setSelectedAssemblyNames}
+            selectedRow={selectedRow}
+            setSelectedRow={setSelectedRow}
+          />
 
-              <IconButton
-                disabled={selectedAssemblyNames.length <= 2}
-                onClick={() => {
-                  model.importFormRemoveRow(idx)
-                  setSelectedAssemblyNames(
-                    selectedAssemblyNames
-                      .map((asm, idx2) => (idx2 === idx ? undefined : asm))
-                      .filter(notEmpty),
-                  )
-                  if (selectedRow >= selectedAssemblyNames.length - 2) {
-                    setSelectedRow(0)
-                  }
-                }}
-              >
-                <CloseIcon />
-              </IconButton>
-              <AssemblySelector
-                helperText=""
-                selected={assemblyName}
-                onChange={newAssembly => {
-                  setSelectedAssemblyNames(
-                    selectedAssemblyNames.map((asm, idx2) =>
-                      idx2 === idx ? newAssembly : asm,
-                    ),
-                  )
-                }}
-                session={session}
-              />
-              {idx !== selectedAssemblyNames.length - 1 ? (
-                <IconButton
-                  data-testid="synbutton"
-                  className={cx(
-                    classes.synbutton,
-                    idx === selectedRow ? classes.bg : undefined,
-                  )}
-                  onClick={() => {
-                    setSelectedRow(idx)
-                  }}
-                >
-                  <ArrowForwardIosIcon />
-                </IconButton>
-              ) : null}
-            </div>
-          ))}
           <div>
             <Button
               className={classes.button}

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react'
 
 import { ErrorMessage } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
-import { Button, Container } from '@mui/material'
+import { Container } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
-import AssemblyRows from './AssemblyRows'
 import ImportSyntenyTrackSelector from './ImportSyntenyTrackSelectorArea'
+import LeftPanel from './LeftPanel'
 import { doSubmit } from './doSubmit'
 
 import type { LinearSyntenyViewModel } from '../../model'
@@ -16,16 +16,9 @@ const useStyles = makeStyles()(theme => ({
   importFormContainer: {
     padding: theme.spacing(4),
   },
-  button: {
-    margin: theme.spacing(2),
-  },
-
   flex: {
     display: 'flex',
     gap: 90,
-  },
-  mb: {
-    marginBottom: 10,
   },
   rightPanel: {
     flexGrow: 11,
@@ -55,59 +48,36 @@ const LinearSyntenyViewImportForm = observer(function ({
   ])
   const [error, setError] = useState<unknown>()
 
+  const handleLaunch = async () => {
+    try {
+      setError(undefined)
+      await doSubmit({
+        selectedAssemblyNames,
+        model,
+      })
+    } catch (e) {
+      console.error(e)
+      setError(e)
+    }
+  }
+
   return (
     <Container className={classes.importFormContainer}>
       {error ? <ErrorMessage error={error} /> : null}
       <div className={classes.flex}>
         <div className={classes.leftPanel}>
-          <div className={classes.mb}>
-            Select assemblies for linear synteny view
-          </div>
-          <AssemblyRows
+          <LeftPanel
             model={model}
             selectedAssemblyNames={selectedAssemblyNames}
             setSelectedAssemblyNames={setSelectedAssemblyNames}
             selectedRow={selectedRow}
             setSelectedRow={setSelectedRow}
+            defaultAssemblyName={defaultAssemblyName}
+            onLaunch={() => {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              handleLaunch()
+            }}
           />
-
-          <div>
-            <Button
-              className={classes.button}
-              variant="contained"
-              color="secondary"
-              onClick={() => {
-                setSelectedAssemblyNames([
-                  ...selectedAssemblyNames,
-                  defaultAssemblyName,
-                ])
-              }}
-            >
-              Add row
-            </Button>
-            <Button
-              className={classes.button}
-              onClick={() => {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                ;(async () => {
-                  try {
-                    setError(undefined)
-                    await doSubmit({
-                      selectedAssemblyNames,
-                      model,
-                    })
-                  } catch (e) {
-                    console.error(e)
-                    setError(e)
-                  }
-                })()
-              }}
-              variant="contained"
-              color="primary"
-            >
-              Launch
-            </Button>
-          </div>
         </div>
 
         <div className={classes.rightPanel}>

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/LinearSyntenyView.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/LinearSyntenyView.tsx
@@ -10,9 +10,11 @@ const LinearSyntenyImportForm = lazy(
   () => import('./ImportForm/LinearSyntenyImportForm'),
 )
 
-type LSV = LinearSyntenyViewModel
-
-const LinearSyntenyView = observer(function ({ model }: { model: LSV }) {
+const LinearSyntenyView = observer(function ({
+  model,
+}: {
+  model: LinearSyntenyViewModel
+}) {
   return !model.initialized ? (
     <LinearSyntenyImportForm model={model} />
   ) : (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/VerticalGuide.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/VerticalGuide.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles()({
     width: 1,
     position: 'absolute',
     background: 'red',
-    zIndex: 4,
+    zIndex: 1001,
   },
   tooltipTarget: {
     position: 'sticky',

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/VerticalGuide.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/VerticalGuide.tsx
@@ -1,11 +1,7 @@
-import { VIEW_HEADER_HEIGHT } from '@jbrowse/core/ui'
-import { getSession, stringify } from '@jbrowse/core/util'
-import { isSessionWithMultipleViews } from '@jbrowse/product-core'
+import { stringify } from '@jbrowse/core/util'
 import { Tooltip } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
-
-import { HEADER_BAR_HEIGHT, HEADER_OVERVIEW_HEIGHT } from '../consts'
 
 import type { LinearGenomeViewModel } from '..'
 
@@ -34,23 +30,8 @@ const VerticalGuide = observer(function VerticalGuide({
   coordX: number
 }) {
   const { classes } = useStyles()
-  const session = getSession(model)
+  const { stickyViewHeaders, rubberbandTop } = model
 
-  let stickyViewHeaders = false
-  if (isSessionWithMultipleViews(session)) {
-    ;({ stickyViewHeaders } = session)
-  }
-
-  let tooltipTop = 0
-  if (stickyViewHeaders) {
-    tooltipTop = VIEW_HEADER_HEIGHT
-    if (!model.hideHeader) {
-      tooltipTop += HEADER_BAR_HEIGHT
-      if (!model.hideHeaderOverview) {
-        tooltipTop += HEADER_OVERVIEW_HEIGHT
-      }
-    }
-  }
   return (
     <>
       <Tooltip
@@ -63,7 +44,7 @@ const VerticalGuide = observer(function VerticalGuide({
           className={classes.tooltipTarget}
           style={{
             left: coordX + 6,
-            top: tooltipTop,
+            top: rubberbandTop,
             position: stickyViewHeaders ? 'sticky' : undefined,
           }}
         />


### PR DESCRIPTION
The code to activate the 'synteny' track selector was returning undefined because the import form was not initializing all the synteny 'levels' (areas between the linear genome views)

This caused this statement to activateTrackSelector to pass an undefined object https://github.com/GMOD/jbrowse-components/blob/ef6d3f895e7d35e7dff78eaea7e5a49ab3386d43/plugins/linear-comparative-view/src/LinearComparativeView/model.ts#L205-L221


This fix makes it so that each level is initialized at least with an empty object, which properly initializes the MST model which can be used for further track selector usage