### PR TITLE
Remove the async keyword from BaseLinearDisplayModel

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
@@ -377,9 +377,7 @@ export function SharedLinearPileupDisplayMixin(
                   icon: MenuOpenIcon,
                   onClick: () => {
                     self.clearFeatureSelection()
-                    self.selectFeature(feat).catch((e: unknown) => {
-                      getSession(self).notifyError(`${e}`, e)
-                    })
+                    self.selectFeature(feat)
                   },
                 },
                 {
@@ -436,7 +434,7 @@ export function SharedLinearPileupDisplayMixin(
                   )) as { feature: SimpleFeatureSerialized | undefined }
 
                   if (isAlive(self) && feature) {
-                    await self.selectFeature(new SimpleFeature(feature))
+                    self.selectFeature(new SimpleFeature(feature))
                   }
                 }
               } catch (e) {


### PR DESCRIPTION
Placing the async keyword on selectFeature, which was added in #5010, causes issues with any display that tries to override the select feature function

This changes it so the async behavior is wrapped in a IIFE


fixes https://github.com/GMOD/jbrowse-components/issues/5030