### PR TITLE
Synthesize displayId if none provided in display config

### DIFF
--- a/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
+++ b/packages/core/pluggableElementTypes/models/baseTrackConfig.ts
@@ -155,7 +155,7 @@ export function createBaseTrackConfig(pluginManager: PluginManager) {
           trackId: string
           name: string
           type: string
-          displays: { type: string; displayId: string }[]
+          displays: { type: string; displayId?: string }[]
         }
         const { displays = [] } = snap
         if (snap.trackId !== 'placeholderId') {
@@ -172,7 +172,14 @@ export function createBaseTrackConfig(pluginManager: PluginManager) {
             }
           }
         }
-        return { ...snap, displays }
+        return {
+          ...snap,
+          displays: displays.map(d => ({
+            ...d,
+            // synthesize displayId if none provided
+            displayId: d.displayId ?? `${snap.trackId}-${d.type}`,
+          })),
+        }
       },
       /**
        * #identifier

--- a/test_data/volvox/config_spec.json
+++ b/test_data/volvox/config_spec.json
@@ -79,6 +79,21 @@
   },
   "tracks": [
     {
+      "type": "VariantTrack",
+      "trackId": "volvox_test_vcf",
+      "name": "volvox 1000genomes vcf",
+      "assemblyNames": ["volvox"],
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "uri": "volvox.test.vcf.gz"
+      },
+      "displays": [
+        {
+          "type": "LinearVariantMatrixDisplay"
+        }
+      ]
+    },
+    {
       "type": "AlignmentsTrack",
       "trackId": "volvox_cram_alignments_ctga",
       "name": "volvox-sorted.cram (ctgA, default display)",


### PR DESCRIPTION
It has commonly been a piece of advice for people customizing jbrowse that they have to manually supply a displayId

This PR automatically adds a displayId with the format `trackId+displayType` so that this is no longer strictly necessary

## Follow up thoughts


It may have been the case that allowing user specified displayId should not even be possible...instead, the displayId should be automatically inferred as e.g. trackID+displayType

This would have allowed displayId to allows be inferred in every case in the UI, without collision or confusion as to what the displayId is

Unfortunately, it would be possibly breaking to try to impose this change at this 'stage in the game' because user customized displayId have been propagated now in various ways