### PR TITLE
Add browser-tests integration tests for workspaces/tiled window manager

### DIFF
--- a/packages/app-core/src/DockviewLayout/index.ts
+++ b/packages/app-core/src/DockviewLayout/index.ts
@@ -95,6 +95,68 @@ export function DockviewLayoutMixin() {
       removePanel(panelId: string) {
         self.panelViewAssignments.delete(panelId)
       },
+
+      /**
+       * #action
+       * Move a view up within its panel's view stack
+       */
+      moveViewUpInPanel(viewId: string) {
+        for (const viewIds of self.panelViewAssignments.values()) {
+          const idx = viewIds.indexOf(viewId)
+          if (idx > 0) {
+            const temp = viewIds[idx - 1]!
+            viewIds[idx - 1] = viewIds[idx]!
+            viewIds[idx] = temp
+            break
+          }
+        }
+      },
+
+      /**
+       * #action
+       * Move a view down within its panel's view stack
+       */
+      moveViewDownInPanel(viewId: string) {
+        for (const viewIds of self.panelViewAssignments.values()) {
+          const idx = viewIds.indexOf(viewId)
+          if (idx !== -1 && idx < viewIds.length - 1) {
+            const temp = viewIds[idx + 1]!
+            viewIds[idx + 1] = viewIds[idx]!
+            viewIds[idx] = temp
+            break
+          }
+        }
+      },
+
+      /**
+       * #action
+       * Move a view to the top of its panel's view stack
+       */
+      moveViewToTopInPanel(viewId: string) {
+        for (const viewIds of self.panelViewAssignments.values()) {
+          const idx = viewIds.indexOf(viewId)
+          if (idx > 0) {
+            viewIds.splice(idx, 1)
+            viewIds.unshift(viewId)
+            break
+          }
+        }
+      },
+
+      /**
+       * #action
+       * Move a view to the bottom of its panel's view stack
+       */
+      moveViewToBottomInPanel(viewId: string) {
+        for (const viewIds of self.panelViewAssignments.values()) {
+          const idx = viewIds.indexOf(viewId)
+          if (idx !== -1 && idx < viewIds.length - 1) {
+            viewIds.splice(idx, 1)
+            viewIds.push(viewId)
+            break
+          }
+        }
+      },
     }))
     .postProcessSnapshot(snap => {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/packages/app-core/src/ui/App/ViewContainer.tsx
+++ b/packages/app-core/src/ui/App/ViewContainer.tsx
@@ -65,7 +65,12 @@ const ViewContainer = observer(function ViewContainer({
   )
 
   return (
-    <Paper ref={ref} elevation={12} className={viewContainerClassName}>
+    <Paper
+      ref={ref}
+      elevation={12}
+      className={viewContainerClassName}
+      data-testid={`view-container-${view.id}`}
+    >
       <ViewHeader
         view={view}
         onClose={() => {

--- a/packages/app-core/src/ui/App/ViewMenu.tsx
+++ b/packages/app-core/src/ui/App/ViewMenu.tsx
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react'
 
 import { useDockview } from './DockviewContext.tsx'
 import { renameIds } from './copyView.ts'
+import { isSessionWithDockviewLayout } from '../../DockviewLayout/index.ts'
 
 import type { IBaseViewModel } from '@jbrowse/core/pluggableElementTypes/models'
 import type { AbstractSessionModel } from '@jbrowse/core/util'
@@ -20,6 +21,18 @@ import type {
   IconButtonProps as IconButtonPropsType,
   SvgIconProps,
 } from '@mui/material'
+
+function getPanelViewCount(session: unknown, viewId: string) {
+  if (!isSessionWithDockviewLayout(session)) {
+    return 0
+  }
+  for (const viewIds of session.panelViewAssignments.values()) {
+    if (viewIds.includes(viewId)) {
+      return viewIds.length
+    }
+  }
+  return 0
+}
 
 const ViewMenu = observer(function ViewMenu({
   model,
@@ -39,6 +52,11 @@ const ViewMenu = observer(function ViewMenu({
   }
 
   const { moveViewToNewTab, moveViewToSplitRight } = useDockview()
+  const usePanel = session.useWorkspaces && isSessionWithDockviewLayout(session)
+  const viewCount = usePanel
+    ? getPanelViewCount(session, model.id)
+    : session.views.length
+
   return (
     <CascadingMenuButton
       data-testid="view_menu_icon"
@@ -78,42 +96,58 @@ const ViewMenu = observer(function ViewMenu({
                 session.setUseWorkspaces(true)
               },
             },
-            ...(session.views.length > 2
+            ...(viewCount > 2
               ? [
                   {
                     label: 'Move view to top',
                     icon: KeyboardDoubleArrowUpIcon,
                     onClick: () => {
-                      session.moveViewToTop(model.id)
+                      if (usePanel) {
+                        session.moveViewToTopInPanel(model.id)
+                      } else {
+                        session.moveViewToTop(model.id)
+                      }
                     },
                   },
                 ]
               : []),
-            ...(session.views.length > 1
+            ...(viewCount > 1
               ? [
                   {
                     label: 'Move view up',
                     icon: KeyboardArrowUpIcon,
                     onClick: () => {
-                      session.moveViewUp(model.id)
+                      if (usePanel) {
+                        session.moveViewUpInPanel(model.id)
+                      } else {
+                        session.moveViewUp(model.id)
+                      }
                     },
                   },
                   {
                     label: 'Move view down',
                     icon: KeyboardArrowDownIcon,
                     onClick: () => {
-                      session.moveViewDown(model.id)
+                      if (usePanel) {
+                        session.moveViewDownInPanel(model.id)
+                      } else {
+                        session.moveViewDown(model.id)
+                      }
                     },
                   },
                 ]
               : []),
-            ...(session.views.length > 2
+            ...(viewCount > 2
               ? [
                   {
                     label: 'Move view to bottom',
                     icon: KeyboardDoubleArrowDownIcon,
                     onClick: () => {
-                      session.moveViewToBottom(model.id)
+                      if (usePanel) {
+                        session.moveViewToBottomInPanel(model.id)
+                      } else {
+                        session.moveViewToBottom(model.id)
+                      }
                     },
                   },
                 ]

--- a/products/jbrowse-web/browser-tests/runner.ts
+++ b/products/jbrowse-web/browser-tests/runner.ts
@@ -247,6 +247,168 @@ interface TestSuite {
 
 const testSuites: TestSuite[] = [
   {
+    name: 'Workspaces',
+    tests: [
+      {
+        name: 'move to new tab enables workspaces',
+        fn: async page => {
+          await navigateToApp(page)
+          // Open view menu
+          const viewMenu = await findByTestId(page, 'view_menu_icon', 10000)
+          await viewMenu?.click()
+          await delay(300)
+          // Click View options
+          const viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          // Click Move to new tab
+          const moveToTab = await findByText(page, 'Move to new tab', 10000)
+          await moveToTab?.click()
+          // Wait for workspaces to be enabled (dockview tabs should appear)
+          await delay(1000)
+          // Verify dockview is present
+          await page.waitForSelector(
+            '.dockview-theme-light, .dockview-theme-dark',
+            { timeout: 10000 },
+          )
+        },
+      },
+      {
+        name: 'move to split right enables workspaces',
+        fn: async page => {
+          await navigateToApp(page)
+          // Open view menu
+          const viewMenu = await findByTestId(page, 'view_menu_icon', 10000)
+          await viewMenu?.click()
+          await delay(300)
+          // Click View options
+          const viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          // Click Move to split view
+          const moveToSplit = await findByText(
+            page,
+            'Move to split view',
+            10000,
+          )
+          await moveToSplit?.click()
+          // Wait for workspaces to be enabled
+          await delay(1000)
+          // Verify dockview is present
+          await page.waitForSelector(
+            '.dockview-theme-light, .dockview-theme-dark',
+            { timeout: 10000 },
+          )
+        },
+      },
+      {
+        name: 'copy view creates second view',
+        fn: async page => {
+          await navigateToApp(page)
+          // Open view menu
+          const viewMenu = await findByTestId(page, 'view_menu_icon', 10000)
+          await viewMenu?.click()
+          await delay(300)
+          // Click View options
+          const viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          // Click Copy view
+          const copyView = await findByText(page, 'Copy view', 10000)
+          await copyView?.click()
+          await delay(1000)
+          // Should now have 2 view menus
+          const viewMenus = await page.$$('[data-testid="view_menu_icon"]')
+          if (viewMenus.length !== 2) {
+            throw new Error(`Expected 2 views, got ${viewMenus.length}`)
+          }
+        },
+      },
+      {
+        name: 'multiple views in workspace - move up and down',
+        fn: async page => {
+          await navigateToApp(page)
+          // First copy the view to get 2 views
+          let viewMenu = await findByTestId(page, 'view_menu_icon', 10000)
+          await viewMenu?.click()
+          await delay(300)
+          let viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          const copyView = await findByText(page, 'Copy view', 10000)
+          await copyView?.click()
+          await delay(1000)
+
+          // Enable workspaces by moving to new tab
+          const viewMenus = await page.$$('[data-testid="view_menu_icon"]')
+          await viewMenus[0]?.click()
+          await delay(300)
+          viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          const moveToTab = await findByText(page, 'Move to new tab', 10000)
+          await moveToTab?.click()
+          await delay(1000)
+
+          // Wait for dockview
+          await page.waitForSelector(
+            '.dockview-theme-light, .dockview-theme-dark',
+            { timeout: 10000 },
+          )
+
+          // Copy view again to have multiple views in one panel
+          viewMenu = await findByTestId(page, 'view_menu_icon', 10000)
+          await viewMenu?.click()
+          await delay(300)
+          viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          const copyView2 = await findByText(page, 'Copy view', 10000)
+          await copyView2?.click()
+          await delay(1000)
+
+          // Get the order of view containers before moving
+          const getViewOrder = () =>
+            page.evaluate(() => {
+              const containers = document.querySelectorAll(
+                '[data-testid^="view-container-"]',
+              )
+              return [...containers].map(c => c.dataset.testid)
+            })
+
+          const orderBefore = await getViewOrder()
+          if (orderBefore.length < 2) {
+            throw new Error(
+              `Expected at least 2 view containers, got ${orderBefore.length}`,
+            )
+          }
+
+          // Now try to move first view down
+          const viewMenusAfter = await page.$$('[data-testid="view_menu_icon"]')
+          await viewMenusAfter[0]?.click()
+          await delay(300)
+          viewOptions = await findByText(page, 'View options', 10000)
+          await viewOptions?.click()
+          await delay(300)
+          const moveDown = await findByText(page, 'Move view down', 10000)
+          await moveDown?.click()
+          await delay(500)
+
+          // Verify the order actually changed
+          const orderAfter = await getViewOrder()
+          if (
+            orderBefore[0] === orderAfter[0] &&
+            orderBefore[1] === orderAfter[1]
+          ) {
+            throw new Error(
+              `View order did not change after move down. Before: ${orderBefore.join(', ')}. After: ${orderAfter.join(', ')}`,
+            )
+          }
+        },
+      },
+    ],
+  },
+  {
     name: 'BasicLinearGenomeView',
     tests: [
       {

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -12,7 +12,6 @@
     "prebuild": "rimraf build",
     "postbuild": "node -e \"fs.writeFileSync('build/version.txt',JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version)\"",
     "prepack": "pnpm build",
-    "pretest:browser": "pnpm build",
     "test:browser": "node --experimental-strip-types browser-tests/runner.ts",
     "test:browser:headed": "node --experimental-strip-types browser-tests/runner.ts --headed",
     "test:browser:update": "node --experimental-strip-types browser-tests/runner.ts --update-snapshots"


### PR DESCRIPTION
The 'workspaces' concept / tiled window manager is a bit complex. This PR adds some basic integration tests for its functionality. It uses the puppeteer based browser-tests because it requires accurate ResizeObserver