### PR TITLE
Create llms.txt file on jbrowse.org site

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -26,3 +26,5 @@ cli.md
 # plugin data from AWS
 plugins.json
 jb2
+llms.txt
+llms-full.txt

--- a/website/package.json
+++ b/website/package.json
@@ -12,9 +12,11 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "typecheck": "tsc",
-    "predeploy": "npm run build",
-    "deploy": "aws s3 sync --delete build s3://jbrowse.org/jb2/",
-    "postdeploy": "aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths \"/jb2/*\""
+    "predeploy": "npm run build && npm run llms && npm run llms-full",
+    "deploy": "aws s3 sync --delete build s3://jbrowse.org/jb2/ && aws s3 cp llms.txt s3://jbrowse.org/jb2/ && aws s3 cp llms-full.txt s3://jbrowse.org/jb2/",
+    "postdeploy": "aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths \"/jb2/*\"",
+    "llms": "cat docs/introduction.md > llms.txt",
+    "llms-full": "cat docs/introduction.md docs/quickstart_web.md docs/quickstart_desktop.md docs/quickstart_adminserver.md docs/urlparams.md docs/user_guide.md docs/user_guides/* docs/embedded_components.md docs/jbrowser.md docs/jbrowse_jupyter.md docs/developer_guides/*.md docs/config_guides/*.md ../products/jbrowse-cli/README.md docs/models/*.md docs/config/*.md > llms-full.txt"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^1.1.0",


### PR DESCRIPTION
Currently @GFJHogue manually fetches from github to retrieve some jbrowse docs to try to give the chatbot more context, however, creating "llm docs" might help

There is currently a "standardization" effort that suggests uploading llms.txt (small, <10kb, contains basic navigation structure) and llms-full.txt  (can be large) to your website.

This current PR just appends many markdown files manually with "cat" in the docusaurus build process. It could be made more "proper" by stripping the markdown header from each file, but I am guessing the llm don't care too much about this

Fixes #5129 