### PR TITLE
Document simple wget method of running jbrowse CLI

### DIFF
--- a/website/docs/quickstart_web.md
+++ b/website/docs/quickstart_web.md
@@ -57,6 +57,14 @@ npx @jbrowse/cli --version
 
 :::
 
+Another way which involves downloading a single file bundle is to use
+
+```sh-session
+wget https://unpkg.com/@jbrowse/cli/bundle/index.js -O jbrowse
+chmod +x jbrowse
+./jbrowse --help
+```
+
 ### Using `jbrowse create` to download JBrowse 2
 
 In the directory where you would like to download JBrowse 2, run


### PR DESCRIPTION
This uses the new single-file bundle of jbrowse to just download a file, chmod +x it, and then execute it