### PR TITLE
Add 'super-compact' display mode for alignments tracks

### DIFF
--- a/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
@@ -573,6 +573,13 @@ export function SharedLinearPileupDisplayMixin(
                   },
                 },
                 {
+                  label: 'Super-compact',
+                  onClick: () => {
+                    self.setFeatureHeight(1)
+                    self.setNoSpacing(true)
+                  },
+                },
+                {
                   label: 'Manually set height',
                   onClick: () => {
                     getSession(self).queueDialog(handleClose => [

--- a/plugins/alignments/src/LinearReadCloudDisplay/model.ts
+++ b/plugins/alignments/src/LinearReadCloudDisplay/model.ts
@@ -201,6 +201,13 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
                   },
                 },
                 {
+                  label: 'Super-compact',
+                  onClick: () => {
+                    self.setFeatureHeight(1)
+                    self.setNoSpacing(true)
+                  },
+                },
+                {
                   label: 'Manually set height...',
                   onClick: () => {
                     getSession(self).queueDialog(handleClose => [


### PR DESCRIPTION
Makes each alignment 1px tall. Often useful for maximizing screen density