### PR TITLE
Make the loading bars occupy full track height

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LoadingOverlay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LoadingOverlay.tsx
@@ -47,14 +47,16 @@ const useStyles = makeStyles()({
 export default function LoadingOverlay({
   statusMessage,
   children,
+  height,
 }: {
   statusMessage?: string
   children?: React.ReactNode
+  height?: number
 }) {
   const { classes } = useStyles()
   const isLoading = !!statusMessage
   return (
-    <div className={classes.container}>
+    <div className={classes.container} style={height ? { height } : undefined}>
       {children}
       <span
         className={cx(classes.overlay, isLoading && classes.visible)}

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/NonBlockCanvasDisplayComponent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/NonBlockCanvasDisplayComponent.tsx
@@ -28,6 +28,7 @@ export interface NonBlockCanvasDisplayModel {
   statusMessage?: string
   showLegend?: boolean
   legendItems?: () => LegendItem[]
+  height: number
 }
 
 const useStyles = makeStyles()({
@@ -87,7 +88,8 @@ const DataDisplay = observer(function DataDisplay({
   model: NonBlockCanvasDisplayModel
   children?: React.ReactNode
 }) {
-  const { drawn, loading, showLegend, legendItems, lastDrawnBpPerPx } = model
+  const { drawn, loading, showLegend, legendItems, lastDrawnBpPerPx, height } =
+    model
   const view = getContainingView(model) as LinearGenomeViewModel
   const items = legendItems?.() ?? []
 
@@ -109,7 +111,10 @@ const DataDisplay = observer(function DataDisplay({
   return (
     // this data-testid is located here because changing props on the canvas
     // itself is very sensitive to triggering ref invalidation
-    <div data-testid={`drawn-${drawn}`}>
+    <div
+      data-testid={`drawn-${drawn}`}
+      style={{ position: 'relative', height }}
+    >
       <div
         style={{
           position: 'absolute',

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/ServerSideRenderedBlockContent.tsx
@@ -18,6 +18,7 @@ const ServerSideRenderedBlockContent = observer(
       statusMessage?: string
       reactElement?: React.ReactElement
       isRenderingPending?: boolean
+      displayHeight?: number
     }
   }) {
     if (model.error) {
@@ -34,7 +35,10 @@ const ServerSideRenderedBlockContent = observer(
       )
     } else {
       return (
-        <LoadingOverlay statusMessage={model.statusMessage}>
+        <LoadingOverlay
+          statusMessage={model.statusMessage}
+          height={model.displayHeight}
+        >
           {model.reactElement}
         </LoadingOverlay>
       )

--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -258,6 +258,10 @@ const blockState = types
             'Loading'
         : undefined
     },
+    get displayHeight() {
+      // @ts-expect-error
+      return self.cachedDisplay?.height as number | undefined
+    },
   }))
   .actions(self => ({
     afterAttach() {


### PR DESCRIPTION
This is a minor improvement when tracks are very tall and can involve scrolling. When this is the case, the loading bar would stay at the top. This makes it so that the entire display height is covered with a loading bar so it is visible even when scrolling