### PR TITLE
Fix errors using @jbrowse/mobx-state-tree with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@mui/material": "^7.0.0",
     "@mui/system": "^7.0.1",
     "@mui/x-data-grid": "^8.0.0",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -42,12 +42,12 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/product-core": "^3.7.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0",
-    "@jbrowse/mobx-state-tree": "^5.0.0",
     "tss-react": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@gmod/abortable-promise-cache": "^3.0.1",
     "@gmod/bgzf-filehandle": "^5.0.2",
     "@gmod/http-range-fetcher": "^5.0.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@leeoniya/ufuzzy": "^1.0.18",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -39,7 +39,7 @@
     "@gmod/bam": "^7.0.6",
     "@gmod/cram": "^6.0.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@jbrowse/plugin-wiggle": "^3.7.0",
     "@jbrowse/sv-core": "^3.7.0",

--- a/plugins/breakpoint-split-view/package.json
+++ b/plugins/breakpoint-split-view/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@gmod/vcf": "^6.1.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",

--- a/plugins/circular-view/package.json
+++ b/plugins/circular-view/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "@types/file-saver-es": "^2.0.0",

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@gmod/tabix": "^3.0.1",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-alignments": "^3.7.0",
     "@mui/material": "^7.0.0",
     "generic-filehandle2": "^2.0.1",

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "mobx": "^6.0.0",

--- a/plugins/data-management/package.json
+++ b/plugins/data-management/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@gmod/ucsc-hub": "^2.0.1",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-config": "^3.7.0",
     "@jbrowse/product-core": "^3.7.0",
     "@mui/icons-material": "^7.0.0",

--- a/plugins/gccontent/package.json
+++ b/plugins/gccontent/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@jbrowse/plugin-sequence": "^3.7.0",
     "@jbrowse/plugin-wiggle": "^3.7.0",

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -39,7 +39,7 @@
     "@flatten-js/interval-tree": "^2.0.0",
     "@gmod/bgzf-filehandle": "^5.0.2",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@mui/material": "^7.0.0",
     "gtf-nostream": "^1.0.0",

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@mui/x-charts-vendor": "^8.0.0",
     "hic-straw": "^2.0.3",

--- a/plugins/lollipop/package.json
+++ b/plugins/lollipop/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "mobx": "^6.0.0",
     "mobx-react": "^9.0.0"

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -40,7 +40,7 @@
     "@gmod/indexedfasta": "^4.0.0",
     "@gmod/twobit": "^6.0.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@mui/material": "^7.0.0",
     "mobx": "^6.0.0",

--- a/plugins/sv-inspector/package.json
+++ b/plugins/sv-inspector/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-circular-view": "^3.7.0",
     "@jbrowse/plugin-spreadsheet-view": "^3.7.0",
     "@jbrowse/sv-core": "^3.7.0",

--- a/plugins/svg/package.json
+++ b/plugins/svg/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@mui/material": "^7.0.0",
     "g2p_mapper": "^1.0.9",
     "mobx": "^6.0.0",

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -41,7 +41,7 @@
     "@gmod/tabix": "^3.0.1",
     "@gmod/vcf": "^6.1.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-circular-view": "^3.7.0",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@jbrowse/sv-core": "^3.7.0",

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -39,7 +39,7 @@
     "@gmod/bbi": "^7.0.0",
     "@gmod/hclust": "^1.0.7",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-data-management": "^3.7.0",
     "@jbrowse/plugin-linear-genome-view": "^3.7.0",
     "@mui/icons-material": "^7.0.0",

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -44,7 +44,7 @@
     "@gmod/faidx": "^2.0.0",
     "@jbrowse/app-core": "^3.7.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-alignments": "^3.7.0",
     "@jbrowse/plugin-arc": "^3.7.0",
     "@jbrowse/plugin-authentication": "^3.7.0",

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -47,7 +47,7 @@
     "@emotion/styled": "^11.8.1",
     "@jbrowse/app-core": "^3.7.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-alignments": "^3.7.0",
     "@jbrowse/plugin-arc": "^3.7.0",
     "@jbrowse/plugin-authentication": "^3.7.0",

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -15,7 +15,7 @@
     "@fontsource/roboto": "^5.0.2",
     "@jbrowse/app-core": "^3.7.0",
     "@jbrowse/core": "^3.7.0",
-    "@jbrowse/mobx-state-tree": "^5.4.5",
+    "@jbrowse/mobx-state-tree": "^5.4.6",
     "@jbrowse/plugin-alignments": "^3.7.0",
     "@jbrowse/plugin-arc": "^3.7.0",
     "@jbrowse/plugin-authentication": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,9 +1060,9 @@
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
 "@csstools/css-syntax-patches-for-csstree@^1.0.14":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.19.tgz#816f93d4cdd4e4978ccd5860e866eb1e737ddbe1"
-  integrity sha512-QW5/SM2ARltEhoKcmRI1LoLf3/C7dHGswwCnfLcoMgqurBT4f8GvwXMgAbK/FwcxthmJRK5MGTtddj0yQn0J9g==
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.20.tgz#b14db34a759b3446b01d7981b4765f92b2d420ae"
+  integrity sha512-8BHsjXfSciZxjmHQOuVdW2b8WLUPts9a+mfL13/PzEviufUEW2xnvQuOlKs9dRBHgRqJ53SF/DUoK9+MZk72oQ==
 
 "@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
@@ -1881,10 +1881,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jbrowse/mobx-state-tree@^5.0.0", "@jbrowse/mobx-state-tree@^5.4.5":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/@jbrowse/mobx-state-tree/-/mobx-state-tree-5.4.5.tgz#13393bed3d32abf696aad402963c6da05316b63b"
-  integrity sha512-Lqbo7si/GLn3vmjnqrZxk7GSsuRyYYL7Q2nTCgFO4fEu3iYlsbJ3ovD8tZADkzxJd67Goqr7Cv/HiuliR5W6Gg==
+"@jbrowse/mobx-state-tree@^5.0.0", "@jbrowse/mobx-state-tree@^5.4.6":
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/@jbrowse/mobx-state-tree/-/mobx-state-tree-5.4.6.tgz#3c0f528637a46a16894d1b360549b7cf5dcb1e09"
+  integrity sha512-5ocFYIbrdDZFxcHaiPCtihERAUw1Mx3lRKsDxQeXvxYE9zjC5QTovdthG9PLqnP9tPUTwDLWvoMDNYZYTpJ3QA==
 
 "@jest/console@30.2.0":
   version "30.2.0"
@@ -12165,9 +12165,9 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^3.2.5:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.1.tgz#8dfbf54c98e85a113962d3d8414ae82ff3722991"
-  integrity sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.2.tgz#7b393a865f9dd97bc244215db9aac8e04dc1841b"
+  integrity sha512-n3HV2J6QhItCXndGa3oMWvWFAgN1ibnS7R9mt6iokScBOC0Ul9/iZORmU2IWUMcyAQaMPjTlY3uT34TqocUxMA==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -13906,9 +13906,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 swr@^2.3.3:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-2.3.6.tgz#5fee0ee8a0762a16871ee371075cb09422b64f50"
-  integrity sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.3.7.tgz#93ca89c9c06a6a8dab72e9d8e85a687123f40356"
+  integrity sha512-ZEquQ82QvalqTxhBVv/DlAg2mbmUjF4UgpPg9wwk4ufb9rQnZXh1iKyyKBqV6bQGu1Ie7L1QwSYO07qFIa1p+g==
   dependencies:
     dequal "^2.0.3"
     use-sync-external-store "^1.4.0"


### PR DESCRIPTION
We tried using a dual "pure-ESM"/CJS build for mobx-state-tree but this caused both versions to get imported which caused mystery errors on vite. This changes back to using "main" (normal CJS) and "module" (pseudo ESM) fields for the @jbrowse/mobx-state-tree package