### PR TITLE
Add ability to make [update docs only] commits to avoid running CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,39 @@
 name: Push
 
-on: push
+on:
+  push:
+    branches:
+      - '*'
 
 jobs:
+  check_commit_message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    outputs:
+      skip_jobs: ${{ steps.check_message.outputs.skip_jobs }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check commit message
+        id: check_message
+        run: |
+          commit_message=$(git log -1 --pretty=%B)
+          if [[ "$commit_message" == *"[update docs only]"* ]]; then
+            echo "skip_jobs=true" >> $GITHUB_OUTPUT
+            echo "Commit message contains [update docs only], skipping regular push jobs"
+          else
+            echo "skip_jobs=false" >> $GITHUB_OUTPUT
+            echo "Running regular push jobs"
+          fi
+
+  # Conditionally run the buildwebsite job
   buildwebsite:
     name: Build website
+    needs: check_commit_message
+    if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +57,11 @@ jobs:
         with:
           args: website/testing/ --check-anchors
 
+  # Conditionally run the buildwholerepo job
   buildwholerepo:
     name: Build whole repo
+    needs: check_commit_message
+    if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,8 +92,11 @@ jobs:
           yarn e2e
         working-directory: component_tests/app-vite
 
+  # Conditionally run the buildjbrowseweb job
   buildjbrowseweb:
     name: Deploy jbrowse-web and storybooks to S3
+    needs: check_commit_message
+    if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -143,8 +178,11 @@ jobs:
           aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/cgv/$(echo ${{github.ref}} | cut -d "/" -f3-)/*"
         working-directory: products/jbrowse-react-circular-genome-view
 
+  # Conditionally run the formatchecks job
   formatchecks:
     name: Lint, typecheck, test
+    needs: check_commit_message
+    if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get -y install tabix
@@ -170,3 +208,4 @@ jobs:
         uses: codecov/codecov-action@v4
       - name: Typecheck codebase
         run: yarn typecheck
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check commit message
         id: check_message
         run: |
-          commit_message=$(git log -1 --pretty=%B)
+          commit_message="${{ github.event.head_commit.message }}"
           if [[ "$commit_message" == *"[update docs only]"* ]]; then
             echo "skip_jobs=true" >> $GITHUB_OUTPUT
             echo "Commit message contains [update docs only], skipping regular push jobs"
@@ -208,4 +208,3 @@ jobs:
         uses: codecov/codecov-action@v4
       - name: Typecheck codebase
         run: yarn typecheck
-

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,13 +1,13 @@
+name: Upload website
 on:
   push:
     branches:
       - main
-name: Upload website
 jobs:
   build:
     name: build-upload
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, 'update docs')"
+    if: ${{ contains(github.event.head_commit.message, 'update docs') || contains(github.event.head_commit.message, '[update docs only]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,7 +7,9 @@ jobs:
   build:
     name: build-upload
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.head_commit.message, 'update docs') || contains(github.event.head_commit.message, '[update docs only]') }}
+    if:
+      ${{ contains(github.event.head_commit.message, 'update docs') ||
+      contains(github.event.head_commit.message, '[update docs only]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/website/docs/user_guides/analyze_trio.md
+++ b/website/docs/user_guides/analyze_trio.md
@@ -94,7 +94,7 @@ that occurs during the development of egg and sperm cells (meiosis)."
 
 But this is an important point: Your parents genomes don't recombine during
 fertilization. Instead, your grandparents genomes recombine during the
-production of the parents gametes.
+production of the parents gametes. We will see shortly why this is the case
 
 ## Converting hap-ibd data into a format for JBrowse
 
@@ -131,6 +131,11 @@ In the above screenshot, you can look at the 'barcode-like' patterns to see the
 matches between MOM A1 (allele 1) in mom and the child, MOM A2 (allele 2) in mom
 and child, DAD A1 (allele 1) in dad and child, DAD A2 (allele 2) in dad and
 child
+
+You can see why we mentioned the grandparents above: for instance, the DAD A1
+and DAD A2 alleles come from the crossing over of his two copies of his
+chromosomes (e.g. the chromosomes he got from his grandparents) and then merges
+into a single line in the child!
 
 ## Footnote
 


### PR DESCRIPTION
This avoids running a bunch of CI just to update the docs

New github action was generated with the help of claude + avante.nvim (which is sort of agentic in that it created a new workflow file, applied edits, all by itself)

I touched up the result only slightly

<details>
```
-------

- Datetime: 2025-05-28 23:04:15

- Model: claude/claude-3-7-sonnet-20250219

- Selected files:
  - .github/workflows/update-docs.yml



I'll help you create a new workflow that runs the update-docs.yml workflow but skips the workflows in push.yml if the commit message contains "[update docs only]".

Based on the push.yml file, I see there are several jobs that we need to conditionally skip when the commit message includes "[update docs only]".

Here's my plan:
1. Create a new workflow file that will run on push events
2. Include a condition to check if the commit message contains "[update docs only]"
3. If it does, only run the website documentation update job
4. If it doesn't, allow the regular push.yml workflow to run

Let me create this new workflow file:


╭─  replace_in_file  succeeded
│   running tool
│   path: .github/workflows/update-docs.yml
╰─  tool finished


I notice there's an error in the YAML syntax. Let me fix the issue:


╭─  replace_in_file  succeeded
│   running tool
│   path: .github/workflows/update-docs.yml
╰─  tool finished


I still see an error. Let me fix the issue with the YAML syntax:


╭─  replace_in_file  succeeded
│   running tool
│   path: .github/workflows/update-docs.yml
╰─  tool finished


Now, I need to create a new workflow file that will conditionally run the push.yml jobs based on the commit message:


╭─  view  succeeded
│   running tool
│   path: .github/workflows/push.yml
╰─  tool finished


Now, I'll create a new workflow file called "conditional-push.yml" that will conditionally skip the push.yml jobs if the commit message contains "[update docs only]":


╭─  replace_in_file  succeeded
│   running tool
│   path: .github/workflows/conditional-push.yml
╰─  tool finished


Now, I need to modify the push.yml workflow to skip its jobs if the conditional-push.yml workflow is handling them:


╭─  replace_in_file  succeeded
│   running tool
│   path: .github/workflows/push.yml
╰─  tool finished


Great! I've successfully created a new workflow system that handles the "[update docs only]" commit message appropriately. Here's a summary of the changes I made:

1. Updated the `.github/workflows/update-docs.yml` workflow to:
   - Run when commit messages contain either "update docs" or "[update docs only]"
   - This ensures the documentation is updated in both cases

2. Created a new `.github/workflows/conditional-push.yml` workflow that:
   - Checks the commit message for "[update docs only]"
   - If found, sets an output variable to skip all the regular push jobs
   - If not found, runs all the regular push jobs from the original push.yml

3. Modified the original `.github/workflows/push.yml` to:
   - Disable it completely using the branches-ignore setting
   - Keep the job definitions for reference, but they won't run

This setup achieves the following workflow:

1. When a commit with "[update docs only]" is pushed:
   - The `update-docs.yml` workflow will run to update the documentation
   - The `conditional-push.yml` workflow will detect the tag and skip all other jobs

2. When a regular commit is pushed:
   - The `update-docs.yml` workflow will not run (unless it contains "update docs")
   - The `conditional-push.yml` workflow will run all the regular jobs

This implementation effectively satisfies your requirement to skip the push.yml workflows when the commit message contains "[update docs only]".

```
</details>