### PR TITLE
Fix UCSC chain parsing which have 'header' lines

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1413,13 +1413,14 @@ export function isGzip(buf: Uint8Array) {
 
 export async function fetchAndMaybeUnzip(
   loc: GenericFilehandle,
-  opts?: BaseOptions,
+  opts: BaseOptions = {},
 ) {
-  const { statusCallback = () => {} } = opts || {}
-  const buf = (await updateStatus('Downloading file', statusCallback, () =>
-    // @ts-expect-error
-    loc.readFile(opts),
-  )) as unknown as Uint8Array
+  const { statusCallback = () => {} } = opts
+  const buf = await updateStatus(
+    'Downloading file',
+    statusCallback,
+    () => loc.readFile(opts) as Promise<Uint8Array>,
+  )
   return isGzip(buf)
     ? await updateStatus('Unzipping', statusCallback, () => unzip(buf))
     : buf

--- a/plugins/comparative-adapters/src/BlastTabularAdapter/BlastTabularAdapter.ts
+++ b/plugins/comparative-adapters/src/BlastTabularAdapter/BlastTabularAdapter.ts
@@ -210,13 +210,18 @@ export default class BlastTabularAdapter extends BaseFeatureDataAdapter {
   }
 
   async setup(opts?: BaseOptions): Promise<BlastRecord[]> {
-    const pm = this.pluginManager
-    const buf = await fetchAndMaybeUnzip(
-      openLocation(readConfObject(this.config, 'blastTableLocation'), pm),
+    const columns: string = readConfObject(this.config, 'columns')
+    return parseLineByLine(
+      await fetchAndMaybeUnzip(
+        openLocation(
+          readConfObject(this.config, 'blastTableLocation'),
+          this.pluginManager,
+        ),
+        opts,
+      ),
+      createBlastLineParser(columns),
       opts,
     )
-    const columns: string = readConfObject(this.config, 'columns')
-    return parseLineByLine(buf, createBlastLineParser(columns), opts)
   }
 
   async hasDataForRefName() {

--- a/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
@@ -8,8 +8,12 @@ import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 export default class ChainAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {
-    const loc = openLocation(this.getConf('chainLocation'), this.pluginManager)
-    const buf = await fetchAndMaybeUnzip(loc, opts)
-    return paf_chain2paf(buf)
+    return paf_chain2paf(
+      await fetchAndMaybeUnzip(
+        openLocation(this.getConf('chainLocation'), this.pluginManager),
+        opts,
+      ),
+      opts,
+    )
   }
 }

--- a/plugins/comparative-adapters/src/ChainAdapter/util.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/util.ts
@@ -69,27 +69,30 @@ export function paf_chain2paf(buffer: Uint8Array, opts?: BaseOptions) {
   let cigar = ''
   const records = []
 
-  let i = 0
   let blockStart = 0
   const decoder = new TextDecoder('utf8')
+  let s = performance.now()
+  let i = 0
   while (blockStart < buffer.length) {
-    if (i++ % 10_000 === 0) {
+    if (i++ % 10_000 === 0 && performance.now() - s > 50) {
       statusCallback(
         `Loading ${getProgressDisplayStr(blockStart, buffer.length)}`,
       )
+      s = performance.now()
     }
     const n = buffer.indexOf(10, blockStart)
     if (n === -1) {
       break
     }
     const b = buffer.subarray(blockStart, n)
-    const l = decoder.decode(b).trim()
+    const line = decoder.decode(b).trim()
     blockStart = n + 1
-    const l_tab = l.replaceAll(' ', '\t') // There are CHAIN files with space-separated fields
-    const l_vec = l_tab.split('\t')
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const l_vec = line.split(/[ \t]+/) // Split on one or more spaces or tabs
 
     if (l_vec[0] === 'chain') {
-      // Emit previous PAF row, if available
       if (cigar) {
         records.push(
           generate_record(
@@ -175,5 +178,6 @@ export function paf_chain2paf(buffer: Uint8Array, opts?: BaseOptions) {
       num_matches,
     )
   }
+
   return records
 }

--- a/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
@@ -8,8 +8,12 @@ import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 export default class DeltaAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {
-    const loc = openLocation(this.getConf('deltaLocation'), this.pluginManager)
-    const buf = await fetchAndMaybeUnzip(loc, opts)
-    return paf_delta2paf(buf)
+    return paf_delta2paf(
+      await fetchAndMaybeUnzip(
+        openLocation(this.getConf('deltaLocation'), this.pluginManager),
+        opts,
+      ),
+      opts,
+    )
   }
 }

--- a/plugins/comparative-adapters/src/DeltaAdapter/util.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/util.ts
@@ -52,11 +52,13 @@ export function paf_delta2paf(buffer: Uint8Array, opts?: BaseOptions) {
   let i = 0
   let j = 0
   const decoder = new TextDecoder('utf8')
+  let s = performance.now()
   while (blockStart < buffer.length) {
-    if (j++ % 10_000 === 0) {
+    if (j++ % 10_000 === 0 && performance.now() - s > 50) {
       statusCallback(
         `Loading ${getProgressDisplayStr(blockStart, buffer.length)}`,
       )
+      s = performance.now()
     }
     const n = buffer.indexOf(10, blockStart)
     if (n === -1) {

--- a/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
+++ b/plugins/comparative-adapters/src/MCScanAnchorsAdapter/MCScanAnchorsAdapter.ts
@@ -1,5 +1,5 @@
 import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { SimpleFeature, doesIntersect2 } from '@jbrowse/core/util'
+import { SimpleFeature, doesIntersect2, updateStatus } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 
@@ -37,14 +37,17 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
     return this.setupP
   }
   async setupPre(opts: BaseOptions) {
+    const { statusCallback = () => {} } = opts
     const assemblyNames = this.getConf('assemblyNames') as string[]
 
     const pm = this.pluginManager
     const bed1 = openLocation(this.getConf('bed1Location'), pm)
     const bed2 = openLocation(this.getConf('bed2Location'), pm)
     const mcscan = openLocation(this.getConf('mcscanAnchorsLocation'), pm)
-    const [bed1text, bed2text, mcscantext] = await Promise.all(
-      [bed1, bed2, mcscan].map(r => readFile(r, opts)),
+    const [bed1text, bed2text, mcscantext] = await updateStatus(
+      'Downloading data',
+      statusCallback,
+      () => Promise.all([bed1, bed2, mcscan].map(r => readFile(r, opts))),
     )
 
     const bed1Map = parseBed(bed1text!)

--- a/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/MCScanSimpleAnchorsAdapter.ts
+++ b/plugins/comparative-adapters/src/MCScanSimpleAnchorsAdapter/MCScanSimpleAnchorsAdapter.ts
@@ -1,5 +1,5 @@
 import { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
-import { doesIntersect2 } from '@jbrowse/core/util'
+import { doesIntersect2, updateStatus } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
 import { ObservableCreate } from '@jbrowse/core/util/rxjs'
 import SimpleFeature from '@jbrowse/core/util/simpleFeature'
@@ -46,14 +46,18 @@ export default class MCScanAnchorsAdapter extends BaseFeatureDataAdapter {
     return this.setupP
   }
   async setupPre(opts: BaseOptions) {
+    const { statusCallback = () => {} } = opts
     const assemblyNames = this.getConf('assemblyNames') as string[]
     const pm = this.pluginManager
     const bed1 = openLocation(this.getConf('bed1Location'), pm)
     const bed2 = openLocation(this.getConf('bed2Location'), pm)
     const mcscan = openLocation(this.getConf('mcscanSimpleAnchorsLocation'), pm)
-    const [bed1text, bed2text, mcscantext] = await Promise.all(
-      [bed1, bed2, mcscan].map(r => readFile(r, opts)),
+    const [bed1text, bed2text, mcscantext] = await updateStatus(
+      'Downloading data',
+      statusCallback,
+      () => Promise.all([bed1, bed2, mcscan].map(r => readFile(r, opts))),
     )
+
     const bed1Map = parseBed(bed1text!)
     const bed2Map = parseBed(bed2text!)
     const feats = mcscantext!

--- a/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
@@ -8,9 +8,14 @@ import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 export default class MashMapAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {
-    const outLoc = openLocation(this.getConf('outLocation'), this.pluginManager)
-    const buf = await fetchAndMaybeUnzip(outLoc, opts)
-    return parseLineByLine(buf, parseMashMapLine, opts)
+    return parseLineByLine(
+      await fetchAndMaybeUnzip(
+        openLocation(this.getConf('outLocation'), this.pluginManager),
+        opts,
+      ),
+      parseMashMapLine,
+      opts,
+    )
   }
 }
 

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -43,10 +43,14 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
   }
 
   async setupPre(opts?: BaseOptions) {
-    const pm = this.pluginManager
-    const pafLocation = openLocation(this.getConf('pafLocation'), pm)
-    const buf = await fetchAndMaybeUnzip(pafLocation, opts)
-    return parseLineByLine(buf, parsePAFLine, opts)
+    return parseLineByLine(
+      await fetchAndMaybeUnzip(
+        openLocation(this.getConf('pafLocation'), this.pluginManager),
+        opts,
+      ),
+      parsePAFLine,
+      opts,
+    )
   }
 
   async hasDataForRefName() {

--- a/plugins/comparative-adapters/src/util.ts
+++ b/plugins/comparative-adapters/src/util.ts
@@ -48,6 +48,7 @@ export function parseLineByLine<T>(
   const decoder = new TextDecoder('utf8')
 
   let i = 0
+  let s = performance.now()
   while (blockStart < buffer.length) {
     const n = buffer.indexOf(10, blockStart)
     if (n === -1) {
@@ -61,10 +62,12 @@ export function parseLineByLine<T>(
         entries.push(entry)
       }
     }
-    if (i++ % 10_000 === 0) {
+
+    if (i++ % 10_000 === 0 && performance.now() - s > 50) {
       statusCallback(
         `Loading ${getProgressDisplayStr(blockStart, buffer.length)}`,
       )
+      s = performance.now()
     }
     blockStart = n + 1
   }


### PR DESCRIPTION
Some chain files have lines starting with hash

e.g. https://hgdownload.soe.ucsc.edu/goldenPath/hg19/vsPapAnu2/hg19.papAnu2.all.chain.gz

this PR fixes this by skipping header lines

it also adds some better status updating to the parsing procedure