### PR TITLE
Fix race condition in data adapter cache initialization

### DIFF
--- a/packages/core/data_adapters/dataAdapterCache.ts
+++ b/packages/core/data_adapters/dataAdapterCache.ts
@@ -12,7 +12,43 @@ interface AdapterCacheEntry {
   sessionIds: Set<string>
 }
 
-let adapterCache: Record<string, AdapterCacheEntry> = {}
+let adapterCache: Record<string, Promise<AdapterCacheEntry>> = {}
+
+async function getAdapterPre(
+  pluginManager: PluginManager,
+  sessionId: string,
+  adapterConfigSnapshot: SnapshotIn<AnyConfigurationSchemaType>,
+) {
+  const adapterType = adapterConfigSnapshot?.type
+
+  if (!adapterType) {
+    throw new Error(
+      `could not determine adapter type from adapter config snapshot ${JSON.stringify(
+        adapterConfigSnapshot,
+      )}`,
+    )
+  }
+  const dataAdapterType = pluginManager.getAdapterType(adapterType)
+  if (!dataAdapterType) {
+    throw new Error(`unknown data adapter type ${adapterType}`)
+  }
+
+  // instantiate the data adapter's config schema so it gets its defaults,
+  // callbacks, etc
+  const adapterConfig = dataAdapterType.configSchema.create(
+    adapterConfigSnapshot,
+    { pluginManager },
+  )
+
+  const getSubAdapter = getAdapter.bind(null, pluginManager, sessionId)
+  const CLASS = await dataAdapterType.getAdapterClass()
+  const dataAdapter = new CLASS(adapterConfig, getSubAdapter, pluginManager)
+
+  return {
+    dataAdapter,
+    sessionIds: new Set([sessionId]),
+  }
+}
 
 /**
  * instantiate a data adapter, or return an already-instantiated one if we have
@@ -31,45 +67,15 @@ export async function getAdapter(
   sessionId: string,
   adapterConfigSnapshot: SnapshotIn<AnyConfigurationSchemaType>,
 ): Promise<AdapterCacheEntry> {
-  // cache the adapter object
   const cacheKey = adapterConfigCacheKey(adapterConfigSnapshot)
-  if (!adapterCache[cacheKey]) {
-    const adapterType = adapterConfigSnapshot?.type
-
-    if (!adapterType) {
-      throw new Error(
-        `could not determine adapter type from adapter config snapshot ${JSON.stringify(
-          adapterConfigSnapshot,
-        )}`,
-      )
-    }
-    const dataAdapterType = pluginManager.getAdapterType(adapterType)
-    if (!dataAdapterType) {
-      throw new Error(`unknown data adapter type ${adapterType}`)
-    }
-
-    // instantiate the data adapter's config schema so it gets its defaults,
-    // callbacks, etc
-    const adapterConfig = dataAdapterType.configSchema.create(
-      adapterConfigSnapshot,
-      { pluginManager },
-    )
-
-    const getSubAdapter = getAdapter.bind(null, pluginManager, sessionId)
-    const CLASS = await dataAdapterType.getAdapterClass()
-    const dataAdapter = new CLASS(adapterConfig, getSubAdapter, pluginManager)
-
-    // store it in our cache
-    adapterCache[cacheKey] = {
-      dataAdapter,
-      sessionIds: new Set([sessionId]),
-    }
-  }
-
-  const cacheEntry = adapterCache[cacheKey]
-  cacheEntry.sessionIds.add(sessionId)
-
-  return cacheEntry
+  adapterCache[cacheKey] ??= getAdapterPre(
+    pluginManager,
+    sessionId,
+    adapterConfigSnapshot,
+  )
+  const ret = await adapterCache[cacheKey]
+  ret.sessionIds.add(sessionId)
+  return ret
 }
 
 /**
@@ -81,7 +87,7 @@ export type getSubAdapterType = (
   adapterConfigSnap: ConfigSnap,
 ) => ReturnType<typeof getAdapter>
 
-export function freeAdapterResources(args: Record<string, any>) {
+export async function freeAdapterResources(args: Record<string, any>) {
   const specKeys = Object.keys(args)
 
   // TODO: little hacky...should make it an explicit command but:
@@ -89,7 +95,8 @@ export function freeAdapterResources(args: Record<string, any>) {
   // with that session
   if (specKeys.length === 1 && specKeys[0] === 'sessionId') {
     const { sessionId } = args
-    for (const [cacheKey, cacheEntry] of Object.entries(adapterCache)) {
+    for (const [cacheKey, cacheEntryP] of Object.entries(adapterCache)) {
+      const cacheEntry = await cacheEntryP
       cacheEntry.sessionIds.delete(sessionId)
       if (cacheEntry.sessionIds.size === 0) {
         delete adapterCache[cacheKey]
@@ -97,7 +104,8 @@ export function freeAdapterResources(args: Record<string, any>) {
     }
   } else {
     // otherwise call freeResources on all the cached data adapters
-    for (const cacheEntry of Object.values(adapterCache)) {
+    for (const cacheEntryP of Object.values(adapterCache)) {
+      const cacheEntry = await cacheEntryP
       const regions = args.regions || (args.region ? [args.region] : [])
       for (const region of regions) {
         if (region.refName !== undefined) {

--- a/packages/core/rpc/methods/CoreFreeResources.ts
+++ b/packages/core/rpc/methods/CoreFreeResources.ts
@@ -11,7 +11,7 @@ export default class CoreFreeResources extends RpcMethodType {
   name = 'CoreFreeResources'
 
   async execute(args: Record<string, unknown>) {
-    freeAdapterResources(args)
+    await freeAdapterResources(args)
     for (const renderer of this.pluginManager.getRendererTypes()) {
       renderer.freeResources(args)
     }


### PR DESCRIPTION
We have a concept of trying to only create a single data adapter for each data file. This makes sure each data file is mapped to a single data adapter, and avoid re-parsing the data multiple times (which is of course slow) 

However, if a request to initialize a data adapter comes multiple times very quickly, then it can cause multiple adapters to be created because we have a race condition


Buggy pseudo-code

```
dataAdapterCache: Record<string,DataAdapter>
async function getDataAdapter(string:adapterId) {
  if(!dataAdapterCache[adapterId]) {
    dataAdapterCache[adapterId]=await generateNewDataAdapter() //<-- has await, so the cache is not initialized until the await is over
  } 
  return dataAdapterCache[adapterId] 
}
```

Corrected pseudo-code

```
dataAdapterCache: Record<string,Promise<DataAdapter>>
function getDataAdapter() {
  function getDataAdapter(string:adapterId) {
  if(!dataAdapterCache[adapterId]) {
    dataAdapterCache[adapterId]=generateNewDataAdapter() //<-- no await, so the cache is synchronously initialized with a promise to a data adapter
  } 
  const result= await dataAdapterCache[adapterId] 
  return result
} 
```