### PR TITLE
Show target zoom level in tooltip on slider

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderZoomControls.tsx
@@ -1,7 +1,7 @@
 import { lazy, useEffect, useState } from 'react'
 
 import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
-import { getSession } from '@jbrowse/core/util'
+import { getBpDisplayStr, getSession } from '@jbrowse/core/util'
 import MoreVert from '@mui/icons-material/MoreVert'
 import ZoomIn from '@mui/icons-material/ZoomIn'
 import ZoomOut from '@mui/icons-material/ZoomOut'
@@ -10,6 +10,7 @@ import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
 import type { LinearGenomeViewModel } from '..'
+import type { SliderValueLabelProps } from '@mui/material'
 
 // lazies
 const RegionWidthEditorDialog = lazy(() => import('./RegionWidthEditorDialog'))
@@ -25,14 +26,27 @@ const useStyles = makeStyles()(theme => ({
     color: theme.palette.text.secondary,
   },
 }))
-
+function ValueLabelComponent(props: SliderValueLabelProps) {
+  const { children, open, value } = props
+  return (
+    <Tooltip
+      open={open}
+      enterTouchDelay={0}
+      placement="top"
+      title={value}
+      arrow
+    >
+      {children}
+    </Tooltip>
+  )
+}
 const HeaderZoomControls = observer(function ({
   model,
 }: {
   model: LinearGenomeViewModel
 }) {
   const { classes } = useStyles()
-  const { maxBpPerPx, minBpPerPx, bpPerPx } = model
+  const { width, maxBpPerPx, minBpPerPx, bpPerPx } = model
   const [value, setValue] = useState(-Math.log2(bpPerPx) * 100)
   useEffect(() => {
     setValue(-Math.log2(bpPerPx) * 100)
@@ -62,6 +76,13 @@ const HeaderZoomControls = observer(function ({
         min={-Math.log2(maxBpPerPx) * 100}
         max={-Math.log2(minBpPerPx) * 100}
         onChangeCommitted={() => model.zoomTo(2 ** (-value / 100))}
+        valueLabelDisplay="auto"
+        valueLabelFormat={newValue =>
+          `Window size: ${getBpDisplayStr(2 ** (-newValue / 100) * width)}`
+        }
+        slots={{
+          valueLabel: ValueLabelComponent,
+        }}
         onChange={(_, val) => {
           setValue(val as number)
         }}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`renders one track, one region 1`] = `
                       autocapitalize="none"
                       autocomplete="off"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
-                      id=":rt:"
+                      id=":ru:"
                       placeholder="Search for location"
                       role="combobox"
                       spellcheck="false"
@@ -276,8 +276,10 @@ exports[`renders one track, one region 1`] = `
                   style="left: 0%; width: 0%;"
                 />
                 <span
+                  aria-label="Window size: 111bp"
                   class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-o0wpuw-MuiSlider-thumb"
                   data-index="0"
+                  data-mui-internal-clone-element="true"
                   style="left: 0%;"
                 >
                   <input
@@ -818,7 +820,7 @@ exports[`renders two tracks, two regions 1`] = `
                       autocapitalize="none"
                       autocomplete="off"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
-                      id=":r1e:"
+                      id=":r1g:"
                       placeholder="Search for location"
                       role="combobox"
                       spellcheck="false"
@@ -920,8 +922,10 @@ exports[`renders two tracks, two regions 1`] = `
                   style="left: 0%; width: 9.774680693120512%;"
                 />
                 <span
+                  aria-label="Window size: 800bp"
                   class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-o0wpuw-MuiSlider-thumb"
                   data-index="0"
+                  data-mui-internal-clone-element="true"
                   style="left: 9.774680693120512%;"
                 >
                   <input

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -357,8 +357,10 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                           style="left: 0%; width: 56.78411120929245%;"
                         />
                         <span
+                          aria-label="Window size: 39bp"
                           class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-o0wpuw-MuiSlider-thumb"
                           data-index="0"
+                          data-mui-internal-clone-element="true"
                           style="left: 56.78411120929245%;"
                         >
                           <input

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -530,3 +530,25 @@ links without the central server.
 Also, if you are implementing JBrowse Web on your own server and would like to
 create your own URL shortener, you can use the shareURL parameter in the
 config.json file to point at your own server instead of ours.
+
+### I get a GLIBC error like this from the linux AppImage of jbrowse desktop
+
+If you see
+
+```
+jbrowse-desktop.bin: /lib64/libm.so.6: version `GLIBC_2.29' not found
+```
+
+Then you are running on an older system that electron might no longer support.
+The last known working version of electron with the working GLIBC for older
+systems is electron@33.2.0. You may be able to manually downgrade electron and
+build a new release of jbrowse using steps like this
+
+```
+git clone git@github.com:GMOD/jbrowse-components
+cd jbrowse-components
+yarn
+cd products/jbrowse-desktop
+// change electronVersion in package.json to 34.0.1->33.2.0
+yarn build-electron:linux
+```

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -530,25 +530,3 @@ links without the central server.
 Also, if you are implementing JBrowse Web on your own server and would like to
 create your own URL shortener, you can use the shareURL parameter in the
 config.json file to point at your own server instead of ours.
-
-### I get a GLIBC error like this from the linux AppImage of jbrowse desktop
-
-If you see
-
-```
-jbrowse-desktop.bin: /lib64/libm.so.6: version `GLIBC_2.29' not found
-```
-
-Then you are running on an older system that electron might no longer support.
-The last known working version of electron with the working GLIBC for older
-systems is electron@33.2.0. You may be able to manually downgrade electron and
-build a new release of jbrowse using steps like this
-
-```
-git clone git@github.com:GMOD/jbrowse-components
-cd jbrowse-components
-yarn
-cd products/jbrowse-desktop
-// change electronVersion in package.json to 34.0.1->33.2.0
-yarn build-electron:linux
-```


### PR DESCRIPTION
This greatly improves the intuition of the slider

Currently the slider is on a 'logarithmic scale' but has no indicators of what zoom level you will end up at

This adds a tooltip while dragging that helps you see the target window size

![image](https://github.com/user-attachments/assets/1baef518-f003-49a0-a473-3a753ccbc91f)
