### PR TITLE
Add basic cytoband for Drosophila

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Cytobands.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Cytobands.tsx
@@ -30,7 +30,7 @@ function leftRoundedRect(
   return `M${x + radius},${y}h${width - radius}v${height}h${radius - width}a${radius},${radius} 0 0 1 ${-radius},${-radius}v${2 * radius - height}a${radius},${radius} 0 0 1 ${radius},${-radius}z`
 }
 
-function leftTriangle(x: number, y: number, width: number, height: number) {
+function leftTriangle(x: number, _y: number, width: number, height: number) {
   return [
     [x, 0],
     [x + width, height / 2],
@@ -38,7 +38,7 @@ function leftTriangle(x: number, y: number, width: number, height: number) {
   ].toString()
 }
 
-function rightTriangle(x: number, y: number, width: number, height: number) {
+function rightTriangle(x: number, _y: number, width: number, height: number) {
   return [
     [x, height / 2],
     [x + width, 0],
@@ -73,16 +73,32 @@ const Cytobands = observer(function ({
 
   const h = HEADER_OVERVIEW_HEIGHT
   let centromereSeen = false
+  let curr = ''
+  let idx = 0
   return (
     <g transform={`translate(-${offsetPx})`}>
       {cytobands.map((args, index) => {
         const k = JSON.stringify(args)
-        const { refName, type, start, end } = args
+        const { refName, name, type, start, end } = args
         const s = overview.bpToPx({ refName, coord: start }) || 0
         const e = overview.bpToPx({ refName, coord: end }) || 0
         const l = Math.min(s, e)
         const w = Math.abs(e - s)
-        const c = colorMap[type] || 'black'
+        if (type === 'n/a') {
+          const match = name?.match(/^(\d+)([A-Za-z])/)
+          const ret = match[1] + match[2]
+          if (ret && ret !== curr) {
+            curr = ret
+            idx++
+          }
+        }
+        const c =
+          type === 'n/a'
+            ? idx % 2
+              ? 'black'
+              : '#a77'
+            : colorMap[type] || 'black'
+
         if (type === 'acen' && !centromereSeen) {
           centromereSeen = true // the next acen entry is drawn with different right triangle
           return (

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberband.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberband.tsx
@@ -19,12 +19,6 @@ const useStyles = makeStyles()({
     width: '100%',
     minHeight: 8,
   },
-  guide: {
-    pointerEvents: 'none',
-    height: '100%',
-    width: 1,
-    position: 'absolute',
-  },
   rel: {
     position: 'relative',
   },

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberbandHoverTooltip.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberbandHoverTooltip.tsx
@@ -9,19 +9,11 @@ import type { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 type LGV = LinearGenomeViewModel
 
 const useStyles = makeStyles()({
-  rubberbandControl: {
-    cursor: 'crosshair',
-    width: '100%',
-    minHeight: 8,
-  },
   guide: {
     pointerEvents: 'none',
     height: '100%',
     width: 1,
     position: 'absolute',
-  },
-  rel: {
-    position: 'relative',
   },
 })
 
@@ -53,7 +45,9 @@ const OverviewRubberbandHoverTooltip = observer(function ({
     <Tooltip
       open={open}
       placement="top"
-      title={[stringify(px), cytoband?.get('name')].join(' ')}
+      title={[stringify(px), cytoband?.get('name'), cytoband?.get('type')].join(
+        ' ',
+      )}
       arrow
     >
       <div className={classes.guide} style={{ left: guideX }} />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -73,6 +73,7 @@ export function getCytobands(assembly: Assembly | undefined, refName: string) {
         start: f.get('start'),
         end: f.get('end'),
         type: f.get('gieStain') as string,
+        name: f.get('name'),
       }))
       .filter(f => f.refName === refName) || []
   )


### PR DESCRIPTION
I looked at drosophila in UCSC and saw they have some cytoband rendering

![image](https://github.com/user-attachments/assets/fef17cbc-b75d-4d9f-97b2-cbfe33fe1e7c)


The cytoband data file however is tricky because because instead of any actual "staining" information, it just says 'n/a' and the color appears to flip flops are from parsing the 'name' which looks like 89B18. The coloring flip flops when the prefix, which includes the starting number+letter, changes

Added in jbrowse

![image](https://github.com/user-attachments/assets/ad2a4efa-2806-422b-8881-8c92a5d7d317)


what it looks like without this PR

![image](https://github.com/user-attachments/assets/ded4c8bf-360c-484f-9cca-946e3d42aab2)
