### PR TITLE
Check that the subtracks of breakpoint split view are ready before fetching

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/model.tsx
@@ -170,10 +170,6 @@ function stateModelFactory(
        * #method
        */
       notReady() {
-        const pNotReady = self.PileupDisplay.renderProps().notReady
-        const snpNotReady = self.SNPCoverageDisplay.renderProps().notReady
-        console.log({ pNotReady, snpNotReady })
-
         return (
           self.PileupDisplay.renderProps().notReady ||
           self.SNPCoverageDisplay.renderProps().notReady

--- a/plugins/alignments/src/LinearAlignmentsDisplay/model.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/model.tsx
@@ -165,6 +165,20 @@ function stateModelFactory(
           displayId: `${self.configuration.displayId}_snpcoverage_xyz`, // xyz to avoid someone accidentally naming the displayId similar to this
         }
       },
+
+      /**
+       * #method
+       */
+      notReady() {
+        const pNotReady = self.PileupDisplay.renderProps().notReady
+        const snpNotReady = self.SNPCoverageDisplay.renderProps().notReady
+        console.log({ pNotReady, snpNotReady })
+
+        return (
+          self.PileupDisplay.renderProps().notReady ||
+          self.SNPCoverageDisplay.renderProps().notReady
+        )
+      },
     }))
     .actions(self => ({
       /**
@@ -281,11 +295,7 @@ function stateModelFactory(
        */
       async renderSvg(opts: { rasterizeLayers?: boolean }) {
         const pileupHeight = self.height - self.SNPCoverageDisplay.height
-        await when(
-          () =>
-            !self.PileupDisplay.renderProps().notReady &&
-            !self.SNPCoverageDisplay.renderProps().notReady,
-        )
+        await when(() => !self.notReady())
         return (
           <>
             <g>{await self.SNPCoverageDisplay.renderSvg(opts)}</g>

--- a/plugins/alignments/src/LinearPileupDisplay/model.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/model.ts
@@ -284,7 +284,6 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
         trackMenuItems() {
           return [
             ...superTrackMenuItems(),
-
             {
               label: 'Sort by...',
               icon: SwapVertIcon,

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/model.ts
@@ -292,17 +292,11 @@ function stateModelFactory(
         /**
          * #getter
          */
-        get renderReady() {
+        renderReady() {
           const superProps = superRenderProps()
           return !superProps.notReady && self.modificationsReady
         },
 
-        /**
-         * #getter
-         */
-        get ready() {
-          return this.renderReady
-        },
         /**
          * #method
          */
@@ -310,7 +304,7 @@ function stateModelFactory(
           const { colorBy, visibleModifications } = self
           return {
             ...superRenderProps(),
-            notReady: !this.ready,
+            notReady: !this.renderReady(),
             colorBy,
             visibleModifications: Object.fromEntries(
               visibleModifications.toJSON(),

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/getClip.test.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/getClip.test.ts
@@ -1,0 +1,8 @@
+import { getClip } from './getClip'
+
+test('test clip', () => {
+  expect(getClip('5S5M', 1)).toBe(5)
+  expect(getClip('5S5M', -1)).toBe(0)
+  expect(getClip('5M5S', 1)).toBe(0)
+  expect(getClip('5M5S', -1)).toBe(5)
+})

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/getClip.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/getClip.ts
@@ -1,0 +1,8 @@
+const startClip = new RegExp(/(\d+)[SH]$/)
+const endClip = new RegExp(/^(\d+)([SH])/)
+
+export function getClip(cigar: string, strand: number) {
+  return strand === -1
+    ? +(startClip.exec(cigar) || [])[1]! || 0
+    : +(endClip.exec(cigar) || [])[1]! || 0
+}

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
@@ -282,9 +282,6 @@ export default function stateModelFactory(pluginManager: PluginManager) {
                 return
               }
 
-              console.log(
-                self.matchedTracks.map(track => track.displays[0].notReady?.()),
-              )
               self.setMatchedTrackFeatures(
                 Object.fromEntries(
                   await Promise.all(

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
@@ -8,7 +8,8 @@ import { saveAs } from 'file-saver'
 import { autorun } from 'mobx'
 import { addDisposer, getPath, onAction, types } from 'mobx-state-tree'
 
-import { calc, getBlockFeatures, getClip, intersect } from './util'
+import { calc, getBlockFeatures, intersect } from './util'
+import { getClip } from './getClip'
 
 import type { ExportSvgOptions } from './types'
 import type PluginManager from '@jbrowse/core/PluginManager'
@@ -25,7 +26,6 @@ const ExportSvgDialog = lazy(() => import('./components/ExportSvgDialog'))
  * - [BaseViewModel](../baseviewmodel)
  */
 export default function stateModelFactory(pluginManager: PluginManager) {
-  const minHeight = 40
   const defaultHeight = 400
   return types
     .compose(
@@ -39,14 +39,7 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         /**
          * #property
          */
-        height: types.optional(
-          types.refinement(
-            'viewHeight',
-            types.number,
-            (n: number) => n >= minHeight,
-          ),
-          defaultHeight,
-        ),
+        height: types.optional(types.number, defaultHeight),
         /**
          * #property
          */
@@ -73,7 +66,13 @@ export default function stateModelFactory(pluginManager: PluginManager) {
       }),
     )
     .volatile(() => ({
+      /**
+       * #volatile
+       */
       width: 800,
+      /**
+       * #volatile
+       */
       matchedTrackFeatures: {} as Record<string, Feature[][]>,
     }))
     .views(self => ({
@@ -278,10 +277,16 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               self.setMatchedTrackFeatures(
                 Object.fromEntries(
                   await Promise.all(
-                    self.matchedTracks.map(async track => [
-                      track.configuration.trackId,
-                      await getBlockFeatures(self, track),
-                    ]),
+                    self.matchedTracks.map(async track => {
+                      console.log(
+                        track,
+                        track.displays[0].PileupDisplay?.renderReady(),
+                      )
+                      return [
+                        track.configuration.trackId,
+                        await getBlockFeatures(self, track),
+                      ]
+                    }),
                   ),
                 ),
               )

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
@@ -15,11 +15,13 @@ interface Display {
   height: number
   scrollTop: number
   SNPCoverageDisplay?: { height: number }
+  notReady?: () => boolean
   searchFeatureByID?: (str: string) => LayoutRecord
 }
 
 interface Track {
   displays: Display[]
+  configuration: AnyConfigurationModel
 }
 
 const [, TOP, , BOTTOM] = [0, 1, 2, 3] as const
@@ -93,24 +95,18 @@ export function intersect<T>(
   return rest.length === 0 ? a12 : intersect(cb, a12, ...rest)
 }
 
-const startClip = new RegExp(/(\d+)[SH]$/)
-const endClip = new RegExp(/^(\d+)([SH])/)
-
 export function calc(track: Track, f: Feature) {
   return track.displays[0]!.searchFeatureByID?.(f.id())
 }
 
 export async function getBlockFeatures(
   model: { views: LinearGenomeViewModel[] },
-  track: { configuration: AnyConfigurationModel },
+  track: Track,
 ) {
   const { views } = model
-  const { rpcManager, assemblyManager } = getSession(model)
+  const { rpcManager } = getSession(model)
   const sessionId = getRpcSessionId(track)
-  const assemblyName = model.views[0]?.assemblyNames[0]
-  const assembly = assemblyName
-    ? await assemblyManager.waitForAssembly(assemblyName)
-    : undefined
+
   return Promise.all(
     views.flatMap(
       async view =>

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
@@ -112,15 +112,11 @@ export async function getBlockFeatures(
 ) {
   const { views } = model
   const { rpcManager, assemblyManager } = getSession(model)
-  const assemblyName = model.views[0]?.assemblyNames[0]
-  if (!assemblyName) {
-    return undefined
-  }
-  const assembly = await assemblyManager.waitForAssembly(assemblyName)
-  if (!assembly) {
-    return undefined
-  }
   const sessionId = getRpcSessionId(track)
+  const assemblyName = model.views[0]?.assemblyNames[0]
+  const assembly = assemblyName
+    ? await assemblyManager.waitForAssembly(assemblyName)
+    : undefined
   return Promise.all(
     views.flatMap(
       async view =>

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/util.ts
@@ -96,12 +96,6 @@ export function intersect<T>(
 const startClip = new RegExp(/(\d+)[SH]$/)
 const endClip = new RegExp(/^(\d+)([SH])/)
 
-export function getClip(cigar: string, strand: number) {
-  return strand === -1
-    ? +(startClip.exec(cigar) || [])[1]! || 0
-    : +(endClip.exec(cigar) || [])[1]! || 0
-}
-
 export function calc(track: Track, f: Feature) {
   return track.displays[0]!.searchFeatureByID?.(f.id())
 }


### PR DESCRIPTION
## Background - prehistory

The breakpoint split view, for better or worse, fetches features independently of the tracks

This is because the tracks don't have full info about the features that they contain, because this is slow due to serialization of data over webworker


## Background - this issue

The breakpoint split view calls CoreGetFeatures independently of the tracks. However, it doesn't check if it is appropriate to call getFeatures (e.g. if it is looking at too large an area)

This can cause it to trigger very large data downloads accidentally in some cases, and this came up when re-navigating breakpoint split views

## This fix


This PR fixes it by checking for the track.displays[0] being not not ready. This may not be a complete solution even in itself yet, because it only checks the flag on the first instance of the track e.g. not both levels of the breakpoint split view

Fixes #5026 

## Random background

We use the term notReady instead of ready because if a track sets the ready flag to undefined, that does not necessarily mean it is not ready even though that is falsy...we try to look for genuine signals from tracks who define the concept of them being not ready but looking for notReady true, which avoids having to reason about ready:undefined being not ready or not


