### PR TITLE
Improve speed of navigation for fragmented assemblies

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import BaseResult, {
   RefSequenceResult,
@@ -83,15 +83,18 @@ const RefNameAutocomplete = observer(function ({
   const inputBoxVal = coarseVisibleLocStrings || value || ''
 
   const regions = assembly?.regions
-  const regionOptions =
-    regions?.map(region => ({
-      result: new RefSequenceResult({
-        refName: region.refName,
-        label: region.refName,
-        displayString: region.refName,
-        matchedAttribute: 'refName',
-      }),
-    })) || []
+  const regionOptions = useMemo(
+    () =>
+      regions?.map(region => ({
+        result: new RefSequenceResult({
+          refName: region.refName,
+          label: region.refName,
+          displayString: region.refName,
+          matchedAttribute: 'refName',
+        }),
+      })) || [],
+    [regions],
+  )
 
   // notes on implementation:
   // The selectOnFocus setting helps highlight the field when clicked


### PR DESCRIPTION
Fragmented assemblies frequently have millions of little scaffolds/contigs, which can slow down the UI

I found some mobx get'ters in the assembly that were being recomputed instead of being cached, so every time you changed chromosome, it would take 5+ seconds with a UI hang

It is somewhat unclear why they are being recomputed instead of cached, but there is a workaround (which i had found earlier in react-msaview code) which is to make an autorun watch the object you want to keep cached
