### PR TITLE
Fix issue where multiple sub-menus could open up at once

### DIFF
--- a/packages/core/ui/CascadingMenu.tsx
+++ b/packages/core/ui/CascadingMenu.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
-import type React from 'react'
-import { useContext, useId, useState } from 'react'
+import { useState } from 'react'
 
 import ChevronRight from '@mui/icons-material/ChevronRight'
 import {
@@ -20,14 +19,7 @@ import {
   MenuItemEndDecoration,
 } from './MenuItems'
 import { bindMenu } from './hooks'
-import {
-  CascadingContext,
-  useAsyncMenuItems,
-  useCascadingContext,
-  useCloseSubmenu,
-  useSubmenuContext,
-  useSubmenuState,
-} from './menuHooks'
+import { useAsyncMenuItems } from './menuHooks'
 
 import type {
   CheckboxMenuItem,
@@ -37,101 +29,10 @@ import type {
   RadioMenuItem,
 } from './MenuTypes'
 import type { PopupState } from './hooks'
-import type { PopoverOrigin, SvgIconProps } from '@mui/material'
+import type { SvgIconProps } from '@mui/material'
 
 export type { MenuItemsGetter } from './MenuTypes'
 type ActionableMenuItem = NormalMenuItem | CheckboxMenuItem | RadioMenuItem
-
-function HelpIconSpacer() {
-  return (
-    <div
-      style={{
-        marginLeft: 4,
-        padding: 4,
-        width: 28,
-        height: 28,
-      }}
-    />
-  )
-}
-
-function CascadingSpacer() {
-  return <div style={{ flexGrow: 1, minWidth: 10 }} />
-}
-
-function EndDecoration({ item }: { item: JBMenuItem }) {
-  if ('subMenu' in item) {
-    return <MenuItemEndDecoration type="subMenu" />
-  }
-  if (item.type === 'checkbox' || item.type === 'radio') {
-    return (
-      <MenuItemEndDecoration
-        type={item.type}
-        checked={item.checked}
-        disabled={item.disabled}
-      />
-    )
-  }
-  return null
-}
-
-function HelpButton({
-  item,
-  showSpacer,
-}: {
-  item: JBMenuItem
-  showSpacer: boolean
-}) {
-  const helpText = 'helpText' in item ? item.helpText : undefined
-  const isCheckOrRadio = item.type === 'checkbox' || item.type === 'radio'
-
-  if (helpText) {
-    return (
-      <CascadingMenuHelpIconButton
-        helpText={helpText}
-        label={'label' in item ? item.label : undefined}
-      />
-    )
-  }
-  if (isCheckOrRadio && showSpacer) {
-    return <HelpIconSpacer />
-  }
-  return null
-}
-
-function CascadingMenuItem({
-  onClick,
-  closeAfterItemClick,
-  children,
-  ...props
-}: {
-  closeAfterItemClick: boolean
-  onClick?: (event: React.MouseEvent<HTMLLIElement>) => void
-  disabled?: boolean
-  children: React.ReactNode
-}) {
-  const { rootPopupState } = useContext(CascadingContext)
-  const closeSubmenu = useCloseSubmenu()
-
-  if (!rootPopupState) {
-    throw new Error('must be used inside a CascadingMenu')
-  }
-
-  return (
-    <MenuItem
-      {...props}
-      onClick={event => {
-        if (closeAfterItemClick) {
-          rootPopupState.close()
-        }
-        onClick?.(event)
-      }}
-      onMouseOver={closeSubmenu}
-    >
-      {children}
-    </MenuItem>
-  )
-}
 
 function CascadingSubmenu({
   title,
@@ -140,6 +41,10 @@ function CascadingSubmenu({
   menuItems,
   onMenuItemClick,
   closeAfterItemClick,
+  onCloseRoot,
+  isOpen,
+  onOpen,
+  onClose,
 }: {
   title: React.ReactNode
   onMenuItemClick: Function
@@ -147,14 +52,16 @@ function CascadingSubmenu({
   inset: boolean
   menuItems: JBMenuItem[]
   closeAfterItemClick: boolean
+  onCloseRoot: () => void
+  isOpen: boolean
+  onOpen: () => void
+  onClose: () => void
 }) {
-  const submenuId = useId()
-  const { isOpen, open, close } = useSubmenuState(submenuId)
   const [anchorEl, setAnchorEl] = useState<HTMLLIElement | null>(null)
 
   return (
     <>
-      <MenuItem ref={setAnchorEl} onMouseOver={open} onFocus={open}>
+      <MenuItem ref={setAnchorEl} onMouseOver={onOpen} onFocus={onOpen}>
         {Icon ? (
           <ListItemIcon>
             <Icon />
@@ -163,113 +70,21 @@ function CascadingSubmenu({
         <ListItemText primary={title} inset={inset} />
         <ChevronRight />
       </MenuItem>
-      <CascadingSubmenuHover
+      <HoverMenu
+        open={isOpen}
+        anchorEl={anchorEl}
+        onClose={onClose}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-        isOpen={isOpen}
-        anchorEl={anchorEl}
-        onClose={close}
       >
         <CascadingMenuList
           closeAfterItemClick={closeAfterItemClick}
           onMenuItemClick={onMenuItemClick}
           menuItems={menuItems}
+          onCloseRoot={onCloseRoot}
         />
-      </CascadingSubmenuHover>
-    </>
-  )
-}
-
-function ActionMenuItem({
-  item,
-  hasIcon,
-  hasCheckboxOrRadioWithHelp,
-  closeAfterItemClick,
-  onMenuItemClick,
-}: {
-  item: ActionableMenuItem
-  hasIcon: boolean
-  hasCheckboxOrRadioWithHelp: boolean
-  closeAfterItemClick: boolean
-  onMenuItemClick: Function
-}) {
-  return (
-    <CascadingMenuItem
-      closeAfterItemClick={closeAfterItemClick}
-      onClick={event => onMenuItemClick(event, item.onClick)}
-      disabled={Boolean(item.disabled)}
-    >
-      {item.icon ? (
-        <ListItemIcon>
-          <item.icon />
-        </ListItemIcon>
-      ) : null}
-      <ListItemText
-        primary={item.label}
-        secondary={item.subLabel}
-        inset={hasIcon && !item.icon}
-      />
-      <CascadingSpacer />
-      <EndDecoration item={item} />
-      <HelpButton item={item} showSpacer={hasCheckboxOrRadioWithHelp} />
-    </CascadingMenuItem>
-  )
-}
-
-function CascadingSubmenuHover({
-  isOpen,
-  anchorEl,
-  onClose,
-  children,
-  anchorOrigin,
-  transformOrigin,
-}: {
-  isOpen: boolean
-  anchorEl: Element | null
-  onClose: () => void
-  anchorOrigin: PopoverOrigin
-  transformOrigin: PopoverOrigin
-  children: React.ReactNode
-}) {
-  const context = useSubmenuContext()
-
-  return (
-    <CascadingContext.Provider value={context}>
-      <HoverMenu
-        open={isOpen}
-        anchorEl={anchorEl}
-        onClose={onClose}
-        anchorOrigin={anchorOrigin}
-        transformOrigin={transformOrigin}
-      >
-        {children}
       </HoverMenu>
-    </CascadingContext.Provider>
-  )
-}
-
-function CascadingMenu({
-  popupState,
-  children,
-}: {
-  popupState: PopupState
-  children?: React.ReactNode
-}) {
-  const context = useCascadingContext(popupState)
-  const { anchorEl, onClose, ...menuProps } = bindMenu(popupState)
-
-  return (
-    <CascadingContext.Provider value={context}>
-      <Menu
-        {...menuProps}
-        anchorEl={anchorEl ?? null}
-        onClose={() => {
-          onClose()
-        }}
-      >
-        {children}
-      </Menu>
-    </CascadingContext.Provider>
+    </>
   )
 }
 
@@ -277,11 +92,18 @@ function CascadingMenuList({
   onMenuItemClick,
   closeAfterItemClick,
   menuItems,
+  onCloseRoot,
 }: {
   menuItems: JBMenuItem[]
   closeAfterItemClick: boolean
   onMenuItemClick: Function
+  onCloseRoot: () => void
 }) {
+  const [openSubmenuIdx, setOpenSubmenuIdx] = useState<number | undefined>()
+  const closeSubmenu = () => {
+    setOpenSubmenuIdx(undefined)
+  }
+
   const hasIcon = menuItems.some(m => 'icon' in m && m.icon)
   const hasCheckboxOrRadioWithHelp = menuItems.some(
     m =>
@@ -307,16 +129,17 @@ function CascadingMenuList({
               onMenuItemClick={onMenuItemClick}
               menuItems={item.subMenu}
               closeAfterItemClick={closeAfterItemClick}
+              onCloseRoot={onCloseRoot}
+              isOpen={openSubmenuIdx === idx}
+              onOpen={() => {
+                setOpenSubmenuIdx(idx)
+              }}
+              onClose={closeSubmenu}
             />
           )
         }
         if (item.type === 'divider') {
-          return (
-            <Divider
-              key={`divider-${JSON.stringify(item)}-${idx}`}
-              component="li"
-            />
-          )
+          return <Divider key={`divider-${idx}`} component="li" />
         }
         if (item.type === 'subHeader') {
           return (
@@ -325,49 +148,92 @@ function CascadingMenuList({
             </ListSubheader>
           )
         }
+
         const actionItem = item as ActionableMenuItem
+        const helpText = actionItem.helpText
+        const isCheckOrRadio =
+          actionItem.type === 'checkbox' || actionItem.type === 'radio'
+
         return (
-          <ActionMenuItem
+          <MenuItem
             key={`${actionItem.label}-${idx}`}
-            item={actionItem}
-            hasIcon={hasIcon}
-            hasCheckboxOrRadioWithHelp={hasCheckboxOrRadioWithHelp}
-            closeAfterItemClick={closeAfterItemClick}
-            onMenuItemClick={onMenuItemClick}
-          />
+            disabled={Boolean(actionItem.disabled)}
+            onClick={event => {
+              if (closeAfterItemClick) {
+                onCloseRoot()
+              }
+              onMenuItemClick(event, actionItem.onClick)
+            }}
+            onMouseOver={closeSubmenu}
+          >
+            {actionItem.icon ? (
+              <ListItemIcon>
+                <actionItem.icon />
+              </ListItemIcon>
+            ) : null}
+            <ListItemText
+              primary={actionItem.label}
+              secondary={actionItem.subLabel}
+              inset={hasIcon && !actionItem.icon}
+            />
+            <div style={{ flexGrow: 1, minWidth: 10 }} />
+            {isCheckOrRadio ? (
+              <MenuItemEndDecoration
+                type={actionItem.type}
+                checked={actionItem.checked}
+                disabled={actionItem.disabled}
+              />
+            ) : null}
+            {helpText ? (
+              <CascadingMenuHelpIconButton
+                helpText={helpText}
+                label={actionItem.label}
+              />
+            ) : isCheckOrRadio && hasCheckboxOrRadioWithHelp ? (
+              <div
+                style={{ marginLeft: 4, padding: 4, width: 28, height: 28 }}
+              />
+            ) : null}
+          </MenuItem>
         )
       })}
     </>
   )
 }
 
-function CascadingMenuChildren(props: {
+export default function CascadingMenuChildren(props: {
   onMenuItemClick: Function
   closeAfterItemClick?: boolean
   menuItems: MenuItemsGetter
   popupState: PopupState
 }) {
-  const { closeAfterItemClick = true, menuItems, popupState, ...rest } = props
+  const { closeAfterItemClick = true, menuItems, popupState } = props
   const { items, loading, error } = useAsyncMenuItems(
     menuItems,
     popupState.isOpen,
   )
+  const { anchorEl, onClose, ...menuProps } = bindMenu(popupState)
 
   return (
-    <CascadingMenu {...rest} popupState={popupState}>
+    <Menu
+      {...menuProps}
+      anchorEl={anchorEl ?? null}
+      onClose={() => {
+        onClose()
+      }}
+    >
       {loading ? (
         <LoadingMenuItem />
       ) : error ? (
         <ErrorMenuItem error={error} />
       ) : (
         <CascadingMenuList
-          {...rest}
           menuItems={items}
           closeAfterItemClick={closeAfterItemClick}
+          onMenuItemClick={props.onMenuItemClick}
+          onCloseRoot={onClose}
         />
       )}
-    </CascadingMenu>
+    </Menu>
   )
 }
-
-export default CascadingMenuChildren

--- a/packages/core/ui/Menu.tsx
+++ b/packages/core/ui/Menu.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { makeStyles } from '@jbrowse/core/util/tss-react'
 import {
@@ -22,11 +22,7 @@ import { useAsyncMenuItems } from './menuHooks'
 import { findLastIndex } from '../util'
 
 import type { MenuItem, MenuItemsGetter } from './MenuTypes'
-import type {
-  MenuItemProps,
-  MenuProps as MUIMenuProps,
-  PopoverProps,
-} from '@mui/material'
+import type { MenuProps as MUIMenuProps, PopoverProps } from '@mui/material'
 
 export type {
   BaseMenuItem,
@@ -56,23 +52,17 @@ const useStyles = makeStyles()({
   },
 })
 
-type AnchorElProp = MUIMenuProps['anchorEl']
-type OpenProp = MUIMenuProps['open']
-type OnCloseProp = MUIMenuProps['onClose']
-
 interface MenuPageProps {
   menuItems: MenuItem[]
   onMenuItemClick: (
     event: React.MouseEvent<HTMLLIElement>,
     callback: (...args: any[]) => void,
   ) => void
-  anchorEl?: AnchorElProp
-  open: OpenProp
-  onClose: OnCloseProp
+  anchorEl?: MUIMenuProps['anchorEl']
+  open: MUIMenuProps['open']
+  onClose: MUIMenuProps['onClose']
   top?: boolean
 }
-
-type MenuItemStyleProp = MenuItemProps['style']
 
 function checkIfValid(m: MenuItem) {
   return m.type !== 'divider' && m.type !== 'subHeader' && !m.disabled
@@ -90,220 +80,181 @@ function findPreviousValidIdx(menuItems: MenuItem[], currentIdx: number) {
   return findLastIndex(menuItems.slice(0, currentIdx), checkIfValid)
 }
 
-const MenuPage = forwardRef<HTMLDivElement, MenuPageProps>(
-  function MenuPage2(props, ref) {
-    const [subMenuAnchorEl, setSubMenuAnchorEl] = useState<HTMLElement>()
-    const [openSubMenuIdx, setOpenSubMenuIdx] = useState<number>()
-    const [isSubMenuOpen, setIsSubMenuOpen] = useState(false)
-    const [selectedMenuItemIdx, setSelectedMenuItemIdx] = useState<number>()
-    const paperRef = useRef<HTMLDivElement | null>(null)
-    const { classes } = useStyles()
+function MenuPage({
+  menuItems,
+  onMenuItemClick,
+  open,
+  onClose,
+  anchorEl,
+  top = false,
+}: MenuPageProps) {
+  const [subMenuAnchorEl, setSubMenuAnchorEl] = useState<HTMLElement>()
+  const [openSubMenuIdx, setOpenSubMenuIdx] = useState<number>()
+  const [isSubMenuOpen, setIsSubMenuOpen] = useState(false)
+  const [selectedMenuItemIdx, setSelectedMenuItemIdx] = useState<number>()
+  const { classes } = useStyles()
 
-    const {
-      menuItems,
-      onMenuItemClick,
-      open,
-      onClose,
-      anchorEl,
-      top = false,
-    } = props
+  // Derive effective submenu state - when menu is closed, submenu is also closed
+  const effectiveSubMenuAnchorEl = open ? subMenuAnchorEl : undefined
+  const effectiveOpenSubMenuIdx = open ? openSubMenuIdx : undefined
 
-    // Derive effective submenu state - when menu is closed, submenu is also closed
-    const effectiveSubMenuAnchorEl = open ? subMenuAnchorEl : undefined
-    const effectiveOpenSubMenuIdx = open ? openSubMenuIdx : undefined
-
-    useEffect(() => {
-      const shouldSubMenuBeOpen = open && Boolean(effectiveSubMenuAnchorEl)
-      let timer: ReturnType<typeof setTimeout>
-      if (shouldSubMenuBeOpen && !isSubMenuOpen) {
-        timer = setTimeout(() => {
-          setIsSubMenuOpen(true)
-        }, 300)
-      } else if (!shouldSubMenuBeOpen && isSubMenuOpen) {
-        timer = setTimeout(() => {
-          setIsSubMenuOpen(false)
-        }, 300)
-      }
-      return () => {
-        clearTimeout(timer)
-      }
-    }, [isSubMenuOpen, open, effectiveSubMenuAnchorEl])
-
-    const position = useMemo(() => {
-      if (anchorEl) {
-        const rect = (anchorEl as HTMLElement).getBoundingClientRect()
-        return { top: rect.top, left: rect.left + rect.width }
-      }
-      return {}
-    }, [anchorEl])
-
-    const hasIcon = menuItems.some(
-      menuItem => 'icon' in menuItem && menuItem.icon,
-    )
-    const menuItemStyle: MenuItemStyleProp = {}
-
-    function handleClick(callback: (...args: any[]) => void) {
-      return (event: React.MouseEvent<HTMLLIElement>) => {
-        onMenuItemClick(event, callback)
-      }
+  useEffect(() => {
+    const shouldSubMenuBeOpen = open && Boolean(effectiveSubMenuAnchorEl)
+    let timer: ReturnType<typeof setTimeout>
+    if (shouldSubMenuBeOpen && !isSubMenuOpen) {
+      timer = setTimeout(() => {
+        setIsSubMenuOpen(true)
+      }, 300)
+    } else if (!shouldSubMenuBeOpen && isSubMenuOpen) {
+      timer = setTimeout(() => {
+        setIsSubMenuOpen(false)
+      }, 300)
     }
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [isSubMenuOpen, open, effectiveSubMenuAnchorEl])
 
-    const ListContents = (
-      <>
-        <MenuList autoFocusItem={open && !isSubMenuOpen} dense>
-          {menuItems
-            .toSorted((a, b) => (b.priority || 0) - (a.priority || 0))
-            .map((menuItem, idx) => {
-              if (menuItem.type === 'divider') {
-                return (
-                  <Divider
-                    key={`divider-${JSON.stringify(menuItem)}-${idx}`}
-                    component="li"
-                  />
-                )
-              }
-              if (menuItem.type === 'subHeader') {
-                return (
-                  <ListSubheader key={`subHeader-${menuItem.label}-${idx}`}>
-                    {menuItem.label}
-                  </ListSubheader>
-                )
-              }
-              let icon = null
-              let endDecoration = null
-              if (menuItem.icon) {
-                const Icon = menuItem.icon
-                icon = (
+  const position = useMemo(() => {
+    if (anchorEl) {
+      const rect = (anchorEl as HTMLElement).getBoundingClientRect()
+      return { top: rect.top, left: rect.left + rect.width }
+    }
+    return {}
+  }, [anchorEl])
+
+  const hasIcon = menuItems.some(
+    menuItem => 'icon' in menuItem && menuItem.icon,
+  )
+
+  const ListContents = (
+    <>
+      <MenuList autoFocusItem={open && !isSubMenuOpen} dense>
+        {menuItems
+          .toSorted((a, b) => (b.priority || 0) - (a.priority || 0))
+          .map((menuItem, idx) => {
+            if (menuItem.type === 'divider') {
+              return <Divider key={`divider-${idx}`} component="li" />
+            }
+            if (menuItem.type === 'subHeader') {
+              return (
+                <ListSubheader key={`subHeader-${menuItem.label}-${idx}`}>
+                  {menuItem.label}
+                </ListSubheader>
+              )
+            }
+            const isCheckOrRadio =
+              menuItem.type === 'checkbox' || menuItem.type === 'radio'
+            const hasSubMenu = 'subMenu' in menuItem
+
+            return (
+              <MUIMenuItem
+                key={menuItem.id || String(menuItem.label)}
+                selected={idx === selectedMenuItemIdx}
+                onClick={
+                  'onClick' in menuItem
+                    ? e => {
+                        onMenuItemClick(e, menuItem.onClick)
+                      }
+                    : undefined
+                }
+                onMouseMove={e => {
+                  if (e.currentTarget !== document.activeElement) {
+                    e.currentTarget.focus()
+                    setSelectedMenuItemIdx(idx)
+                  }
+                  if (hasSubMenu) {
+                    if (effectiveOpenSubMenuIdx !== idx) {
+                      setSubMenuAnchorEl(e.currentTarget)
+                      setOpenSubMenuIdx(idx)
+                    }
+                  } else {
+                    setSubMenuAnchorEl(undefined)
+                    setOpenSubMenuIdx(undefined)
+                  }
+                }}
+                onKeyDown={e => {
+                  switch (e.key) {
+                    case 'ArrowLeft':
+                    case 'Escape': {
+                      onClose?.(e, 'escapeKeyDown')
+                      break
+                    }
+                    case 'ArrowUp': {
+                      setSelectedMenuItemIdx(
+                        findPreviousValidIdx(menuItems, idx),
+                      )
+                      break
+                    }
+                    case 'ArrowDown': {
+                      setSelectedMenuItemIdx(findNextValidIdx(menuItems, idx))
+                      break
+                    }
+                    default: {
+                      if (
+                        hasSubMenu &&
+                        (e.key === 'ArrowRight' || e.key === 'Enter')
+                      ) {
+                        setSubMenuAnchorEl(e.currentTarget)
+                        setOpenSubMenuIdx(idx)
+                        setIsSubMenuOpen(true)
+                      }
+                    }
+                  }
+                }}
+                disabled={Boolean(menuItem.disabled)}
+              >
+                {menuItem.icon ? (
                   <ListItemIcon>
-                    <Icon />
+                    <menuItem.icon />
                   </ListItemIcon>
-                )
-              }
-              if ('subMenu' in menuItem) {
-                endDecoration = <MenuItemEndDecoration type="subMenu" />
-              } else if (
-                menuItem.type === 'checkbox' ||
-                menuItem.type === 'radio'
-              ) {
-                endDecoration = (
+                ) : null}
+                <ListItemText
+                  primary={menuItem.label}
+                  secondary={menuItem.subLabel}
+                  inset={hasIcon && !menuItem.icon}
+                />
+                {hasSubMenu ? (
+                  <MenuItemEndDecoration type="subMenu" />
+                ) : isCheckOrRadio ? (
                   <MenuItemEndDecoration
                     type={menuItem.type}
                     checked={menuItem.checked}
                     disabled={menuItem.disabled}
                   />
-                )
-              }
-              const onClick =
-                'onClick' in menuItem
-                  ? handleClick(menuItem.onClick)
-                  : undefined
-              return (
-                <MUIMenuItem
-                  key={menuItem.id || String(menuItem.label)}
-                  style={menuItemStyle}
-                  selected={idx === selectedMenuItemIdx}
-                  onClick={onClick}
-                  onMouseMove={e => {
-                    if (e.currentTarget !== document.activeElement) {
-                      e.currentTarget.focus()
-                      setSelectedMenuItemIdx(idx)
-                    }
-                    if ('subMenu' in menuItem) {
-                      if (effectiveOpenSubMenuIdx !== idx) {
-                        setSubMenuAnchorEl(e.currentTarget)
-                        setOpenSubMenuIdx(idx)
-                      }
-                    } else {
-                      setSubMenuAnchorEl(undefined)
-                      setOpenSubMenuIdx(undefined)
-                    }
-                  }}
-                  onKeyDown={e => {
-                    switch (e.key) {
-                      case 'ArrowLeft':
-                      case 'Escape': {
-                        onClose?.(e, 'escapeKeyDown')
-                        break
-                      }
-                      case 'ArrowUp': {
-                        setSelectedMenuItemIdx(
-                          findPreviousValidIdx(menuItems, idx),
-                        )
-                        break
-                      }
-                      case 'ArrowDown': {
-                        const a = findNextValidIdx(menuItems, idx)
-                        setSelectedMenuItemIdx(a)
-                        break
-                      }
-                      default: {
-                        if (
-                          'subMenu' in menuItem &&
-                          (e.key === 'ArrowRight' || e.key === 'Enter')
-                        ) {
-                          setSubMenuAnchorEl(e.currentTarget)
-                          setOpenSubMenuIdx(idx)
-                          setIsSubMenuOpen(true)
-                        }
-                      }
-                    }
-                  }}
-                  disabled={Boolean(menuItem.disabled)}
-                >
-                  {icon}
-                  <ListItemText
-                    primary={menuItem.label}
-                    secondary={menuItem.subLabel}
-                    inset={hasIcon && !menuItem.icon}
-                  />
-                  {endDecoration}
-                </MUIMenuItem>
-              )
-            })}
-        </MenuList>
-        {menuItems.map((menuItem, idx) => {
-          let subMenu = null
-          if ('subMenu' in menuItem) {
-            subMenu = (
-              <MenuPage
-                key={menuItem.id || String(menuItem.label)}
-                anchorEl={effectiveSubMenuAnchorEl}
-                open={isSubMenuOpen && effectiveOpenSubMenuIdx === idx}
-                onClose={() => {
-                  setIsSubMenuOpen(false)
-                  setSubMenuAnchorEl(undefined)
-                }}
-                onMenuItemClick={onMenuItemClick}
-                menuItems={menuItem.subMenu}
-              />
+                ) : null}
+              </MUIMenuItem>
             )
-          }
-          return subMenu
-        })}
-      </>
-    )
+          })}
+      </MenuList>
+      {menuItems.map((menuItem, idx) =>
+        'subMenu' in menuItem ? (
+          <MenuPage
+            key={menuItem.id || String(menuItem.label)}
+            anchorEl={effectiveSubMenuAnchorEl}
+            open={isSubMenuOpen && effectiveOpenSubMenuIdx === idx}
+            onClose={() => {
+              setIsSubMenuOpen(false)
+              setSubMenuAnchorEl(undefined)
+            }}
+            onMenuItemClick={onMenuItemClick}
+            menuItems={menuItem.subMenu}
+          />
+        ) : null,
+      )}
+    </>
+  )
 
-    return top ? (
-      ListContents
-    ) : (
-      <Grow
-        in={open}
-        style={{ transformOrigin: '0 0 0' }}
-        timeout={100}
-        ref={ref}
-      >
-        <Paper
-          elevation={8}
-          ref={paperRef}
-          className={classes.paper}
-          style={{ ...position }}
-        >
-          {ListContents}
-        </Paper>
-      </Grow>
-    )
-  },
-)
+  return top ? (
+    ListContents
+  ) : (
+    <Grow in={open} style={{ transformOrigin: '0 0 0' }} timeout={100}>
+      <Paper elevation={8} className={classes.paper} style={position}>
+        {ListContents}
+      </Paper>
+    </Grow>
+  )
+}
 
 export interface MenuProps extends PopoverProps {
   menuItems: MenuItemsGetter

--- a/packages/core/ui/menuHooks.tsx
+++ b/packages/core/ui/menuHooks.tsx
@@ -1,14 +1,6 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useEffect, useState } from 'react'
 
 import type { MenuItem, MenuItemsGetter } from './MenuTypes'
-import type { PopupState } from './hooks'
 
 export function useAsyncMenuItems(
   menuItems: MenuItemsGetter,
@@ -67,68 +59,4 @@ export function useAsyncMenuItems(
 
   const loading = asyncState.fetchedFor !== menuItems
   return { items: asyncState.items, loading, error: asyncState.error }
-}
-
-// Cascading menu specific context and hooks
-
-export const CascadingContext = createContext({
-  rootPopupState: undefined as PopupState | undefined,
-  openSubmenuId: undefined as string | undefined,
-  setOpenSubmenuId: (() => {}) as (id: string | undefined) => void,
-})
-
-export function useCascadingContext(rootPopupState: PopupState) {
-  const [openSubmenuId, setOpenSubmenuId] = useState<string | undefined>()
-
-  return useMemo(
-    () => ({
-      rootPopupState,
-      openSubmenuId,
-      setOpenSubmenuId,
-    }),
-    [rootPopupState, openSubmenuId],
-  )
-}
-
-export function useSubmenuContext() {
-  const { rootPopupState } = useContext(CascadingContext)
-  const [openSubmenuId, setOpenSubmenuId] = useState<string | undefined>()
-
-  return useMemo(
-    () => ({
-      rootPopupState,
-      openSubmenuId,
-      setOpenSubmenuId,
-    }),
-    [rootPopupState, openSubmenuId],
-  )
-}
-
-export function useSubmenuState(submenuId: string) {
-  const { openSubmenuId, setOpenSubmenuId, rootPopupState } =
-    useContext(CascadingContext)
-  const isOpen = openSubmenuId === submenuId
-
-  const open = useCallback(() => {
-    setOpenSubmenuId(submenuId)
-  }, [setOpenSubmenuId, submenuId])
-
-  const close = useCallback(() => {
-    if (openSubmenuId === submenuId) {
-      setOpenSubmenuId(undefined)
-    }
-  }, [openSubmenuId, setOpenSubmenuId, submenuId])
-
-  const closeAll = useCallback(() => {
-    rootPopupState?.close()
-  }, [rootPopupState])
-
-  return { isOpen, open, close, closeAll }
-}
-
-export function useCloseSubmenu() {
-  const { setOpenSubmenuId } = useContext(CascadingContext)
-  return useCallback(() => {
-    setOpenSubmenuId(undefined)
-  }, [setOpenSubmenuId])
 }


### PR DESCRIPTION
I was seeing issues with our dropdown menus sometimes having multiple submenus open at once. This was previously attempted to be solved here https://github.com/GMOD/jbrowse-components/pull/5111

I tried creating a new approach. 

I asked claude repeatedly to simplify the menu code, and finally, to remove the usage of 'React.Context' (context is always a tricky concept to me, it is a mechanism that can help pass state to sub-sub-sub children and avoid 'prop drilling' but i think it was un-needed here). It came up with a solution that is a single useState hook for submenu being opened. This worked well