### PR TITLE
Add deletions and mismatches to the pileup mouseover

### DIFF
--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -6,6 +6,7 @@ import Flatbush from '@jbrowse/core/util/flatbush'
 import { observer } from 'mobx-react'
 
 import type { ColorBy, FilterBy, SortedBy } from '../../shared/types'
+import type { FlatbushItem } from '../types'
 import type { Region } from '@jbrowse/core/util/types'
 import type { BaseLinearDisplayModel } from '@jbrowse/plugin-linear-genome-view'
 
@@ -19,7 +20,7 @@ const PileupRendering = observer(function (props: {
   sortedBy?: SortedBy
   colorBy?: ColorBy
   filterBy?: FilterBy
-  items: { seq: string }[]
+  items: FlatbushItem[]
   flatbush: any
   onMouseMove?: (
     event: React.MouseEvent,
@@ -132,11 +133,18 @@ const PileupRendering = observer(function (props: {
     const px = region.reversed ? width - offsetX : offsetX
     const clientBp = region.start + bpPerPx * px
     const search = flatbush2.search(offsetX, offsetY, offsetX + 1, offsetY + 1)
+    const item = search.length ? items[search[0]!] : undefined
+    const label = item
+      ? item.type === 'insertion'
+        ? `Insertion: ${item.seq}`
+        : item.type === 'deletion'
+          ? `Deletion: ${item.seq}bp`
+          : `Mismatch: ${item.seq}`
+      : undefined
     onMouseMove?.(
       event,
       displayModel?.getFeatureOverlapping(blockKey, clientBp, offsetY),
-
-      search.length ? `Insertion: ${items[search[0]!]!.seq}` : undefined,
+      label,
     )
   }
 

--- a/plugins/alignments/src/PileupRenderer/makeImageData.ts
+++ b/plugins/alignments/src/PileupRenderer/makeImageData.ts
@@ -14,7 +14,7 @@ import {
   shouldDrawSNPsMuted,
 } from './util'
 
-import type { ProcessedRenderArgs } from './types'
+import type { FlatbushItem, ProcessedRenderArgs } from './types'
 import type { Feature } from '@jbrowse/core/util'
 
 interface LayoutFeature {
@@ -58,7 +58,7 @@ export function makeImageData({
   const drawSNPsMuted = shouldDrawSNPsMuted(colorBy?.type)
   const drawIndels = shouldDrawIndels()
   const coords = [] as number[]
-  const items = [] as { seq: string }[]
+  const items = [] as FlatbushItem[]
   forEachWithStopTokenCheck(layoutRecords, stopToken, feat => {
     renderAlignment({
       ctx,

--- a/plugins/alignments/src/PileupRenderer/renderers/renderMismatches.ts
+++ b/plugins/alignments/src/PileupRenderer/renderers/renderMismatches.ts
@@ -4,7 +4,7 @@ import { colord } from '@jbrowse/core/util/colord'
 import { fillRect } from '../util'
 
 import type { Mismatch } from '../../shared/types'
-import type { ProcessedRenderArgs } from '../types'
+import type { FlatbushItem, ProcessedRenderArgs } from '../types'
 import type { LayoutFeature } from '../util'
 
 export function renderMismatches({
@@ -38,7 +38,7 @@ export function renderMismatches({
   charHeight: number
   canvasWidth: number
 }) {
-  const items = [] as { seq: string }[]
+  const items = [] as FlatbushItem[]
   const coords = [] as number[]
   const { bpPerPx, regions } = renderArgs
   const { heightPx, topPx, feature } = feat
@@ -62,6 +62,12 @@ export function renderMismatches({
     const [leftPx, rightPx] = bpSpanPx(mstart, mstart + mlen, region, bpPerPx)
     const widthPx = Math.max(minSubfeatureWidth, rightPx - leftPx)
     if (mismatch.type === 'mismatch') {
+      items.push({
+        type: 'mismatch',
+        seq: mismatch.base,
+      })
+      coords.push(leftPx, topPx, rightPx, topPx + heightPx)
+
       if (!drawSNPsMuted) {
         const baseColor = colorMap[mismatch.base] || '#888'
         const c =
@@ -111,6 +117,11 @@ export function renderMismatches({
           canvasWidth,
           colorMap.deletion,
         )
+        items.push({
+          type: 'deletion',
+          seq: `${mismatch.length}`,
+        })
+        coords.push(leftPx, topPx, rightPx, topPx + heightPx)
         const txt = `${mismatch.length}`
         const rwidth = measureText(txt, 10)
         if (widthPx >= rwidth && heightPx >= heightLim) {
@@ -139,9 +150,10 @@ export function renderMismatches({
           )
           if (1 / bpPerPx >= charWidth && heightPx >= heightLim) {
             items.push({
+              type: 'insertion',
               seq: mismatch.insertedBases || 'unknown',
             })
-            coords.push(leftPx, topPx, leftPx + insW, topPx + heightPx)
+            coords.push(leftPx - 2, topPx, leftPx + insW + 2, topPx + heightPx)
 
             const l = Math.round(pos - insW)
             fillRect(ctx, l, topPx, insW * 3, 1, canvasWidth)
@@ -188,9 +200,10 @@ export function renderMismatches({
         const [leftPx] = bpSpanPx(mstart, mstart + mlen, region, bpPerPx)
         const txt = `${len}`
         items.push({
+          type: 'insertion',
           seq: mismatch.insertedBases || 'unknown',
         })
-        coords.push(leftPx - 1, topPx, leftPx + 2, topPx + heightPx)
+        coords.push(leftPx - 3, topPx, leftPx + 4, topPx + heightPx)
         if (bpPerPx > largeInsertionIndicatorScale) {
           fillRect(
             ctx,

--- a/plugins/alignments/src/PileupRenderer/types.ts
+++ b/plugins/alignments/src/PileupRenderer/types.ts
@@ -13,6 +13,11 @@ export interface LayoutFeature {
   feature: Feature
 }
 
+export interface FlatbushItem {
+  type: 'insertion' | 'deletion' | 'mismatch'
+  seq: string
+}
+
 export interface RenderArgsDeserialized extends BoxRenderArgsDeserialized {
   colorBy?: ColorBy
   colorTagMap?: Record<string, string>


### PR DESCRIPTION
The ability to mouse over individual insertions on reads was added previously https://github.com/GMOD/jbrowse-components/pull/5136

This adds ability to mouseover deletions and mismatches. the deletions says the number of bp deleted

It could in some cases potentially resolve the actual sequence that was deleted but this is not uniformly stored in the 'mismatches' data structure currently, and in some cases, would add extra work where jbrowse would have to fetch the underlying sequence