### PR TITLE
Subfeature labels

### DIFF
--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
@@ -38,6 +38,7 @@ const FeatureGlyph = observer(function (props: {
     shouldShowName,
     feature,
     rootLayout,
+    topLevel,
   } = props
 
   // bad or old code might not be a string id but try to assume it is
@@ -58,6 +59,7 @@ const FeatureGlyph = observer(function (props: {
             y={rootLayout.getSubRecord('nameLabel')?.absolute.top || 0}
             color={readConfObject(config, ['labels', 'nameColor'], { feature })}
             featureWidth={featureLayout.width}
+            bold={topLevel}
             {...props}
           />
         ) : null}
@@ -70,6 +72,7 @@ const FeatureGlyph = observer(function (props: {
               feature,
             })}
             featureWidth={featureLayout.width}
+            bold={topLevel}
             {...props}
           />
         ) : null}

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureLabel.tsx
@@ -23,6 +23,7 @@ const FeatureLabel = observer(function ({
   featureWidth = 0,
   allowedWidthExpansion = 0,
   displayModel = {},
+  bold = false,
 }: {
   text: string
   x: number
@@ -38,6 +39,7 @@ const FeatureLabel = observer(function ({
   exportSVG?: unknown
   region: Region
   viewParams: ViewParams
+  bold?: boolean
 }) {
   const totalWidth = featureWidth + allowedWidthExpansion
   const measuredTextWidth = measureText(text, fontHeight)
@@ -97,6 +99,7 @@ const FeatureLabel = observer(function ({
       y={y + fontHeight}
       fill={color === '#f0f' ? stripAlpha(theme.palette.text.primary) : color}
       fontSize={fontHeight}
+      fontWeight={bold ? 'bold' : 'normal'}
     >
       {measuredTextWidth > totalWidth
         ? `${text.slice(0, totalWidth / (fontHeight * 0.6))}...`

--- a/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/Subfeatures.tsx
@@ -5,8 +5,7 @@ import { observer } from 'mobx-react'
 import FeatureLabel from './FeatureLabel'
 import { chooseGlyphComponent, layOut, layOutFeature } from './util'
 
-import type { DisplayModel, ViewParams } from './types'
-import type { ExtraGlyphValidator } from './types'
+import type { DisplayModel, ExtraGlyphValidator, ViewParams } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Region } from '@jbrowse/core/util'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'
@@ -25,7 +24,19 @@ const Subfeatures = observer(function Subfeatures(props: {
   allowedWidthExpansion?: number
   reversed?: boolean
 }) {
-  const { feature, featureLayout, selected, config, bpPerPx, region, displayModel, exportSVG, viewParams, allowedWidthExpansion = 0, reversed } = props
+  const {
+    feature,
+    featureLayout,
+    selected,
+    config,
+    bpPerPx,
+    region,
+    displayModel,
+    exportSVG,
+    viewParams,
+    allowedWidthExpansion = 0,
+    reversed,
+  } = props
 
   const displayMode = readConfObject(config, 'displayMode')
   const labelAllowed = displayMode !== 'collapsed'
@@ -42,20 +53,23 @@ const Subfeatures = observer(function Subfeatures(props: {
 
     // Calculate label information for subfeatures
     const showLabels = labelAllowed && readConfObject(config, 'showLabels')
-    const showDescriptions = labelAllowed && readConfObject(config, 'showDescriptions')
-    const fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature: subfeature })
+    const showDescriptions =
+      labelAllowed && readConfObject(config, 'showDescriptions')
+    const fontHeight = readConfObject(config, ['labels', 'fontSize'], {
+      feature: subfeature,
+    })
 
-    const name = String(readConfObject(config, ['labels', 'name'], { feature: subfeature }) || '')
+    const name = String(
+      readConfObject(config, ['labels', 'name'], { feature: subfeature }) || '',
+    )
     const shouldShowName = /\S/.test(name) && showLabels
 
-    const description = String(readConfObject(config, ['labels', 'description'], { feature: subfeature }) || '')
+    const description = String(
+      readConfObject(config, ['labels', 'description'], {
+        feature: subfeature,
+      }) || '',
+    )
     const shouldShowDescription = /\S/.test(description) && showDescriptions
-
-    const getWidth = (text: string) => {
-      const glyphWidth = subfeatureLayout.width + allowedWidthExpansion
-      const textWidth = measureText(text, fontHeight)
-      return Math.round(Math.min(textWidth, glyphWidth))
-    }
 
     return (
       <g key={`glyph-${subfeatureId}`}>
@@ -68,9 +82,17 @@ const Subfeatures = observer(function Subfeatures(props: {
         {shouldShowName ? (
           <FeatureLabel
             text={name}
-            x={featureLayout.getSubRecord(`${subfeatureId}-nameLabel`)?.absolute.left || 0}
-            y={featureLayout.getSubRecord(`${subfeatureId}-nameLabel`)?.absolute.top || 0}
-            color={readConfObject(config, ['labels', 'nameColor'], { feature: subfeature })}
+            x={
+              featureLayout.getSubRecord(`${subfeatureId}-nameLabel`)?.absolute
+                .left || 0
+            }
+            y={
+              featureLayout.getSubRecord(`${subfeatureId}-nameLabel`)?.absolute
+                .top || 0
+            }
+            color={readConfObject(config, ['labels', 'nameColor'], {
+              feature: subfeature,
+            })}
             featureWidth={subfeatureLayout.width}
             fontHeight={fontHeight}
             allowedWidthExpansion={allowedWidthExpansion}
@@ -86,9 +108,17 @@ const Subfeatures = observer(function Subfeatures(props: {
         {shouldShowDescription ? (
           <FeatureLabel
             text={description}
-            x={featureLayout.getSubRecord(`${subfeatureId}-descriptionLabel`)?.absolute.left || 0}
-            y={featureLayout.getSubRecord(`${subfeatureId}-descriptionLabel`)?.absolute.top || 0}
-            color={readConfObject(config, ['labels', 'descriptionColor'], { feature: subfeature })}
+            x={
+              featureLayout.getSubRecord(`${subfeatureId}-descriptionLabel`)
+                ?.absolute.left || 0
+            }
+            y={
+              featureLayout.getSubRecord(`${subfeatureId}-descriptionLabel`)
+                ?.absolute.top || 0
+            }
+            color={readConfObject(config, ['labels', 'descriptionColor'], {
+              feature: subfeature,
+            })}
             featureWidth={subfeatureLayout.width}
             fontHeight={fontHeight}
             allowedWidthExpansion={allowedWidthExpansion}
@@ -136,7 +166,8 @@ Subfeatures.layOut = ({
     const subfeatures = feature.get('subfeatures')
     const labelAllowed = displayMode !== 'collapsed'
     const showLabels = labelAllowed && readConfObject(config, 'showLabels')
-    const showDescriptions = labelAllowed && readConfObject(config, 'showDescriptions')
+    const showDescriptions =
+      labelAllowed && readConfObject(config, 'showDescriptions')
     const expansion = readConfObject(config, 'maxFeatureGlyphExpansion') || 0
 
     if (subfeatures) {
@@ -166,10 +197,19 @@ Subfeatures.layOut = ({
 
         // Add label layouts at the subLayout level (not as children of subSubLayout)
         // This prevents them from affecting the glyph's height calculations
-        const fontHeight = readConfObject(config, ['labels', 'fontSize'], { feature: subfeature })
-        const name = String(readConfObject(config, ['labels', 'name'], { feature: subfeature }) || '')
+        const fontHeight = readConfObject(config, ['labels', 'fontSize'], {
+          feature: subfeature,
+        })
+        const name = String(
+          readConfObject(config, ['labels', 'name'], { feature: subfeature }) ||
+            '',
+        )
         const shouldShowName = /\S/.test(name) && showLabels
-        const description = String(readConfObject(config, ['labels', 'description'], { feature: subfeature }) || '')
+        const description = String(
+          readConfObject(config, ['labels', 'description'], {
+            feature: subfeature,
+          }) || '',
+        )
         const shouldShowDescription = /\S/.test(description) && showDescriptions
 
         const getWidth = (text: string) => {


### PR DESCRIPTION
This implements transcript-specific labels for gene glyphs in the SVG renderer

Currently only the gene name is drawn on a gene glyph but this PR allows adding transcript-specific subfeature labels

It may need more work


## Screenshot

<img width="1474" height="430" alt="image" src="https://github.com/user-attachments/assets/e0fad21b-7c60-4d18-80a0-248e25eb6aff" />


## Approach

This PR's code was generated with Claude AI. I asked it " can you please look at the code in plugins/svg/src/SvgFeatureRenderer. It currently draws labels for every feature, but for Gene glyphs in particular, I would like it to draw a label on every subfeature as well. can you try to make this change? it may be complex and require analyzing all the files in plugins/svg/src/SvgFeatureRenderer/components"

It thought awhile and came up with an initially buggy solution but through explaining the bugs, it came to this solution