### PR TITLE
Add 'location markers' that can be toggled in synteny view

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
@@ -1,6 +1,6 @@
 import { doesIntersect2, getContainingView } from '@jbrowse/core/util'
 
-import { draw, drawMatchSimple } from './components/util'
+import { draw, drawLocationMarkers, drawMatchSimple } from './components/util'
 
 import type { LinearSyntenyDisplayModel } from './model'
 import type { LinearSyntenyViewModel } from '../LinearSyntenyView/model'
@@ -40,6 +40,7 @@ export function drawRef(
   const drawCurves = view.drawCurves
   const drawCIGAR = view.drawCIGAR
   const drawCIGARMatchesOnly = view.drawCIGARMatchesOnly
+  const drawLocationMarkersEnabled = view.drawLocationMarkers
   const { level, height, featPositions } = model
   const width = view.width
   const bpPerPxs = view.views.map(v => v.bpPerPx)
@@ -180,10 +181,40 @@ export function drawRef(
                 if (letter === 'M') {
                   draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
                   ctx1.fill()
+                  if (drawLocationMarkersEnabled) {
+                    drawLocationMarkers(
+                      ctx1,
+                      px1,
+                      cx1,
+                      y1,
+                      cx2,
+                      px2,
+                      y2,
+                      mid,
+                      bpPerPxs[level]!,
+                      bpPerPxs[level + 1]!,
+                      drawCurves,
+                    )
+                  }
                 }
               } else {
                 draw(ctx1, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
                 ctx1.fill()
+                if (drawLocationMarkersEnabled) {
+                  drawLocationMarkers(
+                    ctx1,
+                    px1,
+                    cx1,
+                    y1,
+                    cx2,
+                    px2,
+                    y2,
+                    mid,
+                    bpPerPxs[level]!,
+                    bpPerPxs[level + 1]!,
+                    drawCurves,
+                  )
+                }
               }
               if (ctx3) {
                 ctx3.fillStyle = makeColor(idx)
@@ -196,6 +227,21 @@ export function drawRef(
       } else {
         draw(ctx1, x11, x12, y1, x22, x21, y2, mid, drawCurves)
         ctx1.fill()
+        if (drawLocationMarkersEnabled) {
+          drawLocationMarkers(
+            ctx1,
+            x11,
+            x12,
+            y1,
+            x22,
+            x21,
+            y2,
+            mid,
+            bpPerPxs[level]!,
+            bpPerPxs[level + 1]!,
+            drawCurves,
+          )
+        }
       }
     }
   }

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/model.ts
@@ -46,6 +46,10 @@ export default function stateModelFactory(pluginManager: PluginManager) {
          * #property
          */
         drawCurves: false,
+        /**
+         * #property
+         */
+        drawLocationMarkers: false,
       }),
     )
     .volatile(() => ({
@@ -91,6 +95,12 @@ export default function stateModelFactory(pluginManager: PluginManager) {
        */
       setDrawCIGARMatchesOnly(arg: boolean) {
         self.drawCIGARMatchesOnly = arg
+      },
+      /**
+       * #action
+       */
+      setDrawLocationMarkers(arg: boolean) {
+        self.drawLocationMarkers = arg
       },
       /**
        * #action
@@ -177,6 +187,16 @@ export default function stateModelFactory(pluginManager: PluginManager) {
               icon: Curves,
               onClick: () => {
                 self.setDrawCurves(!self.drawCurves)
+              },
+            },
+            {
+              label: 'Draw location markers',
+              type: 'checkbox',
+              checked: self.drawLocationMarkers,
+              description:
+                'Draw periodic markers to show location within large matches',
+              onClick: () => {
+                self.setDrawLocationMarkers(!self.drawLocationMarkers)
               },
             },
             {


### PR DESCRIPTION
When viewing a large "match" for example, it can be unclear where in that large match that you are. This PR adds 'location marker' lines that help show you. They can be toggled on or off, and are drawn at different densities depending on zoom level

This PR's code was generated by Claude AI and took approximately 11 cents of compute :)

Volvox example

<img width="1860" height="766" alt="image" src="https://github.com/user-attachments/assets/0b36fb3d-0205-4bf3-9d67-3d263380eeae" />



Examples browsing the middle of a human mouse comparison

<img width="1860" height="766" alt="image" src="https://github.com/user-attachments/assets/0bced638-3e72-4e14-9846-ff1a5ef80a1a" />

<img width="1860" height="766" alt="image" src="https://github.com/user-attachments/assets/839d9925-7182-4e02-8fde-85dcb74250bb" />


Fixes https://github.com/GMOD/jbrowse-components/issues/4300
