### PR TITLE
Add explicit github workflow permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   check_commit_message:
     name: Check Commit Message

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   createrelease:
     name: Create release tag and JBrowse web release artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Create Release
         id: create_release

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build-upload


### PR DESCRIPTION
Only one of our workflows, the one that creates the github release, needs 'write' permissions

This change was suggested by github CodeQL (security tab) on the repo