### PR TITLE
Scroll only pileup part of the alignments track

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/components/AlignmentsDisplay.tsx
@@ -22,17 +22,20 @@ const AlignmentsDisplay = observer(function AlignmentsDisplay({
 }: {
   model: LinearAlignmentsDisplayModel
 }) {
-  const { PileupDisplay, SNPCoverageDisplay } = model
+  const { PileupDisplay, SNPCoverageDisplay, height, setScrollTop } = model
   const { classes } = useStyles()
   if (!SNPCoverageDisplay) {
     return null
   }
-  const top = SNPCoverageDisplay.height ?? 100
+  const coverageHeight = SNPCoverageDisplay.height ?? 100
+  const pileupHeight = height - coverageHeight
+
   return (
     <div
       data-testid={`display-${getConf(model, 'displayId')}`}
-      style={{ position: 'relative' }}
+      style={{ position: 'relative', height }}
     >
+      {/* Coverage track - fixed at top */}
       <div data-testid="Blockset-snpcoverage">
         <SNPCoverageDisplay.RenderingComponent model={SNPCoverageDisplay} />
       </div>
@@ -42,14 +45,22 @@ const AlignmentsDisplay = observer(function AlignmentsDisplay({
           return delta
         }}
         className={classes.resizeHandle}
-        style={{ top: top - 4 }}
+        style={{ top: coverageHeight - 4 }}
       />
 
+      {/* Pileup track - scrollable container */}
       <div
         data-testid="Blockset-pileup"
         style={{
           position: 'absolute',
-          top,
+          top: coverageHeight,
+          height: pileupHeight,
+          width: '100%',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+        }}
+        onScroll={evt => {
+          setScrollTop(evt.currentTarget.scrollTop)
         }}
       >
         <PileupDisplay.RenderingComponent model={PileupDisplay} />


### PR DESCRIPTION
Currently when you scroll down the in a regular Alignments track, the 'coverage' part goes out of view. With very deep sequencing like 300x you might want to keep seeing coverage but it scrolls out of view, even with very compact settings. 

This fixes https://github.com/GMOD/jbrowse-components/issues/4896

