### PR TITLE
Revert css based --var scrolling due to visual glitches at large bp offset and high zoom levels

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LinearBlocks.tsx
@@ -1,8 +1,10 @@
+import { getContainingView } from '@jbrowse/core/util'
 import { makeStyles } from '@jbrowse/core/util/tss-react'
 import { observer } from 'mobx-react'
 
 import RenderedBlocks from './RenderedBlocks.tsx'
 
+import type { LinearGenomeViewModel } from '../../LinearGenomeView/index.ts'
 import type { BaseLinearDisplayModel } from '../model.ts'
 
 // Warning: these styles are sensitive to causing 1px gaps between blocks.
@@ -10,8 +12,6 @@ import type { BaseLinearDisplayModel } from '../model.ts'
 // Avoid using transform:translateX or inline-block as they cause subpixel
 // rounding issues that result in visible gaps between track blocks.
 const useStyles = makeStyles()({
-  // Block container positioned using CSS calc() with --offset-px variable
-  // set by parent TracksContainer - avoids JS recalculation per track
   linearBlocks: {
     whiteSpace: 'nowrap',
     textAlign: 'left',
@@ -28,13 +28,13 @@ const LinearBlocks = observer(function LinearBlocks({
 }) {
   const { classes } = useStyles()
   const { blockDefinitions } = model
-  // Uses --offset-px CSS variable from TracksContainer parent
+  const viewModel = getContainingView(model) as LinearGenomeViewModel
   // Warning: use style.left here, not transform:translateX, to avoid 1px gaps
   return (
     <div
       className={classes.linearBlocks}
       style={{
-        left: `calc(${blockDefinitions.offsetPx}px - var(--offset-px))`,
+        left: blockDefinitions.offsetPx - viewModel.offsetPx,
       }}
     >
       <RenderedBlocks model={model} />

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Gridlines.tsx
@@ -14,7 +14,6 @@ import type { ContentBlock } from '@jbrowse/core/util/blockTypes'
 type LGV = LinearGenomeViewModel
 
 const useStyles = makeStyles()(theme => ({
-  // Outer container that handles zoom scaling via CSS transform
   verticalGuidesZoomContainer: {
     position: 'absolute',
     top: 0,
@@ -22,7 +21,6 @@ const useStyles = makeStyles()(theme => ({
     width: '100%',
     pointerEvents: 'none',
   },
-  // Inner container positioned using CSS calc() with --offset-px variable
   verticalGuidesContainer: {
     position: 'absolute',
     height: '100%',
@@ -112,7 +110,8 @@ const Gridlines = observer(function Gridlines({
   offset?: number
 }) {
   const { classes } = useStyles()
-  const { staticBlocks, scaleFactor } = model
+  const { staticBlocks, scaleFactor, offsetPx } = model
+  const offsetLeft = staticBlocks.offsetPx - offsetPx
   return (
     <div
       className={classes.verticalGuidesZoomContainer}
@@ -123,8 +122,7 @@ const Gridlines = observer(function Gridlines({
       <div
         className={classes.verticalGuidesContainer}
         style={{
-          // Uses --offset-px CSS variable from parent (TracksContainer or Scalebar)
-          left: `calc(${staticBlocks.offsetPx}px - var(--offset-px) - ${offset}px)`,
+          left: offsetLeft - offset,
           width: staticBlocks.totalWidthPx,
         }}
       >

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/Scalebar.tsx
@@ -20,8 +20,6 @@ const useStyles = makeStyles()({
   zoomContainer: {
     position: 'relative',
   },
-  // Scalebar positioned using CSS calc() with --offset-px variable
-  // Uses translateX for smooth positioning (subpixel gaps less visible here)
   scalebar: {
     position: 'absolute',
     display: 'flex',
@@ -43,15 +41,14 @@ const Scalebar = observer(function Scalebar({
 }: ScalebarProps) {
   const { classes } = useStyles()
   const { scaleFactor, staticBlocks, offsetPx } = model
+  const offsetLeft = Math.round(staticBlocks.offsetPx - offsetPx)
 
   return (
     <Paper
       data-resizer="true" // used to avoid click-and-drag scrolls on trackscontainer
       className={cx(classes.container, className)}
       variant="outlined"
-      style={
-        { ...style, '--offset-px': `${offsetPx}px` } as React.CSSProperties
-      }
+      style={style}
       {...other}
     >
       {/* offset 1px for left track border */}
@@ -65,7 +62,7 @@ const Scalebar = observer(function Scalebar({
         <div
           className={classes.scalebar}
           style={{
-            transform: `translateX(calc(${staticBlocks.offsetPx}px - var(--offset-px) - 1px))`,
+            transform: `translateX(${offsetLeft - 1}px)`,
             width: staticBlocks.totalWidthPx,
           }}
         >

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ScalebarRefNameLabels.tsx
@@ -15,8 +15,6 @@ interface MenuState {
 }
 
 const useStyles = makeStyles()(theme => ({
-  // Base styles for ref name labels (chromosome names in scalebar)
-  // Uses --offset-px CSS variable from parent Scalebar component
   refLabel: {
     fontSize: 11,
     position: 'absolute',
@@ -33,7 +31,6 @@ const useStyles = makeStyles()(theme => ({
       background: theme.palette.grey[300],
     },
   },
-  // First block label when it's not a ContentBlock
   b0: {
     left: 0,
     zIndex: 100,
@@ -114,9 +111,7 @@ const ScalebarRefNameLabels = observer(function ScalebarRefNameLabels({
           <span
             key={`refLabel-${key}-${index}`}
             style={{
-              left: last
-                ? 'max(0px, calc(-1 * var(--offset-px)))'
-                : `calc(${blockOffsetPx}px - var(--offset-px) - 1px)`,
+              left: last ? Math.max(0, -offsetPx) : blockOffsetPx - offsetPx - 1,
               paddingLeft: last ? 0 : 1,
               maxWidth:
                 maxWidth !== undefined && maxWidth > 0 ? maxWidth : undefined,

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/TracksContainer.tsx
@@ -21,9 +21,6 @@ const Highlight = lazy(() => import('./Highlight.tsx'))
 const RubberbandSpan = lazy(() => import('./RubberbandSpan.tsx'))
 
 const useStyles = makeStyles()({
-  // Main container for all tracks
-  // Sets --offset-px CSS variable so children can use calc() for positioning
-  // instead of each observing offsetPx and recalculating in JS
   tracksContainer: {
     position: 'relative',
     contain: 'layout style',
@@ -80,7 +77,6 @@ const TracksContainer = observer(function TracksContainer({
       ref={ref}
       data-testid="tracksContainer"
       className={classes.tracksContainer}
-      style={{ '--offset-px': `${model.offsetPx}px` } as React.CSSProperties}
       onMouseDown={event => {
         mouseDown1(event)
         mouseDown2(event)


### PR DESCRIPTION
In ded2270ff097 we introduced a css based scroll mechanism that changes a CSS variable that represents the offsetPx. This potentially allows less re-rendering of the react components. However, it was observed the scrolling was very choppy for the human genome at high zoom levels with this. There is likely a precision issue with floating points with it

This PR updates to go back to js based scrolling