### PR TITLE
Allow tall features to not trigger max layout height

### DIFF
--- a/packages/core/util/layouts/GranularRectLayout.ts
+++ b/packages/core/util/layouts/GranularRectLayout.ts
@@ -332,7 +332,10 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
       serializableData,
     }
 
-    const maxTop = this.maxHeight - pHeight
+    // Allow features to start at any position up to maxHeight
+    // Features starting at maxHeight or beyond are filtered out, but features
+    // that start below maxHeight and extend past it are allowed
+    const maxTop = this.maxHeight
     // Use startingRow hint if provided (in pixels), convert to pitch rows
     let top =
       startingRow !== undefined


### PR DESCRIPTION
This PR allows tall features to get rendered, even if they go beyond the layout maxheight. 

The current behavior is that features that 'overlap' the max height are not rendered, because it detects if layoutPlacementY+featureHeight>maxLayoutHeight.  
 The current behavior then additionally places the max height indicator at layout.getTotalHeight, which at that point was quite small which was seen in #4996 for genes like brca1 with many isoforms

This PR just makes it layoutPlacementY>maxLayoutHeight. It still places the max height indicator at layout.getTotalHeight, but this is 'large' now


