### PR TITLE
Avoid rendering 'yellow' for low scores in wiggle density renderings with 'log-scale' enabled

### DIFF
--- a/plugins/wiggle/src/drawDensity.ts
+++ b/plugins/wiggle/src/drawDensity.ts
@@ -70,8 +70,13 @@ export function drawDensity(
     const score = feature.get('score')
     hasClipping = hasClipping || score > niceMax || score < niceMin
     const w = rightPx - leftPx + fudgeFactor
-    ctx.fillStyle = cb(feature, score)
-    ctx.fillRect(leftPx, 0, w, height)
+    if (score >= scaleOpts.domain[0]!) {
+      ctx.fillStyle = cb(feature, score)
+      ctx.fillRect(leftPx, 0, w, height)
+    } else {
+      ctx.fillStyle = '#eee'
+      ctx.fillRect(leftPx, 0, w, height)
+    }
   }
 
   // second pass: draw clipping


### PR DESCRIPTION
This is a bit of an odd issue with a couple of heuristics that are hard to explain properly but here is a list of contextual factors

- We have a "log scale" mode for jbrowse wiggle tracks
- The "log scale" mode can apply to both xy, line, and density renderings
- The d3 scales can create an implicit mapping to a "color range" like grey to blue or red to grey to blue
- The log transformation is applied by d3 scales, we never explicitly call Math.log in our own code
- We have a setting that says: if the minimum value is >0, and the maximum value is greater than 1, then just make the domain [1,maxvalue]
- This helps convince d3 to give a "nice" scale, because fractional values can give very large negative values, and so if you are looking at a coverage track, which has some small fractional values occasionally, but the important values are the positive ones, then we don't care about the negative values
- Conversely, if minimum value is >0, and maximum value is <0, then you might be looking at p-values, so then we allow you to plot the negative log values.


So, that is background to this issue

But basically, the issue is that because we force the domain minimum value to 1, but supply values below this occasionally, then d3 maps to [#eee,blue] (grey to blue) to an "out of domain" negative values, which ends up tending to yellow implicitly by their color scale calculation. This looks weird


so, before this PR, e.g. on main, looks like this for rna-seq coverage, with log scale enabled, density mode
![image](https://github.com/user-attachments/assets/9f66493e-2f4b-4c55-8528-ef57f479b320)

after this PR, with log scale enabled, density mode
![image](https://github.com/user-attachments/assets/7acc6c5f-4a2e-4986-9c26-a24d506df097)


