### PR TITLE
Add padding to the genomic window of search result hits

### DIFF
--- a/packages/core/ui/index.ts
+++ b/packages/core/ui/index.ts
@@ -13,5 +13,6 @@ export { default as Menu } from './Menu'
 export { default as PrerenderedCanvas } from './PrerenderedCanvas'
 export { default as ResizeHandle } from './ResizeHandle'
 export { default as SanitizedHTML } from './SanitizedHTML'
+export { default as BaseTooltip } from './BaseTooltip'
 export * from './Menu'
 export const VIEW_HEADER_HEIGHT = 28

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1471,7 +1471,11 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * @param optAssemblyName - (optional) the assembly name to use when
        * navigating to the locstring
        */
-      async navToLocString(input: string, optAssemblyName?: string) {
+      async navToLocString(
+        input: string,
+        optAssemblyName?: string,
+        grow?: number,
+      ) {
         const { assemblyNames } = self
         const { assemblyManager } = getSession(self)
         const assemblyName = optAssemblyName || assemblyNames[0]!
@@ -1484,6 +1488,7 @@ export function stateModelFactory(pluginManager: PluginManager) {
             assemblyManager.isValidRefName(ref, asm),
           ),
           assemblyName,
+          grow,
         )
       },
 
@@ -1516,8 +1521,9 @@ export function stateModelFactory(pluginManager: PluginManager) {
       async navToLocation(
         parsedLocString: ParsedLocString,
         assemblyName?: string,
+        grow?: number,
       ) {
-        return this.navToLocations([parsedLocString], assemblyName)
+        return this.navToLocations([parsedLocString], assemblyName, grow)
       },
 
       /**
@@ -1527,17 +1533,18 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * `setDisplayedRegions` if changing regions
        */
       async navToLocations(
-        parsedLocStrings: ParsedLocString[],
+        regions: ParsedLocString[],
         assemblyName?: string,
+        grow?: number,
       ) {
         const { assemblyManager } = getSession(self)
         await when(() => self.volatileWidth !== undefined)
-
-        const locations = await generateLocations(
-          parsedLocStrings,
+        const locations = await generateLocations({
+          regions,
           assemblyManager,
           assemblyName,
-        )
+          grow,
+        })
 
         if (locations.length === 1) {
           const loc = locations[0]!

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -92,11 +92,17 @@ export function makeTicks(
  *
  * Used by navToLocations and navToLocString
  */
-export async function generateLocations(
-  regions: ParsedLocString[],
-  assemblyManager: AssemblyManager,
-  assemblyName?: string,
-) {
+export async function generateLocations({
+  regions,
+  assemblyManager,
+  assemblyName,
+  grow,
+}: {
+  regions: ParsedLocString[]
+  assemblyManager: AssemblyManager
+  assemblyName?: string
+  grow?: number
+}) {
   return Promise.all(
     regions.map(async region => {
       const asmName = region.assemblyName || assemblyName
@@ -121,10 +127,23 @@ export async function generateLocations(
         throw new Error(`Could not find refName ${refName} in ${asmName}`)
       }
 
-      return {
-        ...(region as Omit<typeof region, symbol>),
-        assemblyName: asmName,
-        parentRegion,
+      const { start, end } = region
+      if (grow && start && end) {
+        const len = end - start
+        const margin = len * grow
+        return {
+          ...(region as Omit<typeof region, symbol>),
+          start: Math.max(0, start - margin),
+          end: end + margin,
+          assemblyName: asmName,
+          parentRegion,
+        }
+      } else {
+        return {
+          ...(region as Omit<typeof region, symbol>),
+          assemblyName: asmName,
+          parentRegion,
+        }
       }
     }),
   )

--- a/plugins/linear-genome-view/src/searchUtils.ts
+++ b/plugins/linear-genome-view/src/searchUtils.ts
@@ -19,7 +19,7 @@ export async function navToOption({
   const location = option.getLocation()
   const trackId = option.getTrackId()
   if (location) {
-    await model.navToLocString(location, assemblyName)
+    await model.navToLocString(location, assemblyName, 0.2)
     if (trackId) {
       model.showTrack(trackId)
     }

--- a/products/jbrowse-web/src/tests/TextSearching.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearching.test.tsx
@@ -9,7 +9,7 @@ beforeEach(() => {
   doBeforeEach()
 })
 
-const delay = { timeout: 30000 }
+const delay = { timeout: 30_000 }
 const opts = [{}, delay]
 
 async function doSetup(val?: unknown) {
@@ -19,12 +19,17 @@ async function doSetup(val?: unknown) {
   const autocomplete = await findByTestId('autocomplete', ...opts)
   const input = (await findByPlaceholderText(
     'Search for location',
+    ...opts,
   )) as HTMLInputElement
 
   autocomplete.focus()
   input.focus()
 
-  return { autocomplete, input, ...args }
+  return {
+    autocomplete,
+    input,
+    ...args,
+  }
 }
 
 test('single result, searching: eden.1', async () => {
@@ -32,9 +37,9 @@ test('single result, searching: eden.1', async () => {
   fireEvent.change(input, { target: { value: 'eden.1' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await waitFor(() => {
-    expect(input.value).toBe('ctgA:1,055..9,005')
+    expect(input.value).toBe('ctgA:1..10,590')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('dialog with multiple results, searching seg02', async () => {
   const { input, findByText, autocomplete } = await doSetup()
@@ -42,14 +47,14 @@ test('dialog with multiple results, searching seg02', async () => {
   fireEvent.change(input, { target: { value: 'seg02' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await findByText('Search results', ...opts)
-}, 30000)
+}, 30_000)
 
 test('dialog with multiple results with jb1 config, searching: eden.1', async () => {
   const { input, findByText, autocomplete } = await doSetup(jb1_config)
   fireEvent.change(input, { target: { value: 'eden.1' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await findByText('Search results', ...opts)
-}, 30000)
+}, 30_000)
 
 test('test navigation with the search input box, {volvox2}ctgB:1..200', async () => {
   const { view, input, autocomplete } = await doSetup()
@@ -59,7 +64,7 @@ test('test navigation with the search input box, {volvox2}ctgB:1..200', async ()
   await waitFor(() => {
     expect(view.displayedRegions[0]!.assemblyName).toEqual('volvox2')
   })
-}, 30000)
+}, 30_000)
 
 test('nav lower case refnames, searching: ctgb:1-100', async () => {
   const { view, input, autocomplete } = await doSetup()
@@ -69,7 +74,7 @@ test('nav lower case refnames, searching: ctgb:1-100', async () => {
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
-}, 30000)
+}, 30_000)
 
 test('nav lower case refnames, searching: ctgb', async () => {
   const { view, input, autocomplete } = await doSetup()
@@ -80,7 +85,7 @@ test('nav lower case refnames, searching: ctgb', async () => {
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
-}, 30000)
+}, 30_000)
 
 test('nav lower case refnames, searching: contigb:1-100', async () => {
   const { view, input, autocomplete } = await doSetup()
@@ -91,7 +96,7 @@ test('nav lower case refnames, searching: contigb:1-100', async () => {
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
-}, 30000)
+}, 30_000)
 
 test('description of gene, searching: kinase', async () => {
   const { input, findByText, autocomplete } = await doSetup()
@@ -100,9 +105,9 @@ test('description of gene, searching: kinase', async () => {
   fireEvent.click(await findByText('EDEN (protein kinase)', ...opts))
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await waitFor(() => {
-    expect(input.value).toBe('ctgA:1,055..9,005')
+    expect(input.value).toBe('ctgA:1..10,590')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('search matches description for feature in two places', async () => {
   const { input, findByText, autocomplete } = await doSetup()
@@ -111,4 +116,4 @@ test('search matches description for feature in two places', async () => {
   fireEvent.click(await findByText(/b101.2/, ...opts))
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await findByText('Search results', ...opts)
-}, 30000)
+}, 30_000)

--- a/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
@@ -24,7 +24,7 @@ test('search eden.1 and hit open', async () => {
   fireEvent.change(input, { target: { value: 'eden.1' } })
   fireEvent.click(await findByText('Open'))
   await waitFor(() => {
-    expect(getInputValue()).toBe('ctgA:1,055..9,005')
+    expect(getInputValue()).toBe('ctgA:1..10,590')
   }, delay)
 }, 30000)
 

--- a/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
@@ -8,69 +8,53 @@ beforeEach(() => {
   doBeforeEach()
 })
 
-const delay = { timeout: 30000 }
+const delay = { timeout: 30_000 }
 const opts = [{}, delay]
 
-test('search eden.1 and hit open', async () => {
-  const { findByPlaceholderText, findByText, getInputValue } =
-    await doSetupForImportForm()
+async function getInput() {
+  const rest = await doSetupForImportForm()
+  return {
+    ...rest,
+    input: (await rest.findByPlaceholderText(
+      'Search for location',
+      ...opts,
+    )) as HTMLInputElement,
+  }
+}
 
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
+test('search eden.1 and hit open', async () => {
+  const { input, findByText, getInputValue } = await getInput()
 
   fireEvent.change(input, { target: { value: 'eden.1' } })
   fireEvent.click(await findByText('Open'))
   await waitFor(() => {
     expect(getInputValue()).toBe('ctgA:1..10,590')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('dialog with multiple results, searching seg02', async () => {
-  const { autocomplete, findByPlaceholderText, findByText } =
-    await doSetupForImportForm()
-
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
+  const { autocomplete, input, findByText } = await getInput()
 
   fireEvent.change(input, { target: { value: 'seg02' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   fireEvent.click(await findByText('Open'))
   await findByText('Search results', ...opts)
-}, 30000)
+}, 30_000)
 
 test('search eden.1 and hit enter', async () => {
-  const { autocomplete, findByPlaceholderText, findByText, getInputValue } =
-    await doSetupForImportForm()
-
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
+  const { getInputValue, autocomplete, input, findByText } = await getInput()
 
   fireEvent.change(input, { target: { value: 'eden.1' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   fireEvent.click(await findByText('Open'))
   await waitFor(() => {
-    expect(getInputValue()).toBe('ctgA:1,055..9,005')
+    expect(getInputValue()).toBe('ctgA:1..10,590')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('lower case refname, searching: contigb', async () => {
-  const { autocomplete, findByPlaceholderText, findByText, getInputValue } =
-    await doSetupForImportForm()
+  const { getInputValue, autocomplete, input, findByText } = await getInput()
 
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
   fireEvent.change(input, { target: { value: 'contigb' } })
   fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
   fireEvent.keyDown(autocomplete, { key: 'Enter' })
@@ -80,39 +64,27 @@ test('lower case refname, searching: contigb', async () => {
   await waitFor(() => {
     expect(getInputValue()).toBe('ctgB:1..6,079')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('description of gene, searching: kinase', async () => {
-  const { findByPlaceholderText, findByText, getInputValue, autocomplete } =
-    await doSetupForImportForm()
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
+  const { getInputValue, autocomplete, input, findByText } = await getInput()
+
   fireEvent.change(input, { target: { value: 'kinase' } })
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
 
   fireEvent.click(await findByText('EDEN (protein kinase)', ...opts))
   fireEvent.click(await findByText('Open'))
   await waitFor(() => {
-    expect(getInputValue()).toBe('ctgA:1,055..9,005')
+    expect(getInputValue()).toBe('ctgA:1..10,590')
   }, delay)
-}, 30000)
+}, 30_000)
 
 test('search matches description for feature in two places', async () => {
-  const { autocomplete, findByPlaceholderText, findByText } =
-    await doSetupForImportForm()
-
-  const input = (await findByPlaceholderText(
-    'Search for location',
-    {},
-    { timeout: 10000 },
-  )) as HTMLInputElement
+  const { autocomplete, input, findByText } = await getInput()
 
   fireEvent.change(input, { target: { value: 'fingerprint' } })
   fireEvent.click(await findByText(/b101.2/, ...opts))
   fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   fireEvent.click(await findByText('Open'))
   await findByText('Search results', ...opts)
-}, 30000)
+}, 30_000)


### PR DESCRIPTION
Currently, when you search for a gene, it zooms you to the exact boundaries of the gene

It is a bit more 'comfortable' to zoom to the gene +/- a small window

This adds a default margin of "0.2*window_size" to both sides of a search result hit

JBrowse 1 has a similar behavior

