### PR TITLE
Fix useSWR usage from plugins

### DIFF
--- a/products/jbrowse-desktop/src/workerPolyfill.js
+++ b/products/jbrowse-desktop/src/workerPolyfill.js
@@ -7,6 +7,7 @@ self.window = {
   fetch: self.fetch.bind(self),
   location: self.location,
   Date: self.Date,
+  removeEventListener() {},
   requestIdleCallback: cb => {
     cb()
   },
@@ -19,6 +20,7 @@ self.window = {
 }
 self.document = {
   createTextNode() {},
+  addEventListener() {},
   querySelector() {
     return { appendChild() {} }
   },

--- a/products/jbrowse-react-app/src/workerPolyfill.js
+++ b/products/jbrowse-react-app/src/workerPolyfill.js
@@ -7,6 +7,7 @@ self.window = {
   fetch: self.fetch.bind(self),
   location: self.location,
   Date: self.Date,
+  removeEventListener() {},
   requestIdleCallback: cb => {
     cb()
   },
@@ -19,6 +20,7 @@ self.window = {
 }
 self.document = {
   createTextNode() {},
+  addEventListener() {},
   querySelector() {
     return { appendChild() {} }
   },

--- a/products/jbrowse-react-linear-genome-view/src/workerPolyfill.js
+++ b/products/jbrowse-react-linear-genome-view/src/workerPolyfill.js
@@ -7,6 +7,7 @@ self.window = {
   fetch: self.fetch.bind(self),
   location: self.location,
   Date: self.Date,
+  removeEventListener() {},
   requestIdleCallback: cb => {
     cb()
   },
@@ -19,6 +20,7 @@ self.window = {
 }
 self.document = {
   createTextNode() {},
+  addEventListener() {},
   querySelector() {
     return { appendChild() {} }
   },

--- a/products/jbrowse-web/src/workerPolyfill.js
+++ b/products/jbrowse-web/src/workerPolyfill.js
@@ -7,6 +7,7 @@ self.window = {
   fetch: self.fetch.bind(self),
   location: self.location,
   Date: self.Date,
+  removeEventListener() {},
   requestIdleCallback: cb => {
     cb()
   },
@@ -19,6 +20,7 @@ self.window = {
 }
 self.document = {
   createTextNode() {},
+  addEventListener() {},
   querySelector() {
     return { appendChild() {} }
   },


### PR DESCRIPTION
Plugins are loaded on both the webworker and main thread

However, some JS code can make inaccurate assumptions about the webworker environment, like that "window" exists on the webworker (it does not normally)

We create a "worker polyfill" to help with this

This PR adds some more entries to our worker polyfill, removeEventListener to fix usage of the useSWR package in plugins

useSWR is basically a react hook that fetches data