### PR TITLE
Avoid aggregating bigbed features with geneName === 'none'

### DIFF
--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -163,7 +163,8 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
       })
 
       const aggr = data[aggregateField]
-      if (!parentAggregation[aggr]) {
+      const aggrIsNotNone = aggr && aggr !== 'none'
+      if (aggrIsNotNone && !parentAggregation[aggr]) {
         parentAggregation[aggr] = []
       }
       const {
@@ -194,8 +195,8 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
         end: feat.end,
         refName: query.refName,
       })
-      if (aggr) {
-        parentAggregation[aggr].push(f)
+      if (aggrIsNotNone) {
+        parentAggregation[aggr]!.push(f)
         parentAggregationFlat.push(f)
       } else {
         if (

--- a/plugins/bed/src/BigBedAdapter/configSchema.ts
+++ b/plugins/bed/src/BigBedAdapter/configSchema.ts
@@ -34,7 +34,7 @@ const BigBedAdapter = ConfigurationSchema(
     aggregateField: {
       type: 'string',
       description: 'An attribute to aggregate features with',
-      defaultValue: 'geneName2',
+      defaultValue: 'geneName',
     },
   },
   {

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -5190,6 +5190,19 @@
         "uri": "https://jbrowse.org/genomes/GRCh38/variants_GRCh38_sv_inv_sym_HGSVC2024v1.0_add_END_to_INFO.vcf"
       },
       "assemblyNames": ["hg38"]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "gencodeV47lift37",
+      "name": "gencodeV47lift37",
+      "adapter": {
+        "type": "BigBedAdapter",
+        "bigBedLocation": {
+          "uri": "https://hgdownload.soe.ucsc.edu/gbdb/hg19/gencode/gencodeV47lift37.bb",
+          "locationType": "UriLocation"
+        }
+      },
+      "assemblyNames": ["hg19"]
     }
   ],
   "connections": [],


### PR DESCRIPTION
This improves the creation of gene level glyphs for certain bigbed files that have geneName==='none'

It also changes the aggregation field from geneName2 to geneName. I think they are generally functionally the same, with maybe one being a identifier and one being a symbol sometimes...