### PR TITLE
Fix errors using 'duplicate session' and viewing recent sessions

### DIFF
--- a/packages/app-core/src/ui/App/AppToolbar.tsx
+++ b/packages/app-core/src/ui/App/AppToolbar.tsx
@@ -39,6 +39,25 @@ type AppSession = SessionWithDrawerWidgets & {
   popSnackbarMessage: () => unknown
 }
 
+function wrapMenuItems(
+  items: JBMenuItem[],
+  session: AppSession | undefined,
+): JBMenuItem[] {
+  return items.map(item => ({
+    ...item,
+    ...('onClick' in item
+      ? {
+          onClick: () => {
+            item.onClick(session)
+          },
+        }
+      : {}),
+    ...('subMenu' in item
+      ? { subMenu: wrapMenuItems(item.subMenu, session) }
+      : {}),
+  }))
+}
+
 const AppToolbar = observer(function AppToolbar({
   session,
   HeaderButtons = <div />,
@@ -60,16 +79,7 @@ const AppToolbar = observer(function AppToolbar({
               typeof menu.menuItems === 'function'
                 ? menu.menuItems()
                 : menu.menuItems
-            return items.map(arg => ({
-              ...arg,
-              ...('onClick' in arg
-                ? {
-                    onClick: () => {
-                      arg.onClick(session)
-                    },
-                  }
-                : {}),
-            }))
+            return wrapMenuItems(items, session)
           }}
         />
       ))}

--- a/packages/app-core/src/ui/App/TiledViewsContainer.tsx
+++ b/packages/app-core/src/ui/App/TiledViewsContainer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { nanoid } from '@jbrowse/core/util/nanoid'
 import { makeStyles } from '@jbrowse/core/util/tss-react'
+import { createElementId } from '@jbrowse/core/util/types/mst'
 import { useTheme } from '@mui/material'
 import { DockviewReact } from 'dockview-react'
 import { autorun } from 'mobx'
@@ -79,7 +79,7 @@ const TiledViewsContainer = observer(function TiledViewsContainer({
       if (!api) {
         return
       }
-      const panelId = `panel-${nanoid()}`
+      const panelId = `panel-${createElementId()}`
       const group = targetGroup ?? api.activeGroup
       api.addPanel({
         ...createPanelConfig(panelId, session, 'New Tab'),
@@ -102,7 +102,7 @@ const TiledViewsContainer = observer(function TiledViewsContainer({
       session.removeViewFromPanel(viewId)
 
       // Create new panel and assign the view to it
-      const panelId = `panel-${nanoid()}`
+      const panelId = `panel-${createElementId()}`
       const group = api.activeGroup
       api.addPanel({
         ...createPanelConfig(panelId, session, 'New Tab'),
@@ -123,7 +123,7 @@ const TiledViewsContainer = observer(function TiledViewsContainer({
       session.removeViewFromPanel(viewId)
 
       // Create new panel to the right of the current group
-      const panelId = `panel-${nanoid()}`
+      const panelId = `panel-${createElementId()}`
       const group = api.activeGroup
       api.addPanel({
         ...createPanelConfig(panelId, session, 'New Tab'),
@@ -149,7 +149,7 @@ const TiledViewsContainer = observer(function TiledViewsContainer({
   )
 
   const createInitialPanel = useCallback((dockviewApi: DockviewApi) => {
-    const panelId = `panel-${nanoid()}`
+    const panelId = `panel-${createElementId()}`
     dockviewApi.addPanel(createPanelConfig(panelId, sessionRef.current))
 
     if (isSessionWithDockviewLayout(sessionRef.current)) {
@@ -243,7 +243,7 @@ const TiledViewsContainer = observer(function TiledViewsContainer({
               if (firstPanel) {
                 activePanelId = firstPanel.id
               } else {
-                activePanelId = `panel-${nanoid()}`
+                activePanelId = `panel-${createElementId()}`
                 api.addPanel(createPanelConfig(activePanelId, session))
               }
               session.setActivePanelId(activePanelId)

--- a/packages/app-core/src/ui/App/copyView.ts
+++ b/packages/app-core/src/ui/App/copyView.ts
@@ -1,4 +1,4 @@
-import { nanoid } from '@jbrowse/core/util/nanoid'
+import { createElementId } from '@jbrowse/core/util/types/mst'
 
 export function renameIds(
   obj: Record<string, unknown>,
@@ -19,7 +19,7 @@ export function renameIds(
       for (const [key, val] of Object.entries(value)) {
         if (key === 'id' && typeof val === 'string') {
           if (!idMap.has(val)) {
-            idMap.set(val, nanoid())
+            idMap.set(val, createElementId())
           }
           result[key] = `${val}-${idMap.get(val)}`
         } else {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -116,7 +116,6 @@
     "./util/layouts/GranularRectLayout": "./src/util/layouts/GranularRectLayout.ts",
     "./util/librpc": "./src/util/librpc.ts",
     "./util/mst-reflection": "./src/util/mst-reflection.ts",
-    "./util/nanoid": "./src/util/nanoid.ts",
     "./util/offscreenCanvasPonyfill": "./src/util/offscreenCanvasPonyfill.tsx",
     "./util/offscreenCanvasUtils": "./src/util/offscreenCanvasUtils.tsx",
     "./util/parseLineByLine": "./src/util/parseLineByLine.ts",
@@ -130,7 +129,8 @@
     "./util/types": "./src/util/types/index.ts",
     "./util/types/mst": "./src/util/types/mst.ts",
     "./util/useMeasure": "./src/util/useMeasure.ts",
-    "./ui/ReturnToImportFormDialog": "./src/ui/ReturnToImportFormDialog.tsx"
+    "./ui/ReturnToImportFormDialog": "./src/ui/ReturnToImportFormDialog.tsx",
+    "./util/nanoid": "./src/util/nanoid.ts"
   },
   "files": [
     "esm"
@@ -569,10 +569,6 @@
         "types": "./esm/util/mst-reflection.d.ts",
         "import": "./esm/util/mst-reflection.js"
       },
-      "./util/nanoid": {
-        "types": "./esm/util/nanoid.d.ts",
-        "import": "./esm/util/nanoid.js"
-      },
       "./util/offscreenCanvasPonyfill": {
         "types": "./esm/util/offscreenCanvasPonyfill.d.ts",
         "import": "./esm/util/offscreenCanvasPonyfill.js"
@@ -628,6 +624,10 @@
       "./ui/ReturnToImportFormDialog": {
         "types": "./esm/ui/ReturnToImportFormDialog.d.ts",
         "import": "./esm/ui/ReturnToImportFormDialog.js"
+      },
+      "./util/nanoid": {
+        "types": "./esm/util/nanoid.d.ts",
+        "import": "./esm/util/nanoid.js"
       }
     }
   },

--- a/packages/core/scripts/generateExports.mjs
+++ b/packages/core/scripts/generateExports.mjs
@@ -8,6 +8,9 @@ const packageRoot = join(__dirname, '..')
 const repoRoot = join(packageRoot, '../..')
 const srcDir = join(packageRoot, 'src')
 
+// Exports to keep even if not used internally (for backwards compatibility)
+const preservedExports = ['@jbrowse/core/util/nanoid']
+
 // Scan the codebase for all @jbrowse/core imports
 function findAllImports() {
   try {
@@ -85,8 +88,8 @@ function getOutputPath(entry) {
   return `/${relativePath}.js`
 }
 
-// Find all imports
-const imports = findAllImports()
+// Find all imports and add preserved exports
+const imports = [...new Set([...findAllImports(), ...preservedExports])]
 console.log(`Found ${imports.length} unique @jbrowse/core import paths`)
 
 // Generate dev exports (pointing to src)

--- a/packages/core/src/util/types/ElementId.ts
+++ b/packages/core/src/util/types/ElementId.ts
@@ -2,4 +2,8 @@ import { types } from '@jbrowse/mobx-state-tree'
 
 import { nanoid } from '../nanoid.ts'
 
-export const ElementId = types.optional(types.identifier, () => nanoid(10))
+export function createElementId() {
+  return nanoid(10)
+}
+
+export const ElementId = types.optional(types.identifier, createElementId)

--- a/packages/core/src/util/types/mst.ts
+++ b/packages/core/src/util/types/mst.ts
@@ -93,4 +93,4 @@ export const FileLocation = types.snapshotProcessor(
   },
 )
 
-export { ElementId } from './ElementId.ts'
+export { ElementId, createElementId } from './ElementId.ts'

--- a/plugins/data-management/src/UCSCTrackHubConnection/doConnect.ts
+++ b/plugins/data-management/src/UCSCTrackHubConnection/doConnect.ts
@@ -2,7 +2,7 @@ import { HubFile, SingleFileHub } from '@gmod/ucsc-hub'
 import { getConf } from '@jbrowse/core/configuration'
 import { getEnv, getSession } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
-import { nanoid } from '@jbrowse/core/util/nanoid'
+import { createElementId } from '@jbrowse/core/util/types/mst'
 
 import { generateTracks } from './ucscTrackHub.ts'
 import { fetchGenomesFile, fetchTrackDbFile, resolve } from './util.ts'
@@ -45,7 +45,7 @@ export async function doConnect(self: {
                   }
                 : {}),
             },
-            trackId: `${genomeName}-${nanoid()}`,
+            trackId: `${genomeName}-${createElementId()}`,
             adapter: {
               type: 'TwoBitAdapter',
               twoBitLocation: {

--- a/products/jbrowse-desktop/src/components/JBrowse.tsx
+++ b/products/jbrowse-desktop/src/components/JBrowse.tsx
@@ -21,7 +21,9 @@ const JBrowseNonNullRoot = observer(function JBrowseNonNullRoot({
   return session ? (
     <ThemeProvider theme={session.theme}>
       <CssBaseline />
-      <App session={session} />
+      {/* key forces React to remount App when session changes (e.g.
+          duplicate session) preventing stale references to old session views */}
+      <App key={session.id} session={session} />
     </ThemeProvider>
   ) : null
 })

--- a/products/jbrowse-react-app/src/JBrowseApp/JBrowseApp.tsx
+++ b/products/jbrowse-react-app/src/JBrowseApp/JBrowseApp.tsx
@@ -32,7 +32,9 @@ const JBrowseApp = observer(function JBrowseApp({
       <div className={classes.avoidParentStyle}>
         <ScopedCssBaseline>
           <Suspense fallback={<LoadingEllipses />}>
-            <App session={session} />
+            {/* key forces React to remount App when session changes (e.g.
+                duplicate session) preventing stale references to old session views */}
+            <App key={session.id} session={session} />
           </Suspense>
         </ScopedCssBaseline>
       </div>

--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -1,6 +1,6 @@
 import PluginLoader from '@jbrowse/core/PluginLoader'
 import { openLocation } from '@jbrowse/core/util/io'
-import { nanoid } from '@jbrowse/core/util/nanoid'
+import { createElementId } from '@jbrowse/core/util/types/mst'
 import { addDisposer, types } from '@jbrowse/mobx-state-tree'
 import { openDB } from 'idb'
 import { autorun } from 'mobx'
@@ -458,7 +458,7 @@ const SessionLoader = types
     async loadDecodedSession(session: Record<string, unknown>) {
       await this.loadSession({
         ...session,
-        id: nanoid(),
+        id: createElementId(),
       })
     },
     /**

--- a/products/jbrowse-web/src/components/JBrowse.tsx
+++ b/products/jbrowse-web/src/components/JBrowse.tsx
@@ -66,7 +66,10 @@ const JBrowse = observer(function JBrowse({
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      {/* key={id} forces React to remount App when session changes (e.g.
+          duplicate session) preventing stale references to old session views */}
       <App
+        key={id}
         // @ts-expect-error
         session={session}
         HeaderButtons={<ShareButton session={session} />}

--- a/products/jbrowse-web/src/components/SessionTriaged.tsx
+++ b/products/jbrowse-web/src/components/SessionTriaged.tsx
@@ -1,4 +1,4 @@
-import { nanoid } from '@jbrowse/core/util/nanoid'
+import { createElementId } from '@jbrowse/core/util/types/mst'
 import { observer } from 'mobx-react'
 
 import ConfigWarningDialog from './ConfigWarningDialog.tsx'
@@ -21,7 +21,7 @@ const SessionTriaged = observer(function SessionTriaged({
         const session = JSON.parse(JSON.stringify(sessionTriaged.snap))
 
         // second param true says we passed user confirmation
-        await loader.loadSession({ ...session, id: nanoid() }, true)
+        await loader.loadSession({ ...session, id: createElementId() }, true)
         loader.setSessionTriaged(undefined)
       }}
       onCancel={() => {
@@ -35,7 +35,7 @@ const SessionTriaged = observer(function SessionTriaged({
       onConfirm={async () => {
         const session = JSON.parse(JSON.stringify(sessionTriaged.snap))
         await loader.fetchPlugins(session)
-        loader.setConfigSnapshot({ ...session, id: nanoid() })
+        loader.setConfigSnapshot({ ...session, id: createElementId() })
         loader.setSessionTriaged(undefined)
       }}
       onCancel={async () => {

--- a/products/jbrowse-web/src/rootModel/rootModel.ts
+++ b/products/jbrowse-web/src/rootModel/rootModel.ts
@@ -47,16 +47,8 @@ import { filterSessionInPlace } from '../util.ts'
 import type { SessionDB, SessionMetadata } from '../types.ts'
 import type { Menu } from '@jbrowse/app-core'
 import type PluginManager from '@jbrowse/core/PluginManager'
-import type {
-  AbstractSessionModel,
-  SessionWithWidgets,
-} from '@jbrowse/core/util'
-import type {
-  IAnyStateTreeNode,
-  IAnyType,
-  Instance,
-  SnapshotIn,
-} from '@jbrowse/mobx-state-tree'
+import type { AbstractSessionModel } from '@jbrowse/core/util'
+import type { IAnyType, Instance, SnapshotIn } from '@jbrowse/mobx-state-tree'
 import type { BaseSessionType, SessionWithDialogs } from '@jbrowse/product-core'
 import type { IDBPDatabase } from 'idb'
 
@@ -372,7 +364,7 @@ export default function RootModel({
         if (ret) {
           this.setSession(ret)
         } else {
-          self.session.notifyError('Session not found')
+          self.session?.notifyError('Session not found')
         }
       },
       /**
@@ -472,44 +464,50 @@ export default function RootModel({
                 {
                   label: 'Import session...',
                   icon: PublishIcon,
-                  onClick: (session: SessionWithWidgets) => {
-                    const widget = session.addWidget(
+                  onClick: () => {
+                    const widget = self.session?.addWidget(
                       'ImportSessionWidget',
                       'importSessionWidget',
                     )
-                    session.showWidget(widget)
+                    if (widget) {
+                      self.session?.showWidget(widget)
+                    }
                   },
                 },
                 {
                   label: 'Export session',
                   icon: GetAppIcon,
-                  onClick: async (session: IAnyStateTreeNode) => {
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated
-                    const { saveAs } = await import('file-saver-es')
+                  onClick: async () => {
+                    if (self.session) {
+                      // eslint-disable-next-line @typescript-eslint/no-deprecated
+                      const { saveAs } = await import('file-saver-es')
 
-                    saveAs(
-                      new Blob(
-                        [
-                          JSON.stringify(
-                            { session: getSnapshot(session) },
-                            null,
-                            2,
-                          ),
-                        ],
-                        { type: 'text/plain;charset=utf-8' },
-                      ),
-                      'session.json',
-                      { autoBom: false },
-                    )
+                      saveAs(
+                        new Blob(
+                          [
+                            JSON.stringify(
+                              { session: getSnapshot(self.session) },
+                              null,
+                              2,
+                            ),
+                          ],
+                          { type: 'text/plain;charset=utf-8' },
+                        ),
+                        'session.json',
+                        { autoBom: false },
+                      )
+                    }
                   },
                 },
                 {
                   label: 'Duplicate session',
                   icon: FileCopyIcon,
                   onClick: () => {
-                    // @ts-expect-error
-                    const { id, ...rest } = getSnapshot(self.session)
-                    self.setSession(rest)
+                    if (self.session) {
+                      // @ts-expect-error
+                      const { id, ...rest } = getSnapshot(self.session)
+                      self.setSession(rest)
+                    }
                   },
                 },
                 ...(preConfiguredSessions?.length
@@ -533,8 +531,8 @@ export default function RootModel({
                         label: 'Favorite sessions...',
                         subMenu: [
                           ...favs.slice(0, 5).map(r => ({
-                            label: `${r.name} (${r.id === self.session.id ? 'current' : formatDistanceToNow(r.createdAt, { addSuffix: true })})`,
-                            disabled: r.id === self.session.id,
+                            label: `${r.name} (${r.id === self.session?.id ? 'current' : formatDistanceToNow(r.createdAt, { addSuffix: true })})`,
+                            disabled: r.id === self.session?.id,
                             icon: StarIcon,
                             onClick: () => {
                               // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -542,7 +540,7 @@ export default function RootModel({
                                 try {
                                   await self.activateSession(r.id)
                                 } catch (e) {
-                                  self.session.notifyError(`${e}`, e)
+                                  self.session?.notifyError(`${e}`, e)
                                 }
                               })()
                             },
@@ -550,12 +548,14 @@ export default function RootModel({
                           {
                             label: 'More...',
                             icon: FolderOpenIcon,
-                            onClick: (session: SessionWithWidgets) => {
-                              const widget = session.addWidget(
+                            onClick: () => {
+                              const widget = self.session?.addWidget(
                                 'SessionManager',
                                 'sessionManager',
                               )
-                              session.showWidget(widget)
+                              if (widget) {
+                                self.session?.showWidget(widget)
+                              }
                             },
                           },
                         ],
@@ -568,15 +568,15 @@ export default function RootModel({
                   subMenu: rest?.length
                     ? [
                         ...rest.map(r => ({
-                          label: `${r.name} (${r.id === self.session.id ? 'current' : formatDistanceToNow(r.createdAt, { addSuffix: true })})`,
-                          disabled: r.id === self.session.id,
+                          label: `${r.name} (${r.id === self.session?.id ? 'current' : formatDistanceToNow(r.createdAt, { addSuffix: true })})`,
+                          disabled: r.id === self.session?.id,
                           onClick: () => {
                             // eslint-disable-next-line @typescript-eslint/no-floating-promises
                             ;(async () => {
                               try {
                                 await self.activateSession(r.id)
                               } catch (e) {
-                                self.session.notifyError(`${e}`, e)
+                                self.session?.notifyError(`${e}`, e)
                               }
                             })()
                           },
@@ -584,12 +584,14 @@ export default function RootModel({
                         {
                           label: 'More...',
                           icon: FolderOpenIcon,
-                          onClick: (session: SessionWithWidgets) => {
-                            const widget = session.addWidget(
+                          onClick: () => {
+                            const widget = self.session?.addWidget(
                               'SessionManager',
                               'sessionManager',
                             )
-                            session.showWidget(widget)
+                            if (widget) {
+                              self.session?.showWidget(widget)
+                            }
                           },
                         },
                       ]
@@ -599,20 +601,24 @@ export default function RootModel({
                 {
                   label: 'Open track...',
                   icon: StorageIcon,
-                  onClick: (session: SessionWithWidgets) => {
-                    if (session.views.length === 0) {
-                      session.notify('Please open a view to add a track first')
-                    } else if (session.views.length > 0) {
-                      const widget = session.addWidget(
-                        'AddTrackWidget',
-                        'addTrackWidget',
-                        { view: session.views[0]!.id },
-                      )
-                      session.showWidget(widget)
-                      if (session.views.length > 1) {
-                        session.notify(
-                          'This will add a track to the first view. Note: if you want to open a track in a specific view open the track selector for that view and use the add track (plus icon) in the bottom right',
+                  onClick: () => {
+                    if (self.session) {
+                      if (self.session.views.length === 0) {
+                        self.session.notify(
+                          'Please open a view to add a track first',
                         )
+                      } else {
+                        const widget = self.session.addWidget(
+                          'AddTrackWidget',
+                          'addTrackWidget',
+                          { view: self.session.views[0]!.id },
+                        )
+                        self.session.showWidget(widget)
+                        if (self.session.views.length > 1) {
+                          self.session.notify(
+                            'This will add a track to the first view. Note: if you want to open a track in a specific view open the track selector for that view and use the add track (plus icon) in the bottom right',
+                          )
+                        }
                       }
                     }
                   },
@@ -620,13 +626,14 @@ export default function RootModel({
                 {
                   label: 'Open connection...',
                   icon: Cable,
-                  onClick: (session: SessionWithWidgets) => {
-                    session.showWidget(
-                      session.addWidget(
-                        'AddConnectionWidget',
-                        'addConnectionWidget',
-                      ),
+                  onClick: () => {
+                    const widget = self.session?.addWidget(
+                      'AddConnectionWidget',
+                      'addConnectionWidget',
                     )
+                    if (widget) {
+                      self.session?.showWidget(widget)
+                    }
                   },
                 },
               ]
@@ -640,7 +647,7 @@ export default function RootModel({
                     {
                       label: 'Set default session',
                       onClick: () => {
-                        self.session.queueDialog((onClose: () => void) => [
+                        self.session?.queueDialog((onClose: () => void) => [
                           SetDefaultSession,
                           {
                             rootModel: self,
@@ -697,7 +704,7 @@ export default function RootModel({
                 label: 'Assembly manager',
                 icon: DNA,
                 onClick: () => {
-                  self.session.queueDialog((onClose: () => void) => [
+                  self.session?.queueDialog((onClose: () => void) => [
                     AssemblyManager,
                     {
                       onClose,

--- a/products/jbrowse-web/src/tests/SessionMenu.test.tsx
+++ b/products/jbrowse-web/src/tests/SessionMenu.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom'
+
+import { fireEvent, waitFor } from '@testing-library/react'
+
+import { createView, doBeforeEach } from './util.tsx'
+
+beforeEach(() => {
+  doBeforeEach()
+  jest.spyOn(console, 'warn').mockImplementation()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('duplicate session creates a new session with different id', async () => {
+  const { rootModel, findByText } = await createView()
+  const originalSessionId = rootModel.session!.id
+
+  // Open File menu and click Duplicate session
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Duplicate session'))
+
+  await waitFor(() => {
+    expect(rootModel.session!.id).not.toBe(originalSessionId)
+  })
+}, 30000)
+
+test('recent sessions shows no autosaves found when empty', async () => {
+  const { findByText } = await createView()
+
+  // Open File menu, then Recent sessions submenu
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Recent sessions...'))
+
+  // When there are no saved sessions, it should show "No autosaves found"
+  expect(await findByText('No autosaves found')).toBeInTheDocument()
+}, 30000)
+
+test('recent sessions more opens session manager widget', async () => {
+  const { rootModel, findByText } = await createView()
+
+  // Mock some saved session metadata so "More..." appears
+  // @ts-expect-error
+  rootModel.setSavedSessionMetadata([
+    {
+      id: 'test-session-1',
+      name: 'Test Session 1',
+      createdAt: new Date(),
+      configPath: '',
+    },
+  ])
+
+  // Open File menu, then Recent sessions submenu, then click More
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Recent sessions...'))
+  fireEvent.click(await findByText('More...'))
+
+  await waitFor(
+    () => {
+      // @ts-expect-error
+      const widgets = [...rootModel.session!.activeWidgets.values()]
+      expect(widgets.some(w => w.type === 'SessionManager')).toBe(true)
+    },
+    { timeout: 10000 },
+  )
+}, 30000)
+
+test('import session menu item opens widget', async () => {
+  const { rootModel, findByText } = await createView()
+
+  // Open File menu and click Import session
+  fireEvent.click(await findByText('File'))
+  fireEvent.click(await findByText('Import session...'))
+
+  await waitFor(
+    () => {
+      // @ts-expect-error
+      const widgets = [...rootModel.session!.activeWidgets.values()]
+      expect(widgets.some(w => w.type === 'ImportSessionWidget')).toBe(true)
+    },
+    { timeout: 10000 },
+  )
+}, 30000)


### PR DESCRIPTION
Would crash with errors like

```
Uncaught runtime errors:
can't access property "addWidget", session is undefined
onClick@home/cdiesh/src/jbrowse-components/products/jbrowse-web/src/rootModel/rootModel.ts:462:32
```

and 
```
Error: no session model found!
../../../packages/core/src/util/index.ts:280:11 (L@)
../../../packages/app-core/src/ui/App/ViewHeader.tsx:48:30 (65826/G<@)
```

this fixes it by adding "key={session.id}" at the app level 