### PR TITLE
Add genotype frequency table to variant feature details

### DIFF
--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail/DataGridDetails.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from 'tss-react/mui'
 
 import FieldName from './FieldName'
 import { SanitizedHTML } from '../../ui'
+import DataGridFlexContainer from '../../ui/DataGridFlexContainer'
 import { getStr, measureGridWidth } from '../../util'
 
 import type { GridColDef } from '@mui/x-data-grid'
@@ -81,9 +82,8 @@ export default function DataGridDetails({
           }
           label={<Typography variant="body2">Show options</Typography>}
         />
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <DataGridFlexContainer>
           <DataGrid
-            disableRowSelectionOnClick
             rows={rows}
             rowHeight={20}
             columnHeaderHeight={35}
@@ -93,19 +93,16 @@ export default function DataGridDetails({
               (val, index) =>
                 ({
                   field: val,
-                  renderCell: params => {
-                    const value = params.value as string
-                    return (
-                      <div className={classes.cell}>
-                        <SanitizedHTML html={getStr(value || '')} />
-                      </div>
-                    )
-                  },
                   width: widths[index],
+                  renderCell: ({ value }) => (
+                    <div className={classes.cell}>
+                      <SanitizedHTML html={getStr(value || '')} />
+                    </div>
+                  ),
                 }) satisfies GridColDef<(typeof rows)[0]>,
             )}
           />
-        </div>
+        </DataGridFlexContainer>
       </div>
     )
   }

--- a/packages/core/ui/DataGridFlexContainer.tsx
+++ b/packages/core/ui/DataGridFlexContainer.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles()({
 })
 
 // https://mui.com/x/react-data-grid/layout/#flex-parent-container
-export default function FlexContainer({
+export default function DataGridFlexContainer({
   children,
 }: {
   children: React.ReactNode

--- a/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
@@ -1,4 +1,5 @@
 import { readConfObject } from '@jbrowse/core/configuration'
+import DataGridFlexContainer from '@jbrowse/core/ui/DataGridFlexContainer'
 import AddIcon from '@mui/icons-material/Add'
 import CreateIcon from '@mui/icons-material/Create'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -23,7 +24,7 @@ const AssemblyTable = observer(function ({
   return (
     <>
       <DialogContent>
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <DataGridFlexContainer>
           <DataGrid
             rowHeight={25}
             columnHeaderHeight={35}
@@ -80,7 +81,7 @@ const AssemblyTable = observer(function ({
               },
             ]}
           />
-        </div>
+        </DataGridFlexContainer>
       </DialogContent>
       <DialogActions>
         <Button

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
@@ -78,7 +78,6 @@ const FacetedDataGrid = observer(function ({
       rowHeight={25}
       columnHeaderHeight={35}
       checkboxSelection
-      disableRowSelectionOnClick
       keepNonExistentRowsSelected
       rows={filteredRows}
       columnVisibilityModel={visible}

--- a/plugins/dotplot-view/src/DotplotView/components/WarningDialog.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/WarningDialog.tsx
@@ -80,7 +80,6 @@ const WarningDialog = observer(function WarningDialog({
           <DataGrid
             rows={rows}
             columns={columns}
-            disableRowSelectionOnClick
             rowHeight={25}
             disableColumnMenu
           />

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
@@ -1,4 +1,5 @@
 import ColorPicker from '@jbrowse/core/ui/ColorPicker'
+import DataGridFlexContainer from '@jbrowse/core/ui/DataGridFlexContainer'
 import {
   assembleLocString,
   getSession,
@@ -13,6 +14,7 @@ import { makeStyles } from 'tss-react/mui'
 import { navToBookmark } from '../utils'
 
 import type { GridBookmarkModel } from '../model'
+import type { GridColDef } from '@mui/x-data-grid'
 
 const useStyles = makeStyles()(() => ({
   cell: {
@@ -68,7 +70,7 @@ const BookmarkGrid = observer(function ({
   ]
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <DataGridFlexContainer>
       <DataGrid
         density="compact"
         rows={rows}
@@ -76,7 +78,7 @@ const BookmarkGrid = observer(function ({
           {
             ...GRID_CHECKBOX_SELECTION_COL_DEF,
             width: widths[0],
-          },
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'locString',
             headerName: 'Bookmark link',
@@ -94,18 +96,18 @@ const BookmarkGrid = observer(function ({
                 {value}
               </Link>
             ),
-          },
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'label',
             headerName: 'Label',
             width: widths[2],
             editable: true,
-          },
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'assemblyName',
             headerName: 'Assembly',
             width: widths[3],
-          },
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'highlight',
             headerName: 'Highlight',
@@ -118,7 +120,7 @@ const BookmarkGrid = observer(function ({
                 }}
               />
             ),
-          },
+          } satisfies GridColDef<(typeof rows)[0]>,
         ]}
         processRowUpdate={row => {
           const target = rows[row.id]!
@@ -142,9 +144,8 @@ const BookmarkGrid = observer(function ({
           type: 'include',
           ids: new Set(selectedBookmarks.map(r => r.id)),
         }}
-        disableRowSelectionOnClick
       />
-    </div>
+    </DataGridFlexContainer>
   )
 })
 

--- a/plugins/menus/src/SessionManager/components/SessionManager.tsx
+++ b/plugins/menus/src/SessionManager/components/SessionManager.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import DataGridFlexContainer from '@jbrowse/core/ui/DataGridFlexContainer'
 import { measureGridWidth, useLocalStorage } from '@jbrowse/core/util'
 import DeleteIcon from '@mui/icons-material/Delete'
 import StarIcon from '@mui/icons-material/Star'
@@ -18,6 +19,7 @@ import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
 import type { SessionModel } from './util'
+import type { GridColDef } from '@mui/x-data-grid'
 
 const useStyles = makeStyles()(theme => ({
   mb: {
@@ -83,9 +85,8 @@ const SessionManager = observer(function ({
         </Button>
       </div>
       {rows ? (
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <DataGridFlexContainer>
           <DataGrid
-            disableRowSelectionOnClick
             columnHeaderHeight={35}
             rowHeight={25}
             hideFooter={rows.length < 100}
@@ -100,90 +101,81 @@ const SessionManager = observer(function ({
                 field: 'fav',
                 headerName: 'Fav',
                 width: 20,
-                renderCell: ({ row }) => {
-                  return (
-                    <IconButton
-                      onClick={() => {
-                        if (row.fav) {
-                          // @ts-expect-error
-                          session.unfavoriteSavedSession(row.id)
-                        } else {
-                          // @ts-expect-error
-                          session.favoriteSavedSession(row.id)
-                        }
-                      }}
-                    >
-                      {row.fav ? <StarIcon /> : <StarBorderIcon />}
-                    </IconButton>
-                  )
-                },
-              },
-
+                renderCell: ({ row }) => (
+                  <IconButton
+                    onClick={() => {
+                      if (row.fav) {
+                        // @ts-expect-error
+                        session.unfavoriteSavedSession(row.id)
+                      } else {
+                        // @ts-expect-error
+                        session.favoriteSavedSession(row.id)
+                      }
+                    }}
+                  >
+                    {row.fav ? <StarIcon /> : <StarBorderIcon />}
+                  </IconButton>
+                ),
+              } satisfies GridColDef<(typeof rows)[0]>,
               {
                 field: 'name',
                 headerName: 'Name',
                 editable: true,
                 width: measureGridWidth(rows.map(r => r.name)),
-                renderCell: ({ row }) => {
-                  return (
-                    <>
-                      <Link
-                        href="#"
-                        onClick={event => {
-                          event.preventDefault()
-                          session.activateSession(row.id)
-                        }}
-                      >
-                        {row.name}
-                      </Link>
-                      {session.id === row.id ? ' (current)' : ''}
-                    </>
-                  )
-                },
-              },
+                renderCell: ({ row }) => (
+                  <>
+                    <Link
+                      href="#"
+                      onClick={event => {
+                        event.preventDefault()
+                        session.activateSession(row.id)
+                      }}
+                    >
+                      {row.name}
+                    </Link>
+                    {session.id === row.id ? ' (current)' : ''}
+                  </>
+                ),
+              } satisfies GridColDef<(typeof rows)[0]>,
               {
                 headerName: 'Created at',
                 field: 'createdAt',
-                renderCell: ({ row }) => {
-                  return (
-                    <Tooltip
-                      disableInteractive
-                      slotProps={{
-                        transition: {
-                          timeout: 0,
-                        },
-                      }}
-                      title={row.createdAt.toLocaleString()}
-                    >
-                      <div>
-                        {formatDistanceToNow(row.createdAt, {
-                          addSuffix: true,
-                        })}
-                      </div>
-                    </Tooltip>
-                  )
-                },
-              },
+                renderCell: ({ row }) => (
+                  <Tooltip
+                    disableInteractive
+                    slotProps={{
+                      transition: {
+                        timeout: 0,
+                      },
+                    }}
+                    title={row.createdAt.toLocaleString()}
+                  >
+                    <div>
+                      {formatDistanceToNow(row.createdAt, {
+                        addSuffix: true,
+                      })}
+                    </div>
+                  </Tooltip>
+                ),
+              } satisfies GridColDef<(typeof rows)[0]>,
               {
                 field: 'delete',
                 width: 10,
                 headerName: 'Delete',
-                renderCell: ({ row }) => {
-                  return (
-                    <IconButton
-                      onClick={() => {
-                        // @ts-expect-error
-                        session.deleteSavedSession(row.id)
-                      }}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  )
-                },
-              },
+                renderCell: ({ row }) => (
+                  <IconButton
+                    onClick={() => {
+                      // @ts-expect-error
+                      session.deleteSavedSession(row.id)
+                    }}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                ),
+              } satisfies GridColDef<(typeof rows)[0]>,
             ]}
           />
-        </div>
+        </DataGridFlexContainer>
       ) : (
         <div>No sessions loaded</div>
       )}

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
@@ -14,7 +14,6 @@ const SpreadsheetDataGrid = observer(function ({
     <DataGrid
       apiRef={apiRef}
       checkboxSelection
-      disableRowSelectionOnClick
       columnHeaderHeight={35}
       columnVisibilityModel={visibleColumns}
       onFilterModelChange={() => {

--- a/plugins/variants/src/MultiLinearVariantRenderer/MultiVariantRenderer.ts
+++ b/plugins/variants/src/MultiLinearVariantRenderer/MultiVariantRenderer.ts
@@ -9,7 +9,7 @@ export default class MultiVariantBaseRenderer extends FeatureRendererType {
 
   async render(renderProps: MultiRenderArgsDeserialized) {
     const features = await this.getFeatures(renderProps)
-    const { height, regions, bpPerPx } = renderProps
+    const { height, referenceDrawingMode, regions, bpPerPx } = renderProps
     const region = regions[0]!
     const width = (region.end - region.start) / bpPerPx
 
@@ -20,8 +20,10 @@ export default class MultiVariantBaseRenderer extends FeatureRendererType {
       height,
       renderProps,
       ctx => {
-        ctx.fillStyle = '#ccc'
-        ctx.fillRect(0, 0, width, height)
+        if (referenceDrawingMode === 'skip') {
+          ctx.fillStyle = '#ccc'
+          ctx.fillRect(0, 0, width, height)
+        }
         return makeImageData(ctx, {
           ...renderProps,
           features,

--- a/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
+++ b/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react'
 
 import { PrerenderedCanvas } from '@jbrowse/core/ui'
+import { getBpDisplayStr } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 import RBush from 'rbush'
 
@@ -27,6 +28,7 @@ interface MinimizedVariantRecord {
   ref: string
   name: string
   description: string
+  length: number
 }
 
 const MultiVariantRendering = observer(function (props: {
@@ -72,7 +74,7 @@ const MultiVariantRendering = observer(function (props: {
       )!
       const ret = featureGenotypeMap[featureId]
       if (ret) {
-        const { ref, alt, name, description } = ret
+        const { ref, alt, name, description, length } = ret
         const alleles = makeSimpleAltString(genotype, ref, alt)
         return {
           ...rest,
@@ -88,6 +90,7 @@ const MultiVariantRendering = observer(function (props: {
           // since descriptions are a join of ALT allele descriptions, just
           // skip this in this case
           description: alt.length >= 3 ? 'multiple ALT alleles' : description,
+          length: getBpDisplayStr(length),
         }
       }
     }

--- a/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
+++ b/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
@@ -24,7 +24,7 @@ export async function makeImageData(
     renderingMode,
     stopToken,
     lengthCutoffFilter,
-    forceReferenceMouseover,
+    referenceDrawingMode,
   } = props
   const region = regions[0]!
 
@@ -60,8 +60,17 @@ export async function makeImageData(
           if (isPhased) {
             const alleles = genotype.split('|')
             if (
-              drawPhased(alleles, ctx, x, y, w, h, HP!, undefined, false) ||
-              forceReferenceMouseover
+              drawPhased(
+                alleles,
+                ctx,
+                x,
+                y,
+                w,
+                h,
+                HP!,
+                undefined,
+                referenceDrawingMode === 'draw',
+              )
             ) {
               rbush.insert({
                 minX: x,
@@ -97,12 +106,11 @@ export async function makeImageData(
               w,
               h,
               mostFrequentAlt,
-              false,
+              referenceDrawingMode === 'draw',
               feature.get('type'),
               feature.get('strand'),
               0.75,
-            ) ||
-            forceReferenceMouseover
+            )
           ) {
             rbush.insert({
               minX: x,

--- a/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
+++ b/plugins/variants/src/MultiLinearVariantRenderer/makeImageData.ts
@@ -138,6 +138,7 @@ export async function makeImageData(
           ref: feature.get('REF'),
           name: feature.get('name'),
           description: feature.get('description'),
+          length: feature.get('end') - feature.get('start'),
         },
       ]),
     ),

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/FlexContainer.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/FlexContainer.tsx
@@ -1,0 +1,18 @@
+import { makeStyles } from 'tss-react/mui'
+
+const useStyles = makeStyles()({
+  flexContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+})
+
+// https://mui.com/x/react-data-grid/layout/#flex-parent-container
+export default function FlexContainer({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { classes } = useStyles()
+  return <div className={classes.flexContainer}>{children}</div>
+}

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantGenotypeFrequencyTable.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantGenotypeFrequencyTable.tsx
@@ -1,0 +1,59 @@
+import { ErrorMessage } from '@jbrowse/core/ui'
+import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
+import { measureGridWidth } from '@jbrowse/core/util'
+import { DataGrid } from '@mui/x-data-grid'
+
+import FlexContainer from './FlexContainer'
+
+import type { FrequencyTable } from './types'
+
+const toP = (s = 0) => +(+s).toFixed(2)
+
+export default function VariantGenotypeFrequencyTable({
+  summary,
+  totalRows,
+}: {
+  summary: FrequencyTable
+  totalRows: number
+}) {
+  const rows = Object.entries(summary).map(([key, val]) => ({
+    id: key,
+    GT: val.GT,
+    genotype: val.genotype,
+    count: `${val.count} / ${totalRows}`,
+    frequency: `${toP(val.count / totalRows)}%`,
+  }))
+  const keys = ['GT', 'count', 'frequency', 'genotype']
+  const widths = keys.map(e =>
+    measureGridWidth(rows.map(r => `${r[e as keyof typeof r]}`)),
+  )
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorMessage}>
+      <FlexContainer>
+        <DataGrid
+          rows={rows}
+          hideFooter
+          columns={[
+            { field: 'GT', width: widths[0] },
+            {
+              field: 'count',
+              width: widths[1],
+            },
+            {
+              field: 'frequency',
+              width: widths[2],
+            },
+            {
+              field: 'genotype',
+              width: widths[3],
+            },
+          ]}
+          disableRowSelectionOnClick
+          rowHeight={25}
+          columnHeaderHeight={35}
+        />
+      </FlexContainer>
+    </ErrorBoundary>
+  )
+}

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/types.ts
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/types.ts
@@ -1,0 +1,7 @@
+export interface FrequencyTableEntry {
+  count: number
+  GT: string
+  genotype: string | undefined
+}
+
+export type FrequencyTable = Record<string, FrequencyTableEntry>

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/types.ts
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/types.ts
@@ -5,3 +5,20 @@ export interface FrequencyTableEntry {
 }
 
 export type FrequencyTable = Record<string, FrequencyTableEntry>
+
+export interface VariantSampleGridRow {
+  sample: string
+  id: string
+  GT: string
+  [key: string]: string
+}
+
+export type InfoFields = Record<string, unknown[]>
+export type Filters = Record<string, string>
+
+interface FormatRecord {
+  Description?: string
+}
+export interface VariantFieldDescriptions {
+  FORMAT?: Record<string, FormatRecord>
+}

--- a/plugins/variants/src/shared/MultiVariantBaseModel.tsx
+++ b/plugins/variants/src/shared/MultiVariantBaseModel.tsx
@@ -82,6 +82,7 @@ export default function MultiVariantBaseModelF(
          * used only if autoHeight is false
          */
         autoHeight: true,
+
         /**
          * #property
          */
@@ -91,10 +92,11 @@ export default function MultiVariantBaseModelF(
          * #property
          */
         jexlFilters: types.maybe(types.array(types.string)),
+
         /**
          * #property
          */
-        forceReferenceMouseover: false,
+        referenceDrawingMode: 'skip',
       }),
     )
     .volatile(() => ({
@@ -225,8 +227,8 @@ export default function MultiVariantBaseModelF(
       /**
        * #action
        */
-      setForceReferenceMouseover(arg: boolean) {
-        self.forceReferenceMouseover = arg
+      setReferenceDrawingMode(arg: string) {
+        self.referenceDrawingMode = arg
       },
     }))
     .views(self => ({
@@ -380,12 +382,28 @@ export default function MultiVariantBaseModelF(
               ],
             },
             {
-              label: 'Force reference mouseover',
-              type: 'checkbox',
-              checked: self.forceReferenceMouseover,
-              onClick: () => {
-                self.setForceReferenceMouseover(!self.forceReferenceMouseover)
-              },
+              label: 'Reference mode',
+              type: 'subMenu',
+              subMenu: [
+                {
+                  label:
+                    'Fill background grey, skip reference allele mouseovers (helps with large overlapping SVs)',
+                  type: 'radio',
+                  checked: self.referenceDrawingMode === 'skip',
+                  onClick: () => {
+                    self.setReferenceDrawingMode('skip')
+                  },
+                },
+                {
+                  label:
+                    "Don't fill background grey, only draw actual reference alleles as grey",
+                  type: 'radio',
+                  checked: self.referenceDrawingMode === 'draw',
+                  onClick: () => {
+                    self.setReferenceDrawingMode('draw')
+                  },
+                },
+              ],
             },
             {
               label: 'Filter by',
@@ -483,7 +501,7 @@ export default function MultiVariantBaseModelF(
           rowHeight: self.rowHeight,
           sources: self.sources,
           scrollTop: self.scrollTop,
-          forceReferenceMouseover: self.forceReferenceMouseover,
+          referenceDrawingMode: self.referenceDrawingMode,
           filters: new SerializableFilterChain({
             filters: self.activeFilters,
           }),

--- a/plugins/variants/src/shared/components/SourcesDataGrid.tsx
+++ b/plugins/variants/src/shared/components/SourcesDataGrid.tsx
@@ -50,7 +50,6 @@ export default function SourcesDataGrid({
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         checkboxSelection
-        disableRowSelectionOnClick
         onRowSelectionModelChange={arg => {
           setSelected([...arg.ids])
         }}

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/SourcesGrid.tsx
@@ -116,7 +116,6 @@ function SourcesGrid({
         <DataGrid
           getRowId={row => row.name}
           checkboxSelection
-          disableRowSelectionOnClick
           onRowSelectionModelChange={arg => {
             setSelected([...arg.ids])
           }}

--- a/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/RecentSessionList.tsx
@@ -9,6 +9,7 @@ import { loadPluginManager } from './util'
 
 import type { RecentSessionData } from './util'
 import type PluginManager from '@jbrowse/core/PluginManager'
+import type { GridColDef } from '@mui/x-data-grid'
 
 const useStyles = makeStyles()({
   cell: {
@@ -90,7 +91,6 @@ export default function RecentSessionsList({
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         checkboxSelection
-        disableRowSelectionOnClick
         onRowSelectionModelChange={args => {
           setSelectedSessions(sessions.filter(s => args.ids.has(s.path)))
         }}
@@ -105,68 +105,60 @@ export default function RecentSessionsList({
             sortable: false,
             filterable: false,
             headerName: ' ',
-            renderCell: params => {
-              return (
-                <IconButton
-                  onClick={() => {
-                    const { lastModified, ...rest } = params.row
-                    setSessionToRename({
-                      ...rest,
-                    })
-                  }}
-                >
-                  <Tooltip title="Rename session">
-                    <EditIcon />
-                  </Tooltip>
-                </IconButton>
-              )
-            },
-          },
+            renderCell: params => (
+              <IconButton
+                onClick={() => {
+                  const { lastModified, ...rest } = params.row
+                  setSessionToRename({
+                    ...rest,
+                  })
+                }}
+              >
+                <Tooltip title="Rename session">
+                  <EditIcon />
+                </Tooltip>
+              </IconButton>
+            ),
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'name',
             headerName: 'Session name',
             width: widths.name,
-            renderCell: params => {
-              const { value } = params
-              return (
-                <Link
-                  href="#"
-                  className={classes.cell}
-                  onClick={async event => {
-                    event.preventDefault()
-                    try {
-                      setPluginManager(await loadPluginManager(params.row.path))
-                    } catch (e) {
-                      console.error(e)
-                      setError(e)
-                    }
-                  }}
-                >
-                  {value as string}
-                </Link>
-              )
-            },
-          },
+            renderCell: ({ value, row }) => (
+              <Link
+                href="#"
+                className={classes.cell}
+                onClick={async event => {
+                  event.preventDefault()
+                  try {
+                    setPluginManager(await loadPluginManager(row.path))
+                  } catch (e) {
+                    console.error(e)
+                    setError(e)
+                  }
+                }}
+              >
+                {value as string}
+              </Link>
+            ),
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'path',
             headerName: 'Session path',
             width: widths.path,
-            renderCell: params => {
-              const { value } = params
-              return (
-                <Tooltip title={String(value)}>
-                  <div className={classes.cell}>{value as string}</div>
-                </Tooltip>
-              )
-            },
-          },
+            renderCell: ({ value }) => (
+              <Tooltip title={String(value)}>
+                <div className={classes.cell}>{value as string}</div>
+              </Tooltip>
+            ),
+          } satisfies GridColDef<(typeof rows)[0]>,
           {
             field: 'lastModified',
             headerName: 'Last modified',
-            renderCell: row =>
-              !row.value ? null : <DateSinceLastUsed row={row.row} />,
             width: widths.lastModified,
-          },
+            renderCell: ({ value, row }) =>
+              !value ? null : <DateSinceLastUsed row={row} />,
+          } satisfies GridColDef<(typeof rows)[0]>,
         ]}
       />
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,9 +2014,9 @@
   integrity sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.1":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz#bfe67b3d334a8579a35e48fe240dc0638d1bcd91"
-  integrity sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz#e4c58fdcf0696e7a5f19c30201ed43123ab15abc"
+  integrity sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
@@ -6411,9 +6411,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001688:
-  version "1.0.30001713"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz#6b33a8857e6c7dcb41a0caa2dd0f0489c823a52d"
-  integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
+  version "1.0.30001714"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz#cfd27ff07e6fa20a0f45c7a10d28a0ffeaba2122"
+  integrity sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==
 
 canvas-sequencer@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This frequency table can be used for simple cases of showing the frequency of different genotypes

![image](https://github.com/user-attachments/assets/f15edc89-2b0a-4f67-8c2f-6685b48b39c8)


Includes an 'allele count' mode which can be helpful with polyploid as the you want more of a 'dosage' calculation instead of raw genotype string matching