### PR TITLE
Avoid 'polynomial regex' in assembly name parsing

### DIFF
--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -16,6 +16,7 @@ import { createRoot } from 'react-dom/client'
 
 import { coarseStripHTML } from './coarseStripHTML'
 import { colord } from './colord'
+import { parseLocString } from './locString'
 import { checkStopToken } from './stopToken'
 import {
   isDisplayModel,
@@ -25,6 +26,7 @@ import {
   isViewModel,
 } from './types'
 
+import type { ParsedLocString } from './locString'
 import type PluginManager from '../PluginManager'
 import type { BaseBlock } from './blockTypes'
 import type { Feature } from './simpleFeature'
@@ -353,13 +355,6 @@ export function assembleLocStringFast(
   }
   return `${assemblyNameString}${refName}${startString}${endString}${rev}`
 }
-
-export {
-  type ParsedLocString,
-  parseLocString,
-  parseLocStringOneBased,
-} from './locString'
-
 export function compareLocs(locA: ParsedLocString, locB: ParsedLocString) {
   const assemblyComp =
     locA.assemblyName || locB.assemblyName
@@ -1401,3 +1396,4 @@ export { blobToDataURL } from './blobToDataURL'
 export { makeAbortableReaction } from './makeAbortableReaction'
 export * from './aborting'
 export * from './linkify'
+export * from './locString'

--- a/packages/core/util/locString.test.ts
+++ b/packages/core/util/locString.test.ts
@@ -307,6 +307,15 @@ describe('parseLocString - edge cases and functional behavior changes', () => {
     expect(result.end).toBe(200)
   })
 
+  test('handles commas in refName', () => {
+    const validRefNameWithComma = (refName: string) =>
+      ['chr1,2', 'chr1'].includes(refName)
+    const result = parseLocString('chr1,2:100..200', validRefNameWithComma)
+    expect(result.refName).toBe('chr1,2')
+    expect(result.start).toBe(99)
+    expect(result.end).toBe(200)
+  })
+
   test('anchored regex requires match from start', () => {
     // Old regex had no anchor, new one has ^
     // Both should work the same since we're using .exec() on the full string


### PR DESCRIPTION
reported by CodeQL