### PR TITLE
v4.0.0 release announcement

### DIFF
--- a/website/release_announcement_drafts/v4.0.0.md
+++ b/website/release_announcement_drafts/v4.0.0.md
@@ -1,0 +1,134 @@
+This is a major update to JBrowse that delivers a number of improvements
+
+## New "Collapsed introns" view
+
+Users can right-click a gene and launch a 'Collapsed introns' view that focuses
+on just the exonic regions. The RNA-seq alignments work with this view also,
+with sashimi arcs connecting across the different regions
+
+<img width="1476" height="926" alt="Screenshot From 2025-12-10 22-36-47" src="https://github.com/user-attachments/assets/b5fb8b8f-a73c-42bd-84bf-458998fb4843" />
+
+<img width="1476" height="584" alt="Screenshot From 2025-12-02 09-20-40" src="https://github.com/user-attachments/assets/0bd4475e-0f7e-4e09-b5ef-14977eaa2ca6" />
+
+## New "Canvas features" track type
+
+We have replaced the SVG feature renderer with a new HTML5 canvas feature
+renderer. This has improved user experience and also comes with new
+functionality including:
+
+- Per-transcript mouseover and feature clicks
+- Ability to show only the "Longest transcript" for gene glyphs with many
+  subtranscripts
+- Improved performance
+- Directional chevrons
+
+<img width="1289" height="459" alt="image" src="https://github.com/user-attachments/assets/ecf66226-64af-4eb4-b741-dc2ea4d10a96" />
+
+Screenshot showing the "Longest transcript" option
+
+## Alignments track performance improvements
+
+Our BAM and CRAM parsers were updated with a variety of performance
+optimizations. We analyzed the entire stack and added
+
+- low level binary for parsing CIGAR strings
+- using WASM for parsing
+- using mosdepth style coverage calculations
+- improved speed for deep RNA-seq data
+
+And much more
+
+## Alignments track mouseovers and new features
+
+We also added many usability improvements to the alignments tracks like adding
+the ability to mouseover and click individual insertions, mismatches, deletions,
+etc.
+
+<img width="1397" height="561" alt="image" src="https://github.com/user-attachments/assets/fdf6f957-a957-4004-b935-bd27ee04db22" />
+
+Users can also optionally turn off drawing mismatches entirely...sometimes it's
+not what you care to see!
+
+## "Linked read display" improvements
+
+In v3.7.0 we announced the "Linked read display" mode
+(https://jbrowse.org/jb2/blog/2025/11/07/v3.7.0-release/#create-linked-read-display-for-alignments-tracks)
+which connects paired end or split long reads. This new release allows drawing
+mismatches on the reads, and generally behaves a lot like the normal alignments
+track!
+
+<img width="1458" height="908" alt="Screenshot From 2025-12-29 17-23-07" src="https://github.com/user-attachments/assets/d2fb12c0-de7c-42b1-94c7-bc38b00c8a87" />
+
+Screenshot showing an inversion with split long reads (the red->blue->red chain
+indicates a single split long read flipping orientation in the middle) and
+paired-end short reads (blue and green reads indicate aberrant pairing)
+
+## Display color legends on screen
+
+We added the ability to show legends on a variety of display types, which will
+help users understand the meaning of colors on the screen!
+
+## "Save track data"
+
+Users can now export data in the visible region in a variety of formats,
+tailored to the track type and file type of interest. This was a commonly
+requested feature, so we are excited to finally solve it
+
+## Simplified configuration
+
+Users no longer have to explicitly supply 'sequenceAdapter' to BAM and CRAM
+files. It will infer the sequence adapter from the assembly. Anyone who directly
+works with JBrowse configuration files will benefit from this simplification!
+
+<img width="1325" height="623" alt="image" src="https://github.com/user-attachments/assets/7bf5cd2d-13c2-486e-b28d-3f49cf7d74fd" />
+
+Screenshot showing a simplified config for a CRAM track
+
+## Much faster load time for large tracklists
+
+Previously, when a JBrowse instance had more than a couple thousand tracks, the
+startup time would slow down dramatically. We made internal changes to our track
+loading that now makes these load times virtually instant now! This was enabled
+by making track configuration models instantiated only when the track is opened,
+which plugin authors should be aware of
+
+<img width="3000" height="1800" alt="load_time_comparison" src="https://github.com/user-attachments/assets/a436fe96-f62b-4414-b37d-6cd3af51717d" />
+
+Graph showing the load time of different tracklist sizes in v3.7.0 and v4.0.0,
+showing runaway showness with v3.7.0 after just a couple thousand tracks that is
+now under control in v4.0.0
+
+## New "Workspaces" feature for tiled window management!
+
+We added the Dockview (https://dockview.dev) window manager to the app
+interface, so you can now create left-right splits, top-bottom splits, new tabs,
+and more in jbrowse web and desktop. This enables a large variety of extra
+layouts compared with the previous vertical-stack-only limitation of previous
+JBrowse 2 versions!
+
+<img width="1861" height="926" alt="Screenshot From 2025-12-10 21-33-08" src="https://github.com/user-attachments/assets/b7c1e268-b7cc-425a-8b3c-093ed9fa8111" />
+
+Screenshot showing left-right split
+
+## Improved user-experience when side-scrolling
+
+Wiggle and Hi-C tracks will now stay on the screen while new renderings (e.g.
+change to y-axis scale) are re-computing. It is a subtle change that we hope
+improves user-experience!
+
+## Breaking changes
+
+There are a large number of internal changes, and it would be hard to fully
+enumerate all the changes, but some of the changes include
+
+- Splitting renderProps (for webworker renderer) and renderingProps (main
+  thread)
+- Changing mobx-state-tree to @jbrowse/mobx-state-tree
+  https://github.com/GMOD/mobx-state-tree
+- Changing jexl to @jbrowse/jexl https://github.com/GMOD/jexl
+- Removal of @jbrowse/plugin-svg, automatically remapping to
+  CanvasFeatureRenderer
+- Make all packages "pure-ESM", may affect node.js usage
+
+A variety of other internal changes took place. If you see any problems after
+migration, please let us know and we will be happy to work with you to help


### PR DESCRIPTION
## Unreleased (2025-12-17)

#### :boom: Breaking Change
* `app-core`, `core`, `product-core`, `web-core`
  * [#4499](https://github.com/GMOD/jbrowse-components/pull/4499) Optimizations to support large tracklists ([@cmdcolin](https://github.com/cmdcolin))
  * [#5255](https://github.com/GMOD/jbrowse-components/pull/5255) Create new 'renderingProps' concept for the 'rendering' react component as a complement to 'renderProps' for renderer ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`
  * [#5270](https://github.com/GMOD/jbrowse-components/pull/5270) Refactor the renderer and RPC stack ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `web-core`
  * [#4938](https://github.com/GMOD/jbrowse-components/pull/4938) Vendor @jbrowse/mobx-state-tree ([@cmdcolin](https://github.com/cmdcolin))

#### :rocket: Enhancement
* `core`
  * [#5318](https://github.com/GMOD/jbrowse-components/pull/5318) Optimizations for multi-wiggle tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#5326](https://github.com/GMOD/jbrowse-components/pull/5326) Multiple optimizations for alignments tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#5330](https://github.com/GMOD/jbrowse-components/pull/5330) Create layout optimizations for deep RNA-seq data ([@cmdcolin](https://github.com/cmdcolin))
  * [#5320](https://github.com/GMOD/jbrowse-components/pull/5320) Add WASM code for unzipping in CRAM, BAM, BigWig, Tabix, etc. ([@cmdcolin](https://github.com/cmdcolin))
  * [#5317](https://github.com/GMOD/jbrowse-components/pull/5317) Add optional directional 'chevrons' to the gene glyphs ([@cmdcolin](https://github.com/cmdcolin))
  * [#5310](https://github.com/GMOD/jbrowse-components/pull/5310) Create optimizations for alignments track ([@cmdcolin](https://github.com/cmdcolin))
  * [#5305](https://github.com/GMOD/jbrowse-components/pull/5305) Make BAM and CRAM adapters use assembly sequence adapter ([@cmdcolin](https://github.com/cmdcolin))
  * [#5284](https://github.com/GMOD/jbrowse-components/pull/5284) Allow rendering inter-chromosomal contacts with Hi-C renderer ([@cmdcolin](https://github.com/cmdcolin))
  * [#5280](https://github.com/GMOD/jbrowse-components/pull/5280) Add better source maps in error stack trace on desktop app ([@cmdcolin](https://github.com/cmdcolin))
  * [#5276](https://github.com/GMOD/jbrowse-components/pull/5276) Add ability to mouseover and click on 'insertions' on SNPCoverage track ([@cmdcolin](https://github.com/cmdcolin))
  * [#5266](https://github.com/GMOD/jbrowse-components/pull/5266) Remove disabled state on zooming buttons to allow rapid clicking of zoom in and out buttons ([@cmdcolin](https://github.com/cmdcolin))
  * [#5263](https://github.com/GMOD/jbrowse-components/pull/5263) Improve performance of track list using custom virtualization routines ([@cmdcolin](https://github.com/cmdcolin))
  * [#5256](https://github.com/GMOD/jbrowse-components/pull/5256) Fix scrolling on multivariant display types ([@cmdcolin](https://github.com/cmdcolin))
  * [#3439](https://github.com/GMOD/jbrowse-components/pull/3439) Save track data method on base track model ([@cmdcolin](https://github.com/cmdcolin))
  * [#5251](https://github.com/GMOD/jbrowse-components/pull/5251) Floating labels optimizations ([@cmdcolin](https://github.com/cmdcolin))
  * [#5249](https://github.com/GMOD/jbrowse-components/pull/5249) Optimizations for fast updating linear genome view scroll elements ([@cmdcolin](https://github.com/cmdcolin))
  * [#5245](https://github.com/GMOD/jbrowse-components/pull/5245) Allow drawing transcript subfeature labels on canvas features ([@cmdcolin](https://github.com/cmdcolin))
  * [#5241](https://github.com/GMOD/jbrowse-components/pull/5241) Limit zoom level for showing 'mismatches' mouseovers on alignments tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#5213](https://github.com/GMOD/jbrowse-components/pull/5213) Add canvas based renderer for regular gene feature tracks ([@cmdcolin](https://github.com/cmdcolin))
  * [#5228](https://github.com/GMOD/jbrowse-components/pull/5228) Miscellaneous improvements to linear read and read arc display types ([@cmdcolin](https://github.com/cmdcolin))
  * [#5218](https://github.com/GMOD/jbrowse-components/pull/5218) Add mismatches to linked reads display, and make linked read and read arc webworker rendered ([@cmdcolin](https://github.com/cmdcolin))
  * [#5214](https://github.com/GMOD/jbrowse-components/pull/5214) Optimizations for granular rect layout ([@cmdcolin](https://github.com/cmdcolin))
  * [#5210](https://github.com/GMOD/jbrowse-components/pull/5210) Add some micro-optimizations for gridlines and scalebar labels ([@cmdcolin](https://github.com/cmdcolin))
  * [#5207](https://github.com/GMOD/jbrowse-components/pull/5207) Add some help text to display types ([@cmdcolin](https://github.com/cmdcolin))
  * [#5205](https://github.com/GMOD/jbrowse-components/pull/5205) Separate layout from rendering in SVG renderer and remove react-dom/server usage in webworker ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#5329](https://github.com/GMOD/jbrowse-components/pull/5329) Filter sashimi arcs by score ([@cmdcolin](https://github.com/cmdcolin))
  * [#5316](https://github.com/GMOD/jbrowse-components/pull/5316) Collapse introns transcript selector ([@cmdcolin](https://github.com/cmdcolin))
  * [#5314](https://github.com/GMOD/jbrowse-components/pull/5314) Avoid "import form flash" during loading ([@cmdcolin](https://github.com/cmdcolin))
  * [#5312](https://github.com/GMOD/jbrowse-components/pull/5312) Avoid drawing tick labels that overlap block boundaries (#5310) ([@cmdcolin](https://github.com/cmdcolin))
  * [#5307](https://github.com/GMOD/jbrowse-components/pull/5307) Improve bigwig Y-scalebar label legibility ([@cmdcolin](https://github.com/cmdcolin))
  * [#5303](https://github.com/GMOD/jbrowse-components/pull/5303) Add gridlines option for SVG export ([@cmdcolin](https://github.com/cmdcolin))
  * [#5301](https://github.com/GMOD/jbrowse-components/pull/5301) Aggregate insertion stats in on SNP coverage track ([@cmdcolin](https://github.com/cmdcolin))
  * [#5246](https://github.com/GMOD/jbrowse-components/pull/5246) Use numeric encodings for SEQ and CIGAR fields for BAM ([@cmdcolin](https://github.com/cmdcolin))
  * [#5294](https://github.com/GMOD/jbrowse-components/pull/5294) Aggregate insertion stats for tooltip ([@cmdcolin](https://github.com/cmdcolin))
  * [#5292](https://github.com/GMOD/jbrowse-components/pull/5292) Simplify VCF feature descriptions ([@cmdcolin](https://github.com/cmdcolin))
  * [#5289](https://github.com/GMOD/jbrowse-components/pull/5289) If &loc= is not specified in URL bar, then show all regions of the genome ([@cmdcolin](https://github.com/cmdcolin))
  * [#5288](https://github.com/GMOD/jbrowse-components/pull/5288) Improve track drag-n-drop re-ordering on linear genome view ([@cmdcolin](https://github.com/cmdcolin))
  * [#5278](https://github.com/GMOD/jbrowse-components/pull/5278) Increase lazy loading of some react components ([@cmdcolin](https://github.com/cmdcolin))
  * [#5277](https://github.com/GMOD/jbrowse-components/pull/5277) Add ability to click and mouseover RNA-seq junction arcs ([@cmdcolin](https://github.com/cmdcolin))
  * [#5264](https://github.com/GMOD/jbrowse-components/pull/5264) Use SanitizedHTML on category names ([@cmdcolin](https://github.com/cmdcolin))
  * [#5259](https://github.com/GMOD/jbrowse-components/pull/5259) Add ability to show longest transcript only and easily filter out gene glyphs ([@cmdcolin](https://github.com/cmdcolin))
  * [#5250](https://github.com/GMOD/jbrowse-components/pull/5250) Optimize the search box using uncontrolled component style ([@cmdcolin](https://github.com/cmdcolin))
  * [#5238](https://github.com/GMOD/jbrowse-components/pull/5238) Allow clicking on mismatches and insertions on alignments track to get more info ([@cmdcolin](https://github.com/cmdcolin))
  * [#5229](https://github.com/GMOD/jbrowse-components/pull/5229) Globally stop swipe action from producing back/forward actions on jbrowse-web ([@cmdcolin](https://github.com/cmdcolin))
  * [#5227](https://github.com/GMOD/jbrowse-components/pull/5227) Preserve old visualization during block re-rendering ([@cmdcolin](https://github.com/cmdcolin))
  * [#5222](https://github.com/GMOD/jbrowse-components/pull/5222) Scroll only the matrix part of the multi-sample variant viewer to keep connecting lines visible ([@cmdcolin](https://github.com/cmdcolin))
  * [#5220](https://github.com/GMOD/jbrowse-components/pull/5220) Scroll only pileup part of the alignments track to keep SNP coverage visible ([@cmdcolin](https://github.com/cmdcolin))
  * [#5217](https://github.com/GMOD/jbrowse-components/pull/5217) Add 'super-compact' display mode for alignments tracks ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `product-core`, `web-core`
  * [#4499](https://github.com/GMOD/jbrowse-components/pull/4499) Optimizations to support large tracklists ([@cmdcolin](https://github.com/cmdcolin))
  * [#5255](https://github.com/GMOD/jbrowse-components/pull/5255) Create new 'renderingProps' concept for the 'rendering' react component as a complement to 'renderProps' for renderer ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `product-core`, `web-core`
  * [#5300](https://github.com/GMOD/jbrowse-components/pull/5300) Add "tiled window manager" to JBrowse apps ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`
  * [#5268](https://github.com/GMOD/jbrowse-components/pull/5268) Allow putting helpText on WidgetType ([@cmdcolin](https://github.com/cmdcolin))
* `core`, `product-core`
  * [#5270](https://github.com/GMOD/jbrowse-components/pull/5270) Refactor the renderer and RPC stack ([@cmdcolin](https://github.com/cmdcolin))
  * [#5206](https://github.com/GMOD/jbrowse-components/pull/5206) Use pako-esm2 and add some async imports for bundle size savings ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `web-core`
  * [#4938](https://github.com/GMOD/jbrowse-components/pull/4938) Vendor @jbrowse/mobx-state-tree ([@cmdcolin](https://github.com/cmdcolin))
* `sv-core`
  * [#5247](https://github.com/GMOD/jbrowse-components/pull/5247) Refactor VcfFeature for speed and clarity ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `text-indexing`, `web-core`
  * [#5236](https://github.com/GMOD/jbrowse-components/pull/5236) Add ability to draw hierarchical tree from clustering on multi-sample variant view ([@cmdcolin](https://github.com/cmdcolin))

#### :bug: Bug Fix
* `core`
  * [#5308](https://github.com/GMOD/jbrowse-components/pull/5308) Fix issue where multiple sub-menus could open up at once ([@cmdcolin](https://github.com/cmdcolin))
  * [#5258](https://github.com/GMOD/jbrowse-components/pull/5258) Avoid 'polynomial regex' in assembly name parsing ([@cmdcolin](https://github.com/cmdcolin))
  * [#5233](https://github.com/GMOD/jbrowse-components/pull/5233) Reduce coarseStripHTML regex complexity to address codeql warning ([@cmdcolin](https://github.com/cmdcolin))
  * [#5226](https://github.com/GMOD/jbrowse-components/pull/5226) Fix click-and-drag starting from a inter-region padding block ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#5281](https://github.com/GMOD/jbrowse-components/pull/5281) Avoid changing displayed regions set when using "Center at feature" in synteny view ([@cmdcolin](https://github.com/cmdcolin))
  * [#5234](https://github.com/GMOD/jbrowse-components/pull/5234) Fix export of SVG hanging if track had error ([@cmdcolin](https://github.com/cmdcolin))
  * [#5221](https://github.com/GMOD/jbrowse-components/pull/5221) Add cancellation stop tokens for linear read arc/cloud displays ([@cmdcolin](https://github.com/cmdcolin))

#### :house: Internal
* `core`
  * [#5309](https://github.com/GMOD/jbrowse-components/pull/5309) Use mobx-state-tree patches instead of full snapshots for undo manager ([@cmdcolin](https://github.com/cmdcolin))
  * [#5223](https://github.com/GMOD/jbrowse-components/pull/5223) Update to jest 30 ([@cmdcolin](https://github.com/cmdcolin))
  * [#5208](https://github.com/GMOD/jbrowse-components/pull/5208) Remove unused makeStyles classes ([@cmdcolin](https://github.com/cmdcolin))
* Other
  * [#5304](https://github.com/GMOD/jbrowse-components/pull/5304) Change JBrowse CLI to use 'fetch against the filesystem' with file:/// ([@cmdcolin](https://github.com/cmdcolin))
  * [#5267](https://github.com/GMOD/jbrowse-components/pull/5267) Create simplified browser test suite using puppeteer ([@cmdcolin](https://github.com/cmdcolin))
  * [#5248](https://github.com/GMOD/jbrowse-components/pull/5248) Remove use-query-params library ([@cmdcolin](https://github.com/cmdcolin))
  * [#5235](https://github.com/GMOD/jbrowse-components/pull/5235) Use 'gh CLI' for release ([@cmdcolin](https://github.com/cmdcolin))
  * [#5232](https://github.com/GMOD/jbrowse-components/pull/5232) Add explicit github workflow permissions ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`
  * [#5271](https://github.com/GMOD/jbrowse-components/pull/5271) Vendor tss-react/mui dependency ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `web-core`
  * [#4938](https://github.com/GMOD/jbrowse-components/pull/4938) Vendor @jbrowse/mobx-state-tree ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `embedded-core`, `product-core`, `sv-core`, `text-indexing`, `web-core`
  * [#5257](https://github.com/GMOD/jbrowse-components/pull/5257) Fix `depcheck` warnings ([@cmdcolin](https://github.com/cmdcolin))
* `app-core`, `core`, `product-core`, `web-core`
  * [#5255](https://github.com/GMOD/jbrowse-components/pull/5255) Create new 'renderingProps' concept for the 'rendering' react component as a complement to 'renderProps' for renderer ([@cmdcolin](https://github.com/cmdcolin))

#### Committers: 1
- Colin Diesh ([@cmdcolin](https://github.com/cmdcolin))
Done in 6.68s.
