### PR TITLE
Add observer names to all functions

### DIFF
--- a/packages/app-core/src/ui/App/App.tsx
+++ b/packages/app-core/src/ui/App/App.tsx
@@ -52,7 +52,7 @@ interface Props {
   }
 }
 
-const LazyDrawerWidget = observer(function (props: Props) {
+const LazyDrawerWidget = observer(function LazyDrawerWidget(props: Props) {
   const { session } = props
   return (
     <Suspense fallback={null}>
@@ -61,7 +61,7 @@ const LazyDrawerWidget = observer(function (props: Props) {
   )
 })
 
-const App = observer(function (props: Props) {
+const App = observer(function App(props: Props) {
   const { session } = props
   const { classes } = useStyles()
   const { minimized, visibleWidget, drawerWidth, drawerPosition } = session

--- a/packages/app-core/src/ui/App/AppFab.tsx
+++ b/packages/app-core/src/ui/App/AppFab.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const AppFab = observer(function ({
+const AppFab = observer(function AppFab({
   session,
 }: {
   session: SessionWithDrawerWidgets

--- a/packages/app-core/src/ui/App/AppToolbar.tsx
+++ b/packages/app-core/src/ui/App/AppToolbar.tsx
@@ -39,7 +39,7 @@ type AppSession = SessionWithDrawerWidgets & {
   popSnackbarMessage: () => unknown
 }
 
-const AppToolbar = observer(function ({
+const AppToolbar = observer(function AppToolbar({
   session,
   HeaderButtons = <div />,
 }: {

--- a/packages/app-core/src/ui/App/DialogQueue.tsx
+++ b/packages/app-core/src/ui/App/DialogQueue.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import type { SessionWithDrawerWidgets } from '@jbrowse/core/util'
 
-const DialogQueue = observer(function ({
+const DialogQueue = observer(function DialogQueue({
   session,
 }: {
   session: SessionWithDrawerWidgets

--- a/packages/app-core/src/ui/App/Drawer.tsx
+++ b/packages/app-core/src/ui/App/Drawer.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Drawer = observer(function ({
+const Drawer = observer(function Drawer({
   children,
   session,
 }: {

--- a/packages/app-core/src/ui/App/DrawerControls.tsx
+++ b/packages/app-core/src/ui/App/DrawerControls.tsx
@@ -8,7 +8,7 @@ import { observer } from 'mobx-react'
 
 import type { SessionWithFocusedViewAndDrawerWidgets } from '@jbrowse/core/util/types'
 
-const DrawerControls = observer(function ({
+const DrawerControls = observer(function DrawerControls({
   session,
 }: {
   session: SessionWithFocusedViewAndDrawerWidgets

--- a/packages/app-core/src/ui/App/DrawerHeader.tsx
+++ b/packages/app-core/src/ui/App/DrawerHeader.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const DrawerHeader = observer(function ({
+const DrawerHeader = observer(function DrawerHeader({
   session,
   setToolbarHeight,
   onPopoutDrawer,

--- a/packages/app-core/src/ui/App/DrawerHeaderHelpButton.tsx
+++ b/packages/app-core/src/ui/App/DrawerHeaderHelpButton.tsx
@@ -8,7 +8,7 @@ import type { SessionWithFocusedViewAndDrawerWidgets } from '@jbrowse/core/util/
 
 const DrawerHeaderHelpDialog = lazy(() => import('./DrawerHeaderHelpDialog'))
 
-const DrawerHeaderHelpButton = observer(function ({
+const DrawerHeaderHelpButton = observer(function DrawerHeaderHelpButton({
   session,
   helpText,
 }: {

--- a/packages/app-core/src/ui/App/DrawerWidget.tsx
+++ b/packages/app-core/src/ui/App/DrawerWidget.tsx
@@ -12,7 +12,7 @@ import type { SessionWithFocusedViewAndDrawerWidgets } from '@jbrowse/core/util/
 
 const ModalWidget = lazy(() => import('./ModalWidget'))
 
-const DrawerWidget = observer(function ({
+const DrawerWidget = observer(function DrawerWidget({
   session,
 }: {
   session: SessionWithFocusedViewAndDrawerWidgets

--- a/packages/app-core/src/ui/App/DrawerWidgetSelector.tsx
+++ b/packages/app-core/src/ui/App/DrawerWidgetSelector.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const DrawerWidgetSelector = observer(function ({
+const DrawerWidgetSelector = observer(function DrawerWidgetSelector({
   session,
 }: {
   session: SessionWithFocusedViewAndDrawerWidgets

--- a/packages/app-core/src/ui/App/ModalWidget.tsx
+++ b/packages/app-core/src/ui/App/ModalWidget.tsx
@@ -56,7 +56,7 @@ const DrawerAppBar = observer(function DrawerAppBar({
   )
 })
 
-const ModalWidget = observer(function ({
+const ModalWidget = observer(function ModalWidget({
   session,
   onClose,
 }: {

--- a/packages/app-core/src/ui/App/ViewButtons.tsx
+++ b/packages/app-core/src/ui/App/ViewButtons.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewButtons = observer(function ({
+const ViewButtons = observer(function ViewButtons({
   view,
   onClose,
   onMinimize,

--- a/packages/app-core/src/ui/App/ViewContainer.tsx
+++ b/packages/app-core/src/ui/App/ViewContainer.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewContainer = observer(function ({
+const ViewContainer = observer(function ViewContainer({
   view,
   session,
 }: {

--- a/packages/app-core/src/ui/App/ViewContainerTitle.tsx
+++ b/packages/app-core/src/ui/App/ViewContainerTitle.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()(theme => ({
     backgroundColor: theme.palette.secondary.light,
   },
 }))
-const ViewContainerTitle = observer(function ({
+const ViewContainerTitle = observer(function ViewContainerTitle({
   view,
 }: {
   view: IBaseViewModel

--- a/packages/app-core/src/ui/App/ViewHeader.tsx
+++ b/packages/app-core/src/ui/App/ViewHeader.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewHeader = observer(function ({
+const ViewHeader = observer(function ViewHeader({
   view,
   onClose,
   onMinimize,

--- a/packages/app-core/src/ui/App/ViewLauncher.tsx
+++ b/packages/app-core/src/ui/App/ViewLauncher.tsx
@@ -30,7 +30,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewLauncher = observer(({ session }: { session: AppSession }) => {
+const ViewLauncher = observer(function ViewLauncher({
+  session,
+}: {
+  session: AppSession
+}) {
   const { classes } = useStyles()
   const { pluginManager } = getEnv(session)
   const viewTypes = pluginManager.getViewElements()

--- a/packages/app-core/src/ui/App/ViewMenu.tsx
+++ b/packages/app-core/src/ui/App/ViewMenu.tsx
@@ -55,7 +55,7 @@ function renameIds(obj: Record<string, unknown>): Record<string, unknown> {
   return transformIds(obj) as Record<string, unknown>
 }
 
-const ViewMenu = observer(function ({
+const ViewMenu = observer(function ViewMenu({
   model,
   IconButtonProps,
   IconProps,

--- a/packages/app-core/src/ui/App/ViewWrapper.tsx
+++ b/packages/app-core/src/ui/App/ViewWrapper.tsx
@@ -10,7 +10,7 @@ import type {
   SessionWithFocusedViewAndDrawerWidgets,
 } from '@jbrowse/core/util'
 
-const ViewWrapper = observer(function ({
+const ViewWrapper = observer(function ViewWrapper({
   view,
   session,
 }: {

--- a/packages/core/BaseFeatureWidget/BaseFeatureDetail/index.tsx
+++ b/packages/core/BaseFeatureWidget/BaseFeatureDetail/index.tsx
@@ -7,7 +7,9 @@ import { replaceUndefinedWithNull } from '../util'
 
 import type { BaseInputProps } from './types'
 
-const BaseFeatureDetail = observer(function ({ model }: BaseInputProps) {
+const BaseFeatureDetail = observer(function BaseFeatureDetail({
+  model,
+}: BaseInputProps) {
   const { error, descriptions, featureData } = model
 
   if (error) {

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceContents.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceContents.tsx
@@ -137,7 +137,7 @@ function RenderedSequenceComponent({
   }
 }
 
-const SequenceContents = observer(function ({
+const SequenceContents = observer(function SequenceContents({
   mode,
   feature,
   sequence,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
@@ -18,7 +18,7 @@ const SequenceDialog = lazy(() => import('./dialogs/SequenceDialog'))
 
 // set the key on this component to feature.id to clear state after new feature
 // is selected
-const SequenceFeatureDetails = observer(function ({
+const SequenceFeatureDetails = observer(function SequenceFeatureDetails({
   model,
   feature,
 }: {

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeaturePanel.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeaturePanel.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()(theme => ({
 // display the stitched-together sequence of a gene's CDS, cDNA, or protein
 // sequence. this is a best effort and weird genomic phenomena could lead these
 // to not be 100% accurate
-const SequenceFeaturePanel = observer(function ({
+const SequenceFeaturePanel = observer(function SequenceFeaturePanel({
   model,
   feature,
 }: {

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceName.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/SequenceName.tsx
@@ -15,7 +15,7 @@ function getStrand(strand: number) {
   }
 }
 
-const SequenceName = observer(function ({
+const SequenceName = observer(function SequenceName({
   mode,
   model,
   feature,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SequenceDialog = observer(function ({
+const SequenceDialog = observer(function SequenceDialog({
   handleClose,
   model,
   feature,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceTypeSelector.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceTypeSelector.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SequenceTypeSelector = observer(function ({
+const SequenceTypeSelector = observer(function SequenceTypeSelector({
   model,
 }: {
   model: SequenceFeatureDetailsModel

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SettingsDialog.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SettingsDialog.tsx
@@ -47,97 +47,99 @@ function FormControl2({ children }: { children: React.ReactNode }) {
   )
 }
 
-const SequenceFeatureSettingsDialog = observer(function ({
-  handleClose,
-  model,
-}: {
-  handleClose: () => void
-  model: SequenceFeatureDetailsModel
-}) {
-  const { classes } = useStyles()
-  const { upperCaseCDS } = model
-  const [intronBp, setIntronBp] = useState(`${model.intronBp}`)
-  const [upDownBp, setUpDownBp] = useState(`${model.upDownBp}`)
-  const intronBpValid = !Number.isNaN(+intronBp)
-  const upDownBpValid = !Number.isNaN(+upDownBp)
-  return (
-    <Dialog
-      maxWidth="xl"
-      open
-      onClose={() => {
-        handleClose()
-      }}
-      title="Feature sequence settings"
-    >
-      <DialogContent className={classes.dialogContent}>
-        <TextField2
-          label="Number of intronic bases around splice site to display"
-          className={classes.formElt}
-          value={intronBp}
-          helperText={!intronBpValid ? 'Not a number' : ''}
-          error={!intronBpValid}
-          onChange={event => {
-            setIntronBp(event.target.value)
-          }}
-        />
-        <TextField2
-          label="Number of bases up/down stream of feature to display"
-          className={classes.formElt}
-          value={upDownBp}
-          helperText={!upDownBpValid ? 'Not a number' : ''}
-          error={!upDownBpValid}
-          onChange={event => {
-            setUpDownBp(event.target.value)
-          }}
-        />
-        <FormControl2>
-          <FormLabel>Sequence capitalization</FormLabel>
-          <RadioGroup
-            value={upperCaseCDS ? 'cds' : 'unchanged'}
-            onChange={e => {
-              model.setUpperCaseCDS(e.target.value === 'cds')
+const SequenceFeatureSettingsDialog = observer(
+  function SequenceFeatureSettingsDialog({
+    handleClose,
+    model,
+  }: {
+    handleClose: () => void
+    model: SequenceFeatureDetailsModel
+  }) {
+    const { classes } = useStyles()
+    const { upperCaseCDS } = model
+    const [intronBp, setIntronBp] = useState(`${model.intronBp}`)
+    const [upDownBp, setUpDownBp] = useState(`${model.upDownBp}`)
+    const intronBpValid = !Number.isNaN(+intronBp)
+    const upDownBpValid = !Number.isNaN(+upDownBp)
+    return (
+      <Dialog
+        maxWidth="xl"
+        open
+        onClose={() => {
+          handleClose()
+        }}
+        title="Feature sequence settings"
+      >
+        <DialogContent className={classes.dialogContent}>
+          <TextField2
+            label="Number of intronic bases around splice site to display"
+            className={classes.formElt}
+            value={intronBp}
+            helperText={!intronBpValid ? 'Not a number' : ''}
+            error={!intronBpValid}
+            onChange={event => {
+              setIntronBp(event.target.value)
             }}
-          >
-            <FormControlLabel
-              value="cds"
-              control={<Radio className={classes.root} size="small" />}
-              label="Capitalize CDS and lower case everything else"
-            />
-            <FormControlLabel
-              value="unchanged"
-              control={<Radio className={classes.root} size="small" />}
-              label="Capitalization from reference genome sequence"
-            />
-          </RadioGroup>
-        </FormControl2>
-      </DialogContent>
+          />
+          <TextField2
+            label="Number of bases up/down stream of feature to display"
+            className={classes.formElt}
+            value={upDownBp}
+            helperText={!upDownBpValid ? 'Not a number' : ''}
+            error={!upDownBpValid}
+            onChange={event => {
+              setUpDownBp(event.target.value)
+            }}
+          />
+          <FormControl2>
+            <FormLabel>Sequence capitalization</FormLabel>
+            <RadioGroup
+              value={upperCaseCDS ? 'cds' : 'unchanged'}
+              onChange={e => {
+                model.setUpperCaseCDS(e.target.value === 'cds')
+              }}
+            >
+              <FormControlLabel
+                value="cds"
+                control={<Radio className={classes.root} size="small" />}
+                label="Capitalize CDS and lower case everything else"
+              />
+              <FormControlLabel
+                value="unchanged"
+                control={<Radio className={classes.root} size="small" />}
+                label="Capitalization from reference genome sequence"
+              />
+            </RadioGroup>
+          </FormControl2>
+        </DialogContent>
 
-      <DialogActions>
-        <Button
-          onClick={() => {
-            model.setIntronBp(+intronBp)
-            model.setUpDownBp(+upDownBp)
-            handleClose()
-          }}
-          disabled={!intronBpValid || !upDownBpValid}
-          color="primary"
-          variant="contained"
-        >
-          Submit
-        </Button>
-        <Button
-          onClick={() => {
-            handleClose()
-          }}
-          color="secondary"
-          autoFocus
-          variant="contained"
-        >
-          Cancel
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-})
+        <DialogActions>
+          <Button
+            onClick={() => {
+              model.setIntronBp(+intronBp)
+              model.setUpDownBp(+upDownBp)
+              handleClose()
+            }}
+            disabled={!intronBpValid || !upDownBpValid}
+            color="primary"
+            variant="contained"
+          >
+            Submit
+          </Button>
+          <Button
+            onClick={() => {
+              handleClose()
+            }}
+            color="secondary"
+            autoFocus
+            variant="contained"
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
 
 export default SequenceFeatureSettingsDialog

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/CDNASequence.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/CDNASequence.tsx
@@ -8,7 +8,7 @@ import type { SimpleFeatureSerialized } from '../../../util'
 import type { Feat } from '../../util'
 import type { SequenceFeatureDetailsModel } from '../model'
 
-const CDNASequence = observer(function ({
+const CDNASequence = observer(function CDNASequence({
   utr,
   cds,
   exons,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/CDSSequence.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/CDSSequence.tsx
@@ -8,7 +8,7 @@ import SequenceDisplay from './SequenceDisplay'
 import type { Feat } from '../../util'
 import type { SequenceFeatureDetailsModel } from '../model'
 
-const CDSSequence = observer(function ({
+const CDSSequence = observer(function CDSSequence({
   cds,
   sequence,
   model,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/GenomicSequence.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/GenomicSequence.tsx
@@ -7,7 +7,7 @@ import SequenceDisplay from './SequenceDisplay'
 import type { SimpleFeatureSerialized } from '../../../util'
 import type { SequenceFeatureDetailsModel } from '../model'
 
-const GenomicSequence = observer(function ({
+const GenomicSequence = observer(function GenomicSequence({
   sequence,
   upstream,
   feature,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/ProteinSequence.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/ProteinSequence.tsx
@@ -8,7 +8,7 @@ import SequenceDisplay from './SequenceDisplay'
 import type { Feat } from '../../util'
 import type { SequenceFeatureDetailsModel } from '../model'
 
-const ProteinSequence = observer(function ({
+const ProteinSequence = observer(function ProteinSequence({
   cds,
   sequence,
   codonTable,

--- a/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/SequenceDisplay.tsx
+++ b/packages/core/BaseFeatureWidget/SequenceFeatureDetails/seqtypes/SequenceDisplay.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import type { SequenceFeatureDetailsModel } from '../model'
 
-const SequenceDisplay = observer(function ({
+const SequenceDisplay = observer(function SequenceDisplay({
   chunks,
   start,
   color,

--- a/packages/core/pluggableElementTypes/models/components/SaveTrackData.tsx
+++ b/packages/core/pluggableElementTypes/models/components/SaveTrackData.tsx
@@ -63,7 +63,7 @@ function roundRegions(regions: Region[]) {
   }))
 }
 
-const SaveTrackDataDialog = observer(function ({
+const SaveTrackDataDialog = observer(function SaveTrackDataDialog({
   model,
   handleClose,
 }: {

--- a/packages/core/ui/AppLogo.tsx
+++ b/packages/core/ui/AppLogo.tsx
@@ -5,7 +5,7 @@ import { LogoFull } from './Logo'
 
 import type { AnyConfigurationModel } from '../configuration'
 
-const Logo = observer(function ({
+const Logo = observer(function Logo({
   session,
 }: {
   session: { configuration: AnyConfigurationModel }

--- a/packages/core/ui/AssemblySelector.tsx
+++ b/packages/core/ui/AssemblySelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 import { makeStyles } from '@jbrowse/core/util/tss-react'
 import { MenuItem, TextField } from '@mui/material'
@@ -15,7 +15,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const AssemblySelector = observer(function ({
+const AssemblySelector = observer(function AssemblySelector({
   session,
   onChange,
   label = 'Assembly',
@@ -40,17 +40,15 @@ const AssemblySelector = observer(function ({
   // constructs a localstorage key based on host/path/config to help
   // remember. non-config assists usage with e.g. embedded apps
   const config = new URLSearchParams(window.location.search).get('config')
-  const [lastSelected, setLastSelected] =
-    typeof jest === 'undefined' && localStorageKey
-      ? useLocalStorage(
-          `lastAssembly-${[
-            window.location.host + window.location.pathname,
-            config,
-            localStorageKey,
-          ].join('-')}`,
-          selected,
-        )
-      : useState(selected)
+  const [lastSelected, setLastSelected] = useLocalStorage(
+    `lastAssembly-${[
+      window.location.host + window.location.pathname,
+      config,
+      localStorageKey,
+    ].join('-')}`,
+    selected,
+    typeof jest === 'undefined' && Boolean(localStorageKey),
+  )
 
   const selection = assemblyNames.includes(lastSelected || '')
     ? lastSelected

--- a/packages/core/ui/ConfirmDialog.tsx
+++ b/packages/core/ui/ConfirmDialog.tsx
@@ -13,7 +13,7 @@ interface Props extends DialogProps {
   submitText?: string
 }
 
-const ConfirmDialog = observer(function (props: Props) {
+const ConfirmDialog = observer(function ConfirmDialog(props: Props) {
   const {
     onSubmit,
     onCancel,

--- a/packages/core/ui/Dialog.tsx
+++ b/packages/core/ui/Dialog.tsx
@@ -47,7 +47,7 @@ export interface Props extends DialogProps {
   titleNode?: React.ReactNode
 }
 
-const Dialog = observer(function (props: Props) {
+const Dialog = observer(function Dialog(props: Props) {
   const { classes } = useStyles()
   const { titleNode, ...rest } = props
   const { title, header, children, onClose } = rest

--- a/packages/core/ui/DropDownMenu.tsx
+++ b/packages/core/ui/DropDownMenu.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const DropDownMenu = observer(function ({
+const DropDownMenu = observer(function DropDownMenu({
   menuTitle,
   session,
   menuItems,

--- a/packages/core/ui/FileSelector/FileSelector.tsx
+++ b/packages/core/ui/FileSelector/FileSelector.tsx
@@ -22,7 +22,7 @@ function getInitialToggleValue(location?: FileLocation) {
   return !location || isUriLocation(location) ? 'url' : 'file'
 }
 
-const FileSelector = observer(function ({
+const FileSelector = observer(function FileSelector({
   inline,
   location,
   name,

--- a/packages/core/ui/FileSelector/UrlChooser.tsx
+++ b/packages/core/ui/FileSelector/UrlChooser.tsx
@@ -5,7 +5,7 @@ import { isUriLocation } from '../../util/types'
 
 import type { FileLocation } from '../../util/types'
 
-const UrlChooser = observer(function ({
+const UrlChooser = observer(function UrlChooser({
   location,
   label,
   style,

--- a/packages/core/ui/ReturnToImportFormDialog.tsx
+++ b/packages/core/ui/ReturnToImportFormDialog.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 
 import Dialog from './Dialog'
 
-const ReturnToImportFormDialog = observer(function ({
+const ReturnToImportFormDialog = observer(function ReturnToImportFormDialog({
   model,
   handleClose,
 }: {

--- a/packages/core/ui/Snackbar.tsx
+++ b/packages/core/ui/Snackbar.tsx
@@ -12,7 +12,11 @@ interface SnackbarSession extends AbstractSessionModel {
   popSnackbarMessage: () => void
 }
 
-const Snackbar = observer(function ({ session }: { session: SnackbarSession }) {
+const Snackbar = observer(function Snackbar({
+  session,
+}: {
+  session: SnackbarSession
+}) {
   const { snackbarMessages } = session
   const latestMessage = snackbarMessages.at(-1)
 

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1095,9 +1095,13 @@ export function getLayoutId({
 }
 
 // Hook from https://usehooks.com/useLocalStorage/
-export function useLocalStorage<T>(key: string, initialValue: T) {
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  enabled = true,
+) {
   const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || !enabled) {
       return initialValue
     }
     try {
@@ -1114,7 +1118,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
         // eslint-disable-next-line unicorn/no-instanceof-builtins
         value instanceof Function ? value(storedValue) : value
       setStoredValue(valueToStore)
-      if (typeof window !== 'undefined') {
+      if (typeof window !== 'undefined' && enabled) {
         window.localStorage.setItem(key, JSON.stringify(valueToStore))
       }
     } catch (error) {

--- a/packages/embedded-core/src/ui/EmbeddedViewContainer.tsx
+++ b/packages/embedded-core/src/ui/EmbeddedViewContainer.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewContainer = observer(function ({
+const ViewContainer = observer(function ViewContainer({
   view,
   children,
 }: {
@@ -48,7 +48,7 @@ const ViewContainer = observer(function ({
   )
 })
 
-const ViewContainerWrapper = observer(function ({
+const ViewContainerWrapper = observer(function ViewContainerWrapper({
   view,
   children,
 }: {

--- a/packages/embedded-core/src/ui/ModalWidget.tsx
+++ b/packages/embedded-core/src/ui/ModalWidget.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const ModalWidget = observer(function ({
+const ModalWidget = observer(function ModalWidget({
   session,
 }: {
   session: SessionWithWidgets

--- a/packages/embedded-core/src/ui/ViewMenu.tsx
+++ b/packages/embedded-core/src/ui/ViewMenu.tsx
@@ -10,7 +10,7 @@ import type {
   SvgIconProps,
 } from '@mui/material'
 
-const ViewMenu = observer(function ({
+const ViewMenu = observer(function ViewMenu({
   model,
   IconButtonProps,
   IconProps,

--- a/packages/embedded-core/src/ui/ViewTitle.tsx
+++ b/packages/embedded-core/src/ui/ViewTitle.tsx
@@ -39,7 +39,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ViewTitle = observer(({ view }: { view: IBaseViewModel }) => {
+const ViewTitle = observer(function ViewTitle({
+  view,
+}: {
+  view: IBaseViewModel
+}) {
   const { classes } = useStyles()
   const { displayName } = view
   const [dialogOpen, setDialogOpen] = useState(false)

--- a/packages/product-core/src/ui/AboutDialogContents.tsx
+++ b/packages/product-core/src/ui/AboutDialogContents.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const AboutDialogContents = observer(function ({
+const AboutDialogContents = observer(function AboutDialogContents({
   config,
   session,
 }: {

--- a/packages/product-core/src/ui/RefNameInfoDialog.tsx
+++ b/packages/product-core/src/ui/RefNameInfoDialog.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const RefNameInfoDialog = observer(function ({
+const RefNameInfoDialog = observer(function RefNameInfoDialog({
   config,
   session,
   onClose,

--- a/packages/sv-core/src/BreakendMultiLevelOptionDialog.tsx
+++ b/packages/sv-core/src/BreakendMultiLevelOptionDialog.tsx
@@ -12,97 +12,99 @@ import type { Track } from './types'
 import type { AbstractSessionModel, Feature } from '@jbrowse/core/util'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const BreakendMultiLevelOptionDialog = observer(function ({
-  session,
-  handleClose,
-  feature,
-  assemblyName,
-  stableViewId,
-  view,
-}: {
-  session: AbstractSessionModel
-  handleClose: () => void
-  feature: Feature
-  view?: LinearGenomeViewModel
-  assemblyName: string
-  stableViewId?: string
-}) {
-  const [copyTracks, setCopyTracks] = useState(true)
-  const [mirror, setMirror] = useState(true)
+const BreakendMultiLevelOptionDialog = observer(
+  function BreakendMultiLevelOptionDialog({
+    session,
+    handleClose,
+    feature,
+    assemblyName,
+    stableViewId,
+    view,
+  }: {
+    session: AbstractSessionModel
+    handleClose: () => void
+    feature: Feature
+    view?: LinearGenomeViewModel
+    assemblyName: string
+    stableViewId?: string
+  }) {
+    const [copyTracks, setCopyTracks] = useState(true)
+    const [mirror, setMirror] = useState(true)
 
-  return (
-    <Dialog
-      open
-      onClose={handleClose}
-      title="Multi-level breakpoint split view options"
-    >
-      <DialogContent>
-        <div>Launch multi-level breakpoint split view</div>
-        {view ? (
-          <>
-            <Checkbox2
-              checked={copyTracks}
-              label="Copy tracks into the new view"
-              onChange={event => {
-                setCopyTracks(event.target.checked)
-              }}
-            />
-
-            {copyTracks ? (
+    return (
+      <Dialog
+        open
+        onClose={handleClose}
+        title="Multi-level breakpoint split view options"
+      >
+        <DialogContent>
+          <div>Launch multi-level breakpoint split view</div>
+          {view ? (
+            <>
               <Checkbox2
-                checked={mirror}
-                disabled={!copyTracks}
-                label="Mirror the copied tracks (only available if copying tracks and using two level)"
+                checked={copyTracks}
+                label="Copy tracks into the new view"
                 onChange={event => {
-                  setMirror(event.target.checked)
+                  setCopyTracks(event.target.checked)
                 }}
               />
-            ) : null}
-          </>
-        ) : null}
-      </DialogContent>
-      <DialogActions>
-        <Button
-          onClick={() => {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            ;(async () => {
-              try {
-                await navToMultiLevelBreak({
-                  stableViewId,
-                  session,
-                  tracks:
-                    copyTracks && view
-                      ? (getSnapshot(view.tracks) as Track[])
-                      : [],
-                  mirror,
-                  feature,
-                  assemblyName,
-                })
-              } catch (e) {
-                console.error(e)
-                session.notifyError(`${e}`, e)
-              }
-            })()
-            handleClose()
-          }}
-          variant="contained"
-          color="primary"
-          autoFocus
-        >
-          OK
-        </Button>
-        <Button
-          color="secondary"
-          variant="contained"
-          onClick={() => {
-            handleClose()
-          }}
-        >
-          Cancel
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-})
+
+              {copyTracks ? (
+                <Checkbox2
+                  checked={mirror}
+                  disabled={!copyTracks}
+                  label="Mirror the copied tracks (only available if copying tracks and using two level)"
+                  onChange={event => {
+                    setMirror(event.target.checked)
+                  }}
+                />
+              ) : null}
+            </>
+          ) : null}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              ;(async () => {
+                try {
+                  await navToMultiLevelBreak({
+                    stableViewId,
+                    session,
+                    tracks:
+                      copyTracks && view
+                        ? (getSnapshot(view.tracks) as Track[])
+                        : [],
+                    mirror,
+                    feature,
+                    assemblyName,
+                  })
+                } catch (e) {
+                  console.error(e)
+                  session.notifyError(`${e}`, e)
+                }
+              })()
+              handleClose()
+            }}
+            variant="contained"
+            color="primary"
+            autoFocus
+          >
+            OK
+          </Button>
+          <Button
+            color="secondary"
+            variant="contained"
+            onClick={() => {
+              handleClose()
+            }}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
 
 export default BreakendMultiLevelOptionDialog

--- a/packages/sv-core/src/BreakendSingleLevelOptionDialog.tsx
+++ b/packages/sv-core/src/BreakendSingleLevelOptionDialog.tsx
@@ -11,106 +11,108 @@ import { navToSingleLevelBreak } from './navToSingleLevelBreak'
 import type { AbstractSessionModel, Feature } from '@jbrowse/core/util'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const BreakendSingleLevelOptionDialog = observer(function ({
-  session,
-  handleClose,
-  feature,
-  stableViewId,
-  assemblyName,
-  view,
-}: {
-  session: AbstractSessionModel
-  handleClose: () => void
-  stableViewId?: string
-  feature: Feature
-  view?: LinearGenomeViewModel
-  assemblyName: string
-}) {
-  const [copyTracks, setCopyTracks] = useState(true)
-  const [focusOnBreakends, setFocusOnBreakends] = useState(true)
-  const [windowSize, setWindowSize] = useLocalStorage(
-    'breakpointWindowSize',
-    '5000',
-  )
+const BreakendSingleLevelOptionDialog = observer(
+  function BreakendSingleLevelOptionDialog({
+    session,
+    handleClose,
+    feature,
+    stableViewId,
+    assemblyName,
+    view,
+  }: {
+    session: AbstractSessionModel
+    handleClose: () => void
+    stableViewId?: string
+    feature: Feature
+    view?: LinearGenomeViewModel
+    assemblyName: string
+  }) {
+    const [copyTracks, setCopyTracks] = useState(true)
+    const [focusOnBreakends, setFocusOnBreakends] = useState(true)
+    const [windowSize, setWindowSize] = useLocalStorage(
+      'breakpointWindowSize',
+      '5000',
+    )
 
-  return (
-    <Dialog
-      open
-      onClose={handleClose}
-      title="Single-level breakpoint split view options"
-    >
-      <DialogContent>
-        {view ? (
+    return (
+      <Dialog
+        open
+        onClose={handleClose}
+        title="Single-level breakpoint split view options"
+      >
+        <DialogContent>
+          {view ? (
+            <Checkbox2
+              checked={copyTracks}
+              label="Copy tracks into the new view"
+              onChange={event => {
+                setCopyTracks(event.target.checked)
+              }}
+            />
+          ) : null}
           <Checkbox2
             checked={copyTracks}
-            label="Copy tracks into the new view"
+            label="Focus on breakends"
             onChange={event => {
-              setCopyTracks(event.target.checked)
+              setFocusOnBreakends(event.target.checked)
             }}
           />
-        ) : null}
-        <Checkbox2
-          checked={copyTracks}
-          label="Focus on breakends"
-          onChange={event => {
-            setFocusOnBreakends(event.target.checked)
-          }}
-        />
 
-        <TextField
-          label="Window size (bp)"
-          value={windowSize}
-          onChange={event => {
-            setWindowSize(event.target.value)
-          }}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button
-          onClick={() => {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            ;(async () => {
-              try {
-                const { assemblyManager } = session
-                const assembly =
-                  await assemblyManager.waitForAssembly(assemblyName)
-                if (!assembly) {
-                  throw new Error(`assembly ${assemblyName} not found`)
+          <TextField
+            label="Window size (bp)"
+            value={windowSize}
+            onChange={event => {
+              setWindowSize(event.target.value)
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              ;(async () => {
+                try {
+                  const { assemblyManager } = session
+                  const assembly =
+                    await assemblyManager.waitForAssembly(assemblyName)
+                  if (!assembly) {
+                    throw new Error(`assembly ${assemblyName} not found`)
+                  }
+                  await navToSingleLevelBreak({
+                    feature,
+                    assemblyName,
+                    focusOnBreakends,
+                    session,
+                    stableViewId,
+                    tracks: view?.tracks,
+                    windowSize: +windowSize || 0,
+                  })
+                } catch (e) {
+                  console.error(e)
+                  session.notifyError(`${e}`, e)
                 }
-                await navToSingleLevelBreak({
-                  feature,
-                  assemblyName,
-                  focusOnBreakends,
-                  session,
-                  stableViewId,
-                  tracks: view?.tracks,
-                  windowSize: +windowSize || 0,
-                })
-              } catch (e) {
-                console.error(e)
-                session.notifyError(`${e}`, e)
-              }
-            })()
-            handleClose()
-          }}
-          variant="contained"
-          color="primary"
-          autoFocus
-        >
-          OK
-        </Button>
-        <Button
-          color="secondary"
-          variant="contained"
-          onClick={() => {
-            handleClose()
-          }}
-        >
-          Cancel
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-})
+              })()
+              handleClose()
+            }}
+            variant="contained"
+            color="primary"
+            autoFocus
+          >
+            OK
+          </Button>
+          <Button
+            color="secondary"
+            variant="contained"
+            onClick={() => {
+              handleClose()
+            }}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
 
 export default BreakendSingleLevelOptionDialog

--- a/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/AlignmentsFeatureDetail.tsx
@@ -17,7 +17,7 @@ import type { SimpleFeatureSerialized } from '@jbrowse/core/util'
 const SupplementaryAlignments = lazy(() => import('./SupplementaryAlignments'))
 const LinkedPairedAlignments = lazy(() => import('./LinkedPairedAlignments'))
 
-const FeatDefined = observer(function (props: {
+const FeatDefined = observer(function FeatDefined(props: {
   feat: SimpleFeatureSerialized
   model: AlignmentFeatureWidgetModel
 }) {
@@ -55,20 +55,22 @@ const FeatDefined = observer(function (props: {
   )
 })
 
-const AlignmentsFeatureDetails = observer(function (props: {
-  model: AlignmentFeatureWidgetModel
-}) {
-  const { model } = props
-  const { featureData } = model
-  const feat = structuredClone(featureData)
-  return feat ? (
-    <FeatDefined feat={feat} {...props} />
-  ) : (
-    <div>
-      No feature loaded, may not be available after page refresh because it was
-      too large for localStorage
-    </div>
-  )
-})
+const AlignmentsFeatureDetails = observer(
+  function AlignmentsFeatureDetails(props: {
+    model: AlignmentFeatureWidgetModel
+  }) {
+    const { model } = props
+    const { featureData } = model
+    const feat = structuredClone(featureData)
+    return feat ? (
+      <FeatDefined feat={feat} {...props} />
+    ) : (
+      <div>
+        No feature loaded, may not be available after page refresh because it
+        was too large for localStorage
+      </div>
+    )
+  },
+)
 
 export default AlignmentsFeatureDetails

--- a/plugins/alignments/src/LinearPileupDisplay/components/ColorByTagDialog.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/ColorByTagDialog.tsx
@@ -15,7 +15,7 @@ interface Tag {
   tag: string
 }
 
-const ColorByTagDialog = observer(function ({
+const ColorByTagDialog = observer(function ColorByTagDialog({
   model,
   handleClose,
 }: {

--- a/plugins/alignments/src/LinearPileupDisplay/components/GroupByDialog.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/GroupByDialog.tsx
@@ -25,7 +25,7 @@ import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { IAnyStateTreeNode } from '@jbrowse/mobx-state-tree'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const GroupByTagDialog = observer(function (props: {
+const GroupByTagDialog = observer(function GroupByTagDialog(props: {
   model: {
     adapterConfig: AnyConfigurationModel
     configuration: AnyConfigurationModel

--- a/plugins/alignments/src/LinearPileupDisplay/components/LinearPileupDisplayBlurb.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/LinearPileupDisplayBlurb.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 
 import type { SortedBy } from '../../shared/types'
 
-const LinearPileupDisplayBlurb = observer(function ({
+const LinearPileupDisplayBlurb = observer(function LinearPileupDisplayBlurb({
   model,
 }: {
   model: {

--- a/plugins/alignments/src/LinearPileupDisplay/components/SetFeatureHeightDialog.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/SetFeatureHeightDialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const SetFeatureHeightDialog = observer(function (props: {
+const SetFeatureHeightDialog = observer(function SetFeatureHeightDialog(props: {
   model: {
     setFeatureHeight: (arg?: number) => void
     setNoSpacing: (arg?: boolean) => void

--- a/plugins/alignments/src/LinearPileupDisplay/components/SortByTagDialog.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/SortByTagDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const SortByTagDialog = observer(function (props: {
+const SortByTagDialog = observer(function SortByTagDialog(props: {
   model: {
     setSortedBy: (arg: string, arg2: string) => void
   }

--- a/plugins/alignments/src/LinearReadArcsDisplay/components/LinearReadArcsReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadArcsDisplay/components/LinearReadArcsReactComponent.tsx
@@ -10,7 +10,7 @@ import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
 type LGV = LinearGenomeViewModel
 
-const Arcs = observer(function ({
+const Arcs = observer(function Arcs({
   model,
 }: {
   model: LinearReadArcsDisplayModel
@@ -41,16 +41,18 @@ const Arcs = observer(function ({
   )
 })
 
-const LinearReadArcsReactComponent = observer(function ({
-  model,
-}: {
-  model: LinearReadArcsDisplayModel
-}) {
-  return (
-    <BaseDisplayComponent model={model}>
-      <Arcs model={model} />
-    </BaseDisplayComponent>
-  )
-})
+const LinearReadArcsReactComponent = observer(
+  function LinearReadArcsReactComponent({
+    model,
+  }: {
+    model: LinearReadArcsDisplayModel
+  }) {
+    return (
+      <BaseDisplayComponent model={model}>
+        <Arcs model={model} />
+      </BaseDisplayComponent>
+    )
+  },
+)
 
 export default LinearReadArcsReactComponent

--- a/plugins/alignments/src/LinearReadCloudDisplay/components/LinearReadCloudReactComponent.tsx
+++ b/plugins/alignments/src/LinearReadCloudDisplay/components/LinearReadCloudReactComponent.tsx
@@ -79,7 +79,7 @@ function MismatchTooltip({
   )
 }
 
-const FeatureHighlights = observer(function ({
+const FeatureHighlights = observer(function FeatureHighlights({
   selectedFeatureBounds,
   hoveredFeature,
   canvasLeft,
@@ -133,7 +133,7 @@ const FeatureHighlights = observer(function ({
   )
 })
 
-const CloudCanvases = observer(function ({
+const CloudCanvases = observer(function CloudCanvases({
   model,
   canvasWidth,
   height,
@@ -194,7 +194,7 @@ const CloudCanvases = observer(function ({
   )
 })
 
-const Cloud = observer(function ({
+const Cloud = observer(function Cloud({
   model,
 }: {
   model: LinearReadCloudDisplayModel
@@ -436,15 +436,17 @@ const Cloud = observer(function ({
   )
 })
 
-const LinearReadCloudReactComponent = observer(function ({
-  model,
-}: {
-  model: LinearReadCloudDisplayModel
-}) {
-  return (
-    <BaseDisplayComponent model={model}>
-      <Cloud model={model} />
-    </BaseDisplayComponent>
-  )
-})
+const LinearReadCloudReactComponent = observer(
+  function LinearReadCloudReactComponent({
+    model,
+  }: {
+    model: LinearReadCloudDisplayModel
+  }) {
+    return (
+      <BaseDisplayComponent model={model}>
+        <Cloud model={model} />
+      </BaseDisplayComponent>
+    )
+  },
+)
 export default LinearReadCloudReactComponent

--- a/plugins/alignments/src/LinearReadCloudDisplay/components/SetFeatureHeightDialog.tsx
+++ b/plugins/alignments/src/LinearReadCloudDisplay/components/SetFeatureHeightDialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const SetFeatureHeightDialog = observer(function (props: {
+const SetFeatureHeightDialog = observer(function SetFeatureHeightDialog(props: {
   model: {
     setFeatureHeight: (arg?: number) => void
     setNoSpacing: (arg?: boolean) => void

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/SNPCoverageDisplayComponent.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/SNPCoverageDisplayComponent.tsx
@@ -5,17 +5,19 @@ import SashimiArcs from './SashimiArcs'
 
 import type { SNPCoverageDisplayModel } from '../model'
 
-const SNPCoverageDisplayComponent = observer(function (props: {
-  model: SNPCoverageDisplayModel
-}) {
-  const { model } = props
+const SNPCoverageDisplayComponent = observer(
+  function SNPCoverageDisplayComponent(props: {
+    model: SNPCoverageDisplayModel
+  }) {
+    const { model } = props
 
-  return (
-    <div style={{ position: 'relative' }}>
-      <LinearWiggleDisplayReactComponent {...props} />
-      <SashimiArcs model={model} />
-    </div>
-  )
-})
+    return (
+      <div style={{ position: 'relative' }}>
+        <LinearWiggleDisplayReactComponent {...props} />
+        <SashimiArcs model={model} />
+      </div>
+    )
+  },
+)
 
 export default SNPCoverageDisplayComponent

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/SashimiArcs.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/SashimiArcs.tsx
@@ -26,7 +26,11 @@ export interface ArcDisplayModel {
   skipFeatures: Feature[]
 }
 
-const SashimiArcs = observer(function ({ model }: { model: ArcDisplayModel }) {
+const SashimiArcs = observer(function SashimiArcs({
+  model,
+}: {
+  model: ArcDisplayModel
+}) {
   const { showArcsSetting, height, skipFeatures } = model
   const view = getContainingView(model) as LinearGenomeViewModel
   const { assemblyManager } = getSession(model)

--- a/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
+++ b/plugins/alignments/src/LinearSNPCoverageDisplay/components/Tooltip.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()(theme => ({
 
 type Coord = [number, number]
 
-const SNPCoverageTooltip = observer(function (props: {
+const SNPCoverageTooltip = observer(function SNPCoverageTooltip(props: {
   model: {
     featureUnderMouse?: Feature
     mouseoverExtraInformation?: string

--- a/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
+++ b/plugins/alignments/src/PileupRenderer/components/PileupRendering.tsx
@@ -21,7 +21,7 @@ import type { FlatbushItem } from '../types'
 import type { Region } from '@jbrowse/core/util/types'
 import type { BaseLinearDisplayModel } from '@jbrowse/plugin-linear-genome-view'
 
-const PileupRendering = observer(function (props: {
+const PileupRendering = observer(function PileupRendering(props: {
   blockKey: string
   displayModel: BaseLinearDisplayModel
   width: number

--- a/plugins/alignments/src/SNPCoverageRenderer/WiggleRendering.tsx
+++ b/plugins/alignments/src/SNPCoverageRenderer/WiggleRendering.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import type { Feature } from '@jbrowse/core/util'
 import type { Region } from '@jbrowse/core/util/types'
 
-const WiggleRendering = observer(function (props: {
+const WiggleRendering = observer(function WiggleRendering(props: {
   regions: Region[]
   features: Map<string, Feature>
   bpPerPx: number

--- a/plugins/alignments/src/SNPCoverageRenderer/components/SNPCoverageRendering.tsx
+++ b/plugins/alignments/src/SNPCoverageRenderer/components/SNPCoverageRendering.tsx
@@ -43,7 +43,7 @@ function getItemLabel(item: ClickMapItem | undefined, refName?: string) {
   return `${label}\nPosition: ${location}`
 }
 
-const SNPCoverageRendering = observer(function (props: {
+const SNPCoverageRendering = observer(function SNPCoverageRendering(props: {
   regions: Region[]
   features: Map<string, Feature>
   bpPerPx: number

--- a/plugins/alignments/src/shared/components/BaseDisplayComponent.tsx
+++ b/plugins/alignments/src/shared/components/BaseDisplayComponent.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const BaseDisplayComponent = observer(function ({
+const BaseDisplayComponent = observer(function BaseDisplayComponent({
   model,
   children,
 }: {
@@ -64,7 +64,7 @@ const BaseDisplayComponent = observer(function ({
   )
 })
 
-const DataDisplay = observer(function ({
+const DataDisplay = observer(function DataDisplay({
   model,
   children,
 }: {
@@ -95,7 +95,11 @@ const DataDisplay = observer(function ({
   )
 })
 
-const LoadingBar = observer(function ({ model }: { model: BaseDisplayModel }) {
+const LoadingBar = observer(function LoadingBar({
+  model,
+}: {
+  model: BaseDisplayModel
+}) {
   const { classes } = useStyles()
   const { statusMessage } = model
   return (

--- a/plugins/alignments/src/shared/components/BlockErrorMessage.tsx
+++ b/plugins/alignments/src/shared/components/BlockErrorMessage.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const BlockErrorMessage = observer(function ({
+const BlockErrorMessage = observer(function BlockErrorMessage({
   model,
 }: {
   model: {

--- a/plugins/alignments/src/shared/components/FilterByTagDialog.tsx
+++ b/plugins/alignments/src/shared/components/FilterByTagDialog.tsx
@@ -75,7 +75,7 @@ function Bitmask(props: { flag?: number; setFlag: (arg: number) => void }) {
   )
 }
 
-const FilterByTagDialog = observer(function (props: {
+const FilterByTagDialog = observer(function FilterByTagDialog(props: {
   model: {
     filterBy: FilterBy
     setFilterBy: (arg: FilterBy) => void

--- a/plugins/alignments/src/shared/components/SetFeatureHeightDialog.tsx
+++ b/plugins/alignments/src/shared/components/SetFeatureHeightDialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const SetFeatureHeightDialog = observer(function (props: {
+const SetFeatureHeightDialog = observer(function SetFeatureHeightDialog(props: {
   model: {
     setFeatureHeight: (arg?: number) => void
     setNoSpacing: (arg?: boolean) => void

--- a/plugins/alignments/src/shared/components/SetMaxHeightDialog.tsx
+++ b/plugins/alignments/src/shared/components/SetMaxHeightDialog.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SetMaxHeightDialog = observer(function (props: {
+const SetMaxHeightDialog = observer(function SetMaxHeightDialog(props: {
   model: {
     maxHeight?: number
     setMaxHeight: (arg?: number) => void

--- a/plugins/alignments/src/shared/components/SetModificationThresholdDialog.tsx
+++ b/plugins/alignments/src/shared/components/SetModificationThresholdDialog.tsx
@@ -12,90 +12,92 @@ import { observer } from 'mobx-react'
 
 import type { ColorBy } from '../types'
 
-const SetModificationThresholdDialog = observer(function (props: {
-  model: {
-    modificationThreshold: number
-    colorBy?: ColorBy
-    setColorScheme: (colorBy: ColorBy) => void
-  }
-  handleClose: () => void
-}) {
-  const { model, handleClose } = props
-  const [threshold, setThreshold] = useState(
-    String(model.modificationThreshold),
-  )
-  const numThreshold = Number.parseFloat(threshold)
-  const validThreshold =
-    !Number.isNaN(numThreshold) && numThreshold >= 0 && numThreshold <= 100
+const SetModificationThresholdDialog = observer(
+  function SetModificationThresholdDialog(props: {
+    model: {
+      modificationThreshold: number
+      colorBy?: ColorBy
+      setColorScheme: (colorBy: ColorBy) => void
+    }
+    handleClose: () => void
+  }) {
+    const { model, handleClose } = props
+    const [threshold, setThreshold] = useState(
+      String(model.modificationThreshold),
+    )
+    const numThreshold = Number.parseFloat(threshold)
+    const validThreshold =
+      !Number.isNaN(numThreshold) && numThreshold >= 0 && numThreshold <= 100
 
-  return (
-    <Dialog open onClose={handleClose} title="Adjust modification threshold">
-      <DialogContent>
-        <Typography>
-          Set the minimum probability threshold for displaying modifications
-        </Typography>
-        <Typography color="textSecondary">
-          Only modifications with probability above this threshold will be
-          displayed (0-100%)
-        </Typography>
-        <TextField
-          value={threshold}
-          onChange={event => {
-            setThreshold(event.target.value)
-          }}
-          placeholder="Enter threshold (e.g., 10)"
-          error={threshold !== '' && !validThreshold}
-          helperText={
-            threshold !== '' && !validThreshold
-              ? 'Must be a number between 0 and 100'
-              : ''
-          }
-          autoComplete="off"
-          type="number"
-          slotProps={{
-            htmlInput: {
-              min: 0,
-              max: 100,
-              step: 1,
-            },
-          }}
-        />
-        <DialogActions>
-          <Button
-            variant="contained"
-            color="primary"
-            type="submit"
-            autoFocus
-            disabled={!validThreshold}
-            onClick={() => {
-              const currentColorBy = model.colorBy || {
-                type: 'modifications',
-              }
-              model.setColorScheme({
-                ...currentColorBy,
-                modifications: {
-                  ...currentColorBy.modifications,
-                  threshold: numThreshold,
-                },
-              })
-              handleClose()
+    return (
+      <Dialog open onClose={handleClose} title="Adjust modification threshold">
+        <DialogContent>
+          <Typography>
+            Set the minimum probability threshold for displaying modifications
+          </Typography>
+          <Typography color="textSecondary">
+            Only modifications with probability above this threshold will be
+            displayed (0-100%)
+          </Typography>
+          <TextField
+            value={threshold}
+            onChange={event => {
+              setThreshold(event.target.value)
             }}
-          >
-            Submit
-          </Button>
-          <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => {
-              handleClose()
+            placeholder="Enter threshold (e.g., 10)"
+            error={threshold !== '' && !validThreshold}
+            helperText={
+              threshold !== '' && !validThreshold
+                ? 'Must be a number between 0 and 100'
+                : ''
+            }
+            autoComplete="off"
+            type="number"
+            slotProps={{
+              htmlInput: {
+                min: 0,
+                max: 100,
+                step: 1,
+              },
             }}
-          >
-            Cancel
-          </Button>
-        </DialogActions>
-      </DialogContent>
-    </Dialog>
-  )
-})
+          />
+          <DialogActions>
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              autoFocus
+              disabled={!validThreshold}
+              onClick={() => {
+                const currentColorBy = model.colorBy || {
+                  type: 'modifications',
+                }
+                model.setColorScheme({
+                  ...currentColorBy,
+                  modifications: {
+                    ...currentColorBy.modifications,
+                    threshold: numThreshold,
+                  },
+                })
+                handleClose()
+              }}
+            >
+              Submit
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={() => {
+                handleClose()
+              }}
+            >
+              Cancel
+            </Button>
+          </DialogActions>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)
 
 export default SetModificationThresholdDialog

--- a/plugins/arc/src/ArcRenderer/ArcRendering.tsx
+++ b/plugins/arc/src/ArcRenderer/ArcRendering.tsx
@@ -126,7 +126,7 @@ function ArcFeature({
   )
 }
 
-const ArcRendering = observer(function ({
+const ArcRendering = observer(function ArcRendering({
   features,
   config,
   regions,

--- a/plugins/arc/src/ArcTooltip.tsx
+++ b/plugins/arc/src/ArcTooltip.tsx
@@ -21,7 +21,11 @@ const TooltipContents = forwardRef<HTMLDivElement, Props>(
   },
 )
 
-const ArcTooltip = observer(function ({ contents }: { contents?: string }) {
+const ArcTooltip = observer(function ArcTooltip({
+  contents,
+}: {
+  contents?: string
+}) {
   return contents ? (
     <Suspense fallback={null}>
       <BaseTooltip>

--- a/plugins/arc/src/LinearPairedArcDisplay/components/Arcs.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/Arcs.tsx
@@ -19,7 +19,7 @@ const ArcTooltip = lazy(() => import('../../ArcTooltip'))
 
 type LGV = LinearGenomeViewModel
 
-const Arc = observer(function ({
+const Arc = observer(function Arc({
   model,
   feature,
   alt,
@@ -124,7 +124,7 @@ const Arc = observer(function ({
   return null
 })
 
-const Wrapper = observer(function ({
+const Wrapper = observer(function Wrapper({
   model,
   exportSVG,
   children,
@@ -145,7 +145,7 @@ const Wrapper = observer(function ({
   )
 })
 
-const Arcs = observer(function ({
+const Arcs = observer(function Arcs({
   model,
   exportSVG,
 }: {

--- a/plugins/arc/src/LinearPairedArcDisplay/components/BaseDisplayComponent.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/BaseDisplayComponent.tsx
@@ -8,7 +8,7 @@ import type { LinearArcDisplayModel } from '../model'
 
 const ErrorMessage = lazy(() => import('./ErrorMessage'))
 
-const BaseDisplayComponent = observer(function ({
+const BaseDisplayComponent = observer(function BaseDisplayComponent({
   model,
   children,
 }: {
@@ -27,7 +27,7 @@ const BaseDisplayComponent = observer(function ({
   )
 })
 
-const DataDisplay = observer(function ({
+const DataDisplay = observer(function DataDisplay({
   model,
   children,
 }: {

--- a/plugins/arc/src/LinearPairedArcDisplay/components/ErrorMessage.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/ErrorMessage.tsx
@@ -5,7 +5,7 @@ import ErrorActions from './ErrorActions'
 
 import type { LinearArcDisplayModel } from '../model'
 
-const ErrorMessage = observer(function ({
+const ErrorMessage = observer(function ErrorMessage({
   model,
 }: {
   model: LinearArcDisplayModel

--- a/plugins/arc/src/LinearPairedArcDisplay/components/LoadingBar.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/LoadingBar.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const LoadingBar = observer(function ({
+const LoadingBar = observer(function LoadingBar({
   model,
 }: {
   model: LinearArcDisplayModel

--- a/plugins/arc/src/LinearPairedArcDisplay/components/ReactComponent.tsx
+++ b/plugins/arc/src/LinearPairedArcDisplay/components/ReactComponent.tsx
@@ -5,7 +5,7 @@ import BaseDisplayComponent from './BaseDisplayComponent'
 
 import type { LinearArcDisplayModel } from '../model'
 
-const LinearArcReactComponent = observer(function ({
+const LinearArcReactComponent = observer(function LinearArcReactComponent({
   model,
   exportSVG,
 }: {

--- a/plugins/breakpoint-split-view/src/BreakpointAlignmentsFeatureDetail/BreakpointAlignmentsFeatureDetail.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointAlignmentsFeatureDetail/BreakpointAlignmentsFeatureDetail.tsx
@@ -7,26 +7,28 @@ import { observer } from 'mobx-react'
 
 import type { SimpleFeatureSerialized } from '@jbrowse/core/util'
 
-const BreakpointAlignmentsFeatureDetail = observer(function ({
-  model,
-}: {
-  model: {
-    featureData: {
-      feature1: SimpleFeatureSerialized
-      feature2: SimpleFeatureSerialized
+const BreakpointAlignmentsFeatureDetail = observer(
+  function BreakpointAlignmentsFeatureDetail({
+    model,
+  }: {
+    model: {
+      featureData: {
+        feature1: SimpleFeatureSerialized
+        feature2: SimpleFeatureSerialized
+      }
     }
-  }
-}) {
-  const { featureData } = model
-  const { feature1, feature2 } = structuredClone(featureData)
-  return (
-    <Paper>
-      <BaseCoreDetails title="Feature 1" feature={feature1} />
-      <BaseCoreDetails title="Feature 2" feature={feature2} />
-      <BaseAttributes title="Feature 1 attributes" feature={feature1} />
-      <BaseAttributes title="Feature 2 attributes" feature={feature2} />
-    </Paper>
-  )
-})
+  }) {
+    const { featureData } = model
+    const { feature1, feature2 } = structuredClone(featureData)
+    return (
+      <Paper>
+        <BaseCoreDetails title="Feature 1" feature={feature1} />
+        <BaseCoreDetails title="Feature 2" feature={feature2} />
+        <BaseAttributes title="Feature 1 attributes" feature={feature1} />
+        <BaseAttributes title="Feature 2 attributes" feature={feature2} />
+      </Paper>
+    )
+  },
+)
 
 export default BreakpointAlignmentsFeatureDetail

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/AlignmentConnections.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/AlignmentConnections.tsx
@@ -26,7 +26,7 @@ import {
 
 import type { OverlayProps } from './overlayUtils'
 
-const AlignmentConnections = observer(function ({
+const AlignmentConnections = observer(function AlignmentConnections({
   model,
   trackId,
   parentRef,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Breakends.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Breakends.tsx
@@ -16,7 +16,7 @@ import { getPxFromCoordinate, useNextFrame, yPos } from '../util'
 
 import type { OverlayProps } from './overlayUtils'
 
-const Breakends = observer(function ({
+const Breakends = observer(function Breakends({
   model,
   trackId,
   parentRef,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitView.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitView.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const BreakpointSplitViewLevels = observer(function ({
+const BreakpointSplitViewLevels = observer(function BreakpointSplitViewLevels({
   model,
 }: {
   model: BreakpointViewModel
@@ -65,7 +65,7 @@ const BreakpointSplitViewLevels = observer(function ({
   )
 })
 
-const BreakpointSplitView = observer(function ({
+const BreakpointSplitView = observer(function BreakpointSplitView({
   model,
 }: {
   model: BreakpointViewModel

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/BreakpointSplitViewOverlay.tsx
@@ -26,36 +26,38 @@ const useStyles = makeStyles()({
   },
 })
 
-const BreakpointSplitViewOverlay = observer(function ({
-  model,
-}: {
-  model: BreakpointViewModel
-}) {
-  const { classes } = useStyles()
-  const { matchedTracks } = model
-  const ref = useRef(null)
-  return (
-    <div className={classes.overlay}>
-      <svg ref={ref} className={classes.base}>
-        {matchedTracks.map(track => (
-          // note: we must pass ref down, because:
-          //
-          // 1. the child component needs to getBoundingClientRect on the this
-          // components SVG, and...
-          //
-          // 2. we cannot rely on using getBoundingClientRect in this component
-          // to make sure this works because if it gets shifted around by
-          // another element, this will not re-render necessarily
-          <Overlay
-            parentRef={ref}
-            key={track.configuration.trackId}
-            model={model}
-            trackId={track.configuration.trackId}
-          />
-        ))}
-      </svg>
-    </div>
-  )
-})
+const BreakpointSplitViewOverlay = observer(
+  function BreakpointSplitViewOverlay({
+    model,
+  }: {
+    model: BreakpointViewModel
+  }) {
+    const { classes } = useStyles()
+    const { matchedTracks } = model
+    const ref = useRef(null)
+    return (
+      <div className={classes.overlay}>
+        <svg ref={ref} className={classes.base}>
+          {matchedTracks.map(track => (
+            // note: we must pass ref down, because:
+            //
+            // 1. the child component needs to getBoundingClientRect on the this
+            // components SVG, and...
+            //
+            // 2. we cannot rely on using getBoundingClientRect in this component
+            // to make sure this works because if it gets shifted around by
+            // another element, this will not re-render necessarily
+            <Overlay
+              parentRef={ref}
+              key={track.configuration.trackId}
+              model={model}
+              trackId={track.configuration.trackId}
+            />
+          ))}
+        </svg>
+      </div>
+    )
+  },
+)
 
 export default BreakpointSplitViewOverlay

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Header.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Header.tsx
@@ -17,7 +17,11 @@ const useStyles = makeStyles()({
   },
 })
 
-const Header = observer(function ({ model }: { model: BreakpointViewModel }) {
+const Header = observer(function Header({
+  model,
+}: {
+  model: BreakpointViewModel
+}) {
   const { classes } = useStyles()
   const { views } = model
   const [showSearchBoxes, setShowSearchBoxes] = useState(views.length <= 3)

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/HeaderSearchBoxes.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/HeaderSearchBoxes.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const HeaderSearchBoxes = observer(function ({
+const HeaderSearchBoxes = observer(function HeaderSearchBoxes({
   view,
 }: {
   view: LinearGenomeViewModel

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Overlay.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Overlay.tsx
@@ -16,7 +16,7 @@ import type { BreakpointViewModel } from '../model'
 //   - Translocations: for TRA type variants (uses INFO.CHR2, INFO.END)
 //   - PairedFeatures: for paired_feature type (e.g. BEDPE-style)
 //   - Breakends: for BND type variants (uses ALT field breakend notation)
-const Overlay = observer(function (props: {
+const Overlay = observer(function Overlay(props: {
   parentRef: React.RefObject<SVGSVGElement | null>
   model: BreakpointViewModel
   trackId: string

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/PairedFeatures.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/PairedFeatures.tsx
@@ -16,7 +16,7 @@ import { getPxFromCoordinate, useNextFrame, yPos } from '../util'
 
 import type { OverlayProps } from './overlayUtils'
 
-const PairedFeatures = observer(function ({
+const PairedFeatures = observer(function PairedFeatures({
   model,
   trackId,
   parentRef,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Rubberband.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Rubberband.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const Rubberband = observer(function ({
+const Rubberband = observer(function Rubberband({
   model,
   ControlComponent = <div />,
 }: {

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Translocations.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/Translocations.tsx
@@ -20,7 +20,7 @@ function str(s: string) {
   return s === '+' ? 1 : s === '-' ? -1 : 0
 }
 
-const Translocations = observer(function ({
+const Translocations = observer(function Translocations({
   model,
   trackId,
   parentRef,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/VerticalGuide.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/VerticalGuide.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const VerticalGuide = observer(function ({
+const VerticalGuide = observer(function VerticalGuide({
   model,
   coordX,
 }: {

--- a/plugins/canvas/src/CanvasFeatureRenderer/CanvasFeatureRendering.tsx
+++ b/plugins/canvas/src/CanvasFeatureRenderer/CanvasFeatureRendering.tsx
@@ -8,7 +8,7 @@ import type { FlatbushItem, SubfeatureInfo } from './types'
 import type { Region } from '@jbrowse/core/util/types'
 import type { BaseLinearDisplayModel } from '@jbrowse/plugin-linear-genome-view'
 
-const CanvasFeatureRendering = observer(function (props: {
+const CanvasFeatureRendering = observer(function CanvasFeatureRendering(props: {
   blockKey: string
   displayModel: BaseLinearDisplayModel
   width: number

--- a/plugins/circular-view/src/CircularView/components/CircularView.tsx
+++ b/plugins/circular-view/src/CircularView/components/CircularView.tsx
@@ -22,7 +22,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Slices = observer(({ model }: { model: CircularViewModel }) => {
+const Slices = observer(function Slices({
+  model,
+}: {
+  model: CircularViewModel
+}) {
   return (
     <>
       {model.staticSlices.map(slice => (
@@ -48,7 +52,11 @@ const Slices = observer(({ model }: { model: CircularViewModel }) => {
   )
 })
 
-const CircularView = observer(({ model }: { model: CircularViewModel }) => {
+const CircularView = observer(function CircularView({
+  model,
+}: {
+  model: CircularViewModel
+}) {
   const { showLoading, showView, showImportForm, loadingMessage } = model
 
   if (showLoading) {
@@ -62,7 +70,7 @@ const CircularView = observer(({ model }: { model: CircularViewModel }) => {
   }
 })
 
-const CircularViewLoaded = observer(function ({
+const CircularViewLoaded = observer(function CircularViewLoaded({
   model,
 }: {
   model: CircularViewModel

--- a/plugins/circular-view/src/CircularView/components/Controls.tsx
+++ b/plugins/circular-view/src/CircularView/components/Controls.tsx
@@ -29,7 +29,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Controls = observer(function ({ model }: { model: CircularViewModel }) {
+const Controls = observer(function Controls({
+  model,
+}: {
+  model: CircularViewModel
+}) {
   const { classes } = useStyles()
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   return (

--- a/plugins/circular-view/src/CircularView/components/ImportForm.tsx
+++ b/plugins/circular-view/src/CircularView/components/ImportForm.tsx
@@ -14,7 +14,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ImportForm = observer(function ({ model }: { model: CircularViewModel }) {
+const ImportForm = observer(function ImportForm({
+  model,
+}: {
+  model: CircularViewModel
+}) {
   const { classes } = useStyles()
   const session = getSession(model)
   const { error } = model

--- a/plugins/circular-view/src/CircularView/components/Ruler.tsx
+++ b/plugins/circular-view/src/CircularView/components/Ruler.tsx
@@ -51,7 +51,7 @@ function sliceArcPath(
   ].join(' ')
 }
 
-const ElisionRulerArc = observer(function ({
+const ElisionRulerArc = observer(function ElisionRulerArc({
   model,
   slice,
   region,
@@ -103,7 +103,7 @@ const ElisionRulerArc = observer(function ({
   )
 })
 
-const RulerLabel = observer(function ({
+const RulerLabel = observer(function RulerLabel({
   view,
   text,
   maxWidthPx,
@@ -179,7 +179,7 @@ const RulerLabel = observer(function ({
   }
 })
 
-const RegionRulerArc = observer(function ({
+const RegionRulerArc = observer(function RegionRulerArc({
   model,
   slice,
   region,
@@ -227,7 +227,7 @@ const RegionRulerArc = observer(function ({
   )
 })
 
-const Ruler = observer(function ({
+const Ruler = observer(function Ruler({
   model,
   slice,
 }: {

--- a/plugins/comparative-adapters/src/ComparativeAddTrackComponent/ComparativeAddTrackComponent.tsx
+++ b/plugins/comparative-adapters/src/ComparativeAddTrackComponent/ComparativeAddTrackComponent.tsx
@@ -4,46 +4,48 @@ import { AssemblySelector } from '@jbrowse/core/ui'
 import { getSession } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 
-const ComparativeAddTrackComponent = observer(function ({ model }: any) {
-  const session = getSession(model)
-  const [r0, setR0] = useState(session.assemblies[0]?.name)
-  const [r1, setR1] = useState(session.assemblies[0]?.name)
-  useEffect(() => {
-    model.setMixinData({
-      adapter: {
-        queryAssembly: r0,
-        targetAssembly: r1,
-      },
-    })
-  }, [model, r0, r1])
-  return (
-    <>
-      <AssemblySelector
-        session={session}
-        label="Query assembly"
-        helperText=""
-        selected={r0}
-        onChange={asm => {
-          setR0(asm)
-        }}
-        TextFieldProps={{
-          fullWidth: true,
-        }}
-      />
-      <AssemblySelector
-        session={session}
-        label="Target assembly"
-        helperText=""
-        selected={r1}
-        onChange={asm => {
-          setR1(asm)
-        }}
-        TextFieldProps={{
-          fullWidth: true,
-        }}
-      />
-    </>
-  )
-})
+const ComparativeAddTrackComponent = observer(
+  function ComparativeAddTrackComponent({ model }: any) {
+    const session = getSession(model)
+    const [r0, setR0] = useState(session.assemblies[0]?.name)
+    const [r1, setR1] = useState(session.assemblies[0]?.name)
+    useEffect(() => {
+      model.setMixinData({
+        adapter: {
+          queryAssembly: r0,
+          targetAssembly: r1,
+        },
+      })
+    }, [model, r0, r1])
+    return (
+      <>
+        <AssemblySelector
+          session={session}
+          label="Query assembly"
+          helperText=""
+          selected={r0}
+          onChange={asm => {
+            setR0(asm)
+          }}
+          TextFieldProps={{
+            fullWidth: true,
+          }}
+        />
+        <AssemblySelector
+          session={session}
+          label="Target assembly"
+          helperText=""
+          selected={r1}
+          onChange={asm => {
+            setR1(asm)
+          }}
+          TextFieldProps={{
+            fullWidth: true,
+          }}
+        />
+      </>
+    )
+  },
+)
 
 export default ComparativeAddTrackComponent

--- a/plugins/comparative-adapters/src/MCScanAddTrackComponent/MCScanAddTrackComponent.tsx
+++ b/plugins/comparative-adapters/src/MCScanAddTrackComponent/MCScanAddTrackComponent.tsx
@@ -7,7 +7,9 @@ import { observer } from 'mobx-react'
 
 import type { FileLocation } from '@jbrowse/core/util'
 
-const MCScanAddTrackComponent = observer(function ({ model }: any) {
+const MCScanAddTrackComponent = observer(function MCScanAddTrackComponent({
+  model,
+}: any) {
   const session = getSession(model)
   const [r0, setR0] = useState(session.assemblies[0]?.name)
   const [r1, setR1] = useState(session.assemblies[0]?.name)

--- a/plugins/config/src/ConfigurationEditorWidget/components/BooleanEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/BooleanEditor.tsx
@@ -6,7 +6,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const BooleanEditor = observer(function ({
+const BooleanEditor = observer(function BooleanEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/CallbackEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/CallbackEditor.tsx
@@ -51,7 +51,7 @@ function validateAndSetCode(
   }
 }
 
-const CallbackEditor = observer(function ({
+const CallbackEditor = observer(function CallbackEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/ColorEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ColorEditor.tsx
@@ -43,7 +43,7 @@ export const ColorSlot = (props: {
   )
 }
 
-const ColorEditor = observer(function (props: {
+const ColorEditor = observer(function ColorEditor(props: {
   slot: {
     name: string
     value: string

--- a/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/ConfigurationEditor.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Member = observer(function (props: {
+const Member = observer(function Member(props: {
   slotName: string
   slotSchema: IAnyType
   schema: AnyConfigurationModel
@@ -104,7 +104,7 @@ const Member = observer(function (props: {
   }
 })
 
-const Schema = observer(function ({
+const Schema = observer(function Schema({
   schema,
   path = [],
 }: {
@@ -127,7 +127,7 @@ const Schema = observer(function ({
   )
 })
 
-const ConfigurationEditor = observer(function ({
+const ConfigurationEditor = observer(function ConfigurationEditor({
   model,
 }: {
   model: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/HeadingComponent.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/HeadingComponent.tsx
@@ -1,7 +1,7 @@
 import { getType, isStateTreeNode } from '@jbrowse/mobx-state-tree'
 import { observer } from 'mobx-react'
 
-const HeadingComponent = observer(function ({
+const HeadingComponent = observer(function HeadingComponent({
   model,
 }: {
   model?: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/NumberEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/NumberEditor.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import ConfigurationTextField from './ConfigurationTextField'
 
-const NumberEditor = observer(function ({
+const NumberEditor = observer(function NumberEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/NumberMapEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/NumberMapEditor.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const NumberMapEditor = observer(function ({
+const NumberMapEditor = observer(function NumberMapEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/SlotEditor.tsx
@@ -27,7 +27,7 @@ import type { FileLocation } from '@jbrowse/core/util'
 import type { ILiteralType } from '@jbrowse/core/util/mst-reflection'
 import type { IAnyType } from '@jbrowse/mobx-state-tree'
 
-const StringEditor = observer(function ({
+const StringEditor = observer(function StringEditor({
   slot,
 }: {
   slot: {
@@ -49,7 +49,7 @@ const StringEditor = observer(function ({
   )
 })
 
-const TextEditor = observer(function ({
+const TextEditor = observer(function TextEditor({
   slot,
 }: {
   slot: {
@@ -79,7 +79,7 @@ const SvgCheckbox = () => (
   </SvgIcon>
 )
 
-const IntegerEditor = observer(function ({
+const IntegerEditor = observer(function IntegerEditor({
   slot,
 }: {
   slot: {
@@ -109,7 +109,7 @@ const IntegerEditor = observer(function ({
   )
 })
 
-const StringEnumEditor = observer(function ({
+const StringEnumEditor = observer(function StringEnumEditor({
   slot,
   slotSchema,
 }: {
@@ -140,7 +140,7 @@ const StringEnumEditor = observer(function ({
   )
 })
 
-const FileSelectorWrapper = observer(function ({
+const FileSelectorWrapper = observer(function FileSelectorWrapper({
   slot,
 }: {
   slot: {
@@ -179,7 +179,7 @@ const valueComponents = {
   configRelationships: JsonEditor,
 }
 
-const SlotEditor = observer(function ({
+const SlotEditor = observer(function SlotEditor({
   slot,
   slotSchema,
 }: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/StringArrayEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/StringArrayEditor.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const StringArrayEditor = observer(function ({
+const StringArrayEditor = observer(function StringArrayEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/StringArrayMapEditor.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/StringArrayMapEditor.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const StringArrayMapEditor = observer(function ({
+const StringArrayMapEditor = observer(function StringArrayMapEditor({
   slot,
 }: {
   slot: {

--- a/plugins/config/src/ConfigurationEditorWidget/components/TypeSelector.tsx
+++ b/plugins/config/src/ConfigurationEditorWidget/components/TypeSelector.tsx
@@ -5,7 +5,7 @@ import { useSlotEditorStyles } from './useSlotEditorStyles'
 
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
-const TypeSelector = observer(function ({
+const TypeSelector = observer(function TypeSelector({
   typeNameChoices,
   slot,
   slotName,

--- a/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.tsx
+++ b/plugins/data-management/src/AddConnectionWidget/components/AddConnectionWidget.tsx
@@ -33,7 +33,11 @@ const useStyles = makeStyles()(theme => ({
 
 const steps = ['Select a Connection Type', 'Configure Connection']
 
-const AddConnectionWidget = observer(function ({ model }: { model: unknown }) {
+const AddConnectionWidget = observer(function AddConnectionWidget({
+  model,
+}: {
+  model: unknown
+}) {
   const [connectionType, setConnectionType] = useState<ConnectionType>()
   const [connectionId, setConnectionId] = useState<string>()
   const [activeStep, setActiveStep] = useState(0)

--- a/plugins/data-management/src/AddConnectionWidget/components/ConfigureConnection.tsx
+++ b/plugins/data-management/src/AddConnectionWidget/components/ConfigureConnection.tsx
@@ -8,7 +8,7 @@ import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { ConnectionType } from '@jbrowse/core/pluggableElementTypes'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 
-const ConfigureConnection = observer(function ({
+const ConfigureConnection = observer(function ConfigureConnection({
   connectionType,
   model,
   session,

--- a/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/AddTrackWidget.tsx
@@ -9,7 +9,7 @@ import PasteConfigWorkflow from './PasteConfigWorkflow'
 
 import type { AddTrackModel } from '../model'
 
-const AddTrackSelector = observer(function ({
+const AddTrackSelector = observer(function AddTrackSelector({
   model,
 }: {
   model: AddTrackModel

--- a/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/DefaultAddTrackWorkflow.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles()(theme => ({
 
 const steps = ['Enter track data', 'Confirm track type']
 
-const DefaultAddTrackWorkflow = observer(function ({
+const DefaultAddTrackWorkflow = observer(function DefaultAddTrackWorkflow({
   model,
 }: {
   model: AddTrackModel

--- a/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/PasteConfigWorkflow.tsx
@@ -24,63 +24,61 @@ const useStyles = makeStyles()({
   },
 })
 
-const PasteConfigAddTrackWorkflow = observer(function ({
-  model,
-}: {
-  model: AddTrackModel
-}) {
-  const { classes } = useStyles()
-  const [val, setVal] = useState('')
-  const [error, setError] = useState<unknown>()
+const PasteConfigAddTrackWorkflow = observer(
+  function PasteConfigAddTrackWorkflow({ model }: { model: AddTrackModel }) {
+    const { classes } = useStyles()
+    const [val, setVal] = useState('')
+    const [error, setError] = useState<unknown>()
 
-  return (
-    <div>
-      {error ? <ErrorMessage error={error} /> : null}
-      <TextField
-        multiline
-        rows={10}
-        value={val}
-        placeholder="Paste track config or array of track configs in JSON format"
-        variant="outlined"
-        className={classes.textbox}
-        onChange={event => {
-          setVal(event.target.value)
-        }}
-      />
-      <Button
-        variant="contained"
-        className={classes.submit}
-        onClick={() => {
-          try {
-            setError(undefined)
-            const session = getSession(model)
-            const conf = JSON.parse(val)
-            const confs = Array.isArray(conf) ? conf : [conf]
-            if (
-              isSessionWithAddTracks(session) &&
-              isSessionModelWithWidgets(session)
-            ) {
-              transaction(() => {
-                for (const c of confs) {
-                  session.addTrackConf(c)
-                }
-                for (const c of confs) {
-                  model.view.showTrack(c.trackId)
-                }
-                model.clearData()
-              })
+    return (
+      <div>
+        {error ? <ErrorMessage error={error} /> : null}
+        <TextField
+          multiline
+          rows={10}
+          value={val}
+          placeholder="Paste track config or array of track configs in JSON format"
+          variant="outlined"
+          className={classes.textbox}
+          onChange={event => {
+            setVal(event.target.value)
+          }}
+        />
+        <Button
+          variant="contained"
+          className={classes.submit}
+          onClick={() => {
+            try {
+              setError(undefined)
+              const session = getSession(model)
+              const conf = JSON.parse(val)
+              const confs = Array.isArray(conf) ? conf : [conf]
+              if (
+                isSessionWithAddTracks(session) &&
+                isSessionModelWithWidgets(session)
+              ) {
+                transaction(() => {
+                  for (const c of confs) {
+                    session.addTrackConf(c)
+                  }
+                  for (const c of confs) {
+                    model.view.showTrack(c.trackId)
+                  }
+                  model.clearData()
+                })
 
-              session.hideWidget(model)
+                session.hideWidget(model)
+              }
+            } catch (e) {
+              console.error(e)
+              setError(e)
             }
-          } catch (e) {
-            console.error(e)
-            setError(e)
-          }
-        }}
-      >
-        Submit
-      </Button>
-    </div>
-  )
-})
+          }}
+        >
+          Submit
+        </Button>
+      </div>
+    )
+  },
+)
 export default PasteConfigAddTrackWorkflow

--- a/plugins/data-management/src/AddTrackWidget/components/TextIndexingConfig.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TextIndexingConfig.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const TextIndexingConfig = observer(function ({
+const TextIndexingConfig = observer(function TextIndexingConfig({
   model,
 }: {
   model: AddTrackModel

--- a/plugins/data-management/src/AddTrackWidget/components/TrackAdapterSelector.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackAdapterSelector.tsx
@@ -6,7 +6,11 @@ import { categorizeAdapters } from './util'
 
 import type { AddTrackModel } from '../model'
 
-const TrackAdapterSelector = observer(({ model }: { model: AddTrackModel }) => {
+const TrackAdapterSelector = observer(function ({
+  model,
+}: {
+  model: AddTrackModel
+}) {
   const { trackAdapter } = model
   const { pluginManager } = getEnv(model)
 

--- a/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackSourceSelect.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const TrackSourceSelect = observer(function ({
+const TrackSourceSelect = observer(function TrackSourceSelect({
   model,
 }: {
   model: AddTrackModel

--- a/plugins/data-management/src/AddTrackWidget/components/TrackTypeSelector.tsx
+++ b/plugins/data-management/src/AddTrackWidget/components/TrackTypeSelector.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import type { AddTrackModel } from '../model'
 
-const TrackTypeSelector = observer(function ({
+const TrackTypeSelector = observer(function TrackTypeSelector({
   model,
 }: {
   model: AddTrackModel

--- a/plugins/data-management/src/AssemblyManager/AssemblyAddForm.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyAddForm.tsx
@@ -16,7 +16,7 @@ import type {
   FileLocation,
 } from '@jbrowse/core/util/types'
 
-const AdapterSelector = observer(function ({
+const AdapterSelector = observer(function AdapterSelector({
   adapterSelection,
   setAdapterSelection,
   adapterTypes,
@@ -45,32 +45,34 @@ const AdapterSelector = observer(function ({
   )
 })
 
-const UnindexedFastaAdapterInput = observer(function ({
-  fastaLocation,
-  setFastaLocation,
-}: {
-  fastaLocation: FileLocation
-  setFastaLocation: (arg: FileLocation) => void
-}) {
-  return (
-    <>
-      <Alert severity="warning" style={{ margin: 8 }}>
-        Note: a FASTA index will be generated on submit, might take a couple
-        minutes and if the file is remote, it will be downloaded in full
-      </Alert>
-      <div>
-        <FileSelector
-          inline
-          name="FASTA file"
-          location={fastaLocation}
-          setLocation={setFastaLocation}
-        />
-      </div>
-    </>
-  )
-})
+const UnindexedFastaAdapterInput = observer(
+  function UnindexedFastaAdapterInput({
+    fastaLocation,
+    setFastaLocation,
+  }: {
+    fastaLocation: FileLocation
+    setFastaLocation: (arg: FileLocation) => void
+  }) {
+    return (
+      <>
+        <Alert severity="warning" style={{ margin: 8 }}>
+          Note: a FASTA index will be generated on submit, might take a couple
+          minutes and if the file is remote, it will be downloaded in full
+        </Alert>
+        <div>
+          <FileSelector
+            inline
+            name="FASTA file"
+            location={fastaLocation}
+            setLocation={setFastaLocation}
+          />
+        </div>
+      </>
+    )
+  },
+)
 
-const IndexedFastaAdapterInput = observer(function ({
+const IndexedFastaAdapterInput = observer(function IndexedFastaAdapterInput({
   fastaLocation,
   faiLocation,
   setFaiLocation,
@@ -103,7 +105,7 @@ const IndexedFastaAdapterInput = observer(function ({
   )
 })
 
-const BgzipFastaAdapterInput = observer(function ({
+const BgzipFastaAdapterInput = observer(function BgzipFastaAdapterInput({
   fastaLocation,
   faiLocation,
   gziLocation,
@@ -148,7 +150,7 @@ const BgzipFastaAdapterInput = observer(function ({
   )
 })
 
-const TwoBitAdapterInput = observer(function ({
+const TwoBitAdapterInput = observer(function TwoBitAdapterInput({
   twoBitLocation,
   chromSizesLocation,
   setTwoBitLocation,
@@ -196,7 +198,7 @@ type AdapterType =
   | 'UnindexedFastaAdapter'
   | 'TwoBitAdapter'
 
-const AssemblyAddForm = observer(function ({
+const AssemblyAddForm = observer(function AssemblyAddForm({
   session,
   onClose,
 }: {

--- a/plugins/data-management/src/AssemblyManager/AssemblyEditor.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyEditor.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles()({
     maxHeight: 600,
   },
 })
-const AssemblyEditor = observer(function ({
+const AssemblyEditor = observer(function AssemblyEditor({
   assembly,
   onClose,
 }: {

--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.tsx
@@ -10,7 +10,7 @@ import AssemblyTable from './AssemblyTable'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 
-const AssemblyManager = observer(function ({
+const AssemblyManager = observer(function AssemblyManager({
   session,
   onClose,
 }: {

--- a/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyTable.tsx
@@ -10,7 +10,7 @@ import { observer } from 'mobx-react'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 
-const AssemblyTable = observer(function ({
+const AssemblyTable = observer(function AssemblyTable({
   onEditAssembly,
   onAddAssembly,
   onClose,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalFab.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalFab.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const HierarchicalFab = observer(function ({
+const HierarchicalFab = observer(function HierarchicalFab({
   model,
 }: {
   model: HierarchicalTrackSelectorModel

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/HierarchicalTrackSelector.tsx
@@ -45,24 +45,29 @@ const Wrapper = ({
     children
   )
 }
-const HierarchicalTrackSelectorContainer = observer(function ({
-  model,
-  toolbarHeight,
-  overrideDimensions,
-}: {
-  model: HierarchicalTrackSelectorModel
-  toolbarHeight: number
-  overrideDimensions?: { width: number; height: number }
-}) {
-  return (
-    <Wrapper overrideDimensions={overrideDimensions}>
-      <HierarchicalTrackSelector model={model} toolbarHeight={toolbarHeight} />
-      <HierarchicalFab model={model} />
-    </Wrapper>
-  )
-})
+const HierarchicalTrackSelectorContainer = observer(
+  function HierarchicalTrackSelectorContainer({
+    model,
+    toolbarHeight,
+    overrideDimensions,
+  }: {
+    model: HierarchicalTrackSelectorModel
+    toolbarHeight: number
+    overrideDimensions?: { width: number; height: number }
+  }) {
+    return (
+      <Wrapper overrideDimensions={overrideDimensions}>
+        <HierarchicalTrackSelector
+          model={model}
+          toolbarHeight={toolbarHeight}
+        />
+        <HierarchicalFab model={model} />
+      </Wrapper>
+    )
+  },
+)
 
-const HierarchicalTrackSelector = observer(function ({
+const HierarchicalTrackSelector = observer(function HierarchicalTrackSelector({
   model,
   toolbarHeight = 0,
 }: {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ShoppingCart.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/ShoppingCart.tsx
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { MenuItem } from '@jbrowse/core/ui/Menu'
 
-const ShoppingCart = observer(function ({
+const ShoppingCart = observer(function ShoppingCart({
   model,
 }: {
   model: {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ManageConnectionsDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ManageConnectionsDialog.tsx
@@ -32,7 +32,7 @@ function DisabledButton() {
   )
 }
 
-const ManageConnectionsDialog = observer(function ({
+const ManageConnectionsDialog = observer(function ManageConnectionsDialog({
   session,
   handleClose,
   breakConnection,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ToggleConnectionsDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/dialogs/ToggleConnectionsDialog.tsx
@@ -91,7 +91,7 @@ const ConnectionList = observer(function ConnectionsList({
   )
 })
 
-const ToggleConnectionDialog = observer(function ({
+const ToggleConnectionDialog = observer(function ToggleConnectionDialog({
   session,
   handleClose,
   breakConnection,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilter.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilter.tsx
@@ -64,7 +64,7 @@ function ExpandButton({
   )
 }
 
-const FacetFilter = observer(function ({
+const FacetFilter = observer(function FacetFilter({
   column,
   vals,
   model,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetFilters.tsx
@@ -6,7 +6,7 @@ import { getRowStr } from './util'
 import type { Row } from './util'
 import type { HierarchicalTrackSelectorModel } from '../../model'
 
-const FacetFilters = observer(function ({
+const FacetFilters = observer(function FacetFilters({
   rows,
   columns,
   model,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDataGrid.tsx
@@ -11,7 +11,7 @@ import { computeInitialWidths } from './computeInitialWidths'
 import type { HierarchicalTrackSelectorModel } from '../../model'
 import type { GridColDef, GridRowId } from '@mui/x-data-grid'
 
-const FacetedDataGrid = observer(function ({
+const FacetedDataGrid = observer(function FacetedDataGrid({
   model,
   columns,
   shownTrackIds,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDialog.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/faceted/FacetedDialog.tsx
@@ -6,23 +6,25 @@ import FacetedSelector from './FacetedSelector'
 
 import type { HierarchicalTrackSelectorModel } from '../../model'
 
-const FacetedTrackSelectorDialog = observer(function (props: {
-  handleClose: () => void
-  model: HierarchicalTrackSelectorModel
-}) {
-  const { handleClose } = props
-  return (
-    <Dialog
-      open
-      onClose={handleClose}
-      maxWidth="xl"
-      title="Faceted track selector"
-    >
-      <DialogContent>
-        <FacetedSelector {...props} />
-      </DialogContent>
-    </Dialog>
-  )
-})
+const FacetedTrackSelectorDialog = observer(
+  function FacetedTrackSelectorDialog(props: {
+    handleClose: () => void
+    model: HierarchicalTrackSelectorModel
+  }) {
+    const { handleClose } = props
+    return (
+      <Dialog
+        open
+        onClose={handleClose}
+        maxWidth="xl"
+        title="Faceted track selector"
+      >
+        <DialogContent>
+          <FacetedSelector {...props} />
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)
 
 export default FacetedTrackSelectorDialog

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/DropdownTrackSelector.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/DropdownTrackSelector.tsx
@@ -12,7 +12,7 @@ import type { HierarchicalTrackSelectorModel } from '../../model'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { MenuItem } from '@jbrowse/core/ui/Menu'
 
-const DropdownTrackSelector = observer(function ({
+const DropdownTrackSelector = observer(function DropdownTrackSelector({
   model,
   tracks,
   extraMenuItems,

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/FavoriteTracks.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/FavoriteTracks.tsx
@@ -11,7 +11,7 @@ import {
 
 import type { HierarchicalTrackSelectorModel } from '../../model'
 
-const FavoriteTracks = observer(function ({
+const FavoriteTracks = observer(function FavoriteTracks({
   model,
 }: {
   model: HierarchicalTrackSelectorModel

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HamburgerMenu.tsx
@@ -44,7 +44,7 @@ interface DialogDetails {
   connectionConf: AnyConfigurationModel
 }
 
-const HamburgerMenu = observer(function ({
+const HamburgerMenu = observer(function HamburgerMenu({
   model,
 }: {
   model: HierarchicalTrackSelectorModel

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalHeader.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalHeader.tsx
@@ -15,37 +15,39 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const HierarchicalTrackSelectorHeader = observer(function ({
-  model,
-  setHeaderHeight,
-}: {
-  model: HierarchicalTrackSelectorModel
-  setHeaderHeight: (n: number) => void
-}) {
-  const { classes } = useStyles()
-  return (
-    <div
-      ref={ref => {
-        setHeaderHeight(ref?.getBoundingClientRect().height || 0)
-      }}
-      data-testid="hierarchical_track_selector"
-    >
-      <div style={{ display: 'flex' }}>
-        <HamburgerMenu model={model} />
-        <ShoppingCart model={model} />
-        <ClearableSearchField
-          className={classes.searchBox}
-          label="Filter tracks"
-          value={model.filterText}
-          onChange={value => {
-            model.setFilterText(value)
-          }}
-        />
-        <RecentlyUsedTracks model={model} />
-        <FavoriteTracks model={model} />
+const HierarchicalTrackSelectorHeader = observer(
+  function HierarchicalTrackSelectorHeader({
+    model,
+    setHeaderHeight,
+  }: {
+    model: HierarchicalTrackSelectorModel
+    setHeaderHeight: (n: number) => void
+  }) {
+    const { classes } = useStyles()
+    return (
+      <div
+        ref={ref => {
+          setHeaderHeight(ref?.getBoundingClientRect().height || 0)
+        }}
+        data-testid="hierarchical_track_selector"
+      >
+        <div style={{ display: 'flex' }}>
+          <HamburgerMenu model={model} />
+          <ShoppingCart model={model} />
+          <ClearableSearchField
+            className={classes.searchBox}
+            label="Filter tracks"
+            value={model.filterText}
+            onChange={value => {
+              model.setFilterText(value)
+            }}
+          />
+          <RecentlyUsedTracks model={model} />
+          <FavoriteTracks model={model} />
+        </div>
       </div>
-    </div>
-  )
-})
+    )
+  },
+)
 
 export default HierarchicalTrackSelectorHeader

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/HierarchicalTree.tsx
@@ -6,7 +6,7 @@ import TreeItem from './TreeItem'
 
 import type { HierarchicalTrackSelectorModel } from '../../model'
 
-const HierarchicalTree = observer(function ({
+const HierarchicalTree = observer(function HierarchicalTree({
   height,
   model,
 }: {

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/RecentlyUsedTracks.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/RecentlyUsedTracks.tsx
@@ -11,7 +11,7 @@ import {
 
 import type { HierarchicalTrackSelectorModel } from '../../model'
 
-const RecentlyUsedTracks = observer(function ({
+const RecentlyUsedTracks = observer(function RecentlyUsedTracks({
   model,
 }: {
   model: HierarchicalTrackSelectorModel

--- a/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
+++ b/plugins/data-management/src/HierarchicalTrackSelectorWidget/components/tree/TrackCategory.tsx
@@ -42,7 +42,7 @@ function getTrackIdsFromCategory(node: TreeCategoryNode): string[] {
     .map(entry => entry.trackId)
 }
 
-const TrackCategory = observer(function ({
+const TrackCategory = observer(function TrackCategory({
   item,
   model,
 }: {

--- a/plugins/data-management/src/PluginStoreWidget/components/AddCustomPluginDialog.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/AddCustomPluginDialog.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const AddCustomPluginDialog = observer(function ({
+const AddCustomPluginDialog = observer(function AddCustomPluginDialog({
   onClose,
   model,
 }: {

--- a/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/InstalledPlugin.tsx
@@ -38,7 +38,7 @@ function LockedPluginIconButton() {
   )
 }
 
-const UninstallPluginIconButton = observer(function ({
+const UninstallPluginIconButton = observer(function UninstallPluginIconButton({
   plugin,
   model,
 }: {
@@ -81,7 +81,7 @@ const UninstallPluginIconButton = observer(function ({
   )
 })
 
-const InstalledPlugin = observer(function ({
+const InstalledPlugin = observer(function InstalledPlugin({
   plugin,
   model,
 }: {

--- a/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.tsx
+++ b/plugins/data-management/src/PluginStoreWidget/components/PluginStoreWidget.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const PluginStoreWidget = observer(function ({
+const PluginStoreWidget = observer(function PluginStoreWidget({
   model,
 }: {
   model: PluginStoreModel

--- a/plugins/dotplot-view/src/DotplotRenderer/components/DotplotRendering.tsx
+++ b/plugins/dotplot-view/src/DotplotRenderer/components/DotplotRendering.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 
 import type { DotplotRenderArgsDeserialized } from '../DotplotRenderer'
 
-const DotplotRendering = observer(function (
+const DotplotRendering = observer(function DotplotRendering(
   props: DotplotRenderArgsDeserialized,
 ) {
   return <PrerenderedCanvas {...props} />

--- a/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()(() => ({
     userSelect: 'none',
   },
 }))
-export const HorizontalAxis = observer(function ({
+export const HorizontalAxis = observer(function HorizontalAxis({
   model,
 }: {
   model: DotplotViewModel
@@ -41,7 +41,7 @@ export const HorizontalAxis = observer(function ({
   )
 })
 
-export const HorizontalAxisRaw = observer(function ({
+export const HorizontalAxisRaw = observer(function HorizontalAxisRaw({
   model,
 }: {
   model: DotplotViewModel
@@ -140,7 +140,7 @@ export const HorizontalAxisRaw = observer(function ({
     </>
   )
 })
-export const VerticalAxis = observer(function ({
+export const VerticalAxis = observer(function VerticalAxis({
   model,
 }: {
   model: DotplotViewModel
@@ -154,7 +154,7 @@ export const VerticalAxis = observer(function ({
   )
 })
 
-export const VerticalAxisRaw = observer(function ({
+export const VerticalAxisRaw = observer(function VerticalAxisRaw({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/ColorBySelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ColorBySelector.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react'
 import type { DotplotDisplayModel } from '../../DotplotDisplay/stateModelFactory'
 import type { DotplotViewModel } from '../model'
 
-const ColorBySelector = observer(function ({
+const ColorBySelector = observer(function ColorBySelector({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/DiagonalizationProgressDialog.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DiagonalizationProgressDialog.tsx
@@ -125,118 +125,128 @@ async function runDiagonalization({
   }
 }
 
-const DiagonalizationProgressDialog = observer(function ({
-  handleClose,
-  model,
-}: {
-  handleClose: () => void
-  model: Pick<
-    DotplotViewModel,
-    'tracks' | 'hview' | 'vview' | 'id' | 'type' | 'displayName'
-  >
-}) {
-  const [progress, setProgress] = useState(0)
-  const [message, setMessage] = useState('Ready to start diagonalization')
-  const [error, setError] = useState<unknown>()
-  const [isRunning, setIsRunning] = useState(false)
-  const [stopToken, setStopToken] = useState<StopToken>()
+const DiagonalizationProgressDialog = observer(
+  function DiagonalizationProgressDialog({
+    handleClose,
+    model,
+  }: {
+    handleClose: () => void
+    model: Pick<
+      DotplotViewModel,
+      'tracks' | 'hview' | 'vview' | 'id' | 'type' | 'displayName'
+    >
+  }) {
+    const [progress, setProgress] = useState(0)
+    const [message, setMessage] = useState('Ready to start diagonalization')
+    const [error, setError] = useState<unknown>()
+    const [isRunning, setIsRunning] = useState(false)
+    const [stopToken, setStopToken] = useState<StopToken>()
 
-  const handleStart = async () => {
-    const session = getSession(model)
-    const token = createStopToken()
-    setStopToken(token)
+    const handleStart = async () => {
+      const session = getSession(model)
+      const token = createStopToken()
+      setStopToken(token)
 
-    try {
-      setIsRunning(true)
-      await runDiagonalization({
-        model,
-        session,
-        stopToken: token,
-        setProgress,
-        setMessage,
-      })
+      try {
+        setIsRunning(true)
+        await runDiagonalization({
+          model,
+          session,
+          stopToken: token,
+          setProgress,
+          setMessage,
+        })
 
-      // Auto-close after success
-      setTimeout(() => {
-        handleClose()
-      }, 2000)
-    } catch (err) {
-      console.error(err)
-      setError(err)
-    } finally {
-      setIsRunning(false)
+        // Auto-close after success
+        setTimeout(() => {
+          handleClose()
+        }, 2000)
+      } catch (err) {
+        console.error(err)
+        setError(err)
+      } finally {
+        setIsRunning(false)
+      }
     }
-  }
 
-  const handleCancel = () => {
-    if (stopToken) {
-      stopStopToken(stopToken)
-      setStopToken(undefined)
-    }
-    handleClose()
-  }
-
-  const handleDialogClose = () => {
-    // Only allow closing if not running
-    if (!isRunning) {
+    const handleCancel = () => {
+      if (stopToken) {
+        stopStopToken(stopToken)
+        setStopToken(undefined)
+      }
       handleClose()
     }
-  }
 
-  return (
-    <Dialog
-      open
-      title="Diagonalize Dotplot"
-      onClose={handleDialogClose}
-      maxWidth="lg"
-    >
-      <DialogContent style={{ minWidth: 400 }}>
-        {message ? <Typography>{message}</Typography> : null}
-        {error ? <ErrorMessage error={error} /> : null}
-        {isRunning ? (
-          <>
-            <LinearProgress
-              variant="determinate"
-              value={progress}
-              style={{ marginTop: 16 }}
-              color={error ? 'error' : 'primary'}
-            />
-            <Typography
-              variant="caption"
-              color="textSecondary"
-              style={{ marginTop: 8, display: 'block' }}
-            >
-              {Math.round(progress)}% complete
-            </Typography>
-          </>
-        ) : null}
-      </DialogContent>
-      <DialogActions>
-        {!isRunning ? (
-          <>
-            <Button onClick={handleClose} color="secondary" variant="contained">
-              Cancel
-            </Button>
+    const handleDialogClose = () => {
+      // Only allow closing if not running
+      if (!isRunning) {
+        handleClose()
+      }
+    }
+
+    return (
+      <Dialog
+        open
+        title="Diagonalize Dotplot"
+        onClose={handleDialogClose}
+        maxWidth="lg"
+      >
+        <DialogContent style={{ minWidth: 400 }}>
+          {message ? <Typography>{message}</Typography> : null}
+          {error ? <ErrorMessage error={error} /> : null}
+          {isRunning ? (
+            <>
+              <LinearProgress
+                variant="determinate"
+                value={progress}
+                style={{ marginTop: 16 }}
+                color={error ? 'error' : 'primary'}
+              />
+              <Typography
+                variant="caption"
+                color="textSecondary"
+                style={{ marginTop: 8, display: 'block' }}
+              >
+                {Math.round(progress)}% complete
+              </Typography>
+            </>
+          ) : null}
+        </DialogContent>
+        <DialogActions>
+          {!isRunning ? (
+            <>
+              <Button
+                onClick={handleClose}
+                color="secondary"
+                variant="contained"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => {
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                  handleStart()
+                }}
+                color="primary"
+                variant="contained"
+              >
+                Start
+              </Button>
+            </>
+          ) : null}
+          {isRunning ? (
             <Button
-              onClick={() => {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                handleStart()
-              }}
-              color="primary"
+              onClick={handleCancel}
+              color="secondary"
               variant="contained"
             >
-              Start
+              Cancel
             </Button>
-          </>
-        ) : null}
-        {isRunning ? (
-          <Button onClick={handleCancel} color="secondary" variant="contained">
-            Cancel
-          </Button>
-        ) : null}
-      </DialogActions>
-    </Dialog>
-  )
-})
+          ) : null}
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
 
 export default DiagonalizationProgressDialog

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
@@ -21,7 +21,7 @@ const DiagonalizationProgressDialog = lazy(
   () => import('./DiagonalizationProgressDialog'),
 )
 
-const DotplotControls = observer(function ({
+const DotplotControls = observer(function DotplotControls({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotGrid.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotGrid.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import type { DotplotViewModel } from '../model'
 
-const DotplotGrid = observer(function ({
+const DotplotGrid = observer(function DotplotGrid({
   model,
   children,
 }: {
@@ -14,6 +14,7 @@ const DotplotGrid = observer(function ({
   const { viewWidth, viewHeight, hview, vview } = model
   const hblocks = hview.dynamicBlocks.contentBlocks
   const vblocks = vview.dynamicBlocks.contentBlocks
+  const theme = useTheme()
   if (!hblocks.length || !vblocks.length) {
     return null
   }
@@ -21,7 +22,6 @@ const DotplotGrid = observer(function ({
   const vtop = vview.displayedRegionsTotalPx - vview.offsetPx
   const hbottom = hblocks[0]!.offsetPx - hview.offsetPx
   const vbottom = vblocks[0]!.offsetPx - vview.offsetPx
-  const theme = useTheme()
   const stroke = theme.palette.divider
 
   // Uses math.max/min avoid making very large SVG rect offscreen element,

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotTooltipClick.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotTooltipClick.tsx
@@ -7,7 +7,7 @@ import type { DotplotViewModel } from '../model'
 
 type Coord = [number, number] | undefined
 
-const DotplotTooltipClick = observer(function ({
+const DotplotTooltipClick = observer(function DotplotTooltipClick({
   model,
   mousedown,
   mousedownClient,

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotTooltipMouseover.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotTooltipMouseover.tsx
@@ -7,7 +7,7 @@ import type { DotplotViewModel } from '../model'
 
 type Coord = [number, number] | undefined
 
-const DotplotTooltipMouseover = observer(function ({
+const DotplotTooltipMouseover = observer(function DotplotTooltipMouseover({
   model,
   mouserect,
   mouserectClient,

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotView.tsx
@@ -61,7 +61,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const RenderedComponent = observer(({ model }: { model: DotplotViewModel }) => {
+const RenderedComponent = observer(function RenderedComponent({
+  model,
+}: {
+  model: DotplotViewModel
+}) {
   const { classes } = useStyles()
   return (
     <div className={classes.overlay}>
@@ -79,7 +83,7 @@ const RenderedComponent = observer(({ model }: { model: DotplotViewModel }) => {
   )
 })
 
-const DotplotViewInternal = observer(function ({
+const DotplotViewInternal = observer(function DotplotViewInternal({
   model,
 }: {
   model: DotplotViewModel
@@ -212,7 +216,11 @@ const DotplotViewInternal = observer(function ({
     </div>
   )
 })
-const DotplotView = observer(function ({ model }: { model: DotplotViewModel }) {
+const DotplotView = observer(function DotplotView({
+  model,
+}: {
+  model: DotplotViewModel
+}) {
   const { initialized, showLoading, error, loadingMessage } = model
 
   if (showLoading) {

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotWarnings.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotWarnings.tsx
@@ -7,7 +7,7 @@ import type { DotplotViewModel } from '../model'
 // lazy components
 const WarningDialog = lazy(() => import('./WarningDialog'))
 
-const DotplotWarnings = observer(function ({
+const DotplotWarnings = observer(function DotplotWarnings({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/Header.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Header.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const DotplotHeader = observer(function ({
+const DotplotHeader = observer(function DotplotHeader({
   model,
   selection,
 }: {

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyOpenCustomTrack.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyOpenCustomTrack.tsx
@@ -22,146 +22,149 @@ import { basename, extName, getName, stripGz } from './util'
 import type { DotplotViewModel } from '../../model'
 import type { FileLocation } from '@jbrowse/core/util/types'
 
-const ImportSyntenyOpenCustomTrack = observer(function ({
-  model,
-  assembly1,
-  assembly2,
-}: {
-  model: DotplotViewModel
-  assembly1: string
-  assembly2: string
-}) {
-  const [swap, setSwap] = useState(false)
-  const [bed2Location, setBed2Location] = useState<FileLocation>()
-  const [bed1Location, setBed1Location] = useState<FileLocation>()
-  const [fileLocation, setFileLocation] = useState<FileLocation>()
-  const [indexFileLocation, setIndexFileLocation] = useState<FileLocation>()
-  const [value, setValue] = useState('')
-  const [error, setError] = useState<unknown>()
-  const fileName = getName(fileLocation)
-
-  const radioOption = value || (fileName ? extName(stripGz(fileName)) : '')
-
-  useEffect(() => {
-    try {
-      if (fileLocation) {
-        const fn = fileName ? basename(fileName) : 'MyTrack'
-        const trackId = `${fn}-${Date.now()}-sessionTrack`
-        setError(undefined)
-
-        model.setImportFormSyntenyTrack(0, {
-          type: 'userOpened',
-          value: {
-            trackId,
-            name: fn,
-            assemblyNames: [assembly2, assembly1],
-            type: 'SyntenyTrack',
-            adapter: getAdapter({
-              radioOption,
-              assembly1: swap ? assembly2 : assembly1,
-              assembly2: swap ? assembly1 : assembly2,
-              fileLocation,
-              indexFileLocation,
-              bed1Location,
-              bed2Location,
-            }),
-          },
-        })
-      }
-    } catch (e) {
-      console.error(e)
-      setError(e)
-    }
-  }, [
-    swap,
+const ImportSyntenyOpenCustomTrack = observer(
+  function ImportSyntenyOpenCustomTrack({
     model,
-    fileName,
     assembly1,
     assembly2,
-    bed1Location,
-    bed2Location,
-    fileLocation,
-    indexFileLocation,
-    radioOption,
-  ])
+  }: {
+    model: DotplotViewModel
+    assembly1: string
+    assembly2: string
+  }) {
+    const [swap, setSwap] = useState(false)
+    const [bed2Location, setBed2Location] = useState<FileLocation>()
+    const [bed1Location, setBed1Location] = useState<FileLocation>()
+    const [fileLocation, setFileLocation] = useState<FileLocation>()
+    const [indexFileLocation, setIndexFileLocation] = useState<FileLocation>()
+    const [value, setValue] = useState('')
+    const [error, setError] = useState<unknown>()
+    const fileName = getName(fileLocation)
 
-  return (
-    <Paper style={{ padding: 12 }}>
-      {error ? <ErrorMessage error={error} /> : null}
-      <Typography style={{ textAlign: 'center' }}>
-        Add a .paf (minimap2), .delta (Mummer), .chain (UCSC liftover), .anchors
-        or .anchors.simple (MCScan), or .pif.gz (jbrowse CLI make-pif) file to
-        view. These file types can also be gzipped.
-      </Typography>
-      <RadioGroup
-        value={radioOption}
-        onChange={event => {
-          setValue(event.target.value)
-        }}
-      >
+    const radioOption = value || (fileName ? extName(stripGz(fileName)) : '')
+
+    useEffect(() => {
+      try {
+        if (fileLocation) {
+          const fn = fileName ? basename(fileName) : 'MyTrack'
+          const trackId = `${fn}-${Date.now()}-sessionTrack`
+          setError(undefined)
+
+          model.setImportFormSyntenyTrack(0, {
+            type: 'userOpened',
+            value: {
+              trackId,
+              name: fn,
+              assemblyNames: [assembly2, assembly1],
+              type: 'SyntenyTrack',
+              adapter: getAdapter({
+                radioOption,
+                assembly1: swap ? assembly2 : assembly1,
+                assembly2: swap ? assembly1 : assembly2,
+                fileLocation,
+                indexFileLocation,
+                bed1Location,
+                bed2Location,
+              }),
+            },
+          })
+        }
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
+    }, [
+      swap,
+      model,
+      fileName,
+      assembly1,
+      assembly2,
+      bed1Location,
+      bed2Location,
+      fileLocation,
+      indexFileLocation,
+      radioOption,
+    ])
+
+    return (
+      <Paper style={{ padding: 12 }}>
+        {error ? <ErrorMessage error={error} /> : null}
+        <Typography style={{ textAlign: 'center' }}>
+          Add a .paf (minimap2), .delta (Mummer), .chain (UCSC liftover),
+          .anchors or .anchors.simple (MCScan), or .pif.gz (jbrowse CLI
+          make-pif) file to view. These file types can also be gzipped.
+        </Typography>
+        <RadioGroup
+          value={radioOption}
+          onChange={event => {
+            setValue(event.target.value)
+          }}
+        >
+          <Grid container justifyContent="center">
+            {[
+              '.paf',
+              '.delta',
+              '.out',
+              '.chain',
+              '.anchors',
+              '.anchors.simple',
+              '.pif.gz',
+            ].map(extension => (
+              <FormControlLabel
+                key={extension}
+                value={extension}
+                control={<Radio />}
+                label={extension}
+              />
+            ))}
+          </Grid>
+        </RadioGroup>
         <Grid container justifyContent="center">
-          {[
-            '.paf',
-            '.delta',
-            '.out',
-            '.chain',
-            '.anchors',
-            '.anchors.simple',
-            '.pif.gz',
-          ].map(extension => (
-            <FormControlLabel
-              key={extension}
-              value={extension}
-              control={<Radio />}
-              label={extension}
+          {radioOption === '.paf' ||
+          radioOption === '.out' ||
+          radioOption === '.delta' ||
+          radioOption === '.chain' ? (
+            <SyntenyFileSelector
+              radioOption={radioOption}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
             />
-          ))}
+          ) : radioOption === '.anchors' ||
+            radioOption === '.anchors.simple' ? (
+            <AnchorsFileSelector
+              radioOption={radioOption}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
+              bed1Location={bed1Location}
+              setBed1Location={setBed1Location}
+              bed2Location={bed2Location}
+              setBed2Location={setBed2Location}
+            />
+          ) : radioOption === '.pif.gz' ? (
+            <PifGzSelector
+              radioOption={radioOption}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
+              indexFileLocation={indexFileLocation}
+              setIndexFileLocation={setIndexFileLocation}
+            />
+          ) : null}
         </Grid>
-      </RadioGroup>
-      <Grid container justifyContent="center">
-        {radioOption === '.paf' ||
-        radioOption === '.out' ||
-        radioOption === '.delta' ||
-        radioOption === '.chain' ? (
-          <SyntenyFileSelector
-            radioOption={radioOption}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-          />
-        ) : radioOption === '.anchors' || radioOption === '.anchors.simple' ? (
-          <AnchorsFileSelector
-            radioOption={radioOption}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-            bed1Location={bed1Location}
-            setBed1Location={setBed1Location}
-            bed2Location={bed2Location}
-            setBed2Location={setBed2Location}
-          />
-        ) : radioOption === '.pif.gz' ? (
-          <PifGzSelector
-            radioOption={radioOption}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-            indexFileLocation={indexFileLocation}
-            setIndexFileLocation={setIndexFileLocation}
-          />
-        ) : null}
-      </Grid>
-    </Paper>
-  )
-})
+      </Paper>
+    )
+  },
+)
 
 export default ImportSyntenyOpenCustomTrack

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyTrackSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/ImportSyntenyTrackSelector.tsx
@@ -24,71 +24,73 @@ function isRelevantTrack(
   )
 }
 
-const ImportSyntenyTrackSelector = observer(function ({
-  model,
-  assembly1,
-  assembly2,
-}: {
-  model: DotplotViewModel
-  assembly1: string
-  assembly2: string
-}) {
-  const session = getSession(model)
-  const { tracks, sessionTracks } = session
-  const allTracks = [
-    ...tracks,
-    ...(sessionTracks || []),
-  ] as AnyConfigurationModel[]
-  const filteredTracks = allTracks.filter(t =>
-    isRelevantTrack(t, assembly2, assembly1),
-  )
-  const resetTrack = filteredTracks[0]?.trackId || ''
-  const [value, setValue] = useState(resetTrack)
-  useEffect(() => {
-    // if assembly1/assembly2 changes, then we will want to use this effect to
-    // change the state of the useState because it otherwise gets locked to a
-    // stale value
-    setValue(resetTrack)
-  }, [resetTrack])
+const ImportSyntenyTrackSelector = observer(
+  function ImportSyntenyTrackSelector({
+    model,
+    assembly1,
+    assembly2,
+  }: {
+    model: DotplotViewModel
+    assembly1: string
+    assembly2: string
+  }) {
+    const session = getSession(model)
+    const { tracks, sessionTracks } = session
+    const allTracks = [
+      ...tracks,
+      ...(sessionTracks || []),
+    ] as AnyConfigurationModel[]
+    const filteredTracks = allTracks.filter(t =>
+      isRelevantTrack(t, assembly2, assembly1),
+    )
+    const resetTrack = filteredTracks[0]?.trackId || ''
+    const [value, setValue] = useState(resetTrack)
+    useEffect(() => {
+      // if assembly1/assembly2 changes, then we will want to use this effect to
+      // change the state of the useState because it otherwise gets locked to a
+      // stale value
+      setValue(resetTrack)
+    }, [resetTrack])
 
-  useEffect(() => {
-    // sets track data in a useEffect because the initial load is needed as
-    // well as onChange's to the select box
-    model.setImportFormSyntenyTrack(0, {
-      type: 'preConfigured',
-      value,
-    })
-  }, [model, value])
+    useEffect(() => {
+      // sets track data in a useEffect because the initial load is needed as
+      // well as onChange's to the select box
+      model.setImportFormSyntenyTrack(0, {
+        type: 'preConfigured',
+        value,
+      })
+    }, [model, value])
 
-  return (
-    <Paper style={{ padding: 12 }}>
-      <Typography>
-        Select a track from the select box below, the track will be shown when
-        you hit "Launch". Note: there is a track selector <i>inside</i> the
-        DotplotView, which can turn on one or more SyntenyTracks (more than one
-        can be displayed at once). Look for the track selector icon{' '}
-        <TrackSelectorIcon />
-      </Typography>
-      {filteredTracks.length ? (
-        <Select
-          value={value}
-          onChange={event => {
-            setValue(event.target.value)
-          }}
-        >
-          {filteredTracks.map(track => (
-            <MenuItem key={track.trackId} value={track.trackId}>
-              {getTrackName(track, session)}
-            </MenuItem>
-          ))}
-        </Select>
-      ) : (
-        <ErrorMessage
-          error={`No synteny tracks found for ${assembly1},${assembly2}`}
-        />
-      )}
-    </Paper>
-  )
-})
+    return (
+      <Paper style={{ padding: 12 }}>
+        <Typography>
+          Select a track from the select box below, the track will be shown when
+          you hit "Launch". Note: there is a track selector <i>inside</i> the
+          DotplotView, which can turn on one or more SyntenyTracks (more than
+          one can be displayed at once). Look for the track selector icon{' '}
+          <TrackSelectorIcon />
+        </Typography>
+        {filteredTracks.length ? (
+          <Select
+            value={value}
+            onChange={event => {
+              setValue(event.target.value)
+            }}
+          >
+            {filteredTracks.map(track => (
+              <MenuItem key={track.trackId} value={track.trackId}>
+                {getTrackName(track, session)}
+              </MenuItem>
+            ))}
+          </Select>
+        ) : (
+          <ErrorMessage
+            error={`No synteny tracks found for ${assembly1},${assembly2}`}
+          />
+        )}
+      </Paper>
+    )
+  },
+)
 
 export default ImportSyntenyTrackSelector

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/TrackSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/TrackSelector.tsx
@@ -14,7 +14,7 @@ import ImportSyntenyTrackSelector from './ImportSyntenyTrackSelector'
 
 import type { DotplotViewModel } from '../../model'
 
-const TrackSelector = observer(function ({
+const TrackSelector = observer(function TrackSelector({
   assembly1,
   assembly2,
   model,

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/index.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/index.tsx
@@ -65,7 +65,7 @@ function doSubmit({
   })
 }
 
-const DotplotImportForm = observer(function ({
+const DotplotImportForm = observer(function DotplotImportForm({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/AnchorsFileSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/AnchorsFileSelector.tsx
@@ -5,7 +5,7 @@ import SwapAssemblies from './SwapAssemblies'
 
 import type { SelectorProps } from './SelectorTypes'
 
-const AnchorsFileSelector = observer(function ({
+const AnchorsFileSelector = observer(function AnchorsFileSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/PifGzSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/PifGzSelector.tsx
@@ -5,7 +5,7 @@ import SwapAssemblies from './SwapAssemblies'
 
 import type { SelectorProps } from './SelectorTypes'
 
-const PifGzSelector = observer(function ({
+const PifGzSelector = observer(function PifGzSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/SwapAssemblies.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/SwapAssemblies.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SwapAssemblies = observer(function ({
+const SwapAssemblies = observer(function SwapAssemblies({
   assembly1,
   assembly2,
   swap,

--- a/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/SyntenyFileSelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ImportForm/selectors/SyntenyFileSelector.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SyntenyFileSelector = observer(function ({
+const SyntenyFileSelector = observer(function SyntenyFileSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/dotplot-view/src/DotplotView/components/MinLengthSlider.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/MinLengthSlider.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const MinLengthSlider = observer(function ({
+const MinLengthSlider = observer(function MinLengthSlider({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/DotplotView/components/OpacitySlider.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/OpacitySlider.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const OpacitySlider = observer(function ({
+const OpacitySlider = observer(function OpacitySlider({
   model,
 }: {
   model: DotplotViewModel

--- a/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
+++ b/plugins/dotplot-view/src/ServerSideRenderedBlockContent.tsx
@@ -38,29 +38,31 @@ function BlockError({ error }: { error: unknown }) {
   return <ErrorMessage error={error} />
 }
 
-const ServerSideRenderedDotplotContent = observer(function ({
-  model,
-  style,
-}: {
-  model: {
-    error?: unknown
-    message?: string
-    filled?: boolean
-    shouldDisplay?: boolean
-    reactElement?: React.ReactElement
-  }
-  style: CSSProperties
-}) {
-  if (model.error) {
-    return <BlockError error={model.error} data-testid="reload_button" />
-  } else if (model.message) {
-    return <BlockMessage messageText={model.message} />
-  } else if (!model.filled) {
-    return <LoadingMessage />
-  } else if (model.shouldDisplay) {
-    return <div style={style}>{model.reactElement}</div>
-  }
-  return null
-})
+const ServerSideRenderedDotplotContent = observer(
+  function ServerSideRenderedDotplotContent({
+    model,
+    style,
+  }: {
+    model: {
+      error?: unknown
+      message?: string
+      filled?: boolean
+      shouldDisplay?: boolean
+      reactElement?: React.ReactElement
+    }
+    style: CSSProperties
+  }) {
+    if (model.error) {
+      return <BlockError error={model.error} data-testid="reload_button" />
+    } else if (model.message) {
+      return <BlockMessage messageText={model.message} />
+    } else if (!model.filled) {
+      return <LoadingMessage />
+    } else if (model.shouldDisplay) {
+      return <div style={style}>{model.reactElement}</div>
+    }
+    return null
+  },
+)
 
 export default ServerSideRenderedDotplotContent

--- a/plugins/dotplot-view/src/ServerSideSyntenyRendering.tsx
+++ b/plugins/dotplot-view/src/ServerSideSyntenyRendering.tsx
@@ -16,36 +16,34 @@ interface ModelType {
     highResolutionScaling?: number
   }
 }
-const ServerSideSyntenyRendering = observer(function ({
-  model,
-}: {
-  model: ModelType
-}) {
-  const { imageData, style, renderProps } = model
-  const { width, height, highResolutionScaling = 1 } = renderProps
+const ServerSideSyntenyRendering = observer(
+  function ServerSideSyntenyRendering({ model }: { model: ModelType }) {
+    const { imageData, style, renderProps } = model
+    const { width, height, highResolutionScaling = 1 } = renderProps
 
-  const featureCanvas = useRef<HTMLCanvasElement>(null)
-  const [done, setDone] = useState(false)
+    const featureCanvas = useRef<HTMLCanvasElement>(null)
+    const [done, setDone] = useState(false)
 
-  useEffect(() => {
-    if (!imageData) {
-      return
-    }
-    const canvas = featureCanvas.current!
-    const context = canvas.getContext('2d')!
-    drawImageOntoCanvasContext(imageData, context)
-    setDone(true)
-  }, [imageData])
+    useEffect(() => {
+      if (!imageData) {
+        return
+      }
+      const canvas = featureCanvas.current!
+      const context = canvas.getContext('2d')!
+      drawImageOntoCanvasContext(imageData, context)
+      setDone(true)
+    }, [imageData])
 
-  return (
-    <canvas
-      data-testid={`prerendered_canvas${done ? '_done' : ''}`}
-      ref={featureCanvas}
-      width={width * highResolutionScaling}
-      height={height * highResolutionScaling}
-      style={{ width, height, ...style }}
-    />
-  )
-})
+    return (
+      <canvas
+        data-testid={`prerendered_canvas${done ? '_done' : ''}`}
+        ref={featureCanvas}
+        width={width * highResolutionScaling}
+        height={height * highResolutionScaling}
+        style={{ width, height, ...style }}
+      />
+    )
+  },
+)
 
 export default ServerSideSyntenyRendering

--- a/plugins/gccontent/src/LinearGCContentDisplay/components/EditGCContentParams.tsx
+++ b/plugins/gccontent/src/LinearGCContentDisplay/components/EditGCContentParams.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const EditGCContentParamsDialog = observer(function ({
+const EditGCContentParamsDialog = observer(function EditGCContentParamsDialog({
   model,
   handleClose,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/AssemblySelector.tsx
@@ -11,7 +11,7 @@ import { observer } from 'mobx-react'
 
 import type { GridBookmarkModel } from '../model'
 
-const AssemblySelector = observer(function ({
+const AssemblySelector = observer(function AssemblySelector({
   model,
 }: {
   model: GridBookmarkModel

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/BookmarkGrid.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const BookmarkGrid = observer(function ({
+const BookmarkGrid = observer(function BookmarkGrid({
   model,
 }: {
   model: GridBookmarkModel

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/DeleteBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/DeleteBookmarksDialog.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 
 import type { GridBookmarkModel } from '../../model'
 
-const DeleteBookmarksDialog = observer(function ({
+const DeleteBookmarksDialog = observer(function DeleteBookmarksDialog({
   onClose,
   model,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/EditHighlightColorDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/EditHighlightColorDialog.tsx
@@ -13,7 +13,7 @@ import { observer } from 'mobx-react'
 
 import type { GridBookmarkModel } from '../../model'
 
-const EditHighlightColorDialog = observer(function ({
+const EditHighlightColorDialog = observer(function EditHighlightColorDialog({
   onClose,
   model,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ExportBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ExportBookmarksDialog.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const ExportBookmarksDialog = observer(function ({
+const ExportBookmarksDialog = observer(function ExportBookmarksDialog({
   model,
   onClose,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/HighlightSettingsDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/HighlightSettingsDialog.tsx
@@ -11,7 +11,7 @@ import { observer } from 'mobx-react'
 
 import type { GridBookmarkModel } from '../../model'
 
-const HighlightSettingsDialog = observer(function ({
+const HighlightSettingsDialog = observer(function HighlightSettingsDialog({
   onClose,
   model,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ImportBookmarksDialog.tsx
@@ -94,7 +94,7 @@ async function getBookmarksFromBEDFile(lines: string[], selectedAsm: string) {
     })
 }
 
-const ImportBookmarksDialog = observer(function ({
+const ImportBookmarksDialog = observer(function ImportBookmarksDialog({
   onClose,
   model,
 }: {

--- a/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ShareBookmarksDialog.tsx
+++ b/plugins/grid-bookmark/src/GridBookmarkWidget/components/dialogs/ShareBookmarksDialog.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const ShareBookmarksDialog = observer(function ({
+const ShareBookmarksDialog = observer(function ShareBookmarksDialog({
   onClose,
   model,
 }: {

--- a/plugins/hic/src/LinearHicDisplay/components/BaseDisplayComponent.tsx
+++ b/plugins/hic/src/LinearHicDisplay/components/BaseDisplayComponent.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const BaseDisplayComponent = observer(function ({
+const BaseDisplayComponent = observer(function BaseDisplayComponent({
   model,
   children,
 }: {
@@ -60,7 +60,7 @@ const BaseDisplayComponent = observer(function ({
   )
 })
 
-const DataDisplay = observer(function ({
+const DataDisplay = observer(function DataDisplay({
   model,
   children,
 }: {
@@ -78,7 +78,11 @@ const DataDisplay = observer(function ({
   )
 })
 
-const LoadingBar = observer(function ({ model }: { model: BaseDisplayModel }) {
+const LoadingBar = observer(function LoadingBar({
+  model,
+}: {
+  model: BaseDisplayModel
+}) {
   const { classes } = useStyles()
   const { message } = model
   return (

--- a/plugins/hic/src/LinearHicDisplay/components/BlockErrorMessage.tsx
+++ b/plugins/hic/src/LinearHicDisplay/components/BlockErrorMessage.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const BlockErrorMessage = observer(function ({
+const BlockErrorMessage = observer(function BlockErrorMessage({
   model,
 }: {
   model: {

--- a/plugins/hic/src/LinearHicDisplay/components/ReactComponent.tsx
+++ b/plugins/hic/src/LinearHicDisplay/components/ReactComponent.tsx
@@ -81,7 +81,7 @@ function screenToUnrotated(
   return { x, y }
 }
 
-const HicCanvas = observer(function ({
+const HicCanvas = observer(function HicCanvas({
   model,
 }: {
   model: LinearHicDisplayModel
@@ -198,7 +198,7 @@ const HicCanvas = observer(function ({
   )
 })
 
-const LinearHicReactComponent = observer(function ({
+const LinearHicReactComponent = observer(function LinearHicReactComponent({
   model,
 }: {
   model: LinearHicDisplayModel

--- a/plugins/jobs-management/src/JobsListWidget/components/JobsListWidget.tsx
+++ b/plugins/jobs-management/src/JobsListWidget/components/JobsListWidget.tsx
@@ -23,7 +23,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const JobsListWidget = observer(function ({ model }: { model: JobsListModel }) {
+const JobsListWidget = observer(function JobsListWidget({
+  model,
+}: {
+  model: JobsListModel
+}) {
   const { classes } = useStyles()
   const { jobs, finished, queued, aborted } = model
   return (

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react'
 import type { LinearSyntenyDisplayModel } from '../../LinearSyntenyDisplay/model'
 import type { LinearComparativeViewModel } from '../model'
 
-const ColorBySelector = observer(function ({
+const ColorBySelector = observer(function ColorBySelector({
   model,
 }: {
   model: LinearComparativeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const Header = observer(function ({
+const Header = observer(function Header({
   model,
 }: {
   model: LinearComparativeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/HeaderSearchBoxes.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/HeaderSearchBoxes.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const HeaderSearchBoxes = observer(function ({
+const HeaderSearchBoxes = observer(function HeaderSearchBoxes({
   view,
 }: {
   view: LinearGenomeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeRenderArea.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeRenderArea.tsx
@@ -37,39 +37,41 @@ function View({ view }: { view: LinearGenomeViewModel }) {
   return <ReactComponent model={view} />
 }
 
-const LinearComparativeRenderArea = observer(function ({
-  model,
-}: {
-  model: LinearComparativeViewModel
-}) {
-  const { classes } = useStyles()
-  const { views, levels } = model
+const LinearComparativeRenderArea = observer(
+  function LinearComparativeRenderArea({
+    model,
+  }: {
+    model: LinearComparativeViewModel
+  }) {
+    const { classes } = useStyles()
+    const { views, levels } = model
 
-  return (
-    <div className={classes.container}>
-      {views.map((view, i) => (
-        <Fragment key={view.id}>
-          {i > 0 ? (
-            <>
-              <div className={classes.container}>
-                <Overlays model={model} level={i - 1} />
-              </div>
-              <ResizeHandle
-                onDrag={n =>
-                  levels[i - 1]?.setHeight((levels[i - 1]?.height || 0) + n)
-                }
-                className={classes.resizeHandle}
-              />
-            </>
-          ) : null}
-          <View view={view} />
-        </Fragment>
-      ))}
-    </div>
-  )
-})
+    return (
+      <div className={classes.container}>
+        {views.map((view, i) => (
+          <Fragment key={view.id}>
+            {i > 0 ? (
+              <>
+                <div className={classes.container}>
+                  <Overlays model={model} level={i - 1} />
+                </div>
+                <ResizeHandle
+                  onDrag={n =>
+                    levels[i - 1]?.setHeight((levels[i - 1]?.height || 0) + n)
+                  }
+                  className={classes.resizeHandle}
+                />
+              </>
+            ) : null}
+            <View view={view} />
+          </Fragment>
+        ))}
+      </div>
+    )
+  },
+)
 
-const Overlays = observer(function ({
+const Overlays = observer(function Overlays({
   model,
   level,
 }: {

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeView.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/LinearComparativeView.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const LinearComparativeView = observer(function ({
+const LinearComparativeView = observer(function LinearComparativeView({
   model,
 }: {
   model: LinearComparativeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/MinLengthSlider.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/MinLengthSlider.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const MinLengthSlider = observer(function ({
+const MinLengthSlider = observer(function MinLengthSlider({
   model,
 }: {
   model: LinearComparativeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/OpacitySlider.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/OpacitySlider.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const OpacitySlider = observer(function ({
+const OpacitySlider = observer(function OpacitySlider({
   model,
 }: {
   model: LinearComparativeViewModel

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Rubberband.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const Rubberband = observer(function ({
+const Rubberband = observer(function Rubberband({
   model,
   ControlComponent = <div />,
 }: {

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/VerticalGuide.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const VerticalGuide = observer(function ({
+const VerticalGuide = observer(function VerticalGuide({
   model,
   coordX,
 }: {

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/Component.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/Component.tsx
@@ -7,20 +7,22 @@ import LoadingMessage from './LoadingMessage'
 
 import type { LinearSyntenyDisplayModel } from '../model'
 
-const ServerSideRenderedBlockContent = observer(function ({
-  model,
-}: {
-  model: LinearSyntenyDisplayModel
-}) {
-  if (model.error) {
-    return <BlockError error={model.error} />
-  } else if (model.message) {
-    return <BlockMessage messageText={model.message} />
-  } else if (!model.features) {
-    return <LoadingMessage message={model.loadingStatus} />
-  } else {
-    return <LinearSyntenyRendering model={model} />
-  }
-})
+const ServerSideRenderedBlockContent = observer(
+  function ServerSideRenderedBlockContent({
+    model,
+  }: {
+    model: LinearSyntenyDisplayModel
+  }) {
+    if (model.error) {
+      return <BlockError error={model.error} />
+    } else if (model.message) {
+      return <BlockMessage messageText={model.message} />
+    } else if (!model.features) {
+      return <LoadingMessage message={model.loadingStatus} />
+    } else {
+      return <LinearSyntenyRendering model={model} />
+    }
+  },
+)
 
 export default ServerSideRenderedBlockContent

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/LinearSyntenyRendering.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/LinearSyntenyRendering.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const LinearSyntenyRendering = observer(function ({
+const LinearSyntenyRendering = observer(function LinearSyntenyRendering({
   model,
 }: {
   model: LinearSyntenyDisplayModel

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/SyntenyTooltip.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/components/SyntenyTooltip.tsx
@@ -2,7 +2,11 @@ import { SanitizedHTML } from '@jbrowse/core/ui'
 import BaseTooltip from '@jbrowse/core/ui/BaseTooltip'
 import { observer } from 'mobx-react'
 
-const SyntenyTooltip = observer(function ({ title }: { title: string }) {
+const SyntenyTooltip = observer(function SyntenyTooltip({
+  title,
+}: {
+  title: string
+}) {
   return title ? (
     <BaseTooltip>
       <SanitizedHTML html={title} />

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/DiagonalizationProgressDialog.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/DiagonalizationProgressDialog.tsx
@@ -17,150 +17,159 @@ import { diagonalizeRegions } from '../util/diagonalize'
 import type { LinearSyntenyViewModel } from '../model'
 import type { AlignmentData } from '../util/diagonalize'
 
-const DiagonalizationProgressDialog = observer(function ({
-  handleClose,
-  model,
-}: {
-  handleClose: () => void
-  model: LinearSyntenyViewModel
-}) {
-  const [progress, setProgress] = useState(0)
-  const [message, setMessage] = useState('Initializing...')
-  const [error, setError] = useState<string>()
+const DiagonalizationProgressDialog = observer(
+  function DiagonalizationProgressDialog({
+    handleClose,
+    model,
+  }: {
+    handleClose: () => void
+    model: LinearSyntenyViewModel
+  }) {
+    const [progress, setProgress] = useState(0)
+    const [message, setMessage] = useState('Initializing...')
+    const [error, setError] = useState<string>()
 
-  useEffect(() => {
-    // Run diagonalization on mount
-    const runDiagonalization = async () => {
-      const session = getSession(model)
+    useEffect(() => {
+      // Run diagonalization on mount
+      const runDiagonalization = async () => {
+        const session = getSession(model)
 
-      try {
-        // Check we have exactly 2 views
-        if (model.views.length !== 2) {
-          setError('Diagonalization requires exactly 2 views')
-          setProgress(100)
-          session.notify('Diagonalization requires exactly 2 views', 'warning')
-          return
-        }
+        try {
+          // Check we have exactly 2 views
+          if (model.views.length !== 2) {
+            setError('Diagonalization requires exactly 2 views')
+            setProgress(100)
+            session.notify(
+              'Diagonalization requires exactly 2 views',
+              'warning',
+            )
+            return
+          }
 
-        const queryView = model.views[1]!
+          const queryView = model.views[1]!
 
-        setProgress(5)
-        setMessage('Collecting alignment data...')
+          setProgress(5)
+          setMessage('Collecting alignment data...')
 
-        // Collect all alignment data from all synteny tracks
-        const alignments: AlignmentData[] = []
+          // Collect all alignment data from all synteny tracks
+          const alignments: AlignmentData[] = []
 
-        for (const level of model.levels) {
-          for (const track of level.tracks) {
-            for (const display of track.displays) {
-              const { featPositions } = display as {
-                featPositions: {
-                  f: {
-                    get: (key: string) => unknown
-                  }
-                }[]
-              }
-
-              for (const { f } of featPositions) {
-                const mate = f.get('mate') as {
-                  refName: string
-                  start: number
-                  end: number
+          for (const level of model.levels) {
+            for (const track of level.tracks) {
+              for (const display of track.displays) {
+                const { featPositions } = display as {
+                  featPositions: {
+                    f: {
+                      get: (key: string) => unknown
+                    }
+                  }[]
                 }
 
-                alignments.push({
-                  queryRefName: f.get('refName') as string,
-                  refRefName: mate.refName,
-                  queryStart: f.get('start') as number,
-                  queryEnd: f.get('end') as number,
-                  refStart: mate.start,
-                  refEnd: mate.end,
-                  strand: (f.get('strand') as number) || 1,
-                })
+                for (const { f } of featPositions) {
+                  const mate = f.get('mate') as {
+                    refName: string
+                    start: number
+                    end: number
+                  }
+
+                  alignments.push({
+                    queryRefName: f.get('refName') as string,
+                    refRefName: mate.refName,
+                    queryStart: f.get('start') as number,
+                    queryEnd: f.get('end') as number,
+                    refStart: mate.start,
+                    refEnd: mate.end,
+                    strand: (f.get('strand') as number) || 1,
+                  })
+                }
               }
             }
           }
-        }
 
-        if (alignments.length === 0) {
-          setError('No alignments found')
+          if (alignments.length === 0) {
+            setError('No alignments found')
+            setProgress(100)
+            session.notify('No alignments found to diagonalize', 'warning')
+            return
+          }
+
+          // Call the utility function with progress callback
+          const result = await diagonalizeRegions(
+            alignments,
+            queryView.displayedRegions,
+            async (prog, msg) => {
+              setProgress(prog)
+              setMessage(msg)
+            },
+          )
+
+          // Apply the new ordering
+          if (result.newRegions.length > 0) {
+            setProgress(95)
+            setMessage('Applying new layout...')
+            transaction(() => {
+              queryView.setDisplayedRegions(result.newRegions)
+            })
+            setProgress(100)
+            setMessage('Diagonalization complete')
+
+            // Auto-close after success
+            setTimeout(() => {
+              handleClose()
+            }, 1500)
+          } else {
+            setError('No regions to reorder')
+            setProgress(100)
+            session.notify('No query regions found to reorder', 'warning')
+          }
+        } catch (err) {
+          console.error('Diagonalization error:', err)
+          setError(`Error: ${err}`)
           setProgress(100)
-          session.notify('No alignments found to diagonalize', 'warning')
-          return
+          session.notify(`Diagonalization failed: ${err}`, 'error')
         }
-
-        // Call the utility function with progress callback
-        const result = await diagonalizeRegions(
-          alignments,
-          queryView.displayedRegions,
-          async (prog, msg) => {
-            setProgress(prog)
-            setMessage(msg)
-          },
-        )
-
-        // Apply the new ordering
-        if (result.newRegions.length > 0) {
-          setProgress(95)
-          setMessage('Applying new layout...')
-          transaction(() => {
-            queryView.setDisplayedRegions(result.newRegions)
-          })
-          setProgress(100)
-          setMessage('Diagonalization complete')
-
-          // Auto-close after success
-          setTimeout(() => {
-            handleClose()
-          }, 1500)
-        } else {
-          setError('No regions to reorder')
-          setProgress(100)
-          session.notify('No query regions found to reorder', 'warning')
-        }
-      } catch (err) {
-        console.error('Diagonalization error:', err)
-        setError(`Error: ${err}`)
-        setProgress(100)
-        session.notify(`Diagonalization failed: ${err}`, 'error')
       }
-    }
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    runDiagonalization()
-  }, [model, handleClose])
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      runDiagonalization()
+    }, [model, handleClose])
 
-  return (
-    <Dialog open title="Diagonalizing" onClose={handleClose}>
-      <DialogContent style={{ minWidth: 400 }}>
-        <Typography
-          variant="body1"
-          gutterBottom
-          color={error ? 'error' : 'inherit'}
-        >
-          {error || message}
-        </Typography>
-        <LinearProgress
-          variant="determinate"
-          value={progress}
-          style={{ marginTop: 16 }}
-          color={error ? 'error' : 'primary'}
-        />
-        <Typography
-          variant="caption"
-          color="textSecondary"
-          style={{ marginTop: 8, display: 'block' }}
-        >
-          {Math.round(progress)}% complete
-        </Typography>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose} color="primary" disabled={progress < 100}>
-          {progress < 100 ? 'Processing...' : 'Done'}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-})
+    return (
+      <Dialog open title="Diagonalizing" onClose={handleClose}>
+        <DialogContent style={{ minWidth: 400 }}>
+          <Typography
+            variant="body1"
+            gutterBottom
+            color={error ? 'error' : 'inherit'}
+          >
+            {error || message}
+          </Typography>
+          <LinearProgress
+            variant="determinate"
+            value={progress}
+            style={{ marginTop: 16 }}
+            color={error ? 'error' : 'primary'}
+          />
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            style={{ marginTop: 8, display: 'block' }}
+          >
+            {Math.round(progress)}% complete
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleClose}
+            color="primary"
+            disabled={progress < 100}
+          >
+            {progress < 100 ? 'Processing...' : 'Done'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  },
+)
 
 export default DiagonalizationProgressDialog

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyOpenCustomTrack.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyOpenCustomTrack.tsx
@@ -22,157 +22,159 @@ import { basename, extName, getName, stripGz } from './util'
 import type { LinearSyntenyViewModel } from '../../model'
 import type { FileLocation } from '@jbrowse/core/util/types'
 
-const ImportSyntenyOpenCustomTrack = observer(function ({
-  model,
-  assembly1,
-  assembly2,
-  selectedRow,
-}: {
-  model: LinearSyntenyViewModel
-  assembly1: string
-  assembly2: string
-  selectedRow: number
-}) {
-  const [swap, setSwap] = useState(false)
-  const [bed2Location, setBed2Location] = useState<FileLocation>()
-  const [bed1Location, setBed1Location] = useState<FileLocation>()
-  const [fileLocation, setFileLocation] = useState<FileLocation>()
-  const [indexFileLocation, setIndexFileLocation] = useState<FileLocation>()
-  const [value, setValue] = useState('')
-  const [error, setError] = useState<unknown>()
-  const fileName = getName(fileLocation)
-
-  const radioOption = value || (fileName ? extName(stripGz(fileName)) : '')
-
-  useEffect(() => {
-    try {
-      if (fileLocation) {
-        const fn = fileName ? basename(fileName) : 'MyTrack'
-        const trackId = `${fn}-${Date.now()}-sessionTrack`
-        setError(undefined)
-
-        model.setImportFormSyntenyTrack(selectedRow, {
-          type: 'userOpened',
-          value: {
-            trackId,
-            name: fn,
-            assemblyNames: [assembly2, assembly1],
-            type: 'SyntenyTrack',
-            adapter: getAdapter({
-              radioOption,
-              assembly1: swap ? assembly2 : assembly1,
-              assembly2: swap ? assembly1 : assembly2,
-              fileLocation,
-              indexFileLocation,
-              bed1Location,
-              bed2Location,
-            }),
-          },
-        })
-      }
-    } catch (e) {
-      console.error(e)
-      setError(e)
-    }
-  }, [
-    swap,
+const ImportSyntenyOpenCustomTrack = observer(
+  function ImportSyntenyOpenCustomTrack({
     model,
-    selectedRow,
-    fileName,
     assembly1,
     assembly2,
-    bed1Location,
-    bed2Location,
-    fileLocation,
-    indexFileLocation,
-    radioOption,
-  ])
-  return (
-    <Paper style={{ padding: 12 }}>
-      {error ? <ErrorMessage error={error} /> : null}
-      <Typography style={{ textAlign: 'center' }}>
-        Add a .paf (minimap2), .delta (Mummer), .chain (UCSC liftover), .anchors
-        or .anchors.simple (MCScan), or .pif.gz (jbrowse CLI make-pif) file to
-        view. These file types can also be gzipped.
-      </Typography>
-      <RadioGroup
-        value={radioOption}
-        onChange={event => {
-          setValue(event.target.value)
-        }}
-      >
+    selectedRow,
+  }: {
+    model: LinearSyntenyViewModel
+    assembly1: string
+    assembly2: string
+    selectedRow: number
+  }) {
+    const [swap, setSwap] = useState(false)
+    const [bed2Location, setBed2Location] = useState<FileLocation>()
+    const [bed1Location, setBed1Location] = useState<FileLocation>()
+    const [fileLocation, setFileLocation] = useState<FileLocation>()
+    const [indexFileLocation, setIndexFileLocation] = useState<FileLocation>()
+    const [value, setValue] = useState('')
+    const [error, setError] = useState<unknown>()
+    const fileName = getName(fileLocation)
+
+    const radioOption = value || (fileName ? extName(stripGz(fileName)) : '')
+
+    useEffect(() => {
+      try {
+        if (fileLocation) {
+          const fn = fileName ? basename(fileName) : 'MyTrack'
+          const trackId = `${fn}-${Date.now()}-sessionTrack`
+          setError(undefined)
+
+          model.setImportFormSyntenyTrack(selectedRow, {
+            type: 'userOpened',
+            value: {
+              trackId,
+              name: fn,
+              assemblyNames: [assembly2, assembly1],
+              type: 'SyntenyTrack',
+              adapter: getAdapter({
+                radioOption,
+                assembly1: swap ? assembly2 : assembly1,
+                assembly2: swap ? assembly1 : assembly2,
+                fileLocation,
+                indexFileLocation,
+                bed1Location,
+                bed2Location,
+              }),
+            },
+          })
+        }
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
+    }, [
+      swap,
+      model,
+      selectedRow,
+      fileName,
+      assembly1,
+      assembly2,
+      bed1Location,
+      bed2Location,
+      fileLocation,
+      indexFileLocation,
+      radioOption,
+    ])
+    return (
+      <Paper style={{ padding: 12 }}>
+        {error ? <ErrorMessage error={error} /> : null}
+        <Typography style={{ textAlign: 'center' }}>
+          Add a .paf (minimap2), .delta (Mummer), .chain (UCSC liftover),
+          .anchors or .anchors.simple (MCScan), or .pif.gz (jbrowse CLI
+          make-pif) file to view. These file types can also be gzipped.
+        </Typography>
+        <RadioGroup
+          value={radioOption}
+          onChange={event => {
+            setValue(event.target.value)
+          }}
+        >
+          <Grid container justifyContent="center">
+            {[
+              '.paf',
+              '.delta',
+              '.out',
+              '.chain',
+              '.anchors',
+              '.anchors.simple',
+              '.pif.gz',
+            ].map(extension => (
+              <FormControlLabel
+                key={extension}
+                value={extension}
+                control={<Radio />}
+                label={extension}
+              />
+            ))}
+          </Grid>
+        </RadioGroup>
         <Grid container justifyContent="center">
-          {[
-            '.paf',
-            '.delta',
-            '.out',
-            '.chain',
-            '.anchors',
-            '.anchors.simple',
-            '.pif.gz',
-          ].map(extension => (
-            <FormControlLabel
-              key={extension}
-              value={extension}
-              control={<Radio />}
-              label={extension}
+          {radioOption === '.paf' ||
+          radioOption === '.out' ||
+          radioOption === '.delta' ||
+          radioOption === '.chain' ? (
+            <StandardFormatSelector
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              radioOption={radioOption}
             />
-          ))}
+          ) : radioOption === '.pif.gz' ? (
+            <PifGzSelector
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              indexFileLocation={indexFileLocation}
+              setIndexFileLocation={setIndexFileLocation}
+              radioOption={radioOption}
+            />
+          ) : value === '.anchors' || value === '.anchors.simple' ? (
+            <AnchorsSelector
+              assembly1={assembly1}
+              assembly2={assembly2}
+              swap={swap}
+              setSwap={setSwap}
+              fileLocation={fileLocation}
+              setFileLocation={setFileLocation}
+              bed1Location={bed1Location}
+              setBed1Location={setBed1Location}
+              bed2Location={bed2Location}
+              setBed2Location={setBed2Location}
+              radioOption={value}
+            />
+          ) : (
+            <FileSelector
+              name={value ? `${value} location` : ''}
+              description=""
+              location={fileLocation}
+              setLocation={loc => {
+                setFileLocation(loc)
+              }}
+            />
+          )}
         </Grid>
-      </RadioGroup>
-      <Grid container justifyContent="center">
-        {radioOption === '.paf' ||
-        radioOption === '.out' ||
-        radioOption === '.delta' ||
-        radioOption === '.chain' ? (
-          <StandardFormatSelector
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            radioOption={radioOption}
-          />
-        ) : radioOption === '.pif.gz' ? (
-          <PifGzSelector
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            indexFileLocation={indexFileLocation}
-            setIndexFileLocation={setIndexFileLocation}
-            radioOption={radioOption}
-          />
-        ) : value === '.anchors' || value === '.anchors.simple' ? (
-          <AnchorsSelector
-            assembly1={assembly1}
-            assembly2={assembly2}
-            swap={swap}
-            setSwap={setSwap}
-            fileLocation={fileLocation}
-            setFileLocation={setFileLocation}
-            bed1Location={bed1Location}
-            setBed1Location={setBed1Location}
-            bed2Location={bed2Location}
-            setBed2Location={setBed2Location}
-            radioOption={value}
-          />
-        ) : (
-          <FileSelector
-            name={value ? `${value} location` : ''}
-            description=""
-            location={fileLocation}
-            setLocation={loc => {
-              setFileLocation(loc)
-            }}
-          />
-        )}
-      </Grid>
-    </Paper>
-  )
-})
+      </Paper>
+    )
+  },
+)
 
 export default ImportSyntenyOpenCustomTrack

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyPreConfigured.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyPreConfigured.tsx
@@ -10,68 +10,70 @@ import { observer } from 'mobx-react'
 import type { LinearSyntenyViewModel } from '../../model'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 
-const ImportSyntenyTrackSelector = observer(function ({
-  model,
-  selectedRow,
-  assembly1,
-  assembly2,
-}: {
-  model: LinearSyntenyViewModel
-  selectedRow: number
-  assembly1: string
-  assembly2: string
-}) {
-  const session = getSession(model)
-  const { importFormSyntenyTrackSelections } = model
-  const { tracks, sessionTracks = [] } = session
-  const allTracks = [...tracks, ...sessionTracks] as AnyConfigurationModel[]
-  const filteredTracks = allTracks.filter(track => {
-    const assemblyNames = readConfObject(track, 'assemblyNames')
-    return (
-      assemblyNames.includes(assembly1) &&
-      assemblyNames.includes(assembly2) &&
-      track.type.includes('Synteny')
-    )
-  })
-  const resetTrack = filteredTracks[0]?.trackId || ''
-  const r = importFormSyntenyTrackSelections[selectedRow]
-  const value = r?.type === 'preConfigured' ? r.value : undefined
-  useEffect(() => {
-    model.setImportFormSyntenyTrack(selectedRow, {
-      type: 'preConfigured',
-      value: resetTrack,
+const ImportSyntenyTrackSelector = observer(
+  function ImportSyntenyTrackSelector({
+    model,
+    selectedRow,
+    assembly1,
+    assembly2,
+  }: {
+    model: LinearSyntenyViewModel
+    selectedRow: number
+    assembly1: string
+    assembly2: string
+  }) {
+    const session = getSession(model)
+    const { importFormSyntenyTrackSelections } = model
+    const { tracks, sessionTracks = [] } = session
+    const allTracks = [...tracks, ...sessionTracks] as AnyConfigurationModel[]
+    const filteredTracks = allTracks.filter(track => {
+      const assemblyNames = readConfObject(track, 'assemblyNames')
+      return (
+        assemblyNames.includes(assembly1) &&
+        assemblyNames.includes(assembly2) &&
+        track.type.includes('Synteny')
+      )
     })
-  }, [assembly2, assembly1, resetTrack, selectedRow, model])
-  return (
-    <Paper style={{ padding: 12 }}>
-      <Typography>
-        Select a track from the select box below, the track will be shown when
-        you hit "Launch".
-      </Typography>
+    const resetTrack = filteredTracks[0]?.trackId || ''
+    const r = importFormSyntenyTrackSelections[selectedRow]
+    const value = r?.type === 'preConfigured' ? r.value : undefined
+    useEffect(() => {
+      model.setImportFormSyntenyTrack(selectedRow, {
+        type: 'preConfigured',
+        value: resetTrack,
+      })
+    }, [assembly2, assembly1, resetTrack, selectedRow, model])
+    return (
+      <Paper style={{ padding: 12 }}>
+        <Typography>
+          Select a track from the select box below, the track will be shown when
+          you hit "Launch".
+        </Typography>
 
-      {value && filteredTracks.map(r => r.trackId).includes(value) ? (
-        <Select
-          value={value}
-          onChange={event => {
-            model.setImportFormSyntenyTrack(selectedRow, {
-              type: 'preConfigured',
-              value: event.target.value,
-            })
-          }}
-        >
-          {filteredTracks.map(track => (
-            <MenuItem key={track.trackId} value={track.trackId}>
-              {getTrackName(track, session)}
-            </MenuItem>
-          ))}
-        </Select>
-      ) : (
-        <ErrorMessage
-          error={`No synteny tracks found for ${assembly1},${assembly2}`}
-        />
-      )}
-    </Paper>
-  )
-})
+        {value && filteredTracks.map(r => r.trackId).includes(value) ? (
+          <Select
+            value={value}
+            onChange={event => {
+              model.setImportFormSyntenyTrack(selectedRow, {
+                type: 'preConfigured',
+                value: event.target.value,
+              })
+            }}
+          >
+            {filteredTracks.map(track => (
+              <MenuItem key={track.trackId} value={track.trackId}>
+                {getTrackName(track, session)}
+              </MenuItem>
+            ))}
+          </Select>
+        ) : (
+          <ErrorMessage
+            error={`No synteny tracks found for ${assembly1},${assembly2}`}
+          />
+        )}
+      </Paper>
+    )
+  },
+)
 
 export default ImportSyntenyTrackSelector

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LeftPanel.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LeftPanel.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const AssemblyRows = observer(function ({
+const AssemblyRows = observer(function AssemblyRows({
   selectedRow,
   selectedAssemblyNames,
   setSelectedRow,
@@ -92,7 +92,7 @@ const AssemblyRows = observer(function ({
   ))
 })
 
-const LeftPanel = observer(function ({
+const LeftPanel = observer(function LeftPanel({
   model,
   selectedAssemblyNames,
   setSelectedAssemblyNames,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/LinearSyntenyImportForm.tsx
@@ -32,69 +32,71 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const LinearSyntenyViewImportForm = observer(function ({
-  model,
-}: {
-  model: LinearSyntenyViewModel
-}) {
-  const { classes } = useStyles()
-  const session = getSession(model)
-  const { assemblyNames } = session
-  const defaultAssemblyName = assemblyNames[0] || ''
-  const [selectedRow, setSelectedRow] = useState(0)
-  const [selectedAssemblyNames, setSelectedAssemblyNames] = useState([
-    defaultAssemblyName,
-    defaultAssemblyName,
-  ])
-  const [error, setError] = useState<unknown>()
+const LinearSyntenyViewImportForm = observer(
+  function LinearSyntenyViewImportForm({
+    model,
+  }: {
+    model: LinearSyntenyViewModel
+  }) {
+    const { classes } = useStyles()
+    const session = getSession(model)
+    const { assemblyNames } = session
+    const defaultAssemblyName = assemblyNames[0] || ''
+    const [selectedRow, setSelectedRow] = useState(0)
+    const [selectedAssemblyNames, setSelectedAssemblyNames] = useState([
+      defaultAssemblyName,
+      defaultAssemblyName,
+    ])
+    const [error, setError] = useState<unknown>()
 
-  const handleLaunch = async () => {
-    try {
-      setError(undefined)
-      await doSubmit({
-        selectedAssemblyNames,
-        model,
-      })
-    } catch (e) {
-      console.error(e)
-      setError(e)
+    const handleLaunch = async () => {
+      try {
+        setError(undefined)
+        await doSubmit({
+          selectedAssemblyNames,
+          model,
+        })
+      } catch (e) {
+        console.error(e)
+        setError(e)
+      }
     }
-  }
 
-  return (
-    <Container className={classes.importFormContainer}>
-      {error ? <ErrorMessage error={error} /> : null}
-      <div className={classes.flex}>
-        <div className={classes.leftPanel}>
-          <LeftPanel
-            model={model}
-            selectedAssemblyNames={selectedAssemblyNames}
-            setSelectedAssemblyNames={setSelectedAssemblyNames}
-            selectedRow={selectedRow}
-            setSelectedRow={setSelectedRow}
-            defaultAssemblyName={defaultAssemblyName}
-            onLaunch={() => {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              handleLaunch()
-            }}
-          />
-        </div>
-
-        <div className={classes.rightPanel}>
-          <div>
-            Synteny dataset to display between row {selectedRow + 1} and{' '}
-            {selectedRow + 2}
+    return (
+      <Container className={classes.importFormContainer}>
+        {error ? <ErrorMessage error={error} /> : null}
+        <div className={classes.flex}>
+          <div className={classes.leftPanel}>
+            <LeftPanel
+              model={model}
+              selectedAssemblyNames={selectedAssemblyNames}
+              setSelectedAssemblyNames={setSelectedAssemblyNames}
+              selectedRow={selectedRow}
+              setSelectedRow={setSelectedRow}
+              defaultAssemblyName={defaultAssemblyName}
+              onLaunch={() => {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                handleLaunch()
+              }}
+            />
           </div>
-          <ImportSyntenyTrackSelector
-            model={model}
-            selectedRow={selectedRow}
-            assembly1={selectedAssemblyNames[selectedRow]!}
-            assembly2={selectedAssemblyNames[selectedRow + 1]!}
-          />
+
+          <div className={classes.rightPanel}>
+            <div>
+              Synteny dataset to display between row {selectedRow + 1} and{' '}
+              {selectedRow + 2}
+            </div>
+            <ImportSyntenyTrackSelector
+              model={model}
+              selectedRow={selectedRow}
+              assembly1={selectedAssemblyNames[selectedRow]!}
+              assembly2={selectedAssemblyNames[selectedRow + 1]!}
+            />
+          </div>
         </div>
-      </div>
-    </Container>
-  )
-})
+      </Container>
+    )
+  },
+)
 
 export default LinearSyntenyViewImportForm

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/AnchorsSelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/AnchorsSelector.tsx
@@ -8,7 +8,7 @@ import type { SelectorProps } from './SelectorTypes'
 /**
  * Component for selecting ANCHORS format files and their related BED files
  */
-const AnchorsSelector = observer(function ({
+const AnchorsSelector = observer(function AnchorsSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/PifGzSelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/PifGzSelector.tsx
@@ -8,7 +8,7 @@ import type { SelectorProps } from './SelectorTypes'
 /**
  * Component for selecting PIF.GZ format files and their indexes
  */
-const PifGzSelector = observer(function ({
+const PifGzSelector = observer(function PifGzSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/StandardFormatSelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/StandardFormatSelector.tsx
@@ -11,7 +11,7 @@ import type { SelectorProps } from './SelectorTypes'
 /**
  * Component for selecting PAF, OUT, DELTA, or CHAIN format files
  */
-const StandardFormatSelector = observer(function ({
+const StandardFormatSelector = observer(function StandardFormatSelector({
   assembly1,
   assembly2,
   swap,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/SwapAssemblies.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/selectors/SwapAssemblies.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SwapAssemblies = observer(function ({
+const SwapAssemblies = observer(function SwapAssemblies({
   assembly1,
   assembly2,
   swap,

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/LinearSyntenyView.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/LinearSyntenyView.tsx
@@ -11,7 +11,7 @@ const LinearSyntenyImportForm = lazy(
   () => import('./ImportForm/LinearSyntenyImportForm'),
 )
 
-const LinearSyntenyView = observer(function ({
+const LinearSyntenyView = observer(function LinearSyntenyView({
   model,
 }: {
   model: LinearSyntenyViewModel

--- a/plugins/linear-comparative-view/src/SyntenyFeatureDetail/LinkToSyntenyView.tsx
+++ b/plugins/linear-comparative-view/src/SyntenyFeatureDetail/LinkToSyntenyView.tsx
@@ -17,7 +17,7 @@ const LaunchSyntenyViewDialog = lazy(
   () => import('../LGVSyntenyDisplay/components/LaunchSyntenyViewDialog'),
 )
 
-const LinkToSyntenyView = observer(function ({
+const LinkToSyntenyView = observer(function LinkToSyntenyView({
   model,
   feat,
 }: {

--- a/plugins/linear-comparative-view/src/SyntenyFeatureDetail/SyntenyFeatureDetail.tsx
+++ b/plugins/linear-comparative-view/src/SyntenyFeatureDetail/SyntenyFeatureDetail.tsx
@@ -8,7 +8,7 @@ import LinkToSyntenyView from './LinkToSyntenyView'
 
 import type { SyntenyFeatureDetailModel } from './types'
 
-const SyntenyFeatureDetail = observer(function (props: {
+const SyntenyFeatureDetail = observer(function SyntenyFeatureDetail(props: {
   model: SyntenyFeatureDetailModel
 }) {
   const { model } = props

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BaseLinearDisplay.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const BaseLinearDisplay = observer(function (props: {
+const BaseLinearDisplay = observer(function BaseLinearDisplay(props: {
   model: BaseLinearDisplayModel
   children?: React.ReactNode
 }) {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/Block.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/Block.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ContentBlock = observer(function ({
+const ContentBlock = observer(function ContentBlock({
   block,
   children,
 }: {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/BlockErrorMessage.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/BlockErrorMessage.tsx
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react'
 
 import BlockMsg from './BlockMsg'
 
-const BlockErrorMessage = observer(function ({
+const BlockErrorMessage = observer(function BlockErrorMessage({
   model,
 }: {
   model: {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/FloatingLabels.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/FloatingLabels.tsx
@@ -3,8 +3,6 @@ import { useMemo } from 'react'
 import { clamp, getContainingView, getSession } from '@jbrowse/core/util'
 import { observer } from 'mobx-react'
 
-import { clampToViewport } from './util'
-
 import type { FeatureTrackModel } from '../../LinearBasicDisplay/model'
 import type { LinearGenomeViewModel } from '../../LinearGenomeView'
 import type { FloatingLabelData, LayoutRecord } from '../types'
@@ -222,6 +220,7 @@ interface LabelProps {
   labelWidth: number
   y: number
   offsetPx: number
+  viewportLeft: number
   tooltip?: string
 }
 
@@ -235,13 +234,12 @@ function FloatingLabel({
   labelWidth,
   y,
   offsetPx,
+  viewportLeft,
   tooltip,
 }: LabelProps) {
-  const { leftPx, rightPx } = clampToViewport(
-    featureLeftPx,
-    featureRightPx,
-    offsetPx,
-  )
+  // Optimize: Use pre-calculated viewportLeft instead of recalculating
+  const leftPx = Math.max(featureLeftPx, viewportLeft)
+  const rightPx = Math.max(featureRightPx, viewportLeft)
 
   const naturalX = leftPx - offsetPx
   const maxX = rightPx - offsetPx - labelWidth
@@ -268,7 +266,7 @@ function FloatingLabel({
   )
 }
 
-const FloatingLabels = observer(function ({
+const FloatingLabels = observer(function FloatingLabels({
   model,
 }: {
   model: FeatureTrackModel
@@ -279,7 +277,6 @@ const FloatingLabels = observer(function ({
   const assembly = assemblyName ? assemblyManager.get(assemblyName) : undefined
   const { layoutFeatures } = model
   const { offsetPx, bpPerPx } = view
-
   const featureLabels = useMemo(
     () =>
       assembly
@@ -297,6 +294,9 @@ const FloatingLabels = observer(function ({
   }
 
   const labels: React.ReactElement[] = []
+
+  // Optimize: Calculate viewport left edge once per render instead of per label
+  const viewportLeft = Math.max(0, offsetPx)
 
   for (const [
     key,
@@ -334,6 +334,7 @@ const FloatingLabels = observer(function ({
           labelWidth={labelWidth}
           y={y}
           offsetPx={offsetPx}
+          viewportLeft={viewportLeft}
           tooltip={tooltip}
         />,
       )

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const LinearBlocks = observer(function ({
+const LinearBlocks = observer(function LinearBlocks({
   model,
 }: {
   model: BaseLinearDisplayModel

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/MenuPage.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/MenuPage.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 import type { Coord } from './types'
 import type { BaseLinearDisplayModel } from '../model'
 
-const MenuPage = observer(function ({
+const MenuPage = observer(function MenuPage({
   onClose,
   contextCoord,
   model,

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/RenderedBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/RenderedBlocks.tsx
@@ -10,7 +10,7 @@ import MaxHeightReached from './MaxHeightReachedIndicator'
 import type { BlockModel } from '../models/serverSideRenderedBlock'
 import type { BlockSet } from '@jbrowse/core/util/blockTypes'
 
-const RenderedBlocks = observer(function ({
+const RenderedBlocks = observer(function RenderedBlocks({
   model,
 }: {
   model: {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -7,37 +7,39 @@ import LoadingOverlay from './LoadingOverlay'
 
 const BlockErrorMessage = lazy(() => import('./BlockErrorMessage'))
 
-const ServerSideRenderedBlockContent = observer(function ({
-  model,
-}: {
-  model: {
-    error?: unknown
-    reload: () => void
-    message?: React.ReactNode
-    statusMessage?: string
-    reactElement?: React.ReactElement
-    isRenderingPending?: boolean
-  }
-}) {
-  if (model.error) {
-    return (
-      <Suspense fallback={null}>
-        <BlockErrorMessage model={model} />
-      </Suspense>
-    )
-  } else if (model.message) {
-    return isValidElement(model.message) ? (
-      model.message
-    ) : (
-      <BlockMsg message={`${model.message}`} severity="info" />
-    )
-  } else {
-    return (
-      <LoadingOverlay statusMessage={model.statusMessage}>
-        {model.reactElement}
-      </LoadingOverlay>
-    )
-  }
-})
+const ServerSideRenderedBlockContent = observer(
+  function ServerSideRenderedBlockContent({
+    model,
+  }: {
+    model: {
+      error?: unknown
+      reload: () => void
+      message?: React.ReactNode
+      statusMessage?: string
+      reactElement?: React.ReactElement
+      isRenderingPending?: boolean
+    }
+  }) {
+    if (model.error) {
+      return (
+        <Suspense fallback={null}>
+          <BlockErrorMessage model={model} />
+        </Suspense>
+      )
+    } else if (model.message) {
+      return isValidElement(model.message) ? (
+        model.message
+      ) : (
+        <BlockMsg message={`${model.message}`} severity="info" />
+      )
+    } else {
+      return (
+        <LoadingOverlay statusMessage={model.statusMessage}>
+          {model.reactElement}
+        </LoadingOverlay>
+      )
+    }
+  },
+)
 
 export default ServerSideRenderedBlockContent

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/TooLargeMessage.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/TooLargeMessage.tsx
@@ -6,7 +6,7 @@ import BlockMsg from '../components/BlockMsg'
 
 import type { FeatureDensityStats } from '@jbrowse/core/data_adapters/BaseAdapter'
 
-const TooLargeMessage = observer(function ({
+const TooLargeMessage = observer(function TooLargeMessage({
   model,
 }: {
   model: {

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/Tooltip.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/Tooltip.tsx
@@ -27,7 +27,7 @@ const TooltipContents = forwardRef<HTMLDivElement, Props>(
 
 type Coord = [number, number]
 
-const Tooltip = observer(function ({
+const Tooltip = observer(function Tooltip({
   model,
   clientMouseCoord,
 }: {

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/components/AddFiltersDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/components/AddFiltersDialog.tsx
@@ -24,7 +24,7 @@ function checkJexl(code: string) {
   stringToJexlExpression(code)
 }
 
-const AddFiltersDialog = observer(function ({
+const AddFiltersDialog = observer(function AddFiltersDialog({
   model,
   handleClose,
 }: {

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/components/LinearBasicDisplayComponent.tsx
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/components/LinearBasicDisplayComponent.tsx
@@ -5,15 +5,15 @@ import FloatingLabels from '../../BaseLinearDisplay/components/FloatingLabels'
 
 import type { FeatureTrackModel } from '../model'
 
-const LinearBasicDisplayComponent = observer(function (props: {
-  model: FeatureTrackModel
-}) {
-  const { model } = props
-  return (
-    <BaseLinearDisplayComponent model={model}>
-      <FloatingLabels model={model} />
-    </BaseLinearDisplayComponent>
-  )
-})
+const LinearBasicDisplayComponent = observer(
+  function LinearBasicDisplayComponent(props: { model: FeatureTrackModel }) {
+    const { model } = props
+    return (
+      <BaseLinearDisplayComponent model={model}>
+        <FloatingLabels model={model} />
+      </BaseLinearDisplayComponent>
+    )
+  },
+)
 
 export default LinearBasicDisplayComponent

--- a/plugins/linear-genome-view/src/LinearBasicDisplay/components/SetMaxHeightDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearBasicDisplay/components/SetMaxHeightDialog.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SetMaxHeightDialog = observer(function ({
+const SetMaxHeightDialog = observer(function SetMaxHeightDialog({
   model,
   handleClose,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/CenterLine.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/CenterLine.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const CenterLine = observer(function ({ model }: { model: LGV }) {
+const CenterLine = observer(function CenterLine({ model }: { model: LGV }) {
   const { bpPerPx, centerLineInfo, trackHeights, tracks, width } = model
   const ref = useRef<HTMLDivElement>(null)
   const { classes } = useStyles()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Cytobands.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Cytobands.tsx
@@ -59,7 +59,7 @@ const colorMap: Record<string, string> = {
   acen: '#800',
 }
 
-const Cytobands = observer(function ({
+const Cytobands = observer(function Cytobands({
   overview,
   block,
   assembly,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/GetSequenceDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/GetSequenceDialog.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const GetSequenceDialog = observer(function ({
+const GetSequenceDialog = observer(function GetSequenceDialog({
   model,
   handleClose,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -70,7 +70,11 @@ function RenderedBlockLines({
     </ContentBlockComponent>
   )
 }
-const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
+const RenderedVerticalGuides = observer(function RenderedVerticalGuides({
+  model,
+}: {
+  model: LGV
+}) {
   const { staticBlocks, bpPerPx } = model
   return (
     <>
@@ -94,7 +98,7 @@ const RenderedVerticalGuides = observer(({ model }: { model: LGV }) => {
     </>
   )
 })
-const Gridlines = observer(function ({
+const Gridlines = observer(function Gridlines({
   model,
   offset = 0,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Header.tsx
@@ -43,7 +43,7 @@ const Controls = function ({ model }: { model: LinearGenomeViewModel }) {
   )
 }
 
-const LinearGenomeViewHeader = observer(function ({
+const LinearGenomeViewHeader = observer(function LinearGenomeViewHeader({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderRegionWidth.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderRegionWidth.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const HeaderRegionWidth = observer(function ({
+const HeaderRegionWidth = observer(function HeaderRegionWidth({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderTrackSelectorButton.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderTrackSelectorButton.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const HeaderTrackSelectorButton = observer(function ({
+const HeaderTrackSelectorButton = observer(function HeaderTrackSelectorButton({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderZoomControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/HeaderZoomControls.tsx
@@ -40,7 +40,7 @@ function ValueLabelComponent(props: SliderValueLabelProps) {
     </Tooltip>
   )
 }
-const HeaderZoomControls = observer(function ({
+const HeaderZoomControls = observer(function HeaderZoomControls({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Highlight.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const Highlight = observer(function ({
+const Highlight = observer(function Highlight({
   model,
   highlight,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportForm.tsx
@@ -33,138 +33,140 @@ const useStyles = makeStyles()(theme => ({
 
 type LGV = LinearGenomeViewModel
 
-const LinearGenomeViewImportForm = observer(function ({
-  model,
-}: {
-  model: LGV
-}) {
-  const { classes } = useStyles()
-  const session = getSession(model)
-  const { assemblyNames, assemblyManager } = session
-  const { error } = model
-  const [selectedAsm, setSelectedAsm] = useState(assemblyNames[0]!)
-  const [option, setOption] = useState<BaseResult>()
-  const assembly = assemblyManager.get(selectedAsm)
-  const assemblyError = assemblyNames.length
-    ? assembly?.error
-    : 'No configured assemblies'
-  const displayError = assemblyError || error
-  const [value, setValue] = useState('')
-  const regions = assembly?.regions
-  const assemblyLoaded = !!regions
-  const r0 = regions ? regions[0]?.refName || '' : ''
+const LinearGenomeViewImportForm = observer(
+  function LinearGenomeViewImportForm({ model }: { model: LGV }) {
+    const { classes } = useStyles()
+    const session = getSession(model)
+    const { assemblyNames, assemblyManager } = session
+    const { error } = model
+    const [selectedAsm, setSelectedAsm] = useState(assemblyNames[0]!)
+    const [option, setOption] = useState<BaseResult>()
+    const assembly = assemblyManager.get(selectedAsm)
+    const assemblyError = assemblyNames.length
+      ? assembly?.error
+      : 'No configured assemblies'
+    const displayError = assemblyError || error
+    const [value, setValue] = useState('')
+    const regions = assembly?.regions
+    const assemblyLoaded = !!regions
+    const r0 = regions ? regions[0]?.refName || '' : ''
 
-  // useEffect resets to an "initial state" of displaying first region from
-  // assembly after assembly change. needs to react to selectedAsm as well as
-  // r0 because changing assembly will run setValue('') and then r0 may not
-  // change if assembly names are the same across assemblies, but it still
-  // needs to be reset
-  /* biome-ignore lint/correctness/useExhaustiveDependencies: */
-  useEffect(() => {
-    setValue(r0)
-  }, [r0, selectedAsm])
+    // useEffect resets to an "initial state" of displaying first region from
+    // assembly after assembly change. needs to react to selectedAsm as well as
+    // r0 because changing assembly will run setValue('') and then r0 may not
+    // change if assembly names are the same across assemblies, but it still
+    // needs to be reset
+    /* biome-ignore lint/correctness/useExhaustiveDependencies: */
+    useEffect(() => {
+      setValue(r0)
+    }, [r0, selectedAsm])
 
-  // implementation notes:
-  // having this wrapped in a form allows intuitive use of enter key to submit
-  return (
-    <div className={classes.container}>
-      {displayError ? <ErrorMessage error={displayError} /> : null}
-      <Container className={classes.importFormContainer}>
-        <form
-          onSubmit={async event => {
-            event.preventDefault()
-            model.setError(undefined)
-            if (value) {
-              // has it's own error handling
-              try {
-                if (
-                  option?.getDisplayString() === value &&
-                  option.hasLocation()
-                ) {
-                  await navToOption({
-                    option,
-                    model,
-                    assemblyName: selectedAsm,
-                  })
-                } else if (option?.results?.length) {
-                  model.setSearchResults(
-                    option.results,
-                    option.getLabel(),
-                    selectedAsm,
-                  )
-                } else if (assembly) {
-                  await handleSelectedRegion({ input: value, assembly, model })
+    // implementation notes:
+    // having this wrapped in a form allows intuitive use of enter key to submit
+    return (
+      <div className={classes.container}>
+        {displayError ? <ErrorMessage error={displayError} /> : null}
+        <Container className={classes.importFormContainer}>
+          <form
+            onSubmit={async event => {
+              event.preventDefault()
+              model.setError(undefined)
+              if (value) {
+                // has it's own error handling
+                try {
+                  if (
+                    option?.getDisplayString() === value &&
+                    option.hasLocation()
+                  ) {
+                    await navToOption({
+                      option,
+                      model,
+                      assemblyName: selectedAsm,
+                    })
+                  } else if (option?.results?.length) {
+                    model.setSearchResults(
+                      option.results,
+                      option.getLabel(),
+                      selectedAsm,
+                    )
+                  } else if (assembly) {
+                    await handleSelectedRegion({
+                      input: value,
+                      assembly,
+                      model,
+                    })
+                  }
+                } catch (e) {
+                  console.error(e)
+                  session.notify(`${e}`, 'warning')
                 }
-              } catch (e) {
-                console.error(e)
-                session.notify(`${e}`, 'warning')
               }
-            }
-          }}
-        >
-          <Grid
-            container
-            spacing={1}
-            justifyContent="center"
-            alignItems="center"
+            }}
           >
-            <FormControl>
-              <AssemblySelector
-                onChange={val => {
-                  setSelectedAsm(val)
-                }}
-                localStorageKey="lgv"
-                session={session}
-                selected={selectedAsm}
-              />
-            </FormControl>
-            {selectedAsm ? (
-              assemblyError ? (
-                <CloseIcon style={{ color: 'red' }} />
-              ) : assemblyLoaded ? (
-                <FormControl>
-                  <ImportFormRefNameAutocomplete
-                    value={value}
-                    setValue={setValue}
-                    selectedAsm={selectedAsm}
-                    setOption={setOption}
-                    model={model}
-                  />
-                </FormControl>
-              ) : (
-                <CircularProgress size={20} disableShrink />
-              )
-            ) : null}
-            <FormControl>
-              <Button
-                type="submit"
-                disabled={!value}
-                className={classes.button}
-                variant="contained"
-                color="primary"
-              >
-                Open
-              </Button>
-            </FormControl>
-            <FormControl>
-              <Button
-                disabled={!value}
-                className={classes.button}
-                onClick={() => {
-                  model.setError(undefined)
-                  model.showAllRegionsInAssembly(selectedAsm)
-                }}
-                variant="contained"
-                color="secondary"
-              >
-                Show all regions in assembly
-              </Button>
-            </FormControl>
-          </Grid>
-        </form>
-      </Container>
-    </div>
-  )
-})
+            <Grid
+              container
+              spacing={1}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <FormControl>
+                <AssemblySelector
+                  onChange={val => {
+                    setSelectedAsm(val)
+                  }}
+                  localStorageKey="lgv"
+                  session={session}
+                  selected={selectedAsm}
+                />
+              </FormControl>
+              {selectedAsm ? (
+                assemblyError ? (
+                  <CloseIcon style={{ color: 'red' }} />
+                ) : assemblyLoaded ? (
+                  <FormControl>
+                    <ImportFormRefNameAutocomplete
+                      value={value}
+                      setValue={setValue}
+                      selectedAsm={selectedAsm}
+                      setOption={setOption}
+                      model={model}
+                    />
+                  </FormControl>
+                ) : (
+                  <CircularProgress size={20} disableShrink />
+                )
+              ) : null}
+              <FormControl>
+                <Button
+                  type="submit"
+                  disabled={!value}
+                  className={classes.button}
+                  variant="contained"
+                  color="primary"
+                >
+                  Open
+                </Button>
+              </FormControl>
+              <FormControl>
+                <Button
+                  disabled={!value}
+                  className={classes.button}
+                  onClick={() => {
+                    model.setError(undefined)
+                    model.showAllRegionsInAssembly(selectedAsm)
+                  }}
+                  variant="contained"
+                  color="secondary"
+                >
+                  Show all regions in assembly
+                </Button>
+              </FormControl>
+            </Grid>
+          </form>
+        </Container>
+      </div>
+    )
+  },
+)
 
 export default LinearGenomeViewImportForm

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ImportFormRefNameAutocomplete.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ImportFormRefNameAutocomplete.tsx
@@ -9,51 +9,53 @@ import type BaseResult from '@jbrowse/core/TextSearch/BaseResults'
 
 type LGV = LinearGenomeViewModel
 
-const ImportFormRefNameAutocomplete = observer(function ({
-  model,
-  selectedAsm,
-  value,
-  setValue,
-  setOption,
-}: {
-  value: string
-  setValue: (arg: string) => void
-  model: LGV
-  selectedAsm: string
-  setOption: (arg: BaseResult) => void
-}) {
-  const session = getSession(model)
-  const { assemblyManager, textSearchManager } = session
-  const { rankSearchResults } = model
-  const searchScope = model.searchScope(selectedAsm)
-  const assembly = assemblyManager.get(selectedAsm)
-  return (
-    <RefNameAutocomplete
-      fetchResults={queryString =>
-        fetchResults({
-          queryString,
-          assembly,
-          textSearchManager,
-          rankSearchResults,
-          searchScope,
-        })
-      }
-      model={model}
-      assemblyName={selectedAsm}
-      value={value}
-      minWidth={270}
-      onChange={str => {
-        setValue(str)
-      }}
-      onSelect={val => {
-        setOption(val)
-      }}
-      TextFieldProps={{
-        variant: 'outlined',
-        helperText: 'Enter sequence name, feature name, or location',
-      }}
-    />
-  )
-})
+const ImportFormRefNameAutocomplete = observer(
+  function ImportFormRefNameAutocomplete({
+    model,
+    selectedAsm,
+    value,
+    setValue,
+    setOption,
+  }: {
+    value: string
+    setValue: (arg: string) => void
+    model: LGV
+    selectedAsm: string
+    setOption: (arg: BaseResult) => void
+  }) {
+    const session = getSession(model)
+    const { assemblyManager, textSearchManager } = session
+    const { rankSearchResults } = model
+    const searchScope = model.searchScope(selectedAsm)
+    const assembly = assemblyManager.get(selectedAsm)
+    return (
+      <RefNameAutocomplete
+        fetchResults={queryString =>
+          fetchResults({
+            queryString,
+            assembly,
+            textSearchManager,
+            rankSearchResults,
+            searchScope,
+          })
+        }
+        model={model}
+        assemblyName={selectedAsm}
+        value={value}
+        minWidth={270}
+        onChange={str => {
+          setValue(str)
+        }}
+        onSelect={val => {
+          setOption(val)
+        }}
+        TextFieldProps={{
+          variant: 'outlined',
+          helperText: 'Enter sequence name, feature name, or location',
+        }}
+      />
+    )
+  },
+)
 
 export default ImportFormRefNameAutocomplete

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeView.tsx
@@ -10,7 +10,7 @@ import type { LinearGenomeViewModel } from '..'
 // lazies
 const ImportForm = lazy(() => import('./ImportForm'))
 
-const LinearGenomeView = observer(function ({
+const LinearGenomeView = observer(function LinearGenomeView({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/LinearGenomeViewContainer.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const LinearGenomeViewContainer = observer(function ({
+const LinearGenomeViewContainer = observer(function LinearGenomeViewContainer({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/MiniControls.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const MiniControls = observer(function ({
+const MiniControls = observer(function MiniControls({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/NoTracksActiveButton.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/NoTracksActiveButton.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const NoTracksActiveButton = observer(function ({
+const NoTracksActiveButton = observer(function NoTracksActiveButton({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberbandHoverTooltip.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewRubberbandHoverTooltip.tsx
@@ -18,45 +18,49 @@ const useStyles = makeStyles()({
   },
 })
 
-const OverviewRubberbandHoverTooltip = observer(function ({
-  model,
-  open,
-  guideX,
-  overview,
-}: {
-  model: LGV
-  open: boolean
-  guideX: number
-  overview: Base1DViewModel
-}) {
-  const { classes } = useStyles()
-  const { cytobandOffset } = model
-  const { assemblyManager } = getSession(model)
+const OverviewRubberbandHoverTooltip = observer(
+  function OverviewRubberbandHoverTooltip({
+    model,
+    open,
+    guideX,
+    overview,
+  }: {
+    model: LGV
+    open: boolean
+    guideX: number
+    overview: Base1DViewModel
+  }) {
+    const { classes } = useStyles()
+    const { cytobandOffset } = model
+    const { assemblyManager } = getSession(model)
 
-  const px = overview.pxToBp(guideX - cytobandOffset)
-  const assembly = assemblyManager.get(px.assemblyName)
-  const cytoband = assembly?.cytobands?.find(
-    f =>
-      px.coord > f.get('start') &&
-      px.coord < f.get('end') &&
-      px.refName === assembly.getCanonicalRefName(f.get('refName')),
-  )
+    const px = overview.pxToBp(guideX - cytobandOffset)
+    const assembly = assemblyManager.get(px.assemblyName)
+    const cytoband = assembly?.cytobands?.find(
+      f =>
+        px.coord > f.get('start') &&
+        px.coord < f.get('end') &&
+        px.refName === assembly.getCanonicalRefName(f.get('refName')),
+    )
 
-  return (
-    <Tooltip
-      open={open}
-      placement="top"
-      title={[stringify(px), cytoband?.get('name'), cytoband?.get('type')].join(
-        ' ',
-      )}
-      arrow
-    >
-      <div
-        className={classes.guide}
-        style={{ transform: `translateX(${guideX}px)` }}
-      />
-    </Tooltip>
-  )
-})
+    return (
+      <Tooltip
+        open={open}
+        placement="top"
+        title={[
+          stringify(px),
+          cytoband?.get('name'),
+          cytoband?.get('type'),
+        ].join(' ')}
+        arrow
+      >
+        <div
+          className={classes.guide}
+          style={{ transform: `translateX(${guideX}px)` }}
+        />
+      </Tooltip>
+    )
+  },
+)
 
 export default OverviewRubberbandHoverTooltip

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebar.tsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles()(theme => ({
 
 type LGV = LinearGenomeViewModel
 
-const OverviewBox = observer(function ({
+const OverviewBox = observer(function OverviewBox({
   scale,
   model,
   block,
@@ -143,7 +143,7 @@ const OverviewBox = observer(function ({
   )
 })
 
-const VisibleRegionBox = observer(function ({
+const VisibleRegionBox = observer(function VisibleRegionBox({
   model,
   overview,
   className,
@@ -192,7 +192,7 @@ const VisibleRegionBox = observer(function ({
   )
 })
 
-const Scalebar = observer(function ({
+const Scalebar = observer(function Scalebar({
   model,
   scale,
   overview,
@@ -248,7 +248,7 @@ const Scalebar = observer(function ({
   )
 })
 
-const OverviewScalebar = observer(function ({
+const OverviewScalebar = observer(function OverviewScalebar({
   model,
   children,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebarPolygon.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebarPolygon.tsx
@@ -7,7 +7,7 @@ import { HEADER_BAR_HEIGHT } from '../consts'
 import type { LinearGenomeViewModel } from '..'
 import type { Base1DViewModel } from '@jbrowse/core/util/Base1DViewModel'
 
-const OverviewScalebarPolygon = observer(function ({
+const OverviewScalebarPolygon = observer(function OverviewScalebarPolygon({
   model,
   overview,
   useOffset = true,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebarTickLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/OverviewScalebarTickLabels.tsx
@@ -22,42 +22,44 @@ const useStyles = makeStyles()({
   },
 })
 
-const OverviewScalebarTickLabels = observer(function ({
-  block,
-  scale,
-  overview,
-  model,
-}: {
-  model: LinearGenomeViewModel
-  scale: number
-  block: ContentBlock
-  overview: Base1DViewModel
-}) {
-  const { classes } = useStyles()
-  const { start, end, reversed, refName, assemblyName } = block
-  const { majorPitch } = chooseGridPitch(scale, 120, 15)
-  const { assemblyManager } = getSession(model)
-  const assembly = assemblyManager.get(assemblyName)
-  const refNameColor = assembly?.getRefNameColor(refName)
+const OverviewScalebarTickLabels = observer(
+  function OverviewScalebarTickLabels({
+    block,
+    scale,
+    overview,
+    model,
+  }: {
+    model: LinearGenomeViewModel
+    scale: number
+    block: ContentBlock
+    overview: Base1DViewModel
+  }) {
+    const { classes } = useStyles()
+    const { start, end, reversed, refName, assemblyName } = block
+    const { majorPitch } = chooseGridPitch(scale, 120, 15)
+    const { assemblyManager } = getSession(model)
+    const assembly = assemblyManager.get(assemblyName)
+    const refNameColor = assembly?.getRefNameColor(refName)
 
-  const tickLabels = []
-  for (let i = 0; i < Math.floor((end - start) / majorPitch); i++) {
-    const offsetLabel = (i + 1) * majorPitch
-    tickLabels.push(reversed ? end - offsetLabel : start + offsetLabel)
-  }
-  return tickLabels.map((tickLabel, labelIdx) => (
-    <Typography
-      key={`${JSON.stringify(block)}-${tickLabel}-${labelIdx}`}
-      className={classes.scalebarLabel}
-      variant="body2"
-      style={{
-        transform: `translateX(${((labelIdx + 1) * majorPitch) / scale}px)`,
-        color: refNameColor,
-      }}
-    >
-      {getTickDisplayStr(tickLabel, overview.bpPerPx)}
-    </Typography>
-  ))
-})
+    const tickLabels = []
+    for (let i = 0; i < Math.floor((end - start) / majorPitch); i++) {
+      const offsetLabel = (i + 1) * majorPitch
+      tickLabels.push(reversed ? end - offsetLabel : start + offsetLabel)
+    }
+    return tickLabels.map((tickLabel, labelIdx) => (
+      <Typography
+        key={`${JSON.stringify(block)}-${tickLabel}-${labelIdx}`}
+        className={classes.scalebarLabel}
+        variant="body2"
+        style={{
+          transform: `translateX(${((labelIdx + 1) * majorPitch) / scale}px)`,
+          color: refNameColor,
+        }}
+      >
+        {getTickDisplayStr(tickLabel, overview.bpPerPx)}
+      </Typography>
+    ))
+  },
+)
 
 export default OverviewScalebarTickLabels

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete/index.tsx
@@ -14,7 +14,7 @@ import type { Option } from './util'
 import type { LinearGenomeViewModel } from '../../model'
 import type { TextFieldProps as TFP } from '@mui/material'
 
-const RefNameAutocomplete = observer(function ({
+const RefNameAutocomplete = observer(function RefNameAutocomplete({
   model,
   onSelect,
   assemblyName,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RegionWidthEditorDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RegionWidthEditorDialog.tsx
@@ -15,7 +15,7 @@ import type { LinearGenomeViewModel } from '../model'
 
 const toP = (s = 0) => +s.toFixed(1)
 
-const RegionWidthEditorDialog = observer(function ({
+const RegionWidthEditorDialog = observer(function RegionWidthEditorDialog({
   model,
   handleClose,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Rubberband.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Rubberband.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const Rubberband = observer(function ({
+const Rubberband = observer(function Rubberband({
   model,
   ControlComponent = <div />,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarCoordinateLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarCoordinateLabels.tsx
@@ -67,7 +67,11 @@ function ContentBlockLabels({
   )
 }
 
-const ScalebarCoordinateLabels = observer(function ({ model }: { model: LGV }) {
+const ScalebarCoordinateLabels = observer(function ScalebarCoordinateLabels({
+  model,
+}: {
+  model: LGV
+}) {
   const { classes, cx } = useStyles()
   const { staticBlocks, bpPerPx } = model
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
@@ -23,7 +23,11 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ScalebarRefNameLabels = observer(function ({ model }: { model: LGV }) {
+const ScalebarRefNameLabels = observer(function ScalebarRefNameLabels({
+  model,
+}: {
+  model: LGV
+}) {
   const { classes, cx } = useStyles()
   const { staticBlocks, offsetPx, scalebarDisplayPrefix } = model
 

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SearchBox.tsx
@@ -46,7 +46,7 @@ async function onSelect({
   }
 }
 
-const SearchBox = observer(function ({
+const SearchBox = observer(function SearchBox({
   model,
   showHelp = true,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceSearchDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/SequenceSearchDialog.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const SequenceSearchDialog = observer(function ({
+const SequenceSearchDialog = observer(function SequenceSearchDialog({
   model,
   handleClose,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackContainer.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles()(theme => ({
 
 type LGV = LinearGenomeViewModel
 
-const TrackContainer = observer(function ({
+const TrackContainer = observer(function TrackContainer({
   model,
   track,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelContainer.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()({
 
 type LGV = LinearGenomeViewModel
 
-const TrackLabelContainer = observer(function ({
+const TrackLabelContainer = observer(function TrackLabelContainer({
   track,
   view,
 }: {

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelMenu.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackLabelMenu.tsx
@@ -15,7 +15,7 @@ import { observer } from 'mobx-react'
 import type { LinearGenomeViewModel } from '../model'
 import type { BaseTrackModel } from '@jbrowse/core/pluggableElementTypes/models'
 
-const TrackLabelMenu = observer(function ({
+const TrackLabelMenu = observer(function TrackLabelMenu({
   track,
 }: {
   track: BaseTrackModel

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TrackRenderingContainer.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()({
 
 type LGV = LinearGenomeViewModel
 
-const TrackRenderingContainer = observer(function ({
+const TrackRenderingContainer = observer(function TrackRenderingContainer({
   model,
   track,
 }: {

--- a/plugins/lollipop/src/LollipopRenderer/components/LollipopRendering.tsx
+++ b/plugins/lollipop/src/LollipopRenderer/components/LollipopRendering.tsx
@@ -40,7 +40,9 @@ function layoutFeat(args: {
   })
 }
 
-const LollipopRendering = observer(function (props: Record<string, any>) {
+const LollipopRendering = observer(function LollipopRendering(
+  props: Record<string, any>,
+) {
   const onMouseDown = (event: MouseEvent) => {
     const { onMouseDown: handler } = props
     return handler?.(event)

--- a/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
+++ b/plugins/menus/src/AboutWidget/components/AboutWidget.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const AboutWidget = observer(function ({
+const AboutWidget = observer(function AboutWidget({
   model,
 }: {
   model: IAnyStateTreeNode

--- a/plugins/menus/src/ImportSessionWidget/components/ImportSessionWidget.tsx
+++ b/plugins/menus/src/ImportSessionWidget/components/ImportSessionWidget.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const ImportSessionWidget = observer(function ({
+const ImportSessionWidget = observer(function ImportSessionWidget({
   model,
 }: {
   model: IAnyStateTreeNode

--- a/plugins/menus/src/SessionManager/components/SessionManager.tsx
+++ b/plugins/menus/src/SessionManager/components/SessionManager.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const SessionManager = observer(function ({
+const SessionManager = observer(function SessionManager({
   session,
 }: {
   session: SessionModel

--- a/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
+++ b/plugins/sequence/src/DivSequenceRenderer/components/DivSequenceRendering.tsx
@@ -167,7 +167,7 @@ function Wrapper({
   )
 }
 
-const DivSequenceRendering = observer(function ({
+const DivSequenceRendering = observer(function DivSequenceRendering({
   exportSVG,
   features,
   regions,

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/ImportWizard.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const ImportWizard = observer(function ({
+const ImportWizard = observer(function ImportWizard({
   model,
 }: {
   model: ImportWizardModel

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/NumberEditor.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/NumberEditor.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const NumberEditor = observer(function ({
+const NumberEditor = observer(function NumberEditor({
   model,
   disabled,
   modelPropName,

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetDataGrid.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react'
 
 import type { SpreadsheetModel } from '../SpreadsheetModel'
 
-const SpreadsheetDataGrid = observer(function ({
+const SpreadsheetDataGrid = observer(function SpreadsheetDataGrid({
   model,
 }: {
   model: SpreadsheetModel

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetView.tsx
@@ -8,7 +8,7 @@ import type { SpreadsheetViewModel } from '../SpreadsheetViewModel'
 
 const ImportWizard = lazy(() => import('./ImportWizard'))
 
-const SpreadsheetContainer = observer(function ({
+const SpreadsheetContainer = observer(function SpreadsheetContainer({
   model,
 }: {
   model: SpreadsheetViewModel

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetViewActual.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/SpreadsheetViewActual.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const SpreadsheetViewActual = observer(function ({
+const SpreadsheetViewActual = observer(function SpreadsheetViewActual({
   model,
 }: {
   model: SpreadsheetViewModel

--- a/plugins/spreadsheet-view/src/SpreadsheetView/components/TrackSelector.tsx
+++ b/plugins/spreadsheet-view/src/SpreadsheetView/components/TrackSelector.tsx
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react'
 
 import type { ImportWizardModel } from '../ImportWizard'
 
-const TrackSelector = observer(function ({
+const TrackSelector = observer(function TrackSelector({
   model,
   selectedAssembly,
 }: {

--- a/plugins/sv-inspector/src/SvInspectorView/components/CircularViewOptions.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/CircularViewOptions.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const CircularViewOptions = observer(function ({
+const CircularViewOptions = observer(function CircularViewOptions({
   svInspector,
 }: {
   svInspector: SvInspectorViewModel

--- a/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
+++ b/plugins/sv-inspector/src/SvInspectorView/components/SvInspectorView.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const SvInspectorView = observer(function ({
+const SvInspectorView = observer(function SvInspectorView({
   model,
 }: {
   model: SvInspectorViewModel

--- a/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/FeatureGlyph.tsx
@@ -5,7 +5,7 @@ import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature, Region } from '@jbrowse/core/util'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'
 
-const FeatureGlyph = observer(function (props: {
+const FeatureGlyph = observer(function FeatureGlyph(props: {
   feature: Feature
   rootLayout: SceneGraph
   config: AnyConfigurationModel

--- a/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/ProcessedTranscript.tsx
@@ -9,7 +9,7 @@ import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature, Region } from '@jbrowse/core/util'
 import type { SceneGraph } from '@jbrowse/core/util/layouts'
 
-const ProcessedTranscript = observer(function (props: {
+const ProcessedTranscript = observer(function ProcessedTranscript(props: {
   feature: Feature
   region: Region
   config: AnyConfigurationModel

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgFeatureRendering.tsx
@@ -160,7 +160,7 @@ function RenderedFeatureGlyph(props: {
   }
 }
 
-const RenderedFeatures = observer(function (props: {
+const RenderedFeatures = observer(function RenderedFeatures(props: {
   features?: Map<string, Feature>
   isFeatureDisplayed?: (f: Feature) => boolean
   bpPerPx: number

--- a/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
+++ b/plugins/svg/src/SvgFeatureRenderer/components/SvgOverlay.tsx
@@ -50,7 +50,7 @@ function OverlayRect({
 type ME = React.MouseEvent<SVGRectElement>
 type MEFE = ME | React.FocusEvent<SVGRectElement>
 
-const SvgOverlay = observer(function ({
+const SvgOverlay = observer(function SvgOverlay({
   displayModel = {},
   blockKey,
   region,

--- a/plugins/variants/src/ChordVariantDisplay/components/ChordVariantDisplay.tsx
+++ b/plugins/variants/src/ChordVariantDisplay/components/ChordVariantDisplay.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 import DisplayError from './DisplayError'
 import Loading from './Loading'
 
-const ChordVariantDisplay = observer(function ({
+const ChordVariantDisplay = observer(function ChordVariantDisplay({
   display,
 }: {
   display: {

--- a/plugins/variants/src/ChordVariantDisplay/components/DisplayError.tsx
+++ b/plugins/variants/src/ChordVariantDisplay/components/DisplayError.tsx
@@ -1,6 +1,6 @@
 import { observer } from 'mobx-react'
 
-const DisplayError = observer(function ({
+const DisplayError = observer(function DisplayError({
   model,
 }: {
   model: { renderProps: { radius: number }; error: unknown }

--- a/plugins/variants/src/ChordVariantDisplay/components/Loading.tsx
+++ b/plugins/variants/src/ChordVariantDisplay/components/Loading.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()(() => {
   }
 })
 
-const Loading = observer(function ({
+const Loading = observer(function Loading({
   model: {
     renderProps: { radius },
   },

--- a/plugins/variants/src/MultiLinearVariantDisplay/components/VariantDisplayComponent.tsx
+++ b/plugins/variants/src/MultiLinearVariantDisplay/components/VariantDisplayComponent.tsx
@@ -8,35 +8,37 @@ import { useMouseTracking } from '../../shared/hooks/useMouseTracking'
 
 import type { MultiLinearVariantDisplayModel } from '../model'
 
-const MultiLinearVariantDisplayComponent = observer(function (props: {
-  model: MultiLinearVariantDisplayModel
-}) {
-  const { model } = props
-  const { height } = model
-  const ref = useRef<HTMLDivElement>(null)
-  const { mouseState, handleMouseMove, handleMouseLeave } =
-    useMouseTracking(ref)
+const MultiLinearVariantDisplayComponent = observer(
+  function MultiLinearVariantDisplayComponent(props: {
+    model: MultiLinearVariantDisplayModel
+  }) {
+    const { model } = props
+    const { height } = model
+    const ref = useRef<HTMLDivElement>(null)
+    const { mouseState, handleMouseMove, handleMouseLeave } =
+      useMouseTracking(ref)
 
-  return (
-    <div
-      ref={ref}
-      style={{ position: 'relative', height }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-    >
-      <ScrollableVariantContainer model={model} />
+    return (
+      <div
+        ref={ref}
+        style={{ position: 'relative', height }}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+      >
+        <ScrollableVariantContainer model={model} />
 
-      {mouseState ? (
-        <Crosshair
-          mouseX={mouseState.x}
-          mouseY={mouseState.y}
-          offsetX={mouseState.offsetX}
-          offsetY={mouseState.offsetY}
-          model={model}
-        />
-      ) : null}
-    </div>
-  )
-})
+        {mouseState ? (
+          <Crosshair
+            mouseX={mouseState.x}
+            mouseY={mouseState.y}
+            offsetX={mouseState.offsetX}
+            offsetY={mouseState.offsetY}
+            model={model}
+          />
+        ) : null}
+      </div>
+    )
+  },
+)
 
 export default MultiLinearVariantDisplayComponent

--- a/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/LinesConnectingMatrixToGenomicPosition.tsx
+++ b/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/LinesConnectingMatrixToGenomicPosition.tsx
@@ -32,7 +32,7 @@ interface MinimalModel {
   featuresVolatile: Feature[] | undefined
 }
 
-const Wrapper = observer(function ({
+const Wrapper = observer(function Wrapper({
   children,
   model,
   exportSVG,
@@ -67,59 +67,61 @@ interface MouseOverLine {
   c: number
 }
 
-const LinesConnectingMatrixToGenomicPosition = observer(function ({
-  model,
-  exportSVG,
-}: {
-  model: MinimalModel
-  exportSVG?: boolean
-}) {
-  const { classes } = useStyles()
-  const { assemblyManager } = getSession(model)
-  const view = getContainingView(model) as LinearGenomeViewModel
-  const [mouseOverLine, setMouseOverLine] = useState<MouseOverLine>()
-  const { lineZoneHeight, featuresVolatile } = model
-  const { assemblyNames, dynamicBlocks } = view
-  const assembly = assemblyManager.get(assemblyNames[0]!)
-  const b0 = dynamicBlocks.contentBlocks[0]?.widthPx || 0
-  const w = b0 / (featuresVolatile?.length || 1)
-  return assembly && featuresVolatile ? (
-    <>
-      <Wrapper exportSVG={exportSVG} model={model}>
-        <AllLines model={model} setMouseOverLine={setMouseOverLine} />
-        {mouseOverLine ? (
-          <>
-            <line
-              stroke="#f00c"
-              strokeWidth={2}
-              style={{
-                pointerEvents: 'none',
-              }}
-              x1={mouseOverLine.idx * w + w / 2}
-              x2={mouseOverLine.c}
-              y1={lineZoneHeight}
-              y2={0}
-              onMouseLeave={() => {
-                setMouseOverLine(undefined)
-              }}
-            />
-            <LineTooltip contents={mouseOverLine.f.get('name')} />
-          </>
+const LinesConnectingMatrixToGenomicPosition = observer(
+  function LinesConnectingMatrixToGenomicPosition({
+    model,
+    exportSVG,
+  }: {
+    model: MinimalModel
+    exportSVG?: boolean
+  }) {
+    const { classes } = useStyles()
+    const { assemblyManager } = getSession(model)
+    const view = getContainingView(model) as LinearGenomeViewModel
+    const [mouseOverLine, setMouseOverLine] = useState<MouseOverLine>()
+    const { lineZoneHeight, featuresVolatile } = model
+    const { assemblyNames, dynamicBlocks } = view
+    const assembly = assemblyManager.get(assemblyNames[0]!)
+    const b0 = dynamicBlocks.contentBlocks[0]?.widthPx || 0
+    const w = b0 / (featuresVolatile?.length || 1)
+    return assembly && featuresVolatile ? (
+      <>
+        <Wrapper exportSVG={exportSVG} model={model}>
+          <AllLines model={model} setMouseOverLine={setMouseOverLine} />
+          {mouseOverLine ? (
+            <>
+              <line
+                stroke="#f00c"
+                strokeWidth={2}
+                style={{
+                  pointerEvents: 'none',
+                }}
+                x1={mouseOverLine.idx * w + w / 2}
+                x2={mouseOverLine.c}
+                y1={lineZoneHeight}
+                y2={0}
+                onMouseLeave={() => {
+                  setMouseOverLine(undefined)
+                }}
+              />
+              <LineTooltip contents={mouseOverLine.f.get('name')} />
+            </>
+          ) : null}
+        </Wrapper>
+        {!exportSVG ? (
+          <ResizeHandle
+            style={{
+              position: 'absolute',
+              top: lineZoneHeight - 4,
+            }}
+            onDrag={n => model.setLineZoneHeight(lineZoneHeight + n)}
+            className={classes.resizeHandle}
+          />
         ) : null}
-      </Wrapper>
-      {!exportSVG ? (
-        <ResizeHandle
-          style={{
-            position: 'absolute',
-            top: lineZoneHeight - 4,
-          }}
-          onDrag={n => model.setLineZoneHeight(lineZoneHeight + n)}
-          className={classes.resizeHandle}
-        />
-      ) : null}
-    </>
-  ) : null
-})
+      </>
+    ) : null
+  },
+)
 interface Props {
   message: React.ReactNode | string
 }
@@ -136,7 +138,11 @@ const TooltipContents = forwardRef<HTMLDivElement, Props>(
     )
   },
 )
-const LineTooltip = observer(function ({ contents }: { contents?: string }) {
+const LineTooltip = observer(function LineTooltip({
+  contents,
+}: {
+  contents?: string
+}) {
   return contents ? (
     <BaseTooltip>
       <TooltipContents message={contents} />
@@ -144,7 +150,7 @@ const LineTooltip = observer(function ({ contents }: { contents?: string }) {
   ) : null
 })
 
-const AllLines = observer(function ({
+const AllLines = observer(function AllLines({
   model,
   setMouseOverLine,
 }: {

--- a/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/VariantDisplayComponent.tsx
+++ b/plugins/variants/src/MultiLinearVariantMatrixDisplay/components/VariantDisplayComponent.tsx
@@ -9,43 +9,45 @@ import { useMouseTracking } from '../../shared/hooks/useMouseTracking'
 
 import type { MultiLinearVariantMatrixDisplayModel } from '../model'
 
-const MultiLinearVariantMatrixDisplayComponent = observer(function (props: {
-  model: MultiLinearVariantMatrixDisplayModel
-}) {
-  const { model } = props
-  const { lineZoneHeight, height } = model
-  const ref = useRef<HTMLDivElement>(null)
-  const { mouseState, handleMouseMove, handleMouseLeave } =
-    useMouseTracking(ref)
+const MultiLinearVariantMatrixDisplayComponent = observer(
+  function MultiLinearVariantMatrixDisplayComponent(props: {
+    model: MultiLinearVariantMatrixDisplayModel
+  }) {
+    const { model } = props
+    const { lineZoneHeight, height } = model
+    const ref = useRef<HTMLDivElement>(null)
+    const { mouseState, handleMouseMove, handleMouseLeave } =
+      useMouseTracking(ref)
 
-  return (
-    <div
-      ref={ref}
-      style={{ position: 'relative', height }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-    >
-      {/* Connecting lines - fixed at top */}
-      <div data-testid="connecting-lines">
-        <LinesConnectingMatrixToGenomicPosition model={model} />
-      </div>
+    return (
+      <div
+        ref={ref}
+        style={{ position: 'relative', height }}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+      >
+        {/* Connecting lines - fixed at top */}
+        <div data-testid="connecting-lines">
+          <LinesConnectingMatrixToGenomicPosition model={model} />
+        </div>
 
-      <ScrollableVariantContainer
-        model={model}
-        topOffset={lineZoneHeight}
-        testId="matrix-display"
-      />
-
-      {mouseState && mouseState.y > lineZoneHeight ? (
-        <Crosshair
-          mouseX={mouseState.x}
-          mouseY={mouseState.y}
-          offsetX={mouseState.offsetX}
-          offsetY={mouseState.offsetY}
+        <ScrollableVariantContainer
           model={model}
+          topOffset={lineZoneHeight}
+          testId="matrix-display"
         />
-      ) : null}
-    </div>
-  )
-})
+
+        {mouseState && mouseState.y > lineZoneHeight ? (
+          <Crosshair
+            mouseX={mouseState.x}
+            mouseY={mouseState.y}
+            offsetX={mouseState.offsetX}
+            offsetY={mouseState.offsetY}
+            model={model}
+          />
+        ) : null}
+      </div>
+    )
+  },
+)
 export default MultiLinearVariantMatrixDisplayComponent

--- a/plugins/variants/src/MultiLinearVariantMatrixRenderer/components/MultiLinearVariantMatrixRendering.tsx
+++ b/plugins/variants/src/MultiLinearVariantMatrixRenderer/components/MultiLinearVariantMatrixRendering.tsx
@@ -16,109 +16,111 @@ interface FeatureData {
   length: number
 }
 
-const MultiLinearVariantMatrixRendering = observer(function (props: {
-  width: number
-  height: number
-  displayModel: MultiVariantBaseModel
-  arr: string[][]
-  featureData: FeatureData[]
-  rowHeight: number
-  origScrollTop: number
-  totalHeight: number
-}) {
-  const {
-    arr,
-    width,
-    displayModel,
-    featureData,
-    totalHeight,
-    origScrollTop,
-    rowHeight,
-  } = props
-  const ref = useRef<HTMLDivElement>(null)
-  const lastHoveredRef = useRef<string | undefined>(undefined)
+const MultiLinearVariantMatrixRendering = observer(
+  function MultiLinearVariantMatrixRendering(props: {
+    width: number
+    height: number
+    displayModel: MultiVariantBaseModel
+    arr: string[][]
+    featureData: FeatureData[]
+    rowHeight: number
+    origScrollTop: number
+    totalHeight: number
+  }) {
+    const {
+      arr,
+      width,
+      displayModel,
+      featureData,
+      totalHeight,
+      origScrollTop,
+      rowHeight,
+    } = props
+    const ref = useRef<HTMLDivElement>(null)
+    const lastHoveredRef = useRef<string | undefined>(undefined)
 
-  const getFeatureUnderMouse = useCallback(
-    (eventClientX: number, eventClientY: number) => {
-      if (!ref.current) {
-        return
-      }
-      const r = ref.current.getBoundingClientRect()
-      const offsetX = eventClientX - r.left
-      const offsetY = eventClientY - r.top
-
-      const { sources } = displayModel
-
-      // Canvas is positioned at top=origScrollTop, so adjust mouse position
-      // relative to canvas top
-      const canvasOffsetY = offsetY - origScrollTop
-      // The first row in the canvas corresponds to source at index startRow
-      const startRow = Math.floor(origScrollTop / rowHeight)
-      const visibleRowIdx = Math.floor(canvasOffsetY / rowHeight)
-      const sourceIdx = startRow + visibleRowIdx
-      const name = sources?.[sourceIdx]?.name
-      const featureIdx = Math.floor((offsetX / width) * arr.length)
-      const genotype = arr[featureIdx]?.[visibleRowIdx]
-      const feature = featureData[featureIdx]
-
-      if (genotype && name && feature) {
-        const { ref, alt, name: featureName, description, length } = feature
-        const alleles = makeSimpleAltString(genotype, ref, alt)
-        return {
-          name,
-          genotype,
-          alleles,
-          featureName,
-          description: alt.length >= 3 ? 'multiple ALT alleles' : description,
-          length: getBpDisplayStr(length),
+    const getFeatureUnderMouse = useCallback(
+      (eventClientX: number, eventClientY: number) => {
+        if (!ref.current) {
+          return
         }
+        const r = ref.current.getBoundingClientRect()
+        const offsetX = eventClientX - r.left
+        const offsetY = eventClientY - r.top
+
+        const { sources } = displayModel
+
+        // Canvas is positioned at top=origScrollTop, so adjust mouse position
+        // relative to canvas top
+        const canvasOffsetY = offsetY - origScrollTop
+        // The first row in the canvas corresponds to source at index startRow
+        const startRow = Math.floor(origScrollTop / rowHeight)
+        const visibleRowIdx = Math.floor(canvasOffsetY / rowHeight)
+        const sourceIdx = startRow + visibleRowIdx
+        const name = sources?.[sourceIdx]?.name
+        const featureIdx = Math.floor((offsetX / width) * arr.length)
+        const genotype = arr[featureIdx]?.[visibleRowIdx]
+        const feature = featureData[featureIdx]
+
+        if (genotype && name && feature) {
+          const { ref, alt, name: featureName, description, length } = feature
+          const alleles = makeSimpleAltString(genotype, ref, alt)
+          return {
+            name,
+            genotype,
+            alleles,
+            featureName,
+            description: alt.length >= 3 ? 'multiple ALT alleles' : description,
+            length: getBpDisplayStr(length),
+          }
+        }
+        return undefined
+      },
+      [arr, width, displayModel, featureData, origScrollTop, rowHeight],
+    )
+
+    const handleMouseMove = useCallback(
+      (e: React.MouseEvent) => {
+        const result = getFeatureUnderMouse(e.clientX, e.clientY)
+        const key = result ? `${result.name}:${result.genotype}` : undefined
+        if (key !== lastHoveredRef.current) {
+          lastHoveredRef.current = key
+          displayModel.setHoveredGenotype(result)
+        }
+      },
+      [getFeatureUnderMouse, displayModel],
+    )
+
+    const handleMouseLeave = useCallback(() => {
+      if (lastHoveredRef.current !== undefined) {
+        lastHoveredRef.current = undefined
+        displayModel.setHoveredGenotype(undefined)
       }
-      return undefined
-    },
-    [arr, width, displayModel, featureData, origScrollTop, rowHeight],
-  )
+    }, [displayModel])
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      const result = getFeatureUnderMouse(e.clientX, e.clientY)
-      const key = result ? `${result.name}:${result.genotype}` : undefined
-      if (key !== lastHoveredRef.current) {
-        lastHoveredRef.current = key
-        displayModel.setHoveredGenotype(result)
-      }
-    },
-    [getFeatureUnderMouse, displayModel],
-  )
-
-  const handleMouseLeave = useCallback(() => {
-    if (lastHoveredRef.current !== undefined) {
-      lastHoveredRef.current = undefined
-      displayModel.setHoveredGenotype(undefined)
-    }
-  }, [displayModel])
-
-  return (
-    <div
-      ref={ref}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-      onMouseOut={handleMouseLeave}
-      style={{
-        overflow: 'visible',
-        position: 'relative',
-        height: totalHeight,
-      }}
-    >
-      <PrerenderedCanvas
-        {...props}
+    return (
+      <div
+        ref={ref}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        onMouseOut={handleMouseLeave}
         style={{
-          position: 'absolute',
-          left: 0,
-          top: origScrollTop,
+          overflow: 'visible',
+          position: 'relative',
+          height: totalHeight,
         }}
-      />
-    </div>
-  )
-})
+      >
+        <PrerenderedCanvas
+          {...props}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: origScrollTop,
+          }}
+        />
+      </div>
+    )
+  },
+)
 
 export default MultiLinearVariantMatrixRendering

--- a/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
+++ b/plugins/variants/src/MultiLinearVariantRenderer/components/MultiLinearVariantRendering.tsx
@@ -27,7 +27,7 @@ interface MinimizedVariantRecord {
   length: number
 }
 
-const MultiVariantRendering = observer(function (props: {
+const MultiVariantRendering = observer(function MultiVariantRendering(props: {
   regions: Region[]
   features: Map<string, Feature>
   bpPerPx: number

--- a/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.tsx
+++ b/plugins/variants/src/StructuralVariantChordRenderer/ReactComponent.tsx
@@ -8,65 +8,67 @@ import type { AnyRegion, Block } from './types'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
 import type { Feature } from '@jbrowse/core/util'
 
-const StructuralVariantChordsReactComponent = observer(function ({
-  features,
-  config,
-  blockDefinitions,
-  radius,
-  bezierRadius,
-  displayModel,
-  onChordClick,
-}: {
-  features: Map<string, Feature>
-  radius: number
-  config: AnyConfigurationModel
-  displayModel?: {
-    id: string
-    selectedFeatureId: string
-  }
-  blockDefinitions: Block[]
-  bezierRadius: number
-  onChordClick: (
-    feature: Feature,
-    reg: AnyRegion,
-    endBlock: AnyRegion,
-    evt: unknown,
-  ) => void
-}) {
-  const { selectedFeatureId } = displayModel || {}
-  const blocksForRefsMemo = useMemo(() => {
-    const blocksForRefs = {} as Record<string, Block>
-    for (const block of blockDefinitions) {
-      const regions = block.region.elided
-        ? block.region.regions
-        : [block.region]
-      for (const region of regions) {
-        blocksForRefs[region.refName] = block
-      }
+const StructuralVariantChordsReactComponent = observer(
+  function StructuralVariantChordsReactComponent({
+    features,
+    config,
+    blockDefinitions,
+    radius,
+    bezierRadius,
+    displayModel,
+    onChordClick,
+  }: {
+    features: Map<string, Feature>
+    radius: number
+    config: AnyConfigurationModel
+    displayModel?: {
+      id: string
+      selectedFeatureId: string
     }
-    return blocksForRefs
-  }, [blockDefinitions])
+    blockDefinitions: Block[]
+    bezierRadius: number
+    onChordClick: (
+      feature: Feature,
+      reg: AnyRegion,
+      endBlock: AnyRegion,
+      evt: unknown,
+    ) => void
+  }) {
+    const { selectedFeatureId } = displayModel || {}
+    const blocksForRefsMemo = useMemo(() => {
+      const blocksForRefs = {} as Record<string, Block>
+      for (const block of blockDefinitions) {
+        const regions = block.region.elided
+          ? block.region.regions
+          : [block.region]
+        for (const region of regions) {
+          blocksForRefs[region.refName] = block
+        }
+      }
+      return blocksForRefs
+    }, [blockDefinitions])
 
-  return (
-    <g data-testid="structuralVariantChordRenderer">
-      {[...features.values()].map(feature => {
-        const id = feature.id()
-        const selected = selectedFeatureId === id
-        return (
-          <Chord
-            key={id}
-            feature={feature}
-            config={config}
-            radius={radius}
-            bezierRadius={bezierRadius}
-            blocksForRefs={blocksForRefsMemo}
-            selected={selected}
-            onClick={onChordClick}
-          />
-        )
-      })}
-    </g>
-  )
-})
+    return (
+      <g data-testid="structuralVariantChordRenderer">
+        {[...features.values()].map(feature => {
+          const id = feature.id()
+          const selected = selectedFeatureId === id
+          return (
+            <Chord
+              key={id}
+              feature={feature}
+              config={config}
+              radius={radius}
+              bezierRadius={bezierRadius}
+              blocksForRefs={blocksForRefsMemo}
+              selected={selected}
+              onClick={onChordClick}
+            />
+          )
+        })}
+      </g>
+    )
+  },
+)
 
 export default StructuralVariantChordsReactComponent

--- a/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantFeatureWidget.tsx
@@ -93,7 +93,7 @@ function LaunchBreakendWidgetArea({
   ) : null
 }
 
-const FeatDefined = observer(function (props: {
+const FeatDefined = observer(function FeatDefined(props: {
   feat: SimpleFeatureSerialized
   model: VariantFeatureWidgetModel
 }) {
@@ -145,7 +145,7 @@ const FeatDefined = observer(function (props: {
   )
 })
 
-const VariantFeatureWidget = observer(function (props: {
+const VariantFeatureWidget = observer(function VariantFeatureWidget(props: {
   model: VariantFeatureWidgetModel
 }) {
   const { model } = props

--- a/plugins/variants/src/shared/components/MultiVariantBaseDisplayComponent.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantBaseDisplayComponent.tsx
@@ -10,35 +10,37 @@ import { useMouseTracking } from '../hooks/useMouseTracking'
 
 import type { MultiVariantBaseModel } from '../MultiVariantBaseModel'
 
-const MultiVariantBaseDisplayComponent = observer(function (props: {
-  model: MultiVariantBaseModel
-}) {
-  const { model } = props
-  const ref = useRef<HTMLDivElement>(null)
-  const { mouseState, handleMouseMove, handleMouseLeave } =
-    useMouseTracking(ref)
+const MultiVariantBaseDisplayComponent = observer(
+  function MultiVariantBaseDisplayComponent(props: {
+    model: MultiVariantBaseModel
+  }) {
+    const { model } = props
+    const ref = useRef<HTMLDivElement>(null)
+    const { mouseState, handleMouseMove, handleMouseLeave } =
+      useMouseTracking(ref)
 
-  return (
-    <div
-      ref={ref}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-    >
-      <BaseLinearDisplayComponent {...props} />
-      <TreeSidebar model={model} />
-      <LegendBar model={model} />
+    return (
+      <div
+        ref={ref}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+      >
+        <BaseLinearDisplayComponent {...props} />
+        <TreeSidebar model={model} />
+        <LegendBar model={model} />
 
-      {mouseState ? (
-        <Crosshair
-          mouseX={mouseState.x}
-          mouseY={mouseState.y}
-          offsetX={mouseState.offsetX}
-          offsetY={mouseState.offsetY}
-          model={model}
-        />
-      ) : null}
-    </div>
-  )
-})
+        {mouseState ? (
+          <Crosshair
+            mouseX={mouseState.x}
+            mouseY={mouseState.y}
+            offsetX={mouseState.offsetX}
+            offsetY={mouseState.offsetY}
+            model={model}
+          />
+        ) : null}
+      </div>
+    )
+  },
+)
 
 export default MultiVariantBaseDisplayComponent

--- a/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialog.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialog.tsx
@@ -56,7 +56,7 @@ function Header({
   )
 }
 
-const ClusterDialog = observer(function ({
+const ClusterDialog = observer(function ClusterDialog({
   model,
   handleClose,
 }: {

--- a/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialogAuto.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialogAuto.tsx
@@ -16,7 +16,7 @@ import type { ReducedModel } from './types'
 import type { StopToken } from '@jbrowse/core/util/stopToken'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const ClusterDialogAuto = observer(function ({
+const ClusterDialogAuto = observer(function ClusterDialogAuto({
   model,
   children,
   handleClose,

--- a/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialogManual.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantClusterDialog/ClusterDialogManual.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles()({
   },
 })
 
-const ClusterDialogManuals = observer(function ({
+const ClusterDialogManuals = observer(function ClusterDialogManuals({
   model,
   handleClose,
   children,

--- a/plugins/variants/src/shared/components/MultiVariantColorLegend.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantColorLegend.tsx
@@ -56,7 +56,7 @@ const LegendItemText = function ({
   )
 }
 
-const MultiVariantColorLegend = observer(function ({
+const MultiVariantColorLegend = observer(function MultiVariantColorLegend({
   model,
   labelWidth,
 }: {

--- a/plugins/variants/src/shared/components/MultiVariantCrosshairs.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantCrosshairs.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-const MultiVariantCrosshairs = observer(function ({
+const MultiVariantCrosshairs = observer(function MultiVariantCrosshairs({
   mouseX,
   mouseY,
   model,

--- a/plugins/variants/src/shared/components/MultiVariantLegendBar.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantLegendBar.tsx
@@ -8,7 +8,7 @@ import MultiVariantLegendBarWrapper from './MultiVariantLegendBarWrapper'
 
 import type { LegendBarModel } from './types'
 
-const MultiVariantLegendBar = observer(function (props: {
+const MultiVariantLegendBar = observer(function MultiVariantLegendBar(props: {
   model: LegendBarModel
   orientation?: string
   exportSVG?: boolean

--- a/plugins/variants/src/shared/components/MultiVariantLegendBarWrapper.tsx
+++ b/plugins/variants/src/shared/components/MultiVariantLegendBarWrapper.tsx
@@ -3,44 +3,46 @@ import { observer } from 'mobx-react'
 
 import type { LegendBarModel } from './types'
 
-const MultiVariantLegendBarWrapper = observer(function ({
-  children,
-  model,
-  exportSVG,
-}: {
-  model: LegendBarModel
-  children: React.ReactNode
-  exportSVG?: boolean
-}) {
-  const { id, scrollTop, height, hierarchy, treeAreaWidth, showTree } = model
-  const clipid = `legend-${typeof jest === 'undefined' ? id : 'test'}`
-  const leftOffset = hierarchy && showTree ? treeAreaWidth : 0
-  return exportSVG ? (
-    <>
-      <defs>
-        <clipPath id={clipid}>
-          <rect x={0} y={0} width={1000} height={height} />
-        </clipPath>
-      </defs>
-      <g clipPath={`url(#${clipid})`}>
-        <g transform={`translate(0,${-scrollTop})`}>{children}</g>
-      </g>
-    </>
-  ) : (
-    <svg
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: leftOffset,
-        zIndex: 100,
-        pointerEvents: 'none',
-        height: model.totalHeight,
-        width: getContainingView(model).width,
-      }}
-    >
-      {children}
-    </svg>
-  )
-})
+const MultiVariantLegendBarWrapper = observer(
+  function MultiVariantLegendBarWrapper({
+    children,
+    model,
+    exportSVG,
+  }: {
+    model: LegendBarModel
+    children: React.ReactNode
+    exportSVG?: boolean
+  }) {
+    const { id, scrollTop, height, hierarchy, treeAreaWidth, showTree } = model
+    const clipid = `legend-${typeof jest === 'undefined' ? id : 'test'}`
+    const leftOffset = hierarchy && showTree ? treeAreaWidth : 0
+    return exportSVG ? (
+      <>
+        <defs>
+          <clipPath id={clipid}>
+            <rect x={0} y={0} width={1000} height={height} />
+          </clipPath>
+        </defs>
+        <g clipPath={`url(#${clipid})`}>
+          <g transform={`translate(0,${-scrollTop})`}>{children}</g>
+        </g>
+      </>
+    ) : (
+      <svg
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: leftOffset,
+          zIndex: 100,
+          pointerEvents: 'none',
+          height: model.totalHeight,
+          width: getContainingView(model).width,
+        }}
+      >
+        {children}
+      </svg>
+    )
+  },
+)
 
 export default MultiVariantLegendBarWrapper

--- a/plugins/variants/src/shared/components/ScrollableVariantContainer.tsx
+++ b/plugins/variants/src/shared/components/ScrollableVariantContainer.tsx
@@ -12,41 +12,43 @@ interface ScrollableVariantContainerProps {
   testId?: string
 }
 
-const ScrollableVariantContainer = observer(function ({
-  model,
-  topOffset = 0,
-  testId,
-}: ScrollableVariantContainerProps) {
-  const { setScrollTop, autoHeight, availableHeight } = model
+const ScrollableVariantContainer = observer(
+  function ScrollableVariantContainer({
+    model,
+    topOffset = 0,
+    testId,
+  }: ScrollableVariantContainerProps) {
+    const { setScrollTop, autoHeight, availableHeight } = model
 
-  return (
-    <div
-      data-testid={testId}
-      style={{
-        position: 'absolute',
-        top: topOffset,
-        height: availableHeight,
-        width: '100%',
-        overflowY: autoHeight ? 'hidden' : 'auto',
-        overflowX: 'hidden',
-      }}
-      onScroll={evt => {
-        setScrollTop(evt.currentTarget.scrollTop)
-      }}
-    >
-      <TreeSidebar model={model} />
-      <LegendBar model={model} />
+    return (
       <div
+        data-testid={testId}
         style={{
           position: 'absolute',
-          left: 0,
+          top: topOffset,
+          height: availableHeight,
           width: '100%',
+          overflowY: autoHeight ? 'hidden' : 'auto',
+          overflowX: 'hidden',
+        }}
+        onScroll={evt => {
+          setScrollTop(evt.currentTarget.scrollTop)
         }}
       >
-        <BaseLinearDisplayComponent model={model} />
+        <TreeSidebar model={model} />
+        <LegendBar model={model} />
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            width: '100%',
+          }}
+        >
+          <BaseLinearDisplayComponent model={model} />
+        </div>
       </div>
-    </div>
-  )
-})
+    )
+  },
+)
 
 export default ScrollableVariantContainer

--- a/plugins/variants/src/shared/components/SvgTree.tsx
+++ b/plugins/variants/src/shared/components/SvgTree.tsx
@@ -2,7 +2,11 @@ import { observer } from 'mobx-react'
 
 import type { LegendBarModel } from './types'
 
-const SvgTree = observer(function ({ model }: { model: LegendBarModel }) {
+const SvgTree = observer(function SvgTree({
+  model,
+}: {
+  model: LegendBarModel
+}) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { treeAreaWidth: _treeAreaWidth, hierarchy } = model
   const svg = []

--- a/plugins/variants/src/shared/components/TreeSidebar.tsx
+++ b/plugins/variants/src/shared/components/TreeSidebar.tsx
@@ -42,7 +42,11 @@ function getDescendantNames(node: ClusterHierarchyNode): string[] {
  * The sticky container keeps the tree visible when the parent scrolls.
  * The tree drawing uses translate(-scrollTop) to show the correct portion.
  */
-const TreeSidebar = observer(function ({ model }: { model: TreeSidebarModel }) {
+const TreeSidebar = observer(function TreeSidebar({
+  model,
+}: {
+  model: TreeSidebarModel
+}) {
   const { classes } = useStyles()
   const { width: viewWidth } = getContainingView(model) as LinearGenomeViewModel
   const [nodeIndex, setNodeIndex] = useState<Flatbush | null>(null)

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/Tooltip.tsx
@@ -55,7 +55,7 @@ const TooltipContents = forwardRef<HTMLDivElement, Props>(
 
 type Coord = [number, number]
 
-const WiggleTooltip = observer(function (props: {
+const WiggleTooltip = observer(function WiggleTooltip(props: {
   model: {
     featureUnderMouse?: Feature
   }

--- a/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/LinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -14,7 +14,7 @@ import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
 type LGV = LinearGenomeViewModel
 
-const LinearWiggleDisplay = observer(function (props: {
+const LinearWiggleDisplay = observer(function LinearWiggleDisplay(props: {
   model: WiggleDisplayModel
 }) {
   const { model } = props

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ColorLegend.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ColorLegend.tsx
@@ -10,7 +10,7 @@ import RectBg from './RectBg'
 
 import type { MinimalModel } from './types'
 
-const ColorLegend = observer(function ({
+const ColorLegend = observer(function ColorLegend({
   model,
   rowHeight,
   exportSVG,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/FullHeightScaleBar.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/FullHeightScaleBar.tsx
@@ -8,7 +8,7 @@ import YScaleBar from '../../shared/YScaleBar'
 import type { WiggleDisplayModel } from '../model'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const FullHeightScaleBar = observer(function ({
+const FullHeightScaleBar = observer(function FullHeightScaleBar({
   model,
   orientation,
   exportSVG,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/IndividualScaleBars.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/IndividualScaleBars.tsx
@@ -6,7 +6,7 @@ import YScaleBar from '../../shared/YScaleBar'
 
 import type { WiggleDisplayModel } from '../model'
 
-const IndividualScaleBars = observer(function ({
+const IndividualScaleBars = observer(function IndividualScaleBars({
   model,
   orientation,
   exportSVG,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ScoreLegend.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/ScoreLegend.tsx
@@ -8,7 +8,11 @@ import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
 type LGV = LinearGenomeViewModel
 
-const ScoreLegend = observer(({ model }: { model: WiggleDisplayModel }) => {
+const ScoreLegend = observer(function ScoreLegend({
+  model,
+}: {
+  model: WiggleDisplayModel
+}) {
   const { ticks, scaleType } = model
   const { width } = getContainingView(model) as LGV
   const legend = `[${ticks?.values[0]}-${ticks?.values[1]}]${scaleType === 'log' ? ' (log scale)' : ''}`

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/Tooltip.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/Tooltip.tsx
@@ -82,7 +82,7 @@ const TooltipContents = forwardRef<HTMLDivElement, Props>(
 
 type Coord = [number, number]
 
-const WiggleTooltip = observer(function (props: {
+const WiggleTooltip = observer(function WiggleTooltip(props: {
   model: { featureUnderMouse: Feature; sources: Source[]; rowHeight: number }
   height: number
   offsetMouseCoord: Coord

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialog.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialog.tsx
@@ -51,7 +51,7 @@ function Header({
   )
 }
 
-const WiggleClusterDialog = observer(function ({
+const WiggleClusterDialog = observer(function WiggleClusterDialog({
   model,
   handleClose,
 }: {

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialogAuto.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialogAuto.tsx
@@ -24,7 +24,7 @@ import type { Source } from '../../../util'
 import type { StopToken } from '@jbrowse/core/util/stopToken'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const WiggleClusterDialogAuto = observer(function ({
+const WiggleClusterDialogAuto = observer(function WiggleClusterDialogAuto({
   model,
   children,
   handleClose,

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialogManual.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleClusterDialog/WiggleClusterDialogManual.tsx
@@ -32,284 +32,289 @@ const useStyles = makeStyles()({
   },
 })
 
-const WiggleClusterDialogManuals = observer(function ({
-  model,
-  handleClose,
-  children,
-}: {
-  model: ReducedModel
-  handleClose: () => void
-  children: React.ReactNode
-}) {
-  const { classes } = useStyles()
+const WiggleClusterDialogManuals = observer(
+  function WiggleClusterDialogManuals({
+    model,
+    handleClose,
+    children,
+  }: {
+    model: ReducedModel
+    handleClose: () => void
+    children: React.ReactNode
+  }) {
+    const { classes } = useStyles()
 
-  const [paste, setPaste] = useState('')
-  const [ret, setRet] = useState<Record<string, number[]>>()
-  const [error, setError] = useState<unknown>()
-  const [loading, setLoading] = useState(false)
-  const [showAdvanced, setShowAdvanced] = useLocalStorage(
-    'cluster-showAdvanced',
-    false,
-  )
-  const [clusterMethod, setClusterMethod] = useState('single')
-  const [samplesPerPixel, setSamplesPerPixel] = useState('1')
+    const [paste, setPaste] = useState('')
+    const [ret, setRet] = useState<Record<string, number[]>>()
+    const [error, setError] = useState<unknown>()
+    const [loading, setLoading] = useState(false)
+    const [showAdvanced, setShowAdvanced] = useLocalStorage(
+      'cluster-showAdvanced',
+      false,
+    )
+    const [clusterMethod, setClusterMethod] = useState('single')
+    const [samplesPerPixel, setSamplesPerPixel] = useState('1')
 
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    ;(async () => {
-      try {
-        setError(undefined)
-        setRet(undefined)
-        setLoading(true)
-        const view = getContainingView(model) as LinearGenomeViewModel
-        const { dynamicBlocks, bpPerPx } = view
-        const { rpcManager } = getSession(model)
-        const { sourcesWithoutLayout, adapterConfig } = model
-        const sessionId = getRpcSessionId(model)
-        const ret = (await rpcManager.call(
-          sessionId,
-          'MultiWiggleGetScoreMatrix',
-          {
-            regions: dynamicBlocks.contentBlocks,
-            sources: sourcesWithoutLayout,
+    useEffect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      ;(async () => {
+        try {
+          setError(undefined)
+          setRet(undefined)
+          setLoading(true)
+          const view = getContainingView(model) as LinearGenomeViewModel
+          const { dynamicBlocks, bpPerPx } = view
+          const { rpcManager } = getSession(model)
+          const { sourcesWithoutLayout, adapterConfig } = model
+          const sessionId = getRpcSessionId(model)
+          const ret = (await rpcManager.call(
             sessionId,
-            adapterConfig,
-            bpPerPx: bpPerPx / +samplesPerPixel,
-          },
-        )) as Record<string, number[]>
+            'MultiWiggleGetScoreMatrix',
+            {
+              regions: dynamicBlocks.contentBlocks,
+              sources: sourcesWithoutLayout,
+              sessionId,
+              adapterConfig,
+              bpPerPx: bpPerPx / +samplesPerPixel,
+            },
+          )) as Record<string, number[]>
 
-        setRet(ret)
-      } catch (e) {
-        if (!isAbortException(e) && isAlive(model)) {
-          console.error(e)
-          setError(e)
+          setRet(ret)
+        } catch (e) {
+          if (!isAbortException(e) && isAlive(model)) {
+            console.error(e)
+            setError(e)
+          }
+        } finally {
+          setLoading(false)
         }
-      } finally {
-        setLoading(false)
-      }
-    })()
-  }, [model, samplesPerPixel])
+      })()
+    }, [model, samplesPerPixel])
 
-  const results = ret
-    ? String.raw`inputMatrix<-matrix(c(${Object.values(ret)
-        .map(val => val.join(','))
-        .join(',\n')}
+    const results = ret
+      ? String.raw`inputMatrix<-matrix(c(${Object.values(ret)
+          .map(val => val.join(','))
+          .join(',\n')}
 ),nrow=${Object.values(ret).length},byrow=TRUE)
 rownames(inputMatrix)<-c(${Object.keys(ret)
-        .map(key => `'${key}'`)
-        .join(',')})
+          .map(key => `'${key}'`)
+          .join(',')})
 resultClusters<-hclust(dist(inputMatrix), method='${clusterMethod}')
 cat(resultClusters$order,sep='\n')`
-    : undefined
+      : undefined
 
-  const resultsTsv = ret
-    ? Object.entries(ret)
-        .map(([key, val]) => [key, ...val].join('\t'))
-        .join('\n')
-    : undefined
+    const resultsTsv = ret
+      ? Object.entries(ret)
+          .map(([key, val]) => [key, ...val].join('\t'))
+          .join('\n')
+      : undefined
 
-  return (
-    <>
-      <DialogContent>
-        {children}
-        <div style={{ marginTop: 50 }}>
-          <div>
-            <div
-              style={{
-                display: 'flex',
-                gap: '8px',
-                flexWrap: 'wrap',
-                marginBottom: '16px',
-              }}
-            >
-              <Button
-                variant="contained"
-                onClick={async () => {
-                  // eslint-disable-next-line @typescript-eslint/no-deprecated
-                  const { saveAs } = await import('file-saver-es')
-
-                  saveAs(
-                    new Blob([results || ''], {
-                      type: 'text/plain;charset=utf-8',
-                    }),
-                    'cluster.R',
-                  )
-                }}
-              >
-                Download Rscript
-              </Button>{' '}
-              or{' '}
-              <Button
-                variant="contained"
-                onClick={async () => {
-                  const { default: copy } = await import('copy-to-clipboard')
-                  copy(results || '')
-                }}
-              >
-                Copy Rscript to clipboard
-              </Button>{' '}
-              or{' '}
-              <Button
-                variant="contained"
-                onClick={async () => {
-                  // eslint-disable-next-line @typescript-eslint/no-deprecated
-                  const { saveAs } = await import('file-saver-es')
-
-                  saveAs(
-                    new Blob([resultsTsv || ''], {
-                      type: 'text/plain;charset=utf-8',
-                    }),
-                    'scores.tsv',
-                  )
-                }}
-              >
-                Download TSV
-              </Button>
-            </div>
+    return (
+      <>
+        <DialogContent>
+          {children}
+          <div style={{ marginTop: 50 }}>
             <div>
-              <Button
-                variant="contained"
-                onClick={() => {
-                  setShowAdvanced(!showAdvanced)
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  flexWrap: 'wrap',
+                  marginBottom: '16px',
                 }}
               >
-                {showAdvanced
-                  ? 'Hide advanced options'
-                  : 'Show advanced options'}
-              </Button>
-            </div>
-            {showAdvanced ? (
-              <div>
-                <Typography variant="h6">Advanced options</Typography>
-                <RadioGroup>
-                  {Object.entries({
-                    single: 'Single',
-                    complete: 'Complete',
-                  }).map(([key, val]) => (
-                    <FormControlLabel
-                      key={key}
-                      control={
-                        <Radio
-                          checked={clusterMethod === key}
-                          onChange={() => {
-                            setClusterMethod(key)
-                          }}
-                        />
-                      }
-                      label={val}
-                    />
-                  ))}
-                </RadioGroup>
-                <div style={{ marginTop: 20 }}>
-                  <Typography>
-                    This procedure samples the data at each 'pixel' across the
-                    visible by default
-                  </Typography>
-                  <TextField
-                    label="Samples per pixel (>1 for denser sampling, between 0-1 for sparser sampling)"
-                    variant="outlined"
-                    size="small"
-                    value={samplesPerPixel}
-                    onChange={event => {
-                      setSamplesPerPixel(event.target.value)
-                    }}
-                  />
-                </div>
+                <Button
+                  variant="contained"
+                  onClick={async () => {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
+                    const { saveAs } = await import('file-saver-es')
+
+                    saveAs(
+                      new Blob([results || ''], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      'cluster.R',
+                    )
+                  }}
+                >
+                  Download Rscript
+                </Button>{' '}
+                or{' '}
+                <Button
+                  variant="contained"
+                  onClick={async () => {
+                    const { default: copy } = await import('copy-to-clipboard')
+                    copy(results || '')
+                  }}
+                >
+                  Copy Rscript to clipboard
+                </Button>{' '}
+                or{' '}
+                <Button
+                  variant="contained"
+                  onClick={async () => {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
+                    const { saveAs } = await import('file-saver-es')
+
+                    saveAs(
+                      new Blob([resultsTsv || ''], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      'scores.tsv',
+                    )
+                  }}
+                >
+                  Download TSV
+                </Button>
               </div>
-            ) : null}
-            {results ? (
-              <div />
-            ) : loading ? (
-              <LoadingEllipses variant="h6" message="Generating score matrix" />
-            ) : error ? (
-              <ErrorMessage error={error} />
-            ) : null}
-          </div>
+              <div>
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    setShowAdvanced(!showAdvanced)
+                  }}
+                >
+                  {showAdvanced
+                    ? 'Hide advanced options'
+                    : 'Show advanced options'}
+                </Button>
+              </div>
+              {showAdvanced ? (
+                <div>
+                  <Typography variant="h6">Advanced options</Typography>
+                  <RadioGroup>
+                    {Object.entries({
+                      single: 'Single',
+                      complete: 'Complete',
+                    }).map(([key, val]) => (
+                      <FormControlLabel
+                        key={key}
+                        control={
+                          <Radio
+                            checked={clusterMethod === key}
+                            onChange={() => {
+                              setClusterMethod(key)
+                            }}
+                          />
+                        }
+                        label={val}
+                      />
+                    ))}
+                  </RadioGroup>
+                  <div style={{ marginTop: 20 }}>
+                    <Typography>
+                      This procedure samples the data at each 'pixel' across the
+                      visible by default
+                    </Typography>
+                    <TextField
+                      label="Samples per pixel (>1 for denser sampling, between 0-1 for sparser sampling)"
+                      variant="outlined"
+                      size="small"
+                      value={samplesPerPixel}
+                      onChange={event => {
+                        setSamplesPerPixel(event.target.value)
+                      }}
+                    />
+                  </div>
+                </div>
+              ) : null}
+              {results ? (
+                <div />
+              ) : loading ? (
+                <LoadingEllipses
+                  variant="h6"
+                  message="Generating score matrix"
+                />
+              ) : error ? (
+                <ErrorMessage error={error} />
+              ) : null}
+            </div>
 
-          <div>
-            <Typography
-              variant="subtitle2"
-              gutterBottom
-              style={{ marginTop: '16px' }}
-            >
-              Clustering Results:
-            </Typography>
-            <TextField
-              multiline
-              fullWidth
-              variant="outlined"
-              placeholder="Paste results from Rscript here (sequence of numbers, one per line, specifying the new ordering)"
-              rows={10}
-              value={paste}
-              onChange={event => {
-                setPaste(event.target.value)
-              }}
-              slotProps={{
-                input: {
-                  classes: {
-                    input: classes.textAreaFont,
+            <div>
+              <Typography
+                variant="subtitle2"
+                gutterBottom
+                style={{ marginTop: '16px' }}
+              >
+                Clustering Results:
+              </Typography>
+              <TextField
+                multiline
+                fullWidth
+                variant="outlined"
+                placeholder="Paste results from Rscript here (sequence of numbers, one per line, specifying the new ordering)"
+                rows={10}
+                value={paste}
+                onChange={event => {
+                  setPaste(event.target.value)
+                }}
+                slotProps={{
+                  input: {
+                    classes: {
+                      input: classes.textAreaFont,
+                    },
                   },
-                },
-              }}
-            />
+                }}
+              />
+            </div>
           </div>
-        </div>
-      </DialogContent>
-      <DialogActions>
-        <Button
-          variant="contained"
-          onClick={() => {
-            const { sourcesWithoutLayout } = model
-            if (sourcesWithoutLayout) {
-              try {
-                // Preserve color and other layout customizations
-                const currentLayout = model.layout?.length
-                  ? model.layout
-                  : sourcesWithoutLayout
-                const sourcesByName = Object.fromEntries(
-                  currentLayout.map((s: Source) => [s.name, s]),
-                )
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="contained"
+            onClick={() => {
+              const { sourcesWithoutLayout } = model
+              if (sourcesWithoutLayout) {
+                try {
+                  // Preserve color and other layout customizations
+                  const currentLayout = model.layout?.length
+                    ? model.layout
+                    : sourcesWithoutLayout
+                  const sourcesByName = Object.fromEntries(
+                    currentLayout.map((s: Source) => [s.name, s]),
+                  )
 
-                model.setLayout(
-                  paste
-                    .split('\n')
-                    .map(t => t.trim())
-                    .filter(f => !!f)
-                    .map(r => +r)
-                    .map(idx => {
-                      const sourceItem = sourcesWithoutLayout[idx - 1]
-                      if (!sourceItem) {
-                        throw new Error(`out of bounds at ${idx}`)
-                      }
-                      // Preserve customizations from current layout
-                      return {
-                        ...sourceItem,
-                        ...sourcesByName[sourceItem.name],
-                      }
-                    }),
-                )
-              } catch (e) {
-                console.error(e)
-                getSession(model).notifyError(`${e}`, e)
+                  model.setLayout(
+                    paste
+                      .split('\n')
+                      .map(t => t.trim())
+                      .filter(f => !!f)
+                      .map(r => +r)
+                      .map(idx => {
+                        const sourceItem = sourcesWithoutLayout[idx - 1]
+                        if (!sourceItem) {
+                          throw new Error(`out of bounds at ${idx}`)
+                        }
+                        // Preserve customizations from current layout
+                        return {
+                          ...sourceItem,
+                          ...sourcesByName[sourceItem.name],
+                        }
+                      }),
+                  )
+                } catch (e) {
+                  console.error(e)
+                  getSession(model).notifyError(`${e}`, e)
+                }
               }
-            }
-            handleClose()
-          }}
-        >
-          Apply clustering
-        </Button>
-        <Button
-          variant="contained"
-          color="secondary"
-          onClick={() => {
-            handleClose()
-          }}
-        >
-          Cancel
-        </Button>
-      </DialogActions>
-    </>
-  )
-})
+              handleClose()
+            }}
+          >
+            Apply clustering
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => {
+              handleClose()
+            }}
+          >
+            Cancel
+          </Button>
+        </DialogActions>
+      </>
+    )
+  },
+)
 
 export default WiggleClusterDialogManuals

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/WiggleDisplayComponent.tsx
@@ -5,17 +5,19 @@ import YScaleBars from './YScaleBars'
 
 import type { WiggleDisplayModel } from '../model'
 
-const MultiLinearWiggleDisplayComponent = observer(function (props: {
-  model: WiggleDisplayModel
-}) {
-  const { model } = props
+const MultiLinearWiggleDisplayComponent = observer(
+  function MultiLinearWiggleDisplayComponent(props: {
+    model: WiggleDisplayModel
+  }) {
+    const { model } = props
 
-  return (
-    <div>
-      <BaseLinearDisplayComponent {...props} />
-      <YScaleBars model={model} />
-    </div>
-  )
-})
+    return (
+      <div>
+        <BaseLinearDisplayComponent {...props} />
+        <YScaleBars model={model} />
+      </div>
+    )
+  },
+)
 
 export default MultiLinearWiggleDisplayComponent

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/YScaleBars.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/YScaleBars.tsx
@@ -6,7 +6,7 @@ import YScaleBarsWrapper from './YScaleBarsWrapper'
 
 import type { WiggleDisplayModel } from '../model'
 
-const YScaleBars = observer(function (props: {
+const YScaleBars = observer(function YScaleBars(props: {
   model: WiggleDisplayModel
   orientation?: string
   exportSVG?: boolean

--- a/plugins/wiggle/src/MultiLinearWiggleDisplay/components/YScaleBarsWrapper.tsx
+++ b/plugins/wiggle/src/MultiLinearWiggleDisplay/components/YScaleBarsWrapper.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 
 import type { WiggleDisplayModel } from '../model'
 
-const YScaleBarsWrapper = observer(function ({
+const YScaleBarsWrapper = observer(function YScaleBarsWrapper({
   children,
   model,
   exportSVG,

--- a/plugins/wiggle/src/MultiWiggleAddTrackWorkflow/AddTrackWorkflow.tsx
+++ b/plugins/wiggle/src/MultiWiggleAddTrackWorkflow/AddTrackWorkflow.tsx
@@ -88,86 +88,84 @@ function doSubmit({
   }
 }
 
-const MultiWiggleAddTrackWorkflow = observer(function ({
-  model,
-}: {
-  model: AddTrackModel
-}) {
-  const { classes } = useStyles()
-  const [val, setVal] = useState('')
-  const [trackName, setTrackName] = useState(`MultiWiggle${Date.now()}`)
-  return (
-    <Paper className={classes.paper}>
-      <ul>
-        <li>Enter list of URLs for bigwig files in the textbox</li>
-        <li>
-          Or, use the button below the text box to select files from your
-          computer
-        </li>
-      </ul>
-      <TextField
-        multiline
-        fullWidth
-        rows={10}
-        value={val}
-        placeholder="Paste list of URLs here, or use file selector below"
-        variant="outlined"
-        onChange={event => {
-          setVal(event.target.value)
-        }}
-      />
-      <Button variant="outlined" component="label">
-        Choose Files from your computer
-        <input
-          type="file"
-          hidden
-          multiple
-          onChange={({ target }) => {
-            setVal(
-              JSON.stringify(
-                [...(target.files || [])].map(file => ({
-                  type: 'BigWigAdapter',
-                  bigWigLocation: makeFileLocation(file),
-                  source: file.name,
-                })),
-                null,
-                2,
-              ),
-            )
+const MultiWiggleAddTrackWorkflow = observer(
+  function MultiWiggleAddTrackWorkflow({ model }: { model: AddTrackModel }) {
+    const { classes } = useStyles()
+    const [val, setVal] = useState('')
+    const [trackName, setTrackName] = useState(`MultiWiggle${Date.now()}`)
+    return (
+      <Paper className={classes.paper}>
+        <ul>
+          <li>Enter list of URLs for bigwig files in the textbox</li>
+          <li>
+            Or, use the button below the text box to select files from your
+            computer
+          </li>
+        </ul>
+        <TextField
+          multiline
+          fullWidth
+          rows={10}
+          value={val}
+          placeholder="Paste list of URLs here, or use file selector below"
+          variant="outlined"
+          onChange={event => {
+            setVal(event.target.value)
           }}
         />
-      </Button>
-      <TextField
-        value={trackName}
-        helperText="Track name"
-        onChange={event => {
-          setTrackName(event.target.value)
-        }}
-      />
-      <Button
-        variant="contained"
-        className={classes.submit}
-        onClick={() => {
-          doSubmit({ trackName, val, model })
-        }}
-      >
-        Submit
-      </Button>
-      <p>Additional notes: </p>
-      <ul>
-        <li>
-          The list of bigwig files in the text box can be a list of URLs, or a
-          list of elements like{' '}
-          <code>{`[{"type":"BigWigAdapter","bigWigLocation":{"uri":"http://host/file.bw"}, "color":"green","source":"name for subtrack"}]`}</code>{' '}
-          to apply e.g. the color attribute to the view
-        </li>
-        <li>
-          Adding local files will update the textbox with JSON contents that are
-          ready to submit with the "Submit" button
-        </li>
-      </ul>
-    </Paper>
-  )
-})
+        <Button variant="outlined" component="label">
+          Choose Files from your computer
+          <input
+            type="file"
+            hidden
+            multiple
+            onChange={({ target }) => {
+              setVal(
+                JSON.stringify(
+                  [...(target.files || [])].map(file => ({
+                    type: 'BigWigAdapter',
+                    bigWigLocation: makeFileLocation(file),
+                    source: file.name,
+                  })),
+                  null,
+                  2,
+                ),
+              )
+            }}
+          />
+        </Button>
+        <TextField
+          value={trackName}
+          helperText="Track name"
+          onChange={event => {
+            setTrackName(event.target.value)
+          }}
+        />
+        <Button
+          variant="contained"
+          className={classes.submit}
+          onClick={() => {
+            doSubmit({ trackName, val, model })
+          }}
+        >
+          Submit
+        </Button>
+        <p>Additional notes: </p>
+        <ul>
+          <li>
+            The list of bigwig files in the text box can be a list of URLs, or a
+            list of elements like{' '}
+            <code>{`[{"type":"BigWigAdapter","bigWigLocation":{"uri":"http://host/file.bw"}, "color":"green","source":"name for subtrack"}]`}</code>{' '}
+            to apply e.g. the color attribute to the view
+          </li>
+          <li>
+            Adding local files will update the textbox with JSON contents that
+            are ready to submit with the "Submit" button
+          </li>
+        </ul>
+      </Paper>
+    )
+  },
+)
 
 export default MultiWiggleAddTrackWorkflow

--- a/plugins/wiggle/src/MultiWiggleRendering.tsx
+++ b/plugins/wiggle/src/MultiWiggleRendering.tsx
@@ -8,7 +8,7 @@ import type { Source } from './util'
 import type { Feature } from '@jbrowse/core/util'
 import type { Region } from '@jbrowse/core/util/types'
 
-const MultiWiggleRendering = observer(function (props: {
+const MultiWiggleRendering = observer(function MultiWiggleRendering(props: {
   regions: Region[]
   features: Map<string, Feature>
   bpPerPx: number

--- a/plugins/wiggle/src/WiggleRendering.tsx
+++ b/plugins/wiggle/src/WiggleRendering.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import type { Feature } from '@jbrowse/core/util'
 import type { Region } from '@jbrowse/core/util/types'
 
-const WiggleRendering = observer(function (props: {
+const WiggleRendering = observer(function WiggleRendering(props: {
   regions: Region[]
   features: Map<string, Feature>
   bpPerPx: number

--- a/plugins/wiggle/src/shared/YScaleBar.tsx
+++ b/plugins/wiggle/src/shared/YScaleBar.tsx
@@ -5,7 +5,7 @@ import type axisPropsFromTickScale from './axisPropsFromTickScale'
 
 type Ticks = ReturnType<typeof axisPropsFromTickScale>
 
-const YScaleBar = observer(function ({
+const YScaleBar = observer(function YScaleBar({
   model,
   orientation,
 }: {

--- a/products/jbrowse-desktop/src/components/JBrowse.tsx
+++ b/products/jbrowse-desktop/src/components/JBrowse.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import type { DesktopRootModel } from '../rootModel/rootModel'
 import type PluginManager from '@jbrowse/core/PluginManager'
 
-const JBrowseNonNullRoot = observer(function ({
+const JBrowseNonNullRoot = observer(function JBrowseNonNullRoot({
   rootModel,
 }: {
   rootModel: DesktopRootModel
@@ -26,7 +26,7 @@ const JBrowseNonNullRoot = observer(function ({
   ) : null
 })
 
-const JBrowse = observer(function ({
+const JBrowse = observer(function JBrowse({
   pluginManager,
 }: {
   pluginManager: PluginManager

--- a/products/jbrowse-desktop/src/components/Loader.tsx
+++ b/products/jbrowse-desktop/src/components/Loader.tsx
@@ -13,7 +13,7 @@ import { loadPluginManager } from './StartScreen/util'
 
 import type PluginManager from '@jbrowse/core/PluginManager'
 
-const Loader = observer(() => {
+const Loader = observer(function Loader() {
   const [pluginManager, setPluginManager] = useState<PluginManager>()
   const [config, setConfig] = useQueryParam('config')
   const [error, setError] = useState<unknown>()

--- a/products/jbrowse-desktop/src/components/OpenSequenceDialog.tsx
+++ b/products/jbrowse-desktop/src/components/OpenSequenceDialog.tsx
@@ -46,7 +46,7 @@ function isBlank(location: FileLocation) {
   return 'uri' in location && location.uri === ''
 }
 
-const AdapterSelector = observer(function ({
+const AdapterSelector = observer(function AdapterSelector({
   adapterSelection,
   setAdapterSelection,
   adapterTypes,
@@ -76,7 +76,7 @@ const AdapterSelector = observer(function ({
   )
 })
 
-const FastaAdapterInput = observer(function ({
+const FastaAdapterInput = observer(function FastaAdapterInput({
   fastaLocation,
   setFastaLocation,
 }: {
@@ -99,7 +99,7 @@ const FastaAdapterInput = observer(function ({
   )
 })
 
-const IndexedFastaAdapterInput = observer(function ({
+const IndexedFastaAdapterInput = observer(function IndexedFastaAdapterInput({
   fastaLocation,
   faiLocation,
   setFastaLocation,
@@ -128,7 +128,7 @@ const IndexedFastaAdapterInput = observer(function ({
   )
 })
 
-const BgzipFastaAdapterInput = observer(function ({
+const BgzipFastaAdapterInput = observer(function BgzipFastaAdapterInput({
   fastaLocation,
   faiLocation,
   gziLocation,
@@ -167,7 +167,7 @@ const BgzipFastaAdapterInput = observer(function ({
   )
 })
 
-const TwoBitAdapterInput = observer(function ({
+const TwoBitAdapterInput = observer(function TwoBitAdapterInput({
   twoBitLocation,
   chromSizesLocation,
   setTwoBitLocation,
@@ -209,7 +209,7 @@ type AdapterType =
   | 'FastaAdapter'
   | 'TwoBitAdapter'
 
-const OpenSequenceDialog = observer(function ({
+const OpenSequenceDialog = observer(function OpenSequenceDialog({
   onClose,
 }: {
   onClose: (conf?: unknown) => Promise<void>

--- a/products/jbrowse-desktop/src/components/PreferencesDialog.tsx
+++ b/products/jbrowse-desktop/src/components/PreferencesDialog.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const PreferencesDialog = observer(function ({
+const PreferencesDialog = observer(function PreferencesDialog({
   handleClose,
   session,
 }: {

--- a/products/jbrowse-react-app/src/JBrowseApp/JBrowseApp.tsx
+++ b/products/jbrowse-react-app/src/JBrowseApp/JBrowseApp.tsx
@@ -18,7 +18,11 @@ const useStyles = makeStyles()({
   },
 })
 
-const JBrowseApp = observer(function ({ viewState }: { viewState: ViewModel }) {
+const JBrowseApp = observer(function JBrowseApp({
+  viewState,
+}: {
+  viewState: ViewModel
+}) {
   const { classes } = useStyles()
   const session = viewState.session
   const theme = createJBrowseTheme(getConf(viewState.jbrowse, 'theme'))

--- a/products/jbrowse-react-app/src/components/PreferencesDialog.tsx
+++ b/products/jbrowse-react-app/src/components/PreferencesDialog.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const PreferencesDialog = observer(function ({
+const PreferencesDialog = observer(function PreferencesDialog({
   handleClose,
   session,
 }: {

--- a/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/JBrowseCircularGenomeView.tsx
+++ b/products/jbrowse-react-circular-genome-view/src/JBrowseCircularGenomeView/JBrowseCircularGenomeView.tsx
@@ -9,7 +9,7 @@ import { observer } from 'mobx-react'
 
 import type { ViewModel } from '../createModel/createModel'
 
-const JBrowseCircularGenomeView = observer(function ({
+const JBrowseCircularGenomeView = observer(function JBrowseCircularGenomeView({
   viewState,
 }: {
   viewState: ViewModel

--- a/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
+++ b/products/jbrowse-react-linear-genome-view/src/JBrowseLinearGenomeView/JBrowseLinearGenomeView.tsx
@@ -9,7 +9,7 @@ import { observer } from 'mobx-react'
 
 import type { ViewModel } from '../createModel/createModel'
 
-const JBrowseLinearGenomeView = observer(function ({
+const JBrowseLinearGenomeView = observer(function JBrowseLinearGenomeView({
   viewState,
 }: {
   viewState: ViewModel

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleFeatures.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleFeatures.tsx
@@ -15,7 +15,7 @@ import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 // import { createViewState, JBrowseLinearGenomeView } from '@jbrowse/react-linear-genome-view2'
 
 // specifically coded to fetch from the first track (view.tracks[0])
-const VisibleFeatures = observer(function ({
+const VisibleFeatures = observer(function VisibleFeatures({
   session,
 }: {
   session: { rpcManager: RpcManager; view: LinearGenomeViewModel }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleRegions.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleRegions.tsx
@@ -13,7 +13,7 @@ function loc(r: Region) {
 
 type ViewState = ReturnType<typeof createViewState>
 
-const VisibleRegions = observer(function ({
+const VisibleRegions = observer(function VisibleRegions({
   viewState,
 }: {
   viewState: ViewState

--- a/products/jbrowse-web/src/components/JBrowse.tsx
+++ b/products/jbrowse-web/src/components/JBrowse.tsx
@@ -11,7 +11,7 @@ import { readQueryParams, setQueryParams } from '../useQueryParam'
 import type { WebSessionModel } from '../sessionModel'
 import type PluginManager from '@jbrowse/core/PluginManager'
 
-const JBrowse = observer(function ({
+const JBrowse = observer(function JBrowse({
   pluginManager,
 }: {
   pluginManager: PluginManager

--- a/products/jbrowse-web/src/components/Loader.tsx
+++ b/products/jbrowse-web/src/components/Loader.tsx
@@ -92,7 +92,7 @@ export function Loader({
   return <Renderer loader={loader} />
 }
 
-const Renderer = observer(function ({
+const Renderer = observer(function Renderer({
   loader: firstLoader,
 }: {
   loader: SessionLoaderModel

--- a/products/jbrowse-web/src/components/PreferencesDialog.tsx
+++ b/products/jbrowse-web/src/components/PreferencesDialog.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()(() => ({
   },
 }))
 
-const PreferencesDialog = observer(function ({
+const PreferencesDialog = observer(function PreferencesDialog({
   handleClose,
   session,
 }: {

--- a/products/jbrowse-web/src/components/SessionTriaged.tsx
+++ b/products/jbrowse-web/src/components/SessionTriaged.tsx
@@ -8,7 +8,7 @@ import factoryReset from '../factoryReset'
 import type { SessionLoaderModel } from '../SessionLoader'
 import type { SessionTriagedInfo } from '../types'
 
-const SessionTriaged = observer(function ({
+const SessionTriaged = observer(function SessionTriaged({
   sessionTriaged,
   loader,
 }: {

--- a/products/jbrowse-web/src/components/SetDefaultSession.tsx
+++ b/products/jbrowse-web/src/components/SetDefaultSession.tsx
@@ -2,7 +2,7 @@ import { Dialog } from '@jbrowse/core/ui'
 import { Button, DialogActions, DialogContent, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 
-const SetDefaultSession = observer(function ({
+const SetDefaultSession = observer(function SetDefaultSession({
   rootModel,
   onClose,
 }: {

--- a/products/jbrowse-web/src/components/ShareButton.tsx
+++ b/products/jbrowse-web/src/components/ShareButton.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()(theme => ({
 
 const ShareDialog = lazy(() => import('./ShareDialog'))
 
-const ShareButton = observer(function (props: {
+const ShareButton = observer(function ShareButton(props: {
   session: AbstractSessionModel & { shareURL: string }
 }) {
   const [open, setOpen] = useState(false)

--- a/products/jbrowse-web/src/components/ShareDialog.tsx
+++ b/products/jbrowse-web/src/components/ShareDialog.tsx
@@ -28,7 +28,7 @@ const SettingsDialog = lazy(() => import('./ShareSettingsDialog'))
 
 const SHARE_URL_LOCALSTORAGE_KEY = 'jbrowse-shareURL'
 
-const ShareDialog = observer(function ({
+const ShareDialog = observer(function ShareDialog({
   handleClose,
   session,
 }: {


### PR DESCRIPTION

Instead of anonymous functions, which can be hard to debug, this PR gives all function components a name

Generated using a global source code function like this

ruplacer 'const (\w+) = observer\(function \(' "const \$1 = observer(function \$1(" --go
