### PR TITLE
Update link to color by pair orientation guide in docs

### DIFF
--- a/website/docs/user_guides/alignments_track.md
+++ b/website/docs/user_guides/alignments_track.md
@@ -34,8 +34,8 @@ either be removed from the alignment (hard clipping) or can be included, and not
 shown by default (soft clipping).
 
 JBrowse 2 also contains an option to "show the soft clipping" that has occurred.
-This can be valuable to show the stopToken around a region that contains
-structural variation or difficult mappability.
+This can be valuable to show the signal around a region that contains structural
+variation or difficult mappability.
 
 <Figure caption="The soft clipping option is a toggle in the 'Pileup settings' menu." src="/img/alignments_soft_clipped_menu.png" />
 <Figure caption="Shows what turning on soft-clipping enables for a simulated long-read dataset. There is a simulated structural variant, a deletion, at this position, so the read has bases that map to the other side of the deletion being revealed by this." src="/img/alignments_soft_clipped.png" />
@@ -107,7 +107,7 @@ These pair orientations can be used to reveal complex patterns of structural
 variation.
 
 See
-[IGV's Interpreting Color by Pair Orientation guide](https://software.broadinstitute.org/software/igv/interpreting_pair_orientations)
+[IGV's Interpreting Color by Pair Orientation guide](https://igv.org/doc/desktop/#UserGuide/tracks/alignments/paired_end_alignments/#pair-orientation)
 for further details on interpreting these pair orientations.
 
 <Figure caption="This shows an inverted duplication, the tandem duplication can produce green arrows which have reads pointing in opposite directions e.g. <-- and -->, while blue arrows which can indicate an inversion point in the same direction e.g. --> and -->." src="/img/inverted_duplication.png" />


### PR DESCRIPTION
It looks like the IGV website changed and the link to their docs broke, so I updated the link to what I'm pretty sure is the right guide.

Also one typo fix.