### PR TITLE
Add general concept for showing legends on tracks

### DIFF
--- a/plugins/alignments/src/LinearAlignmentsDisplay/model.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/model.ts
@@ -1,6 +1,7 @@
 import { getConf } from '@jbrowse/core/configuration'
 import { BaseDisplay } from '@jbrowse/core/pluggableElementTypes/models'
 import { addDisposer, getSnapshot, types } from '@jbrowse/mobx-state-tree'
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import deepEqual from 'fast-deep-equal'
 import { autorun } from 'mobx'
 
@@ -55,6 +56,14 @@ function stateModelFactory(
       setSNPCoverageHeight(n: number) {
         self.snpCovHeight = n
       },
+
+      /**
+       * #action
+       * Toggle legend visibility on the PileupDisplay sub-display
+       */
+      setShowLegend(s: boolean) {
+        self.PileupDisplay?.setShowLegend(s)
+      },
     }))
     .views(self => ({
       /**
@@ -72,6 +81,14 @@ function stateModelFactory(
           self.PileupDisplay.featureIdUnderMouse ||
           self.SNPCoverageDisplay.featureIdUnderMouse
         )
+      },
+
+      /**
+       * #getter
+       * Returns true if PileupDisplay has legend shown
+       */
+      get showLegend() {
+        return self.PileupDisplay?.showLegend
       },
     }))
     .views(self => ({
@@ -302,27 +319,43 @@ function stateModelFactory(
             return []
           }
           const extra = getLowerPanelDisplays(pluginManager).map(d => ({
-            type: 'radio',
+            type: 'radio' as const,
             label: d.displayName,
             checked: d.name === self.PileupDisplay.type,
             onClick: () => {
               self.setLowerPanelType(d.name)
             },
           }))
+          const filterLegendItem = (items: MenuItem[]) =>
+            items.filter(
+              item => !('label' in item && item.label === 'Show legend'),
+            )
+
           return [
             ...superTrackMenuItems(),
             {
-              type: 'subMenu',
+              label: 'Show legend',
+              icon: FormatListBulletedIcon,
+              type: 'checkbox' as const,
+              checked: self.showLegend,
+              onClick: () => {
+                self.setShowLegend(!self.showLegend)
+              },
+            },
+            {
+              type: 'subMenu' as const,
               label: 'Pileup settings',
-              subMenu: self.PileupDisplay.trackMenuItems(),
+              subMenu: filterLegendItem(self.PileupDisplay.trackMenuItems()),
             },
             {
-              type: 'subMenu',
+              type: 'subMenu' as const,
               label: 'SNPCoverage settings',
-              subMenu: self.SNPCoverageDisplay.trackMenuItems(),
+              subMenu: filterLegendItem(
+                self.SNPCoverageDisplay.trackMenuItems(),
+              ),
             },
             {
-              type: 'subMenu',
+              type: 'subMenu' as const,
               label: 'Replace lower panel with...',
               subMenu: extra,
             },

--- a/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
+++ b/plugins/alignments/src/LinearPileupDisplay/SharedLinearPileupDisplayMixin.ts
@@ -19,10 +19,12 @@ import { cast, isAlive, types } from '@jbrowse/mobx-state-tree'
 import { BaseLinearDisplay } from '@jbrowse/plugin-linear-genome-view'
 import FilterListIcon from '@mui/icons-material/ClearAll'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import MenuOpenIcon from '@mui/icons-material/MenuOpen'
 import { observable } from 'mobx'
 
 import LinearPileupDisplayBlurb from './components/LinearPileupDisplayBlurb'
+import { getPileupLegendItems } from '../shared/legendUtils'
 
 import type { ColorBy, FilterBy } from '../shared/types'
 import type {
@@ -30,7 +32,11 @@ import type {
   AnyConfigurationSchemaType,
 } from '@jbrowse/core/configuration'
 import type { Feature, SimpleFeatureSerialized } from '@jbrowse/core/util'
-import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
+import type {
+  LegendItem,
+  LinearGenomeViewModel,
+} from '@jbrowse/plugin-linear-genome-view'
+import type { Theme } from '@mui/material'
 // lazies
 const FilterByTagDialog = lazy(
   () => import('../shared/components/FilterByTagDialog'),
@@ -345,6 +351,14 @@ export function SharedLinearPileupDisplayMixin(
       get filters() {
         return new SerializableFilterChain({ filters: self.jexlFilters })
       },
+
+      /**
+       * #method
+       * Returns legend items based on current colorBy setting
+       */
+      legendItems(theme?: Theme): LegendItem[] {
+        return getPileupLegendItems(self.colorBy, theme)
+      },
     }))
     .views(self => {
       const {
@@ -641,6 +655,15 @@ export function SharedLinearPileupDisplayMixin(
                     handleClose,
                   },
                 ])
+              },
+            },
+            {
+              label: 'Show legend',
+              icon: FormatListBulletedIcon,
+              type: 'checkbox',
+              checked: self.showLegend,
+              onClick: () => {
+                self.setShowLegend(!self.showLegend)
               },
             },
           ]

--- a/plugins/alignments/src/LinearReadArcsDisplay/components/LinearReadArcsReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/components/LinearReadArcsReactComponent.tsx
@@ -29,13 +29,15 @@ const Arcs = observer(function ({
 
   // note: the position absolute below avoids scrollbar from appearing on track
   return (
-    <canvas
-      data-testid="arc-canvas"
-      ref={cb}
-      style={{ width, height, position: 'absolute' }}
-      width={width * 2}
-      height={height * 2}
-    />
+    <div style={{ position: 'relative', width, height }}>
+      <canvas
+        data-testid="arc-canvas"
+        ref={cb}
+        style={{ width, height, position: 'absolute' }}
+        width={width * 2}
+        height={height * 2}
+      />
+    </div>
   )
 })
 

--- a/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/drawFeats.ts
@@ -2,6 +2,7 @@ import { getContainingView, getSession } from '@jbrowse/core/util'
 
 import { featurizeSA } from '../MismatchParser'
 import {
+  fillColor,
   getPairedInsertSizeAndOrientationColor,
   getPairedInsertSizeColor,
   getPairedOrientationColor,
@@ -104,7 +105,7 @@ export function drawFeats(
       }
 
       if (longRange && drawArcInsteadOfBezier) {
-        ctx.strokeStyle = 'red'
+        ctx.strokeStyle = fillColor.color_longinsert
       } else {
         if (hasPaired) {
           if (type === 'insertSizeAndOrientation') {
@@ -115,18 +116,20 @@ export function drawFeats(
           } else if (type === 'orientation') {
             ctx.strokeStyle = getPairedOrientationColor(k1)[0]
           } else if (type === 'insertSize') {
-            ctx.strokeStyle = getPairedInsertSizeColor(k1, stats)?.[0] || 'grey'
+            ctx.strokeStyle =
+              getPairedInsertSizeColor(k1, stats)?.[0] ||
+              fillColor.color_unknown
           } else if (type === 'gradient') {
             ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
           }
         } else {
           if (type === 'orientation' || type === 'insertSizeAndOrientation') {
             if (s1 === -1 && s2 === 1) {
-              ctx.strokeStyle = 'navy'
+              ctx.strokeStyle = fillColor.color_longread_rev_fwd
             } else if (s1 === 1 && s2 === -1) {
-              ctx.strokeStyle = 'green'
+              ctx.strokeStyle = fillColor.color_longread_fwd_rev
             } else {
-              ctx.strokeStyle = 'grey'
+              ctx.strokeStyle = fillColor.color_longread_same
             }
           } else if (type === 'gradient') {
             ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
@@ -140,8 +143,18 @@ export function drawFeats(
         // avoid drawing gigantic circles that glitch out the rendering,
         // instead draw vertical lines
         if (absrad > 100_000) {
-          drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
-          drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
+          drawLineAtOffset(
+            ctx,
+            p + jitter(jitterVal),
+            height,
+            fillColor.color_longinsert,
+          )
+          drawLineAtOffset(
+            ctx,
+            p2 + jitter(jitterVal),
+            height,
+            fillColor.color_longinsert,
+          )
         } else if (drawArcInsteadOfBezier) {
           ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
           ctx.stroke()
@@ -168,7 +181,12 @@ export function drawFeats(
         ctx.stroke()
       }
     } else if (r1 && drawInter) {
-      drawLineAtOffset(ctx, r1 - view.offsetPx, height, 'purple')
+      drawLineAtOffset(
+        ctx,
+        r1 - view.offsetPx,
+        height,
+        fillColor.color_interchrom,
+      )
     }
   }
 

--- a/plugins/alignments/src/LinearReadArcsDisplay/drawFeatsRPC.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/drawFeatsRPC.ts
@@ -2,6 +2,7 @@ import { forEachWithStopTokenCheck } from '@jbrowse/core/util'
 
 import { featurizeSA } from '../MismatchParser'
 import {
+  fillColor,
   getPairedInsertSizeAndOrientationColor,
   getPairedInsertSizeColor,
   getPairedOrientationColor,
@@ -106,7 +107,7 @@ export function drawFeatsRPC(params: DrawFeatsRPCParams) {
       }
 
       if (longRange && drawArcInsteadOfBezier) {
-        ctx.strokeStyle = 'red'
+        ctx.strokeStyle = fillColor.color_longinsert
       } else {
         if (hasPaired) {
           if (type === 'insertSizeAndOrientation') {
@@ -117,18 +118,20 @@ export function drawFeatsRPC(params: DrawFeatsRPCParams) {
           } else if (type === 'orientation') {
             ctx.strokeStyle = getPairedOrientationColor(k1)[0]
           } else if (type === 'insertSize') {
-            ctx.strokeStyle = getPairedInsertSizeColor(k1, stats)?.[0] || 'grey'
+            ctx.strokeStyle =
+              getPairedInsertSizeColor(k1, stats)?.[0] ||
+              fillColor.color_unknown
           } else if (type === 'gradient') {
             ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
           }
         } else {
           if (type === 'orientation' || type === 'insertSizeAndOrientation') {
             if (s1 === -1 && s2 === 1) {
-              ctx.strokeStyle = 'navy'
+              ctx.strokeStyle = fillColor.color_longread_rev_fwd
             } else if (s1 === 1 && s2 === -1) {
-              ctx.strokeStyle = 'green'
+              ctx.strokeStyle = fillColor.color_longread_fwd_rev
             } else {
-              ctx.strokeStyle = 'grey'
+              ctx.strokeStyle = fillColor.color_longread_same
             }
           } else if (type === 'gradient') {
             ctx.strokeStyle = `hsl(${Math.log10(absrad) * 10},50%,50%)`
@@ -142,8 +145,18 @@ export function drawFeatsRPC(params: DrawFeatsRPCParams) {
         // avoid drawing gigantic circles that glitch out the rendering,
         // instead draw vertical lines
         if (absrad > 100_000) {
-          drawLineAtOffset(ctx, p + jitter(jitterVal), height, 'red')
-          drawLineAtOffset(ctx, p2 + jitter(jitterVal), height, 'red')
+          drawLineAtOffset(
+            ctx,
+            p + jitter(jitterVal),
+            height,
+            fillColor.color_longinsert,
+          )
+          drawLineAtOffset(
+            ctx,
+            p2 + jitter(jitterVal),
+            height,
+            fillColor.color_longinsert,
+          )
         } else if (drawArcInsteadOfBezier) {
           ctx.arc(p + radius + jitter(jitterVal), 0, absrad, 0, Math.PI)
           ctx.stroke()
@@ -170,7 +183,7 @@ export function drawFeatsRPC(params: DrawFeatsRPCParams) {
         ctx.stroke()
       }
     } else if (r1 && drawInter) {
-      drawLineAtOffset(ctx, r1 - offsetPx, height, 'purple')
+      drawLineAtOffset(ctx, r1 - offsetPx, height, fillColor.color_interchrom)
     }
   }
 

--- a/plugins/alignments/src/LinearReadArcsDisplay/model.ts
+++ b/plugins/alignments/src/LinearReadArcsDisplay/model.ts
@@ -8,8 +8,10 @@ import {
   FeatureDensityMixin,
   TrackHeightMixin,
 } from '@jbrowse/plugin-linear-genome-view'
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 
 import { LinearReadDisplayBaseMixin } from '../shared/LinearReadDisplayBaseMixin'
+import { getReadArcsLegendItems } from '../shared/legendUtils'
 import {
   getColorSchemeMenuItem,
   getFilterByMenuItem,
@@ -18,7 +20,10 @@ import {
 import type { AnyConfigurationSchemaType } from '@jbrowse/core/configuration'
 import type { StopToken } from '@jbrowse/core/util/stopToken'
 import type { Instance } from '@jbrowse/mobx-state-tree'
-import type { ExportSvgDisplayOptions } from '@jbrowse/plugin-linear-genome-view'
+import type {
+  ExportSvgDisplayOptions,
+  LegendItem,
+} from '@jbrowse/plugin-linear-genome-view'
 
 /**
  * #stateModel LinearReadArcsDisplay
@@ -70,6 +75,11 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
          * Whether to draw long-range connections
          */
         drawLongRange: true,
+
+        /**
+         * #property
+         */
+        showLegend: types.maybe(types.boolean),
       }),
     )
     .volatile(() => ({
@@ -153,6 +163,22 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       setRenderingStopToken(token?: StopToken) {
         self.renderingStopToken = token
+      },
+
+      /**
+       * #action
+       */
+      setShowLegend(s: boolean) {
+        self.showLegend = s
+      },
+    }))
+    .views(self => ({
+      /**
+       * #method
+       * Returns legend items based on current colorBy setting
+       */
+      legendItems(): LegendItem[] {
+        return getReadArcsLegendItems(self.colorBy)
       },
     }))
     .views(self => ({
@@ -264,6 +290,15 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
               },
             },
             getColorSchemeMenuItem(self),
+            {
+              label: 'Show legend',
+              icon: FormatListBulletedIcon,
+              type: 'checkbox',
+              checked: self.showLegend,
+              onClick: () => {
+                self.setShowLegend(!self.showLegend)
+              },
+            },
           ]
         },
 

--- a/plugins/alignments/src/LinearReadCloudDisplay/model.ts
+++ b/plugins/alignments/src/LinearReadCloudDisplay/model.ts
@@ -14,14 +14,17 @@ import { types } from '@jbrowse/mobx-state-tree'
 import {
   type ExportSvgDisplayOptions,
   FeatureDensityMixin,
+  type LegendItem,
   TrackHeightMixin,
 } from '@jbrowse/plugin-linear-genome-view'
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 
 import { chainToSimpleFeature } from '../LinearReadArcsDisplay/chainToSimpleFeature'
 import { LinearReadDisplayBaseMixin } from '../shared/LinearReadDisplayBaseMixin'
 import { LinearReadDisplayWithLayoutMixin } from '../shared/LinearReadDisplayWithLayoutMixin'
 import { LinearReadDisplayWithPairFiltersMixin } from '../shared/LinearReadDisplayWithPairFiltersMixin'
 import { SharedModificationsMixin } from '../shared/SharedModificationsMixin'
+import { getReadCloudLegendItems } from '../shared/legendUtils'
 import {
   getColorSchemeMenuItem,
   getFilterByMenuItem,
@@ -81,6 +84,11 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
          * Maximum height for the layout (prevents infinite stacking)
          */
         trackMaxHeight: types.maybe(types.number),
+
+        /**
+         * #property
+         */
+        showLegend: types.maybe(types.boolean),
       }),
     )
     .volatile(() => ({
@@ -212,6 +220,22 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
       setRenderingStopToken(token?: StopToken) {
         self.renderingStopToken = token
       },
+
+      /**
+       * #action
+       */
+      setShowLegend(s: boolean) {
+        self.showLegend = s
+      },
+    }))
+    .views(self => ({
+      /**
+       * #method
+       * Returns legend items based on current colorBy setting
+       */
+      legendItems(): LegendItem[] {
+        return getReadCloudLegendItems(self.colorBy, self.visibleModifications)
+      },
     }))
     .views(self => {
       const {
@@ -325,6 +349,15 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
             },
             getFilterByMenuItem(self),
             getColorSchemeMenuItem(self),
+            {
+              label: 'Show legend',
+              icon: FormatListBulletedIcon,
+              type: 'checkbox',
+              checked: self.showLegend,
+              onClick: () => {
+                self.setShowLegend(!self.showLegend)
+              },
+            },
           ]
         },
 

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/model.ts
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/model.ts
@@ -12,10 +12,12 @@ import {
 } from '@jbrowse/mobx-state-tree'
 import { linearWiggleDisplayModelFactory } from '@jbrowse/plugin-wiggle'
 import FilterListIcon from '@mui/icons-material/FilterList'
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 
 import { SharedModificationsMixin } from '../shared/SharedModificationsMixin'
 import { getUniqueModifications } from '../shared/getUniqueModifications'
+import { getSNPCoverageLegendItems } from '../shared/legendUtils'
 import { createAutorun } from '../util'
 
 import type { ColorBy, FilterBy } from '../shared/types'
@@ -28,8 +30,10 @@ import type { Feature } from '@jbrowse/core/util'
 import type { Instance } from '@jbrowse/mobx-state-tree'
 import type {
   ExportSvgDisplayOptions,
+  LegendItem,
   LinearGenomeViewModel,
 } from '@jbrowse/plugin-linear-genome-view'
+import type { Theme } from '@mui/material'
 
 // lazies
 const Tooltip = lazy(() => import('./components/Tooltip'))
@@ -457,6 +461,15 @@ function stateModelFactory(
                 ])
               },
             },
+            {
+              label: 'Show legend',
+              icon: FormatListBulletedIcon,
+              type: 'checkbox',
+              checked: self.showLegend,
+              onClick: () => {
+                self.setShowLegend(!self.showLegend)
+              },
+            },
           ]
         },
 
@@ -465,6 +478,18 @@ function stateModelFactory(
          */
         get filters() {
           return new SerializableFilterChain({ filters: self.jexlFilters })
+        },
+
+        /**
+         * #method
+         * Returns legend items for SNP coverage display
+         */
+        legendItems(theme?: Theme): LegendItem[] {
+          return getSNPCoverageLegendItems(
+            self.colorBy,
+            self.visibleModifications,
+            theme,
+          )
         },
       }
     })

--- a/plugins/alignments/src/shared/color.ts
+++ b/plugins/alignments/src/shared/color.ts
@@ -43,6 +43,10 @@ export const fillColor = {
   color_shortinsert: 'pink',
   color_unmapped_mate: '#8B008B',
   color_unknown: 'grey',
+  // Long-read split alignment orientation colors
+  color_longread_rev_fwd: 'navy',
+  color_longread_fwd_rev: 'green',
+  color_longread_same: 'grey',
 }
 
 // manually calculated by running
@@ -70,6 +74,10 @@ export const strokeColor = {
   color_shortinsert: '#FF3A5C',
   color_unmapped_mate: '#5A005A',
   color_unknown: '#444',
+  // Long-read split alignment orientation stroke colors
+  color_longread_rev_fwd: '#00004D',
+  color_longread_fwd_rev: '#005A00',
+  color_longread_same: '#444',
 }
 
 const defaultColor = [

--- a/plugins/alignments/src/shared/legendUtils.ts
+++ b/plugins/alignments/src/shared/legendUtils.ts
@@ -1,0 +1,203 @@
+import { fillColor } from './color'
+
+import type { ColorBy, ModificationTypeWithColor } from './types'
+import type { Theme } from '@mui/material'
+
+export interface LegendItem {
+  color?: string
+  label: string
+}
+
+/**
+ * Get legend items for pileup display based on colorBy setting
+ */
+export function getPileupLegendItems(
+  colorBy: ColorBy | undefined,
+  theme?: Theme,
+): LegendItem[] {
+  const colorType = colorBy?.type
+
+  if (colorType === 'strand') {
+    return [
+      { color: fillColor.color_fwd_strand, label: 'Forward strand' },
+      { color: fillColor.color_rev_strand, label: 'Reverse strand' },
+    ]
+  }
+  if (colorType === 'stranded') {
+    return [
+      { color: fillColor.color_fwd_strand, label: 'First-of-pair forward' },
+      { color: fillColor.color_rev_strand, label: 'First-of-pair reverse' },
+    ]
+  }
+  if (colorType === 'insertSize') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+      { color: fillColor.color_unmapped_mate, label: 'Unmapped mate' },
+    ]
+  }
+  if (colorType === 'pairOrientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'LR (proper)' },
+      { color: fillColor.color_pair_rr, label: 'RR' },
+      { color: fillColor.color_pair_rl, label: 'RL' },
+      { color: fillColor.color_pair_ll, label: 'LL' },
+      { color: fillColor.color_unmapped_mate, label: 'Unmapped mate' },
+    ]
+  }
+  if (colorType === 'insertSizeAndPairOrientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal (LR)' },
+      { color: fillColor.color_pair_rr, label: 'RR orientation' },
+      { color: fillColor.color_pair_rl, label: 'RL orientation' },
+      { color: fillColor.color_pair_ll, label: 'LL orientation' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+      { color: fillColor.color_unmapped_mate, label: 'Unmapped mate' },
+    ]
+  }
+
+  // Default: show ACGT, insertion, deletion, hardclip, softclip
+  const bases = theme?.palette?.bases
+  const insertion = theme?.palette?.insertion
+  const deletion = theme?.palette?.deletion
+  const hardclip = theme?.palette?.hardclip
+  const softclip = theme?.palette?.softclip
+  return [
+    { color: bases?.A?.main, label: 'A' },
+    { color: bases?.C?.main, label: 'C' },
+    { color: bases?.G?.main, label: 'G' },
+    { color: bases?.T?.main, label: 'T' },
+    { color: insertion, label: 'Insertion' },
+    { color: deletion, label: 'Deletion' },
+    { color: hardclip, label: 'Hard clip' },
+    { color: softclip, label: 'Soft clip' },
+  ]
+}
+
+/**
+ * Get legend items for SNP coverage display based on colorBy setting
+ */
+export function getSNPCoverageLegendItems(
+  colorBy: ColorBy | undefined,
+  visibleModifications: Map<string, ModificationTypeWithColor>,
+  theme?: Theme,
+): LegendItem[] {
+  if (colorBy?.type === 'methylation') {
+    return [
+      { color: 'red', label: 'CpG methylated' },
+      { color: 'blue', label: 'CpG unmethylated' },
+    ]
+  }
+  if (colorBy?.type === 'modifications') {
+    const items: LegendItem[] = []
+    for (const [type, mod] of visibleModifications.entries()) {
+      items.push({
+        color: mod.color,
+        label: type,
+      })
+    }
+    return items
+  }
+
+  const bases = theme?.palette?.bases
+  const insertion = theme?.palette?.insertion
+  const deletion = theme?.palette?.deletion
+  return [
+    { color: bases?.A?.main, label: 'A' },
+    { color: bases?.C?.main, label: 'C' },
+    { color: bases?.G?.main, label: 'G' },
+    { color: bases?.T?.main, label: 'T' },
+    { color: insertion, label: 'Insertion' },
+    { color: deletion, label: 'Deletion' },
+  ]
+}
+
+/**
+ * Get legend items for read cloud/arcs display based on colorBy setting
+ */
+export function getReadCloudLegendItems(
+  colorBy: ColorBy | undefined,
+  visibleModifications?: Map<string, ModificationTypeWithColor>,
+): LegendItem[] {
+  const colorType = colorBy?.type
+
+  if (colorType === 'modifications' && visibleModifications) {
+    const items: LegendItem[] = []
+    for (const [type, mod] of visibleModifications.entries()) {
+      items.push({ color: mod.color, label: type })
+    }
+    return items
+  }
+  if (colorType === 'insertSizeAndOrientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal (LR)' },
+      { color: fillColor.color_pair_rr, label: 'RR orientation' },
+      { color: fillColor.color_pair_rl, label: 'RL orientation' },
+      { color: fillColor.color_pair_ll, label: 'LL orientation' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+    ]
+  }
+  if (colorType === 'insertSize') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+    ]
+  }
+  if (colorType === 'orientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'LR (proper)' },
+      { color: fillColor.color_pair_rr, label: 'RR' },
+      { color: fillColor.color_pair_rl, label: 'RL' },
+      { color: fillColor.color_pair_ll, label: 'LL' },
+    ]
+  }
+
+  return []
+}
+
+/**
+ * Get legend items for read arcs display based on colorBy setting
+ */
+export function getReadArcsLegendItems(
+  colorBy: ColorBy | undefined,
+): LegendItem[] {
+  const colorType = colorBy?.type
+
+  if (colorType === 'insertSizeAndOrientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal (LR)' },
+      { color: fillColor.color_pair_rr, label: 'RR orientation' },
+      { color: fillColor.color_pair_rl, label: 'RL orientation' },
+      { color: fillColor.color_pair_ll, label: 'LL orientation' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+    ]
+  }
+  if (colorType === 'insertSize') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'Normal' },
+      { color: fillColor.color_longinsert, label: 'Long insert' },
+      { color: fillColor.color_shortinsert, label: 'Short insert' },
+      { color: fillColor.color_interchrom, label: 'Inter-chromosomal' },
+    ]
+  }
+  if (colorType === 'orientation') {
+    return [
+      { color: fillColor.color_pair_lr, label: 'LR (proper)' },
+      { color: fillColor.color_pair_rr, label: 'RR' },
+      { color: fillColor.color_pair_rl, label: 'RL' },
+      { color: fillColor.color_pair_ll, label: 'LL' },
+    ]
+  }
+
+  return []
+}

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/SVGLegend.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/SVGLegend.tsx
@@ -1,0 +1,63 @@
+import type { LegendItem } from './components/FloatingLegend'
+
+export default function SVGLegend({
+  items,
+  width,
+}: {
+  items: LegendItem[]
+  width: number
+}) {
+  if (items.length === 0) {
+    return null
+  }
+
+  const boxSize = 12
+  const fontSize = 10
+  const padding = 3
+  const itemHeight = boxSize + 2
+  const legendHeight = items.length * itemHeight + padding * 2
+
+  // Calculate legend width based on longest label
+  const maxLabelWidth = Math.max(...items.map(item => item.label.length * 6))
+  const legendWidth = boxSize + 8 + maxLabelWidth + padding * 2
+
+  const x = width - legendWidth - 10
+  const y = 10
+
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <rect
+        x={0}
+        y={0}
+        width={legendWidth}
+        height={legendHeight}
+        fill="rgba(255,255,255,0.7)"
+        rx={4}
+      />
+      {items.map((item, idx) => (
+        <g
+          key={`legend-${idx}`}
+          transform={`translate(${padding}, ${padding + idx * itemHeight})`}
+        >
+          {item.color ? (
+            <rect
+              x={0}
+              y={0}
+              width={boxSize}
+              height={boxSize}
+              fill={item.color}
+            />
+          ) : null}
+          <text
+            x={boxSize + 6}
+            y={boxSize - 2}
+            fontSize={fontSize}
+            fill="black"
+          >
+            {item.label}
+          </text>
+        </g>
+      ))}
+    </g>
+  )
+}

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -2,8 +2,10 @@ import { Suspense, useRef, useState } from 'react'
 
 import { getConf } from '@jbrowse/core/configuration'
 import { makeStyles } from '@jbrowse/core/util/tss-react'
+import { useTheme } from '@mui/material'
 import { observer } from 'mobx-react'
 
+import FloatingLegend from './FloatingLegend'
 import LinearBlocks from './LinearBlocks'
 import MenuPage from './MenuPage'
 
@@ -31,7 +33,10 @@ const BaseLinearDisplay = observer(function (props: {
   const [clientMouseCoord, setClientMouseCoord] = useState<Coord>([0, 0])
   const [contextCoord, setContextCoord] = useState<Coord>()
   const { model, children } = props
-  const { TooltipComponent, DisplayMessageComponent, height } = model
+  const { TooltipComponent, DisplayMessageComponent, height, showLegend } =
+    model
+  const theme = useTheme()
+  const legendItems = model.legendItems(theme)
   return (
     <div
       ref={ref}
@@ -63,6 +68,10 @@ const BaseLinearDisplay = observer(function (props: {
         <LinearBlocks {...props} />
       )}
       {children}
+
+      {showLegend && legendItems.length > 0 ? (
+        <FloatingLegend items={legendItems} />
+      ) : null}
 
       <Suspense fallback={null}>
         <TooltipComponent

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/FloatingLegend.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/FloatingLegend.tsx
@@ -1,0 +1,68 @@
+import { makeStyles } from '@jbrowse/core/util/tss-react'
+import { observer } from 'mobx-react'
+
+const useStyles = makeStyles()({
+  legend: {
+    position: 'absolute',
+    right: 10,
+    top: 10,
+    background: 'rgba(255,255,255,0.4)',
+    padding: 3,
+    fontSize: 10,
+    pointerEvents: 'none',
+    zIndex: 100,
+    maxWidth: 200,
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: 1,
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  },
+  colorBox: {
+    width: 12,
+    height: 12,
+    marginRight: 6,
+    flexShrink: 0,
+  },
+  label: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+})
+
+export interface LegendItem {
+  color?: string
+  label: string
+}
+
+const FloatingLegend = observer(function FloatingLegend({
+  items,
+}: {
+  items: LegendItem[]
+}) {
+  const { classes } = useStyles()
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={classes.legend}>
+      {items.map((item, idx) => (
+        <div key={`${item.label}-${idx}`} className={classes.item}>
+          <div
+            className={classes.colorBox}
+            style={{ backgroundColor: item.color }}
+          />
+          <span className={classes.label}>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+})
+
+export default FloatingLegend

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/index.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/index.ts
@@ -5,6 +5,7 @@ export type {
   BaseLinearDisplayModel,
   BaseLinearDisplayStateModel,
   ExportSvgDisplayOptions,
+  LegendItem,
 } from './model'
 export {
   BlockMsg,

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/model.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/model.ts
@@ -30,11 +30,12 @@ import BlockState from './models/serverSideRenderedBlock'
 
 import type { LinearGenomeViewModel } from '../LinearGenomeView'
 import type { ExportSvgOptions } from '../LinearGenomeView/types'
+import type { LegendItem } from './components/FloatingLegend'
 import type { MenuItem } from '@jbrowse/core/ui'
 import type { AnyReactComponentType, Feature } from '@jbrowse/core/util'
 import type { BaseBlock } from '@jbrowse/core/util/blockTypes'
 import type { Instance } from '@jbrowse/mobx-state-tree'
-import type { ThemeOptions } from '@mui/material'
+import type { Theme, ThemeOptions } from '@mui/material'
 
 // lazies
 const Tooltip = lazy(() => import('./components/Tooltip'))
@@ -128,6 +129,10 @@ function stateModelFactory() {
          * #property
          */
         configuration: ConfigurationReference(configSchema),
+        /**
+         * #property
+         */
+        showLegend: types.maybe(types.boolean),
       }),
     )
     .volatile(() => ({
@@ -182,6 +187,15 @@ function stateModelFactory() {
        */
       get TooltipComponent(): AnyReactComponentType {
         return Tooltip as AnyReactComponentType
+      },
+
+      /**
+       * #method
+       * Override in subclasses to provide legend items for the display
+       * @param _theme - MUI theme for accessing palette colors
+       */
+      legendItems(_theme?: Theme): LegendItem[] {
+        return []
       },
 
       /**
@@ -367,6 +381,12 @@ function stateModelFactory() {
        */
       setMouseoverExtraInformation(extra?: string) {
         self.mouseoverExtraInformation = extra
+      },
+      /**
+       * #action
+       */
+      setShowLegend(s: boolean) {
+        self.showLegend = s
       },
     }))
 
@@ -588,3 +608,5 @@ export const BaseLinearDisplay = stateModelFactory()
 
 export type BaseLinearDisplayStateModel = typeof BaseLinearDisplay
 export type BaseLinearDisplayModel = Instance<BaseLinearDisplayStateModel>
+
+export { type LegendItem } from './components/FloatingLegend'

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/renderSvg.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/renderSvg.tsx
@@ -1,11 +1,13 @@
 import { Fragment } from 'react'
 
+import { createJBrowseTheme } from '@jbrowse/core/ui'
 import {
   ReactRendering,
   getContainingView,
   getSession,
 } from '@jbrowse/core/util'
 
+import SVGLegend from './SVGLegend'
 import BlockState, { renderBlockData } from './models/serverSideRenderedBlock'
 import { getId } from './models/util'
 import { ErrorBox } from '../LinearGenomeView/SVGErrorBox'
@@ -87,6 +89,10 @@ export async function renderBaseLinearDisplaySvg(
   // Create a clip path ID for the labels that covers the entire view
   const labelsClipId = getId(id, 'labels')
 
+  // Get legend items if legend is enabled
+  const theme = createJBrowseTheme(opts.theme)
+  const legendItems = self.showLegend ? self.legendItems(theme) : []
+
   return (
     <>
       {renderings.map(([block, rendering], index) => {
@@ -137,6 +143,9 @@ export async function renderBaseLinearDisplaySvg(
           </g>
         ))}
       </g>
+      {legendItems.length > 0 ? (
+        <SVGLegend items={legendItems} width={width} />
+      ) : null}
     </>
   )
 }

--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -79,6 +79,7 @@ export type {
   BaseLinearDisplayModel,
   BlockModel,
   ExportSvgDisplayOptions,
+  LegendItem,
 } from './BaseLinearDisplay'
 
 export {


### PR DESCRIPTION
This PR helps show a basic 'legend' floating top right on tracks. This helps make tracks easier to understand. The legend can be toggled on and off via the track menu and different track types can customize what is displayed in the legend. There may be cases where it is not possible to even do this in a reasonable way, but honestly, this is not super common