### PR TITLE
Ability to make help text on menu items

### DIFF
--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -118,6 +118,7 @@ export interface BaseMenuItem {
   subLabel?: string
   icon?: React.ComponentType<SvgIconProps>
   disabled?: boolean
+  helpText?: string
 }
 
 export interface NormalMenuItem extends BaseMenuItem {


### PR DESCRIPTION
Menu items can be sort of hard to understand, they require a compact description of their functionality. This adds the ability to make a "helpText" on a menuItem, which shows a question mark icon, that when clicked, opens a dialog with the helpText shown. This can help clarify some complex functions shown by the menu items

Code created with assist of Claude Code