### PR TITLE
Avoid clearing click-and-drag rubberband boundaries onMouseOut to fix "Zoom to region", bookmark region, etc.

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/useRangeSelect.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/useRangeSelect.ts
@@ -111,7 +111,6 @@ export function useRangeSelect(
 
   function mouseOut() {
     setGuideX(undefined)
-    model.setOffsets(undefined, undefined)
   }
 
   function handleClose() {


### PR DESCRIPTION
There is a line of code that 'unsets' the rubberband left and right offsets "onMouseOut"

This seems unintentional because anytime the mouse goes slightly out of bounds of the scalebar, it makes it so that the left and right offsets are cleared

Possible fix for #5112