### PR TITLE
v3.3.0 release announcement

### DIFF
--- a/website/docs/user_guides/multiquantitative_track.md
+++ b/website/docs/user_guides/multiquantitative_track.md
@@ -5,10 +5,10 @@ title: Multi-quantitative tracks
 
 import Figure from '../figure'
 
-In 2.1.0, we created the ability to have "Multi-quantitative tracks" which is a
-single track composed of multiple quantitative stopTokens, which have their
-Y-scalebar synchronized. There are 5 rendering modes for the multi-quantitative
-tracks.
+JBrowse can show "Multi-quantitative tracks" which is a single track composed of
+multiple quantitative signals, which have their Y-scalebar synchronized.
+
+There are 5 rendering modes for the multi-quantitative tracks.
 
 - xyplot
 - multirowxyplot

--- a/website/docs/user_guides/multivariant_track.md
+++ b/website/docs/user_guides/multivariant_track.md
@@ -1,0 +1,45 @@
+---
+id: multivariant_track
+title: Multi-sample variant displays
+---
+
+import Figure from '../figure'
+
+VCF files frequently contain information on multiple samples. JBrowse 2 added
+the ability to show the data from multiple samples using a custom Variant track
+"display type"
+
+There are two different display types:
+
+1. "Multi-sample variant display (matrix)"
+2. "Multi-sample variant display (normal)"
+
+## Normal mode - optimized for showing all types of variants, including structural variants
+
+In the normal mode, each variant is drawn at it's proper genomic location, and
+produces multiple rows for each sample.
+
+Notably, the normal mode is actually capable of showing structural variants, and
+if there are overlaps, it will draw each one over the other. There is a slight
+transparency, so you can distinguish small overlaps. If there are cases where
+there are too many overlaps, you can add filters to try to hide larger variants,
+or filter specific variants by name, using jexl via the "Edit filters" track
+menu item
+
+## Matrix mode - optimized for showing patterns of diversity, focused on small variants and SNPs
+
+In the matrix mode, each variant in the visible region is drawn into a 'matrix'
+where each row is a sample and each column is a variant.
+
+In this case, the variants are not actually rendered at their exact genomic
+position, however a black line is drawn to connect the columns of the matrix to
+their variant position
+
+The matrix mode is ideal to 'densify' the sparse patterns of variation. For
+example, if there was one SNP per 1,000bp on a given genome, and you were zoomed
+out to a large genomic region of 100,000bp, then you may only see 100 variants,
+and each one would be very thin e.g. 1px in the "Multi-sample variant display
+(normal)"
+
+However, with the matrix mode, each variant would occupy e.g.
+your_screen_width/100 which for a 2000px wide screen is a nice 20px

--- a/website/release_announcement_drafts/v3.3.0.md
+++ b/website/release_announcement_drafts/v3.3.0.md
@@ -1,14 +1,10 @@
 This release adds a significant update to the multi-variant renderer that allows
-it to be used for visualizing structural variants
+it to be used for visualizing structural variants Previously, all variants >10bp
+were filtered out, with the idea that overlapping variants are too difficult to
+interpret
 
-Previously, all variants >10bp were filtered out, with the idea that overlapping
-variants are too difficult to interpret
-
-This PR now just displays overlapping variants, but does not specifically draw
-the reference allele, which allows it to highlight the alternate structural
-variant alleles, and can display complex SV VCFs in the "Multi-variant
-(regular)" display type.
-
-Note: The "Multi-variant (matrix)" display type is not suited for this SV VCF
-rendering as it takes every variant and just gives it a single column in the
-matrix.
+This PR now allows drawing large structural variants in the multi-sample variant
+display type. One compromise is that it specifically does not draw the reference
+allele using grey, but instead paints the entire background as grey, and only
+highlights non-reference variation. This is capable of displaying complex
+overlapping structural multi-sample VCF

--- a/website/release_announcement_drafts/v3.3.0.md
+++ b/website/release_announcement_drafts/v3.3.0.md
@@ -4,7 +4,16 @@ were filtered out, with the idea that overlapping variants are too difficult to
 interpret
 
 This PR now allows drawing large structural variants in the multi-sample variant
-display type. One compromise is that it specifically does not draw the reference
-allele using grey, but instead paints the entire background as grey, and only
-highlights non-reference variation. This is capable of displaying complex
-overlapping structural multi-sample VCF
+display type. It will actually draw long, even overlapping, structural variants!
+
+![image](https://github.com/user-attachments/assets/80010297-fc5b-4575-8c71-54d038a81575)
+
+Figure: Screenshot showing many SV calls over a 5Mbp+ region from the 3,202
+human samples from the 1000 genomes project, with a large "inversion" variant
+showing the shaded triangles. The right side panel shows the feature details for
+this inversion variant showing the new genotype frequency panel, indicating
+about 47% of samples have a 'heterozygous' inversion call here
+
+We hope that you enjoy these new features! The visualizations may be visually
+complex but we hope it can be a magnifying glass to see the true complexity of
+your datasets! Feel free to let us know if you have any feedback

--- a/website/release_announcement_drafts/v3.3.0.md
+++ b/website/release_announcement_drafts/v3.3.0.md
@@ -1,0 +1,14 @@
+This release adds a significant update to the multi-variant renderer that allows
+it to be used for visualizing structural variants
+
+Previously, all variants >10bp were filtered out, with the idea that overlapping
+variants are too difficult to interpret
+
+This PR now just displays overlapping variants, but does not specifically draw
+the reference allele, which allows it to highlight the alternate structural
+variant alleles, and can display complex SV VCFs in the "Multi-variant
+(regular)" display type.
+
+Note: The "Multi-variant (matrix)" display type is not suited for this SV VCF
+rendering as it takes every variant and just gives it a single column in the
+matrix.


### PR DESCRIPTION
This release significantly helps showing structural variants in the multi-sample SV display

## Unreleased (2025-04-11)

#### :rocket: Enhancement
* Other
  * [#4931](https://github.com/GMOD/jbrowse-components/pull/4931) Show target zoom level in tooltip on slider ([@cmdcolin](https://github.com/cmdcolin))
  * [#4930](https://github.com/GMOD/jbrowse-components/pull/4930) Upload last release build to https://jbrowse.org/code/jb2/latest ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4922](https://github.com/GMOD/jbrowse-components/pull/4922) Add Multi-variant SV display ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* Other
  * [#4929](https://github.com/GMOD/jbrowse-components/pull/4929) Fix broken bigbed features when there is gene level aggregation ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4923](https://github.com/GMOD/jbrowse-components/pull/4923) Fix dark stock theme showing bad colors ([@cmdcolin](https://github.com/cmdcolin))

#### :memo: Documentation

* Other
  * [#4925](https://github.com/GMOD/jbrowse-components/pull/4925) Update docs with phased VCF tutorial ([@cmdcolin](https://github.com/cmdcolin))
* `core`
  * [#4924](https://github.com/GMOD/jbrowse-components/pull/4924) Add config docs for pre-processors with simplified config snapshots ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* `core`
  * [#4926](https://github.com/GMOD/jbrowse-components/pull/4926) Skip running hydration for server side rendering ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 1
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 1.54s.
