### PR TITLE
Globally stop swipe action from producing back/forward actions on jbrowse-web

### DIFF
--- a/products/jbrowse-web/public/index.html
+++ b/products/jbrowse-web/public/index.html
@@ -21,8 +21,15 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>JBrowse</title>
+    <style>
+      /* Disable horizontal overscroll behavior to prevent unintended navigation gestures */
+      html,
+      body {
+        overscroll-behavior-x: none;
+      }
+    </style>
   </head>
-  <body style="overscroll-behavior: none">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--


### PR DESCRIPTION
Uses a global css style overflow-behavior-x: none

https://stackoverflow.com/a/56071966

Note that this is jbrowse-web specific, but that is a majority use case