### PR TITLE
Use trash icon for uninstall in plugin store, and add version number string

### DIFF
--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
@@ -2,11 +2,13 @@ import { lazy } from 'react'
 
 import { getEnv, getSession } from '@jbrowse/core/util'
 import { isSessionWithSessionPlugins } from '@jbrowse/core/util/types'
-import CloseIcon from '@mui/icons-material/Close'
+import DeleteIcon from '@mui/icons-material/Delete'
 import LockIcon from '@mui/icons-material/Lock'
 import { IconButton, ListItem, Tooltip, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
+
+import { isSessionPlugin } from './util'
 
 import type { PluginStoreModel } from '../model'
 import type { BasePlugin } from '@jbrowse/core/util/types'
@@ -15,22 +17,69 @@ import type { BasePlugin } from '@jbrowse/core/util/types'
 const DeletePluginDialog = lazy(() => import('./DeletePluginDialog'))
 
 const useStyles = makeStyles()(() => ({
-  lockedPluginTooltip: {
+  iconMargin: {
     marginRight: '0.5rem',
   },
 }))
 
-function LockedPlugin() {
+function LockedPluginIconButton() {
   const { classes } = useStyles()
   return (
     <Tooltip
-      className={classes.lockedPluginTooltip}
+      className={classes.iconMargin}
       title="This plugin was installed by an administrator, you cannot remove it."
     >
-      <LockIcon />
+      <span>
+        <IconButton disabled>
+          <LockIcon />
+        </IconButton>
+      </span>
     </Tooltip>
   )
 }
+
+const UninstallPluginIconButton = observer(function ({
+  plugin,
+  model,
+}: {
+  plugin: BasePlugin
+  model: PluginStoreModel
+}) {
+  const { classes } = useStyles()
+  const { pluginManager } = getEnv(model)
+  const session = getSession(model)
+  const { jbrowse, adminMode } = session
+  return (
+    <Tooltip className={classes.iconMargin} title="Uninstall plugin">
+      <IconButton
+        data-testid={`removePlugin-${plugin.name}`}
+        onClick={() => {
+          session.queueDialog(onClose => [
+            DeletePluginDialog,
+            {
+              plugin: plugin.name,
+              onClose: (name?: string) => {
+                if (name) {
+                  const pluginMetadata =
+                    pluginManager.pluginMetadata[plugin.name]
+
+                  if (adminMode) {
+                    jbrowse.removePlugin(pluginMetadata)
+                  } else if (isSessionWithSessionPlugins(session)) {
+                    session.removeSessionPlugin(pluginMetadata)
+                  }
+                }
+                onClose()
+              },
+            },
+          ])
+        }}
+      >
+        <DeleteIcon />
+      </IconButton>
+    </Tooltip>
+  )
+})
 
 const InstalledPlugin = observer(function ({
   plugin,
@@ -39,46 +88,15 @@ const InstalledPlugin = observer(function ({
   plugin: BasePlugin
   model: PluginStoreModel
 }) {
-  const { pluginManager } = getEnv(model)
   const session = getSession(model)
-  const { jbrowse, adminMode } = session
-  const isSessionPlugin = isSessionWithSessionPlugins(session)
-    ? session.sessionPlugins.some(
-        p => pluginManager.pluginMetadata[plugin.name]?.url === p.url,
-      )
-    : false
+  const { adminMode } = session
 
   return (
     <ListItem key={plugin.name}>
-      {adminMode || isSessionPlugin ? (
-        <IconButton
-          data-testid={`removePlugin-${plugin.name}`}
-          onClick={() => {
-            session.queueDialog(onClose => [
-              DeletePluginDialog,
-              {
-                plugin: plugin.name,
-                onClose: (name?: string) => {
-                  if (name) {
-                    const pluginMetadata =
-                      pluginManager.pluginMetadata[plugin.name]
-
-                    if (adminMode) {
-                      jbrowse.removePlugin(pluginMetadata)
-                    } else if (isSessionWithSessionPlugins(session)) {
-                      session.removeSessionPlugin(pluginMetadata)
-                    }
-                  }
-                  onClose()
-                },
-              },
-            ])
-          }}
-        >
-          <CloseIcon />
-        </IconButton>
+      {adminMode || isSessionPlugin(plugin, session) ? (
+        <UninstallPluginIconButton plugin={plugin} model={model} />
       ) : (
-        <LockedPlugin />
+        <LockedPluginIconButton />
       )}
       <Typography>
         {[plugin.name, plugin.version ? `(v${plugin.version})` : '']

--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
@@ -80,7 +80,11 @@ const InstalledPlugin = observer(function ({
       ) : (
         <LockedPlugin />
       )}
-      <Typography>{plugin.name}</Typography>
+      <Typography>
+        {[plugin.name, plugin.version ? `(v${plugin.version})` : '']
+          .filter(f => !!f)
+          .join(' ')}
+      </Typography>
     </ListItem>
   )
 })

--- a/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.tsx.snap
+++ b/plugins/data-management/src/PluginStoreWidget/components/__snapshots__/PluginStoreWidget.test.tsx.snap
@@ -109,19 +109,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -131,19 +142,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -153,19 +175,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -175,19 +208,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -197,19 +241,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -219,19 +274,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -241,19 +307,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -263,19 +340,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -285,19 +373,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -307,19 +406,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -329,19 +439,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -351,19 +472,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -373,19 +505,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -395,19 +538,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -417,19 +571,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -439,19 +604,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -461,19 +637,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -483,19 +670,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -505,19 +703,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -527,19 +736,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -549,19 +769,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -571,19 +802,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -593,19 +835,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -615,19 +868,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -637,19 +901,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -659,19 +934,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -681,19 +967,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -703,19 +1000,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >
@@ -725,19 +1033,30 @@ exports[`renders with the available plugins 1`] = `
                   <li
                     class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-qyw6ft-MuiListItem-root"
                   >
-                    <svg
-                      aria-hidden="true"
+                    <span
                       aria-label="This plugin was installed by an administrator, you cannot remove it."
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-sosa8k-MuiSvgIcon-root-lockedPluginTooltip"
+                      class="css-1xdepnh-iconMargin"
                       data-mui-internal-clone-element="true"
-                      data-testid="LockIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
                     >
-                      <path
-                        d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
-                      />
-                    </svg>
+                      <button
+                        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-13z539w-MuiButtonBase-root-MuiIconButton-root"
+                        disabled=""
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-14500qs-MuiSvgIcon-root"
+                          data-testid="LockIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
                     >

--- a/plugins/data-management/src/PluginStoreWidget/components/util.ts
+++ b/plugins/data-management/src/PluginStoreWidget/components/util.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 
-import type { JBrowsePlugin } from '@jbrowse/core/util/types'
+import { getEnv, isSessionWithSessionPlugins } from '@jbrowse/core/util'
+
+import type {
+  AbstractSessionModel,
+  BasePlugin,
+  JBrowsePlugin,
+} from '@jbrowse/core/util/types'
 
 export function useFetchPlugins() {
   const [plugins, setPlugins] = useState<JBrowsePlugin[]>()
@@ -23,4 +29,16 @@ export function useFetchPlugins() {
     })()
   }, [])
   return { plugins, error }
+}
+
+export function isSessionPlugin(
+  plugin: BasePlugin,
+  session: AbstractSessionModel,
+) {
+  const { pluginManager } = getEnv(session)
+  return isSessionWithSessionPlugins(session)
+    ? session.sessionPlugins.some(
+        p => pluginManager.pluginMetadata[plugin.name]?.url === p.url,
+      )
+    : false
 }


### PR DESCRIPTION
This changes the icon to be "Trash can" for plugin uninstall, and adds disabled state to the "lock" icon

It also adds the plugin version to the description

before
<img width="399" alt="Screenshot 2025-05-19 at 12 41 01 PM" src="https://github.com/user-attachments/assets/0a5082d4-bca7-4003-a3e9-7aeef2509d19" />

after
<img width="403" alt="Screenshot 2025-05-19 at 12 41 48 PM" src="https://github.com/user-attachments/assets/3efb8cc4-7cbf-4de8-b909-2284ec1bd665" />
