### PR TITLE
Add 'genotype' column to the Variant sample grid

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { Checkbox, FormControlLabel, Typography } from '@mui/material'
-import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { DataGrid } from '@mui/x-data-grid'
 import { makeStyles } from 'tss-react/mui'
 
 import FieldName from './FieldName'
@@ -88,16 +88,7 @@ export default function DataGridDetails({
             rowHeight={20}
             columnHeaderHeight={35}
             hideFooter={rows.length < 25}
-            slots={{
-              toolbar: checked ? GridToolbar : undefined,
-            }}
-            slotProps={{
-              toolbar: {
-                printOptions: {
-                  disableToolbarButton: true,
-                },
-              },
-            }}
+            showToolbar={checked}
             columns={colNames.map(
               (val, index) =>
                 ({

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { getEnv, measureGridWidth } from '@jbrowse/core/util'
-import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { DataGrid } from '@mui/x-data-grid'
 import { transaction } from 'mobx'
 import { observer } from 'mobx-react'
 import { getRoot, resolveIdentifier } from 'mobx-state-tree'
@@ -36,7 +36,10 @@ const FacetedDataGrid = observer(function ({
     name:
       measureGridWidth(
         rows.map(r => r.name),
-        { maxWidth: 500, stripHTML: true },
+        {
+          maxWidth: 500,
+          stripHTML: true,
+        },
       ) + 15,
     ...Object.fromEntries(
       filteredNonMetadataKeys
@@ -45,7 +48,10 @@ const FacetedDataGrid = observer(function ({
           e,
           measureGridWidth(
             rows.map(r => r[e as keyof typeof r] as string),
-            { maxWidth: 400, stripHTML: true },
+            {
+              maxWidth: 400,
+              stripHTML: true,
+            },
           ),
         ]),
     ),
@@ -57,7 +63,10 @@ const FacetedDataGrid = observer(function ({
             `metadata.${e}`,
             measureGridWidth(
               rows.map(r => r.metadata[e]),
-              { maxWidth: 400, stripHTML: true },
+              {
+                maxWidth: 400,
+                stripHTML: true,
+              },
             ),
           ]
         }),
@@ -66,21 +75,23 @@ const FacetedDataGrid = observer(function ({
 
   return (
     <DataGrid
+      rowHeight={25}
+      columnHeaderHeight={35}
+      checkboxSelection
+      disableRowSelectionOnClick
+      keepNonExistentRowsSelected
       rows={filteredRows}
+      columnVisibilityModel={visible}
+      showToolbar={showOptions}
       onColumnWidthChange={arg => {
         setWidths({
           ...widths,
           [arg.colDef.field]: arg.width,
         })
       }}
-      columnVisibilityModel={visible}
       onColumnVisibilityModelChange={n => {
         model.faceted.setVisible(n)
       }}
-      columnHeaderHeight={35}
-      checkboxSelection
-      disableRowSelectionOnClick
-      keepNonExistentRowsSelected
       onRowSelectionModelChange={userSelectedIds => {
         if (!useShoppingCart) {
           const a1 = shownTrackIds
@@ -112,21 +123,13 @@ const FacetedDataGrid = observer(function ({
           useShoppingCart ? selection.map(s => s.trackId) : [...shownTrackIds],
         ),
       }}
-      slots={{
-        toolbar: showOptions ? GridToolbar : undefined,
-      }}
-      slotProps={{
-        toolbar: {
-          printOptions: {
-            disableToolbarButton: true,
-          },
-        },
-      }}
-      columns={columns.map(r => ({
-        ...r,
-        width: widths[r.field],
-      }))}
-      rowHeight={25}
+      columns={columns.map(
+        r =>
+          ({
+            ...r,
+            width: widths[r.field],
+          }) satisfies GridColDef<(typeof rows)[0]>,
+      )}
     />
   )
 })

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
@@ -1,4 +1,4 @@
-import { DataGrid, GridToolbar, useGridApiRef } from '@mui/x-data-grid'
+import { DataGrid, useGridApiRef } from '@mui/x-data-grid'
 import { observer } from 'mobx-react'
 
 import type { SpreadsheetModel } from '../SpreadsheetModel'
@@ -31,14 +31,12 @@ const SpreadsheetDataGrid = observer(function ({
       }}
       rowHeight={25}
       hideFooter={rows.length < 100}
-      slots={{
-        toolbar: GridToolbar,
-      }}
       slotProps={{
         toolbar: {
           showQuickFilter: true,
         },
       }}
+      showToolbar
       rows={rows}
       columns={dataGridColumns}
     />

--- a/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
+++ b/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
@@ -1,11 +1,10 @@
 import { useMemo, useRef } from 'react'
 
 import { PrerenderedCanvas } from '@jbrowse/core/ui'
-import { getBpDisplayStr } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 import RBush from 'rbush'
 
-import { getMinimalDesc } from '../../VcfFeature/util'
+import { makeSimpleAltString } from '../../VcfFeature/util'
 
 import type { Source } from '../../shared/types'
 import type { Feature } from '@jbrowse/core/util'
@@ -81,18 +80,11 @@ const MultiVariantRendering = observer(function (props: {
       const ret = featureGenotypeMap[featureId]
       if (ret) {
         const { ref, alt } = ret
+        const alleles = makeSimpleAltString(genotype, ref, alt)
         return {
           ...rest,
-          alleles: genotype
-            .split(/[/|]/)
-            .map(r =>
-              r === '.'
-                ? '.'
-                : +r === 0
-                  ? `ref(${ref.length < 10 ? ref : getBpDisplayStr(ref.length)})`
-                  : getMinimalDesc(ref, alt[+r - 1] || ''),
-            )
-            .join(genotype.includes('|') ? '|' : '/'),
+          GT: genotype,
+          ...(genotype === alleles ? {} : { alleles }),
         }
       }
     }

--- a/plugins/variants/src/MultiLinearVariantRenderer/components/util.ts
+++ b/plugins/variants/src/MultiLinearVariantRenderer/components/util.ts
@@ -1,0 +1,13 @@
+export function minElt<T>(arr: Iterable<T>, cb: (arg: T) => number) {
+  let min = Infinity
+  let minElement: T | undefined
+  for (const entry of arr) {
+    const val = cb(entry)
+
+    if (val < min) {
+      min = val
+      minElement = entry
+    }
+  }
+  return minElement
+}

--- a/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
+++ b/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
@@ -24,6 +24,7 @@ export async function makeImageData(
     renderingMode,
     stopToken,
     lengthCutoffFilter,
+    forceReferenceMouseover,
   } = props
   const region = regions[0]!
 
@@ -58,7 +59,10 @@ export async function makeImageData(
           const isPhased = genotype.includes('|')
           if (isPhased) {
             const alleles = genotype.split('|')
-            if (drawPhased(alleles, ctx, x, y, w, h, HP!, undefined, false)) {
+            if (
+              drawPhased(alleles, ctx, x, y, w, h, HP!, undefined, false) ||
+              forceReferenceMouseover
+            ) {
               rbush.insert({
                 minX: x,
                 maxX: x + w,
@@ -97,7 +101,8 @@ export async function makeImageData(
               feature.get('type'),
               feature.get('strand'),
               0.75,
-            )
+            ) ||
+            forceReferenceMouseover
           ) {
             rbush.insert({
               minX: x,
@@ -123,6 +128,8 @@ export async function makeImageData(
         {
           alt: feature.get('ALT'),
           ref: feature.get('REF'),
+          name: feature.get('name'),
+          description: feature.get('description'),
         },
       ]),
     ),

--- a/plugins/variants/src/VariantFeatureWidget/VariantConsequenceDataGridWrapper.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantConsequenceDataGridWrapper.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import { measureGridWidth } from '@jbrowse/core/util'
 import { Checkbox, FormControlLabel, Typography } from '@mui/material'
-import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { DataGrid } from '@mui/x-data-grid'
 
 import type { GridColDef, GridValidRowModel } from '@mui/x-data-grid'
 
@@ -19,6 +19,7 @@ export default function VariantConsequenceDataGridWrapper({
   return rows.length ? (
     <div>
       <FormControlLabel
+        label={<Typography variant="body2">Show options</Typography>}
         control={
           <Checkbox
             checked={checked}
@@ -27,20 +28,20 @@ export default function VariantConsequenceDataGridWrapper({
             }}
           />
         }
-        label={<Typography variant="body2">Show options</Typography>}
       />
 
       <DataGrid
         rowHeight={25}
         hideFooter={rows.length < 100}
         rows={rows}
-        columns={columns.map((c, i) => ({
-          ...c,
-          width: widths[i],
-        }))}
-        slots={{
-          toolbar: checked ? GridToolbar : undefined,
-        }}
+        showToolbar={checked}
+        columns={columns.map(
+          (c, i) =>
+            ({
+              ...c,
+              width: widths[i],
+            }) satisfies GridColDef<(typeof rows)[0]>,
+        )}
       />
     </div>
   ) : null

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
@@ -4,6 +4,7 @@ import BaseCard from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/BaseCard
 import { measureGridWidth } from '@jbrowse/core/util'
 import { Checkbox, FormControlLabel, Typography } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
+import { makeStyles } from 'tss-react/mui'
 
 import SampleFilters from './VariantSampleFilters'
 import { makeSimpleAltString } from '../../VcfFeature/util'
@@ -17,7 +18,7 @@ interface Entry {
   [key: string]: string
 }
 
-type InfoFields = Record<string, unknown>
+type InfoFields = Record<string, unknown[]>
 type Filters = Record<string, string>
 
 interface FormatRecord {
@@ -27,18 +28,17 @@ interface Descriptions {
   FORMAT?: Record<string, FormatRecord>
 }
 
+const useStyles = makeStyles()({
+  flexContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+})
+
 // https://mui.com/x/react-data-grid/layout/#flex-parent-container
 function FlexContainer({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      {children}
-    </div>
-  )
+  const { classes } = useStyles()
+  return <div className={classes.flexContainer}>{children}</div>
 }
 
 export default function VariantSamples(props: {
@@ -55,7 +55,7 @@ export default function VariantSamples(props: {
       key,
       {
         ...val,
-        genotype: makeSimpleAltString(val.GT?.[0] || '', REF, ALT),
+        genotype: makeSimpleAltString(`${val.GT?.[0]}`, REF, ALT),
       },
     ] as const
   })

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
@@ -3,11 +3,13 @@ import { useState } from 'react'
 import BaseCard from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/BaseCard'
 import { measureGridWidth } from '@jbrowse/core/util'
 import { Checkbox, FormControlLabel, Typography } from '@mui/material'
-import { DataGrid, GridToolbar } from '@mui/x-data-grid'
+import { DataGrid } from '@mui/x-data-grid'
 
 import SampleFilters from './VariantSampleFilters'
+import { makeSimpleAltString } from '../../VcfFeature/util'
 
 import type { SimpleFeatureSerialized } from '@jbrowse/core/util'
+import type { GridColDef } from '@mui/x-data-grid'
 
 interface Entry {
   sample: string
@@ -25,6 +27,20 @@ interface Descriptions {
   FORMAT?: Record<string, FormatRecord>
 }
 
+// https://mui.com/x/react-data-grid/layout/#flex-parent-container
+function FlexContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
 export default function VariantSamples(props: {
   feature: SimpleFeatureSerialized
   descriptions?: Descriptions | null
@@ -32,7 +48,17 @@ export default function VariantSamples(props: {
   const { feature, descriptions = {} } = props
   const [filter, setFilter] = useState<Filters>({})
   const samples = (feature.samples || {}) as Record<string, InfoFields>
-  const preFilteredRows = Object.entries(samples)
+  const ALT = feature.ALT as string[]
+  const REF = feature.REF as string
+  const preFilteredRows = Object.entries(samples).map(([key, val]) => {
+    return [
+      key,
+      {
+        ...val,
+        genotype: makeSimpleAltString(val.GT?.[0] || '', REF, ALT),
+      },
+    ] as const
+  })
 
   let error: unknown
   let rows = [] as Entry[]
@@ -43,13 +69,16 @@ export default function VariantSamples(props: {
   // sortable by the data-grid
   try {
     rows = preFilteredRows
-      .map(row => {
+      .map(([key, val]) => {
         return {
           ...Object.fromEntries(
-            Object.entries(row[1]).map(e => [e[0], `${e[1]}`]),
+            Object.entries(val).map(([formatField, formatValue]) => [
+              formatField,
+              formatValue,
+            ]),
           ),
-          sample: row[0],
-          id: row[0],
+          sample: key,
+          id: key,
         } as Entry
       })
       .filter(row =>
@@ -63,17 +92,21 @@ export default function VariantSamples(props: {
           : true,
       )
   } catch (e) {
+    console.error(e)
     error = e
   }
 
   const [checked, setChecked] = useState(false)
   const keys = ['sample', ...Object.keys(preFilteredRows[0]?.[1] || {})]
   const widths = keys.map(e => measureGridWidth(rows.map(r => r[e])))
-  const columns = keys.map((field, index) => ({
-    field,
-    description: descriptions?.FORMAT?.[field]?.Description,
-    width: widths[index],
-  }))
+  const columns = keys.map(
+    (field, index) =>
+      ({
+        field,
+        description: descriptions?.FORMAT?.[field]?.Description,
+        width: widths[index],
+      }) satisfies GridColDef<(typeof rows)[0]>,
+  )
 
   // disableRowSelectionOnClick helps avoid
   // https://github.com/mui-org/material-ui-x/issues/1197
@@ -99,12 +132,7 @@ export default function VariantSamples(props: {
         />
       ) : null}
 
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
+      <FlexContainer>
         <DataGrid
           rows={rows}
           hideFooter={rows.length < 100}
@@ -112,17 +140,9 @@ export default function VariantSamples(props: {
           disableRowSelectionOnClick
           rowHeight={25}
           columnHeaderHeight={35}
-          disableColumnMenu
-          slots={{ toolbar: checked ? GridToolbar : undefined }}
-          slotProps={{
-            toolbar: {
-              printOptions: {
-                disableToolbarButton: true,
-              },
-            },
-          }}
+          showToolbar={checked}
         />
-      </div>
+      </FlexContainer>
     </BaseCard>
   )
 }

--- a/plugins/variants/src/VcfFeature/util.ts
+++ b/plugins/variants/src/VcfFeature/util.ts
@@ -213,3 +213,20 @@ export function getMinimalDesc(ref: string, alt: string) {
 function makeDescriptionString(soTerm: string, ref: string, alt: string) {
   return `${soTerm} ${[ref, alt].join(' -> ')}`
 }
+
+export function makeSimpleAltString(
+  genotype: string,
+  ref: string,
+  alt: string[],
+) {
+  return genotype
+    .split(/[/|]/)
+    .map(r =>
+      r === '.'
+        ? '.'
+        : +r === 0
+          ? `ref(${ref.length < 10 ? ref : getBpDisplayStr(ref.length)})`
+          : getMinimalDesc(ref, alt[+r - 1] || ''),
+    )
+    .join(genotype.includes('|') ? '|' : '/')
+}

--- a/plugins/variants/src/shared/MultiVariantBaseModel.tsx
+++ b/plugins/variants/src/shared/MultiVariantBaseModel.tsx
@@ -91,6 +91,10 @@ export default function MultiVariantBaseModelF(
          * #property
          */
         jexlFilters: types.maybe(types.array(types.string)),
+        /**
+         * #property
+         */
+        forceReferenceMouseover: false,
       }),
     )
     .volatile(() => ({
@@ -217,6 +221,12 @@ export default function MultiVariantBaseModelF(
         if (!deepEqual(arg, self.sampleInfo)) {
           self.sampleInfo = arg
         }
+      },
+      /**
+       * #action
+       */
+      setForceReferenceMouseover(arg: boolean) {
+        self.forceReferenceMouseover = arg
       },
     }))
     .views(self => ({
@@ -370,6 +380,14 @@ export default function MultiVariantBaseModelF(
               ],
             },
             {
+              label: 'Force reference mouseover',
+              type: 'checkbox',
+              checked: self.forceReferenceMouseover,
+              onClick: () => {
+                self.setForceReferenceMouseover(!self.forceReferenceMouseover)
+              },
+            },
+            {
               label: 'Filter by',
               icon: FilterListIcon,
               subMenu: [
@@ -429,6 +447,9 @@ export default function MultiVariantBaseModelF(
       }
     })
     .views(self => ({
+      /**
+       * #getter
+       */
       get canDisplayLabels() {
         return self.rowHeight >= 8 && self.showSidebarLabelsSetting
       },
@@ -446,6 +467,9 @@ export default function MultiVariantBaseModelF(
       },
     }))
     .views(self => ({
+      /**
+       * #method
+       */
       renderProps() {
         const superProps = self.adapterProps()
         return {
@@ -459,6 +483,7 @@ export default function MultiVariantBaseModelF(
           rowHeight: self.rowHeight,
           sources: self.sources,
           scrollTop: self.scrollTop,
+          forceReferenceMouseover: self.forceReferenceMouseover,
           filters: new SerializableFilterChain({
             filters: self.activeFilters,
           }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,9 +1690,9 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -1760,24 +1760,24 @@
     plist "^3.1.0"
 
 "@emnapi/core@^1.1.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.1.tgz#1841d87508c70d9f3008da52a4a50579e03e5728"
-  integrity sha512-4JFstCTaToCFrPqrGzgkF8N2NHjtsaY4uRh6brZQ5L9e4wbMieX8oDT8N7qfVFTQecHFEtkj4ve49VIZ3mKVqw==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"
+  integrity sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==
   dependencies:
-    "@emnapi/wasi-threads" "1.0.1"
+    "@emnapi/wasi-threads" "1.0.2"
     tslib "^2.4.0"
 
 "@emnapi/runtime@^1.1.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.4.1.tgz#79e54e3cc7f1955b3080f6e1e0e111e06114e114"
-  integrity sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.4.3.tgz#c0564665c80dc81c448adac23f9dfbed6c838f7d"
+  integrity sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/wasi-threads@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz#d7ae71fd2166b1c916c6cd2d0df2ef565a2e1a5b"
-  integrity sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==
+"@emnapi/wasi-threads@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz#977f44f844eac7d6c138a415a123818c655f874c"
+  integrity sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==
   dependencies:
     tslib "^2.4.0"
 


### PR DESCRIPTION
Follow up to #4944  which added a stringified version of the genotype to the mouseover of the multi-variant view (so instead of just 1/0 it can say T/ref(C) for example)

This adds a column to the variant datagrid for this too