### PR TITLE
Allow hiding insertion and deletion in synteny view to help chain file visualization

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
@@ -40,8 +40,17 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
       }),
     )
     .volatile((/* self */) => ({
+      /**
+       * #volatile
+       */
       renderInProgress: undefined as string | undefined,
+      /**
+       * #volatile
+       */
       features: undefined as Feature[] | undefined,
+      /**
+       * #volatile
+       */
       message: undefined as string | undefined,
     }))
     .views(self => ({

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/HeaderSearchBoxes.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/HeaderSearchBoxes.tsx
@@ -1,4 +1,4 @@
-import { toLocale } from '@jbrowse/core/util'
+import { getBpDisplayStr } from '@jbrowse/core/util'
 import { SearchBox } from '@jbrowse/plugin-linear-genome-view'
 import { Typography } from '@mui/material'
 import { observer } from 'mobx-react'
@@ -28,7 +28,7 @@ const HeaderSearchBoxes = observer(function ({
     <span className={classes.searchBox}>
       <SearchBox model={view} showHelp={false} />
       <Typography variant="body2" color="textSecondary" className={classes.bp}>
-        {assemblyNames.join(',')} {toLocale(Math.round(coarseTotalBp))} bp
+        {assemblyNames.join(',')} {getBpDisplayStr(coarseTotalBp)}
       </Typography>
     </span>
   )

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
@@ -39,6 +39,7 @@ export function drawRef(
   const view = getContainingView(model) as LinearSyntenyViewModel
   const drawCurves = view.drawCurves
   const drawCIGAR = view.drawCIGAR
+  const drawCIGARMatchesOnly = view.drawCIGARMatchesOnly
   const { level, height, featPositions } = model
   const width = view.width
   const bpPerPxs = view.views.map(v => v.bpPerPx)
@@ -173,12 +174,19 @@ export function drawRef(
               // allow rendering the dominant color when using continuing
               // flag if the last element of continuing was a large
               // feature, else just use match
-              ctx1.fillStyle =
-                colorMap[(continuingFlag && d1 > 1) || d2 > 1 ? op : 'M']
+              const letter = (continuingFlag && d1 > 1) || d2 > 1 ? op : 'M'
+              ctx1.fillStyle = colorMap[letter]
               continuingFlag = false
 
-              draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
-              ctx1.fill()
+              if (drawCIGARMatchesOnly) {
+                if (letter === 'M') {
+                  draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
+                  ctx1.fill()
+                }
+              } else {
+                draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
+                ctx1.fill()
+              }
               if (ctx3) {
                 ctx3.fillStyle = makeColor(idx)
                 draw(ctx3, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ExportSvgDialog.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ExportSvgDialog.tsx
@@ -10,12 +10,12 @@ import {
   DialogContent,
   FormControlLabel,
   MenuItem,
-  TextField,
   Typography,
 } from '@mui/material'
 
-import type { ExportSvgOptions } from '../model'
-import type { TextFieldProps } from '@mui/material'
+import TextField2 from './TextField2'
+
+import type { ExportSvgOptions } from '../types'
 
 function LoadingMessage() {
   return (
@@ -30,13 +30,6 @@ function useSvgLocal<T>(key: string, val: T) {
   return useLocalStorage(`svg-${key}`, val)
 }
 
-function TextField2({ children, ...rest }: TextFieldProps) {
-  return (
-    <div>
-      <TextField {...rest}>{children}</TextField>
-    </div>
-  )
-}
 export default function ExportSvgDialog({
   model,
   handleClose,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/TextField2.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/TextField2.tsx
@@ -1,0 +1,11 @@
+import { TextField } from '@mui/material'
+
+import type { TextFieldProps } from '@mui/material'
+
+export default function TextField2({ children, ...rest }: TextFieldProps) {
+  return (
+    <div>
+      <TextField {...rest}>{children}</TextField>
+    </div>
+  )
+}

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
@@ -1,4 +1,3 @@
-import type React from 'react'
 import { lazy } from 'react'
 
 import { getSession } from '@jbrowse/core/util'
@@ -13,27 +12,12 @@ import { types } from 'mobx-state-tree'
 import { Curves } from './components/Icons'
 import baseModel from '../LinearComparativeView/model'
 
-import type { ImportFormSyntenyTrack } from './types'
+import type { ExportSvgOptions, ImportFormSyntenyTrack } from './types'
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { Instance } from 'mobx-state-tree'
 
 // lazies
 const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
-
-export interface ExportSvgOptions {
-  rasterizeLayers?: boolean
-  scale?: number
-  filename?: string
-  Wrapper?: React.FC<{ children: React.ReactNode }>
-  fontSize?: number
-  rulerHeight?: number
-  textHeight?: number
-  paddingHeight?: number
-  headerHeight?: number
-  cytobandHeight?: number
-  themeName?: string
-  trackLabels?: string
-}
 
 /**
  * #stateModel LinearSyntenyView
@@ -54,6 +38,10 @@ export default function stateModelFactory(pluginManager: PluginManager) {
          * #property/
          */
         drawCIGAR: true,
+        /**
+         * #property/
+         */
+        drawCIGARMatchesOnly: false,
         /**
          * #property
          */
@@ -97,6 +85,12 @@ export default function stateModelFactory(pluginManager: PluginManager) {
        */
       setDrawCIGAR(arg: boolean) {
         self.drawCIGAR = arg
+      },
+      /**
+       * #action
+       */
+      setDrawCIGARMatchesOnly(arg: boolean) {
+        self.drawCIGARMatchesOnly = arg
       },
       /**
        * #action
@@ -151,9 +145,20 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               label: 'Draw CIGAR',
               checked: self.drawCIGAR,
               type: 'checkbox',
-              description: 'Draws per-base CIGAR level alignments',
+              description:
+                'If disabled, only draws the broad scale CIGAR match',
               onClick: () => {
                 self.setDrawCIGAR(!self.drawCIGAR)
+              },
+            },
+            {
+              label: 'Draw only CIGAR matches',
+              checked: self.drawCIGARMatchesOnly,
+              type: 'checkbox',
+              description:
+                'If enabled, it hides the insertions and deletions in the CIGAR strings, helps with divergent',
+              onClick: () => {
+                self.setDrawCIGARMatchesOnly(!self.drawCIGARMatchesOnly)
               },
             },
             {

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/svgcomponents/SVGLinearSyntenyView.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/svgcomponents/SVGLinearSyntenyView.tsx
@@ -18,7 +18,8 @@ import SVGBackground from './SVGBackground'
 import SVGLinearGenomeView from './SVGLinearGenomeView'
 import { drawRef } from '../../LinearSyntenyDisplay/drawSynteny'
 
-import type { ExportSvgOptions, LinearSyntenyViewModel } from '../model'
+import type { LinearSyntenyViewModel } from '../model'
+import type { ExportSvgOptions } from '../types'
 
 // render LGV to SVG
 export async function renderToSvg(

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/types.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/types.ts
@@ -1,3 +1,5 @@
+import type React from 'react'
+
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { SnapshotIn } from 'mobx-state-tree'
 
@@ -7,3 +9,18 @@ export type ImportFormSyntenyTrack =
   | { type: 'preConfigured'; value: string }
   | { type: 'userOpened'; value: Conf }
   | { type: 'none' }
+
+export interface ExportSvgOptions {
+  rasterizeLayers?: boolean
+  scale?: number
+  filename?: string
+  Wrapper?: React.FC<{ children: React.ReactNode }>
+  fontSize?: number
+  rulerHeight?: number
+  textHeight?: number
+  paddingHeight?: number
+  headerHeight?: number
+  cytobandHeight?: number
+  themeName?: string
+  trackLabels?: string
+}


### PR DESCRIPTION
Our processing of Chain files changes them into 'normal alignments' with a CIGAR string. These files will have a very large insertion directly following by a very large deletion. These are especially prevalent in distant evolutionary distances e.g. human vs mouse. It is not really that informative to see these "giant insertion+giant deletion" (that is just a big substitution or something that completely changed), so this PR adds an option to just hide all insertions and deletions in the CIGAR rendering called "Draw CIGAR matches only"

As implemented in this PR, this setting is a bit obscure that most people may not find, but hopefully could help some users and it might be something that could automatically toggle e.g. the rendering pipeline could detect these (insertion followed by deletion) cases

Example with this setting

Before
![image](https://github.com/user-attachments/assets/da86d6f9-0e21-4bce-90dc-ccbdd143e10f)


After
![image](https://github.com/user-attachments/assets/86191416-1b18-406c-a1cf-1f2668b7e9f4)
