### PR TITLE
Link to "Genomes" in jbrowse website header bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,6 +21,11 @@ module.exports = {
       },
       items: [
         {
+          to: 'http://jbrowse.org/demos/jb2hubs/',
+          label: 'Genomes',
+          position: 'left',
+        },
+        {
           to: 'docs/',
           activeBasePath: 'docs',
           label: 'Docs',


### PR DESCRIPTION
This is a proposal to integrate our "jb2hubs" with the jbrowse website

It just puts the word "Genomes" in the header bar, and then explains things once you click that


These genomes can also be launched from the jbrowse desktop app
Example screenshot

<img width="1856" height="807" alt="image" src="https://github.com/user-attachments/assets/1c24625e-e584-40e4-81b7-f2cc8f070385" />



## Consideration: the genomes is a separate non-docusaurus resource

This Genomes page links to a non-docusaurus sub-URI. This Genomes page, the jb2hubs, are implemented in next.js

I have tried to make the look and feel of the jb2hubs very similar to the docusaurus portal of the rest of the jbrowse website, so that it feels like a "regular page"


Potentially the docusaurus site could be converted to next.js to make it a single platform, or the next.js website could be converted to docusaurus or something else to create a more seamless dev experience on the website

This always seems to come up on websites ...if you have multiple frontend frameworks they struggle to share styles...




## Why now


This decision is following the method to allow synteny views to be dynamically launched


