### PR TITLE
Add optimizations to mobx-state-tree and track loading

### DIFF
--- a/packages/core/PluginManager.ts
+++ b/packages/core/PluginManager.ts
@@ -390,10 +390,18 @@ export default class PluginManager {
       )
       return fallback
     }
-    const typeMap = Object.fromEntries(pluggableTypes.map(t => [t.name, t]))
+    const typeMap = Object.fromEntries(
+      pluggableTypes.map(t => {
+        // @ts-expect-error - access internal MST properties
+        const typeLiteral = t.properties?.type?.value
+        const key = typeLiteral ?? t.name
+        return [key, t]
+      }),
+    )
     return types.union(
       {
         dispatcher: (snapshot: { type?: string }) =>
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           (snapshot?.type ? typeMap[snapshot.type] : undefined) ??
           pluggableTypes[0]!,
       },
@@ -415,10 +423,17 @@ export default class PluginManager {
     if (pluggableTypes.length === 0) {
       pluggableTypes.push(ConfigurationSchema('Null', {}))
     }
-    const typeMap = Object.fromEntries(pluggableTypes.map(t => [t.name, t]))
+    const typeMap = Object.fromEntries(
+      pluggableTypes.map(t => {
+        // Strip ConfigurationSchema suffix to match snapshot type field
+        const key = t.name.replace(/ConfigurationSchema$/, '')
+        return [key, t]
+      }),
+    )
     return types.union(
       {
         dispatcher: (snapshot: { type?: string }) =>
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           (snapshot?.type ? typeMap[snapshot.type] : undefined) ??
           pluggableTypes[0]!,
       },

--- a/packages/core/rpc/configSchema.ts
+++ b/packages/core/rpc/configSchema.ts
@@ -29,6 +29,7 @@ export default ConfigurationSchema(
         types.union(
           {
             dispatcher: (snapshot: { type?: string }) => {
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               switch (snapshot?.type) {
                 case 'MainThreadRpcDriver':
                   return MainThreadRpcDriverConfigSchema

--- a/plugins/alignments/src/LinearAlignmentsDisplay/alignmentsModel.tsx
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/alignmentsModel.tsx
@@ -27,6 +27,7 @@ export function LinearAlignmentsDisplayMixin(
         return types.union(
           {
             dispatcher: (snapshot: { type?: string }) =>
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               (snapshot?.type ? typeMap[snapshot.type] : undefined) ??
               displayTypes[0]!,
           },

--- a/products/jbrowse-web/src/jbrowseModel.ts
+++ b/products/jbrowse-web/src/jbrowseModel.ts
@@ -6,8 +6,6 @@ import { removeAttr } from './util'
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { AnyConfigurationSchemaType } from '@jbrowse/core/configuration'
 
-console.log('hi')
-
 // poke some things for testing (this stuff will eventually be removed)
 // @ts-expect-error
 window.getSnapshot = getSnapshot


### PR DESCRIPTION
When loading large track configs, it can be quite slow. The current suggestion is to use frozen_tracks4 but it has been challenging to make that track work correctly. It might still be worth doing but this is an alternative approach that gets a reasonable speedup

Our fork of mobx-state-tree, which did nothing but removed all the down-transpiling for older browsers, got ~2x speedup, and this PR adds approx another ~2x speedup

When loading the 1000 genomes config, which has about ~3500 tracks

~15.75s v3.7.0
~8.2 with current main with @jbrowse/mobx-state-tree update
~5.3 with this branch with @jbrowse/mobx-state-tree+types.union dispatcher
~3.5s with this branch with @jbrowse/mobx-state-tree+types.union dispatcher+automated optimizations to @jbrowse/mobx-state-tree

