### PR TITLE
Add re-exports to enable embedded apps to use webworkers after v4

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/model.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/model.ts
@@ -24,7 +24,7 @@ import MenuOpenIcon from '@mui/icons-material/MenuOpen'
 import { autorun } from 'mobx'
 
 import { deduplicateFeatureLabels } from './components/util.ts'
-import { calculateSvgLegendWidth } from './index.ts'
+import { calculateSvgLegendWidth } from './calculateSvgLegendWidth.ts'
 import FeatureDensityMixin from './models/FeatureDensityMixin.tsx'
 import TrackHeightMixin from './models/TrackHeightMixin.tsx'
 import configSchema from './models/configSchema.ts'

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowse/react-app2",
-  "version": "4.0.4",
+  "version": "4.0.3",
   "description": "JBrowse 2 app React component",
   "keywords": [
     "jbrowse",
@@ -17,7 +17,13 @@
   "author": "JBrowse Team",
   "main": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./esm/makeWorkerInstance": "./src/makeWorkerInstance.ts",
+    "./esm/makeWorkerInstance.js": "./src/makeWorkerInstance.ts",
+    "./esm/rpcWorker": "./src/rpcWorker.ts",
+    "./esm/rpcWorker.js": "./src/rpcWorker.ts",
+    "./esm/workerPolyfill": "./src/workerPolyfill.js",
+    "./esm/workerPolyfill.js": "./src/workerPolyfill.js"
   },
   "files": [
     "esm",
@@ -92,6 +98,28 @@
       ".": {
         "types": "./esm/index.d.ts",
         "import": "./esm/index.js"
+      },
+      "./esm/makeWorkerInstance": {
+        "types": "./esm/makeWorkerInstance.d.ts",
+        "import": "./esm/makeWorkerInstance.js"
+      },
+      "./esm/makeWorkerInstance.js": {
+        "types": "./esm/makeWorkerInstance.d.ts",
+        "import": "./esm/makeWorkerInstance.js"
+      },
+      "./esm/rpcWorker": {
+        "types": "./esm/rpcWorker.d.ts",
+        "import": "./esm/rpcWorker.js"
+      },
+      "./esm/rpcWorker.js": {
+        "types": "./esm/rpcWorker.d.ts",
+        "import": "./esm/rpcWorker.js"
+      },
+      "./esm/workerPolyfill": {
+        "import": "./esm/workerPolyfill.js"
+      },
+      "./esm/workerPolyfill.js": {
+        "import": "./esm/workerPolyfill.js"
       }
     }
   },

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowse/react-linear-genome-view2",
-  "version": "4.0.4",
+  "version": "4.0.3",
   "description": "JBrowse 2 linear genome view React component",
   "keywords": [
     "jbrowse",
@@ -17,7 +17,13 @@
   "author": "JBrowse Team",
   "main": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./esm/makeWorkerInstance": "./src/makeWorkerInstance.ts",
+    "./esm/makeWorkerInstance.js": "./src/makeWorkerInstance.ts",
+    "./esm/rpcWorker": "./src/rpcWorker.ts",
+    "./esm/rpcWorker.js": "./src/rpcWorker.ts",
+    "./esm/workerPolyfill": "./src/workerPolyfill.js",
+    "./esm/workerPolyfill.js": "./src/workerPolyfill.js"
   },
   "files": [
     "esm",
@@ -75,6 +81,28 @@
       ".": {
         "types": "./esm/index.d.ts",
         "import": "./esm/index.js"
+      },
+      "./esm/makeWorkerInstance": {
+        "types": "./esm/makeWorkerInstance.d.ts",
+        "import": "./esm/makeWorkerInstance.js"
+      },
+      "./esm/makeWorkerInstance.js": {
+        "types": "./esm/makeWorkerInstance.d.ts",
+        "import": "./esm/makeWorkerInstance.js"
+      },
+      "./esm/rpcWorker": {
+        "types": "./esm/rpcWorker.d.ts",
+        "import": "./esm/rpcWorker.js"
+      },
+      "./esm/rpcWorker.js": {
+        "types": "./esm/rpcWorker.d.ts",
+        "import": "./esm/rpcWorker.js"
+      },
+      "./esm/workerPolyfill": {
+        "import": "./esm/workerPolyfill.js"
+      },
+      "./esm/workerPolyfill.js": {
+        "import": "./esm/workerPolyfill.js"
       }
     }
   },


### PR DESCRIPTION
The change to pure-ESM in v4 means we need to manually re-export the code in package.json to allow embedded apps (importers of @jbrowse/react-linear-genome-view2 et al.) to use the webworker

The unrelated change in plugins/linear-genome-view/src/BaseLinearDisplay/model.ts also untangles a circular dependency that causes a rollup warning for embedded users