### PR TITLE
Avoid inferring CDS subfeatures from non-coding gene pred features

### DIFF
--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -62,12 +62,12 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
     const { header } = await this.configure(opts)
     const ret = await Promise.all(
       Object.keys(header.refsByName).map(
-        async r =>
+        async refName =>
           (
             await firstValueFrom(
               this.getFeatures({
                 assemblyName: '',
-                refName: r,
+                refName,
                 start: 0,
                 end: 1,
               }).pipe(toArray()),
@@ -104,11 +104,11 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
   async getHeader(opts?: BaseOptions) {
     const { parser, header } = await this.configure(opts)
     const { version, fileType } = header
-    const { fields, ...rest } = parser.autoSql
+    const { fields, ...autoSql } = parser.autoSql
     return {
       version,
       fileType,
-      autoSql: { ...rest },
+      autoSql,
       fields: await this.getMetadata(opts),
     }
   }
@@ -150,126 +150,134 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
         }),
     )
 
-    const parentAggregation = {} as Record<string, SimpleFeatureSerialized[]>
-    const parentAggregationFlat = []
+    await updateStatus('Processing features', statusCallback, async () => {
+      const parentAggregation = {} as Record<string, SimpleFeatureSerialized[]>
+      const parentAggregationFlat = []
 
-    if (feats.some(f => f.uniqueId === undefined)) {
-      throw new Error('found uniqueId undefined')
-    }
-    for (const feat of feats) {
-      const splitLine = [
-        query.refName,
-        `${feat.start}`,
-        `${feat.end}`,
-        ...(feat.rest?.split('\t') || []),
-      ]
-      const data = parser.parseLine(splitLine, {
-        uniqueId: feat.uniqueId!,
-      })
-
-      const aggr = data[aggregateField]
-      const aggrIsNotNone = aggr && aggr !== 'none'
-      if (aggrIsNotNone && !parentAggregation[aggr]) {
-        parentAggregation[aggr] = []
+      if (feats.some(f => f.uniqueId === undefined)) {
+        throw new Error('found uniqueId undefined')
       }
-      const {
-        uniqueId,
-        type,
-        chrom,
-        chromStart,
-        chromEnd,
-        description,
-        chromStarts: chromStarts2,
-        blockStarts: blockStarts2,
-        blockSizes: blockSizes2,
-        score: score2,
-        blockCount,
-        thickStart,
-        thickEnd,
-        strand,
-        ...rest
-      } = data
+      for (const feat of feats) {
+        const splitLine = [
+          query.refName,
+          `${feat.start}`,
+          `${feat.end}`,
+          ...(feat.rest?.split('\t') || []),
+        ]
+        const data = parser.parseLine(splitLine, {
+          uniqueId: feat.uniqueId!,
+        })
 
-      const f = featureData2({
-        ...rest,
-        scoreColumn,
-        splitLine,
-        parser,
-        uniqueId,
-        start: feat.start,
-        end: feat.end,
-        refName: query.refName,
-      })
-      if (aggrIsNotNone) {
-        parentAggregation[aggr]!.push(f)
-        parentAggregationFlat.push(f)
-      } else {
-        if (
-          doesIntersect2(f.start, f.end, originalQuery.start, originalQuery.end)
-        ) {
+        const aggr = data[aggregateField]
+        const aggrIsNotNone = aggr && aggr !== 'none'
+        if (aggrIsNotNone && !parentAggregation[aggr]) {
+          parentAggregation[aggr] = []
+        }
+        const {
+          uniqueId,
+          type,
+          chrom,
+          chromStart,
+          chromEnd,
+          description,
+          chromStarts: chromStarts2,
+          blockStarts: blockStarts2,
+          blockSizes: blockSizes2,
+          score: score2,
+          blockCount,
+          thickStart,
+          thickEnd,
+          strand,
+          ...rest
+        } = data
+
+        const f = featureData2({
+          ...rest,
+          scoreColumn,
+          splitLine,
+          parser,
+          uniqueId,
+          start: feat.start,
+          end: feat.end,
+          refName: query.refName,
+        })
+        if (aggrIsNotNone) {
+          parentAggregation[aggr]!.push(f)
+          parentAggregationFlat.push(f)
+        } else {
+          if (
+            doesIntersect2(
+              f.start,
+              f.end,
+              originalQuery.start,
+              originalQuery.end,
+            )
+          ) {
+            observer.next(
+              new SimpleFeature({
+                id: `${this.id}-${uniqueId}`,
+                data: f,
+              }),
+            )
+          }
+        }
+      }
+
+      if (allowRedispatch && parentAggregationFlat.length) {
+        let minStart = Number.POSITIVE_INFINITY
+        let maxEnd = Number.NEGATIVE_INFINITY
+        for (const feat of parentAggregationFlat) {
+          if (feat.start < minStart) {
+            minStart = feat.start
+          }
+          if (feat.end > maxEnd) {
+            maxEnd = feat.end
+          }
+        }
+
+        if (maxEnd > query.end || minStart < query.start) {
+          await this.getFeaturesHelper({
+            query: {
+              ...query,
+              // re-query with 500kb added onto start and end, in order to catch
+              // gene subfeatures that may not overlap your view
+              start: minStart - 500_000,
+              end: maxEnd + 500_000,
+            },
+            opts,
+            observer,
+            allowRedispatch: false,
+            originalQuery: query,
+          })
+          return
+        }
+      }
+
+      Object.entries(parentAggregation).map(([name, subfeatures]) => {
+        const s = min(subfeatures.map(f => f.start))
+        const e = max(subfeatures.map(f => f.end))
+        if (doesIntersect2(s, e, originalQuery.start, originalQuery.end)) {
+          const subs = subfeatures.sort((a, b) =>
+            a.uniqueId.localeCompare(b.uniqueId),
+          )
           observer.next(
             new SimpleFeature({
-              id: `${this.id}-${uniqueId}`,
-              data: f,
+              id: `${this.id}-${subs[0]?.uniqueId}-parent`,
+              data: {
+                type: 'gene',
+                subfeatures: subs,
+                strand: subs[0]?.strand || 1,
+                name,
+                start: s,
+                end: e,
+                refName: query.refName,
+              },
             }),
           )
         }
-      }
-    }
-
-    if (allowRedispatch && parentAggregationFlat.length) {
-      let minStart = Number.POSITIVE_INFINITY
-      let maxEnd = Number.NEGATIVE_INFINITY
-      for (const feat of parentAggregationFlat) {
-        if (feat.start < minStart) {
-          minStart = feat.start
-        }
-        if (feat.end > maxEnd) {
-          maxEnd = feat.end
-        }
-      }
-
-      if (maxEnd > query.end || minStart < query.start) {
-        await this.getFeaturesHelper({
-          query: {
-            ...query,
-            // re-query with 500kb added onto start and end, in order to catch
-            // gene subfeatures that may not overlap your view
-            start: minStart - 500_000,
-            end: maxEnd + 500_000,
-          },
-          opts,
-          observer,
-          allowRedispatch: false,
-          originalQuery: query,
-        })
-        return
-      }
-    }
-
-    Object.entries(parentAggregation).map(([name, subfeatures]) => {
-      const s = min(subfeatures.map(f => f.start))
-      const e = max(subfeatures.map(f => f.end))
-      if (doesIntersect2(s, e, originalQuery.start, originalQuery.end)) {
-        const subs = subfeatures.sort((a, b) =>
-          a.uniqueId.localeCompare(b.uniqueId),
-        )
-        observer.next(
-          new SimpleFeature({
-            id: `${this.id}-${subs[0]?.uniqueId}-parent`,
-            data: {
-              type: 'gene',
-              subfeatures: subs,
-              strand: subs[0]?.strand || 1,
-              name,
-              start: s,
-              end: e,
-              refName: query.refName,
-            },
-          }),
-        )
-      }
+      })
     })
+
     observer.complete()
   }
   public getFeatures(query: Region, opts: BaseOptions = {}) {

--- a/plugins/bed/src/generateUcscTranscript.ts
+++ b/plugins/bed/src/generateUcscTranscript.ts
@@ -38,91 +38,114 @@ export function generateUcscTranscript(data: TranscriptFeat) {
     .filter(child => child.type === 'block')
     .sort((a, b) => a.start - b.start)
 
-  for (const block of feats) {
-    const start = block.start
-    const end = block.end
-    if (thickStart >= end) {
-      // left-side UTR
-      subfeatures.push({
-        type: `${strand > 0 ? 'five' : 'three'}_prime_UTR`,
-        start,
-        end,
-        refName,
-      })
-    } else if (thickStart > start && thickStart < end && thickEnd >= end) {
-      // UTR | CDS
-      subfeatures.push(
-        {
+  const { cdsEndStat, cdsStartStat } = rest2
+  if (cdsStartStat === 'none' && cdsEndStat === 'none') {
+    return {
+      ...rest2,
+      uniqueId,
+      strand,
+      type: 'transcript',
+      refName,
+      subfeatures: feats.map(e => ({
+        ...e,
+        type: 'exon',
+      })),
+    }
+  } else {
+    for (const block of feats) {
+      const start = block.start
+      const end = block.end
+      if (thickStart >= end) {
+        // left-side UTR
+        subfeatures.push({
           type: `${strand > 0 ? 'five' : 'three'}_prime_UTR`,
           start,
-          end: thickStart,
-          refName,
-        },
-        {
-          type: 'CDS',
-          phase: 0,
-          start: thickStart,
           end,
           refName,
-        },
-      )
-    } else if (thickStart <= start && thickEnd >= end) {
-      // CDS
-      subfeatures.push({
-        type: 'CDS',
-        phase: 0,
-        start,
-        end,
-        refName,
-      })
-    } else if (thickStart > start && thickStart < end && thickEnd < end) {
-      // UTR | CDS | UTR
-      subfeatures.push(
-        {
-          type: `${strand > 0 ? 'five' : 'three'}_prime_UTR`,
-          start,
-          end: thickStart,
-          refName,
-        },
-        {
-          type: 'CDS',
-          phase: 0,
-          start: thickStart,
-          end: thickEnd,
-          refName,
-        },
-        {
-          type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
-          start: thickEnd,
-          end,
-          refName,
-        },
-      )
-    } else if (thickStart <= start && thickEnd > start && thickEnd < end) {
-      // CDS | UTR
-      subfeatures.push(
-        {
+        })
+      } else if (thickStart > start && thickStart < end && thickEnd >= end) {
+        // UTR | CDS
+        subfeatures.push(
+          {
+            type: `${strand > 0 ? 'five' : 'three'}_prime_UTR`,
+            start,
+            end: thickStart,
+            refName,
+          },
+          {
+            type: 'CDS',
+            phase: 0,
+            start: thickStart,
+            end,
+            refName,
+          },
+        )
+      } else if (thickStart <= start && thickEnd >= end) {
+        // CDS
+        subfeatures.push({
           type: 'CDS',
           phase: 0,
           start,
-          end: thickEnd,
-          refName,
-        },
-        {
-          type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
-          start: thickEnd,
           end,
           refName,
-        },
-      )
-    } else if (thickEnd <= start) {
-      // right-side UTR
-      subfeatures.push({
-        type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
-        start,
-        end,
-        refName,
-      })
+        })
+      } else if (thickStart > start && thickStart < end && thickEnd < end) {
+        // UTR | CDS | UTR
+        subfeatures.push(
+          {
+            type: `${strand > 0 ? 'five' : 'three'}_prime_UTR`,
+            start,
+            end: thickStart,
+            refName,
+          },
+          {
+            type: 'CDS',
+            phase: 0,
+            start: thickStart,
+            end: thickEnd,
+            refName,
+          },
+          {
+            type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
+            start: thickEnd,
+            end,
+            refName,
+          },
+        )
+      } else if (thickStart <= start && thickEnd > start && thickEnd < end) {
+        // CDS | UTR
+        subfeatures.push(
+          {
+            type: 'CDS',
+            phase: 0,
+            start,
+            end: thickEnd,
+            refName,
+          },
+          {
+            type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
+            start: thickEnd,
+            end,
+            refName,
+          },
+        )
+      } else if (thickEnd <= start) {
+        // right-side UTR
+        subfeatures.push({
+          type: `${strand > 0 ? 'three' : 'five'}_prime_UTR`,
+          start,
+          end,
+          refName,
+        })
+      }
+    }
+    return {
+      ...rest2,
+      uniqueId,
+      strand,
+      type: 'mRNA',
+      refName,
+      subfeatures,
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,9 +148,9 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-s3@^3.787.0":
-  version "3.812.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.812.0.tgz#bb7264ebb4982379f725a1ee164741decc9d4d95"
-  integrity sha512-kHgw9JDXNPLa/mHtWpOd5btBVXFSe+wwp1Ed9+bqz9uLkv0iV4joZrdQwnydkO8zlTs60Sc5ez+P2OiZ76i2Qg==
+  version "3.815.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.815.0.tgz#4caac6c581a100f9615e4f830892de14265e9755"
+  integrity sha512-tpJyXuGYIPHIu8G53jXQw3mN5ZK6LdL+tcEF3kRJuQ377Vbo+BSfqaizt9Qb3JuOGcNwCp83jd2LlmcXypN5fg==
   dependencies:
     "@aws-crypto/sha1-browser" "5.2.0"
     "@aws-crypto/sha256-browser" "5.2.0"
@@ -159,7 +159,7 @@
     "@aws-sdk/credential-provider-node" "3.812.0"
     "@aws-sdk/middleware-bucket-endpoint" "3.808.0"
     "@aws-sdk/middleware-expect-continue" "3.804.0"
-    "@aws-sdk/middleware-flexible-checksums" "3.812.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.815.0"
     "@aws-sdk/middleware-host-header" "3.804.0"
     "@aws-sdk/middleware-location-constraint" "3.804.0"
     "@aws-sdk/middleware-logger" "3.804.0"
@@ -395,10 +395,10 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-flexible-checksums@3.812.0":
-  version "3.812.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.812.0.tgz#f8177c919b5878972a5d3152700f9a87c999fe14"
-  integrity sha512-/ayAooUZvV1GTomNMrfbhjUHAEaz0Wmio3lKyaTJsW4WdLJXBuzdo57YADRmYYUqx6awzJ6VJ6HGc1Uc6tOlbw==
+"@aws-sdk/middleware-flexible-checksums@3.815.0":
+  version "3.815.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.815.0.tgz#29718913a6fa220f697ecce2ad60b7b3c158937e"
+  integrity sha512-cv/BO7saBbHTrLMUJiClZHM/GB4xDBbJmZ70f9HwcNBP59tBB8TgF/vSyi8SdFM82TvRP+Zzi1AZ8hXcwElaCg==
   dependencies:
     "@aws-crypto/crc32" "5.2.0"
     "@aws-crypto/crc32c" "5.2.0"
@@ -2938,9 +2938,9 @@
     react-is "^19.1.0"
 
 "@mui/x-charts-vendor@^8.0.0":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-charts-vendor/-/x-charts-vendor-8.3.1.tgz#5bf352fe2ae878f61a94bad978ff688f3a468d9b"
-  integrity sha512-UcUa7HDIpSfeVBYgeHewWoVALcB4Gg9we53l78j2cyadYBZOWdtLj8fezo9zAhxfZ5s9T+1yIyuD+CCnYJnUpQ==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-charts-vendor/-/x-charts-vendor-8.4.0.tgz#72a489bb12a51ffff2287bbe6843939d1e391ceb"
+  integrity sha512-0VvwJSeFezJTnjoKg5YUbbI82a60+VZfH2RyqaosmKH516lKYKSCuAFmkj4vUBP6+ZJPZDW5mWI3VhwD4DN6hg==
   dependencies:
     "@babel/runtime" "^7.27.1"
     "@types/d3-color" "^3.1.3"
@@ -2961,22 +2961,22 @@
     robust-predicates "^3.0.2"
 
 "@mui/x-data-grid@^8.0.0":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-8.3.1.tgz#4bb4d8ce794b073cd140a8877ede2069afbd4c08"
-  integrity sha512-mSo2g0ZZzasDQ4kKrFdJVk7dJgz77jF/e8udvGqnnTgnQXlqLMpKne/veL3gRdi3TJxxTv2vqXtX7IZfWGJecQ==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-8.4.0.tgz#cef56df7c1c1b40278ca55dae112b9aaece0e8c5"
+  integrity sha512-c0fgMhvQTjCSo3LgRK1Mdk2msktCl9uwMYUYlP6bbqJ7I03IvS+1aZ+s3nSLmaq1aVh7sE2Bnuz63OnVerTLJA==
   dependencies:
     "@babel/runtime" "^7.27.1"
     "@mui/utils" "^7.0.2"
-    "@mui/x-internals" "8.3.1"
+    "@mui/x-internals" "8.4.0"
     clsx "^2.1.1"
     prop-types "^15.8.1"
     reselect "^5.1.1"
     use-sync-external-store "^1.5.0"
 
-"@mui/x-internals@8.3.1":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-8.3.1.tgz#1d83b984eee7e847594348513a6356df0be8b457"
-  integrity sha512-8kIxT66cea63iEseEIHSWzKju2Wzl7MsWFoAUQEyRvYqOFa2j9Un2Vn/EH2vy9nm/MtMAYpwOE/nt68/KTIA2w==
+"@mui/x-internals@8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-8.4.0.tgz#593b36cab7050fe1e4ca8dc3ce455349a3edae5d"
+  integrity sha512-Z7FCahC4MLfTVzEwnKOB7P1fiR9DzFuMzHOPRNaMXc/rsS7unbtBKAG94yvsRzReCyjzZUVA7h37lnQ1DoPKJw==
   dependencies:
     "@babel/runtime" "^7.27.1"
     "@mui/utils" "^7.0.2"
@@ -4836,9 +4836,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.17.16"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
-  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.17.tgz#fb85a04f47e9e4da888384feead0de05f7070355"
+  integrity sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==
 
 "@types/mdx@^2.0.0":
   version "2.0.13"
@@ -4888,16 +4888,16 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^22.5.5", "@types/node@^22.7.7":
-  version "22.15.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.19.tgz#ba9f321675243af0456d607fa82a4865931e0cef"
-  integrity sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==
+  version "22.15.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.21.tgz#196ef14fe20d87f7caf1e7b39832767f9a995b77"
+  integrity sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==
   dependencies:
     undici-types "~6.21.0"
 
 "@types/node@^20.0.0":
-  version "20.17.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.48.tgz#5a4028ae0d22985c30cc100e589b7d50ae783457"
-  integrity sha512-KpSfKOHPsiSC4IkZeu2LsusFwExAIVGkhG1KkbaBMLwau0uMhj0fCrvyg9ddM2sAvd+gtiBJLir4LAw1MNMIaw==
+  version "20.17.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.50.tgz#d2640af991fc839ba746f799516fc6a4e47ebe50"
+  integrity sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==
   dependencies:
     undici-types "~6.19.2"
 
@@ -4986,9 +4986,9 @@
     react-virtualized-auto-sizer "*"
 
 "@types/react@^19.0.1":
-  version "19.1.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.4.tgz#4d125f014d6ac26b4759775698db118701e314fe"
-  integrity sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==
+  version "19.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.5.tgz#9feb3bdeb506d0c79d8533b6ebdcacdbcb4756db"
+  integrity sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==
   dependencies:
     csstype "^3.0.2"
 
@@ -8204,26 +8204,26 @@ error-stack-parser@^2.0.6:
     stackframe "^1.3.4"
 
 es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9:
-  version "1.23.9"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.23.9.tgz#5b45994b7de78dada5c1bebf1379646b32b9d606"
-  integrity sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==
+  version "1.23.10"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.23.10.tgz#84792c152ff2898ec73efe33c1c1323a3dfd87f8"
+  integrity sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==
   dependencies:
     array-buffer-byte-length "^1.0.2"
     arraybuffer.prototype.slice "^1.0.4"
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.8"
-    call-bound "^1.0.3"
+    call-bound "^1.0.4"
     data-view-buffer "^1.0.2"
     data-view-byte-length "^1.0.2"
     data-view-byte-offset "^1.0.1"
     es-define-property "^1.0.1"
     es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
+    es-object-atoms "^1.1.1"
     es-set-tostringtag "^2.1.0"
     es-to-primitive "^1.3.0"
     function.prototype.name "^1.1.8"
-    get-intrinsic "^1.2.7"
-    get-proto "^1.0.0"
+    get-intrinsic "^1.3.0"
+    get-proto "^1.0.1"
     get-symbol-description "^1.1.0"
     globalthis "^1.0.4"
     gopd "^1.2.0"
@@ -8239,13 +8239,13 @@ es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23
     is-shared-array-buffer "^1.0.4"
     is-string "^1.1.1"
     is-typed-array "^1.1.15"
-    is-weakref "^1.1.0"
+    is-weakref "^1.1.1"
     math-intrinsics "^1.1.0"
-    object-inspect "^1.13.3"
+    object-inspect "^1.13.4"
     object-keys "^1.1.1"
     object.assign "^4.1.7"
     own-keys "^1.0.1"
-    regexp.prototype.flags "^1.5.3"
+    regexp.prototype.flags "^1.5.4"
     safe-array-concat "^1.1.3"
     safe-push-apply "^1.0.0"
     safe-regex-test "^1.1.0"
@@ -8258,7 +8258,7 @@ es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23
     typed-array-byte-offset "^1.0.4"
     typed-array-length "^1.0.7"
     unbox-primitive "^1.1.0"
-    which-typed-array "^1.1.18"
+    which-typed-array "^1.1.19"
 
 es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
@@ -10517,7 +10517,7 @@ is-weakmap@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
   integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
 
-is-weakref@^1.0.2, is-weakref@^1.1.0:
+is-weakref@^1.0.2, is-weakref@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.1.tgz#eea430182be8d64174bd96bffbc46f21bf3f9293"
   integrity sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==
@@ -10842,9 +10842,9 @@ jest-haste-map@^29.7.0:
     fsevents "^2.3.2"
 
 jest-image-snapshot@^6.1.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-6.5.0.tgz#4a200802cf52e53686e3d5e83138a6f2b6119a39"
-  integrity sha512-oTMGQEpvW3Q3+BwlULINBJRpvsVDXAILqjniCuiUT7us4f1YDQF99fPrMVy4yIQui1ZIHe7fjqRsErfK6tUlSQ==
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-6.5.1.tgz#cc714aff86187ecf38f90c506b443769aff87499"
+  integrity sha512-xlJFufgfY2Z4DsRsjcnTwxuynvo1bKdhf4OfcEftNuUAK+BwSCUtPmwlBGJhQ0XJXfm9JMAi/4BhQiHbaV8HrA==
   dependencies:
     chalk "^4.0.0"
     get-stdin "^5.0.1"
@@ -12665,7 +12665,7 @@ object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-object-inspect@^1.13.3:
+object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
@@ -14189,7 +14189,7 @@ regexp-tree@^0.1.27:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
   integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
 
-regexp.prototype.flags@^1.5.3:
+regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -16223,9 +16223,9 @@ walker@^1.0.8:
     makeerror "1.0.12"
 
 watchpack@^2.4.1:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.3.tgz#110b3a600c525f6a39ab66cf354cf08b205c29dc"
-  integrity sha512-adBYQLivcg1jbdKEJeqScJJFvgm4qY9+3tXw+jdG6lkVeqRJEtiQmSWjmth8GKmDZuX7sYM4YFxQsf0AzMfGGw==
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.4.tgz#473bda72f0850453da6425081ea46fc0d7602947"
+  integrity sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -16506,7 +16506,7 @@ which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.16, which-typed-array@^1.1.18, which-typed-array@^1.1.2:
+which-typed-array@^1.1.16, which-typed-array@^1.1.19, which-typed-array@^1.1.2:
   version "1.1.19"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.19.tgz#df03842e870b6b88e117524a4b364b6fc689f956"
   integrity sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==
@@ -16795,6 +16795,6 @@ zod-validation-error@^3.0.3:
   integrity sha512-1KP64yqDPQ3rupxNv7oXhf7KdhHHgaqbKuspVoiN93TT0xrBjql+Svjkdjq/Qh/7GSMmgQs3AfvBT0heE35thw==
 
 zod@^3.22.4:
-  version "3.25.7"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.7.tgz#74184ecfe03ef8c67a62393008117b3b8d9cc48c"
-  integrity sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==
+  version "3.25.20"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.20.tgz#c36739c52f6d01cf04c53bf56d99f2f5488739ee"
+  integrity sha512-z03fqpTMDF1G02VLKUMt6vyACE7rNWkh3gpXVHgPTw28NPtDFRGvcpTtPwn2kMKtQ0idtYJUTxchytmnqYswcw==


### PR DESCRIPTION
There is a special field of "gene pred" type files from e.g. bigbed or ucsc exports that is called cdsStartStat and cdsEndStat. If it is set to 'none' then there is no CDS information. This is set to none for non-coding e.g. lncRNAs

Before, thinks entire gene is 'five_prime_UTR'
![image](https://github.com/user-attachments/assets/9137329a-8a30-4435-9291-981d714ec32d)


After
![image](https://github.com/user-attachments/assets/75bcb1d0-1497-438c-b104-8f7477aa3634)


we don't have a built-in way to distinguish between coding and non-coding features on our gene tracks, and it could be argued that the before behavior was 'better' at distinguishing, but it was basically improper behavior, so this PR changes it for the better in that regard
