### PR TITLE
Add locstrings to synteny mouseovers

### DIFF
--- a/packages/product-core/src/ui/AboutDialogContents.tsx
+++ b/packages/product-core/src/ui/AboutDialogContents.tsx
@@ -4,13 +4,13 @@ import Attributes from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/Attrib
 import BaseCard from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/BaseCard'
 import { getConf, readConfObject } from '@jbrowse/core/configuration'
 import { getEnv, getSession } from '@jbrowse/core/util'
-import { Button } from '@mui/material'
-import copy from 'copy-to-clipboard'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
 import FileInfoPanel from './FileInfoPanel'
+import HeaderButtons from './HeaderButtons'
 import RefNameInfoDialog from './RefNameInfoDialog'
+import { generateDisplayableConfig } from './util'
 
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
@@ -18,28 +18,13 @@ const useStyles = makeStyles()({
   content: {
     minWidth: 800,
   },
-  button: {
-    float: 'right',
-  },
 })
-
-function removeAttr(obj: Record<string, unknown>, attr: string) {
-  for (const prop in obj) {
-    if (prop === attr) {
-      delete obj[prop]
-    } else if (typeof obj[prop] === 'object') {
-      removeAttr(obj[prop] as Record<string, unknown>, attr)
-    }
-  }
-  return obj
-}
 
 const AboutDialogContents = observer(function ({
   config,
 }: {
   config: AnyConfigurationModel
 }) {
-  const [copied, setCopied] = useState(false)
   const conf = readConfObject(config)
   const session = getSession(config)
   const { classes } = useStyles()
@@ -51,58 +36,27 @@ const AboutDialogContents = observer(function ({
 
   const { pluginManager } = getEnv(session)
 
-  const confPostExt = pluginManager.evaluateExtensionPoint(
-    'Core-customizeAbout',
-    {
-      config: {
-        ...conf,
-        ...getConf(session, ['formatAbout', 'config'], { config: conf }),
-        ...readConfObject(config, ['formatAbout', 'config'], { config: conf }),
-      },
-    },
-    { session, config },
-  ) as {
-    config: { metadata?: Record<string, unknown>; [key: string]: unknown }
-  }
+  const confPostExt = generateDisplayableConfig({
+    config,
+    pluginManager,
+  })
 
   const ExtraPanel = pluginManager.evaluateExtensionPoint(
     'Core-extraAboutPanel',
     null,
     { session, config },
   ) as { name: string; Component: React.FC<any> } | null
+  const hideFields = ['displays', 'baseUri', 'refNames', 'formatAbout']
 
   return (
     <div className={classes.content}>
       <BaseCard title="Configuration">
         {!hideUris ? (
-          <span className={classes.button}>
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={() => {
-                setShowRefNames(true)
-              }}
-            >
-              Show ref names
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => {
-                const snap = removeAttr(structuredClone(conf), 'baseUri')
-                copy(JSON.stringify(snap, null, 2))
-                setCopied(true)
-                setTimeout(() => {
-                  setCopied(false)
-                }, 1000)
-              }}
-            >
-              {copied ? 'Copied to clipboard!' : 'Copy config'}
-            </Button>
-          </span>
+          <HeaderButtons conf={conf} setShowRefNames={setShowRefNames} />
         ) : null}
         <Attributes
           attributes={confPostExt.config}
-          omit={['displays', 'baseUri', 'refNames', 'formatAbout', 'metadata']}
+          omit={[...hideFields, 'metadata']}
           hideUris={hideUris}
         />
       </BaseCard>
@@ -110,7 +64,7 @@ const AboutDialogContents = observer(function ({
         <BaseCard title="Metadata">
           <Attributes
             attributes={confPostExt.config.metadata}
-            omit={['displays', 'baseUri', 'refNames', 'formatAbout']}
+            omit={hideFields}
             hideUris={hideUris}
           />
         </BaseCard>

--- a/packages/product-core/src/ui/HeaderButtons.tsx
+++ b/packages/product-core/src/ui/HeaderButtons.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+import { Button } from '@mui/material'
+import copy from 'copy-to-clipboard'
+import { makeStyles } from 'tss-react/mui'
+
+import { removeAttr } from './util'
+
+const useStyles = makeStyles()({
+  button: {
+    float: 'right',
+  },
+})
+
+interface HeaderButtonsProps {
+  conf: Record<string, unknown>
+  setShowRefNames: (show: boolean) => void
+}
+
+function HeaderButtons({ conf, setShowRefNames }: HeaderButtonsProps) {
+  const [copied, setCopied] = useState(false)
+  const { classes } = useStyles()
+
+  return (
+    <span className={classes.button}>
+      <Button
+        variant="contained"
+        color="secondary"
+        onClick={() => {
+          setShowRefNames(true)
+        }}
+      >
+        Show ref names
+      </Button>
+      <Button
+        variant="contained"
+        onClick={() => {
+          const snap = removeAttr(structuredClone(conf), 'baseUri')
+          copy(JSON.stringify(snap, null, 2))
+          setCopied(true)
+          setTimeout(() => {
+            setCopied(false)
+          }, 1000)
+        }}
+      >
+        {copied ? 'Copied to clipboard!' : 'Copy config'}
+      </Button>
+    </span>
+  )
+}
+
+export default HeaderButtons

--- a/packages/product-core/src/ui/util.ts
+++ b/packages/product-core/src/ui/util.ts
@@ -1,0 +1,40 @@
+import { getConf, readConfObject } from '@jbrowse/core/configuration'
+import { getSession } from '@jbrowse/core/util'
+
+import type PluginManager from '@jbrowse/core/PluginManager'
+import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
+
+export function removeAttr(obj: Record<string, unknown>, attr: string) {
+  for (const prop in obj) {
+    if (prop === attr) {
+      delete obj[prop]
+    } else if (typeof obj[prop] === 'object') {
+      removeAttr(obj[prop] as Record<string, unknown>, attr)
+    }
+  }
+  return obj
+}
+
+export function generateDisplayableConfig({
+  config,
+  pluginManager,
+}: {
+  config: AnyConfigurationModel
+  pluginManager: PluginManager
+}) {
+  const session = getSession(config)
+  const conf = readConfObject(config)
+  return pluginManager.evaluateExtensionPoint(
+    'Core-customizeAbout',
+    {
+      config: {
+        ...conf,
+        ...getConf(session, ['formatAbout', 'config'], { config: conf }),
+        ...readConfObject(config, ['formatAbout', 'config'], { config: conf }),
+      },
+    },
+    { session, config },
+  ) as {
+    config: { metadata?: Record<string, unknown>; [key: string]: unknown }
+  }
+}

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
@@ -1,5 +1,5 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
-import { assembleLocStringFast, getBpDisplayStr } from '@jbrowse/core/util'
+import { assembleLocString, toLocale } from '@jbrowse/core/util'
 import { linearPileupDisplayConfigSchemaFactory } from '@jbrowse/plugin-alignments'
 
 import type PluginManager from '@jbrowse/core/PluginManager'
@@ -12,29 +12,25 @@ import type { Feature } from '@jbrowse/core/util'
  */
 function configSchemaF(pluginManager: PluginManager) {
   pluginManager.jexl.addFunction('lgvSyntenyTooltip', (f: Feature) => {
-    const m = f.get('mate')
+    const mate = f.get('mate')
     const l1name = f.get('name') || f.get('id')
-    const l2name = m?.name || m?.id
-    const l1loc = assembleLocStringFast(
-      {
+    const l2name = mate?.name || mate?.id
+    return [
+      l1name ? `Name1: ${l1name}` : '',
+      l2name ? `Name1: ${l2name}` : '',
+      `Loc1: ${assembleLocString({
         refName: f.get('refName'),
         start: f.get('start'),
         end: f.get('end'),
-      },
-      n => getBpDisplayStr(n),
-    )
-    const l2loc = assembleLocStringFast(
-      {
-        refName: m.refName,
-        start: m.start,
-        end: m.end,
-      },
-      n => getBpDisplayStr(n),
-    )
-    return [
-      `Loc1: ${[l1name, l1loc].filter(f => !!f).join(' ')}`,
-      `Loc2: ${[l2name, l2loc].filter(f => !!f).join(' ')}`,
-    ].join('<br/>')
+      })} (${toLocale(f.get('end') - f.get('start'))}bp)`,
+      `Loc2: ${assembleLocString({
+        refName: mate.refName,
+        start: mate.start,
+        end: mate.end,
+      })} (${toLocale(mate.end - mate.start)}bp)`,
+    ]
+      .filter(f => !!f)
+      .join('<br/>')
   })
   return ConfigurationSchema(
     'LGVSyntenyDisplay',

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/configSchemaF.ts
@@ -1,4 +1,5 @@
 import { ConfigurationSchema } from '@jbrowse/core/configuration'
+import { assembleLocStringFast, getBpDisplayStr } from '@jbrowse/core/util'
 import { linearPileupDisplayConfigSchemaFactory } from '@jbrowse/plugin-alignments'
 
 import type PluginManager from '@jbrowse/core/PluginManager'
@@ -12,9 +13,28 @@ import type { Feature } from '@jbrowse/core/util'
 function configSchemaF(pluginManager: PluginManager) {
   pluginManager.jexl.addFunction('lgvSyntenyTooltip', (f: Feature) => {
     const m = f.get('mate')
-    return [f.get('name') || f.get('id'), m?.name || m?.id]
-      .filter(f => !!f)
-      .join('<br/>')
+    const l1name = f.get('name') || f.get('id')
+    const l2name = m?.name || m?.id
+    const l1loc = assembleLocStringFast(
+      {
+        refName: f.get('refName'),
+        start: f.get('start'),
+        end: f.get('end'),
+      },
+      n => getBpDisplayStr(n),
+    )
+    const l2loc = assembleLocStringFast(
+      {
+        refName: m.refName,
+        start: m.start,
+        end: m.end,
+      },
+      n => getBpDisplayStr(n),
+    )
+    return [
+      `Loc1: ${[l1name, l1loc].filter(f => !!f).join(' ')}`,
+      `Loc2: ${[l2name, l2loc].filter(f => !!f).join(' ')}`,
+    ].join('<br/>')
   })
   return ConfigurationSchema(
     'LGVSyntenyDisplay',


### PR DESCRIPTION
this could probably be improved even further, but this adds locstrings so you can see the source of features in the LGV synteny display feature mouseovers

example: 
<img width="1857" height="621" alt="image" src="https://github.com/user-attachments/assets/21ef9921-4e42-42db-909d-0c7bf510ffad" />


this could also be made to read the CIGAR string to show where the 'current visible' region maps to but this is just where the entire alignment block maps to