### PR TITLE
Avoid aggregating features on opposite strands in BigBedAdapter

### DIFF
--- a/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
+++ b/plugins/bed/src/BigBedAdapter/BigBedAdapter.ts
@@ -260,20 +260,43 @@ export default class BigBedAdapter extends BaseFeatureDataAdapter {
           const subs = subfeatures.sort((a, b) =>
             a.uniqueId.localeCompare(b.uniqueId),
           )
-          observer.next(
-            new SimpleFeature({
-              id: `${this.id}-${subs[0]?.uniqueId}-parent`,
-              data: {
-                type: 'gene',
-                subfeatures: subs,
-                strand: subs[0]?.strand || 1,
-                name,
-                start: s,
-                end: e,
-                refName: query.refName,
-              },
-            }),
-          )
+          if (
+            subs.every(s => {
+              return s.strand === (subs[0]?.strand || 1)
+            })
+          ) {
+            observer.next(
+              new SimpleFeature({
+                id: `${this.id}-${subs[0]?.uniqueId}-parent`,
+                data: {
+                  type: 'gene',
+                  subfeatures: subs,
+                  strand: subs[0]?.strand || 1,
+                  name,
+                  start: s,
+                  end: e,
+                  refName: query.refName,
+                },
+              }),
+            )
+          } else {
+            for (const sub of subs) {
+              observer.next(
+                new SimpleFeature({
+                  id: `${this.id}-${sub.uniqueId}-parent`,
+                  data: {
+                    type: 'gene',
+                    subfeatures: [sub],
+                    strand: subs[0]?.strand || 1,
+                    name,
+                    start: sub.start,
+                    end: sub.end,
+                    refName: query.refName,
+                  },
+                }),
+              )
+            }
+          }
         }
       })
     })


### PR DESCRIPTION
The BigBedAdapter uses some heuristics to merge individual transcripts into a gene glyph, namely combining features if they share the same 'gene name' (geneName2 field by default)

This PR addresses a case with a viral genome where it was aggregatign features across a long distance at the ends of the viral genome




Before

![image](https://github.com/user-attachments/assets/377d22db-c93e-48d1-a27a-af8bfa6d2d32)


After

![image](https://github.com/user-attachments/assets/e79b154b-6e08-4238-8cc5-2968a0c6031c)



schematic from a paper, showing that there are terminal inverted repeats on the virus 

![image](https://github.com/user-attachments/assets/de6aee62-b7e3-48a5-897a-78c3dc4c4c1a)

fig3 https://www.sciencedirect.com/science/article/pii/S1876034123000345?via%3Dihub

I guess you could say it is 'nice' that it helps reveal the terminal inverted repeats but that might be done better in another way