### PR TITLE
Clean up listeners when model is destroyed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,7 +45,6 @@ Chrome)
 
 **Whether you are using the web version or desktop version**
 
-
 **Additional context**
 
 <!-- Add any other context about the problem here. -->

--- a/packages/app-core/src/HistoryManagement/index.ts
+++ b/packages/app-core/src/HistoryManagement/index.ts
@@ -17,43 +17,49 @@ export function HistoryManagementMixin() {
        */
       history: types.optional(TimeTraveller, { targetPath: '../session' }),
     })
-    .actions(self => ({
-      afterCreate() {
-        document.addEventListener('keydown', e => {
-          if (
-            self.history.canRedo &&
-            // ctrl+shift+z or cmd+shift+z
-            (((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'KeyZ') ||
-              // ctrl+y
-              (e.ctrlKey && !e.shiftKey && e.code === 'KeyY')) &&
-            document.activeElement?.tagName.toUpperCase() !== 'INPUT'
-          ) {
-            self.history.redo()
-          }
-          if (
-            self.history.canUndo &&
-            // ctrl+z or cmd+z
-            (e.ctrlKey || e.metaKey) &&
-            !e.shiftKey &&
-            e.code === 'KeyZ' &&
-            document.activeElement?.tagName.toUpperCase() !== 'INPUT'
-          ) {
-            self.history.undo()
-          }
-        })
-        addDisposer(
-          self,
-          autorun(() => {
-            const { session } = self as typeof self & BaseRootModel
-            if (session) {
-              // we use a specific initialization routine after session is
-              // created to get it to start tracking itself sort of related
-              // issue here
-              // https://github.com/mobxjs/mobx-state-tree/issues/1089#issuecomment-441207911
-              self.history.initialize()
-            }
-          }),
-        )
-      },
-    }))
+    .actions(self => {
+      const keydownListener = (e: KeyboardEvent) => {
+        if (
+          self.history.canRedo &&
+          // ctrl+shift+z or cmd+shift+z
+          (((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'KeyZ') ||
+            // ctrl+y
+            (e.ctrlKey && !e.shiftKey && e.code === 'KeyY')) &&
+          document.activeElement?.tagName.toUpperCase() !== 'INPUT'
+        ) {
+          self.history.redo()
+        }
+        if (
+          self.history.canUndo &&
+          // ctrl+z or cmd+z
+          (e.ctrlKey || e.metaKey) &&
+          !e.shiftKey &&
+          e.code === 'KeyZ' &&
+          document.activeElement?.tagName.toUpperCase() !== 'INPUT'
+        ) {
+          self.history.undo()
+        }
+      }
+      return {
+        afterCreate() {
+          document.addEventListener('keydown', keydownListener)
+          addDisposer(
+            self,
+            autorun(() => {
+              const { session } = self as typeof self & BaseRootModel
+              if (session) {
+                // we use a specific initialization routine after session is
+                // created to get it to start tracking itself sort of related
+                // issue here
+                // https://github.com/mobxjs/mobx-state-tree/issues/1089#issuecomment-441207911
+                self.history.initialize()
+              }
+            }),
+          )
+        },
+        beforeDestroy() {
+          document.removeEventListener('keydown', keydownListener)
+        },
+      }
+    })
 }

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -203,7 +203,7 @@ const DotplotViewInternal = observer(function ({
     window.addEventListener('keyup', globalCtrlKeyUp)
     return () => {
       window.removeEventListener('keydown', globalCtrlKeyDown)
-      window.addEventListener('keyup', globalCtrlKeyUp)
+      window.removeEventListener('keyup', globalCtrlKeyUp)
     }
   }, [])
 

--- a/plugins/grid-bookmark/src/index.ts
+++ b/plugins/grid-bookmark/src/index.ts
@@ -195,26 +195,32 @@ export default class GridBookmarkPlugin extends Plugin {
                 },
               }
             })
-            .actions(self => ({
-              afterCreate() {
-                document.addEventListener('keydown', e => {
-                  const activationSequence =
-                    (e.ctrlKey || e.metaKey) && e.shiftKey
-                  // ctrl+shift+d or cmd+shift+d
-                  if (activationSequence && e.code === 'KeyD') {
-                    e.preventDefault()
-                    self.activateBookmarkWidget()
-                    self.bookmarkCurrentRegion()
-                    getSession(self).notify('Bookmark created.', 'success')
-                  }
-                  // ctrl+shift+m or cmd+shift+m
-                  if (activationSequence && e.code === 'KeyM') {
-                    e.preventDefault()
-                    self.navigateNewestBookmark()
-                  }
-                })
-              },
-            }))
+            .actions(self => {
+              const keydownListener = (e: KeyboardEvent) => {
+                const activationSequence =
+                  (e.ctrlKey || e.metaKey) && e.shiftKey
+                // ctrl+shift+d or cmd+shift+d
+                if (activationSequence && e.code === 'KeyD') {
+                  e.preventDefault()
+                  self.activateBookmarkWidget()
+                  self.bookmarkCurrentRegion()
+                  getSession(self).notify('Bookmark created.', 'success')
+                }
+                // ctrl+shift+m or cmd+shift+m
+                if (activationSequence && e.code === 'KeyM') {
+                  e.preventDefault()
+                  self.navigateNewestBookmark()
+                }
+              }
+              return {
+                afterCreate() {
+                  document.addEventListener('keydown', keydownListener)
+                },
+                beforeDestroy() {
+                  document.removeEventListener('keydown', keydownListener)
+                },
+              }
+            })
 
           ;(pluggableElement as ViewType).stateModel = newStateModel
         }

--- a/products/jbrowse-web/src/rootModel/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel/rootModel.ts
@@ -30,7 +30,14 @@ import { formatDistanceToNow } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { openDB } from 'idb'
 import { autorun } from 'mobx'
-import { addDisposer, cast, getSnapshot, getType, types } from 'mobx-state-tree'
+import {
+  addDisposer,
+  cast,
+  getSnapshot,
+  getType,
+  isAlive,
+  types,
+} from 'mobx-state-tree'
 
 import packageJSON from '../../package.json'
 import jbrowseWebFactory from '../jbrowseModel'
@@ -221,6 +228,9 @@ export default function RootModel({
                       // triggered the autorun
                       if (self.sessionDB) {
                         await sessionDB.put('sessions', getSnapshot(s), s.id)
+                        if (!isAlive(self)) {
+                          return
+                        }
 
                         const ret = await self.sessionDB.get('metadata', s.id)
                         await sessionDB.put(


### PR DESCRIPTION
Since #5146 was merged it has highlighted a couple places where models weren't cleaning up keyboard listeners. This wasn't noticeable before since they would act on the orphaned (but still not destroyed) model. Now that models are destroyed, if the listeners fired they would give an warning about trying to act on a detached state tree node. This adds some `removeEventListener`s to fix that.

Also adds an `isAlive` check to an async autorun that sometimes would try to do things after the model was destroyed.