### PR TITLE
All-vs-all PAF adapter

### DIFF
--- a/packages/core/src/configuration/configurationSchema.ts
+++ b/packages/core/src/configuration/configurationSchema.ts
@@ -208,7 +208,6 @@ function makeConfigurationSchemaModel<
   completeModel = completeModel.postProcessSnapshot(snap => {
     const newSnap: SnapshotOut<typeof completeModel> = {}
     let matchesDefault = true
-    // let keyCount = 0
     for (const [key, value] of Object.entries(snap)) {
       if (matchesDefault) {
         if (typeof defaultSnap[key] === 'object' && typeof value === 'object') {
@@ -225,14 +224,10 @@ function makeConfigurationSchemaModel<
         !isEmptyObject(value) &&
         !isEmptyArray(value)
       ) {
-        // keyCount += 1
         newSnap[key] = value
       }
     }
-    if (matchesDefault) {
-      return {}
-    }
-    return newSnap
+    return matchesDefault ? {} : newSnap
   })
 
   if (options.preProcessSnapshot) {

--- a/plugins/comparative-adapters/src/AllVsAllPAFAdapter/AllVsAllPAFAdapter.ts
+++ b/plugins/comparative-adapters/src/AllVsAllPAFAdapter/AllVsAllPAFAdapter.ts
@@ -1,0 +1,176 @@
+import { readConfObject } from '@jbrowse/core/configuration'
+import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
+import { fetchAndMaybeUnzip } from '@jbrowse/core/util'
+import { openLocation } from '@jbrowse/core/util/io'
+import { doesIntersect2 } from '@jbrowse/core/util/range'
+import { ObservableCreate } from '@jbrowse/core/util/rxjs'
+import { MismatchParser } from '@jbrowse/plugin-alignments'
+
+import SyntenyFeature from '../SyntenyFeature'
+import {
+  flipCigar,
+  parseLineByLine,
+  parsePAFLine,
+  swapIndelCigar,
+} from '../util'
+import { getWeightedMeans } from './util'
+
+import type { PAFRecord } from './util'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
+import type { Feature } from '@jbrowse/core/util'
+import type { Region } from '@jbrowse/core/util/types'
+
+const { parseCigar } = MismatchParser
+
+interface PAFOptions extends BaseOptions {
+  config?: AnyConfigurationModel
+}
+
+export default class AllVsAllPAFAdapter extends BaseFeatureDataAdapter {
+  private setupP?: Promise<PAFRecord[]>
+
+  public static capabilities = ['getFeatures', 'getRefNames']
+
+  async setup(opts?: BaseOptions) {
+    if (!this.setupP) {
+      this.setupP = this.setupPre(opts).catch((e: unknown) => {
+        this.setupP = undefined
+        throw e
+      })
+    }
+    return this.setupP
+  }
+
+  async setupPre(opts?: BaseOptions) {
+    return parseLineByLine(
+      await fetchAndMaybeUnzip(
+        openLocation(this.getConf('pafLocation'), this.pluginManager),
+        opts,
+      ),
+      parsePAFLine,
+      opts,
+    )
+  }
+
+  async hasDataForRefName() {
+    // determining this properly is basically a call to getFeatures so is not
+    // really that important, and has to be true or else getFeatures is never
+    // called (BaseAdapter filters it out)
+    return true
+  }
+
+  getAssemblyNames() {
+    return this.getConf('assemblyNames') as string[]
+  }
+
+  async getRefNames(opts: BaseOptions = {}) {
+    // @ts-expect-error
+    const r1 = opts.regions?.[0].assemblyName
+    const feats = await this.setup(opts)
+
+    const idx = this.getAssemblyNames().indexOf(r1)
+    if (idx !== -1) {
+      const set = new Set<string>()
+      for (const feat of feats) {
+        set.add(idx === 0 ? feat.qname : feat.tname)
+      }
+      return [...set]
+    }
+    console.warn('Unable to do ref renaming on adapter')
+    return []
+  }
+
+  getFeatures(query: Region, opts: PAFOptions = {}) {
+    return ObservableCreate<Feature>(async observer => {
+      let pafRecords = await this.setup(opts)
+      const { config } = opts
+
+      // note: this is not the adapter config, it is responding to a display
+      // setting passed in via the opts parameter
+      if (config && readConfObject(config, 'colorBy') === 'meanQueryIdentity') {
+        pafRecords = getWeightedMeans(pafRecords)
+      }
+      const assemblyNames = this.getAssemblyNames()
+
+      // The index of the assembly name in the query list corresponds to the
+      // adapter in the subadapters list
+      const { start: qstart, end: qend, refName: qref, assemblyName } = query
+      const index = assemblyNames.indexOf(assemblyName)
+
+      // if the getFeatures::query is on the query assembly, flip orientation
+      // of data
+      const flip = index === 0
+      if (index === -1) {
+        console.warn(`${assemblyName} not found in this adapter`)
+        observer.complete()
+      }
+
+      // eslint-disable-next-line unicorn/no-for-loop
+      for (let i = 0; i < pafRecords.length; i++) {
+        const r = pafRecords[i]!
+        let start = 0
+        let end = 0
+        let refName = ''
+        let mateName = ''
+        let mateStart = 0
+        let mateEnd = 0
+
+        if (flip) {
+          start = r.qstart
+          end = r.qend
+          refName = r.qname
+          mateName = r.tname
+          mateStart = r.tstart
+          mateEnd = r.tend
+        } else {
+          start = r.tstart
+          end = r.tend
+          refName = r.tname
+          mateName = r.qname
+          mateStart = r.qstart
+          mateEnd = r.qend
+        }
+        const { extra, strand } = r
+        if (refName === qref && doesIntersect2(qstart, qend, start, end)) {
+          const { numMatches = 0, blockLen = 1, cg, ...rest } = extra
+
+          let CIGAR = extra.cg
+          if (extra.cg) {
+            if (flip && strand === -1) {
+              CIGAR = flipCigar(parseCigar(extra.cg)).join('')
+            } else if (flip) {
+              CIGAR = swapIndelCigar(extra.cg)
+            }
+          }
+
+          observer.next(
+            new SyntenyFeature({
+              uniqueId: i + assemblyName,
+              assemblyName,
+              start,
+              end,
+              type: 'match',
+              refName,
+              strand,
+              ...rest,
+              CIGAR,
+              syntenyId: i,
+              identity: numMatches / blockLen,
+              numMatches,
+              blockLen,
+              mate: {
+                start: mateStart,
+                end: mateEnd,
+                refName: mateName,
+                assemblyName: assemblyNames[+flip],
+              },
+            }),
+          )
+        }
+      }
+
+      observer.complete()
+    })
+  }
+}

--- a/plugins/comparative-adapters/src/AllVsAllPAFAdapter/configSchema.ts
+++ b/plugins/comparative-adapters/src/AllVsAllPAFAdapter/configSchema.ts
@@ -1,0 +1,61 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+/**
+ * #config AllVsAllPAFAdapter
+ */
+function x() {} // eslint-disable-line @typescript-eslint/no-unused-vars
+
+const AllVsAllPAFAdapter = ConfigurationSchema(
+  'AllVsAllPAFAdapter',
+  {
+    /**
+     * #slot
+     */
+    assemblyNames: {
+      type: 'stringArray',
+      defaultValue: [],
+      description:
+        'Array of assembly names to use for this file. The query assembly name is the first value in the array, target assembly name is the second',
+    },
+    /**
+     * #slot
+     * can be optionally gzipped
+     */
+    pafLocation: {
+      type: 'fileLocation',
+      defaultValue: {
+        uri: '/path/to/file.paf',
+        locationType: 'UriLocation',
+      },
+    },
+  },
+  {
+    explicitlyTyped: true,
+
+    /**
+     * #preProcessSnapshot
+     *
+     *
+     * preprocessor to allow minimal config:
+     * ```json
+     * {
+     *   "type": "AllVsAllPAFAdapter",
+     *   "uri": "file.paf.gz"
+     * }
+     * ```
+     */
+    preProcessSnapshot: snap => {
+      return snap.uri
+        ? {
+            ...snap,
+            pafLocation: {
+              uri: snap.uri,
+              baseUri: snap.baseUri,
+            },
+          }
+        : snap
+    },
+  },
+)
+
+export default AllVsAllPAFAdapter

--- a/plugins/comparative-adapters/src/AllVsAllPAFAdapter/index.ts
+++ b/plugins/comparative-adapters/src/AllVsAllPAFAdapter/index.ts
@@ -1,0 +1,21 @@
+import AdapterType from '@jbrowse/core/pluggableElementTypes/AdapterType'
+
+import configSchema from './configSchema'
+
+import type PluginManager from '@jbrowse/core/PluginManager'
+
+export default function AllVsAllPAFAdapterF(pluginManager: PluginManager) {
+  pluginManager.addAdapterType(
+    () =>
+      new AdapterType({
+        name: 'AllVsAllPAFAdapter',
+        displayName: 'AllVsAllPAF adapter',
+        configSchema,
+        adapterMetadata: {
+          category: 'Synteny adapters',
+        },
+        getAdapterClass: () =>
+          import('./AllVsAllPAFAdapter').then(r => r.default),
+      }),
+  )
+}

--- a/plugins/comparative-adapters/src/AllVsAllPAFAdapter/util.ts
+++ b/plugins/comparative-adapters/src/AllVsAllPAFAdapter/util.ts
@@ -1,0 +1,108 @@
+import { zip } from '../util'
+
+export interface PAFRecord {
+  qname: string
+  qstart: number
+  qend: number
+  tname: string
+  tstart: number
+  tend: number
+  strand: number
+  extra: {
+    cg?: string
+    blockLen?: number
+    mappingQual?: number
+    numMatches?: number
+    meanScore?: number
+  }
+}
+// based on "weighted mean" method from https://github.com/tpoorten/dotPlotly
+// License reproduced here
+//
+// MIT License
+
+// Copyright (c) 2017 Tom Poorten
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Notes: in the weighted mean longer alignments factor in more heavily of all
+// the fragments of a query vs the reference that it mapped to
+//
+// this uses a combined key query+'-'+ref to iteratively map all the alignments
+// that match a particular ref from a particular query (so 1d array of what
+// could be a 2d map)
+//
+// the result is a single number that says e.g. chr5 from human mapped to chr5
+// on mouse with 0.8 quality, and that0.8 is then attached to all the pieces of
+// chr5 on human that mapped to chr5 on mouse. if chr5 on human also more
+// weakly mapped to chr6 on mouse, then it would have another value e.g. 0.6.
+// this can show strong and weak levels of synteny, especially in polyploidy
+// situations
+
+export function getWeightedMeans(ret: PAFRecord[]) {
+  const scoreMap: Record<string, { quals: number[]; len: number[] }> = {}
+  for (const entry of ret) {
+    const query = entry.qname
+    const target = entry.tname
+    const key = `${query}-${target}`
+    if (!scoreMap[key]) {
+      scoreMap[key] = { quals: [], len: [] }
+    }
+    scoreMap[key].quals.push(entry.extra.mappingQual || 1)
+    scoreMap[key].len.push(entry.extra.blockLen || 1)
+  }
+
+  const meanScoreMap = Object.fromEntries(
+    Object.entries(scoreMap).map(([key, val]) => {
+      const vals = zip(val.quals, val.len)
+      return [key, weightedMean(vals)]
+    }),
+  )
+  for (const entry of ret) {
+    const query = entry.qname
+    const target = entry.tname
+    const key = `${query}-${target}`
+    entry.extra.meanScore = meanScoreMap[key]
+  }
+
+  let min = 10000
+  let max = 0
+  for (const entry of ret) {
+    min = Math.min(entry.extra.meanScore || 0, min)
+    max = Math.max(entry.extra.meanScore || 0, max)
+  }
+  for (const entry of ret) {
+    const b = entry.extra.meanScore || 0
+    entry.extra.meanScore = (b - min) / (max - min)
+  }
+
+  return ret
+}
+
+// https://gist.github.com/stekhn/a12ed417e91f90ecec14bcfa4c2ae16a
+function weightedMean(tuples: [number, number][]) {
+  const [valueSum, weightSum] = tuples.reduce(
+    ([valueSum, weightSum], [value, weight]) => [
+      valueSum + value * weight,
+      weightSum + weight,
+    ],
+    [0, 0],
+  )
+  return valueSum / weightSum
+}

--- a/plugins/comparative-adapters/src/index.ts
+++ b/plugins/comparative-adapters/src/index.ts
@@ -1,16 +1,17 @@
 import Plugin from '@jbrowse/core/Plugin'
 
-import BlastTabularAdapter from './BlastTabularAdapter/index.ts'
-import ChainAdapterF from './ChainAdapter/index.ts'
-import ComparativeAddTrackComponentF from './ComparativeAddTrackComponent/index.tsx'
-import DeltaAdapterF from './DeltaAdapter/index.ts'
-import GuessAdapterF from './GuessAdapter/index.ts'
-import MCScanAddTrackComponentF from './MCScanAddTrackComponent/index.tsx'
-import MCScanAnchorsAdapterF from './MCScanAnchorsAdapter/index.ts'
-import MCScanSimpleAnchorsAdapterF from './MCScanSimpleAnchorsAdapter/index.ts'
-import MashMapAdapterF from './MashMapAdapter/index.ts'
-import PAFAdapterF from './PAFAdapter/index.ts'
-import PairwiseIndexedPAFAdapterF from './PairwiseIndexedPAFAdapter/index.ts'
+import AllVsAllPAFAdapterF from './AllVsAllPAFAdapter'
+import BlastTabularAdapter from './BlastTabularAdapter'
+import ChainAdapterF from './ChainAdapter'
+import ComparativeAddTrackComponentF from './ComparativeAddTrackComponent'
+import DeltaAdapterF from './DeltaAdapter'
+import GuessAdapterF from './GuessAdapter'
+import MCScanAddTrackComponentF from './MCScanAddTrackComponent'
+import MCScanAnchorsAdapterF from './MCScanAnchorsAdapter'
+import MCScanSimpleAnchorsAdapterF from './MCScanSimpleAnchorsAdapter'
+import MashMapAdapterF from './MashMapAdapter'
+import PAFAdapterF from './PAFAdapter'
+import PairwiseIndexedPAFAdapterF from './PairwiseIndexedPAFAdapter'
 
 import type PluginManager from '@jbrowse/core/PluginManager'
 
@@ -19,6 +20,7 @@ export default class ComparativeAdaptersPlugin extends Plugin {
 
   install(pluginManager: PluginManager) {
     PAFAdapterF(pluginManager)
+    AllVsAllPAFAdapterF(pluginManager)
     PairwiseIndexedPAFAdapterF(pluginManager)
     DeltaAdapterF(pluginManager)
     ChainAdapterF(pluginManager)


### PR DESCRIPTION
This is an experimental stub for an "all vs all" PAF adapter. It is similar to the normal PAF adapter, except it assumes all refNames are prefixed with a assembly name

All-vs-all PAF can be produced by concatenating multiple genome assemblies into a single FASTA file, and running

```
minimap2 file.fa file.fa > out.paf
```

A command similar to the above is run by the PGGB workflow as a step (https://github.com/pangenome/pggb)

It is often advisable to include the assembly name in the FASTA file, so there is the PanSN spec that recommends prepending the assembly name (and haplotype number), example tool https://github.com/ekg/fastix


I ran this with about 14 different c.elegans assemblies and results look like this

![image](https://github.com/user-attachments/assets/6c2c40c5-0bbb-458f-a913-c7480ce520d2)


Potentially this type of workflow can be leveraged to produce multi-way synteny visualizations in a more intuitive way. Instead of a user having to configure A vs B and B vs C manually, it is just known that all comparisons exist, so it can be automatically prepared.

Not all situations have all vs all, but for those that do, this can work
