### PR TITLE
Reduce S3 uploads per-branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cd products/jbrowse-web/build && zip -r "jbrowse-web-$(echo ${{github.ref}} | cut -d '/' -f3-).zip" . && cd -
           cp products/jbrowse-web/build/test_data/config.json products/jbrowse-web/build/config.json
-          aws s3 sync --delete products/jbrowse-web/build s3://jbrowse.org/code/jb2/$(echo ${{github.ref}} | cut -d "/" -f3-)
+          aws s3 sync --delete --exclude="*.map" products/jbrowse-web/build s3://jbrowse.org/code/jb2/$(echo ${{github.ref}} | cut -d "/" -f3-)
           aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/code/jb2/$(echo ${{github.ref}} | cut -d "/" -f3-)/*"
 
       - name: Build LGV
@@ -138,6 +138,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Deploy LGV
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           pwd
           aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/lgv/$(echo ${{github.ref}} | cut -d "/" -f3-)
@@ -155,6 +156,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy React App
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           pwd
           aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/app/$(echo ${{github.ref}} | cut -d "/" -f3-)
@@ -172,6 +174,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy CGV
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           pwd
           aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/cgv/$(echo ${{github.ref}} | cut -d "/" -f3-)


### PR DESCRIPTION
The availability of auto-built artifacts on s3 has been very useful and productive but we can probably try to trim it down

We currently auto-deploy jbrowse-web and all storybooks of every branch to s3

I happen to make a lot of branches so this can add up

This PR

a) continues to deploys jbrowse-web for every branch, but filters out source map files, which are about half the size (so it uploads about 25Mb instead of 50Mb). these deployments are useful for testing, and for linking people to deploy a branch with jbrowse create --branch. 
b) stops deploying storybooks for every branch, and instead just does it on tags