### PR TITLE
Fix `addToExtensionPoint` example in docs

### DIFF
--- a/website/docs/developer_guides/extension_points.md
+++ b/website/docs/developer_guides/extension_points.md
@@ -23,13 +23,19 @@ const ret = pluginManager.evaluateExtensionPoint('ExtensionPointName', {
 And consumers can say:
 
 ```typescript
-pluginManager.addToExtensionPoint('ExtensionPointName', arg => {
-  return arg.value + 1
-})
+pluginManager.addToExtensionPoint(
+  'ExtensionPointName',
+  (arg: { value: number }) => {
+    return { value: arg.value + 1 }
+  },
+)
 
-pluginManager.addToExtensionPoint('ExtensionPointName', arg => {
-  return arg.value + 1
-})
+pluginManager.addToExtensionPoint(
+  'ExtensionPointName',
+  (arg: { value: number }) => {
+    return { value: arg.value + 1 }
+  },
+)
 ```
 
 In this case, `arg` that is passed in evaluateExtensionPoint calls all the


### PR DESCRIPTION
The first extension point example in the docs didn't work because the extension point didn't return a value that was the same type as its input (input was an object, returned a number).

The fixed version adds types to the `arg` so that typescript ensures that the input and return are the same type. If a more minimal example is desired, the following also works, but typescript complains about being unable to determine types.

```js
pluginManager.addToExtensionPoint('ExtensionPointName', (arg) => {
  return { value: arg.value + 1 }
})

pluginManager.addToExtensionPoint('ExtensionPointName', (arg) => {
  return { value: arg.value + 1 }
})
```