### PR TITLE
Fix gridlines mis-rendering at different zoom levels

### DIFF
--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@jbrowse/core/util/tss-react'
 import { useTheme } from '@mui/material'
 import { autorun } from 'mobx'
 
-import { makeTicks } from '../util'
+import { getCachedElements, makeTicks } from '../util'
 
 import type { LinearGenomeViewModel } from '..'
 import type { BaseBlock } from '@jbrowse/core/util/blockTypes'
@@ -141,19 +141,12 @@ function Gridlines({ model, offset = 0 }: { model: LGV; offset?: number }) {
           return
         }
 
-        // Clear cache if bpPerPx changed - all elements need recomputation
-        const bpPerPxChanged = lastBpPerPxRef.current !== bpPerPx
-        lastBpPerPxRef.current = bpPerPx
-
-        const existingKeys = new Map<string, HTMLDivElement>()
-        if (!bpPerPxChanged) {
-          for (const child of inner.children) {
-            const key = (child as HTMLElement).dataset.blockKey
-            if (key) {
-              existingKeys.set(key, child as HTMLDivElement)
-            }
-          }
-        }
+        const existingKeys = getCachedElements<HTMLDivElement>(
+          inner,
+          bpPerPx,
+          lastBpPerPxRef,
+          'blockKey',
+        )
 
         const fragment = document.createDocumentFragment()
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarCoordinateLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarCoordinateLabels.tsx
@@ -4,7 +4,7 @@ import { getTickDisplayStr } from '@jbrowse/core/util'
 import { useTheme } from '@mui/material'
 import { autorun } from 'mobx'
 
-import { makeTicks } from '../util'
+import { getCachedElements, makeTicks } from '../util'
 
 import type { LinearGenomeViewModel } from '..'
 import type { BaseBlock } from '@jbrowse/core/util/blockTypes'
@@ -78,19 +78,12 @@ function ScalebarCoordinateLabels({ model }: { model: LGV }) {
           return
         }
 
-        // Clear cache if bpPerPx changed - all elements need recomputation
-        const bpPerPxChanged = lastBpPerPxRef.current !== bpPerPx
-        lastBpPerPxRef.current = bpPerPx
-
-        const existingKeys = new Map<string, HTMLDivElement>()
-        if (!bpPerPxChanged) {
-          for (const child of container.children) {
-            const key = (child as HTMLElement).dataset.blockKey
-            if (key) {
-              existingKeys.set(key, child as HTMLDivElement)
-            }
-          }
-        }
+        const existingKeys = getCachedElements<HTMLDivElement>(
+          container,
+          bpPerPx,
+          lastBpPerPxRef,
+          'blockKey',
+        )
 
         const fragment = document.createDocumentFragment()
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarPinnedLabel.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarPinnedLabel.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react'
+
+import { useTheme } from '@mui/material'
+import { autorun } from 'mobx'
+
+import type { LinearGenomeViewModel } from '..'
+
+type LGV = LinearGenomeViewModel
+
+function ScalebarPinnedLabel({ model }: { model: LGV }) {
+  const theme = useTheme()
+  const spanRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    return autorun(
+      function pinnedLabelAutorun() {
+        const { staticBlocks, offsetPx, scaleBarDisplayPrefix } = model
+
+        const span = spanRef.current
+        if (!span) {
+          return
+        }
+
+        // Find which block should be pinned (one that's off-screen left)
+        let pinnedBlockIndex = -1
+        let i = 0
+        for (const block of staticBlocks) {
+          if (block.offsetPx - offsetPx < 0) {
+            pinnedBlockIndex = i
+          } else {
+            break
+          }
+          i++
+        }
+
+        const pinnedBlock = staticBlocks.blocks[pinnedBlockIndex]
+        if (pinnedBlockIndex >= 0 && pinnedBlock?.type === 'ContentBlock') {
+          const val = scaleBarDisplayPrefix()
+          span.style.display = ''
+          span.textContent = (val ? `${val}:` : '') + pinnedBlock.refName
+        } else {
+          span.style.display = 'none'
+        }
+      },
+      { name: 'ScalebarPinnedLabel' },
+    )
+  }, [model])
+
+  return (
+    <span
+      ref={spanRef}
+      style={{
+        fontSize: '11px',
+        position: 'absolute',
+        left: 0,
+        top: '-1px',
+        fontWeight: 'bold',
+        lineHeight: 'normal',
+        zIndex: 2,
+        background: theme.palette.background.paper,
+      }}
+    />
+  )
+}
+
+export default ScalebarPinnedLabel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
@@ -3,6 +3,9 @@ import { useEffect, useRef } from 'react'
 import { useTheme } from '@mui/material'
 import { autorun } from 'mobx'
 
+import { getCachedElements } from '../util'
+import ScalebarPinnedLabel from './ScalebarPinnedLabel'
+
 import type { LinearGenomeViewModel } from '..'
 
 type LGV = LinearGenomeViewModel
@@ -10,46 +13,16 @@ type LGV = LinearGenomeViewModel
 function ScalebarRefNameLabels({ model }: { model: LGV }) {
   const theme = useTheme()
   const innerRef = useRef<HTMLDivElement>(null)
-  const pinnedRef = useRef<HTMLSpanElement | null>(null)
   const lastBpPerPxRef = useRef<number | null>(null)
 
-  // Handle offsetPx changes - update container position and pinned label
+  // Handle offsetPx changes - update container position
   useEffect(() => {
     return autorun(
       function refNameLabelsOffsetAutorun() {
-        const { staticBlocks, offsetPx, scaleBarDisplayPrefix } = model
-
+        const { offsetPx } = model
         const inner = innerRef.current
-        if (!inner) {
-          return
-        }
-
-        // Translate container to account for scroll position
-        inner.style.transform = `translateX(${-offsetPx}px)`
-
-        // Find which block should be pinned (one that's off-screen left)
-        let pinnedBlockIndex = -1
-        let i = 0
-        for (const block of staticBlocks) {
-          if (block.offsetPx - offsetPx < 0) {
-            pinnedBlockIndex = i
-          } else {
-            break
-          }
-          i++
-        }
-
-        const pinned = pinnedRef.current
-        if (pinned) {
-          const pinnedBlock = staticBlocks.blocks[pinnedBlockIndex]
-          if (pinnedBlockIndex >= 0 && pinnedBlock?.type === 'ContentBlock') {
-            const val = scaleBarDisplayPrefix()
-            pinned.style.transform = `translateX(${Math.max(0, offsetPx)}px)`
-            pinned.style.display = ''
-            pinned.textContent = (val ? `${val}:` : '') + pinnedBlock.refName
-          } else {
-            pinned.style.display = 'none'
-          }
+        if (inner) {
+          inner.style.transform = `translateX(${-offsetPx}px)`
         }
       },
       { name: 'RefNameLabelsOffset' },
@@ -68,19 +41,12 @@ function ScalebarRefNameLabels({ model }: { model: LGV }) {
           return
         }
 
-        // Clear cache if bpPerPx changed - all elements need recomputation
-        const bpPerPxChanged = lastBpPerPxRef.current !== bpPerPx
-        lastBpPerPxRef.current = bpPerPx
-
-        const existingKeys = new Map<string, HTMLSpanElement>()
-        if (!bpPerPxChanged) {
-          for (const child of inner.children) {
-            const key = (child as HTMLElement).dataset.labelKey
-            if (key) {
-              existingKeys.set(key, child as HTMLSpanElement)
-            }
-          }
-        }
+        const existingKeys = getCachedElements<HTMLSpanElement>(
+          inner,
+          bpPerPx,
+          lastBpPerPxRef,
+          'labelKey',
+        )
 
         const fragment = document.createDocumentFragment()
 
@@ -109,26 +75,18 @@ function ScalebarRefNameLabels({ model }: { model: LGV }) {
           index++
         }
 
-        // Create pinned label
-        const key = 'pinned-label'
-        let pinned = existingKeys.get(key)
-        if (!pinned) {
-          pinned = createLabelElement(bgColor)
-          pinned.dataset.labelKey = key
-          pinned.style.zIndex = '2'
-        }
-        pinned.style.left = '0px'
-        pinned.style.paddingLeft = '0px'
-        pinnedRef.current = pinned
-        fragment.append(pinned)
-
         inner.replaceChildren(fragment)
       },
       { name: 'RefNameLabelsLayout' },
     )
   }, [model, theme])
 
-  return <div ref={innerRef} style={{ position: 'absolute' }} />
+  return (
+    <>
+      <div ref={innerRef} style={{ position: 'absolute' }} />
+      <ScalebarPinnedLabel model={model} />
+    </>
+  )
 }
 
 function createLabelElement(bgColor: string) {

--- a/plugins/linear-genome-view/src/LinearGenomeView/util.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/util.ts
@@ -1,7 +1,35 @@
+import type { RefObject } from 'react'
+
 import { assembleLocString, parseLocString } from '@jbrowse/core/util'
 
 import type { AssemblyManager, ParsedLocString } from '@jbrowse/core/util'
 import type { BaseBlock } from '@jbrowse/core/util/blockTypes'
+
+/**
+ * Gets a map of existing child elements keyed by their data-* attribute,
+ * but only if bpPerPx hasn't changed. When bpPerPx changes, returns an
+ * empty map to force recreation of all elements.
+ */
+export function getCachedElements<T extends HTMLElement>(
+  container: HTMLElement,
+  bpPerPx: number,
+  lastBpPerPxRef: RefObject<number | null>,
+  dataKey: string,
+) {
+  const bpPerPxChanged = lastBpPerPxRef.current !== bpPerPx
+  lastBpPerPxRef.current = bpPerPx
+
+  const existingKeys = new Map<string, T>()
+  if (!bpPerPxChanged) {
+    for (const child of container.children) {
+      const key = (child as HTMLElement).dataset[dataKey]
+      if (key) {
+        existingKeys.set(key, child as T)
+      }
+    }
+  }
+  return existingKeys
+}
 
 /**
  * Given a scale ( bp/px ) and minimum distances (px) between major and minor


### PR DESCRIPTION
This is a fix after  #5249 #5210 and related PRs made a bug. Those PRs aim to accelerate various scrolling operations by removing components from the React VDOM lifecycle and managing DOM manually so this just fixes up bugs related to that