### PR TITLE
Destroy old root model on pm reload

### DIFF
--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -3,6 +3,7 @@ import { Suspense, lazy, useEffect, useState } from 'react'
 import { FatalErrorDialog } from '@jbrowse/core/ui'
 import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
 import { observer } from 'mobx-react'
+import { destroy } from 'mobx-state-tree'
 import {
   QueryParamProvider,
   StringParam,
@@ -128,12 +129,16 @@ const Renderer = observer(function ({
 
     try {
       if (ready) {
+        if (pluginManager?.rootModel) {
+          destroy(pluginManager.rootModel)
+        }
         setPluginManager(createPluginManager(loader, reloadPluginManager))
       }
     } catch (e) {
       console.error(e)
       setError(e)
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loader, ready])
 
   const err = configError || error

--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -138,7 +138,7 @@ const Renderer = observer(function ({
       console.error(e)
       setError(e)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loader, ready])
 
   const err = configError || error

--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -129,16 +129,17 @@ const Renderer = observer(function ({
 
     try {
       if (ready) {
-        if (pluginManager?.rootModel) {
-          destroy(pluginManager.rootModel)
-        }
-        setPluginManager(createPluginManager(loader, reloadPluginManager))
+        setPluginManager(previousPluginManager => {
+          if (previousPluginManager?.rootModel) {
+            destroy(previousPluginManager.rootModel)
+          }
+          return createPluginManager(loader, reloadPluginManager)
+        })
       }
     } catch (e) {
       console.error(e)
       setError(e)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loader, ready])
 
   const err = configError || error

--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -1,3 +1,5 @@
+import { FatalErrorDialog } from '@jbrowse/core/ui'
+import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
 import { render, waitFor } from '@testing-library/react'
 import { Image, createCanvas } from 'canvas'
 import { LocalFile } from 'generic-filehandle2'
@@ -116,7 +118,17 @@ test('can use config from a url with nonexistent share param ', async () => {
 
 test('can catch error from loading a bad config', async () => {
   const { findAllByText } = render(
-    <App search="?config=test_data/bad_config_test/config.json" />,
+    <ErrorBoundary
+      FallbackComponent={props => (
+        <FatalErrorDialog
+          {...props}
+          resetButtonText="Reset Session"
+          onFactoryReset={() => {}}
+        />
+      )}
+    >
+      <App search="?config=test_data/bad_config_test/config.json" />
+    </ErrorBoundary>,
   )
   await findAllByText(/Error while converting/)
 }, 20000)


### PR DESCRIPTION
Marking as draft since I'm not sure this is the right way to do this.

If you add a log as described in issue #5139, you'll see that with this branch the `beforeDestroy` hook gets triggered when a plugin is added from the plugin store.

However, this involves violating the rules of hooks, since if you add the plugin manager to the `useEffect` dependencies, it triggers an infinite loop.

Fixes #5139 