### PR TITLE
Fix crash on multi-wiggle importer on jbrowse-web

### DIFF
--- a/plugins/wiggle/src/MultiWiggleAddTrackWorkflow/AddTrackWorkflow.tsx
+++ b/plugins/wiggle/src/MultiWiggleAddTrackWorkflow/AddTrackWorkflow.tsx
@@ -27,10 +27,9 @@ const useStyles = makeStyles()(theme => ({
 
 // on electron, use path to LocalFileLocation, on web, use the BlobLocation
 function makeFileLocation(file: File) {
-  const { webUtils } = window.require('electron')
   return isElectron
     ? {
-        localPath: webUtils.getPathForFile(file),
+        localPath: window.require('electron').webUtils.getPathForFile(file),
         locationType: 'LocalPathLocation',
       }
     : storeBlobLocation({ blob: file })


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/5072

Was trying to use window.require, a desktop specific function, which is not defined on web and crashed before it could update the forms