### PR TITLE
Allow plugins to make custom radio items for synteny import forms

### DIFF
--- a/plugins/dotplot-view/src/index.ts
+++ b/plugins/dotplot-view/src/index.ts
@@ -13,6 +13,8 @@ import LaunchDotplotViewF from './LaunchDotplotView.ts'
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 
+export type { DotplotImportFormSyntenyOption } from './DotplotView/components/ImportForm/TrackSelector'
+
 export default class DotplotPlugin extends Plugin {
   name = 'DotplotPlugin'
 

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyTrackSelectorArea.tsx
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/components/ImportForm/ImportSyntenyTrackSelectorArea.tsx
@@ -1,11 +1,23 @@
 import { useEffect, useState } from 'react'
 
+import { getEnv } from '@jbrowse/core/util'
 import { FormControl, FormControlLabel, Radio, RadioGroup } from '@mui/material'
 
 import ImportCustomTrack from './ImportSyntenyOpenCustomTrack.tsx'
 import ImportSyntenyTrackSelector from './ImportSyntenyPreConfigured.tsx'
 
 import type { LinearSyntenyViewModel } from '../../model.ts'
+
+export interface LinearSyntenyImportFormSyntenyOption {
+  value: string
+  label: string
+  ReactComponent: React.FC<{
+    model: LinearSyntenyViewModel
+    assembly1: string
+    assembly2: string
+    selectedRow: number
+  }>
+}
 
 export default function ImportSyntenyTrackSelectorArea({
   model,
@@ -18,7 +30,16 @@ export default function ImportSyntenyTrackSelectorArea({
   assembly2: string
   selectedRow: number
 }) {
+  const { pluginManager } = getEnv(model)
   const [choice, setChoice] = useState('tracklist')
+
+  const customOptions = pluginManager.evaluateExtensionPoint(
+    'LinearSyntenyView-ImportFormSyntenyOptions',
+    [] as LinearSyntenyImportFormSyntenyOption[],
+    { model, assembly1, assembly2, selectedRow },
+  ) as LinearSyntenyImportFormSyntenyOption[]
+
+  const selectedCustomOption = customOptions.find(opt => opt.value === choice)
 
   useEffect(() => {
     if (choice === 'none' || choice === 'custom') {
@@ -47,6 +68,14 @@ export default function ImportSyntenyTrackSelectorArea({
             control={<Radio />}
             label="New track"
           />
+          {customOptions.map(opt => (
+            <FormControlLabel
+              key={opt.value}
+              value={opt.value}
+              control={<Radio />}
+              label={opt.label}
+            />
+          ))}
         </RadioGroup>
       </FormControl>
       {choice === 'custom' ? (
@@ -63,6 +92,14 @@ export default function ImportSyntenyTrackSelectorArea({
           selectedRow={selectedRow}
           assembly1={assembly1}
           assembly2={assembly2}
+        />
+      ) : null}
+      {selectedCustomOption ? (
+        <selectedCustomOption.ReactComponent
+          model={model}
+          assembly1={assembly1}
+          assembly2={assembly2}
+          selectedRow={selectedRow}
         />
       ) : null}
     </div>

--- a/plugins/linear-comparative-view/src/index.ts
+++ b/plugins/linear-comparative-view/src/index.ts
@@ -16,6 +16,7 @@ import SyntenyTrackF from './SyntenyTrack/index.tsx'
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
 
+export type { LinearSyntenyImportFormSyntenyOption } from './LinearSyntenyView/components/ImportForm/ImportSyntenyTrackSelectorArea.tsx'
 export type { LinearSyntenyViewModel } from './LinearSyntenyView/model.ts'
 
 export default class LinearComparativeViewPlugin extends Plugin {

--- a/website/docs/developer_guides/extension_points.md
+++ b/website/docs/developer_guides/extension_points.md
@@ -476,6 +476,123 @@ Allows rendering a custom component as a child of the LinearGenomeView's
 "TracksContainer". Used to render highlights for example with a div of height
 100% over the TracksContainer
 
+### DotplotView-ImportFormSyntenyOptions
+
+type: synchronous
+
+- `args` - `DotplotImportFormSyntenyOption[]` - an array of custom radio options
+  to add to the dotplot import form's synteny track selector
+- `props` - an object of the type below
+
+```typescript
+interface props {
+  model: DotplotViewModel // instance of the dotplot view model
+  assembly1: string // name of the y-axis assembly
+  assembly2: string // name of the x-axis assembly
+}
+```
+
+Allows plugins to add custom radio options to the DotplotView import form. When
+a user selects a custom radio option, the plugin's React component is rendered.
+
+Each option in the array should have the following structure:
+
+```typescript
+interface DotplotImportFormSyntenyOption {
+  value: string // unique identifier for the radio option
+  label: string // display text for the radio option
+  ReactComponent: React.FC<{
+    model: DotplotViewModel
+    assembly1: string
+    assembly2: string
+  }>
+}
+```
+
+Example: adding a custom synteny option that fetches data from a server
+
+```typescript
+import type { DotplotImportFormSyntenyOption } from '@jbrowse/plugin-dotplot-view'
+
+pluginManager.addToExtensionPoint(
+  'DotplotView-ImportFormSyntenyOptions',
+  (
+    options: DotplotImportFormSyntenyOption[],
+    { model, assembly1, assembly2 },
+  ) => {
+    return [
+      ...options,
+      {
+        value: 'my-server-synteny',
+        label: 'Load from my server',
+        ReactComponent: MySyntenyServerComponent,
+      },
+    ]
+  },
+)
+```
+
+### LinearSyntenyView-ImportFormSyntenyOptions
+
+type: synchronous
+
+- `args` - `LinearSyntenyImportFormSyntenyOption[]` - an array of custom radio
+  options to add to the linear synteny view import form's synteny track selector
+- `props` - an object of the type below
+
+```typescript
+interface props {
+  model: LinearSyntenyViewModel // instance of the linear synteny view model
+  assembly1: string // name of the top assembly
+  assembly2: string // name of the bottom assembly
+  selectedRow: number // which row is currently selected (0-indexed)
+}
+```
+
+Allows plugins to add custom radio options to the LinearSyntenyView import form.
+When a user selects a custom radio option, the plugin's React component is
+rendered. This is similar to `DotplotView-ImportFormSyntenyOptions` but includes
+an additional `selectedRow` prop since the linear synteny view can have multiple
+rows.
+
+Each option in the array should have the following structure:
+
+```typescript
+interface LinearSyntenyImportFormSyntenyOption {
+  value: string // unique identifier for the radio option
+  label: string // display text for the radio option
+  ReactComponent: React.FC<{
+    model: LinearSyntenyViewModel
+    assembly1: string
+    assembly2: string
+    selectedRow: number
+  }>
+}
+```
+
+Example: adding a custom synteny option
+
+```typescript
+import type { LinearSyntenyImportFormSyntenyOption } from '@jbrowse/plugin-linear-comparative-view'
+
+pluginManager.addToExtensionPoint(
+  'LinearSyntenyView-ImportFormSyntenyOptions',
+  (
+    options: LinearSyntenyImportFormSyntenyOption[],
+    { model, assembly1, assembly2, selectedRow },
+  ) => {
+    return [
+      ...options,
+      {
+        value: 'my-server-synteny',
+        label: 'Load from my server',
+        ReactComponent: MySyntenyServerComponent,
+      },
+    ]
+  },
+)
+```
+
 ### Extension point footnote
 
 Users that want to add further extension points can do so, by simply calling


### PR DESCRIPTION
Possible fix for https://github.com/GMOD/jbrowse-components/issues/5370

It uses the extension point concept to allow users to create new radio items in the linear synteny import form and dotplot import form