### PR TITLE
Fix for tracks from wrong assembly showing up in track list when using connections

### DIFF
--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/model.ts
@@ -458,7 +458,7 @@ export default function stateTreeFactory(pluginManager: PluginManager) {
           },
           ...connectionInstances.flatMap(c => ({
             group: getConf(c, 'name'),
-            tracks: c.tracks,
+            tracks: filterTracks(c.tracks, self),
             noCategories: false,
             menuItems: [],
           })),


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/5082

This fix was fully generated by Google Gemini CLI which has generous free tier

I asked 

"I am seeing that when I am using connections, there are tracks from the wrong assembly showing up in the track selector. can you please analyze the code in plugins/data-management/src/HierarchicalTrackSelectorWidget/  to see why this might happen"

It made the one line code fix