### PR TITLE
Remove some unused functions on the session model

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1454,6 +1454,10 @@ export function localStorageGetBoolean(key: string, defaultVal: boolean) {
   )
 }
 
+export function localStorageSetBoolean(key: string, value: boolean) {
+  localStorageSetItem(key, JSON.stringify(value))
+}
+
 export function forEachWithStopTokenCheck<T>(
   iter: Iterable<T>,
   stopToken: string | undefined,

--- a/packages/product-core/src/Session/MultipleViews.ts
+++ b/packages/product-core/src/Session/MultipleViews.ts
@@ -1,20 +1,16 @@
-import { readConfObject } from '@jbrowse/core/configuration'
-import { localStorageGetBoolean, localStorageSetItem } from '@jbrowse/core/util'
+import {
+  localStorageGetBoolean,
+  localStorageSetBoolean,
+} from '@jbrowse/core/util'
 import { autorun } from 'mobx'
-import { addDisposer, cast, getSnapshot, types } from 'mobx-state-tree'
+import { addDisposer, cast, types } from 'mobx-state-tree'
 
 import { BaseSessionModel, isBaseSession } from './BaseSession'
 import { DrawerWidgetSessionMixin } from './DrawerWidgets'
 
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes'
-import type { IBaseViewModelWithDisplayedRegions } from '@jbrowse/core/pluggableElementTypes/models/BaseViewModel'
-import type { Region } from '@jbrowse/core/util'
 import type { IAnyStateTreeNode, Instance } from 'mobx-state-tree'
-
-function localStorageSetBoolean(key: string, value: boolean) {
-  localStorageSetItem(key, JSON.stringify(value))
-}
 
 /**
  * #stateModel MultipleViewsSessionMixin
@@ -112,55 +108,8 @@ export function MultipleViewsSessionMixin(pluginManager: PluginManager) {
       /**
        * #action
        */
-      addLinearGenomeViewOfAssembly(assemblyName: string, initialState = {}) {
-        return this.addViewOfAssembly(
-          'LinearGenomeView',
-          assemblyName,
-          initialState,
-        )
-      },
-
-      /**
-       * #action
-       */
-      addViewOfAssembly(
-        viewType: string,
-        assemblyName: string,
-        initialState: Record<string, unknown> = {},
-      ) {
-        const asm = self.assemblies.find(
-          s => readConfObject(s, 'name') === assemblyName,
-        )
-        if (!asm) {
-          throw new Error(
-            `Could not add view of assembly "${assemblyName}", assembly name not found`,
-          )
-        }
-        return this.addView(viewType, {
-          ...initialState,
-          displayRegionsFromAssemblyName: readConfObject(asm, 'name'),
-        })
-      },
-
-      /**
-       * #action
-       */
-      addViewFromAnotherView(
-        viewType: string,
-        otherView: IBaseViewModelWithDisplayedRegions,
-        initialState: { displayedRegions?: Region[] } = {},
-      ) {
-        const state = { ...initialState }
-        state.displayedRegions = getSnapshot(otherView.displayedRegions)
-        return this.addView(viewType, state)
-      },
-
-      /**
-       * #action
-       */
       setStickyViewHeaders(sticky: boolean) {
         self.stickyViewHeaders = sticky
-        localStorageSetBoolean('stickyViewHeaders', sticky)
       },
 
       afterAttach() {


### PR DESCRIPTION
This PR removes session functions:

addViewOfAssembly
addLinearGenomeViewOfAssembly

These were likely inoperable because they used a field  `displayRegionsFromAssemblyName` that has not been defined since at least 2020

```
commit 3f84c5ae0d404e335cb487d7923f0ebfaa8ad176
Merge: f09fbb792 4d59e0433
Author: Robert Buels <rbuels@gmail.com>
Date:   Fri Mar 13 10:47:25 2020 -0700

    Merge pull request #838 from GMOD/remove_displayRegionsFromAssemblyName

    Remove displayRegionsFromAssemblyName

```