### PR TITLE
Avoid changing displayed regions set when using "Center at feature" in synteny view

### DIFF
--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/SyntenyContextMenu.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/SyntenyContextMenu.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@jbrowse/core/ui'
-import { getContainingView, getSession } from '@jbrowse/core/util'
+import { getContainingView } from '@jbrowse/core/util'
 
 import type { LinearSyntenyViewModel } from '../../LinearSyntenyView/model'
 import type { LinearSyntenyDisplayModel } from '../model'
@@ -60,24 +60,12 @@ export default function SyntenyContextMenu({
 
             const l1 = view.views[model.level]!
             const l2 = view.views[model.level + 1]!
-            const l1asm = l1.assemblyNames[0]
-            const l2asm = l2.assemblyNames[0]
 
-            l1.navToLocString(`${refName}:${start}-${end}`).catch(
-              (e: unknown) => {
-                const err = `${l1asm}:${e}`
-                console.error(l1asm, err)
-                getSession(model).notifyError(err, e)
-              },
-            )
+            const center1 = (start + end) / 2
+            const center2 = (mate.start + mate.end) / 2
 
-            l2.navToLocString(
-              `${mate.refName}:${mate.start}-${mate.end}`,
-            ).catch((e: unknown) => {
-              const err = `${l2asm}:${e}`
-              console.error(l2asm, err)
-              getSession(model).notifyError(err, e)
-            })
+            l1.centerAt(center1, refName)
+            l2.centerAt(center2, mate.refName)
           },
         },
       ]}


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/4474

Could do more advanced things potentially if CIGAR string is available but this is a fix for the current behavior

Claude code generated fix