### PR TITLE
Optimize fetching many small sequences from IndexedFasta (e.g. MSA datasets)

### DIFF
--- a/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
+++ b/plugins/sequence/src/IndexedFastaAdapter/IndexedFastaAdapter.ts
@@ -102,9 +102,15 @@ export default class IndexedFastaAdapter extends BaseSequenceAdapter {
             }
 
             checkStopToken(stopToken)
-            chunks.push(
-              await this.seqCache.get(JSON.stringify(r), { ...r, fasta }),
-            )
+
+            const res = await this.seqCache.get(JSON.stringify(r), {
+              ...r,
+              fasta,
+            })
+            if (!res) {
+              break
+            }
+            chunks.push(res)
           }
           const seq = chunks
             .filter(f => !!f)


### PR DESCRIPTION
The jbrowse-plugin-msaview plugin added the concept of MSA datasets

It can fetch MSA data from BgzipFastaAdapter based datasets for example

This involves fetching many different 'refNames'

However this is slow currently because the IndexedFastaAdapter tries to eagerly fetch extra chunks using a cache. Most of those chunks are empty for the MSA use case here, so this PR makes it stop fetching once it encounters a empty block