### PR TITLE
Show full dotplot when zoomed all the way out

### DIFF
--- a/plugins/dotplot-view/src/DotplotView/1dview.ts
+++ b/plugins/dotplot-view/src/DotplotView/1dview.ts
@@ -48,16 +48,30 @@ const Dotplot1DView = Base1DView.extend(self => {
        * #getter
        */
       get maxOffset() {
+        const contentPx = self.displayedRegionsTotalPx
+        const viewWidth = self.width
+        // When content is smaller than view (zoomed out), center it
+        if (contentPx <= viewWidth) {
+          return (contentPx - viewWidth) / 2
+        }
+        // Otherwise allow scrolling with small padding
         const leftPadding = 10
-        return self.displayedRegionsTotalPx - leftPadding
+        return contentPx - leftPadding
       },
 
       /**
        * #getter
        */
       get minOffset() {
+        const contentPx = self.displayedRegionsTotalPx
+        const viewWidth = self.width
+        // When content is smaller than view (zoomed out), center it
+        if (contentPx <= viewWidth) {
+          return (contentPx - viewWidth) / 2
+        }
+        // Otherwise allow scrolling with small padding
         const rightPadding = 30
-        return -self.width + rightPadding
+        return -viewWidth + rightPadding
       },
     },
     actions: {

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -432,6 +432,13 @@ export default function stateModelFactory(pm: PluginManager) {
       zoomOut() {
         self.hview.zoomOut()
         self.vview.zoomOut()
+        // Center when zoomed out to show all content
+        if (self.hview.bpPerPx >= self.hview.maxBpPerPx * 0.99) {
+          self.hview.center()
+        }
+        if (self.vview.bpPerPx >= self.vview.maxBpPerPx * 0.99) {
+          self.vview.center()
+        }
       },
       /**
        * #action


### PR DESCRIPTION
Currently if you zoom the dotplot all the way out, it can kind of just be in a random zoomed out 'quadrant' of the view

This PR makes it show the whole visualization when zoomed all the way out

Fixes https://github.com/GMOD/jbrowse-components/issues/4105