### PR TITLE
Only set sticky view headers on "top-level linear genome views"

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
     // pointerEvents:'auto' to retoggle it back on for a single e.g. svg line
     pointerEvents: 'none',
     width: '100%',
-    zIndex: 1001, // above the 1000 z-index of the floating view header
+    zIndex: 100,
   },
 })
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -14,6 +14,9 @@ const useStyles = makeStyles()(theme => ({
     position: 'absolute',
     right: 0,
     background: theme.palette.background.paper,
+
+    // needed when sticky header is off in lgv, e.g. in breakpoint split view
+    zIndex: 2,
   },
   focusedBackground: {
     background: alpha(theme.palette.secondary.light, 0.2),

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabel.tsx
@@ -17,6 +17,8 @@ import type { BaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
 
 const useStyles = makeStyles()(theme => ({
   root: {
+    // above breakpoint split view
+    zIndex: 200,
     background: alpha(theme.palette.background.paper, 0.8),
     '&:hover': {
       background: theme.palette.background.paper,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelMenu.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelMenu.tsx
@@ -23,16 +23,10 @@ const TrackLabelMenu = observer(function ({
   const trackConf = track.configuration
   const minimized = track.minimized
   const pinned = track.pinned
-  let lgvHasParentView: boolean
-  try {
-    getContainingView(view)
-    lgvHasParentView = true
-  } catch (error) {
-    lgvHasParentView = false
-  }
+  const { isTopLevelView } = view
 
   const items = [
-    ...(lgvHasParentView
+    ...(isTopLevelView
       ? []
       : [
           {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -518,7 +518,7 @@ exports[`renders one track, one region 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u7uo4q-MuiPaper-root-root-unpinnedTrack"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-19mv1l5-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1i0p0kv-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span
@@ -1588,7 +1588,7 @@ exports[`renders two tracks, two regions 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u7uo4q-MuiPaper-root-root-unpinnedTrack"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-19mv1l5-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1i0p0kv-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span
@@ -1711,7 +1711,7 @@ exports[`renders two tracks, two regions 1`] = `
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u7uo4q-MuiPaper-root-root-unpinnedTrack"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-19mv1l5-MuiPaper-root-trackLabel-trackLabelOverlap-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1i0p0kv-MuiPaper-root-trackLabel-trackLabelOverlap-root"
           style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
         >
           <span

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -347,13 +347,22 @@ export function stateModelFactory(pluginManager: PluginManager) {
       },
       /**
        * #getter
-       * only uses sticky view headers when the lgv is a top level view
+       * checking if lgv is a 'top-level' view is used for toggling pin track
+       * capability, sticky positioning
+       */
+      get isTopLevelView() {
+        const session = getSession(self)
+        return session.views.find(r => r.id === self.id)
+      },
+      /**
+       * #getter
+       * only uses sticky view headers when it is a 'top-level' view and
+       * session allows it
        */
       get stickyViewHeaders() {
         const session = getSession(self)
         return isSessionWithMultipleViews(session)
-          ? session.views.find(r => r.id === self.id) &&
-              session.stickyViewHeaders
+          ? this.isTopLevelView && session.stickyViewHeaders
           : false
       },
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -345,13 +345,21 @@ export function stateModelFactory(pluginManager: PluginManager) {
           ...new Set(self.displayedRegions.map(region => region.assemblyName)),
         ]
       },
+      /**
+       * #getter
+       * only uses sticky view headers when the lgv is a top level view
+       */
       get stickyViewHeaders() {
         const session = getSession(self)
         return isSessionWithMultipleViews(session)
-          ? session.stickyViewHeaders
+          ? session.views.find(r => r.id === self.id) &&
+              session.stickyViewHeaders
           : false
       },
 
+      /**
+       * #getter
+       */
       get rubberbandTop() {
         let pinnedTracksTop = 0
         if (this.stickyViewHeaders) {

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -1308,7 +1308,7 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                 class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u7uo4q-MuiPaper-root-root-unpinnedTrack"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1osk2yv-MuiPaper-root-trackLabel-trackLabelOffset-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1fyjxz2-MuiPaper-root-trackLabel-trackLabelOffset-root"
                   style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
                 >
                   <span


### PR DESCRIPTION
This checks if the linear genome view is in the list of session.views

If it is, it is allowed to set sticky view headers, otherwise it doesn't

This is a 'general' way of expressing "is this linear genomeview a top level view", and captures the similar notion of "is this linear genome view a subview" (e.g. in breakpoint split view)

Fixes #5023
