### PR TITLE
Add google form/survey to collect feedback

### DIFF
--- a/website/src/pages/contact.mdx
+++ b/website/src/pages/contact.mdx
@@ -18,6 +18,8 @@ import GoogleCalendarScheduleFunction from './util'
 - Chat https://app.gitter.im/#/room/#GMOD_jbrowse2:gitter.im
 - Mailing list (send email to `gmod-ajax@lists.sourceforge.net`)
 - Email jbrowse2@berkeley.edu
+- Add feedback on our Google Form https://forms.gle/CRf9Ur9iXu2uuz1o9
+
 
 ## Social media
 


### PR DESCRIPTION
I created a basic google form just to help collect user feedback. 

The idea behind this is that it is more anonymous/less official/easy, and can collect users 'real feelings' more than e.g. a github issue. 

We could send this to PAG participants in workshop for example to try to get some initial feedback. The survey can be indefinitely 'run' so there is not any limit...i think long text questions likely better than any particular numeric values we can collect from multiple choice questions

Screenshot of survey
<img width="759" height="934" alt="image" src="https://github.com/user-attachments/assets/e694c20c-9500-4646-8ca1-39821222c365" />

Live link
https://forms.gle/EYtQcGkxnzLapAeS7

The survey is anonymous by default unless the user wants to add their email
