### PR TITLE
Revert "Add sequence length to the searchbox/refnameautocomplete dropdown"

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
@@ -3,12 +3,7 @@ import { useEffect, useState } from 'react'
 import BaseResult, {
   RefSequenceResult,
 } from '@jbrowse/core/TextSearch/BaseResults'
-import {
-  getBpDisplayStr,
-  getSession,
-  measureText,
-  useDebounce,
-} from '@jbrowse/core/util'
+import { getSession, measureText, useDebounce } from '@jbrowse/core/util'
 import { Autocomplete } from '@mui/material'
 import { observer } from 'mobx-react'
 
@@ -82,7 +77,7 @@ const RefNameAutocomplete = observer(function ({
       result: new RefSequenceResult({
         refName: region.refName,
         label: region.refName,
-        displayString: `${region.refName} (${getBpDisplayStr(region.end - region.start)})`,
+        displayString: region.refName,
         matchedAttribute: 'refName',
       }),
     })) || []
@@ -132,7 +127,11 @@ const RefNameAutocomplete = observer(function ({
 
         if (typeof selectedOption === 'string') {
           // handles string inputs on keyPress enter
-          onSelect?.(new BaseResult({ label: selectedOption }))
+          onSelect?.(
+            new BaseResult({
+              label: selectedOption,
+            }),
+          )
         } else {
           onSelect?.(selectedOption.result)
         }

--- a/products/jbrowse-web/src/tests/TextSearching.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearching.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, within } from '@testing-library/react'
 
 import { createView, doBeforeEach, setup } from './util'
 import jb1_config from '../../test_data/volvox/volvox_jb1_text_config.json'
@@ -11,6 +11,17 @@ beforeEach(() => {
 
 const delay = { timeout: 30_000 }
 const opts = [{}, delay]
+
+function typeAndEnter({
+  input,
+  value,
+}: {
+  input: HTMLInputElement
+  value: string
+}) {
+  fireEvent.change(input, { target: { value } })
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+}
 
 async function doSetup(val?: unknown) {
   const args = await createView(val)
@@ -32,88 +43,85 @@ async function doSetup(val?: unknown) {
   }
 }
 
+test('lower case refname, click ctgB', async () => {
+  const { input, findByRole } = await doSetup()
+
+  fireEvent.mouseDown(input)
+  fireEvent.click(within(await findByRole('listbox')).getByText(/ctgB/))
+
+  await waitFor(() => {
+    expect(input.value).toBe('ctgB:1..6,079')
+  }, delay)
+}, 50_000)
+
 test('single result, searching: eden.1', async () => {
-  const { input, autocomplete } = await doSetup()
-  fireEvent.change(input, { target: { value: 'eden.1' } })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  const { input } = await doSetup()
+  typeAndEnter({ input, value: 'eden.1' })
   await waitFor(() => {
     expect(input.value).toBe('ctgA:1..10,590')
   }, delay)
 }, 30_000)
 
 test('dialog with multiple results, searching seg02', async () => {
-  const { input, findByText, autocomplete } = await doSetup()
+  const { input, findByText } = await doSetup()
 
-  fireEvent.change(input, { target: { value: 'seg02' } })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  typeAndEnter({ input, value: 'seg02' })
   await findByText('Search results', ...opts)
 }, 30_000)
 
 test('dialog with multiple results with jb1 config, searching: eden.1', async () => {
-  const { input, findByText, autocomplete } = await doSetup(jb1_config)
-  fireEvent.change(input, { target: { value: 'eden.1' } })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  const { input, findByText } = await doSetup(jb1_config)
+  typeAndEnter({ input, value: 'eden.1' })
   await findByText('Search results', ...opts)
 }, 30_000)
 
 test('test navigation with the search input box, {volvox2}ctgB:1..200', async () => {
-  const { view, input, autocomplete } = await doSetup()
-  fireEvent.change(input, { target: { value: '{volvox2}ctgB:1..200' } })
-  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  const { view, input } = await doSetup()
+  typeAndEnter({ input, value: '{volvox2}ctgB:1..200' })
   await waitFor(() => {
     expect(view.displayedRegions[0]!.assemblyName).toEqual('volvox2')
   })
 }, 30_000)
 
 test('nav lower case refnames, searching: ctgb:1-100', async () => {
-  const { view, input, autocomplete } = await doSetup()
-  fireEvent.change(input, { target: { value: 'ctgb:1-100' } })
-  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  const { view, input } = await doSetup()
+  typeAndEnter({ input, value: 'ctgb:1-100' })
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
 }, 30_000)
 
 test('nav lower case refnames, searching: ctgb', async () => {
-  const { view, input, autocomplete } = await doSetup()
+  const { view, input } = await doSetup()
 
-  fireEvent.change(input, { target: { value: 'ctgb' } })
-  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  typeAndEnter({ input, value: 'ctgb' })
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
 }, 30_000)
 
 test('nav lower case refnames, searching: contigb:1-100', async () => {
-  const { view, input, autocomplete } = await doSetup()
-
-  fireEvent.change(input, { target: { value: 'contigb:1-100' } })
-  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
+  const { view, input } = await doSetup()
+  typeAndEnter({ input, value: 'contigb:1-100' })
   await waitFor(() => {
     expect(view.displayedRegions[0]!.refName).toBe('ctgB')
   })
 }, 30_000)
 
 test('description of gene, searching: kinase', async () => {
-  const { input, findByText, autocomplete } = await doSetup()
+  const { input, findByText } = await doSetup()
 
   fireEvent.change(input, { target: { value: 'kinase' } })
   fireEvent.click(await findByText('EDEN (protein kinase)', ...opts))
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await waitFor(() => {
     expect(input.value).toBe('ctgA:1..10,590')
   }, delay)
 }, 30_000)
 
 test('search matches description for feature in two places', async () => {
-  const { input, findByText, autocomplete } = await doSetup()
+  const { input, findByText } = await doSetup()
 
   fireEvent.change(input, { target: { value: 'fingerprint' } })
   fireEvent.click(await findByText(/b101.2/, ...opts))
-  fireEvent.keyDown(autocomplete, { key: 'Enter', code: 'Enter' })
   await findByText('Search results', ...opts)
 }, 30_000)

--- a/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, waitFor, within } from '@testing-library/react'
 
 import { doBeforeEach, doSetupForImportForm, setup } from './util'
 
@@ -67,11 +67,10 @@ test('lower case refname, searching: contigb', async () => {
 }, 30_000)
 
 test('lower case refname, click ctgB', async () => {
-  const { getInputValue, autocomplete, input, findByText } = await getInput()
+  const { getInputValue, findByRole, input, findByText } = await getInput()
 
-  fireEvent.click(input)
-  fireEvent.click(autocomplete)
-  fireEvent.click(await findByText(/ctgB/))
+  fireEvent.mouseDown(input)
+  fireEvent.click(within(await findByRole('listbox')).getByText(/ctgB/))
   fireEvent.click(await findByText('Open'))
 
   await waitFor(() => {

--- a/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
+++ b/products/jbrowse-web/src/tests/TextSearchingImportForm.test.tsx
@@ -66,6 +66,19 @@ test('lower case refname, searching: contigb', async () => {
   }, delay)
 }, 30_000)
 
+test('lower case refname, click ctgB', async () => {
+  const { getInputValue, autocomplete, input, findByText } = await getInput()
+
+  fireEvent.click(input)
+  fireEvent.click(autocomplete)
+  fireEvent.click(await findByText(/ctgB/))
+  fireEvent.click(await findByText('Open'))
+
+  await waitFor(() => {
+    expect(getInputValue()).toBe('ctgB:1..6,079')
+  }, delay)
+}, 30_000)
+
 test('description of gene, searching: kinase', async () => {
   const { getInputValue, autocomplete, input, findByText } = await getInput()
 


### PR DESCRIPTION
This PR https://github.com/GMOD/jbrowse-components/pull/4981 introduced a regression in the linear genome view import form where clicking the drop down, selecting "ctgB" then  hitting "Open" would say "Unknown reference sequence (6.1kbp)"

there was no test that did this click->refname select drop down action

This PR reverts the PR #4981 (will take time to debug and fix this properly) and adds a integration test for the click->select refname drop down action