### PR TITLE
Potential fix for code scanning alert no. 13: Prototype-polluting function

### DIFF
--- a/plugins/legacy-jbrowse/src/JBrowse1Connection/util.ts
+++ b/plugins/legacy-jbrowse/src/JBrowse1Connection/util.ts
@@ -18,6 +18,13 @@ type Obj = Record<string, any>
 export function deepUpdate(a: Obj, b: Obj): Obj {
   for (const prop of Object.keys(b)) {
     if (
+      prop === '__proto__' ||
+      prop === 'constructor' ||
+      prop === 'prototype'
+    ) {
+      continue
+    }
+    if (
       prop in a &&
       typeof b[prop] === 'object' &&
       typeof a[prop] === 'object'


### PR DESCRIPTION
Potential fix for [https://github.com/GMOD/jbrowse-components/security/code-scanning/13](https://github.com/GMOD/jbrowse-components/security/code-scanning/13)

To mitigate prototype pollution risk, we must prevent dangerous property names such as `__proto__`, `constructor`, and (optionally) `prototype` from being copied or merged. The best way is to check for these property names in the key loop within `deepUpdate`. Specifically, add a guard to skip keys equal to `"__proto__"`, `"constructor"`, or `"prototype"` before assigning or recursing. This change should be made to the block inside the for loop at line 19 in `plugins/legacy-jbrowse/src/JBrowse1Connection/util.ts`, covering all cases where `a[prop]` might be overwritten or merged. No additional imports or helper functions are needed; simply use an `if` statement for these checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
