### PR TITLE
Add 'SyRI' data adapter and color scheme for synteny views

### DIFF
--- a/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
+++ b/plugins/comparative-adapters/src/ChainAdapter/ChainAdapter.ts
@@ -3,19 +3,21 @@ import { openLocation } from '@jbrowse/core/util/io'
 
 import { paf_chain2paf } from './util.ts'
 import PAFAdapter from '../PAFAdapter/PAFAdapter.ts'
-import { getWeightedMeans } from '../PAFAdapter/util.ts'
+import { addSyriTypes, getWeightedMeans } from '../PAFAdapter/util.ts'
 
 import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 export default class ChainAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {
-    return getWeightedMeans(
-      paf_chain2paf(
-        await fetchAndMaybeUnzip(
-          openLocation(this.getConf('chainLocation'), this.pluginManager),
+    return addSyriTypes(
+      getWeightedMeans(
+        paf_chain2paf(
+          await fetchAndMaybeUnzip(
+            openLocation(this.getConf('chainLocation'), this.pluginManager),
+            opts,
+          ),
           opts,
         ),
-        opts,
       ),
     )
   }

--- a/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
+++ b/plugins/comparative-adapters/src/DeltaAdapter/DeltaAdapter.ts
@@ -3,19 +3,21 @@ import { openLocation } from '@jbrowse/core/util/io'
 
 import { paf_delta2paf } from './util.ts'
 import PAFAdapter from '../PAFAdapter/PAFAdapter.ts'
-import { getWeightedMeans } from '../PAFAdapter/util.ts'
+import { addSyriTypes, getWeightedMeans } from '../PAFAdapter/util.ts'
 
 import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
 export default class DeltaAdapter extends PAFAdapter {
   async setupPre(opts?: BaseOptions) {
-    return getWeightedMeans(
-      paf_delta2paf(
-        await fetchAndMaybeUnzip(
-          openLocation(this.getConf('deltaLocation'), this.pluginManager),
+    return addSyriTypes(
+      getWeightedMeans(
+        paf_delta2paf(
+          await fetchAndMaybeUnzip(
+            openLocation(this.getConf('deltaLocation'), this.pluginManager),
+            opts,
+          ),
           opts,
         ),
-        opts,
       ),
     )
   }

--- a/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
+++ b/plugins/comparative-adapters/src/MashMapAdapter/MashMapAdapter.ts
@@ -3,7 +3,7 @@ import { openLocation } from '@jbrowse/core/util/io'
 import { parseLineByLine } from '@jbrowse/core/util/parseLineByLine'
 
 import PAFAdapter from '../PAFAdapter/PAFAdapter.ts'
-import { getWeightedMeans } from '../PAFAdapter/util.ts'
+import { addSyriTypes, getWeightedMeans } from '../PAFAdapter/util.ts'
 
 import type { BaseOptions } from '@jbrowse/core/data_adapters/BaseAdapter'
 
@@ -21,7 +21,7 @@ export default class MashMapAdapter extends PAFAdapter {
       },
       opts?.statusCallback,
     )
-    return getWeightedMeans(lines)
+    return addSyriTypes(getWeightedMeans(lines))
   }
 }
 

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.test.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.test.ts
@@ -3,6 +3,9 @@ import { toArray } from 'rxjs/operators'
 
 import Adapter from './PAFAdapter.ts'
 import MyConfigSchema from './configSchema.ts'
+import { addSyriTypes, getWeightedMeans } from './util.ts'
+
+import type { PAFRecord } from './util.ts'
 
 test('adapter can fetch features from peach_grape.paf', async () => {
   const adapter = new Adapter(
@@ -35,4 +38,157 @@ test('adapter can fetch features from peach_grape.paf', async () => {
   expect(fa2.length).toBe(5)
   expect(fa1[0]!.get('refName')).toBe('Pp01')
   expect(fa2[0]!.get('refName')).toBe('chr1')
+
+  // Verify syriType is set on features
+  const syriType1 = fa1[0]!.get('syriType')
+  expect(['SYN', 'INV', 'TRANS', 'DUP']).toContain(syriType1)
+})
+
+describe('syriType classification', () => {
+  // Helper to create a PAFRecord
+  function createRecord(
+    qname: string,
+    qstart: number,
+    qend: number,
+    tname: string,
+    tstart: number,
+    tend: number,
+    strand: number,
+  ): PAFRecord {
+    return {
+      qname,
+      qstart,
+      qend,
+      tname,
+      tstart,
+      tend,
+      strand,
+      extra: {
+        numMatches: Math.abs(qend - qstart),
+        blockLen: Math.abs(qend - qstart),
+        mappingQual: 60,
+      },
+    }
+  }
+
+  test('classifies SYN for same chromosome forward strand alignments', () => {
+    // chr1 maps primarily to chrA (largest coverage)
+    // This alignment is chr1 -> chrA, forward strand = SYN
+    const records: PAFRecord[] = [
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1),
+      createRecord('chr1', 100000, 200000, 'chrA', 100000, 200000, 1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('SYN')
+    expect(result[1]!.extra.syriType).toBe('SYN')
+  })
+
+  test('classifies INV for same chromosome reverse strand alignments', () => {
+    // chr1 maps primarily to chrA
+    // This alignment is chr1 -> chrA, reverse strand = INV
+    const records: PAFRecord[] = [
+      createRecord('chr1', 0, 100000, 'chrA', 100000, 0, -1),
+      createRecord('chr1', 100000, 200000, 'chrA', 200000, 100000, -1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('INV')
+    expect(result[1]!.extra.syriType).toBe('INV')
+  })
+
+  test('classifies TRANS for alignments to non-primary target', () => {
+    // chr1 maps primarily to chrA (larger total coverage)
+    // But one alignment goes to chrB = TRANS
+    const records: PAFRecord[] = [
+      // 200kb to chrA - this is the primary target
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1),
+      createRecord('chr1', 100000, 200000, 'chrA', 100000, 200000, 1),
+      // 50kb to chrB - this is a translocation
+      createRecord('chr1', 200000, 250000, 'chrB', 0, 50000, 1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('SYN') // to chrA
+    expect(result[1]!.extra.syriType).toBe('SYN') // to chrA
+    expect(result[2]!.extra.syriType).toBe('TRANS') // to chrB (not primary)
+  })
+
+  test('classifies DUP for non-collinear mappings within same target', () => {
+    // chr1 maps to chrA
+    // Query positions are close (10kb gap) but target positions jump >100kb
+    // This indicates a potential duplication
+    const records: PAFRecord[] = [
+      // First block: query 0-100kb maps to target 0-100kb
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1),
+      // Second block: query 110kb-200kb (10kb gap) maps to target 500kb-590kb (400kb jump)
+      // This is a non-collinear pattern suggesting duplication
+      createRecord('chr1', 110000, 200000, 'chrA', 500000, 590000, 1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('DUP')
+    expect(result[1]!.extra.syriType).toBe('DUP')
+  })
+
+  test('does not classify as DUP when target gap is proportional to query gap', () => {
+    // Normal collinear alignment - gaps are proportional
+    const records: PAFRecord[] = [
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1),
+      // 50kb gap in query, ~50kb gap in target - this is normal, not DUP
+      createRecord('chr1', 150000, 250000, 'chrA', 150000, 250000, 1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('SYN')
+    expect(result[1]!.extra.syriType).toBe('SYN')
+  })
+
+  test('mixed classifications in a complex scenario', () => {
+    const records: PAFRecord[] = [
+      // chr1 primarily maps to chrA (300kb total)
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1), // SYN
+      createRecord('chr1', 100000, 200000, 'chrA', 100000, 200000, 1), // SYN
+      createRecord('chr1', 200000, 300000, 'chrA', 200000, 300000, -1), // INV (reverse)
+
+      // chr1 also has a small alignment to chrB (translocation)
+      createRecord('chr1', 300000, 350000, 'chrB', 0, 50000, 1), // TRANS
+
+      // chr2 primarily maps to chrB
+      createRecord('chr2', 0, 100000, 'chrB', 100000, 200000, 1), // SYN
+      createRecord('chr2', 100000, 200000, 'chrB', 200000, 300000, 1), // SYN
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+
+    // chr1 -> chrA alignments
+    expect(result[0]!.extra.syriType).toBe('SYN')
+    expect(result[1]!.extra.syriType).toBe('SYN')
+    expect(result[2]!.extra.syriType).toBe('INV')
+
+    // chr1 -> chrB (translocation since chr1 primarily maps to chrA)
+    expect(result[3]!.extra.syriType).toBe('TRANS')
+
+    // chr2 -> chrB alignments
+    expect(result[4]!.extra.syriType).toBe('SYN')
+    expect(result[5]!.extra.syriType).toBe('SYN')
+  })
+
+  test('handles single alignment correctly', () => {
+    const records: PAFRecord[] = [
+      createRecord('chr1', 0, 100000, 'chrA', 0, 100000, 1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('SYN')
+  })
+
+  test('handles single reverse strand alignment as INV', () => {
+    const records: PAFRecord[] = [
+      createRecord('chr1', 0, 100000, 'chrA', 100000, 0, -1),
+    ]
+
+    const result = addSyriTypes(getWeightedMeans(records))
+    expect(result[0]!.extra.syriType).toBe('INV')
+  })
 })

--- a/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/PAFAdapter.ts
@@ -8,7 +8,7 @@ import { MismatchParser } from '@jbrowse/plugin-alignments'
 
 import SyntenyFeature from '../SyntenyFeature/index.ts'
 import { flipCigar, parsePAFLine, swapIndelCigar } from '../util.ts'
-import { getWeightedMeans } from './util.ts'
+import { addSyriTypes, getWeightedMeans } from './util.ts'
 
 import type { PAFRecord } from './util.ts'
 import type { AnyConfigurationModel } from '@jbrowse/core/configuration'
@@ -50,7 +50,8 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
       },
       opts?.statusCallback,
     )
-    return getWeightedMeans(lines)
+    // Compute weighted means and syri types from full dataset
+    return addSyriTypes(getWeightedMeans(lines))
   }
 
   async hasDataForRefName() {
@@ -161,6 +162,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
               identity: numMatches / blockLen,
               numMatches,
               blockLen,
+              syriType: extra.syriType,
               mate: {
                 start: mateStart,
                 end: mateEnd,

--- a/plugins/comparative-adapters/src/PAFAdapter/util.ts
+++ b/plugins/comparative-adapters/src/PAFAdapter/util.ts
@@ -1,3 +1,7 @@
+import { computeSyriTypes } from '../syriUtils.ts'
+
+import type { SyriType } from '../syriUtils.ts'
+
 export interface PAFRecord {
   qname: string
   qstart: number
@@ -12,6 +16,7 @@ export interface PAFRecord {
     mappingQual?: number
     numMatches?: number
     meanScore?: number
+    syriType?: SyriType
   }
 }
 // based on "weighted mean" method from https://github.com/tpoorten/dotPlotly
@@ -89,4 +94,16 @@ export function getWeightedMeans(ret: PAFRecord[]) {
   }
 
   return ret
+}
+
+/**
+ * Add SyRI-style classification to all records.
+ * Computes syriType (SYN, INV, TRANS, DUP) based on the full dataset.
+ */
+export function addSyriTypes(records: PAFRecord[]) {
+  const syriTypes = computeSyriTypes(records)
+  for (let i = 0; i < records.length; i++) {
+    records[i]!.extra.syriType = syriTypes[i]
+  }
+  return records
 }

--- a/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/PairwiseIndexedPAFAdapter.ts
+++ b/plugins/comparative-adapters/src/PairwiseIndexedPAFAdapter/PairwiseIndexedPAFAdapter.ts
@@ -141,6 +141,7 @@ export default class PAFAdapter extends BaseFeatureDataAdapter {
                 identity: numMatches / blockLen,
                 numMatches,
                 blockLen,
+                syriType: extra.sy, // Pre-computed by make-pif
                 mate: {
                   start: mateStart,
                   end: mateEnd,

--- a/plugins/comparative-adapters/src/syriUtils.test.ts
+++ b/plugins/comparative-adapters/src/syriUtils.test.ts
@@ -1,0 +1,123 @@
+import {
+  buildChromosomeMapping,
+  computeSyriTypes,
+} from './syriUtils.ts'
+
+describe('syriUtils', () => {
+  describe('buildChromosomeMapping', () => {
+    test('maps query to target with highest coverage', () => {
+      const records = [
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr1', qstart: 100000, qend: 200000, tname: 'chrA', tstart: 100000, tend: 200000, strand: 1 },
+        { qname: 'chr1', qstart: 200000, qend: 250000, tname: 'chrB', tstart: 0, tend: 50000, strand: 1 },
+      ]
+
+      const mapping = buildChromosomeMapping(records)
+
+      // chr1 has 200kb to chrA vs 50kb to chrB, so chrA is primary
+      expect(mapping.get('chr1')).toBe('chrA')
+    })
+
+    test('handles multiple query chromosomes', () => {
+      const records = [
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr2', qstart: 0, qend: 100000, tname: 'chrB', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr3', qstart: 0, qend: 50000, tname: 'chrA', tstart: 200000, tend: 250000, strand: 1 },
+        { qname: 'chr3', qstart: 50000, qend: 150000, tname: 'chrC', tstart: 0, tend: 100000, strand: 1 },
+      ]
+
+      const mapping = buildChromosomeMapping(records)
+
+      expect(mapping.get('chr1')).toBe('chrA')
+      expect(mapping.get('chr2')).toBe('chrB')
+      expect(mapping.get('chr3')).toBe('chrC') // 100kb to chrC vs 50kb to chrA
+    })
+
+    test('returns empty map for empty input', () => {
+      const mapping = buildChromosomeMapping([])
+      expect(mapping.size).toBe(0)
+    })
+  })
+
+  describe('computeSyriTypes', () => {
+    test('classifies SYN correctly', () => {
+      const records = [
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('SYN')
+    })
+
+    test('classifies INV correctly', () => {
+      const records = [
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 100000, tend: 0, strand: -1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('INV')
+    })
+
+    test('classifies TRANS correctly', () => {
+      const records = [
+        // Primary mapping to chrA
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr1', qstart: 100000, qend: 200000, tname: 'chrA', tstart: 100000, tend: 200000, strand: 1 },
+        // Translocation to chrB
+        { qname: 'chr1', qstart: 200000, qend: 250000, tname: 'chrB', tstart: 0, tend: 50000, strand: 1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('SYN')
+      expect(types[1]).toBe('SYN')
+      expect(types[2]).toBe('TRANS')
+    })
+
+    test('classifies DUP for non-collinear mappings', () => {
+      const records = [
+        // Query positions close together, but target positions jump significantly
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr1', qstart: 110000, qend: 200000, tname: 'chrA', tstart: 500000, tend: 590000, strand: 1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('DUP')
+      expect(types[1]).toBe('DUP')
+    })
+
+    test('does not classify as DUP when gaps are proportional', () => {
+      const records = [
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        { qname: 'chr1', qstart: 150000, qend: 250000, tname: 'chrA', tstart: 150000, tend: 250000, strand: 1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('SYN')
+      expect(types[1]).toBe('SYN')
+    })
+
+    test('handles complex mixed scenario', () => {
+      const records = [
+        // chr1 -> chrA (SYN)
+        { qname: 'chr1', qstart: 0, qend: 100000, tname: 'chrA', tstart: 0, tend: 100000, strand: 1 },
+        // chr1 -> chrA (INV)
+        { qname: 'chr1', qstart: 100000, qend: 200000, tname: 'chrA', tstart: 200000, tend: 100000, strand: -1 },
+        // chr1 -> chrB (TRANS - chr1 primarily maps to chrA)
+        { qname: 'chr1', qstart: 200000, qend: 220000, tname: 'chrB', tstart: 0, tend: 20000, strand: 1 },
+        // chr2 -> chrB (SYN)
+        { qname: 'chr2', qstart: 0, qend: 100000, tname: 'chrB', tstart: 0, tend: 100000, strand: 1 },
+      ]
+
+      const types = computeSyriTypes(records)
+      expect(types[0]).toBe('SYN')
+      expect(types[1]).toBe('INV')
+      expect(types[2]).toBe('TRANS')
+      expect(types[3]).toBe('SYN')
+    })
+
+    test('returns empty array for empty input', () => {
+      const types = computeSyriTypes([])
+      expect(types).toEqual([])
+    })
+  })
+})

--- a/plugins/comparative-adapters/src/syriUtils.ts
+++ b/plugins/comparative-adapters/src/syriUtils.ts
@@ -1,0 +1,187 @@
+/**
+ * SyRI-style classification utilities for synteny features.
+ * Classifies alignments as SYN (syntenic), INV (inversion), TRANS (translocation), or DUP (duplication).
+ *
+ * Based on the syri/plotsr color scheme from schneebergerlab.
+ */
+
+export type SyriType = 'SYN' | 'INV' | 'TRANS' | 'DUP'
+
+interface SyntenyRecord {
+  qname: string
+  qstart: number
+  qend: number
+  tname: string
+  tstart: number
+  tend: number
+  strand: number
+}
+
+/**
+ * Build a mapping from query chromosomes to their primary target chromosome
+ * based on total alignment coverage. For each query chromosome, finds the
+ * target chromosome where it has the most aligned bases.
+ */
+export function buildChromosomeMapping(
+  records: SyntenyRecord[],
+): Map<string, string> {
+  // Track alignment coverage: queryChrom -> targetChrom -> totalBases
+  const coverageMap = new Map<string, Map<string, number>>()
+
+  for (const r of records) {
+    const { qname, tname, qstart, qend } = r
+    if (!qname || !tname) {
+      continue
+    }
+
+    const alignmentLength = Math.abs(qend - qstart)
+
+    if (!coverageMap.has(qname)) {
+      coverageMap.set(qname, new Map())
+    }
+    const targetMap = coverageMap.get(qname)!
+    const currentCoverage = targetMap.get(tname) || 0
+    targetMap.set(tname, currentCoverage + alignmentLength)
+  }
+
+  // For each query chromosome, find the target with highest coverage
+  const mapping = new Map<string, string>()
+  for (const [qname, targetMap] of coverageMap) {
+    let bestTarget = ''
+    let bestCoverage = 0
+    for (const [tname, coverage] of targetMap) {
+      if (coverage > bestCoverage) {
+        bestCoverage = coverage
+        bestTarget = tname
+      }
+    }
+    if (bestTarget) {
+      mapping.set(qname, bestTarget)
+    }
+  }
+
+  return mapping
+}
+
+/**
+ * Detect duplications by finding query regions that map to multiple
+ * non-collinear locations on the same target chromosome.
+ *
+ * Returns a Set of record indices that are classified as duplications.
+ */
+export function detectDuplications(
+  records: SyntenyRecord[],
+  chromosomeMapping: Map<string, string>,
+): Set<number> {
+  const duplicateIndices = new Set<number>()
+
+  // Group records by query chromosome, keeping track of indices
+  const recordsByQuery = new Map<string, { record: SyntenyRecord; index: number }[]>()
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i]!
+    const { qname } = record
+    if (!recordsByQuery.has(qname)) {
+      recordsByQuery.set(qname, [])
+    }
+    recordsByQuery.get(qname)!.push({ record, index: i })
+  }
+
+  // For each query chromosome, check for non-collinear mappings
+  for (const [qname, queryRecords] of recordsByQuery) {
+    const expectedTarget = chromosomeMapping.get(qname)
+    if (!expectedTarget) {
+      continue
+    }
+
+    // Get records that map to the expected target
+    const recordsToExpectedTarget = queryRecords.filter(
+      ({ record }) => record.tname === expectedTarget,
+    )
+
+    if (recordsToExpectedTarget.length <= 1) {
+      continue
+    }
+
+    // Sort by query position
+    recordsToExpectedTarget.sort((a, b) => a.record.qstart - b.record.qstart)
+
+    // Check for non-monotonic target positions (indicates duplication/rearrangement)
+    for (let i = 1; i < recordsToExpectedTarget.length; i++) {
+      const prev = recordsToExpectedTarget[i - 1]!
+      const curr = recordsToExpectedTarget[i]!
+
+      const prevQueryEnd = prev.record.qend
+      const currQueryStart = curr.record.qstart
+      const queryGap = currQueryStart - prevQueryEnd
+
+      const prevTargetEnd = Math.max(prev.record.tstart, prev.record.tend)
+      const currTargetStart = Math.min(curr.record.tstart, curr.record.tend)
+      const targetGap = Math.abs(currTargetStart - prevTargetEnd)
+
+      // If target gap is much larger than query gap, might be duplication
+      // Threshold: target jumps > 10x the query gap and > 100kb
+      if (queryGap >= 0 && queryGap < 50000 && targetGap > queryGap * 10 && targetGap > 100000) {
+        duplicateIndices.add(prev.index)
+        duplicateIndices.add(curr.index)
+      }
+    }
+  }
+
+  return duplicateIndices
+}
+
+/**
+ * Classify a single synteny record as SYN, INV, TRANS, or DUP.
+ */
+export function classifySyriType(
+  record: SyntenyRecord,
+  chromosomeMapping: Map<string, string>,
+  isDuplicate: boolean,
+): SyriType {
+  // Check for duplication first
+  if (isDuplicate) {
+    return 'DUP'
+  }
+
+  const { qname, tname, strand } = record
+
+  // Use coverage-based mapping to determine if this is a translocation
+  const expectedTarget = chromosomeMapping.get(qname)
+
+  // If the target doesn't match the expected target, it's a translocation
+  if (expectedTarget && tname && expectedTarget !== tname) {
+    return 'TRANS'
+  }
+
+  // Same/matching chromosome - check strand for inversion
+  if (strand === -1) {
+    return 'INV'
+  }
+
+  return 'SYN'
+}
+
+/**
+ * Compute SyRI types for all records at once.
+ * This is the main entry point - call this on the full dataset.
+ *
+ * @param records - Array of synteny records
+ * @returns Array of SyriType classifications, one per record
+ */
+export function computeSyriTypes(records: SyntenyRecord[]): SyriType[] {
+  // Build chromosome mapping from full dataset
+  const chromosomeMapping = buildChromosomeMapping(records)
+
+  // Detect duplications
+  const duplicateIndices = detectDuplications(records, chromosomeMapping)
+
+  // Classify each record
+  const syriTypes: SyriType[] = []
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i]!
+    const isDuplicate = duplicateIndices.has(i)
+    syriTypes.push(classifySyriType(record, chromosomeMapping, isDuplicate))
+  }
+
+  return syriTypes
+}

--- a/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/Axes.tsx
@@ -77,16 +77,13 @@ export const HorizontalAxisRaw = observer(function HorizontalAxisRaw({
       {dblocks
         .filter(region => !hide.has(region.key))
         .map(region => {
-          const x = region.offsetPx
-          const y = 0
-          const xoff = Math.floor(x - hview.offsetPx)
-
+          const xoff = Math.floor(region.offsetPx - hview.offsetPx)
           return (
             <text
-              transform={`rotate(${htextRotation},${xoff},${y})`}
-              key={JSON.stringify(region)}
+              transform={`rotate(${htextRotation},${xoff},0)`}
+              key={region.key}
               x={xoff}
-              y={y + 1}
+              y={1}
               fontSize={11}
               dominantBaseline="hanging"
               textAnchor="end"
@@ -99,13 +96,13 @@ export const HorizontalAxisRaw = observer(function HorizontalAxisRaw({
       {ticks.map(([tick, x]) =>
         x > 0 && x < width ? (
           <line
-            key={`line-${JSON.stringify(tick)}`}
+            key={`line-${tick.refName}-${tick.base}`}
             x1={x}
             x2={x}
             y1={0}
             y2={tick.type === 'major' ? 6 : 4}
             strokeWidth={1}
-            {...getFillProps(theme.palette.text.primary)}
+            {...getStrokeProps(theme.palette.text.primary)}
           />
         ) : null,
       )}
@@ -117,7 +114,7 @@ export const HorizontalAxisRaw = observer(function HorizontalAxisRaw({
               x={x - 7}
               y={0}
               transform={`rotate(${htextRotation},${x},0)`}
-              key={`text-${JSON.stringify(tick)}`}
+              key={`text-${tick.refName}-${tick.base}`}
               fontSize={11}
               dominantBaseline="middle"
               textAnchor="end"
@@ -189,15 +186,12 @@ export const VerticalAxisRaw = observer(function VerticalAxisRaw({
       {dblocks
         .filter(region => !hide.has(region.key))
         .map(region => {
-          const y = region.offsetPx
-          const x = borderX
-          const yoff = Math.floor(viewHeight - y + offsetPx)
-
+          const yoff = Math.floor(viewHeight - region.offsetPx + offsetPx)
           return (
             <text
-              transform={`rotate(${vtextRotation},${x},${y})`}
-              key={JSON.stringify(region)}
-              x={x}
+              transform={`rotate(${vtextRotation},${borderX},${region.offsetPx})`}
+              key={region.key}
+              x={borderX}
               y={yoff}
               fontSize={11}
               textAnchor="end"
@@ -208,15 +202,15 @@ export const VerticalAxisRaw = observer(function VerticalAxisRaw({
           )
         })}
       {ticks.map(([tick, y]) =>
-        y > 0 ? (
+        y > 0 && y < viewHeight ? (
           <line
-            key={`line-${JSON.stringify(tick)}`}
+            key={`line-${tick.refName}-${tick.base}`}
             y1={viewHeight - y}
             y2={viewHeight - y}
             x1={borderX}
             x2={borderX - (tick.type === 'major' ? 6 : 4)}
             strokeWidth={1}
-            {...getStrokeProps(theme.palette.grey[400])}
+            {...getStrokeProps(theme.palette.text.primary)}
           />
         ) : null,
       )}
@@ -227,7 +221,7 @@ export const VerticalAxisRaw = observer(function VerticalAxisRaw({
             <text
               y={viewHeight - y - 3}
               x={borderX - 7}
-              key={`text-${JSON.stringify(tick)}`}
+              key={`text-${tick.refName}-${tick.base}`}
               textAnchor="end"
               dominantBaseline="hanging"
               fontSize={11}

--- a/plugins/dotplot-view/src/DotplotView/components/ColorBySelector.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ColorBySelector.tsx
@@ -89,6 +89,16 @@ const ColorBySelector = observer(function ColorBySelector({
           helpText:
             'Color alignments by query sequence name. Each unique query sequence is assigned a consistent color based on its name, making it easy to visually distinguish between different sequences.',
         },
+        {
+          label: 'SyRI',
+          type: 'radio',
+          checked: colorBy === 'syri',
+          onClick: () => {
+            setColorBy('syri')
+          },
+          helpText:
+            'Color alignments by structural variation type (SyRI scheme): grey for syntenic matches (same chromosome, forward strand), orange for inversions (same chromosome, reverse strand), green for translocations (different chromosomes).',
+        },
       ]}
     >
       <PaletteIcon />

--- a/plugins/dotplot-view/src/DotplotView/components/ColorLegend.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ColorLegend.tsx
@@ -2,17 +2,17 @@ import { makeStyles } from '@jbrowse/core/util/tss-react'
 import { Tooltip, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 
-import { syriColors, strandColors } from '../../LinearSyntenyDisplay/drawSynteny.ts'
+import { syriColors, strandColors } from '../../DotplotRenderer/drawDotplot.ts'
 
-import type { LinearSyntenyDisplayModel } from '../../LinearSyntenyDisplay/model.ts'
-import type { LinearComparativeViewModel } from '../model.ts'
+import type { DotplotDisplayModel } from '../../DotplotDisplay/stateModelFactory.tsx'
+import type { DotplotViewModel } from '../model.ts'
 
 const useStyles = makeStyles()(theme => ({
   legend: {
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    marginLeft: theme.spacing(1),
+    marginLeft: theme.spacing(0.5),
     padding: theme.spacing(0.25, 0.5),
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.action.hover,
@@ -55,12 +55,12 @@ const strandLegend: LegendItem[] = [
 const ColorLegend = observer(function ColorLegend({
   model,
 }: {
-  model: LinearComparativeViewModel
+  model: DotplotViewModel
 }) {
   const { classes } = useStyles()
 
-  const firstDisplay = model.levels[0]?.tracks[0]?.displays[0] as
-    | LinearSyntenyDisplayModel
+  const firstDisplay = model.tracks[0]?.displays[0] as
+    | DotplotDisplayModel
     | undefined
 
   const colorBy = firstDisplay?.colorBy ?? 'default'

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotControls.tsx
@@ -11,6 +11,7 @@ import { IconButton } from '@mui/material'
 import { observer } from 'mobx-react'
 
 import ColorBySelector from './ColorBySelector.tsx'
+import ColorLegend from './ColorLegend.tsx'
 import { CursorMouse, CursorMove } from './CursorIcon.tsx'
 import MinLengthSlider from './MinLengthSlider.tsx'
 import OpacitySlider from './OpacitySlider.tsx'
@@ -198,6 +199,7 @@ const DotplotControls = observer(function DotplotControls({
         <MoreVert />
       </CascadingMenuButton>
       <ColorBySelector model={model} />
+      <ColorLegend model={model} />
 
       {hasDisplays && showDynamicControls ? (
         <>

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotGrid.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotGrid.tsx
@@ -31,8 +31,22 @@ const DotplotGrid = observer(function DotplotGrid({
   const w = Math.min(htop - hbottom, viewWidth)
   const h = Math.min(viewHeight - vbottom - ry, viewHeight)
 
-  let lastx = Number.POSITIVE_INFINITY
-  let lasty = Number.POSITIVE_INFINITY
+  // Filter blocks to avoid rendering duplicate lines at the same pixel position
+  const hlines = hblocks.filter((region, idx) => {
+    const x = Math.floor(region.offsetPx - hview.offsetPx)
+    const prevX =
+      idx > 0 ? Math.floor(hblocks[idx - 1]!.offsetPx - hview.offsetPx) : null
+    return x !== prevX
+  })
+  const vlines = vblocks.filter((region, idx) => {
+    const y = Math.floor(viewHeight - (region.offsetPx - vview.offsetPx))
+    const prevY =
+      idx > 0
+        ? Math.floor(viewHeight - (vblocks[idx - 1]!.offsetPx - vview.offsetPx))
+        : null
+    return y !== prevY
+  })
+
   return (
     <>
       <rect
@@ -43,39 +57,31 @@ const DotplotGrid = observer(function DotplotGrid({
         {...getFillProps(theme.palette.background.default)}
       />
       <g>
-        {hblocks.map(region => {
+        {hlines.map(region => {
           const x = region.offsetPx - hview.offsetPx
-          const render = Math.floor(x) !== Math.floor(lastx)
-          if (render) {
-            lastx = x
-          }
-          return render ? (
+          return (
             <line
-              key={JSON.stringify(region)}
+              key={region.key}
               x1={x}
               y1={0}
               x2={x}
               y2={viewHeight}
               {...getStrokeProps(stroke)}
             />
-          ) : null
+          )
         })}
-        {vblocks.map(region => {
+        {vlines.map(region => {
           const y = viewHeight - (region.offsetPx - vview.offsetPx)
-          const render = Math.floor(y) !== Math.floor(lasty)
-          if (render) {
-            lasty = y
-          }
-          return render ? (
+          return (
             <line
-              key={JSON.stringify(region)}
+              key={region.key}
               x1={0}
               y1={y}
               x2={viewWidth}
               y2={y}
               {...getStrokeProps(stroke)}
             />
-          ) : null
+          )
         })}
         <line
           x1={htop}

--- a/plugins/dotplot-view/src/DotplotView/components/DotplotGridWrapper.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/DotplotGridWrapper.tsx
@@ -1,8 +1,10 @@
+import { observer } from 'mobx-react'
+
 import DotplotGrid from './DotplotGrid.tsx'
 
 import type { DotplotViewModel } from '../model.ts'
 
-export default function DotplotGridWrapper({
+const DotplotGridWrapper = observer(function DotplotGridWrapper({
   model,
   children,
 }: {
@@ -19,4 +21,6 @@ export default function DotplotGridWrapper({
       <DotplotGrid model={model}>{children}</DotplotGrid>
     </svg>
   )
-}
+})
+
+export default DotplotGridWrapper

--- a/plugins/dotplot-view/src/DotplotView/components/MouseInteractionLayer.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/MouseInteractionLayer.tsx
@@ -1,3 +1,5 @@
+import { observer } from 'mobx-react'
+
 import DotplotGridWrapper from './DotplotGridWrapper.tsx'
 
 import type { DotplotViewModel } from '../model.ts'
@@ -18,7 +20,7 @@ interface MouseInteractionLayerProps {
   setCtrlKeyWasUsed: (wasUsed: boolean) => void
 }
 
-export default function MouseInteractionLayer({
+const MouseInteractionLayer = observer(function MouseInteractionLayer({
   model,
   ctrlKeyDown,
   cursorMode,
@@ -56,4 +58,6 @@ export default function MouseInteractionLayer({
       </DotplotGridWrapper>
     </div>
   )
-}
+})
+
+export default MouseInteractionLayer

--- a/plugins/dotplot-view/src/DotplotView/components/util.ts
+++ b/plugins/dotplot-view/src/DotplotView/components/util.ts
@@ -26,14 +26,25 @@ export function getBlockLabelKeysToHide(
     const blen = b.end - b.start
     return blen - alen
   })
-  const positions = Array.from({ length: Math.round(length) })
+  const occupiedPositions = new Set<number>()
   for (const { key, offsetPx } of sortedBlocks) {
     const y = Math.round(length - offsetPx + viewOffsetPx)
-    const labelBounds = [Math.max(y - 12, 0), y]
-    if (y === 0 || positions.slice(...labelBounds).some(Boolean)) {
+    const labelStart = Math.max(y - 12, 0)
+    let hasOverlap = y === 0
+    if (!hasOverlap) {
+      for (let i = labelStart; i < y; i++) {
+        if (occupiedPositions.has(i)) {
+          hasOverlap = true
+          break
+        }
+      }
+    }
+    if (hasOverlap) {
       blockLabelKeysToHide.add(key)
     } else {
-      positions.fill(true, ...labelBounds)
+      for (let i = labelStart; i < y; i++) {
+        occupiedPositions.add(i)
+      }
     }
   }
   return blockLabelKeysToHide

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
@@ -61,6 +61,16 @@ const ColorBySelector = observer(function ColorBySelector({
           helpText:
             'Color alignments by query sequence name. Each unique query sequence is assigned a consistent color based on its name, making it easy to visually distinguish between different sequences.',
         },
+        {
+          label: 'SyRI',
+          type: 'radio',
+          checked: colorBy === 'syri',
+          onClick: () => {
+            setColorBy('syri')
+          },
+          helpText:
+            'Color alignments by structural variation type using the SyRI color scheme: grey for syntenic matches (same chromosome, forward strand), orange for inversions (same chromosome, reverse strand), and green for translocations (different chromosomes).',
+        },
       ]}
     >
       <PaletteIcon />

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
@@ -69,7 +69,7 @@ const ColorBySelector = observer(function ColorBySelector({
             setColorBy('syri')
           },
           helpText:
-            'Color alignments by structural variation type using the SyRI color scheme: grey for syntenic matches (same chromosome, forward strand), orange for inversions (same chromosome, reverse strand), and green for translocations (different chromosomes).',
+            'Color alignments by structural variation type (SyRI scheme): grey for syntenic matches, orange for inversions, green for translocations (different chromosomes), blue for duplications (overlapping query regions).',
         },
       ]}
     >

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorBySelector.tsx
@@ -69,7 +69,7 @@ const ColorBySelector = observer(function ColorBySelector({
             setColorBy('syri')
           },
           helpText:
-            'Color alignments by structural variation type (SyRI scheme): grey for syntenic matches, orange for inversions, green for translocations (different chromosomes), blue for duplications (overlapping query regions).',
+            'Color alignments by structural variation type (SyRI scheme): grey for syntenic matches (same chromosome, forward strand), orange for inversions (same chromosome, reverse strand), green for translocations (different chromosomes).',
         },
       ]}
     >

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorLegend.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/ColorLegend.tsx
@@ -1,0 +1,92 @@
+import { makeStyles } from '@jbrowse/core/util/tss-react'
+import { Tooltip, Typography } from '@mui/material'
+import { observer } from 'mobx-react'
+
+import { syriColors, strandColors } from '../../LinearSyntenyDisplay/drawSynteny.ts'
+
+import type { LinearSyntenyDisplayModel } from '../../LinearSyntenyDisplay/model.ts'
+import type { LinearComparativeViewModel } from '../model.ts'
+
+const useStyles = makeStyles()(theme => ({
+  legend: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginLeft: theme.spacing(1),
+    padding: theme.spacing(0.25, 0.5),
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.action.hover,
+  },
+  legendItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.25),
+  },
+  colorBox: {
+    width: 12,
+    height: 12,
+    borderRadius: 2,
+    border: `1px solid ${theme.palette.divider}`,
+  },
+  label: {
+    fontSize: '0.7rem',
+    lineHeight: 1,
+  },
+}))
+
+interface LegendItem {
+  color: string
+  label: string
+  tooltip: string
+}
+
+const syriLegend: LegendItem[] = [
+  { color: syriColors.SYN, label: 'SYN', tooltip: 'Syntenic (same chromosome, forward strand)' },
+  { color: syriColors.INV, label: 'INV', tooltip: 'Inversion (same chromosome, reverse strand)' },
+  { color: syriColors.TRANS, label: 'TRANS', tooltip: 'Translocation (different chromosome)' },
+  { color: syriColors.DUP, label: 'DUP', tooltip: 'Duplication (overlapping query region)' },
+]
+
+const strandLegend: LegendItem[] = [
+  { color: strandColors.pos, label: '+', tooltip: 'Forward strand' },
+  { color: strandColors.neg, label: '-', tooltip: 'Reverse strand' },
+]
+
+const ColorLegend = observer(function ColorLegend({
+  model,
+}: {
+  model: LinearComparativeViewModel
+}) {
+  const { classes } = useStyles()
+
+  const firstDisplay = model.levels[0]?.tracks[0]?.displays[0] as
+    | LinearSyntenyDisplayModel
+    | undefined
+
+  const colorBy = firstDisplay?.colorBy ?? 'default'
+
+  // Only show legend for strand and syri modes
+  if (colorBy !== 'strand' && colorBy !== 'syri') {
+    return null
+  }
+
+  const legendItems = colorBy === 'syri' ? syriLegend : strandLegend
+
+  return (
+    <div className={classes.legend}>
+      {legendItems.map(item => (
+        <Tooltip key={item.label} title={item.tooltip} arrow>
+          <div className={classes.legendItem}>
+            <div
+              className={classes.colorBox}
+              style={{ backgroundColor: item.color }}
+            />
+            <Typography className={classes.label}>{item.label}</Typography>
+          </div>
+        </Tooltip>
+      ))}
+    </div>
+  )
+})
+
+export default ColorLegend

--- a/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
+++ b/plugins/linear-comparative-view/src/LinearComparativeView/components/Header.tsx
@@ -9,6 +9,7 @@ import { FormGroup } from '@mui/material'
 import { observer } from 'mobx-react'
 
 import ColorBySelector from './ColorBySelector.tsx'
+import ColorLegend from './ColorLegend.tsx'
 import HeaderSearchBoxes from './HeaderSearchBoxes.tsx'
 import MinLengthSlider from './MinLengthSlider.tsx'
 import OpacitySlider from './OpacitySlider.tsx'
@@ -110,6 +111,7 @@ const Header = observer(function Header({
       {hasDisplays && showDynamicControls ? (
         <>
           <ColorBySelector model={model} />
+          <ColorLegend model={model} />
           <OpacitySlider model={model} />
           <MinLengthSlider model={model} />
         </>

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/afterAttach.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/afterAttach.ts
@@ -29,54 +29,6 @@ interface FeatPos {
 
 type LSV = LinearSyntenyViewModel
 
-/**
- * Computes a mapping from query chromosomes to target chromosomes based on
- * alignment coverage. For each query chromosome, finds the target chromosome
- * that has the most aligned bases. This is used by syri color mode to
- * distinguish translocations (alignments to non-primary target chromosomes)
- * from syntenic alignments.
- */
-function computeChromosomeMapping(features: Feature[]): Map<string, string> {
-  // Track alignment coverage: queryChrom -> targetChrom -> totalBases
-  const coverageMap = new Map<string, Map<string, number>>()
-
-  for (const f of features) {
-    const queryChrom = f.get('refName')
-    const mate = f.get('mate')
-    const targetChrom = mate?.refName
-    if (!queryChrom || !targetChrom) {
-      continue
-    }
-
-    const alignmentLength = Math.abs(f.get('end') - f.get('start'))
-
-    if (!coverageMap.has(queryChrom)) {
-      coverageMap.set(queryChrom, new Map())
-    }
-    const targetMap = coverageMap.get(queryChrom)!
-    const currentCoverage = targetMap.get(targetChrom) || 0
-    targetMap.set(targetChrom, currentCoverage + alignmentLength)
-  }
-
-  // For each query chromosome, find the target with highest coverage
-  const mapping = new Map<string, string>()
-  for (const [queryChrom, targetMap] of coverageMap) {
-    let bestTarget = ''
-    let bestCoverage = 0
-    for (const [targetChrom, coverage] of targetMap) {
-      if (coverage > bestCoverage) {
-        bestCoverage = coverage
-        bestTarget = targetChrom
-      }
-    }
-    if (bestTarget) {
-      mapping.set(queryChrom, bestTarget)
-    }
-  }
-
-  return mapping
-}
-
 export function doAfterAttach(self: LinearSyntenyDisplayModel) {
   addDisposer(
     self,
@@ -220,10 +172,6 @@ export function doAfterAttach(self: LinearSyntenyDisplayModel) {
         }
 
         self.setFeatPositions(map)
-
-        // Compute chromosome mapping for syri color mode
-        const chromosomeMapping = computeChromosomeMapping(feats)
-        self.setChromosomeMapping(chromosomeMapping)
       },
       { fireImmediately: true },
     ),

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/drawSynteny.ts
@@ -36,70 +36,61 @@ function getQueryColor(queryName: string) {
   const hash = hashString(queryName)
   return category10[hash % category10.length]!
 }
-// Default CIGAR operation colors
-const defaultCigarColors = {
-  I: '#ff03',
-  N: '#0a03',
-  D: '#00f3',
-  X: 'brown',
-  M: '#f003',
-  '=': '#f003',
-}
 
-// Strand-specific CIGAR operation colors (purple deletion instead of blue)
-const strandCigarColors = {
-  I: '#ff03',
-  N: '#a020f0', // Purple for deletion
-  D: '#a020f0', // Purple for deletion
-  X: 'brown',
-  M: '#f003',
-  '=': '#f003',
+// CIGAR operation colors (used for insertions/deletions in all color modes)
+const cigarColors = {
+  I: '#ff03', // yellow - insertion
+  N: '#0a03', // green - skipped region
+  D: '#00f3', // blue - deletion
+  X: 'brown', // mismatch
+  M: '#f003', // red - match (default)
+  '=': '#f003', // red - sequence match
 }
 
 // SyRI-style colors (based on schneebergerlab/plotsr)
-// SYN (syntenic): grey, INV (inversion): orange, TRANS (translocation): green, DUP (duplication): blue
 const syriColors = {
-  SYN: '#808080', // grey for matches
+  SYN: '#808080', // grey for syntenic matches
   INV: '#FFA500', // orange for inversions
   TRANS: '#228B22', // forest green for translocations
   DUP: '#00BBFF', // cyan-blue for duplications
 }
 
-// Color scheme configuration
-const colorSchemes = {
-  default: {
-    cigarColors: defaultCigarColors,
-  },
-  strand: {
-    posColor: 'red',
-    negColor: 'blue',
-    cigarColors: strandCigarColors,
-  },
-  query: {
-    cigarColors: defaultCigarColors,
-  },
-  syri: {
-    cigarColors: defaultCigarColors,
-    syriColors,
-  },
+// Strand colors
+const strandColors = {
+  pos: 'red',
+  neg: 'blue',
 }
 
-type ColorScheme = keyof typeof colorSchemes
+type SyriType = keyof typeof syriColors
+type CigarOp = keyof typeof cigarColors
+
+// Normalize chromosome name for comparison across assemblies
+// Handles common variations: chr1/1/Chr1/CHR1, chrM/MT/M, etc.
+function normalizeChromosomeName(name: string): string {
+  if (!name) {
+    return ''
+  }
+  // Remove common prefixes (case-insensitive)
+  let normalized = name.replace(/^chr/i, '')
+  // Normalize mitochondrial chromosome names
+  if (normalized === 'M' || normalized === 'MT' || normalized === 'Mt') {
+    normalized = 'M'
+  }
+  // Normalize to lowercase for comparison
+  return normalized.toLowerCase()
+}
 
 // Classify a synteny feature as SYN, INV, TRANS, or DUP based on syri conventions
-// SYN: same chromosome, forward strand
-// INV: same chromosome, reverse strand
-// TRANS: different chromosomes
-// DUP: currently not detected (would need overlap analysis)
 function classifySyriType(
   queryRefName: string,
-  mateRefName: string,
+  mateRefName: string | undefined,
   strand: number,
-): keyof typeof syriColors {
-  // Compare refNames to detect translocations
-  // Note: This is a simplification - true translocation detection would need
-  // to account for chromosome naming differences between assemblies
-  if (queryRefName !== mateRefName) {
+): SyriType {
+  // Compare normalized refNames to detect translocations
+  const normalizedQuery = normalizeChromosomeName(queryRefName)
+  const normalizedMate = normalizeChromosomeName(mateRefName || '')
+
+  if (normalizedQuery !== normalizedMate) {
     return 'TRANS'
   }
   // Same chromosome - check strand for inversion
@@ -110,19 +101,122 @@ function classifySyriType(
 }
 
 function applyAlpha(color: string, alpha: number) {
-  // Skip colord processing if alpha is 1 (optimization)
   if (alpha === 1) {
     return color
   }
   return colord(color).alpha(alpha).toHex()
 }
 
-const lineLimit = 3
+// Process a CIGAR operation and update positions
+// Returns the new cx1, cx2 values
+function processCigarOp(
+  op: string,
+  len: number,
+  cx1: number,
+  cx2: number,
+  rev1: number,
+  rev2: number,
+  bpPerPxInv0: number,
+  bpPerPxInv1: number,
+): [number, number] {
+  const d1 = len * bpPerPxInv0
+  const d2 = len * bpPerPxInv1
 
+  if (op === 'M' || op === '=' || op === 'X') {
+    return [cx1 + d1 * rev1, cx2 + d2 * rev2]
+  }
+  if (op === 'D' || op === 'N') {
+    return [cx1 + d1 * rev1, cx2]
+  }
+  if (op === 'I') {
+    return [cx1, cx2 + d2 * rev2]
+  }
+  return [cx1, cx2]
+}
+
+const lineLimit = 3
 const oobLimit = 1600
 
 export function getId(r: number, g: number, b: number, unitMultiplier: number) {
   return Math.floor((r * 255 * 255 + g * 255 + b - 1) / unitMultiplier)
+}
+
+// Color resolver that handles all colorBy modes
+interface ColorResolver {
+  getMatchColor: (
+    strand: number,
+    refName: string,
+    mateRefName: string | undefined,
+  ) => string
+  getCigarColor: (op: CigarOp) => string
+  defaultColor: string
+}
+
+function createColorResolver(
+  colorBy: string,
+  alpha: number,
+  queryColorCache: Map<string, string>,
+): ColorResolver {
+  // Pre-calculate colors with alpha for the active mode only
+  const cigarColorsWithAlpha = {
+    I: applyAlpha(cigarColors.I, alpha),
+    N: applyAlpha(cigarColors.N, alpha),
+    D: applyAlpha(cigarColors.D, alpha),
+    X: applyAlpha(cigarColors.X, alpha),
+    M: applyAlpha(cigarColors.M, alpha),
+    '=': applyAlpha(cigarColors['='], alpha),
+  }
+
+  const defaultColor = cigarColorsWithAlpha.M
+
+  const getQueryColorWithAlpha = (queryName: string) => {
+    if (!queryColorCache.has(queryName)) {
+      queryColorCache.set(queryName, applyAlpha(getQueryColor(queryName), alpha))
+    }
+    return queryColorCache.get(queryName)!
+  }
+
+  if (colorBy === 'strand') {
+    const posColor = applyAlpha(strandColors.pos, alpha)
+    const negColor = applyAlpha(strandColors.neg, alpha)
+    return {
+      getMatchColor: strand => (strand === -1 ? negColor : posColor),
+      getCigarColor: op => cigarColorsWithAlpha[op],
+      defaultColor,
+    }
+  }
+
+  if (colorBy === 'query') {
+    return {
+      getMatchColor: (_strand, refName) => getQueryColorWithAlpha(refName),
+      getCigarColor: op => cigarColorsWithAlpha[op],
+      defaultColor,
+    }
+  }
+
+  if (colorBy === 'syri') {
+    const syriColorsWithAlpha = {
+      SYN: applyAlpha(syriColors.SYN, alpha),
+      INV: applyAlpha(syriColors.INV, alpha),
+      TRANS: applyAlpha(syriColors.TRANS, alpha),
+      DUP: applyAlpha(syriColors.DUP, alpha),
+    }
+    return {
+      getMatchColor: (strand, refName, mateRefName) => {
+        const syriType = classifySyriType(refName, mateRefName, strand)
+        return syriColorsWithAlpha[syriType]
+      },
+      getCigarColor: op => cigarColorsWithAlpha[op],
+      defaultColor,
+    }
+  }
+
+  // Default mode - use CIGAR colors for everything
+  return {
+    getMatchColor: () => defaultColor,
+    getCigarColor: op => cigarColorsWithAlpha[op],
+    defaultColor,
+  }
 }
 
 export function drawCigarClickMap(
@@ -130,120 +224,107 @@ export function drawCigarClickMap(
   cigarClickMapCanvas: CanvasRenderingContext2D,
 ) {
   const view = getContainingView(model) as LinearSyntenyViewModel
-  const drawCurves = view.drawCurves
-  const drawCIGAR = view.drawCIGAR
-  const drawCIGARMatchesOnly = view.drawCIGARMatchesOnly
+  const { drawCurves, drawCIGAR, drawCIGARMatchesOnly, width } = view
   const { level, height, featPositions } = model
-  const width = view.width
   const bpPerPxs = view.views.map(v => v.bpPerPx)
 
   cigarClickMapCanvas.imageSmoothingEnabled = false
   cigarClickMapCanvas.clearRect(0, 0, width, height)
 
   const offsets = view.views.map(v => v.offsetPx)
-
-  // Cache reciprocals for division in CIGAR loop
+  const offsetL0 = offsets[level]!
+  const offsetL1 = offsets[level + 1]!
   const bpPerPxInv0 = 1 / bpPerPxs[level]!
   const bpPerPxInv1 = 1 / bpPerPxs[level + 1]!
+  const y1 = 0
+  const y2 = height
+  const mid = height / 2
 
   for (const { p11, p12, p21, p22, f, cigar } of featPositions) {
-    const x11 = p11.offsetPx - offsets[level]!
-    const x12 = p12.offsetPx - offsets[level]!
-    const x21 = p21.offsetPx - offsets[level + 1]!
-    const x22 = p22.offsetPx - offsets[level + 1]!
+    const x11 = p11.offsetPx - offsetL0
+    const x12 = p12.offsetPx - offsetL0
+    const x21 = p21.offsetPx - offsetL1
+    const x22 = p22.offsetPx - offsetL1
     const l1 = Math.abs(x12 - x11)
     const l2 = Math.abs(x22 - x21)
     const minX = Math.min(x21, x22)
     const maxX = Math.max(x21, x22)
-    const y1 = 0
-    const y2 = height
-    const mid = (y2 - y1) / 2
 
     if (
-      !(l1 <= lineLimit && l2 <= lineLimit) &&
-      doesIntersect2(minX, maxX, -oobLimit, view.width + oobLimit)
+      l1 <= lineLimit &&
+      l2 <= lineLimit
     ) {
-      const s1 = f.get('strand')
-      const k1 = s1 === -1 ? x12 : x11
-      const k2 = s1 === -1 ? x11 : x12
+      continue
+    }
+    if (!doesIntersect2(minX, maxX, -oobLimit, width + oobLimit)) {
+      continue
+    }
+    if (!cigar.length || !drawCIGAR) {
+      continue
+    }
 
-      const rev1 = k1 < k2 ? 1 : -1
-      const rev2 = (x21 < x22 ? 1 : -1) * s1
+    const s1 = f.get('strand')
+    const k1 = s1 === -1 ? x12 : x11
+    const k2 = s1 === -1 ? x11 : x12
+    const rev1 = k1 < k2 ? 1 : -1
+    const rev2 = (x21 < x22 ? 1 : -1) * s1
 
-      let cx1 = k1
-      let cx2 = s1 === -1 ? x22 : x21
-      if (cigar.length && drawCIGAR) {
-        let continuingFlag = false
-        let px1 = 0
-        let px2 = 0
-        const unitMultiplier2 = Math.floor(MAX_COLOR_RANGE / cigar.length)
+    let cx1 = k1
+    let cx2 = s1 === -1 ? x22 : x21
+    let continuingFlag = false
+    let px1 = 0
+    let px2 = 0
+    const unitMultiplier2 = Math.floor(MAX_COLOR_RANGE / cigar.length)
 
-        for (let j = 0; j < cigar.length; j += 2) {
-          const len = +cigar[j]!
-          const op = cigar[j + 1] as keyof typeof defaultCigarColors
+    for (let j = 0; j < cigar.length; j += 2) {
+      const len = +cigar[j]!
+      const op = cigar[j + 1]!
 
-          if (!continuingFlag) {
-            px1 = cx1
-            px2 = cx2
-          }
+      if (!continuingFlag) {
+        px1 = cx1
+        px2 = cx2
+      }
 
-          const d1 = len * bpPerPxInv0
-          const d2 = len * bpPerPxInv1
+      ;[cx1, cx2] = processCigarOp(
+        op,
+        len,
+        cx1,
+        cx2,
+        rev1,
+        rev2,
+        bpPerPxInv0,
+        bpPerPxInv1,
+      )
 
-          if (op === 'M' || op === '=' || op === 'X') {
-            cx1 += d1 * rev1
-            cx2 += d2 * rev2
-          } else if (op === 'D' || op === 'N') {
-            cx1 += d1 * rev1
-          }
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          else if (op === 'I') {
-            cx2 += d2 * rev2
-          }
+      // Skip if entirely out of view
+      if (
+        Math.max(px1, px2, cx1, cx2) < 0 ||
+        Math.min(px1, px2, cx1, cx2) > width
+      ) {
+        continue
+      }
 
-          if (
-            !(
-              Math.max(px1, px2, cx1, cx2) < 0 ||
-              Math.min(px1, px2, cx1, cx2) > width
-            )
-          ) {
-            const isNotLast = j < cigar.length - 2
-            if (
-              Math.abs(cx1 - px1) <= 1 &&
-              Math.abs(cx2 - px2) <= 1 &&
-              isNotLast
-            ) {
-              continuingFlag = true
-            } else {
-              continuingFlag = false
-              // When drawCIGARMatchesOnly is enabled, only draw match operations (M, =, X)
-              // Skip insertions (I) and deletions (D, N)
-              // Also skip very thin rectangles which tend to be glitchy
-              const shouldDraw =
-                !drawCIGARMatchesOnly ||
-                ((op === 'M' || op === '=' || op === 'X') &&
-                  Math.abs(cx1 - px1) > 1 &&
-                  Math.abs(cx2 - px2) > 1)
+      const isNotLast = j < cigar.length - 2
+      if (
+        Math.abs(cx1 - px1) <= 1 &&
+        Math.abs(cx2 - px2) <= 1 &&
+        isNotLast
+      ) {
+        continuingFlag = true
+        continue
+      }
 
-              if (shouldDraw) {
-                const idx = j * unitMultiplier2 + 1
-                cigarClickMapCanvas.fillStyle = makeColor(idx)
-                draw(
-                  cigarClickMapCanvas,
-                  px1,
-                  cx1,
-                  y1,
-                  cx2,
-                  px2,
-                  y2,
-                  mid,
-                  drawCurves,
-                )
-                cigarClickMapCanvas.fill()
-              }
-            }
-          }
-        }
+      continuingFlag = false
+      const isMatch = op === 'M' || op === '=' || op === 'X'
+      const shouldDraw =
+        !drawCIGARMatchesOnly ||
+        (isMatch && Math.abs(cx1 - px1) > 1 && Math.abs(cx2 - px2) > 1)
+
+      if (shouldDraw) {
+        const idx = j * unitMultiplier2 + 1
+        cigarClickMapCanvas.fillStyle = makeColor(idx)
+        draw(cigarClickMapCanvas, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
+        cigarClickMapCanvas.fill()
       }
     }
   }
@@ -254,168 +335,92 @@ export function drawRef(
   mainCanvas: CanvasRenderingContext2D,
 ) {
   const view = getContainingView(model) as LinearSyntenyViewModel
-  const drawCurves = view.drawCurves
-  const drawCIGAR = view.drawCIGAR
-  const drawCIGARMatchesOnly = view.drawCIGARMatchesOnly
-  const drawLocationMarkersEnabled = view.drawLocationMarkers
+  const {
+    drawCurves,
+    drawCIGAR,
+    drawCIGARMatchesOnly,
+    drawLocationMarkers: drawLocationMarkersEnabled,
+    width,
+  } = view
   const { level, height, featPositions, alpha, minAlignmentLength, colorBy } =
     model
-  const width = view.width
   const bpPerPxs = view.views.map(v => v.bpPerPx)
+  const offsets = view.views.map(v => v.offsetPx)
+  const offsetL0 = offsets[level]!
+  const offsetL1 = offsets[level + 1]!
+  const bpPerPx0 = bpPerPxs[level]!
+  const bpPerPx1 = bpPerPxs[level + 1]!
+  const bpPerPxInv0 = 1 / bpPerPx0
+  const bpPerPxInv1 = 1 / bpPerPx1
+  const y1 = 0
+  const y2 = height
+  const mid = height / 2
 
-  // Calculate total alignment length per query sequence
-  // Group by query name and sum up all alignment lengths
-  const queryTotalLengths = new Map<string, number>()
+  // Pre-filter features by minAlignmentLength (improvement #3)
+  let filteredPositions = featPositions
   if (minAlignmentLength > 0) {
+    const queryTotalLengths = new Map<string, number>()
     for (const { f } of featPositions) {
       const queryName = f.get('name') || f.get('id') || f.id()
       const alignmentLength = Math.abs(f.get('end') - f.get('start'))
       const currentTotal = queryTotalLengths.get(queryName) || 0
       queryTotalLengths.set(queryName, currentTotal + alignmentLength)
     }
+    filteredPositions = featPositions.filter(({ f }) => {
+      const queryName = f.get('name') || f.get('id') || f.id()
+      return (queryTotalLengths.get(queryName) || 0) >= minAlignmentLength
+    })
   }
 
-  // Get the appropriate color map for the current scheme
-  const schemeConfig =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    colorSchemes[colorBy as ColorScheme] || colorSchemes.default
-  const activeColorMap = schemeConfig.cigarColors
-
-  // Define colors for strand-based coloring
-  const posColor = colorBy === 'strand' ? colorSchemes.strand.posColor : 'red'
-  const negColor = colorBy === 'strand' ? colorSchemes.strand.negColor : 'blue'
-
-  // Precalculate colors with alpha applied to avoid repeated calls
-  const colorMapWithAlpha = {
-    I: applyAlpha(activeColorMap.I, alpha),
-    N: applyAlpha(activeColorMap.N, alpha),
-    D: applyAlpha(activeColorMap.D, alpha),
-    X: applyAlpha(activeColorMap.X, alpha),
-    M: applyAlpha(activeColorMap.M, alpha),
-    '=': applyAlpha(activeColorMap['='], alpha),
-  }
-
-  // Precalculate strand colors with alpha
-  const posColorWithAlpha = applyAlpha(posColor, alpha)
-  const negColorWithAlpha = applyAlpha(negColor, alpha)
-
-  // Precalculate syri colors with alpha
-  const useSyriColor = colorBy === 'syri'
-  const syriColorsWithAlpha = useSyriColor
-    ? {
-        SYN: applyAlpha(syriColors.SYN, alpha),
-        INV: applyAlpha(syriColors.INV, alpha),
-        TRANS: applyAlpha(syriColors.TRANS, alpha),
-        DUP: applyAlpha(syriColors.DUP, alpha),
-      }
-    : null
-
-  // Cache for query colors with alpha applied
+  // Create color resolver (handles all colorBy modes - improvement #8)
   const queryColorCache = new Map<string, string>()
+  const colors = createColorResolver(colorBy, alpha, queryColorCache)
+  const useCustomColor = colorBy !== 'default'
 
-  const getQueryColorWithAlpha = (queryName: string) => {
-    if (!queryColorCache.has(queryName)) {
-      const color = getQueryColor(queryName)
-      queryColorCache.set(queryName, applyAlpha(color, alpha))
-    }
-    return queryColorCache.get(queryName)!
-  }
-
-  mainCanvas.beginPath()
-  const offsets = view.views.map(v => v.offsetPx)
-  const offsetsL0 = offsets[level]!
-  const offsetsL1 = offsets[level + 1]!
-  const unitMultiplier = Math.floor(MAX_COLOR_RANGE / featPositions.length)
-  const y1 = 0
-  const y2 = height
-  const mid = (y2 - y1) / 2
-
-  // Cache colorBy checks outside loop for performance
-  const useStrandColorThin = colorBy === 'strand'
-  const useQueryColorThin = colorBy === 'query'
-  const useSyriColorThin = colorBy === 'syri'
-
-  mainCanvas.fillStyle = colorMapWithAlpha.M
-  mainCanvas.strokeStyle = colorMapWithAlpha.M
-
-  // Group features by color to batch state changes
+  // Group thin features by color for batched drawing
   const thinLinesByColor = new Map<
     string,
-    { x11: number; x21: number; y1: number; y2: number; mid: number }[]
+    { x11: number; x21: number }[]
   >()
 
-  for (const { p11, p12, p21, p22, f } of featPositions) {
-    // Filter by total alignment length for this query sequence
-    if (minAlignmentLength > 0) {
-      const queryName = f.get('name') || f.get('id') || f.id()
-      const totalLength = queryTotalLengths.get(queryName) || 0
-      if (totalLength < minAlignmentLength) {
-        continue
-      }
-    }
-
-    const x11 = p11.offsetPx - offsetsL0
-    const x12 = p12.offsetPx - offsetsL0
-    const x21 = p21.offsetPx - offsetsL1
-    const x22 = p22.offsetPx - offsetsL1
+  for (const { p11, p12, p21, p22, f } of filteredPositions) {
+    const x11 = p11.offsetPx - offsetL0
+    const x12 = p12.offsetPx - offsetL0
+    const x21 = p21.offsetPx - offsetL1
+    const x22 = p22.offsetPx - offsetL1
     const l1 = Math.abs(x12 - x11)
     const l2 = Math.abs(x22 - x21)
 
-    // drawing a line if the results are thin results in much less pixellation
-    // than filling in a thin polygon
+    // Thin lines get batched by color for efficient drawing
     if (
       l1 <= lineLimit &&
       l2 <= lineLimit &&
       x21 < width + oobLimit &&
       x21 > -oobLimit
     ) {
-      // Determine color key for batching
-      let colorKey = 'default'
-      if (useStrandColorThin) {
-        const strand = f.get('strand')
-        colorKey = strand === -1 ? 'neg' : 'pos'
-      } else if (useQueryColorThin) {
-        colorKey = f.get('refName')
-      } else if (useSyriColorThin) {
-        const strand = f.get('strand')
-        const queryRefName = f.get('refName')
-        const mate = f.get('mate')
-        const mateRefName = mate?.refName
-        colorKey = `syri_${classifySyriType(queryRefName, mateRefName, strand)}`
-      }
+      const strand = f.get('strand')
+      const refName = f.get('refName')
+      const mate = f.get('mate')
+      const colorKey = colors.getMatchColor(strand, refName, mate?.refName)
 
       if (!thinLinesByColor.has(colorKey)) {
         thinLinesByColor.set(colorKey, [])
       }
-      thinLinesByColor.get(colorKey)!.push({ x11, x21, y1, y2, mid })
+      thinLinesByColor.get(colorKey)!.push({ x11, x21 })
     }
   }
 
-  // Now draw all thin lines batched by color
+  // Draw thin lines batched by color
   for (const [colorKey, lines] of thinLinesByColor) {
-    // Set color once for all lines in this batch
-    if (colorKey === 'pos') {
-      mainCanvas.strokeStyle = posColorWithAlpha
-    } else if (colorKey === 'neg') {
-      mainCanvas.strokeStyle = negColorWithAlpha
-    } else if (colorKey.startsWith('syri_')) {
-      const syriType = colorKey.slice(5) as keyof typeof syriColors
-      mainCanvas.strokeStyle = syriColorsWithAlpha![syriType]
-    } else if (colorKey !== 'default') {
-      mainCanvas.strokeStyle = getQueryColorWithAlpha(colorKey)
-    } else {
-      mainCanvas.strokeStyle = colorMapWithAlpha.M
-    }
-
-    // Create single path for all lines with same color
+    mainCanvas.strokeStyle = colorKey
     mainCanvas.beginPath()
     if (drawCurves) {
-      for (const { x11, x21, y1, y2, mid } of lines) {
+      for (const { x11, x21 } of lines) {
         mainCanvas.moveTo(x11, y1)
         mainCanvas.bezierCurveTo(x11, mid, x21, mid, x21, y2)
       }
     } else {
-      for (const { x11, x21, y1, y2 } of lines) {
+      for (const { x11, x21 } of lines) {
         mainCanvas.moveTo(x11, y1)
         mainCanvas.lineTo(x21, y2)
       }
@@ -423,198 +428,132 @@ export function drawRef(
     mainCanvas.stroke()
   }
 
-  // Cache bpPerPx values and reciprocals for division in CIGAR loop
-  const bpPerPx0 = bpPerPxs[level]!
-  const bpPerPx1 = bpPerPxs[level + 1]!
-  const bpPerPxInv0 = 1 / bpPerPx0
-  const bpPerPxInv1 = 1 / bpPerPx1
-
-  // Cache colorBy checks outside loop for performance
-  const useStrandColor = colorBy === 'strand'
-  const useQueryColor = colorBy === 'query'
-
-  mainCanvas.fillStyle = colorMapWithAlpha.M
-  mainCanvas.strokeStyle = colorMapWithAlpha.M
-  for (const { p11, p12, p21, p22, f, cigar } of featPositions) {
-    // Cache feature properties at loop start
+  // Draw thick features (with CIGAR if available)
+  mainCanvas.fillStyle = colors.defaultColor
+  for (const { p11, p12, p21, p22, f, cigar } of filteredPositions) {
     const strand = f.get('strand')
     const refName = f.get('refName')
-    const mate = useSyriColor ? f.get('mate') : null
+    const mate = f.get('mate')
     const mateRefName = mate?.refName
 
-    // Filter by total alignment length for this query sequence
-    if (minAlignmentLength > 0) {
-      const queryName = f.get('name') || f.get('id') || f.id()
-      const totalLength = queryTotalLengths.get(queryName) || 0
-      if (totalLength < minAlignmentLength) {
-        continue
-      }
-    }
-
-    const x11 = p11.offsetPx - offsetsL0
-    const x12 = p12.offsetPx - offsetsL0
-    const x21 = p21.offsetPx - offsetsL1
-    const x22 = p22.offsetPx - offsetsL1
+    const x11 = p11.offsetPx - offsetL0
+    const x12 = p12.offsetPx - offsetL0
+    const x21 = p21.offsetPx - offsetL1
+    const x22 = p22.offsetPx - offsetL1
     const l1 = Math.abs(x12 - x11)
     const l2 = Math.abs(x22 - x21)
+
+    // Skip thin features (already drawn above)
+    if (l1 <= lineLimit && l2 <= lineLimit) {
+      continue
+    }
+
     const minX = Math.min(x21, x22)
     const maxX = Math.max(x21, x22)
+    if (!doesIntersect2(minX, maxX, -oobLimit, width + oobLimit)) {
+      continue
+    }
 
-    if (
-      !(l1 <= lineLimit && l2 <= lineLimit) &&
-      doesIntersect2(minX, maxX, -oobLimit, view.width + oobLimit)
-    ) {
-      const s1 = strand
-      const k1 = s1 === -1 ? x12 : x11
-      const k2 = s1 === -1 ? x11 : x12
+    const k1 = strand === -1 ? x12 : x11
+    const k2 = strand === -1 ? x11 : x12
+    const rev1 = k1 < k2 ? 1 : -1
+    const rev2 = (x21 < x22 ? 1 : -1) * strand
 
-      // rev1/rev2 flip the direction of the CIGAR drawing in horizontally flipped
-      // modes. somewhat heuristically determined, but tested for
-      const rev1 = k1 < k2 ? 1 : -1
-      const rev2 = (x21 < x22 ? 1 : -1) * s1
-
-      // cx1/cx2 are the current x positions on top and bottom rows
+    if (cigar.length && drawCIGAR) {
       let cx1 = k1
-      let cx2 = s1 === -1 ? x22 : x21
-      if (cigar.length && drawCIGAR) {
-        // continuingFlag skips drawing commands on very small CIGAR features
-        let continuingFlag = false
+      let cx2 = strand === -1 ? x22 : x21
+      let continuingFlag = false
+      let px1 = 0
+      let px2 = 0
 
-        // px1/px2 are the previous x positions on the top and bottom rows
-        let px1 = 0
-        let px2 = 0
+      for (let j = 0; j < cigar.length; j += 2) {
+        const len = +cigar[j]!
+        const op = cigar[j + 1]!
 
-        for (let j = 0; j < cigar.length; j += 2) {
-          const len = +cigar[j]!
-          const op = cigar[j + 1] as keyof typeof defaultCigarColors
-
-          if (!continuingFlag) {
-            px1 = cx1
-            px2 = cx2
-          }
-
-          const d1 = len * bpPerPxInv0
-          const d2 = len * bpPerPxInv1
-
-          if (op === 'M' || op === '=' || op === 'X') {
-            cx1 += d1 * rev1
-            cx2 += d2 * rev2
-          } else if (op === 'D' || op === 'N') {
-            cx1 += d1 * rev1
-          }
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          else if (op === 'I') {
-            cx2 += d2 * rev2
-          }
-
-          // check that we are even drawing in view here, e.g. that all
-          // points are not all less than 0 or greater than width
-          if (
-            !(
-              Math.max(px1, px2, cx1, cx2) < 0 ||
-              Math.min(px1, px2, cx1, cx2) > width
-            )
-          ) {
-            // if it is a small feature and not the last element of the
-            // CIGAR (which could skip rendering it entire if we did turn
-            // it on), then turn on continuing flag
-            const isNotLast = j < cigar.length - 2
-            if (
-              Math.abs(cx1 - px1) <= 1 &&
-              Math.abs(cx2 - px2) <= 1 &&
-              isNotLast
-            ) {
-              continuingFlag = true
-            } else {
-              // allow rendering the dominant color when using continuing
-              // flag if the last element of continuing was a large
-              // feature, else just use match
-              const letter = (continuingFlag && d1 > 1) || d2 > 1 ? op : 'M'
-
-              // Use custom coloring based on colorBy setting
-              // Always keep yellow/blue for insertions/deletions regardless of colorBy
-              const isInsertionOrDeletion =
-                letter === 'I' || letter === 'D' || letter === 'N'
-              if (useStrandColor && !isInsertionOrDeletion) {
-                mainCanvas.fillStyle =
-                  strand === -1 ? negColorWithAlpha : posColorWithAlpha
-              } else if (useQueryColor && !isInsertionOrDeletion) {
-                mainCanvas.fillStyle = getQueryColorWithAlpha(refName)
-              } else if (useSyriColor && !isInsertionOrDeletion) {
-                const syriType = classifySyriType(refName, mateRefName, strand)
-                mainCanvas.fillStyle = syriColorsWithAlpha![syriType]
-              } else {
-                mainCanvas.fillStyle = colorMapWithAlpha[letter]
-              }
-
-              continuingFlag = false
-
-              if (drawCIGARMatchesOnly) {
-                if (letter === 'M') {
-                  draw(mainCanvas, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
-                  mainCanvas.fill()
-                  if (drawLocationMarkersEnabled) {
-                    drawLocationMarkers(
-                      mainCanvas,
-                      px1,
-                      cx1,
-                      y1,
-                      cx2,
-                      px2,
-                      y2,
-                      mid,
-                      bpPerPx0,
-                      bpPerPx1,
-                      drawCurves,
-                    )
-                  }
-                }
-              } else {
-                draw(mainCanvas, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
-                mainCanvas.fill()
-                if (drawLocationMarkersEnabled) {
-                  drawLocationMarkers(
-                    mainCanvas,
-                    px1,
-                    cx1,
-                    y1,
-                    cx2,
-                    px2,
-                    y2,
-                    mid,
-                    bpPerPx0,
-                    bpPerPx1,
-                    drawCurves,
-                  )
-                }
-              }
-            }
-          }
-        }
-      } else {
-        // Use custom coloring based on colorBy setting
-        if (useStrandColor) {
-          mainCanvas.fillStyle =
-            strand === -1 ? negColorWithAlpha : posColorWithAlpha
-        } else if (useQueryColor) {
-          mainCanvas.fillStyle = getQueryColorWithAlpha(refName)
-        } else if (useSyriColor) {
-          const syriType = classifySyriType(refName, mateRefName, strand)
-          mainCanvas.fillStyle = syriColorsWithAlpha![syriType]
+        if (!continuingFlag) {
+          px1 = cx1
+          px2 = cx2
         }
 
-        draw(mainCanvas, x11, x12, y1, x22, x21, y2, mid, drawCurves)
+        const d1 = len * bpPerPxInv0
+        ;[cx1, cx2] = processCigarOp(
+          op,
+          len,
+          cx1,
+          cx2,
+          rev1,
+          rev2,
+          bpPerPxInv0,
+          bpPerPxInv1,
+        )
+
+        // Skip if entirely out of view
+        if (
+          Math.max(px1, px2, cx1, cx2) < 0 ||
+          Math.min(px1, px2, cx1, cx2) > width
+        ) {
+          continue
+        }
+
+        const isNotLast = j < cigar.length - 2
+        if (
+          Math.abs(cx1 - px1) <= 1 &&
+          Math.abs(cx2 - px2) <= 1 &&
+          isNotLast
+        ) {
+          continuingFlag = true
+          continue
+        }
+
+        const letter = (continuingFlag && d1 > 1) ? op : 'M'
+        continuingFlag = false
+
+        // Use match color for non-indel operations, CIGAR colors for indels
+        const isIndel = letter === 'I' || letter === 'D' || letter === 'N'
+        if (useCustomColor && !isIndel) {
+          mainCanvas.fillStyle = colors.getMatchColor(
+            strand,
+            refName,
+            mateRefName,
+          )
+        } else {
+          mainCanvas.fillStyle = colors.getCigarColor(letter as CigarOp)
+        }
+
+        const isMatch = letter === 'M' || letter === '=' || letter === 'X'
+        if (drawCIGARMatchesOnly && !isMatch) {
+          continue
+        }
+
+        draw(mainCanvas, px1, cx1, y1, cx2, px2, y2, mid, drawCurves)
         mainCanvas.fill()
-
-        // Reset to default color if needed
-        if (useStrandColor || useQueryColor || useSyriColor) {
-          mainCanvas.fillStyle = colorMapWithAlpha.M
+        if (drawLocationMarkersEnabled) {
+          drawLocationMarkers(
+            mainCanvas,
+            px1,
+            cx1,
+            y1,
+            cx2,
+            px2,
+            y2,
+            mid,
+            bpPerPx0,
+            bpPerPx1,
+            drawCurves,
+          )
         }
       }
+    } else {
+      // No CIGAR - draw simple shape
+      if (useCustomColor) {
+        mainCanvas.fillStyle = colors.getMatchColor(strand, refName, mateRefName)
+      }
+      draw(mainCanvas, x11, x12, y1, x22, x21, y2, mid, drawCurves)
+      mainCanvas.fill()
     }
   }
 
-  // draw click map
+  // Draw click map
   const ctx2 = model.clickMapCanvas?.getContext('2d')
   if (!ctx2) {
     return
@@ -622,24 +561,12 @@ export function drawRef(
   ctx2.imageSmoothingEnabled = false
   ctx2.clearRect(0, 0, width, height)
 
-  // eslint-disable-next-line unicorn/no-for-loop
-  for (let i = 0; i < featPositions.length; i++) {
-    const feature = featPositions[i]!
-
-    // Filter by total alignment length for this query sequence
-    if (minAlignmentLength > 0) {
-      const queryName =
-        feature.f.get('name') || feature.f.get('id') || feature.f.id()
-      const totalLength = queryTotalLengths.get(queryName) || 0
-      if (totalLength < minAlignmentLength) {
-        continue
-      }
-    }
-
+  const unitMultiplier = Math.floor(MAX_COLOR_RANGE / filteredPositions.length)
+  for (let i = 0; i < filteredPositions.length; i++) {
+    const feature = filteredPositions[i]!
     const idx = i * unitMultiplier + 1
     ctx2.fillStyle = makeColor(idx)
 
-    // too many click map false positives with colored stroked lines
     drawMatchSimple({
       cb: ctx => {
         ctx.fill()
@@ -650,7 +577,7 @@ export function drawRef(
       level,
       offsets,
       oobLimit,
-      viewWidth: view.width,
+      viewWidth: width,
       hideTiny: true,
       height,
     })

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
@@ -112,14 +112,6 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        * minimum alignment length to display (in bp)
        */
       minAlignmentLength: 0,
-
-      /**
-       * #volatile
-       * Maps query chromosome names to their best-matching target chromosome
-       * based on alignment coverage. Used by syri color mode to detect
-       * translocations (alignments to non-matching chromosomes).
-       */
-      chromosomeMapping: null as Map<string, string> | null,
     }))
     .actions(self => ({
       /**
@@ -187,13 +179,6 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       setColorBy(value: string) {
         self.colorBy = value
-      },
-      /**
-       * #action
-       * Sets the chromosome mapping based on alignment coverage analysis
-       */
-      setChromosomeMapping(mapping: Map<string, string> | null) {
-        self.chromosomeMapping = mapping
       },
     }))
 

--- a/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyDisplay/model.ts
@@ -112,6 +112,14 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        * minimum alignment length to display (in bp)
        */
       minAlignmentLength: 0,
+
+      /**
+       * #volatile
+       * Maps query chromosome names to their best-matching target chromosome
+       * based on alignment coverage. Used by syri color mode to detect
+       * translocations (alignments to non-matching chromosomes).
+       */
+      chromosomeMapping: null as Map<string, string> | null,
     }))
     .actions(self => ({
       /**
@@ -179,6 +187,13 @@ function stateModelFactory(configSchema: AnyConfigurationSchemaType) {
        */
       setColorBy(value: string) {
         self.colorBy = value
+      },
+      /**
+       * #action
+       * Sets the chromosome mapping based on alignment coverage analysis
+       */
+      setChromosomeMapping(mapping: Map<string, string> | null) {
+        self.chromosomeMapping = mapping
       },
     }))
 

--- a/products/jbrowse-cli/src/commands/make-pif/syri-utils.ts
+++ b/products/jbrowse-cli/src/commands/make-pif/syri-utils.ts
@@ -1,0 +1,174 @@
+/**
+ * SyRI-style classification utilities for make-pif command.
+ * Computes syriType (SYN, INV, TRANS, DUP) for PAF records.
+ */
+
+export type SyriType = 'SYN' | 'INV' | 'TRANS' | 'DUP'
+
+export interface PAFRecord {
+  qname: string
+  qstart: number
+  qend: number
+  tname: string
+  tstart: number
+  tend: number
+  strand: number
+  index: number
+}
+
+/**
+ * Parse a PAF line into a record for syri computation.
+ */
+export function parsePAFLineForSyri(line: string, index: number): PAFRecord {
+  const fields = line.split('\t')
+  return {
+    qname: fields[0]!,
+    qstart: +fields[2]!,
+    qend: +fields[3]!,
+    tname: fields[5]!,
+    tstart: +fields[7]!,
+    tend: +fields[8]!,
+    strand: fields[4] === '-' ? -1 : 1,
+    index,
+  }
+}
+
+/**
+ * Build a mapping from query chromosomes to their primary target chromosome
+ * based on total alignment coverage.
+ */
+function buildChromosomeMapping(records: PAFRecord[]): Map<string, string> {
+  const coverageMap = new Map<string, Map<string, number>>()
+
+  for (const r of records) {
+    const { qname, tname, qstart, qend } = r
+    const alignmentLength = Math.abs(qend - qstart)
+
+    if (!coverageMap.has(qname)) {
+      coverageMap.set(qname, new Map())
+    }
+    const targetMap = coverageMap.get(qname)!
+    const currentCoverage = targetMap.get(tname) || 0
+    targetMap.set(tname, currentCoverage + alignmentLength)
+  }
+
+  const mapping = new Map<string, string>()
+  for (const [qname, targetMap] of coverageMap) {
+    let bestTarget = ''
+    let bestCoverage = 0
+    for (const [tname, coverage] of targetMap) {
+      if (coverage > bestCoverage) {
+        bestCoverage = coverage
+        bestTarget = tname
+      }
+    }
+    if (bestTarget) {
+      mapping.set(qname, bestTarget)
+    }
+  }
+
+  return mapping
+}
+
+/**
+ * Detect duplications by finding query regions that map to multiple
+ * non-collinear locations on the same target chromosome.
+ */
+function detectDuplications(
+  records: PAFRecord[],
+  chromosomeMapping: Map<string, string>,
+): Set<number> {
+  const duplicateIndices = new Set<number>()
+
+  // Group records by query chromosome
+  const recordsByQuery = new Map<string, PAFRecord[]>()
+  for (const record of records) {
+    const { qname } = record
+    if (!recordsByQuery.has(qname)) {
+      recordsByQuery.set(qname, [])
+    }
+    recordsByQuery.get(qname)!.push(record)
+  }
+
+  // For each query chromosome, check for non-collinear mappings
+  for (const [qname, queryRecords] of recordsByQuery) {
+    const expectedTarget = chromosomeMapping.get(qname)
+    if (!expectedTarget) {
+      continue
+    }
+
+    // Get records that map to the expected target
+    const recordsToExpectedTarget = queryRecords.filter(
+      r => r.tname === expectedTarget,
+    )
+
+    if (recordsToExpectedTarget.length <= 1) {
+      continue
+    }
+
+    // Sort by query position
+    recordsToExpectedTarget.sort((a, b) => a.qstart - b.qstart)
+
+    // Check for non-monotonic target positions
+    for (let i = 1; i < recordsToExpectedTarget.length; i++) {
+      const prev = recordsToExpectedTarget[i - 1]!
+      const curr = recordsToExpectedTarget[i]!
+
+      const queryGap = curr.qstart - prev.qend
+      const prevTargetEnd = Math.max(prev.tstart, prev.tend)
+      const currTargetStart = Math.min(curr.tstart, curr.tend)
+      const targetGap = Math.abs(currTargetStart - prevTargetEnd)
+
+      // If target gap is much larger than query gap, might be duplication
+      if (queryGap >= 0 && queryGap < 50000 && targetGap > queryGap * 10 && targetGap > 100000) {
+        duplicateIndices.add(prev.index)
+        duplicateIndices.add(curr.index)
+      }
+    }
+  }
+
+  return duplicateIndices
+}
+
+/**
+ * Classify a single record as SYN, INV, TRANS, or DUP.
+ */
+function classifySyriType(
+  record: PAFRecord,
+  chromosomeMapping: Map<string, string>,
+  isDuplicate: boolean,
+): SyriType {
+  if (isDuplicate) {
+    return 'DUP'
+  }
+
+  const { qname, tname, strand } = record
+  const expectedTarget = chromosomeMapping.get(qname)
+
+  if (expectedTarget && tname && expectedTarget !== tname) {
+    return 'TRANS'
+  }
+
+  if (strand === -1) {
+    return 'INV'
+  }
+
+  return 'SYN'
+}
+
+/**
+ * Compute SyRI types for all records.
+ * Call this once with all records, then use the returned Map to look up types.
+ */
+export function computeSyriTypesMap(records: PAFRecord[]): Map<number, SyriType> {
+  const chromosomeMapping = buildChromosomeMapping(records)
+  const duplicateIndices = detectDuplications(records, chromosomeMapping)
+
+  const syriTypes = new Map<number, SyriType>()
+  for (const record of records) {
+    const isDuplicate = duplicateIndices.has(record.index)
+    syriTypes.set(record.index, classifySyriType(record, chromosomeMapping, isDuplicate))
+  }
+
+  return syriTypes
+}


### PR DESCRIPTION
This PR tries to add support for plotting SyRI data and a SyRI style color scheme

Not complete yet, but SyRI has a nice algorithm that automatically identifies duplications, translocations, and inversions when comparing two genomes. This is actually not necessarily easy to do...the analysis could potentially be done on-the-fly in the jbrowse app but it uses some analysis steps that aren't immediately obvious from just inspecting individual alignments. Techniques described in their 2019 paper https://link.springer.com/article/10.1186/s13059-019-1911-0