### PR TITLE
Allow easily filtering samples in the variant feature details by genotype/dosage

### DIFF
--- a/packages/core/ui/DataGridFlexContainer.tsx
+++ b/packages/core/ui/DataGridFlexContainer.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react'
+
 import { makeStyles } from '@jbrowse/core/util/tss-react'
 
 const useStyles = makeStyles()({
@@ -10,9 +12,15 @@ const useStyles = makeStyles()({
 // https://mui.com/x/react-data-grid/layout/#flex-parent-container
 export default function DataGridFlexContainer({
   children,
+  style,
 }: {
   children: React.ReactNode
+  style?: CSSProperties
 }) {
   const { classes } = useStyles()
-  return <div className={classes.flexContainer}>{children}</div>
+  return (
+    <div className={classes.flexContainer} style={style}>
+      {children}
+    </div>
+  )
 }

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantGenotypeFrequencyTable.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantGenotypeFrequencyTable.tsx
@@ -1,6 +1,5 @@
-import DataGridFlexContainer from '@jbrowse/core/ui/DataGridFlexContainer'
 import { measureGridWidth } from '@jbrowse/core/util'
-import { Checkbox, FormControlLabel, Typography } from '@mui/material'
+import { Checkbox } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
 
 import type { FrequencyTable, VariantSampleGridRow } from './types'
@@ -11,12 +10,14 @@ function toP(n: number) {
 
 export default function VariantGenotypeFrequencyTable({
   rows,
-  useCounts,
-  setUseCounts,
+  selectedGenotypes,
+  setSelectedGenotypes,
+  showToolbar,
 }: {
   rows: VariantSampleGridRow[]
-  useCounts: boolean
-  setUseCounts: (v: boolean) => void
+  selectedGenotypes: Set<string> | null
+  setSelectedGenotypes: (v: Set<string> | null) => void
+  showToolbar?: boolean
 }) {
   const summary = {} as FrequencyTable
   for (const row of rows) {
@@ -37,42 +38,89 @@ export default function VariantGenotypeFrequencyTable({
     frequency: `${toP((val.count / rows.length) * 100)}%`,
   }))
 
+  const allSelected =
+    selectedGenotypes === null ||
+    gridRows.every(r => selectedGenotypes.has(r.GT))
+
+  const height = 25 + gridRows.length * 25 + 15 + (showToolbar ? 40 : 0)
+
   return (
-    <div>
-      <FormControlLabel
-        control={<Checkbox checked={useCounts} />}
-        label={
-          <Typography variant="body2">
-            Use allele counts instead of exact GT
-          </Typography>
-        }
-        onChange={(_, checked) => {
-          setUseCounts(checked)
-        }}
+    <div style={{ height }}>
+      <DataGrid
+        rows={gridRows}
+        hideFooter
+        rowHeight={25}
+        columnHeaderHeight={25}
+        columns={[
+          {
+            field: 'select',
+            headerName: '',
+            width: 27,
+            sortable: false,
+            disableColumnMenu: true,
+            renderHeader: () => (
+              <Checkbox
+                checked={allSelected}
+                indeterminate={
+                  selectedGenotypes !== null &&
+                  selectedGenotypes.size > 0 &&
+                  selectedGenotypes.size < gridRows.length
+                }
+                onChange={(_, checked) => {
+                  if (checked) {
+                    setSelectedGenotypes(null)
+                  } else {
+                    setSelectedGenotypes(new Set())
+                  }
+                }}
+                size="small"
+              />
+            ),
+            renderCell: params => {
+              const isChecked =
+                selectedGenotypes === null ||
+                selectedGenotypes.has(params.row.GT)
+              return (
+                <Checkbox
+                  checked={isChecked}
+                  onChange={(_, checked) => {
+                    const newSet = new Set(
+                      selectedGenotypes === null
+                        ? gridRows.map(r => r.GT)
+                        : selectedGenotypes,
+                    )
+                    if (checked) {
+                      newSet.add(params.row.GT)
+                    } else {
+                      newSet.delete(params.row.GT)
+                    }
+                    if (newSet.size === gridRows.length) {
+                      setSelectedGenotypes(null)
+                    } else {
+                      setSelectedGenotypes(newSet)
+                    }
+                  }}
+                  size="small"
+                />
+              )
+            },
+          },
+          { field: 'GT', width: measureGridWidth(gridRows.map(r => r.GT)) },
+          {
+            field: 'count',
+            width: measureGridWidth(gridRows.map(r => r.count)),
+          },
+          {
+            field: 'frequency',
+            width: measureGridWidth(gridRows.map(r => r.frequency)),
+          },
+          {
+            field: 'genotype',
+            width: measureGridWidth(gridRows.map(r => r.genotype)),
+          },
+        ]}
+        showToolbar={showToolbar}
       />
-      <DataGridFlexContainer>
-        <DataGrid
-          rows={gridRows}
-          hideFooter
-          rowHeight={25}
-          columnHeaderHeight={35}
-          columns={[
-            { field: 'GT', width: measureGridWidth(gridRows.map(r => r.GT)) },
-            {
-              field: 'count',
-              width: measureGridWidth(gridRows.map(r => r.count)),
-            },
-            {
-              field: 'frequency',
-              width: measureGridWidth(gridRows.map(r => r.frequency)),
-            },
-            {
-              field: 'genotype',
-              width: measureGridWidth(gridRows.map(r => r.genotype)),
-            },
-          ]}
-        />
-      </DataGridFlexContainer>
     </div>
   )
 }

--- a/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
+++ b/plugins/variants/src/VariantFeatureWidget/VariantSampleGrid/VariantSampleGrid.tsx
@@ -1,17 +1,13 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import BaseCard from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail/BaseCard'
 import { ErrorMessage } from '@jbrowse/core/ui'
+import CascadingMenuButton from '@jbrowse/core/ui/CascadingMenuButton'
 import DataGridFlexContainer from '@jbrowse/core/ui/DataGridFlexContainer'
 import { ErrorBoundary } from '@jbrowse/core/ui/ErrorBoundary'
 import { measureGridWidth } from '@jbrowse/core/util'
-import {
-  Checkbox,
-  FormControlLabel,
-  ToggleButton,
-  ToggleButtonGroup,
-  Typography,
-} from '@mui/material'
+import SettingsIcon from '@mui/icons-material/Settings'
+import { ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
 
 import VariantGenotypeFrequencyTable from './VariantGenotypeFrequencyTable'
@@ -36,94 +32,153 @@ export default function VariantSampleGrid(props: {
   const [columnDisplayMode, setColumnDisplayMode] =
     useState<ColumnDisplayMode>('all')
   const [showFilters, setShowFilters] = useState(false)
+  const [showFrequencyTable, setShowFrequencyTable] = useState(true)
+  const [showToolbar, setShowToolbar] = useState(false)
   const [useCounts, setUseCounts] = useState(false)
+  const [selectedGenotypes, setSelectedGenotypes] =
+    useState<Set<string> | null>(null)
   const samples = (feature.samples || {}) as Record<string, InfoFields>
   const ALT = feature.ALT as string[]
   const REF = feature.REF as string
 
-  const { rows, error } = getSampleGridRows(samples, REF, ALT, filter, useCounts)
-
-  const keys = [
-    'sample',
-    ...Object.keys(rows[0] || {}).filter(k => k !== 'id' && k !== 'sample'),
-  ]
-  const columns = keys.map(
-    field =>
-      ({
-        field,
-        description: descriptions?.FORMAT?.[field]?.Description,
-        width: measureGridWidth(rows.map(r => r[field])),
-      }) satisfies GridColDef<(typeof rows)[0]>,
+  const { rows, error } = getSampleGridRows(
+    samples,
+    REF,
+    ALT,
+    filter,
+    useCounts,
   )
 
+  const filteredRows = useMemo(
+    () =>
+      selectedGenotypes === null
+        ? rows
+        : rows.filter(row => selectedGenotypes.has(row.GT)),
+    [rows, selectedGenotypes],
+  )
+
+  const columns = useMemo(() => {
+    const keys = [
+      'sample',
+      ...Object.keys(rows[0] || {}).filter(k => k !== 'id' && k !== 'sample'),
+    ]
+    return keys.map(
+      field =>
+        ({
+          field,
+          description: descriptions?.FORMAT?.[field]?.Description,
+          width: measureGridWidth(filteredRows.map(r => r[field])),
+        }) satisfies GridColDef<(typeof rows)[0]>,
+    )
+  }, [rows, filteredRows, descriptions])
+
   return !rows.length ? null : (
-    <>
-      <BaseCard {...props} title="Genotype frequencies">
-        <ErrorBoundary FallbackComponent={ErrorMessage}>
-          <VariantGenotypeFrequencyTable
-            rows={rows}
-            useCounts={useCounts}
-            setUseCounts={setUseCounts}
-          />
-        </ErrorBoundary>
-      </BaseCard>
-      <BaseCard {...props} title="Samples">
-        {error ? <Typography color="error">{`${error}`}</Typography> : null}
-        <div>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={showFilters}
-                onChange={event => {
-                  setShowFilters(event.target.checked)
-                }}
-              />
+    <BaseCard {...props} title="Samples">
+      {error ? <Typography color="error">{`${error}`}</Typography> : null}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <CascadingMenuButton
+          menuItems={[
+            {
+              label: 'Show allele counts ("dosage") instead of exact GT',
+              helpText:
+                'This converts a genotype like 1/1 into 1:2 which says there were two occurrences of the ALT allele 1 in the genotype',
+              type: 'checkbox',
+              checked: useCounts,
+              onClick: () => {
+                setUseCounts(!useCounts)
+                setSelectedGenotypes(null)
+              },
+            },
+            {
+              label: 'Show frequency table',
+              type: 'checkbox',
+              checked: showFrequencyTable,
+              onClick: () => {
+                setShowFrequencyTable(!showFrequencyTable)
+              },
+            },
+            {
+              label: 'Show filters',
+              type: 'checkbox',
+              checked: showFilters,
+              onClick: () => {
+                setShowFilters(!showFilters)
+              },
+            },
+            {
+              label: 'Show toolbar',
+              type: 'checkbox',
+              checked: showToolbar,
+              onClick: () => {
+                setShowToolbar(!showToolbar)
+              },
+            },
+          ]}
+        >
+          <SettingsIcon />
+        </CascadingMenuButton>
+        <ToggleButtonGroup
+          value={columnDisplayMode}
+          exclusive
+          size="small"
+          onChange={(_, newValue) => {
+            if (newValue !== null) {
+              setColumnDisplayMode(newValue as ColumnDisplayMode)
             }
-            label={<Typography variant="body2">Show filters</Typography>}
-          />
-          <ToggleButtonGroup
-            value={columnDisplayMode}
-            exclusive
-            size="small"
-            onChange={(_, newValue) => {
-              if (newValue !== null) {
-                setColumnDisplayMode(newValue as ColumnDisplayMode)
-              }
-            }}
-          >
-            <ToggleButton value="all">All</ToggleButton>
-            <ToggleButton value="gtOnly">GT only</ToggleButton>
-            <ToggleButton value="genotypeOnly">
-              GT+resolved genotype
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </div>
+          }}
+        >
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="gtOnly">GT only</ToggleButton>
+          <ToggleButton value="genotypeOnly">GT+resolved genotype</ToggleButton>
+        </ToggleButtonGroup>
+      </div>
 
-        {showFilters ? (
-          <SampleFilters
-            setFilter={setFilter}
-            columns={columns}
-            filter={filter}
-          />
-        ) : null}
+      {showFilters ? (
+        <SampleFilters
+          setFilter={setFilter}
+          columns={columns}
+          filter={filter}
+        />
+      ) : null}
 
-        <DataGridFlexContainer>
-          <DataGrid
-            rows={rows}
-            hideFooter={rows.length < 100}
-            columns={
-              columnDisplayMode === 'gtOnly'
-                ? columns.filter(f => gtOnlyFields.has(f.field))
-                : columnDisplayMode === 'genotypeOnly'
-                  ? columns.filter(f => genotypeFields.has(f.field))
-                  : columns
-            }
-            rowHeight={25}
-            columnHeaderHeight={35}
-            showToolbar
-          />
-        </DataGridFlexContainer>
-      </BaseCard>
-    </>
+      {showFrequencyTable ? (
+        <>
+          <Typography variant="subtitle2" style={{ marginTop: 8 }}>
+            Genotype frequencies (click to filter)
+          </Typography>
+          <ErrorBoundary FallbackComponent={ErrorMessage}>
+            <VariantGenotypeFrequencyTable
+              rows={rows}
+              selectedGenotypes={selectedGenotypes}
+              setSelectedGenotypes={setSelectedGenotypes}
+              showToolbar={showToolbar}
+            />
+          </ErrorBoundary>
+        </>
+      ) : null}
+
+      <Typography variant="subtitle2" style={{ marginTop: 16 }}>
+        Samples{' '}
+        {selectedGenotypes !== null
+          ? `(${filteredRows.length} of ${rows.length})`
+          : `(${rows.length})`}
+      </Typography>
+      <DataGridFlexContainer>
+        <DataGrid
+          rows={filteredRows}
+          hideFooter={filteredRows.length < 100}
+          columns={
+            columnDisplayMode === 'gtOnly'
+              ? columns.filter(f => gtOnlyFields.has(f.field))
+              : columnDisplayMode === 'genotypeOnly'
+                ? columns.filter(f => genotypeFields.has(f.field))
+                : columns
+          }
+          rowHeight={25}
+          columnHeaderHeight={25}
+          showToolbar={showToolbar}
+        />
+      </DataGridFlexContainer>
+    </BaseCard>
   )
 }


### PR DESCRIPTION
Currently we have the 'variant frequency table' which shows e.g. what percentage of samples are homozygous for the variant. Then there is the 'variant sample table' which shows each sample

This PR links their functionality, so you can filter the sample table using the frequency table, to e.g. show only the homozygous samples with a single click