### PR TITLE
Improve website docs with grammarly suggestions

### DIFF
--- a/website/docs/config_guides/assemblies.md
+++ b/website/docs/config_guides/assemblies.md
@@ -6,10 +6,10 @@ title: Configuring assemblies
 An assembly configuration includes the "name" of your assembly, any "aliases"
 that might be associated with that assembly e.g. GRCh37 is sometimes seen as an
 alias for hg19, and then a "sequence" configuration containing a reference
-sequence track config. This is provides a special "track" that is outside the
+sequence track config. This provides a special "track" that is outside the
 normal track config.
 
-Here is a complete config.json file containing only an hg19 assembly:
+Here is a complete config.json file containing only the hg19 assembly:
 
 ```json
 {
@@ -193,20 +193,20 @@ Here is a complete config.json that has the hg19 genome loaded:
 }
 ```
 
-The top level config is an array of assemblies; each assembly contains:
+The top level config is an array of assemblies. Each assembly contains:
 
-- `name` - a name to refer to the assembly by. each track that is related to
+- `name` - a name to refer to the assembly by. Each track that is related to
   this assembly references this name
 - `aliases` - sometimes genome assemblies have aliases like hg19, GRCh37, b37p5,
   etc. while there may be small differences between these different sequences,
   they often largely have the same coordinates, so you might want to be able to
   associate tracks from these different assemblies together. The assembly
-  aliases are most helpful when loading from a UCSC trackHub which specifies the
-  genome assembly names it uses, so you can connect to a UCSC trackHub if your
-  assembly name or aliases match.
+  aliases are most helpful when loading from a UCSC trackHub, which specifies
+  the genome assembly names it uses, so you can connect to a UCSC trackHub if
+  your assembly name or aliases match.
 - `sequence` - this is a complete "track" definition for your genome assembly.
-  we specify that it is a track of type ReferenceSequenceTrack, give it a
-  trackId, and an adapter configuration. an adapter configuration can specify
+  We specify that it is a track of type ReferenceSequenceTrack, give it a
+  trackId, and an adapter configuration. An adapter configuration can specify
   IndexedFastaAdapter (fasta.fa and fasta.fai), BgzipFastaAdapter (fasta.fa.gz,
   fasta.fa.gz.fai, fasta.gz.gzi), ChromSizesAdapter (which fetches no sequences,
   just chromosome names)
@@ -311,7 +311,8 @@ section to either the IndexedFastaAdapter or BgzipFastaAdapter configuration.
 One option for the contents of this metadata is the FFRGS (Fair Formatted
 Reference Genome Standard) header specification for FASTA files can be found
 [here](https://github.com/FFRGS/FFRGS-Specification), however, just the raw
-plaintext is displayed for this file so the format is not strict.
+plaintext is displayed for this file, so the format is not strict from JBrowse's
+perspective.
 
 ```json
   "metadataLocation": {

--- a/website/docs/config_guides/customizing_feature_colors.md
+++ b/website/docs/config_guides/customizing_feature_colors.md
@@ -11,30 +11,23 @@ callback.
 For example, create a file named "myplugin.js" (see also Footnote 1)
 
 ```js
-// myplugin.js
-;(function () {
-  class MyPlugin {
-    install() {}
-    configure(pluginManager) {
-      pluginManager.jexl.addFunction('colorFeature', feature => {
-        let type = feature.get('type')
-        if (type === 'CDS') {
-          return 'red'
-        } else if (type === 'exon') {
-          return 'green'
-        } else {
-          return 'purple'
-        }
-      })
-    }
+export default class MyPlugin {
+  name = 'MyPlugin'
+  version = '1.0.0'
+  install() {}
+  configure(pluginManager) {
+    pluginManager.jexl.addFunction('colorFeature', feature => {
+      let type = feature.get('type')
+      if (type === 'CDS') {
+        return 'red'
+      } else if (type === 'exon') {
+        return 'green'
+      } else {
+        return 'purple'
+      }
+    })
   }
-
-  // the plugin will be included in both the main thread and web worker, so
-  // install plugin to either window or self (webworker global scope)
-  ;(typeof self !== 'undefined' ? self : window).JBrowsePluginMyPlugin = {
-    default: MyPlugin,
-  }
-})()
+}
 ```
 
 Then put `myplugin.js` in the same folder as your config file, and then you can
@@ -45,7 +38,7 @@ use the custom `jexl` function in your config callbacks as follows:
   "plugins": [
     {
       "name": "MyPlugin",
-      "umdLoc": { "uri": "myplugin.js" }
+      "esmLoc": { "uri": "myplugin.js" }
     }
   ],
   "tracks": [
@@ -85,7 +78,7 @@ more info on setting up a simple plugin for doing these customizations.
 #### Footnote 1
 
 `myplugin.js` does not have to use the jbrowse-plugin-template if it is small
-and self contained like this, and does not import other modules. if you import
+and self-contained like this, and does not import other modules. If you import
 other modules from your plugin, then it can be worth it to use the
 jbrowse-plugin-template.
 

--- a/website/docs/config_guides/customizing_feature_details.md
+++ b/website/docs/config_guides/customizing_feature_details.md
@@ -35,7 +35,7 @@ Here is an example track with a formatter:
 <Figure src="/img/customized_feature_details.png" caption="Example screenshot showing customized feature detail panel with links"/>
 
 This feature formatter changes the `"name"` field in the feature detail panel to
-have a link to a google search for that feature's name. This can be used to link
+have a link to a Google search for that feature's name. This can be used to link
 to gene pages for example as well.
 
 In addition, this example also adds a custom field called `"newfield"` and
@@ -69,22 +69,16 @@ You can make a small plugin file "myplugin.js"
 
 ```js
 // myplugin.js
-;(function () {
-  class MyPlugin {
-    install() {}
-    configure(pluginManager) {
-      pluginManager.jexl.addFunction('formatName', feature => {
-        return `<a href="${feature.name}">${feature.name}</a>`
-      })
-    }
+export default class MyPlugin {
+  name = 'MyPlugin'
+  version = '1.0.0'
+  install() {}
+  configure(pluginManager) {
+    pluginManager.jexl.addFunction('formatName', feature => {
+      return `<a href="${feature.name}">${feature.name}</a>`
+    })
   }
-
-  // the plugin will be included in both the main thread and web worker, so
-  // install plugin to either window or self (webworker global scope)
-  ;(typeof self !== 'undefined' ? self : window).JBrowsePluginMyPlugin = {
-    default: MyPlugin,
-  }
-})()
+}
 ```
 
 Then you can put myplugin.js in the same directory as your config file, and can
@@ -95,7 +89,7 @@ use the custom `jexl` function in your config callbacks as follows:
   "plugins": [
     {
       "name": "MyPlugin",
-      "umdLoc": { "uri": "myplugin.js" }
+      "esmLoc": { "uri": "myplugin.js" }
     }
   ],
   "tracks": [
@@ -122,42 +116,36 @@ of your data file, you could make a jexl function such as the following
 
 ```js
 // myplugin.js
-;(function () {
-  class MyPlugin {
-    install() {}
-    configure(pluginManager) {
-      pluginManager.jexl.addFunction('linkout', feature => {
-        // no dbxref found, so return empty string
-        if (!feature.dbxref) {
-          return ''
+export default class MyPlugin {
+  name = 'MyPlugin'
+  version = '1.0.0'
+  install() {}
+  configure(pluginManager) {
+    pluginManager.jexl.addFunction('linkout', feature => {
+      // no dbxref found, so return empty string
+      if (!feature.dbxref) {
+        return ''
+      }
+      const dbxrefs = Array.isArray(feature.dbxref)
+        ? feature.dbxref
+        : [feature.dbxref]
+      return dbxrefs.map(dbxref => {
+        // customized link for Genbank dbxref
+        if (dbxref.startsWith('Genbank:')) {
+          const ref = dbxref.replace('Genbank:', '')
+          return `<a href="https://www.ncbi.nlm.nih.gov/gene/?term=${ref}">${dbxref}</a>`
         }
-        const dbxrefs = Array.isArray(feature.dbxref)
-          ? feature.dbxref
-          : [feature.dbxref]
-        return dbxrefs.map(dbxref => {
-          // customized link for Genbank dbxref
-          if (dbxref.startsWith('Genbank:')) {
-            const ref = dbxref.replace('Genbank:', '')
-            return `<a href="https://www.ncbi.nlm.nih.gov/gene/?term=${ref}">${dbxref}</a>`
-          }
-          // customized link for GeneID dbxref
-          else if (dbxref.startsWith('GeneID:')) {
-            const ref = dbxref.replace('GeneID:', '')
-            return `<a href="https://www.ncbi.nlm.nih.gov/gene/?term=${ref}">${dbxref}</a>`
-          }
-          // no link, just plaintext returned
-          return dbxref
-        })
+        // customized link for GeneID dbxref
+        else if (dbxref.startsWith('GeneID:')) {
+          const ref = dbxref.replace('GeneID:', '')
+          return `<a href="https://www.ncbi.nlm.nih.gov/gene/?term=${ref}">${dbxref}</a>`
+        }
+        // no link, just plaintext returned
+        return dbxref
       })
-    }
+    })
   }
-
-  // the plugin will be included in both the main thread and web worker, so
-  // install plugin to either window or self (webworker global scope)
-  ;(typeof self !== 'undefined' ? self : window).JBrowsePluginMyPlugin = {
-    default: MyPlugin,
-  }
-})()
+}
 ```
 
 And then in your config.json
@@ -167,7 +155,7 @@ And then in your config.json
   "plugins": [
     {
       "name": "MyPlugin",
-      "umdLoc": { "uri": "myplugin.js" }
+      "esmLoc": { "uri": "myplugin.js" }
     }
   ],
   "tracks": [
@@ -195,8 +183,8 @@ is serialized into the session.
 #### Footnote 2 - why are feature details plain JSON objects when other usages aren't?
 
 You might also ask why aren't all features serialized or plain JSON objects
-normally? Well, some feature types like alignments features benefit from only
-being partially serialized e.g. getting only a couple attributes via
+normally? Well, some feature types like alignment track features benefit from
+only being partially serialized e.g. getting only a couple attributes via
 `feature.get('attribute')` (completely converting them to a raw JSON expression
 is expensive). It is a little confusing, but that is why in the feature details,
 you can access the plain JS object e.g. `feature.start` while in color callbacks

--- a/website/docs/config_guides/default_session.md
+++ b/website/docs/config_guides/default_session.md
@@ -11,9 +11,9 @@ default application state that is loaded for all your users.
 
 The session is a representation of the 'internal state' of the app, so it can be
 hard to programmatically write, but you can manually use the app, get to a state
-you want it to be in, and then select "File->Export session". This will give you
-a session.json file, and then you can copy the "session" from this file into the
-"defaultSession" in your config.json
+you want it to be in, and then select "File -> Export session". This will give
+you a session.json file, and then you can copy the "session" from this file into
+the "defaultSession" in your config.json
 
 Example session (reduced for example purposes)
 

--- a/website/docs/config_guides/hic_track.md
+++ b/website/docs/config_guides/hic_track.md
@@ -38,7 +38,7 @@ We just simply supply a `hicLocation` currently for the HicAdapter:
 #### HicRenderer config
 
 - `baseColor` - the default baseColor of the Hi-C plot is red #f00, you can
-  change it to blue so then the shading will be done in blue with #00f
+  change it to blue, so then the shading will be done in blue with #00f
 - `color` - this is a color callback that adapts the current Hi-C contact
   feature with the baseColor to generate a shaded block. The default color
   callback function is

--- a/website/docs/config_guides/intro.md
+++ b/website/docs/config_guides/intro.md
@@ -31,8 +31,8 @@ The most important thing to configure are your assemblies and your tracks.
 
 :::info
 
-Note: On jbrowse desktop, a "session" refers to a config.json with a .jbrowse
-file extension
+Note: On jbrowse desktop, a "session" is essentially a complete JBrowse config
+with a .jbrowse file extension
 
 :::
 
@@ -44,7 +44,7 @@ not accept a config file but rather an object at runtime with the config loaded.
 To fetch a config.json object on the fly in @jbrowse/react-linear-genome-view,
 you might use something like this:
 
-```js
+```typescript
 const response = await fetch('config.json')
 if (!response.ok) {
   throw new Error(`HTTP status ${response.status} fetching ${url}`)

--- a/website/docs/config_guides/multiquantitative_track.md
+++ b/website/docs/config_guides/multiquantitative_track.md
@@ -87,5 +87,5 @@ Example with group field:
 }
 ```
 
-The "name" or "source" field on the subadapters will be used as the subtrack
+The "name" or "source" field on the sub-adapters will be used as the sub-track
 label (where, "source" will be given priority over "name" if specified)

--- a/website/docs/config_guides/plugins.md
+++ b/website/docs/config_guides/plugins.md
@@ -77,9 +77,6 @@ helpful for storing the plugin.js in the same folder as your config
 
 `esmUrl` is resolved relative to the index.html of the file, so can be a
 relative path in your root directory or an absolute URL to somewhere on the web.
-Note that ESM modules are currently not supported in web workers in firefox, so
-you can use MainThreadRpc, or use alternative module formats like UMD for broad
-compatibility.
 
 #### esmLoc
 
@@ -96,9 +93,6 @@ compatibility.
 
 `esmLoc` is resolved relative to the config.json that is being loaded, so is
 helpful for storing the plugin.js in the same folder as your config. Note that
-ESM modules are currently not supported in web workers in firefox, so you can
-use MainThreadRpc, or use alternative module formats like UMD for broad
-compatibility.
 
 #### cjsUrl
 

--- a/website/docs/config_guides/quantitative_track.md
+++ b/website/docs/config_guides/quantitative_track.md
@@ -25,9 +25,9 @@ Example QuantitativeTrack config:
 
 #### General QuantitativeTrack options
 
-- `scaleType` - options: linear, log, to display the coverage data. default:
+- `scaleType` - options: linear, log, to display the coverage data. Default:
   linear
-- `adapter` - an adapter that returns numeric stopToken data, e.g.
+- `adapter` - an adapter that returns numeric score data, e.g.
   feature.get('score')
 
 #### Autoscale options for QuantitativeTrack

--- a/website/docs/config_guides/synteny_track.md
+++ b/website/docs/config_guides/synteny_track.md
@@ -52,10 +52,10 @@ minimap2. It can be used for SyntenyTracks:
 Slots
 
 - `pafLocation` - the location of the PAF file. The pafLocation can refer to a
-  gzipped or unzipped delta file. It will be read into memory entirely as it is
+  gzip'ed or plaintext delta file. It will be read into memory entirely as it is
   not an indexed file format.
 - `assemblyNames` - list of assembly names, typically two (first in list is
-  target, second is query)
+  target assembly, second is query assembly)
 - `queryAssembly` - alternative to assemblyNames: just the assemblyName of the
   query
 - `targetAssembly` - alternative to assemblyNames: just the assemblyName of the
@@ -79,10 +79,10 @@ for SyntenyTracks:
 Slots
 
 - `deltaLocation` - the location of the delta file. The deltaLocation can refer
-  to a gzipped or unzipped delta file. It will be read into memory entirely as
+  to a gzip'ed or unzipped delta file. It will be read into memory entirely as
   it is not an indexed file format.
 - `assemblyNames` - list of assembly names, typically two (first in list is
-  target, second is query)
+  target assembly, second is query assembly)
 - `queryAssembly` - alternative to assemblyNames: just the assemblyName of the
   query
 - `targetAssembly` - alternative to assemblyNames: just the assemblyName of the
@@ -106,10 +106,10 @@ for SyntenyTracks:
 Slots
 
 - `chainLocation` - the location of the UCSC chain file. The chainLocation can
-  refer to a gzipped or unzipped delta file. It will be read into memory
+  refer to a gzip'ed or unzipped delta file. It will be read into memory
   entirely as it is not an indexed file format.
 - `assemblyNames` - list of assembly names, typically two (first in list is
-  target, second is query)
+  target assembly, second is query assembly)
 - `queryAssembly` - alternative to assemblyNames: just the assemblyName of the
   query
 - `targetAssembly` - alternative to assemblyNames: just the assemblyName of the
@@ -144,10 +144,10 @@ MCScanAnchorsAdapter).
 Slots:
 
 - `mcscanAnchorsLocation` - the location of the .anchors file from the MCScan
-  workflow. The .anchors file has three columns. It can be gzipped or ungzipped,
+  workflow. The .anchors file has three columns. It can be gzip'd or plaintext,
   and is read into memory whole
 - `bed1Location` - the location of the first assemblies .bed file from the
-  MCScan workflow. It can be gzipped or ungzipped, and is read into memory
+  MCScan workflow. It can be gzip'ed or plaintext, and is read into memory
   whole. This would refer to the gene names on the "left" side of the .anchors
   file.
 - `bed2Location` - the location of the second assemblies .bed file from the

--- a/website/docs/config_guides/variant_track.md
+++ b/website/docs/config_guides/variant_track.md
@@ -3,9 +3,6 @@ id: variant_track
 title: Variant track configuration
 ---
 
-- `defaultRendering` - options: 'pileup' or 'svg'. default 'svg'
-- `adapter` - a variant type adapter config e.g. a VcfTabixAdapter
-
 Example config:
 
 ```json
@@ -32,10 +29,10 @@ Example config:
 
 #### VcfTabixAdapter configuration options
 
-- `vcfGzLocation` - a 'file location' for the BigWig
-- `index` - a subconfiguration schema containing
-  - indexType: options TBI or CSI. default TBI
-  - location: the location of the index
+- `vcfGzLocation` - a 'file location' for the bgzip'd VCF file
+- `index` - a sub-configuration schema containing
+  - indexType: 'TBI' or 'CSI'. Default: 'TBI'
+  - location: a 'file location' for the index
 
 Example VcfTabixAdapter adapter config:
 

--- a/website/docs/developer_guides/creating_renderer.md
+++ b/website/docs/developer_guides/creating_renderer.md
@@ -8,7 +8,7 @@ import Figure from '../figure'
 ### What is a renderer
 
 In JBrowse 1, a track type typically would directly call the data parser and do
-it's own rendering. In JBrowse 2, the data parsing and rendering is offloaded to
+its own rendering. In JBrowse 2, the data parsing and rendering is offloaded to
 a web-worker or other RPC. This allows things to be faster in many cases. This
 is conceptually related to "server side rendering" or SSR in React terms.
 
@@ -81,7 +81,7 @@ The layout is available on BoxRendererType renderers so that it can layout
 things in pileup format, and has an addRect function to get the y-coordinate at
 which to render your data.
 
-The features argument is a map of feature ID to the feature itself. To iterate
+The `features` argument is a map of feature ID to the feature itself. To iterate
 over the features Map, we can use an iterator or convert to an array:
 
 ```js
@@ -137,7 +137,7 @@ const model = types
 
 ### Rendering SVG
 
-Our SVG renderer is an example, where it extends the existing built in renderer
+Our SVG renderer is an example, where it extends the existing built-in renderer
 type with a custom ReactComponent only:
 
 ```js
@@ -192,17 +192,17 @@ export default function SvgFeatureRendering(props) {
 
 :::info Note
 
-1.The above SVG renderer is highly simplified, but it shows that you can have a
-simple React component that leverages the existing `BoxRendererType`, so that
-you do not have to necessarily create your own renderer class
+1. The above SVG renderer is highly simplified, but it shows that you can have a
+   simple React component that leverages the existing `BoxRendererType`, so that
+   you do not have to necessarily create your own renderer class
 
-2.The renderers receive an array of regions to render, but if they are only
-equipped to handle one region at a time then they can select only rendering to
-`regions[0]`
+2. The renderers receive an array of regions to render, but if they are only
+   equipped to handle one region at a time then they can select only rendering
+   to `regions[0]`
 
 :::
 
-### Overriding the renderer's getFeatures method
+### Overriding the renderer's `getFeatures` method
 
 Normally, it is sufficient to override the `getFeatures` function in your
 dataAdapter.

--- a/website/docs/developer_guides/no_build_plugin.md
+++ b/website/docs/developer_guides/no_build_plugin.md
@@ -82,7 +82,10 @@ plugin class.
 `myplugin.js`
 
 ```typescript
-// ...
+export default class MyPlugin {
+  name = 'MyPlugin'
+  version = '1.0'
+  install() {}
   configure(pluginManager) {
     // this is called in the web worker as well, which does not have a
     // rootModel, so check for existence of pluginManager.rootModel before
@@ -94,11 +97,13 @@ plugin class.
       // appending a menu item to the new menu
       pluginManager.rootModel.appendToMenu('Citations', {
         label: 'Cite this JBrowse session',
-        onClick: (session) => { /* do nothing for now, see below for example */ }
+        onClick: session => {
+          /* do nothing for now, see below for example */
+        },
       })
     }
   }
-// ...
+}
 ```
 
 ### Importing with jbrequire
@@ -116,7 +121,7 @@ might look like this:
 const { types } = pluginManager.jbrequire('mobx-state-tree')
 ```
 
-which would provide the functionality of mobx-state-tree through that value.
+This would provide the functionality of mobx-state-tree through that value.
 
 ## Complete example
 

--- a/website/docs/developer_guides/pluggable_elements.md
+++ b/website/docs/developer_guides/pluggable_elements.md
@@ -9,7 +9,7 @@ A plugin is an independently distributed package of code that is designed to
 "plug in" to a JBrowse application.
 
 It's implemented as a class that extends `@jbrowse/core/Plugin`. It gets
-instantiated by the application that it plugs into, and it has an `install`
+instantiated by the application that it plugs into, and it has a `install`
 method and a `configure` method that the application calls.
 
 This class is distributed as a webpack bundle that exports it to a namespace on
@@ -55,11 +55,11 @@ Examples of pluggable types include:
 - Add track workflow
 
 In additional to creating plugins that create new adapters, track types, etc.
-note that you can also wrap the behavior of another track so these elements are
+note that you can also wrap the behavior of another track, so these elements are
 composable.
 
 For example, we can have adapters that perform calculations on the results of
-another adapter, views that contains other subviews, and tracks that contain
+another adapter, views that contain other sub-views, and tracks that contain
 other tracks, leading to a lot of interesting behavior.
 
 Let's dive further into these details, and look at some examples.
@@ -75,8 +75,8 @@ We have demonstrated a couple new view types in JBrowse 2 already, including:
 - `LinearGenomeView` - the classic linear view of a genome
 - `CircularView` - a Circos-like circular whole genome view
 - `DotplotView` - a comparative 2-D genome view
-- `SvInspectorView` - superview containing `CircularView` and `SpreadsheetView`
-  subviews
+- `SvInspectorView` - super-view containing `CircularView` and `SpreadsheetView`
+  sub-views
 - And more!
 
 We think the boundaries for this are just your imagination, and there can also
@@ -94,7 +94,7 @@ adapter types:
 - `BamAdapter` - This adapter uses the `@gmod/bam` NPM module, and adapts it for
   use by the browser.
 - `CramAdapter` - This adapter uses the `@gmod/cram` NPM module. Note that
-  CramAdapter also takes a sequenceAdapter as a subadapter configuration, and
+  CramAdapter also takes a sequenceAdapter as a sub-adapter configuration, and
   uses getSubAdapter to instantiate it
 
 ### Track types
@@ -105,7 +105,8 @@ like:
 
 - Control what widget pops up on feature click
 - Add extra menu items to the track menu
-- Create subtracks (See `AlignmentsTrack`)
+- Create sub-tracks (See `AlignmentsTrack`, a composition of the pileup and
+  coverage display)
 - Choose "static-blocks" rendering styles, which keeps contents stable while the
   user scrolls, or "dynamic-blocks" that update on each scroll
 
@@ -114,7 +115,7 @@ Example tracks: the `@jbrowse/plugin-alignments` exports multiple track types:
 - `VariantTrack` - displays variant features
 - `FeatureTrack` - displays generic features including gene glyphs
 - `AlignmentsTrack` - shows both a pileup or reads and the coverage as a
-  quantiative track
+  quantitative track
 
 ### Displays
 
@@ -142,7 +143,7 @@ which has two display methods
 
 Renderers are a new concept in JBrowse 2, and are related to the concept of
 server side rendering (SSR), but can be used not just on the server but also in
-contexts like the web worker (e.g. the webworker can draw the features to an
+contexts like the web worker (e.g. the web worker can draw the features to an
 OffscreenCanvas). For more info see
 [creating renderers](/docs/developer_guides/creating_renderer/).
 
@@ -162,7 +163,7 @@ remember the relationship between these four pluggable elements is as follows:
 
 1. A view is a container for anything, views typically _have tracks_ (the linear
    genome view especially)
-2. A track controls the _what_ (kind of data, data adapters used) and _how_
+2. A track controls _what_ (kind of data, data adapters used) and _how_
    (displays, renderers) of the data you'd like to display, typically within a
    view
 3. A display is a way you might want to display the data on a track, you might
@@ -204,7 +205,7 @@ The wiggle plugin, for example, registers two custom RPC method types:
 
 - `WiggleGetMultiRegionQuantitativeStats`
 
-These methods can run in the webworker when available.
+These methods can run in the web worker when available.
 
 ### Add track workflows
 
@@ -228,7 +229,7 @@ Now that you have an overview of the different pluggable element types that are
 available to you, review your
 [understanding of the configuration model](../config_model).
 
-Also checkout the [guided tutorial](/docs/developer_guides/simple_plugin/) for
+Also, checkout the [guided tutorial](/docs/developer_guides/simple_plugin/) for
 writing a plugin, which will take you through everything from installation,
 creating a new pluggable element, and general development tips for working with
 JBrowse 2.

--- a/website/docs/developer_guides/simple_plugin.md
+++ b/website/docs/developer_guides/simple_plugin.md
@@ -1,13 +1,13 @@
 ---
 id: simple_plugin
-title: Writing a plugin using the plugin-template
+title: Writing a plugin using jbrowse-plugin-template
 toplevel: true
 ---
 
 import Figure from '../figure'
 
 JBrowse 2 plugins can be used to add new pluggable elements (views, tracks,
-adapters, etc), and to modify behavior of the application by adding code that
+adapters, etc.), and to modify behavior of the application by adding code that
 watches the application's state.
 
 For the full list of what kinds of pluggable element types plugins can add, see
@@ -136,7 +136,7 @@ chord on the circular genome view.
 Add a new directory under `src` called `CircularViewChordWidget` with two files
 `CircularViewChordWidget.tsx`, and `index.tsx`.
 
-This component is essentially just a react component we're going to embed in a
+This component is essentially just a React component we're going to embed in a
 JBrowse widget.
 
 ### A widget's `index.tsx`
@@ -546,8 +546,8 @@ or equivalent to see JBrowse running with your config.
 
 Now navigate:
 
-1. Click `Start a new session` -> `Empty`
-2. In the top menu bar, click `Add` -> `Circular view`
+1. Click `Start a new session` → `Empty`
+2. In the top menu bar, click `Add` → `Circular view`
 3. When the view is open, click `Open` beside the assembly
 4. Click the far right three rows of rectangles icon in the top left of the
    circular view, `Open track selector`
@@ -556,7 +556,7 @@ Now navigate:
 
 Expected result:
 
-The widget opens on the right hand side with two panels, one with our editable
+The widget opens on the right-hand side with two panels, one with our editable
 widget byline, and one with our feature data.
 
 <Figure src="/img/plugin-dev-tutorial-final.png" caption="A screenshot of the widget displayed after clicking on the chord." />
@@ -580,7 +580,7 @@ that future changes we make do not break the application.
 The `jbrowse-plugin-template` uses cypress to write its integration tests. For
 plugins, integration tests are a particularly good way to test functionality, as
 a failing test might indicate the plugin needs to be updated for a new version
-of JBrowse, or, if interfacing with a third-party API or toolset, that the
+of JBrowse, or, if interfacing with a third-party API or tool set, that the
 plugin might have to be tweaked to suit these changes.
 
 We're going to write a simple integration test suite that executes the action we
@@ -621,8 +621,8 @@ Right now our test does two things:
 - visits our JBrowse URL (default configured to `localhost:8999`) with that
   configuration and a circular view open
 
-Notice the use of [URL params](/docs/urlparams) to speed up the test setup;
-using URL params like this can come in handy for larger suites.
+Notice the use of [URL parameters](/docs/urlparams) to speed up the test setup;
+using URL parameters like this can come in handy for larger suites.
 
 Take a moment to add the track specification to `hello_view.json` for testing
 purposes:
@@ -735,9 +735,9 @@ so please set that up first through the NPM site.
 If you'd prefer not to publish to NPM, you can host your plugin files elsewhere,
 just ensure the link is accessible publicly.
 
-When your plugin is in a publishable state and you have NPM credentials, you can
-run the following within your plugin's root directory (where `package.json` is
-found):
+When your plugin is in a publishable state, and you have NPM credentials, you
+can run the following within your plugin's root directory (where `package.json`
+is found):
 
 ```bash
 yarn publish
@@ -755,13 +755,13 @@ JBrowse plugins.
 
 Navigate to the
 [plugin list repository](https://github.com/GMOD/jbrowse-plugin-list) and use
-the github UI to **Fork** the repository.
+the GitHub UI to **Fork** the repository.
 
 <Figure src="/img/publish_fork_repo_guide.png" caption="Click the 'Fork' option at the top of the repository to create an editable clone of the repo." />
 
 :::info Tip
 
-It's easy enough to edit the files required using the github UI, but feel free
+It's easy enough to edit the files required using the GitHub UI, but feel free
 to clone and push to the forked repo using your local environment as well.
 
 :::
@@ -832,7 +832,7 @@ In this tutorial, we set up a development environment for JBrowse 2 and added a
 custom pluggable element to a plugin.
 
 We also published the plugin to NPM and requested that it be added to the
-JBrowse plugin store so others can access our plugin.
+JBrowse plugin store, so others can access our plugin.
 
 To learn more about the various pluggable elements available in JBrowse (and
 thus more that you can do with plugins!) checkout our
@@ -841,5 +841,5 @@ thus more that you can do with plugins!) checkout our
 If you have further questions about plugin development, or development with
 JBrowse in general, stop by the JBrowse team
 [gitter channel](https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im), or
-start a discssion on the
+start a discussion on the
 [jbrowse-components discussions forum](https://github.com/GMOD/jbrowse-components/discussions).

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -14,7 +14,7 @@ We recommend that you have the following:
 - Git
 - [Yarn](https://classic.yarnpkg.com/en/docs/install/debian-stable)
 
-Then you can follow steps from our
+Then you can follow the steps from our
 [README](https://github.com/gmod/jbrowse-components).
 
 It basically boils down to:
@@ -31,8 +31,8 @@ This will boot up a development instance of `jbrowse-web` on port `3000`.
 
 You can use `PORT=8080 yarn start` to manually specify a different port.
 
-You can also instead go to the `products/jbrowse-desktop` directory to do this
-on desktop.
+Alternatively, to boot up JBrowse Desktop, you can go to the
+`products/jbrowse-desktop` directory.
 
 For the embedded components e.g. `products/jbrowse-react-linear-genome-view`,
 use `yarn storybook` instead of `yarn start`.
@@ -42,11 +42,11 @@ use `yarn storybook` instead of `yarn start`.
 ### What is special about JBrowse 2
 
 One thing that makes JBrowse 2 special is that we can create new view types via
-our plugin system, e.g. circular, dotplot, etc.. Anything you want can be added
+our plugin system, e.g. circular, dotplot, etc. Anything you want can be added
 as a view, and can be shown alongside our other views.
 
-This makes JBrowse 2 more than just a genome browser: it is really a platform
-that can be built upon.
+This makes JBrowse 2 more than just a genome browser: it is a platform that can
+be built upon.
 
 ### What are new features in JBrowse 2
 
@@ -57,16 +57,19 @@ See the https://jbrowse.org/jb2/features page for an overview of features
 ### What web server do I need to run JBrowse 2
 
 JBrowse 2 by itself is just a set of JS, CSS, and HTML files that can be
-statically hosted on a webserver without any backend services running.
+statically hosted on a web server without any backend services running.
 
 Therefore, running JBrowse 2 generally involves just copying the JBrowse 2
-folder to your web server html folder e.g. copy `/var/www/html/` to Amazon S3.
+folder to your web server HTML folder e.g. copy `/var/www/html/` to Amazon S3.
 
-If you use a different platform such as Django, you may want to put it in the
-static resources folder.
+If you use a different platform, such as Django, you may want to put jbrowse-web
+in the static resources folder, but note that data files are not properly served
+by the Django static resources folder: you will want to use a different external
+server. See https://github.com/cmdcolin/django-jbrowse2-nonworking-example for
+notes
 
 Note that the server that you use should support byte-range requests (e.g. the
-[Range HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range)
+[Range HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range))
 so that JBrowse can get small slices of large binary data files.
 
 ### BAM files do not work on my server
@@ -91,7 +94,7 @@ You can also use `jbrowse upgrade /var/www/html/jb2` to get the latest version.
 
 To install the @jbrowse/cli tool, you can use `npm install -g @jbrowse/cli`
 
-You can use this same command to upgrade the tool too.
+Re-running that command will get the latest version of the @jbrowse/cli.
 
 This command will give you a command named `jbrowse` which should automatically
 be in your path if you have a standard installation of nodejs. We recommend
@@ -103,10 +106,11 @@ config.json, it is **not used to run any server-side code**.
 ### How can I make a header on a jbrowse-web instance
 
 You can edit the index.html that comes with jbrowse-web to have custom contents.
-The jbrowse-web app just looks at the div that it renders into, but any contents
-outside of that you can edit for custom purposes. If you need more advanced
-embedding, you can consider @jbrowse/react-linear-genome-view or similar, but
-the jbrowse-web app is not available as an npm installable package yet.
+The jbrowse-web app just looks at the `div` that it renders into, but any
+contents outside that you can edit for custom purposes. If you need more
+advanced embedding, you can consider @jbrowse/react-linear-genome-view or
+similar, but the jbrowse-web app is not available as an npm installable package
+yet.
 
 ### How do I update my instance of jbrowse-web
 
@@ -146,7 +150,7 @@ To configure JBrowse using the admin-server GUI, checkout our
 
 Understanding the [config basics](/docs/config_guides/intro) will come in handy
 also because you can manually edit in advanced configs after your tracks are
-loaded; however be careful:s corrupt configs can produce hard to understand
+loaded; however be careful as corrupt configs can produce hard to understand
 errors, because our config system is strongly typed.
 
 Reach out to the team
@@ -161,7 +165,7 @@ command, e.g.:
 
     jbrowse add-track myfile.bw -a hg19
 
-This will setup a bigwig track on the hg19 assembly in your config.json.
+This will set up a bigwig track on the hg19 assembly in your config.json.
 
 Make sure to run the command inside your current jbrowse2 folder e.g.
 /var/www/html/jbrowse2 or wherever you are currently setting up a config.json
@@ -175,7 +179,7 @@ The add-track command will do as much as possible to infer from the file
 extension how to configure this track, and automatically infer the index to be
 myfile.bam.bai.
 
-As mentioned [above](#how-can-i-setup-jbrowse-2-without-the-cli-tools) you can
+As mentioned [above](#how-can-i-setup-jbrowse-2-without-the-cli-tools), you can
 also manually edit your config file, or use the GUI.
 
 ### How do I customize the color of the features displayed on my track
@@ -204,16 +208,16 @@ making a color callback.
 In brief, to add a configuration callback to a track using the GUI, perform the
 following steps:
 
-1. On the track you're meaning to color, click on the three vertical dots '...'
-   on the right side of the track label
+1. On the track you intend to color, click on the three vertical dots '...' on
+   the right side of the track label
 2. Click "Settings" (if this option is greyed out, copy the track with "Copy
    Track", then open up the track under "Session Tracks" and repeat steps 1-2)
 3. Scroll down to the "display 1 renderer" heading (this is typically the
    display you want to edit, if not scroll to display 2)
 4. Click on the circle to the right of the color you'd like to change
 5. In this text box, enter in the [Jexl](https://github.com/TomFrost/Jexl)
-   callback for the feature colouration, e.g. "get(feature,'strand') == -1 ?
-   'red' : 'blue'"
+   callback for the feature coloration, e.g.
+   `get(feature,'strand') == -1 ? 'red' : 'blue'`
 
 ### Adding color callbacks via the command line
 
@@ -314,12 +318,12 @@ with JBrowse 2, the top level menu only performs global operations and the
 linear genome view has its own hamburger menu. Note that each track also has its
 own track level menu.
 
-### Why do some of my reads not display soft clipping
+### Why do some of my reads not display soft-clipping
 
-Some reads, such as secondary reads, do not have a SEQ field on their records,
-so they will not display softclipping.
+Some reads, such as secondary reads, do not have a `SEQ` field on their records,
+so they will not display soft-clipping.
 
-The soft clipping indicators on these reads will appear black.
+The soft-clipping indicators on these reads will appear black.
 
 ### Do you have any tips for learning React and mobx-state-tree
 
@@ -345,8 +349,9 @@ Yes! JBrowse 2 may load ~5MB of JS resources (2.5MB for main thread bundle,
 has to download though is only 1.4MB. We have worked on making bundle size small
 with lazy loading and other methods but adding gzip will help your users.
 
-It will depend on your particular server setup e.g. apache, nginx, cloudfront,
-etc. how this may be done, but it is recommended to look into this.
+It will depend on your particular server setup e.g. apache, nginx, AWS
+CloudFront, plain S3 bucket, etc. how this may be done, but it is recommended to
+look into this.
 
 ### How does JBrowse know when to display the "Zoom in to see more features" message
 
@@ -357,7 +362,8 @@ The general outline is:
 
 - It doesn't display a zoom in message if zoomed in closer than 20kb
 - It performs byte size estimation for BAM and CRAM type files (you will see a
-  byte size estimation displayed alongside the "Zoom in to see features" message
+  byte size estimation displayed alongside the "Zoom in to see features"
+  message)
 - Other data types that don't use byte size estimation use feature density based
   calculation
 - Hi-C, BigWig, and sequence adapters are hardcoded to return
@@ -399,7 +405,7 @@ Example config with a small feature screen density:
 }
 ```
 
-Example config for a CRAM file with a small fetchSizeLimit configured:
+Example config for a CRAM file with a small `fetchSizeLimit` configured:
 
 ```json
 {
@@ -437,8 +443,8 @@ alternative temporary directory using the environment variable
 
 ### How does the jbrowse text-index trix format work
 
-The `jbrowse text-index` command creates text searching indexes using trix. The
-trix indexes are based on the format described by UCSC here
+The `jbrowse text-index` command creates text searching indexes using `trix`.
+The trix indexes are based on the format described by UCSC here
 https://genome.ucsc.edu/goldenPath/help/trix.html, but we re-implemented the
 code the create these index formats in the JBrowse CLI so you do not have to
 install the UCSC tools.
@@ -459,16 +465,16 @@ Pax6  GENE002
 Wnt  GENE001
 ```
 
-Then a second file, the .ixx file, tells us at what byte offset certain lines in
-the file are e.g.:
+Then a second file, the `.ixx` file, tells us at what byte offset certain lines
+in the file are e.g.
 
 ```
 signa000000435
 ```
 
 Note that JBrowse creates a specialized trix index also. Instead of creating a
-ix file with just the gene names, it also provides their name and location in an
-encoded format.
+`ix` file with just the gene names, it also provides their name and location in
+an encoded format.
 
 ## URL params
 
@@ -491,13 +497,13 @@ own computer, and JBrowse will restore the session using BroadcastChannel
 
 ### How does the session sharing work with shortened URLs work in JBrowse Web
 
-We have a central database hosted as a AWS dynamoDB that stores encrypted
-session snapshots that users create when they use the "Share" button. The
-"Share" button creates a random key on the client side (which becomes the
-&password= component of the share URL), encrypts the session client side, and
-sends the encrypted session without the key to the AWS dynamoDB.
+We have a central database hosted at AWS dynamoDB that stores encrypted session
+snapshots that users create when they use the "Share" button. The "Share" button
+creates a random key on the client side (which becomes the &password= component
+of the share URL), encrypts the session client side, and sends the encrypted
+session without the key to the AWS dynamoDB.
 
-This process, generates a URL with the format:
+This process generates a URL with the format:
 
 &session=share-&lt;DYNAMODBID&gt;&password=&lt;DECODEKEY&gt;
 
@@ -515,16 +521,16 @@ Doing things like:
 - Changing trackIds
 - Deleting tracks
 
-Can make user's saved sessions fail to load. If part of a session is
+Can make users' saved sessions fail to load. If part of a session is
 inconsistent, currently, the entire session will fail to load. Therefore, make
 decisions to delete or change IDs carefully.
 
 ### What should I do if the Share system isn't working?
 
 If for any reason the session sharing system isn't working, e.g. you are behind
-a firewall or you are not able to connect to the central share server, you can
+a firewall, or you are not able to connect to the central share server, you can
 click the "Gear" icon in the "Share" button pop-up, and it will give you the
-option to use "Long URL" instead of "Short URL" which let's you create share
+option to use "Long URL" instead of "Short URL" which lets you create share
 links without the central server.
 
 Also, if you are implementing JBrowse Web on your own server and would like to

--- a/website/docs/quickstart_desktop.md
+++ b/website/docs/quickstart_desktop.md
@@ -40,7 +40,7 @@ Start it in one of two ways:
 
 #### In the terminal
 
-Using the AppImage file on linux, all that is needed is to make the file
+Using the AppImage file on Linux, all that is needed is to make the file
 executable which you can do in a terminal
 
 ```sh
@@ -68,12 +68,12 @@ like this:
 
 <Figure src="/img/desktop-landing.png" caption="Screenshot showing the start screen on JBrowse desktop"/>
 
-**On the left hand panel,** "Launch new session" can launch a new session using
+**On the left-hand panel,** "Launch new session" can launch a new session using
 either your own custom genome (which you can load using an indexed FASTA or a
 twobit file via `open sequence file`) or a pre-loaded genome via the "Quickstart
 list".
 
-**On the right hand panel** is the "Recently opened sessions". This includes
+**On the right-hand panel** is the "Recently opened sessions". This includes
 sessions that you have explicitly saved, and sessions that were autosaved (i.e.
 ones that you didn't explicitly use "Save as" on). You can re-open your sessions
 by clicking on the session name.

--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -66,8 +66,12 @@ jbrowse create jbrowse2
 ```
 
 This fetches the latest version of jbrowse-web and unzips it to a folder named
-"jbrowse2" from github (https://github.com/GMOD/jbrowse-components/releases),
-you could run this step manually if you wanted to instead.
+"jbrowse2". You can name the folder anything you want to, it is just a folder
+containing html, css, and js files. It is not a fancy installation
+
+Also note: as an alternative to the jbrowse create command, you can manually
+download the jbrowse-web zip from
+https://github.com/GMOD/jbrowse-components/releases
 
 ### Checking the download
 
@@ -335,13 +339,13 @@ To upgrade the CLI tools, you can re-run the install command
 npm install -g @jbrowse/cli
 ```
 
-### Output to a custom named config file, and output to subfolders
+### Output to a custom config file name
 
 You can use filenames other than config.json, and put configs in subfolders of
 your jbrowse 2 installation too
 
 ```bash
-jbrowse add-assembly mygenome.fa --out /path/to/my/jbrowse2/subfolder/alt_config.json --load copy
+jbrowse add-assembly mygenome.fa --out /path/to/my/jbrowse2/alt_config.json --load copy
 ```
 
 This would then be accessible at e.g.

--- a/website/docs/urlparams.md
+++ b/website/docs/urlparams.md
@@ -9,9 +9,11 @@ import Figure from './figure'
 JBrowse Web features the ability to automatically provide URL parameters to
 setup a session
 
-Note that the embedded components like @jbrowse/react-linear-genome-view make no
-assumptions on how URL params are used, so would have to be implemented by the
-consumer of the library
+:::info note
+
+Note: that the embedded components like @jbrowse/react-linear-genome-view make
+no assumptions on how URL parameters are used, so would have to be implemented
+by the consumer of the library :::
 
 ## Linear genome view (simple)
 
@@ -22,7 +24,7 @@ Example
 
 `http://host/jbrowse2/?config=test_data/config.json&loc=chr1:6000-7000&assembly=hg19&tracks=gene_track,vcf_track`
 
-Here are the query params used here
+Here is a list the allowed query parameters in jbrowse-web
 
 ### ?config=
 
@@ -43,8 +45,8 @@ Example
 `&assembly=hg19`
 
 The &assembly parameter refers to an assembly's "name" field one of the
-"assemblies" array in the from the config.json. This is only used for launching
-a single linear genome view.
+"assemblies" array in the config.json. This is only used for launching a single
+linear genome view.
 
 ### &loc=
 
@@ -359,7 +361,7 @@ view types other than the linear genome view
 ### &session=json-
 
 Similar to encoded sessions, but more readable, `&session=json-` type sessions
-let you specify the input a JSON snapshot of a session session. This is slightly
+let you specify the input a JSON snapshot of a session. This is slightly
 different from a session spec, which has extra logic that loads the session.
 JSON sessions are literal session snapshots, like those that might come from the
 "Export session..." process


### PR DESCRIPTION
I thought it would be good to have some grammar suggestions on doc pages, similar to the typo checker.

I used the languagetool plugin for vscode to help do this

 I had to use vscode cause the neovim suggestions wasn't working quite right