### PR TITLE
Allow rapid clicking of zoom in and out buttons

### DIFF
--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -405,7 +405,12 @@ const MenuPage = forwardRef<HTMLDivElement, MenuPageProps>(
       ListContents
     ) : (
       // Grow is required for cascading sub-menus
-      <Grow in={open} style={{ transformOrigin: '0 0 0' }} timeout={100} ref={ref}>
+      <Grow
+        in={open}
+        style={{ transformOrigin: '0 0 0' }}
+        timeout={100}
+        ref={ref}
+      >
         <Paper
           elevation={8}
           ref={paperRef}

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -29,7 +29,7 @@ const MiniControls = observer(function ({
   model: LinearGenomeViewModel
 }) {
   const { classes } = useStyles()
-  const { id, bpPerPx, maxBpPerPx, minBpPerPx, scaleFactor, hideHeader } = model
+  const { id, bpPerPx, maxBpPerPx, minBpPerPx, hideHeader } = model
   const { focusedViewId } = getSession(model)
   return hideHeader ? (
     <Paper className={classes.background}>
@@ -44,7 +44,7 @@ const MiniControls = observer(function ({
           onClick={() => {
             model.zoom(bpPerPx * 2)
           }}
-          disabled={bpPerPx >= maxBpPerPx - 0.0001 || scaleFactor !== 1}
+          disabled={bpPerPx >= maxBpPerPx - 0.0001}
         >
           <ZoomOut fontSize="small" />
         </IconButton>
@@ -53,7 +53,7 @@ const MiniControls = observer(function ({
           onClick={() => {
             model.zoom(bpPerPx / 2)
           }}
-          disabled={bpPerPx <= minBpPerPx + 0.0001 || scaleFactor !== 1}
+          disabled={bpPerPx <= minBpPerPx + 0.0001}
         >
           <ZoomIn fontSize="small" />
         </IconButton>

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1162,6 +1162,8 @@ export function stateModelFactory(pluginManager: PluginManager) {
        * perform animated zoom
        */
       function zoom(targetBpPerPx: number) {
+        cancelLastAnimation()
+        self.setScaleFactor(1)
         self.zoomTo(self.bpPerPx)
         if (
           // already zoomed all the way in
@@ -1181,7 +1183,6 @@ export function stateModelFactory(pluginManager: PluginManager) {
             self.setScaleFactor(1)
           },
         )
-        cancelLastAnimation()
         cancelLastAnimation = cancelAnimation!
         animate!()
       }
@@ -1874,10 +1875,10 @@ export function stateModelFactory(pluginManager: PluginManager) {
             } else if (e.code === 'ArrowRight') {
               e.preventDefault()
               self.slide(0.9)
-            } else if (e.code === 'ArrowUp' && self.scaleFactor === 1) {
+            } else if (e.code === 'ArrowUp') {
               e.preventDefault()
               self.zoom(self.bpPerPx / 2)
-            } else if (e.code === 'ArrowDown' && self.scaleFactor === 1) {
+            } else if (e.code === 'ArrowDown') {
               e.preventDefault()
               self.zoom(self.bpPerPx * 2)
             }


### PR DESCRIPTION
Currently the zoom buttons are disabled while the zoom animation is playing. This fixes it so you can rapid click and the animation will adapt