### PR TITLE
Add missing "tmp" dependency to `@jbrowse/cli` package.json

### DIFF
--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -43,7 +43,8 @@
     "express": "^5.1.0",
     "ixixx": "^2.0.1",
     "json-parse-better-errors": "^1.0.2",
-    "node-fetch-native": "^1.6.4"
+    "node-fetch-native": "^1.6.4",
+    "tmp": "^0.2.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This adds a missing dependency `tmp` to the `@jbrowse/cli` package.json. `tmp` is used in `products/jbrowse-cli/src/commands/sort-gff-utils/sort-utils.ts`.

I found this when trying to run `@jbrowse/cli` under yarn v4, which gave this error:

```
Run yarn run jbrowse create --nightly .jbrowse
/home/runner/work/Apollo3/Apollo3/.pnp.cjs:48122
      Error.captureStackTrace(firstError);
            ^

Error: @jbrowse/cli tried to access tmp, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: tmp
Required by: @jbrowse/cli@npm:3.6.5 (via /home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/commands/sort-gff-utils/)

Require stack:
- /home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/commands/sort-gff-utils/sort-utils.js
- /home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/commands/sort-gff.js
- /home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/index.js
- /home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/bin.js
    at require$$0.Module._resolveFilename (/home/runner/work/Apollo3/Apollo3/.pnp.cjs:48122:13)
    at Module._load (node:internal/modules/cjs/loader:1038:27)
    at require$$0.Module._load (/home/runner/work/Apollo3/Apollo3/.pnp.cjs:48013:31)
    at Module.require (node:internal/modules/cjs/loader:1289:19)
    at require (node:internal/modules/helpers:182:18)
    at Object.<anonymous> (/home/runner/work/Apollo3/Apollo3/.yarn/cache/@jbrowse-cli-npm-3.6.5-5b2f0d341b-f6e58285b3.zip/node_modules/@jbrowse/cli/dist/commands/sort-gff-utils/sort-utils.js:13:31)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
```