### PR TITLE
Avoid showing cross-origin config warning when plugins come from plugin store

### DIFF
--- a/products/jbrowse-web/src/checkPlugins.test.ts
+++ b/products/jbrowse-web/src/checkPlugins.test.ts
@@ -1,0 +1,225 @@
+import { checkPluginsAgainstStore, fetchPlugins } from './checkPlugins'
+
+import type { PluginDefinition } from '@jbrowse/core/PluginLoader'
+
+describe('checkPluginsAgainstStore', () => {
+  const mockStorePlugins: { plugins: PluginDefinition[] } = {
+    plugins: [
+      { name: 'StorePlugin1', umdUrl: 'https://example.com/plugin1.umd.js' },
+      { name: 'StorePlugin2', url: 'https://example.com/plugin2.js' },
+      { esmUrl: 'https://example.com/plugin3.esm.js' },
+      { cjsUrl: 'https://example.com/plugin4.cjs.js' },
+      {
+        name: 'StorePluginLoc',
+        umdLoc: { uri: 'plugin5.umd.js', baseUri: 'https://example.com/' },
+      },
+      { esmLoc: { uri: 'plugin6.esm.js', baseUri: 'https://example.com/' } },
+    ],
+  }
+
+  it('returns true for empty plugin list', () => {
+    expect(checkPluginsAgainstStore([], mockStorePlugins)).toBe(true)
+  })
+
+  it('returns true for UMD plugin with matching umdUrl', () => {
+    const plugins: PluginDefinition[] = [
+      { name: 'StorePlugin1', umdUrl: 'https://example.com/plugin1.umd.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+  })
+
+  it('returns true for UMD plugin with matching legacy url', () => {
+    const plugins: PluginDefinition[] = [
+      { name: 'StorePlugin2', url: 'https://example.com/plugin2.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+  })
+
+  it('returns true for ESM plugin with matching esmUrl', () => {
+    const plugins: PluginDefinition[] = [
+      { esmUrl: 'https://example.com/plugin3.esm.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+  })
+
+  it('returns true for CJS plugin with matching cjsUrl', () => {
+    const plugins: PluginDefinition[] = [
+      { cjsUrl: 'https://example.com/plugin4.cjs.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+  })
+
+  it('returns false for unknown UMD plugin', () => {
+    const plugins: PluginDefinition[] = [
+      { name: 'UnknownPlugin', umdUrl: 'https://evil.com/malicious.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(false)
+  })
+
+  it('returns false for unknown ESM plugin', () => {
+    const plugins: PluginDefinition[] = [
+      { esmUrl: 'https://evil.com/malicious.esm.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(false)
+  })
+
+  it('returns false for unknown CJS plugin', () => {
+    const plugins: PluginDefinition[] = [
+      { cjsUrl: 'https://evil.com/malicious.cjs.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(false)
+  })
+
+  it('returns false if any plugin in the list is unknown', () => {
+    const plugins: PluginDefinition[] = [
+      { name: 'StorePlugin1', umdUrl: 'https://example.com/plugin1.umd.js' },
+      { name: 'UnknownPlugin', umdUrl: 'https://evil.com/malicious.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(false)
+  })
+
+  it('returns true for all known plugins', () => {
+    const plugins: PluginDefinition[] = [
+      { name: 'StorePlugin1', umdUrl: 'https://example.com/plugin1.umd.js' },
+      { esmUrl: 'https://example.com/plugin3.esm.js' },
+    ]
+    expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+  })
+
+  describe('umdLoc format', () => {
+    it('matches plugin defined with umdLoc against store with umdLoc', () => {
+      const plugins: PluginDefinition[] = [
+        {
+          name: 'TestPlugin',
+          umdLoc: { uri: 'plugin5.umd.js', baseUri: 'https://example.com/' },
+        },
+      ]
+      expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+    })
+  })
+
+  describe('esmLoc format', () => {
+    it('matches plugin defined with esmLoc against store with esmLoc', () => {
+      const plugins: PluginDefinition[] = [
+        { esmLoc: { uri: 'plugin6.esm.js', baseUri: 'https://example.com/' } },
+      ]
+      expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+    })
+  })
+
+  describe('trusted URL prefixes', () => {
+    it('trusts plugins from https://jbrowse.org/plugins/', () => {
+      const plugins: PluginDefinition[] = [
+        {
+          name: 'TrustedPlugin',
+          umdUrl: 'https://jbrowse.org/plugins/MyPlugin/dist/plugin.umd.js',
+        },
+      ]
+      expect(checkPluginsAgainstStore(plugins, { plugins: [] })).toBe(true)
+    })
+
+    it('trusts ESM plugins from https://jbrowse.org/plugins/', () => {
+      const plugins: PluginDefinition[] = [
+        { esmUrl: 'https://jbrowse.org/plugins/MyPlugin/dist/plugin.esm.js' },
+      ]
+      expect(checkPluginsAgainstStore(plugins, { plugins: [] })).toBe(true)
+    })
+
+    it('trusts CJS plugins from https://jbrowse.org/plugins/', () => {
+      const plugins: PluginDefinition[] = [
+        { cjsUrl: 'https://jbrowse.org/plugins/MyPlugin/dist/plugin.cjs.js' },
+      ]
+      expect(checkPluginsAgainstStore(plugins, { plugins: [] })).toBe(true)
+    })
+
+    it('does not trust similar-looking domains', () => {
+      const plugins: PluginDefinition[] = [
+        {
+          name: 'EvilPlugin',
+          umdUrl: 'https://jbrowse.org.evil.com/plugins/malicious.js',
+        },
+      ]
+      expect(checkPluginsAgainstStore(plugins, { plugins: [] })).toBe(false)
+    })
+
+    it('does not trust http version of trusted prefix', () => {
+      const plugins: PluginDefinition[] = [
+        {
+          name: 'InsecurePlugin',
+          umdUrl: 'http://jbrowse.org/plugins/MyPlugin/dist/plugin.umd.js',
+        },
+      ]
+      expect(checkPluginsAgainstStore(plugins, { plugins: [] })).toBe(false)
+    })
+
+    it('mixes trusted URLs and store-validated plugins', () => {
+      const plugins: PluginDefinition[] = [
+        {
+          name: 'TrustedPlugin',
+          umdUrl: 'https://jbrowse.org/plugins/MyPlugin/dist/plugin.umd.js',
+        },
+        {
+          name: 'StorePlugin1',
+          umdUrl: 'https://example.com/plugin1.umd.js',
+        },
+      ]
+      expect(checkPluginsAgainstStore(plugins, mockStorePlugins)).toBe(true)
+    })
+  })
+})
+
+describe('checkPlugins with real plugin store', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    fetch.enableMocks()
+  })
+
+  afterEach(() => {
+    // @ts-expect-error
+    fetch.resetMocks()
+  })
+
+  it('validates mafviewer plugin from plugins.json', async () => {
+    const mockPluginsJson = {
+      plugins: [
+        {
+          name: 'MafViewer',
+          url: 'https://jbrowse.org/plugins/jbrowse-plugin-mafviewer/dist/jbrowse-plugin-mafviewer.umd.production.min.js',
+        },
+      ],
+    }
+    // @ts-expect-error
+    fetch.mockResponseOnce(JSON.stringify(mockPluginsJson))
+
+    const storePlugins = await fetchPlugins()
+    const plugins: PluginDefinition[] = [
+      {
+        name: 'MafViewer',
+        url: 'https://jbrowse.org/plugins/jbrowse-plugin-mafviewer/dist/jbrowse-plugin-mafviewer.umd.production.min.js',
+      },
+    ]
+    expect(checkPluginsAgainstStore(plugins, storePlugins)).toBe(true)
+  })
+
+  it('rejects unknown plugin not in plugins.json', async () => {
+    const mockPluginsJson = {
+      plugins: [
+        {
+          name: 'MafViewer',
+          url: 'https://jbrowse.org/plugins/jbrowse-plugin-mafviewer/dist/jbrowse-plugin-mafviewer.umd.production.min.js',
+        },
+      ],
+    }
+    // @ts-expect-error
+    fetch.mockResponseOnce(JSON.stringify(mockPluginsJson))
+
+    const storePlugins = await fetchPlugins()
+    const plugins: PluginDefinition[] = [
+      {
+        name: 'FakePlugin',
+        url: 'https://evil.com/fake-plugin.umd.js',
+      },
+    ]
+    expect(checkPluginsAgainstStore(plugins, storePlugins)).toBe(false)
+  })
+})

--- a/products/jbrowse-web/src/checkPlugins.ts
+++ b/products/jbrowse-web/src/checkPlugins.ts
@@ -1,0 +1,69 @@
+import {
+  isCJSPluginDefinition,
+  isESMPluginDefinition,
+  isUMDPluginDefinition,
+  pluginUrl,
+} from '@jbrowse/core/PluginLoader'
+
+import type { PluginDefinition } from '@jbrowse/core/PluginLoader'
+
+export const TRUSTED_PLUGIN_URL_PREFIXES = ['https://jbrowse.org/plugins/']
+
+export async function fetchPlugins() {
+  const response = await fetch('https://jbrowse.org/plugin-store/plugins.json')
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} fetching plugins`,
+    )
+  }
+  return response.json() as Promise<{ plugins: PluginDefinition[] }>
+}
+
+function isTrustedUrl(url: string) {
+  return TRUSTED_PLUGIN_URL_PREFIXES.some(prefix => url.startsWith(prefix))
+}
+
+function isPluginInStore(
+  p: PluginDefinition,
+  storePlugins: { plugins: PluginDefinition[] },
+) {
+  const url = pluginUrl(p)
+  if (isUMDPluginDefinition(p)) {
+    return storePlugins.plugins.some(
+      pp => isUMDPluginDefinition(pp) && pluginUrl(pp) === url,
+    )
+  }
+  if (isESMPluginDefinition(p)) {
+    return storePlugins.plugins.some(
+      pp => isESMPluginDefinition(pp) && pluginUrl(pp) === url,
+    )
+  }
+  if (isCJSPluginDefinition(p)) {
+    return storePlugins.plugins.some(
+      pp => isCJSPluginDefinition(pp) && pluginUrl(pp) === url,
+    )
+  }
+  return false
+}
+
+export async function checkPlugins(pluginsToCheck: PluginDefinition[]) {
+  if (pluginsToCheck.length === 0) {
+    return true
+  }
+  const storePlugins = await fetchPlugins()
+  return pluginsToCheck.every(
+    p => isTrustedUrl(pluginUrl(p)) || isPluginInStore(p, storePlugins),
+  )
+}
+
+export function checkPluginsAgainstStore(
+  pluginsToCheck: PluginDefinition[],
+  storePlugins: { plugins: PluginDefinition[] },
+) {
+  if (pluginsToCheck.length === 0) {
+    return true
+  }
+  return pluginsToCheck.every(
+    p => isTrustedUrl(pluginUrl(p)) || isPluginInStore(p, storePlugins),
+  )
+}

--- a/products/jbrowse-web/src/util.ts
+++ b/products/jbrowse-web/src/util.ts
@@ -1,9 +1,4 @@
 import {
-  isCJSPluginDefinition,
-  isESMPluginDefinition,
-  isUMDPluginDefinition,
-} from '@jbrowse/core/PluginLoader'
-import {
   getChildType,
   getPropertyMembers,
   isArrayType,
@@ -13,7 +8,6 @@ import {
   isValidReference,
 } from '@jbrowse/mobx-state-tree'
 
-import type { PluginDefinition } from '@jbrowse/core/PluginLoader'
 import type {
   IAnyStateTreeNode,
   IAnyType,
@@ -158,46 +152,7 @@ export function readConf({ configuration }: Root, attr: string, def: string) {
   return configuration?.[attr] || def
 }
 
-export async function fetchPlugins() {
-  const response = await fetch('https://jbrowse.org/plugin-store/plugins.json')
-  if (!response.ok) {
-    throw new Error(
-      `HTTP ${response.status} ${response.statusText} fetching plugins`,
-    )
-  }
-  return response.json() as Promise<{ plugins: PluginDefinition[] }>
-}
-
-export async function checkPlugins(pluginsToCheck: PluginDefinition[]) {
-  if (pluginsToCheck.length === 0) {
-    return true
-  }
-  const storePlugins = await fetchPlugins()
-  return pluginsToCheck.every(p => {
-    if (isUMDPluginDefinition(p)) {
-      return storePlugins.plugins.some(
-        pp =>
-          isUMDPluginDefinition(p) &&
-          (('url' in pp && 'url' in p && p.url === pp.url) ||
-            ('umdUrl' in pp && 'umdUrl' in p && p.umdUrl === pp.umdUrl)),
-      )
-    }
-    if (isESMPluginDefinition(p)) {
-      return storePlugins.plugins.some(
-        pp =>
-          // @ts-expect-error
-          isESMPluginDefinition(p) && 'esmUrl' in p && p.esmUrl === pp.esmUrl,
-      )
-    }
-    if (isCJSPluginDefinition(p)) {
-      return storePlugins.plugins.some(
-        // @ts-expect-error
-        pp => isCJSPluginDefinition(p) && p.cjsUrl === pp.cjsUrl,
-      )
-    }
-    return false
-  })
-}
+export { checkPlugins, fetchPlugins } from './checkPlugins'
 
 export function removeAttr(obj: Record<string, unknown>, attr: string) {
   for (const prop in obj) {


### PR DESCRIPTION
This avoids popping up the 'Are you sure you want to load...' when getting a cross origin config

## Context

used for synteny viewer page effort, which is currently loading a cross origin config (config generated dynamically by aws lambda). that's not a hard requirement, it might work best if it was 