### PR TITLE
Fix rubberband getting stuck under certain conditions

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
@@ -1,4 +1,4 @@
-import { Popover, Typography } from '@mui/material'
+import { Tooltip, Typography } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 
 const useStyles = makeStyles()(theme => {
@@ -25,23 +25,21 @@ export default function RubberbandTooltip({
 }) {
   const { classes } = useStyles()
   return (
-    <Popover
-      className={classes.popover}
-      classes={{ paper: classes.paper }}
+    <Tooltip
+      title={<Typography>{text}</Typography>}
       open
-      anchorEl={anchorEl}
-      anchorOrigin={{
-        vertical: 'top',
-        horizontal: side === 'left' ? 'left' : 'right',
+      placement={side === 'left' ? 'left' : 'right'}
+      PopperProps={{
+        anchorEl,
+        disableRestoreFocus: true,
+        keepMounted: true,
       }}
-      transformOrigin={{
-        vertical: 'bottom',
-        horizontal: side === 'left' ? 'right' : 'left',
+      classes={{
+        tooltip: classes.paper,
+        popper: classes.popover,
       }}
-      keepMounted
-      disableRestoreFocus
     >
-      <Typography>{text}</Typography>
-    </Popover>
+      <span></span>
+    </Tooltip>
   )
 }

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
@@ -28,15 +28,23 @@ export default function RubberbandTooltip({
     <Tooltip
       title={<Typography>{text}</Typography>}
       open
-      placement={side === 'left' ? 'left' : 'right'}
-      PopperProps={{
-        anchorEl,
-        disableRestoreFocus: true,
-        keepMounted: true,
-      }}
+      placement={side === 'left' ? 'left-start' : 'right-start'}
       classes={{
         tooltip: classes.paper,
         popper: classes.popover,
+      }}
+      slotProps={{
+        popper: {
+          anchorEl,
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [-30, -10],
+              },
+            },
+          ],
+        },
       }}
     >
       <span></span>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RubberbandTooltip.tsx
@@ -1,18 +1,4 @@
-import { Tooltip, Typography } from '@mui/material'
-import { makeStyles } from 'tss-react/mui'
-
-const useStyles = makeStyles()(theme => {
-  return {
-    popover: {
-      mouseEvents: 'none',
-      cursor: 'crosshair',
-    },
-    paper: {
-      paddingLeft: theme.spacing(1),
-      paddingRight: theme.spacing(1),
-    },
-  }
-})
+import { Tooltip } from '@mui/material'
 
 export default function RubberbandTooltip({
   anchorEl,
@@ -23,16 +9,11 @@ export default function RubberbandTooltip({
   side: string
   text: string
 }) {
-  const { classes } = useStyles()
   return (
     <Tooltip
-      title={<Typography>{text}</Typography>}
+      title={text}
       open
       placement={side === 'left' ? 'left-start' : 'right-start'}
-      classes={{
-        tooltip: classes.paper,
-        popper: classes.popover,
-      }}
       slotProps={{
         popper: {
           anchorEl,
@@ -40,6 +21,8 @@ export default function RubberbandTooltip({
             {
               name: 'offset',
               options: {
+                // first number is y-offset (which docs refer to as skid),
+                // second number is x-offset (which docs refer to as distance)
                 offset: [-30, -10],
               },
             },


### PR DESCRIPTION
It was reported in #5083 that the rubberband could get stuck

This happened under 'high CPU load' sometimes

This was a tricky one to debug, but I noticed that there were actually three popovers active at once with the rubberband

1) The rubberband menu (which used a @jbrowse/core/ui/Menu which uses a MUI Popover)
2) The left RubberbandTooltip (which used a MUI Popover)
3) The right RubberbandTooltip (which used a MUI Popover)

I changed the RubberbandTooltip component to use a normal MUI Tooltip instead of a MUI Popover, and I think the error has gone away

this was a hard-to-reproduce bug, so i can't 100% confirm this PR fixes the issue, but I believe that the use of MUI tooltip is probably more natural anyways

Fixes #5083