### PR TITLE
Optionally use "Virtual scrollbars" instead of native scrollbars on per-track scrolling

### DIFF
--- a/packages/product-core/src/Session/MultipleViews.ts
+++ b/packages/product-core/src/Session/MultipleViews.ts
@@ -35,6 +35,12 @@ export function MultipleViewsSessionMixin(pluginManager: PluginManager) {
       stickyViewHeaders: types.optional(types.boolean, () =>
         localStorageGetBoolean('stickyViewHeaders', true),
       ),
+      /**
+       * #property
+       */
+      useVirtualScrollbars: types.optional(types.boolean, () =>
+        localStorageGetBoolean('useVirtualScrollbars', false),
+      ),
     })
     .actions(self => ({
       /**
@@ -112,11 +118,27 @@ export function MultipleViewsSessionMixin(pluginManager: PluginManager) {
         self.stickyViewHeaders = sticky
       },
 
+      /**
+       * #action
+       */
+      setUseVirtualScrollbars(use: boolean) {
+        self.useVirtualScrollbars = use
+      },
+
       afterAttach() {
         addDisposer(
           self,
           autorun(() => {
             localStorageSetBoolean('stickyViewHeaders', self.stickyViewHeaders)
+          }),
+        )
+        addDisposer(
+          self,
+          autorun(() => {
+            localStorageSetBoolean(
+              'useVirtualScrollbars',
+              self.useVirtualScrollbars,
+            )
           }),
         )
       },

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/VirtualScrollbar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/VirtualScrollbar.tsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { makeStyles } from 'tss-react/mui'
+
+const useStyles = makeStyles()(theme => ({
+  container: {
+    position: 'relative',
+    height: '100%',
+    width: '100%',
+  },
+  content: {
+    height: '100%',
+    width: '100%',
+    overflow: 'hidden',
+    position: 'relative',
+    // Ensure no native scrollbars appear
+    scrollbarWidth: 'none', // Firefox
+    msOverflowStyle: 'none', // IE and Edge
+    '&::-webkit-scrollbar': { // Chrome, Safari
+      display: 'none',
+    },
+  },
+  scrollbar: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    width: 8,
+    height: '100%',
+    backgroundColor: theme.palette.action.hover,
+    opacity: 0.7, // Make visible by default for debugging
+    transition: 'opacity 0.2s ease',
+    zIndex: 1000,
+    '&:hover': {
+      opacity: 1,
+    },
+  },
+  scrollbarVisible: {
+    opacity: 0.9,
+  },
+  thumb: {
+    position: 'absolute',
+    right: 0,
+    width: '100%',
+    backgroundColor: theme.palette.action.active,
+    borderRadius: 4,
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.action.focus,
+    },
+  },
+}))
+
+interface VirtualScrollbarProps {
+  children: React.ReactNode
+  contentHeight: number
+  containerHeight: number
+  scrollTop: number
+  onScroll: (scrollTop: number) => void
+  className?: string
+}
+
+const VirtualScrollbar: React.FC<VirtualScrollbarProps> = ({
+  children,
+  contentHeight,
+  containerHeight,
+  scrollTop,
+  onScroll,
+  className,
+}) => {
+  const { classes } = useStyles()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [scrollbarVisible, setScrollbarVisible] = useState(false)
+  const dragStartRef = useRef({ y: 0, scrollTop: 0 })
+
+  // Calculate scrollbar dimensions
+  const needsScrollbar = contentHeight > containerHeight
+  const scrollRatio = containerHeight / contentHeight
+  const thumbHeight = Math.max(20, containerHeight * scrollRatio)
+  const maxScrollTop = Math.max(0, contentHeight - containerHeight)
+  const thumbTop = maxScrollTop > 0 ? (scrollTop / maxScrollTop) * (containerHeight - thumbHeight) : 0
+
+  // Use native event listener to avoid passive listener issues
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+
+    const handleWheel = (event: WheelEvent) => {
+      // Don't scroll, but prevent the event from bubbling to browser
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    element.addEventListener('wheel', handleWheel, { passive: false })
+    return () => {
+      element.removeEventListener('wheel', handleWheel)
+    }
+  }, [])
+
+  const handleThumbMouseDown = useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+    setIsDragging(true)
+    dragStartRef.current = {
+      y: event.clientY,
+      scrollTop,
+    }
+  }, [scrollTop])
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    if (!isDragging || !needsScrollbar) return
+
+    event.preventDefault()
+    const deltaY = event.clientY - dragStartRef.current.y
+    const scrollDelta = (deltaY / (containerHeight - thumbHeight)) * (contentHeight - containerHeight)
+    const maxScrollTop = contentHeight - containerHeight
+    const newScrollTop = Math.max(0, Math.min(
+      maxScrollTop,
+      dragStartRef.current.scrollTop + scrollDelta
+    ))
+
+    console.log('Drag scroll:', {
+      contentHeight,
+      containerHeight,
+      maxScrollTop,
+      thumbHeight,
+      deltaY,
+      scrollDelta,
+      oldScrollTop: dragStartRef.current.scrollTop,
+      newScrollTop
+    })
+
+    onScroll(newScrollTop)
+  }, [isDragging, needsScrollbar, containerHeight, thumbHeight, contentHeight, onScroll])
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+      }
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp])
+
+  return (
+    <div
+      ref={containerRef}
+      className={`${classes.container} ${className || ''}`}
+      style={{ height: containerHeight }}
+    >
+      <div
+        className={classes.content}
+        style={{
+          transform: `translateY(-${scrollTop}px)`,
+          height: contentHeight,
+        }}
+        title={`ScrollTop: ${scrollTop}/${contentHeight - containerHeight}`}
+      >
+        {children}
+      </div>
+
+      {needsScrollbar && (
+        <div
+          className={`${classes.scrollbar} ${scrollbarVisible || isDragging ? classes.scrollbarVisible : ''}`}
+        >
+          <div
+            className={classes.thumb}
+            style={{
+              height: thumbHeight,
+              top: thumbTop,
+            }}
+            onMouseDown={handleThumbMouseDown}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default VirtualScrollbar

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/useSideScroll.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/useSideScroll.ts
@@ -16,6 +16,12 @@ export function useSideScroll(model: LinearGenomeViewModel) {
 
     function globalMouseMove(event: MouseEvent) {
       event.preventDefault()
+
+      // Don't do horizontal scrolling if a virtual scrollbar is being dragged
+      if (document.body.getAttribute('data-virtual-scrollbar-dragging')) {
+        return
+      }
+
       const currX = event.clientX
       const distance = currX - prevX.current
       if (distance) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/useWheelScroll.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/useWheelScroll.ts
@@ -63,9 +63,18 @@ export function useWheelScroll(
           samples = []
         }, 300)
       } else {
-        // prevent browser default behavior like back/forward navigation
-        // since this component handles horizontal scrolling internally
-        event.preventDefault()
+        // Don't do horizontal scrolling if a virtual scrollbar is being dragged
+        if (document.body.getAttribute('data-virtual-scrollbar-dragging')) {
+          return
+        }
+
+        // Use original heuristic but be more conservative to allow page scrolling
+        // Only prevent default when horizontal wheel is significantly greater than vertical
+        if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+          event.preventDefault()
+        }
+
+        // Handle horizontal scrolling
         delta.current += event.deltaX
         if (!scheduled.current) {
           // use rAF to make it so multiple event handlers aren't fired per-frame

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/useWheelScroll.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/useWheelScroll.ts
@@ -63,12 +63,9 @@ export function useWheelScroll(
           samples = []
         }, 300)
       } else {
-        // this is needed to stop the event from triggering "back button
-        // action" on MacOSX etc.  but is a heuristic to avoid preventing the
-        // inner-track scroll behavior
-        if (Math.abs(event.deltaX) > Math.abs(2 * event.deltaY)) {
-          event.preventDefault()
-        }
+        // prevent browser default behavior like back/forward navigation
+        // since this component handles horizontal scrolling internally
+        event.preventDefault()
         delta.current += event.deltaX
         if (!scheduled.current) {
           // use rAF to make it so multiple event handlers aren't fired per-frame

--- a/products/jbrowse-web/src/components/PreferencesDialog.tsx
+++ b/products/jbrowse-web/src/components/PreferencesDialog.tsx
@@ -31,6 +31,8 @@ const PreferencesDialog = observer(function ({
     setThemeName: (arg: string) => void
     stickyViewHeaders: boolean
     setStickyViewHeaders(sticky: boolean): void
+    useVirtualScrollbars: boolean
+    setUseVirtualScrollbars(use: boolean): void
   }
 }) {
   const { classes } = useStyles()
@@ -57,6 +59,13 @@ const PreferencesDialog = observer(function ({
             label="Keep view header visible"
             onChange={(_, checked) => {
               session.setStickyViewHeaders(checked)
+            }}
+          />
+          <FormControlLabel
+            control={<Checkbox checked={session.useVirtualScrollbars} />}
+            label="Use virtual scrollbars for tracks"
+            onChange={(_, checked) => {
+              session.setUseVirtualScrollbars(checked)
             }}
           />
         </FormGroup>


### PR DESCRIPTION

 This PR adds the option to change per-track scrolls into "virtual scrollbars" that do not respect normal vertical wheel scroll by default

Instead, you must do the following to perform per track scroll

- click and drag vertically on the virtual scrollbar
- hold shift + vertical wheel scroll


This PR makes it easier to scroll the "outer page" instead of getting distracted by per track scrolls

It is currently a preference that is off by default


