### PR TITLE
Add plugins from plugin store without reloading page

### DIFF
--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
 
 import { FatalErrorDialog, LoadingEllipses } from '@jbrowse/core/ui'
 import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
@@ -112,24 +112,52 @@ const PluginManagerLoaded = observer(function ({
 })
 
 const Renderer = observer(function ({
-  loader,
+  loader: firstLoader,
 }: {
   loader: SessionLoaderModel
 }) {
+  const [loader, setLoader] = useState(firstLoader)
   const { configError, ready, sessionTriaged } = loader
   const [pluginManager, setPluginManager] = useState<PluginManager>()
   const [error, setError] = useState<unknown>()
 
+  const reloadPluginManager = useCallback(
+    (
+      configSnapshot?: Record<string, unknown>,
+      sessionSnapshot?: Record<string, unknown>,
+    ) => {
+      const newLoader = SessionLoader.create({
+        configPath: loader.configPath,
+        sessionQuery: loader.sessionQuery,
+        password: loader.password,
+        adminKey: loader.adminKey,
+        loc: loader.loc,
+        assembly: loader.assembly,
+        tracks: loader.tracks,
+        sessionTracks: loader.sessionTracks,
+        tracklist: loader.tracklist,
+        highlight: loader.highlight,
+        nav: loader.nav,
+        hubURL: loader.hubURL,
+        initialTimestamp: Date.now(),
+        configSnapshot,
+        sessionSnapshot,
+      })
+      setLoader(newLoader)
+    },
+    [loader],
+  )
+
   useEffect(() => {
     try {
       if (ready) {
-        setPluginManager(createPluginManager(loader))
+        setPluginManager(createPluginManager(loader, reloadPluginManager))
       }
     } catch (e) {
       console.error(e)
       setError(e)
     }
-  }, [loader, ready])
+  }, [loader, ready, reloadPluginManager])
 
   const err = configError || error
   if (err) {

--- a/products/jbrowse-web/src/createPluginManager.ts
+++ b/products/jbrowse-web/src/createPluginManager.ts
@@ -9,7 +9,13 @@ import sessionModelFactory from './sessionModel'
 
 import type { SessionLoaderModel } from './SessionLoader'
 
-export function createPluginManager(model: SessionLoaderModel) {
+export function createPluginManager(
+  model: SessionLoaderModel,
+  reloadPluginManagerCallback: (
+    configSnapshot?: Record<string, unknown>,
+    sessionSnapshot?: Record<string, unknown>,
+  ) => void,
+) {
   // it is ready when a session has loaded and when there is no config error
   //
   // Assuming that the query changes model.sessionError or
@@ -51,6 +57,8 @@ export function createPluginManager(model: SessionLoaderModel) {
       },
       { pluginManager },
     )
+
+    rootModel.setReloadPluginManagerCallback(reloadPluginManagerCallback)
 
     // @ts-expect-error
     if (!model.configSnapshot.configuration?.rpc?.defaultDriver) {

--- a/products/jbrowse-web/src/rootModel/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel/rootModel.ts
@@ -154,6 +154,15 @@ export default function RootModel({
        * #volatile
        */
       error: undefined as unknown,
+      /**
+       * #volatile
+       */
+      reloadPluginManagerCallback: (
+        _configSnapshot?: Record<string, unknown>,
+        _sessionSnapshot?: Record<string, unknown>,
+      ) => {
+        console.error('reloadPluginManagerCallback unimplemented')
+      },
     }))
 
     .actions(self => ({
@@ -269,7 +278,9 @@ export default function RootModel({
                     // autorun at current time because it depends on session
                     // storage snapshot being set above
                     if (self.pluginsUpdated) {
-                      window.location.reload()
+                      self.reloadPluginManagerCallback(
+                        JSON.parse(JSON.stringify(getSnapshot(self.jbrowse))),
+                      )
                     }
                   } catch (e) {
                     console.error(e)
@@ -316,6 +327,17 @@ export default function RootModel({
        */
       setPluginsUpdated(flag: boolean) {
         self.pluginsUpdated = flag
+      },
+      /**
+       * #action
+       */
+      setReloadPluginManagerCallback(
+        callback: (
+          configSnapshot?: Record<string, unknown>,
+          sessionSnapshot?: Record<string, unknown>,
+        ) => void,
+      ) {
+        self.reloadPluginManagerCallback = callback
       },
       /**
        * #action


### PR DESCRIPTION
Title of this PR ("Add plugins from plugin store without reloading page") is what the end users will see, but this change was motivated by Apollo 3 needs. Here's some background/motivation.

**What Apollo 3 needs:**
A way to reload the plugin manager using the config and session that is already loaded.

The way I solved that also enables plugins from the plugin store to be installed without a whole page refresh, so I also added that in this PR as well.

**How I implemented this:**
I added a callback to the root model in JBrowse Web called `reloadPluginManagerCallback`, inspired by the `setOpenNewSessionCallback` in JBrowse Desktop. This callback can optionally take a config snapshot and a session snapshot. If a config is provided, it is used instead of re-fetching the config.json. If a session is provided, it is used instead of re-fetching the session.

This callback makes a new `SessionLoader`, which then triggers the `Loader` component to make a new `PluginManager`.