### PR TITLE
Use standard sessionId for linear synteny view to reduce data re-fetching

### DIFF
--- a/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
+++ b/plugins/linear-comparative-view/src/LinearComparativeDisplay/stateModelFactory.ts
@@ -195,7 +195,7 @@ function renderBlockData(self: LinearComparativeDisplay) {
     ? {
         rpcManager,
         renderProps: {
-          ...display.renderProps(),
+          ...(display.renderProps() as Record<string, unknown>),
           level,
           view: parent,
           adapterConfig,
@@ -213,11 +213,11 @@ async function renderBlockEffect(props: ReturnType<typeof renderBlockData>) {
   }
 
   const { rpcManager, renderProps } = props
-  const { adapterConfig, level } = renderProps
-  const view = renderProps.view.views[level]
+  const { sessionId, adapterConfig, level } = renderProps
+  const view = renderProps.view.views[level]!
   const features = (await rpcManager.call('getFeats', 'CoreGetFeatures', {
     regions: view.staticBlocks.contentBlocks,
-    sessionId: 'getFeats',
+    sessionId,
     adapterConfig,
   })) as Feature[]
 


### PR DESCRIPTION
Fixes #5046 