### PR TITLE
Clean up plugin manager

### DIFF
--- a/products/jbrowse-web/src/tests/Loader.test.tsx
+++ b/products/jbrowse-web/src/tests/Loader.test.tsx
@@ -1,5 +1,3 @@
-import { FatalErrorDialog } from '@jbrowse/core/ui'
-import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
 import { render, waitFor } from '@testing-library/react'
 import { Image, createCanvas } from 'canvas'
 import { LocalFile } from 'generic-filehandle2'
@@ -118,17 +116,7 @@ test('can use config from a url with nonexistent share param ', async () => {
 
 test('can catch error from loading a bad config', async () => {
   const { findAllByText } = render(
-    <ErrorBoundary
-      FallbackComponent={props => (
-        <FatalErrorDialog
-          {...props}
-          resetButtonText="Reset Session"
-          onFactoryReset={() => {}}
-        />
-      )}
-    >
-      <App search="?config=test_data/bad_config_test/config.json" />
-    </ErrorBoundary>,
+    <App search="?config=test_data/bad_config_test/config.json" />,
   )
   await findAllByText(/Error while converting/)
 }, 20000)


### PR DESCRIPTION
It turns out https://github.com/GMOD/jbrowse-components/pull/5140 had a problem in that it was creating two `pluginManager`s and not cleaning them up (even if you didn't e.g. add a plugin to reload the page). This was due to the React's strict mode running the `useEffect` twice, but there not being any proper cleanup.

This PR is another try at accomplishing the same thing https://github.com/GMOD/jbrowse-components/pull/5140 was trying to accomplish, this time storing the `pluginManager` in a ref and cleaning it up in the useEffect's cleanup function.