### PR TITLE
Optimize gridlines component

### DIFF
--- a/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/model.ts
@@ -3,6 +3,7 @@ import { lazy } from 'react'
 import { ConfigurationReference, getConf } from '@jbrowse/core/configuration'
 import SerializableFilterChain from '@jbrowse/core/pluggableElementTypes/renderers/util/serializableFilterChain'
 import { getSession } from '@jbrowse/core/util'
+import FilterAltIcon from '@mui/icons-material/FilterAlt'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import { cast, getEnv, types } from 'mobx-state-tree'
 
@@ -238,6 +239,7 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
             },
             {
               label: 'Edit filters',
+              icon: FilterAltIcon,
               onClick: () => {
                 getSession(self).queueDialog(handleClose => [
                   AddFiltersDialog,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -1,3 +1,7 @@
+import { memo, useEffect, useMemo, useRef } from 'react'
+
+import { useTheme } from '@mui/material'
+import { reaction } from 'mobx'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -20,17 +24,20 @@ const useStyles = makeStyles()(theme => ({
     height: '100%',
     width: '100%',
     pointerEvents: 'none',
+    contain: 'layout style paint',
   },
   verticalGuidesContainer: {
     position: 'absolute',
     height: '100%',
     pointerEvents: 'none',
     display: 'flex',
+    contain: 'layout style',
   },
   tick: {
     position: 'absolute',
     height: '100%',
     width: 1,
+    willChange: 'transform',
   },
   majorTick: {
     background: theme.palette.action.disabled,
@@ -40,60 +47,175 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-function RenderedBlockLines({
-  block,
-  bpPerPx,
-}: {
-  block: ContentBlock
-  bpPerPx: number
-}) {
-  const { classes, cx } = useStyles()
-  const ticks = makeTicks(block.start, block.end, bpPerPx)
-  return (
-    <ContentBlockComponent block={block}>
-      {ticks.map(({ type, base }) => {
+const RenderedBlockLines = memo(
+  function RenderedBlockLines({
+    block,
+    bpPerPx,
+    majorColor,
+    minorColor,
+  }: {
+    block: ContentBlock
+    bpPerPx: number
+    majorColor: string
+    minorColor: string
+  }) {
+    const svgRef = useRef<SVGSVGElement>(null)
+    const lastRenderedKey = useRef<string>('')
+
+    // Update SVG lines directly without React, with manual caching
+    useEffect(() => {
+      const svg = svgRef.current
+      if (!svg) {
+        return
+      }
+
+      // Create a cache key based on actual values
+      const cacheKey = `${block.key}-${block.start}-${block.end}-${block.reversed}-${bpPerPx}-${majorColor}-${minorColor}`
+
+      // Skip if nothing actually changed
+      if (lastRenderedKey.current === cacheKey) {
+        return
+      }
+
+      lastRenderedKey.current = cacheKey
+
+      const ticks = makeTicks(block.start, block.end, bpPerPx)
+
+      // Clear existing lines
+      svg.innerHTML = ''
+
+      // Create lines directly in SVG
+      const fragment = document.createDocumentFragment()
+      for (const { type, base } of ticks) {
         const x =
           (block.reversed ? block.end - base : base - block.start) / bpPerPx
-        return (
-          <div
-            key={base}
-            className={cx(
-              classes.tick,
-              type === 'major' || type === 'labeledMajor'
-                ? classes.majorTick
-                : classes.minorTick,
-            )}
-            style={{ left: x }}
-          />
+        const line = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'line',
         )
-      })}
-    </ContentBlockComponent>
+        line.setAttribute('x1', String(x))
+        line.setAttribute('y1', '0')
+        line.setAttribute('x2', String(x))
+        line.setAttribute('y2', '100%')
+        line.setAttribute(
+          'stroke',
+          type === 'major' || type === 'labeledMajor' ? majorColor : minorColor,
+        )
+        line.setAttribute('stroke-width', '1')
+        fragment.append(line)
+      }
+      svg.append(fragment)
+    }) // No dependencies - runs every render but has manual cache check
+
+    return (
+      <ContentBlockComponent block={block}>
+        <svg
+          ref={svgRef}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            pointerEvents: 'none',
+          }}
+        />
+      </ContentBlockComponent>
+    )
+  },
+  (prevProps, nextProps) => {
+    // Only re-render if block key or bpPerPx actually changes
+    return (
+      prevProps.block.key === nextProps.block.key &&
+      prevProps.bpPerPx === nextProps.bpPerPx &&
+      prevProps.majorColor === nextProps.majorColor &&
+      prevProps.minorColor === nextProps.minorColor
+    )
+  },
+)
+
+const RenderedVerticalGuides = observer(function ({ model }: { model: LGV }) {
+  const { coarseStaticBlocks, bpPerPx } = model
+  const theme = useTheme()
+
+  // Memoize theme colors to prevent unnecessary recalculations
+  const { majorColor, minorColor } = useMemo(
+    () => ({
+      majorColor: theme.palette.action.disabled,
+      minorColor: theme.palette.divider,
+    }),
+    [theme.palette.action.disabled, theme.palette.divider],
   )
-}
-const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
-  const { staticBlocks, bpPerPx } = model
-  return (
-    <>
-      {staticBlocks.map((block, index) => {
-        const k = `${block.key}-${index}`
-        if (block.type === 'ContentBlock') {
-          return <RenderedBlockLines key={k} block={block} bpPerPx={bpPerPx} />
-        } else if (block.type === 'ElidedBlock') {
-          return <ElidedBlockComponent key={k} width={block.widthPx} />
-        } else if (block.type === 'InterRegionPaddingBlock') {
-          return (
-            <InterRegionPaddingBlockComponent
-              key={k}
-              width={block.widthPx}
-              boundary={block.variant === 'boundary'}
-            />
-          )
-        }
-        return null
-      })}
-    </>
+
+  // Create stable key to prevent unnecessary re-renders when blocks haven't changed
+  const blocksKey = useMemo(
+    () =>
+      coarseStaticBlocks
+        ? coarseStaticBlocks.map(b => `${b.key}-${b.widthPx}`).join(',')
+        : '',
+    [coarseStaticBlocks],
   )
+
+  // Memoize block elements to prevent recreation on every render
+  // Note: blocksKey changes only when actual blocks change, not when coarseStaticBlocks reference changes
+  const blockElements = useMemo(
+    () =>
+      coarseStaticBlocks ? (
+        <>
+          {coarseStaticBlocks.map((block, index) => {
+            const k = `${block.key}-${index}`
+            if (block.type === 'ContentBlock') {
+              return (
+                <RenderedBlockLines
+                  key={k}
+                  block={block}
+                  bpPerPx={bpPerPx}
+                  majorColor={majorColor}
+                  minorColor={minorColor}
+                />
+              )
+            } else if (block.type === 'ElidedBlock') {
+              return <ElidedBlockComponent key={k} width={block.widthPx} />
+            } else if (block.type === 'InterRegionPaddingBlock') {
+              return (
+                <InterRegionPaddingBlockComponent
+                  key={k}
+                  width={block.widthPx}
+                  boundary={block.variant === 'boundary'}
+                />
+              )
+            }
+            return null
+          })}
+        </>
+      ) : null,
+    // Claude Code reasoning for the disable:
+    //
+    // The Pattern:
+    //
+    // const blocksKey = useMemo(() =>
+    //   coarseStaticBlocks?.map(b => `${b.key}-${b.widthPx}`).join(','),
+    //   [coarseStaticBlocks]
+    // )
+    //
+    // const blockElements = useMemo(() => {
+    //   // Use coarseStaticBlocks here
+    // }, [blocksKey, ...]) // But depend on blocksKey, not coarseStaticBlocks
+    //
+    // This is a legitimate use case for eslint-disable because:
+    // - We have a derived value (blocksKey) that better represents when to update
+    // - The linter can't understand this semantic relationship
+    // - The disable is narrow in scope and well-documented
+    //
+    // The alternative (using refs) adds complexity without benefit
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [blocksKey, bpPerPx, majorColor, minorColor],
+  )
+
+  return blockElements
 })
+
 const Gridlines = observer(function ({
   model,
   offset = 0,
@@ -102,23 +224,46 @@ const Gridlines = observer(function ({
   offset?: number
 }) {
   const { classes } = useStyles()
-  // find the block that needs pinning to the left side for context
-  const offsetLeft = model.staticBlocks.offsetPx - model.offsetPx
+  const containerRef = useRef<HTMLDivElement>(null)
+  const guidesRef = useRef<HTMLDivElement>(null)
+
+  // Use MobX reaction to update DOM directly without triggering React re-renders
+  useEffect(() => {
+    const container = containerRef.current
+    const guides = guidesRef.current
+    if (!container || !guides) {
+      return
+    }
+
+    // MobX reaction tracks observables and updates DOM directly
+    const disposer = reaction(
+      () => ({
+        scaleFactor: model.scaleFactor,
+        offsetPx: model.offsetPx,
+        blocksOffsetPx: model.coarseStaticBlocks?.offsetPx,
+        totalWidthPx: model.coarseStaticBlocks?.totalWidthPx,
+      }),
+      ({ scaleFactor, offsetPx, blocksOffsetPx, totalWidthPx }) => {
+        // Update scale transform
+        container.style.transform =
+          scaleFactor !== 1 ? `scaleX(${scaleFactor})` : ''
+
+        // Update position and width
+        if (blocksOffsetPx !== undefined && totalWidthPx !== undefined) {
+          const translateX = blocksOffsetPx - offsetPx - offset
+          guides.style.transform = `translateX(${translateX}px)`
+          guides.style.width = `${totalWidthPx}px`
+        }
+      },
+      { fireImmediately: true },
+    )
+
+    return disposer
+  }, [model, offset])
+
   return (
-    <div
-      className={classes.verticalGuidesZoomContainer}
-      style={{
-        transform:
-          model.scaleFactor !== 1 ? `scaleX(${model.scaleFactor})` : undefined,
-      }}
-    >
-      <div
-        className={classes.verticalGuidesContainer}
-        style={{
-          left: offsetLeft - offset,
-          width: model.staticBlocks.totalWidthPx,
-        }}
-      >
+    <div ref={containerRef} className={classes.verticalGuidesZoomContainer}>
+      <div ref={guidesRef} className={classes.verticalGuidesContainer}>
         <RenderedVerticalGuides model={model} />
       </div>
     </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/__snapshots__/LinearGenomeView.test.tsx.snap
@@ -354,11 +354,11 @@ exports[`renders one track, one region 1`] = `
       data-testid="tracksContainer"
     >
       <div
-        class="css-n6mj5o-verticalGuidesZoomContainer"
+        class="css-1vexmld-verticalGuidesZoomContainer"
       >
         <div
-          class="css-14511yq-verticalGuidesContainer"
-          style="left: -800px; width: 1700px;"
+          class="css-pntkbn-verticalGuidesContainer"
+          style="transform: translateX(-800px); width: 1700px;"
         >
           <div
             class="css-a9ifge-boundaryPaddingBlock"
@@ -368,42 +368,82 @@ exports[`renders one track, one region 1`] = `
             class="css-1dmfa10-contentBlock"
             style="width: 100px;"
           >
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: -21px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: -1px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 19px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 39px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 59px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 79px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 99px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 119px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 139px;"
-            />
+            <svg
+              style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+            >
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="-21"
+                x2="-21"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="-1"
+                x2="-1"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="19"
+                x2="19"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="39"
+                x2="39"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="59"
+                x2="59"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="79"
+                x2="79"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="99"
+                x2="99"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="119"
+                x2="119"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="139"
+                x2="139"
+                y1="0"
+                y2="100%"
+              />
+            </svg>
           </div>
           <div
             class="css-a9ifge-boundaryPaddingBlock"
@@ -422,11 +462,11 @@ exports[`renders one track, one region 1`] = `
           style="height: 17px; box-sizing: border-box;"
         >
           <div
-            class="css-n6mj5o-verticalGuidesZoomContainer"
+            class="css-1vexmld-verticalGuidesZoomContainer"
           >
             <div
-              class="css-14511yq-verticalGuidesContainer"
-              style="left: -801px; width: 1700px;"
+              class="css-pntkbn-verticalGuidesContainer"
+              style="transform: translateX(-801px); width: 1700px;"
             >
               <div
                 class="css-a9ifge-boundaryPaddingBlock"
@@ -436,42 +476,82 @@ exports[`renders one track, one region 1`] = `
                 class="css-1dmfa10-contentBlock"
                 style="width: 100px;"
               >
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: -21px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: -1px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 19px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 39px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 59px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 79px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 99px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 119px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 139px;"
-                />
+                <svg
+                  style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                >
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="-21"
+                    x2="-21"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="-1"
+                    x2="-1"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="19"
+                    x2="19"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="39"
+                    x2="39"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="59"
+                    x2="59"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="79"
+                    x2="79"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="99"
+                    x2="99"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="119"
+                    x2="119"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="139"
+                    x2="139"
+                    y1="0"
+                    y2="100%"
+                  />
+                </svg>
               </div>
               <div
                 class="css-a9ifge-boundaryPaddingBlock"
@@ -1000,11 +1080,11 @@ exports[`renders two tracks, two regions 1`] = `
       data-testid="tracksContainer"
     >
       <div
-        class="css-n6mj5o-verticalGuidesZoomContainer"
+        class="css-1vexmld-verticalGuidesZoomContainer"
       >
         <div
-          class="css-14511yq-verticalGuidesContainer"
-          style="left: -800px; width: 1702px;"
+          class="css-pntkbn-verticalGuidesContainer"
+          style="transform: translateX(-800px); width: 1702px;"
         >
           <div
             class="css-a9ifge-boundaryPaddingBlock"
@@ -1014,42 +1094,82 @@ exports[`renders two tracks, two regions 1`] = `
             class="css-1dmfa10-contentBlock"
             style="width: 100px;"
           >
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: -21px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: -1px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 19px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 39px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 59px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 79px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 99px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 119px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 139px;"
-            />
+            <svg
+              style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+            >
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="-21"
+                x2="-21"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="-1"
+                x2="-1"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="19"
+                x2="19"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="39"
+                x2="39"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="59"
+                x2="59"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="79"
+                x2="79"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="99"
+                x2="99"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="119"
+                x2="119"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="139"
+                x2="139"
+                y1="0"
+                y2="100%"
+              />
+            </svg>
           </div>
           <div
             class="css-1b6zgog-interRegionPaddingBlock"
@@ -1059,182 +1179,362 @@ exports[`renders two tracks, two regions 1`] = `
             class="css-1dmfa10-contentBlock"
             style="width: 800px;"
           >
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: -21px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: -1px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 19px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 39px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 59px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 79px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 99px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 119px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 139px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 159px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 179px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: 199px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 219px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 239px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 259px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 279px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 299px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 319px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 339px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 359px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 379px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: 399px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 419px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 439px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 459px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 479px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 499px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 519px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 539px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 559px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 579px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: 599px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 619px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 639px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 659px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 679px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 699px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 719px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 739px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 759px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 779px;"
-            />
-            <div
-              class="css-1qcgmte-tick-majorTick"
-              style="left: 799px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 819px;"
-            />
-            <div
-              class="css-i794sq-tick-minorTick"
-              style="left: 839px;"
-            />
+            <svg
+              style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+            >
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="-21"
+                x2="-21"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="-1"
+                x2="-1"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="19"
+                x2="19"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="39"
+                x2="39"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="59"
+                x2="59"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="79"
+                x2="79"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="99"
+                x2="99"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="119"
+                x2="119"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="139"
+                x2="139"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="159"
+                x2="159"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="179"
+                x2="179"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="199"
+                x2="199"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="219"
+                x2="219"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="239"
+                x2="239"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="259"
+                x2="259"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="279"
+                x2="279"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="299"
+                x2="299"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="319"
+                x2="319"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="339"
+                x2="339"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="359"
+                x2="359"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="379"
+                x2="379"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="399"
+                x2="399"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="419"
+                x2="419"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="439"
+                x2="439"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="459"
+                x2="459"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="479"
+                x2="479"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="499"
+                x2="499"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="519"
+                x2="519"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="539"
+                x2="539"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="559"
+                x2="559"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="579"
+                x2="579"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="599"
+                x2="599"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="619"
+                x2="619"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="639"
+                x2="639"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="659"
+                x2="659"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="679"
+                x2="679"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="699"
+                x2="699"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="719"
+                x2="719"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="739"
+                x2="739"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="759"
+                x2="759"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="779"
+                x2="779"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.26)"
+                stroke-width="1"
+                x1="799"
+                x2="799"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="819"
+                x2="819"
+                y1="0"
+                y2="100%"
+              />
+              <line
+                stroke="rgba(0, 0, 0, 0.12)"
+                stroke-width="1"
+                x1="839"
+                x2="839"
+                y1="0"
+                y2="100%"
+              />
+            </svg>
           </div>
         </div>
       </div>
@@ -1249,11 +1549,11 @@ exports[`renders two tracks, two regions 1`] = `
           style="height: 17px; box-sizing: border-box;"
         >
           <div
-            class="css-n6mj5o-verticalGuidesZoomContainer"
+            class="css-1vexmld-verticalGuidesZoomContainer"
           >
             <div
-              class="css-14511yq-verticalGuidesContainer"
-              style="left: -801px; width: 1702px;"
+              class="css-pntkbn-verticalGuidesContainer"
+              style="transform: translateX(-801px); width: 1702px;"
             >
               <div
                 class="css-a9ifge-boundaryPaddingBlock"
@@ -1263,42 +1563,82 @@ exports[`renders two tracks, two regions 1`] = `
                 class="css-1dmfa10-contentBlock"
                 style="width: 100px;"
               >
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: -21px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: -1px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 19px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 39px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 59px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 79px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 99px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 119px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 139px;"
-                />
+                <svg
+                  style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                >
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="-21"
+                    x2="-21"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="-1"
+                    x2="-1"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="19"
+                    x2="19"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="39"
+                    x2="39"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="59"
+                    x2="59"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="79"
+                    x2="79"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="99"
+                    x2="99"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="119"
+                    x2="119"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="139"
+                    x2="139"
+                    y1="0"
+                    y2="100%"
+                  />
+                </svg>
               </div>
               <div
                 class="css-1b6zgog-interRegionPaddingBlock"
@@ -1308,182 +1648,362 @@ exports[`renders two tracks, two regions 1`] = `
                 class="css-1dmfa10-contentBlock"
                 style="width: 800px;"
               >
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: -21px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: -1px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 19px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 39px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 59px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 79px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 99px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 119px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 139px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 159px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 179px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: 199px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 219px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 239px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 259px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 279px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 299px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 319px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 339px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 359px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 379px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: 399px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 419px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 439px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 459px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 479px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 499px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 519px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 539px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 559px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 579px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: 599px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 619px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 639px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 659px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 679px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 699px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 719px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 739px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 759px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 779px;"
-                />
-                <div
-                  class="css-1qcgmte-tick-majorTick"
-                  style="left: 799px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 819px;"
-                />
-                <div
-                  class="css-i794sq-tick-minorTick"
-                  style="left: 839px;"
-                />
+                <svg
+                  style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                >
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="-21"
+                    x2="-21"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="-1"
+                    x2="-1"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="19"
+                    x2="19"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="39"
+                    x2="39"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="59"
+                    x2="59"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="79"
+                    x2="79"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="99"
+                    x2="99"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="119"
+                    x2="119"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="139"
+                    x2="139"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="159"
+                    x2="159"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="179"
+                    x2="179"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="199"
+                    x2="199"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="219"
+                    x2="219"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="239"
+                    x2="239"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="259"
+                    x2="259"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="279"
+                    x2="279"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="299"
+                    x2="299"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="319"
+                    x2="319"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="339"
+                    x2="339"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="359"
+                    x2="359"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="379"
+                    x2="379"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="399"
+                    x2="399"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="419"
+                    x2="419"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="439"
+                    x2="439"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="459"
+                    x2="459"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="479"
+                    x2="479"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="499"
+                    x2="499"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="519"
+                    x2="519"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="539"
+                    x2="539"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="559"
+                    x2="559"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="579"
+                    x2="579"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="599"
+                    x2="599"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="619"
+                    x2="619"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="639"
+                    x2="639"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="659"
+                    x2="659"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="679"
+                    x2="679"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="699"
+                    x2="699"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="719"
+                    x2="719"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="739"
+                    x2="739"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="759"
+                    x2="759"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="779"
+                    x2="779"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.26)"
+                    stroke-width="1"
+                    x1="799"
+                    x2="799"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="819"
+                    x2="819"
+                    y1="0"
+                    y2="100%"
+                  />
+                  <line
+                    stroke="rgba(0, 0, 0, 0.12)"
+                    stroke-width="1"
+                    x1="839"
+                    x2="839"
+                    y1="0"
+                    y2="100%"
+                  />
+                </svg>
               </div>
             </div>
           </div>

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -288,6 +288,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
       /**
        * #volatile
        */
+      coarseStaticBlocks: undefined as BlockSet | undefined,
+      /**
+       * #volatile
+       */
       leftOffset: undefined as undefined | BpOffset,
       /**
        * #volatile
@@ -1481,6 +1485,12 @@ export function stateModelFactory(pluginManager: PluginManager) {
         self.coarseDynamicBlocks = blocks.contentBlocks
         self.coarseTotalBp = blocks.totalBp
       },
+      /**
+       * #action
+       */
+      setCoarseStaticBlocks(blocks: BlockSet) {
+        self.coarseStaticBlocks = blocks
+      },
     }))
     .actions(self => ({
       /**
@@ -1897,9 +1907,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
             () => {
               if (self.initialized) {
                 self.setCoarseDynamicBlocks(self.dynamicBlocks)
+                self.setCoarseStaticBlocks(self.staticBlocks)
               }
             },
-            { delay: 150 },
+            { delay: 300 },
           ),
         )
 

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/__snapshots__/JBrowseLinearGenomeView.test.tsx.snap
@@ -434,11 +434,11 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
               data-testid="tracksContainer"
             >
               <div
-                class="css-n6mj5o-verticalGuidesZoomContainer"
+                class="css-1vexmld-verticalGuidesZoomContainer"
               >
                 <div
-                  class="css-14511yq-verticalGuidesContainer"
-                  style="left: -800px; width: 2400px;"
+                  class="css-pntkbn-verticalGuidesContainer"
+                  style="transform: translateX(-800px); width: 2400px;"
                 >
                   <div
                     class="css-a9ifge-boundaryPaddingBlock"
@@ -448,355 +448,707 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                     class="css-1dmfa10-contentBlock"
                     style="width: 800px;"
                   >
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: -20px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 0px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 20px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 40px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 60px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 80px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 100px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 120px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 140px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 160px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 180px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 200px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 220px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 240px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 260px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 280px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 300px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 320px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 340px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 360px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 380px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 400px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 420px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 440px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 460px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 480px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 500px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 520px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 540px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 560px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 580px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 600px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 620px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 640px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 660px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 680px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 700px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 720px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 740px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 760px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 780px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 800px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 820px;"
-                    />
+                    <svg
+                      style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                    >
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="-20"
+                        x2="-20"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="0"
+                        x2="0"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="20"
+                        x2="20"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="40"
+                        x2="40"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="60"
+                        x2="60"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="80"
+                        x2="80"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="100"
+                        x2="100"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="120"
+                        x2="120"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="140"
+                        x2="140"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="160"
+                        x2="160"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="180"
+                        x2="180"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="200"
+                        x2="200"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="220"
+                        x2="220"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="240"
+                        x2="240"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="260"
+                        x2="260"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="280"
+                        x2="280"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="300"
+                        x2="300"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="320"
+                        x2="320"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="340"
+                        x2="340"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="360"
+                        x2="360"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="380"
+                        x2="380"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="400"
+                        x2="400"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="420"
+                        x2="420"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="440"
+                        x2="440"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="460"
+                        x2="460"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="480"
+                        x2="480"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="500"
+                        x2="500"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="520"
+                        x2="520"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="540"
+                        x2="540"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="560"
+                        x2="560"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="580"
+                        x2="580"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="600"
+                        x2="600"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="620"
+                        x2="620"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="640"
+                        x2="640"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="660"
+                        x2="660"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="680"
+                        x2="680"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="700"
+                        x2="700"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="720"
+                        x2="720"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="740"
+                        x2="740"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="760"
+                        x2="760"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="780"
+                        x2="780"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="800"
+                        x2="800"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="820"
+                        x2="820"
+                        y1="0"
+                        y2="100%"
+                      />
+                    </svg>
                   </div>
                   <div
                     class="css-1dmfa10-contentBlock"
                     style="width: 800px;"
                   >
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: -20px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 0px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 20px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 40px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 60px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 80px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 100px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 120px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 140px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 160px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 180px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 200px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 220px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 240px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 260px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 280px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 300px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 320px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 340px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 360px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 380px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 400px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 420px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 440px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 460px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 480px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 500px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 520px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 540px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 560px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 580px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 600px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 620px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 640px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 660px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 680px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 700px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 720px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 740px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 760px;"
-                    />
-                    <div
-                      class="css-1qcgmte-tick-majorTick"
-                      style="left: 780px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 800px;"
-                    />
-                    <div
-                      class="css-i794sq-tick-minorTick"
-                      style="left: 820px;"
-                    />
+                    <svg
+                      style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                    >
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="-20"
+                        x2="-20"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="0"
+                        x2="0"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="20"
+                        x2="20"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="40"
+                        x2="40"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="60"
+                        x2="60"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="80"
+                        x2="80"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="100"
+                        x2="100"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="120"
+                        x2="120"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="140"
+                        x2="140"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="160"
+                        x2="160"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="180"
+                        x2="180"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="200"
+                        x2="200"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="220"
+                        x2="220"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="240"
+                        x2="240"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="260"
+                        x2="260"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="280"
+                        x2="280"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="300"
+                        x2="300"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="320"
+                        x2="320"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="340"
+                        x2="340"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="360"
+                        x2="360"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="380"
+                        x2="380"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="400"
+                        x2="400"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="420"
+                        x2="420"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="440"
+                        x2="440"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="460"
+                        x2="460"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="480"
+                        x2="480"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="500"
+                        x2="500"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="520"
+                        x2="520"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="540"
+                        x2="540"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="560"
+                        x2="560"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="580"
+                        x2="580"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="600"
+                        x2="600"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="620"
+                        x2="620"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="640"
+                        x2="640"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="660"
+                        x2="660"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="680"
+                        x2="680"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="700"
+                        x2="700"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="720"
+                        x2="720"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="740"
+                        x2="740"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="760"
+                        x2="760"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.26)"
+                        stroke-width="1"
+                        x1="780"
+                        x2="780"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="800"
+                        x2="800"
+                        y1="0"
+                        y2="100%"
+                      />
+                      <line
+                        stroke="rgba(0, 0, 0, 0.12)"
+                        stroke-width="1"
+                        x1="820"
+                        x2="820"
+                        y1="0"
+                        y2="100%"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -811,11 +1163,11 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                   style="height: 17px; box-sizing: border-box;"
                 >
                   <div
-                    class="css-n6mj5o-verticalGuidesZoomContainer"
+                    class="css-1vexmld-verticalGuidesZoomContainer"
                   >
                     <div
-                      class="css-14511yq-verticalGuidesContainer"
-                      style="left: -801px; width: 2400px;"
+                      class="css-pntkbn-verticalGuidesContainer"
+                      style="transform: translateX(-801px); width: 2400px;"
                     >
                       <div
                         class="css-a9ifge-boundaryPaddingBlock"
@@ -825,355 +1177,707 @@ exports[`<JBrowseLinearGenomeView /> renders successfully 1`] = `
                         class="css-1dmfa10-contentBlock"
                         style="width: 800px;"
                       >
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: -20px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 0px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 20px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 40px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 60px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 80px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 100px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 120px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 140px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 160px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 180px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 200px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 220px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 240px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 260px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 280px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 300px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 320px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 340px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 360px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 380px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 400px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 420px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 440px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 460px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 480px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 500px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 520px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 540px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 560px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 580px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 600px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 620px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 640px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 660px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 680px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 700px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 720px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 740px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 760px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 780px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 800px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 820px;"
-                        />
+                        <svg
+                          style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                        >
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="-20"
+                            x2="-20"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="0"
+                            x2="0"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="20"
+                            x2="20"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="40"
+                            x2="40"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="60"
+                            x2="60"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="80"
+                            x2="80"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="100"
+                            x2="100"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="120"
+                            x2="120"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="140"
+                            x2="140"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="160"
+                            x2="160"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="180"
+                            x2="180"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="200"
+                            x2="200"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="220"
+                            x2="220"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="240"
+                            x2="240"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="260"
+                            x2="260"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="280"
+                            x2="280"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="300"
+                            x2="300"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="320"
+                            x2="320"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="340"
+                            x2="340"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="360"
+                            x2="360"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="380"
+                            x2="380"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="400"
+                            x2="400"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="420"
+                            x2="420"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="440"
+                            x2="440"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="460"
+                            x2="460"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="480"
+                            x2="480"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="500"
+                            x2="500"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="520"
+                            x2="520"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="540"
+                            x2="540"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="560"
+                            x2="560"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="580"
+                            x2="580"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="600"
+                            x2="600"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="620"
+                            x2="620"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="640"
+                            x2="640"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="660"
+                            x2="660"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="680"
+                            x2="680"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="700"
+                            x2="700"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="720"
+                            x2="720"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="740"
+                            x2="740"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="760"
+                            x2="760"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="780"
+                            x2="780"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="800"
+                            x2="800"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="820"
+                            x2="820"
+                            y1="0"
+                            y2="100%"
+                          />
+                        </svg>
                       </div>
                       <div
                         class="css-1dmfa10-contentBlock"
                         style="width: 800px;"
                       >
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: -20px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 0px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 20px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 40px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 60px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 80px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 100px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 120px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 140px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 160px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 180px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 200px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 220px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 240px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 260px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 280px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 300px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 320px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 340px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 360px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 380px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 400px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 420px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 440px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 460px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 480px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 500px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 520px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 540px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 560px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 580px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 600px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 620px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 640px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 660px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 680px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 700px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 720px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 740px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 760px;"
-                        />
-                        <div
-                          class="css-1qcgmte-tick-majorTick"
-                          style="left: 780px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 800px;"
-                        />
-                        <div
-                          class="css-i794sq-tick-minorTick"
-                          style="left: 820px;"
-                        />
+                        <svg
+                          style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; pointer-events: none;"
+                        >
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="-20"
+                            x2="-20"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="0"
+                            x2="0"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="20"
+                            x2="20"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="40"
+                            x2="40"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="60"
+                            x2="60"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="80"
+                            x2="80"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="100"
+                            x2="100"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="120"
+                            x2="120"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="140"
+                            x2="140"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="160"
+                            x2="160"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="180"
+                            x2="180"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="200"
+                            x2="200"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="220"
+                            x2="220"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="240"
+                            x2="240"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="260"
+                            x2="260"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="280"
+                            x2="280"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="300"
+                            x2="300"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="320"
+                            x2="320"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="340"
+                            x2="340"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="360"
+                            x2="360"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="380"
+                            x2="380"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="400"
+                            x2="400"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="420"
+                            x2="420"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="440"
+                            x2="440"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="460"
+                            x2="460"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="480"
+                            x2="480"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="500"
+                            x2="500"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="520"
+                            x2="520"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="540"
+                            x2="540"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="560"
+                            x2="560"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="580"
+                            x2="580"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="600"
+                            x2="600"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="620"
+                            x2="620"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="640"
+                            x2="640"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="660"
+                            x2="660"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="680"
+                            x2="680"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="700"
+                            x2="700"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="720"
+                            x2="720"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="740"
+                            x2="740"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="760"
+                            x2="760"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.26)"
+                            stroke-width="1"
+                            x1="780"
+                            x2="780"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="800"
+                            x2="800"
+                            y1="0"
+                            y2="100%"
+                          />
+                          <line
+                            stroke="rgba(0, 0, 0, 0.12)"
+                            stroke-width="1"
+                            x1="820"
+                            x2="820"
+                            y1="0"
+                            y2="100%"
+                          />
+                        </svg>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
The simple 'vertical lines' in the linear genome view often have an unfortunately large impact on side scrolling performance

This PR optimizes the code to take the rendering of the features outside of the react 'lifecycle' which has a lot of virtual dom overhead, and instead renders it manually

This optimization was aided by using Claude Code and the Google Devtools MCP which allows the Claude Code AI to talk to the performance profiling devtools of Google Chrome for example

I ran "claude mcp add chrome-devtools npx chrome-devtools-mcp@latest" to add the google chrome devtools mcp to claude code

https://github.com/ChromeDevTools/chrome-devtools-mcp?tab=readme-ov-file#getting-started

Here was my prompt

" I have a tab open with the url "http://localhost:3001/?config=test_data%2Fconfig_synteny_grape_peach.json&session=local-Afiay0eI1". can you click-and-drag sideways on the element with data-testid="synteny_canvas" and record a performance trace while doing so"


and then some subsequent Q&A revealed these optimizations for Gridlines that were affecting synteny side scroll performance


