### PR TITLE
Remove react-dom/server usage in webworker

### DIFF
--- a/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.tsx
+++ b/packages/core/pluggableElementTypes/renderers/ServerSideRendererType.tsx
@@ -1,10 +1,7 @@
-import { ThemeProvider } from '@mui/material/styles'
 import { getSnapshot, isStateTreeNode } from 'mobx-state-tree'
-import { renderToString } from 'react-dom/server'
 
 import RendererType from './RendererType'
 import ServerSideRenderedContent from './ServerSideRenderedContent'
-import { createJBrowseTheme } from '../../ui'
 import SerializableFilterChain from './util/serializableFilterChain'
 import { getSerializedSvg, updateStatus } from '../../util'
 import { checkStopToken } from '../../util/stopToken'
@@ -138,15 +135,13 @@ export default class ServerSideRenderer extends RendererType {
    */
   serializeResultsInWorker(
     results: RenderResults,
-    args: RenderArgsDeserialized,
+    _args: RenderArgsDeserialized,
   ): ResultsSerialized {
-    const html = renderToString(
-      <ThemeProvider theme={createJBrowseTheme(args.theme)}>
-        {results.reactElement}
-      </ThemeProvider>,
-    )
     results.reactElement = undefined
-    return { ...results, html }
+    return {
+      ...results,
+      html: '',
+    }
   }
 
   /**

--- a/plugins/svg/src/SvgFeatureRenderer/SvgFeatureRenderer.ts
+++ b/plugins/svg/src/SvgFeatureRenderer/SvgFeatureRenderer.ts
@@ -1,5 +1,49 @@
+import { readConfObject } from '@jbrowse/core/configuration'
 import { BoxRendererType } from '@jbrowse/core/pluggableElementTypes'
+import { updateStatus } from '@jbrowse/core/util'
+
+import { layoutFeatures } from './components/util'
+
+import type { RenderArgsDeserialized } from '@jbrowse/core/pluggableElementTypes/renderers/BoxRendererType'
 
 export default class SvgFeatureRenderer extends BoxRendererType {
   supportsSVG = true
+
+  async render(renderProps: RenderArgsDeserialized) {
+    const features = await this.getFeatures(renderProps)
+    const layout = this.createLayoutInWorker(renderProps)
+    const { statusCallback = () => {}, regions, bpPerPx, config } = renderProps
+    const region = regions[0]!
+    const displayMode = readConfObject(config, 'displayMode') as string
+
+    // Perform layout computation upfront in the worker
+    // This populates the layout object with collision detection and positioning
+    // Note: we don't return the SceneGraph objects as they contain React components
+    // and cannot be serialized across the worker boundary
+    await updateStatus(
+      'Computing feature layout',
+      statusCallback as (arg: string) => void,
+      () => {
+        layoutFeatures({
+          features,
+          bpPerPx,
+          region,
+          config,
+          layout,
+          displayMode,
+          extraGlyphs: (renderProps as any).extraGlyphs,
+        })
+      },
+    )
+
+    const result = await super.render({
+      ...renderProps,
+      layout,
+    })
+
+    return {
+      ...result,
+      layout,
+    }
+  }
 }


### PR DESCRIPTION
Early work on jbrowse 2 involved making react run on the webworker


This had good intentions but did not seem to improve performance, and at the same time it was quite awkward (almost no one does this...) and made things very complex

## Old code flow

Main thread sends 'rendering requests' to web worker
Web worker calls react-dom/server::renderToString
Main thread receives results, runs react-dom/client::hydrateRoot

## The trouble with the old code flow

The hydration caused lots of trouble and 'hydration mismatch' errors that were extremely hard to debug due to rapid blocks coming in and out of existence having a terrible time meshing with the asynchronous logic regarding the hydration, and at the same time, also did not seem to improve performance (for another source similar to this, see: hydration is pure overhead https://www.builder.io/blog/hydration-is-pure-overhead, an opinionated post created by angular/solidjs guy but its not far from the truth) compared to just rendering from scratch on the main thread

## Current main branch code flow

The concept of hydration was removed in #4926  so the current main branch code flow is

Main thread sends 'rendering requests' to web worker
Web worker calls react-dom/server::renderToString
Main thread receives results, throws away the result of renderToString (making it wasted work), and then calls react-dom/client::render to create results from scratch

## This PR code flow


This PR removes react-dom/server::renderToString usage which makes the code flow


Main thread sends 'rendering requests' to web worker
Web worker calls regular 'render' operations but does NOT run react code
Main thread receives results, calls react-dom/client::render to create results from scratch

a) Takes a good 60kb off the bundle (10%)
b) Is approx 2x faster
c) Makes it more clear that the SVG layout is separate from react rendering (current SvgFeatureRenderer code performs feature layout during React rendering which is an antipattern -- it's not good to mutate data structures while rendering)
