### PR TITLE
Use 'gh CLI' for release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,10 +48,11 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install website deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-        with:
-          working-directory: website
+          cache: 'yarn'
+          cache-dependency-path: 'website/yarn.lock'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: website
       - name: Build website
         run: |
           cd website/
@@ -65,7 +66,7 @@ jobs:
 
   # Conditionally run the buildwholerepo job
   buildwholerepo:
-    name: Build whole repo
+    name: Build and test full repository
     needs: check_commit_message
     if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
@@ -76,25 +77,26 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build codebase
         run: yarn build
       - name: Test build
         run: BUILT_TESTS=1 yarn built-test-ci
-      - name: Test embedded lgv
+      - name: Test embedded LGV component
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn e2e
         working-directory: component_tests/lgv-vite
-      - name: Test embedded cgv
+      - name: Test embedded CGV component
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn e2e
         working-directory: component_tests/cgv-vite
-      - name: Test embedded react-app
+      - name: Test embedded React app component
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn e2e
         working-directory: component_tests/app-vite
 
@@ -111,137 +113,97 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-      - name: Build project
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Validate branch/tag name for S3 path safety
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo $RELEASE_VERSION
+          if ! [[ "$REF_NAME" =~ ^[a-zA-Z0-9_.\-]+$ ]]; then
+            echo "Error: Invalid ref name '$REF_NAME'"
+            echo "Ref names must contain only alphanumeric characters, hyphens, underscores, and periods"
+            echo "This prevents path traversal attacks on S3"
+            exit 1
+          fi
+          echo "Ref name validated: $REF_NAME"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Build and deploy jbrowse-web
+        run: |
           cd products/jbrowse-web/
           NODE_OPTIONS='--max-old-space-size=6500' yarn build
-          cd ../../
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Copy branch build to S3
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          # Validate ref_name contains only safe characters (alphanumeric, hyphen, underscore, period)
-          if ! [[ "$REF_NAME" =~ ^[a-zA-Z0-9_.\-]+$ ]]; then
-            echo "Invalid ref name: $REF_NAME"
-            exit 1
-          fi
-          cd products/jbrowse-web/build && zip -r "jbrowse-web-${REF_NAME}.zip" . && cd -
-          cp products/jbrowse-web/build/test_data/config.json products/jbrowse-web/build/config.json
-          aws s3 sync --delete --exclude="*.map" products/jbrowse-web/build s3://jbrowse.org/code/jb2/${REF_NAME}
-          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/code/jb2/${REF_NAME}/*"
+          cd build && zip -r "jbrowse-web-${{ github.ref_name }}.zip" . && cd -
+          cp build/test_data/config.json build/config.json
+          aws s3 sync --delete --exclude="*.map" build s3://jbrowse.org/code/jb2/${{ github.ref_name }}
+          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/code/jb2/${{ github.ref_name }}/*"
 
-      - name: Build LGV
-        run: |
-          yarn storybook:build
-        working-directory: products/jbrowse-react-linear-genome-view
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Deploy LGV
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          # Validate ref_name contains only safe characters (alphanumeric, hyphen, underscore, period)
-          if ! [[ "$REF_NAME" =~ ^[a-zA-Z0-9_.\-]+$ ]]; then
-            echo "Invalid ref name: $REF_NAME"
-            exit 1
-          fi
-          pwd
-          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/lgv/${REF_NAME}
-          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/lgv/${REF_NAME}/*"
+      - name: Build LGV storybook
+        run: yarn storybook:build
         working-directory: products/jbrowse-react-linear-genome-view
 
-      - name: Build React App
-        run: |
-          yarn storybook:build
-        working-directory: products/jbrowse-react-app
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Deploy React App
+      - name: Deploy LGV storybook
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          REF_NAME: ${{ github.ref_name }}
         run: |
-          # Validate ref_name contains only safe characters (alphanumeric, hyphen, underscore, period)
-          if ! [[ "$REF_NAME" =~ ^[a-zA-Z0-9_.\-]+$ ]]; then
-            echo "Invalid ref name: $REF_NAME"
-            exit 1
-          fi
-          pwd
-          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/app/${REF_NAME}
-          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/app/${REF_NAME}/*"
+          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/lgv/${{ github.ref_name }}
+          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/lgv/${{ github.ref_name }}/*"
+        working-directory: products/jbrowse-react-linear-genome-view
+
+      - name: Build React App storybook
+        run: yarn storybook:build
         working-directory: products/jbrowse-react-app
 
-      - name: Build CGV
+      - name: Deploy React App storybook
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          yarn storybook:build
+          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/app/${{ github.ref_name }}
+          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/app/${{ github.ref_name }}/*"
+        working-directory: products/jbrowse-react-app
+
+      - name: Build CGV storybook
+        run: yarn storybook:build
         working-directory: products/jbrowse-react-circular-genome-view
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Deploy CGV
+
+      - name: Deploy CGV storybook
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          REF_NAME: ${{ github.ref_name }}
         run: |
-          # Validate ref_name contains only safe characters (alphanumeric, hyphen, underscore, period)
-          if ! [[ "$REF_NAME" =~ ^[a-zA-Z0-9_.\-]+$ ]]; then
-            echo "Invalid ref name: $REF_NAME"
-            exit 1
-          fi
-          pwd
-          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/cgv/${REF_NAME}
-          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/cgv/${REF_NAME}/*"
+          aws s3 sync --delete storybook-static s3://jbrowse.org/storybook/cgv/${{ github.ref_name }}
+          aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/storybook/cgv/${{ github.ref_name }}/*"
         working-directory: products/jbrowse-react-circular-genome-view
 
   # Conditionally run the formatchecks job
   formatchecks:
-    name: Lint, typecheck, test
+    name: Lint, typecheck, and test
     needs: check_commit_message
     if: needs.check_commit_message.outputs.skip_jobs != 'true'
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get -y install tabix
+      - name: Install tabix
+        run: sudo apt-get -y install tabix
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-      - name: Check codebase format
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Check code formatting
         run: yarn prettier --check .
-      - name: Check autogen docs
+      - name: Check autogenerated docs are up to date
         run: yarn statedocs && yarn configdocs
       - name: Spellcheck
         uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1
-      - name: Lint codebase
+      - name: Lint code
         run: yarn lint
-      - name: Test codebase
+      - name: Run tests
         run: yarn test-ci
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-      - name: Typecheck codebase
+      - name: Typecheck code
         run: yarn typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,45 +14,32 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          # This allows us to manually edit the release body text before publishing
-          draft: true
-          prerelease: false
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - name: Use Node.js 22
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Set env
+          cache: 'yarn'
+      - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Install deps
-        run: yarn
-      - name: Build project
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build jbrowse-web
         run: |
           echo $RELEASE_VERSION
           cd products/jbrowse-web/
           NODE_OPTIONS='--max-old-space-size=6500' yarn build
           cd build
           zip -r "jbrowse-web-${RELEASE_VERSION}.zip" .
-      - name: Upload jbrowse-web build
-        id: upload-release-asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
+      - name: Create draft release with jbrowse-web artifact
+        run: |
+          gh release create ${{ github.ref_name }} \
+            ./products/jbrowse-web/build/jbrowse-web-${RELEASE_VERSION}.zip \
+            --draft \
+            --title "Release ${{ github.ref_name }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./products/jbrowse-web/build/jbrowse-web-${{env.RELEASE_VERSION}}.zip
-          asset_name: jbrowse-web-${{env.RELEASE_VERSION}}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   buildwindows:
     needs: createrelease
     name: Build Windows desktop app
@@ -63,8 +50,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Setup java
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
@@ -112,16 +99,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Use Node.js 22
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install build deps
+          cache: 'yarn'
+      - name: Install build dependencies
         run: |
           brew install pkg-config cairo pango libpng jpeg giflib librsvg
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-      - name: Build app
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build Mac app
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -140,17 +127,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Use Node.js 22
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-      - name: Install build deps
+          cache: 'yarn'
+      - name: Install build dependencies
         run: |
           sudo apt update
           sudo apt install -y python3 make gcc libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-      - name: Build app
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build Linux app
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -167,9 +154,10 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-      - name: Build project
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build jbrowse-web
         run: |
           echo $RELEASE_VERSION
           cd products/jbrowse-web/

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-    name: build-upload
+    name: Build and upload website to production
     runs-on: ubuntu-latest
     if:
       ${{ contains(github.event.head_commit.message, 'update docs') ||
@@ -21,22 +21,22 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
-      - name: Configure AWS Credentials
+          cache: 'yarn'
+          cache-dependency-path: 'website/yarn.lock'
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
-      - name: Install deps (with cache)
-        uses: bahmutov/npm-install@3714964fb879ebbbc108e167f0f3a0c81ec075c9 # v1.10.10
-        with:
-          working-directory: website
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: website
       - name: Build website
+        run: yarn build
+        working-directory: website
+      - name: Upload to S3 and invalidate CloudFront cache
         run: |
-          cd website/
-          yarn build
-      - name: Upload
-        run: |
-          cd website/
           aws s3 sync --delete build s3://jbrowse.org/jb2/
           aws cloudfront create-invalidation --distribution-id E13LGELJOT4GQO --paths "/jb2/*"
+        working-directory: website


### PR DESCRIPTION
The uploader has been stable but is unmaintained https://github.com/actions/upload-release-asset

This converts the CI to use 'gh CLI' for release actions