### PR TITLE
Fix theme augmentation for primary/secondary colors in v3.3.0

### DIFF
--- a/packages/core/ui/theme.ts
+++ b/packages/core/ui/theme.ts
@@ -460,14 +460,22 @@ export function createJBrowseTheme(
 // augments them to have light and dark variants but not for anything else, so
 // we augment them here
 function augmentThemeColors(theme: ThemeOptions = {}) {
-  for (const entry of ['tertiary', 'quaternary', 'highlight'] as const) {
+  for (const entry of [
+    'primary',
+    'secondary',
+    'tertiary',
+    'quaternary',
+    'highlight',
+  ] as const) {
     if (theme.palette?.[entry]) {
       theme = deepmerge(theme, {
         palette: {
           [entry]: refTheme.palette.augmentColor(
             'color' in theme.palette[entry]
               ? (theme.palette[entry] as PaletteAugmentColorOptions)
-              : { color: theme.palette[entry] },
+              : {
+                  color: theme.palette[entry],
+                },
           ),
         },
       })


### PR DESCRIPTION
Fix #4966

Our view titles uniquely used the dark variants of the secondary color, which if customized by the user, didn't get, apparently, automatically augmented with the dark variant under mui v7

This forces user customized primary+secondary to get augmentations