### PR TITLE
Fix issues with large VCF files not displaying in v4.0.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -152,7 +152,7 @@
     "@emotion/utils": "^1.4.2",
     "@floating-ui/react": "^0.27.16",
     "@gmod/abortable-promise-cache": "^3.0.4",
-    "@gmod/bgzf-filehandle": "^6.0.10",
+    "@gmod/bgzf-filehandle": "^6.0.12",
     "@gmod/http-range-fetcher": "^5.0.7",
     "@jbrowse/jexl": "^3.0.1",
     "@jbrowse/mobx-state-tree": "^5.5.0",

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@flatten-js/interval-tree": "^2.0.3",
-    "@gmod/bgzf-filehandle": "^6.0.10",
+    "@gmod/bgzf-filehandle": "^6.0.12",
     "@jbrowse/core": "workspace:^",
     "@jbrowse/mobx-state-tree": "^5.5.0",
     "@jbrowse/plugin-linear-genome-view": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,8 +393,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       '@gmod/bgzf-filehandle':
-        specifier: ^6.0.10
-        version: 6.0.10
+        specifier: ^6.0.12
+        version: 6.0.12
       '@gmod/http-range-fetcher':
         specifier: ^5.0.7
         version: 5.0.7
@@ -1134,8 +1134,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       '@gmod/bgzf-filehandle':
-        specifier: ^6.0.10
-        version: 6.0.10
+        specifier: ^6.0.12
+        version: 6.0.12
       '@jbrowse/core':
         specifier: workspace:^
         version: link:../../packages/core
@@ -3457,8 +3457,8 @@ packages:
     resolution: {integrity: sha512-begb47SbolFRLXUaQA8w1yBdzPFEw+FncHvfLMxfDC0nacDeU3N72BUPhK4Dq51mi8QpN4NfT3dR8O2j2g1Lww==}
     engines: {node: '>=6'}
 
-  '@gmod/bgzf-filehandle@6.0.10':
-    resolution: {integrity: sha512-xXGAsuRw20Y9SI9Lt2W2YjxMLUaiEoiYB/aRzS3m8m1Mw3KG1pbargEPgTNXuRigwTT6oSPIgMlEhR02VQlfwQ==}
+  '@gmod/bgzf-filehandle@6.0.12':
+    resolution: {integrity: sha512-VTFaF6gVNZmGTTDpiQnPxiBEEV6Cw6yKFFbfoV3TyIamejLBHQq5kodjIhBbL/VJ6ooSOugFno7+eRURd6mGbQ==}
     engines: {node: '>=6'}
 
   '@gmod/cram@8.0.0':
@@ -5816,8 +5816,8 @@ packages:
   devtools-protocol@0.0.1534754:
     resolution: {integrity: sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   dir-compare@4.2.0:
@@ -10825,7 +10825,7 @@ snapshots:
 
   '@gmod/bam@7.1.15(buffer@6.0.3)':
     dependencies:
-      '@gmod/bgzf-filehandle': 6.0.10
+      '@gmod/bgzf-filehandle': 6.0.12
       '@jbrowse/quick-lru': 7.3.5
       crc: 4.3.2(buffer@6.0.3)
       generic-filehandle2: 2.0.18
@@ -10842,7 +10842,7 @@ snapshots:
 
   '@gmod/bed@2.1.10': {}
 
-  '@gmod/bgzf-filehandle@6.0.10':
+  '@gmod/bgzf-filehandle@6.0.12':
     dependencies:
       generic-filehandle2: 2.0.18
       pako-esm2: 2.0.2
@@ -10866,7 +10866,7 @@ snapshots:
 
   '@gmod/indexedfasta@5.0.2':
     dependencies:
-      '@gmod/bgzf-filehandle': 6.0.10
+      '@gmod/bgzf-filehandle': 6.0.12
       generic-filehandle2: 2.0.18
 
   '@gmod/nclist@3.0.4':
@@ -10878,7 +10878,7 @@ snapshots:
   '@gmod/tabix@3.2.2':
     dependencies:
       '@gmod/abortable-promise-cache': 3.0.4
-      '@gmod/bgzf-filehandle': 6.0.10
+      '@gmod/bgzf-filehandle': 6.0.12
       '@jbrowse/quick-lru': 7.3.5
       generic-filehandle2: 2.0.18
 
@@ -13630,7 +13630,7 @@ snapshots:
 
   devtools-protocol@0.0.1534754: {}
 
-  diff@4.0.2:
+  diff@4.0.4:
     optional: true
 
   dir-compare@4.2.0:
@@ -17629,7 +17629,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1

--- a/test_data/config_demo.json
+++ b/test_data/config_demo.json
@@ -4119,7 +4119,6 @@
         "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/hg002/HG002_ONTrel2_16x_RG_HP10xtrioRTG.bam"
       }
     },
-
     {
       "type": "AlignmentsTrack",
       "trackId": "hg002_cram",
@@ -5035,6 +5034,26 @@
         "uri": "https://hgdownload.gi.ucsc.edu/gbdb/hg19/bbi/hic/GSE63525_HMEC_combined.hic"
       },
       "assemblyNames": ["hg19"]
+    },
+    {
+      "type": "VariantTrack",
+      "trackId": "freq.vcf",
+      "name": "freq.vcf",
+      "adapter": {
+        "type": "VcfTabixAdapter",
+        "vcfGzLocation": {
+          "uri": "https://ftp.ncbi.nih.gov/snp/population_frequency/latest_release/freq.vcf.gz",
+          "locationType": "UriLocation"
+        },
+        "index": {
+          "location": {
+            "uri": "https://ftp.ncbi.nih.gov/snp/population_frequency/latest_release/freq.vcf.gz.tbi",
+            "locationType": "UriLocation"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "assemblyNames": ["hg38"]
     }
   ],
   "connections": [],


### PR DESCRIPTION
there was an issue with the newer WASM based bgzf unzip code, where it would truncate 64-bit floats

Fixes https://github.com/GMOD/jbrowse-components/issues/5431

This wasn't very visible in tests because e.g. 1000genomes vcf are split by chromosome, so we don't have a massive VCF file for testing

It might have also affected BAM since it is also bgzf based but i did not get a chance to test that yet