### PR TITLE
Add sequence length to the searchbox/refnameautocomplete dropdown

### DIFF
--- a/packages/core/TextSearch/BaseResults.ts
+++ b/packages/core/TextSearch/BaseResults.ts
@@ -51,6 +51,7 @@ export default class BaseResult {
   locString?: string
 
   results?: BaseResult[]
+
   constructor(args: BaseResultArgs) {
     this.label = args.label
     this.locString = args.locString

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
@@ -3,7 +3,12 @@ import { useEffect, useState } from 'react'
 import BaseResult, {
   RefSequenceResult,
 } from '@jbrowse/core/TextSearch/BaseResults'
-import { getSession, measureText, useDebounce } from '@jbrowse/core/util'
+import {
+  getBpDisplayStr,
+  getSession,
+  measureText,
+  useDebounce,
+} from '@jbrowse/core/util'
 import { Autocomplete } from '@mui/material'
 import { observer } from 'mobx-react'
 
@@ -71,12 +76,13 @@ const RefNameAutocomplete = observer(function ({
 
   const inputBoxVal = coarseVisibleLocStrings || value || ''
 
-  const refNames = assembly?.refNames
+  const regions = assembly?.regions
   const regionOptions =
-    refNames?.map(refName => ({
+    regions?.map(region => ({
       result: new RefSequenceResult({
-        refName,
-        label: refName,
+        refName: region.refName,
+        label: region.refName,
+        displayString: `${region.refName} (${getBpDisplayStr(region.end - region.start)})`,
         matchedAttribute: 'refName',
       }),
     })) || []

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/util.ts
@@ -25,24 +25,28 @@ export async function fetchResults({
     console.warn('No text search manager')
   }
 
-  const textSearchResults = await textSearchManager?.search(
-    {
-      queryString,
-      searchType,
-    },
-    searchScope,
-    rankSearchResults,
-  )
+  const textSearchResults =
+    (await textSearchManager?.search(
+      {
+        queryString,
+        searchType,
+      },
+      searchScope,
+      rankSearchResults,
+    )) || []
 
-  const refNameResults = assembly?.allRefNames
-    ?.filter(ref => ref.toLowerCase().startsWith(queryString.toLowerCase()))
-    .slice(0, 10)
-    .map(r => new BaseResult({ label: r }))
+  const refNameResults =
+    assembly?.allRefNames
+      ?.filter(ref => ref.toLowerCase().startsWith(queryString.toLowerCase()))
+      .slice(0, 10)
+      .map(
+        r =>
+          new BaseResult({
+            label: r,
+          }),
+      ) || []
 
-  return dedupe(
-    [...(refNameResults || []), ...(textSearchResults || [])],
-    elt => elt.getId(),
-  )
+  return dedupe([...refNameResults, ...textSearchResults], elt => elt.getId())
 }
 
 // splits on the last instance of a character

--- a/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
+++ b/products/jbrowse-web/src/tests/BasicLinearGenomeView.test.tsx
@@ -159,7 +159,7 @@ test('test choose option from dropdown refName autocomplete', async () => {
   autocomplete.focus()
   fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
   fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
-  fireEvent.click((await screen.findAllByText('ctgB'))[0]!)
+  fireEvent.click((await screen.findAllByText(/ctgB/))[0]!)
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
 
   await waitFor(() => {


### PR DESCRIPTION
Not sure if this is great but for unknown genomes, this could be useful

![image](https://github.com/user-attachments/assets/9c9e41d1-bd41-4758-94ed-b995f86f4e23)


If we want to go farther down this route, people really like looking at little 'ideograms' of chromosomes also...could just mock them up based on chr length in some cases