### PR TITLE
Change multi-wiggle rendering into a serial process

### DIFF
--- a/plugins/wiggle/src/MultiDensityRenderer/makeImageData.ts
+++ b/plugins/wiggle/src/MultiDensityRenderer/makeImageData.ts
@@ -5,13 +5,6 @@ export async function makeImageData(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const { renderMultiWiggle } = await import('../multiRendererHelper.ts')
-  return renderMultiWiggle(
-    pluginManager,
-    renderProps,
-    async (props, features) => {
-      const { renderMultiDensity } = await import('./renderMultiDensity.ts')
-      return renderMultiDensity(props, features)
-    },
-  )
+  const { renderMultiDensity } = await import('./renderMultiDensity.ts')
+  return renderMultiDensity(renderProps, pluginManager)
 }

--- a/plugins/wiggle/src/MultiDensityRenderer/renderMultiDensity.ts
+++ b/plugins/wiggle/src/MultiDensityRenderer/renderMultiDensity.ts
@@ -4,10 +4,7 @@ import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawDensity } from '../drawDensity.ts'
-import {
-  forEachSourceFeatures,
-  getAdaptersForPerSourceRendering,
-} from '../multiRendererHelper.ts'
+import { forEachSourceFeatures } from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
@@ -32,11 +29,6 @@ export async function renderMultiDensity(
   const rowHeight = height / sources.length
   const lastCheck = createStopTokenChecker(stopToken)
 
-  const adapterBySource = await getAdaptersForPerSourceRendering(
-    pluginManager,
-    renderProps,
-  )
-
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
@@ -45,22 +37,16 @@ export async function renderMultiDensity(
         let feats: Feature[] = []
         ctx.save()
 
-        await forEachSourceFeatures(
-          adapterBySource,
-          sources,
-          region,
-          renderProps,
-          (source, features) => {
-            const { reducedFeatures } = drawDensity(ctx, {
-              ...renderProps,
-              features,
-              height: rowHeight,
-              lastCheck,
-            })
-            ctx.translate(0, rowHeight)
-            feats = feats.concat(reducedFeatures)
-          },
-        )
+        await forEachSourceFeatures(pluginManager, renderProps, (source, features) => {
+          const { reducedFeatures } = drawDensity(ctx, {
+            ...renderProps,
+            features,
+            height: rowHeight,
+            lastCheck,
+          })
+          ctx.translate(0, rowHeight)
+          feats = feats.concat(reducedFeatures)
+        })
 
         ctx.restore()
         return { reducedFeatures: feats }

--- a/plugins/wiggle/src/MultiLineRenderer/makeImageData.ts
+++ b/plugins/wiggle/src/MultiLineRenderer/makeImageData.ts
@@ -5,13 +5,6 @@ export async function makeImageData(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const { renderMultiWiggle } = await import('../multiRendererHelper.ts')
-  return renderMultiWiggle(
-    pluginManager,
-    renderProps,
-    async (props, features) => {
-      const { renderMultiLine } = await import('./renderMultiLine.ts')
-      return renderMultiLine(props, features)
-    },
-  )
+  const { renderMultiLine } = await import('./renderMultiLine.ts')
+  return renderMultiLine(renderProps, pluginManager)
 }

--- a/plugins/wiggle/src/MultiLineRenderer/renderMultiLine.ts
+++ b/plugins/wiggle/src/MultiLineRenderer/renderMultiLine.ts
@@ -1,21 +1,22 @@
-import {
-  groupBy,
-  renderToAbstractCanvas,
-  updateStatus,
-} from '@jbrowse/core/util'
+import { renderToAbstractCanvas, updateStatus } from '@jbrowse/core/util'
 import { rpcResult } from '@jbrowse/core/util/librpc'
 import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill'
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawLine } from '../drawLine.ts'
+import {
+  forEachSourceFeatures,
+  getAdaptersForPerSourceRendering,
+} from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
+import type PluginManager from '@jbrowse/core/PluginManager'
 import type { Feature } from '@jbrowse/core/util'
 
 export async function renderMultiLine(
   renderProps: MultiRenderArgsDeserialized,
-  features: Feature[],
+  pluginManager: PluginManager,
 ) {
   const {
     sources,
@@ -30,23 +31,35 @@ export async function renderMultiLine(
   const width = (region.end - region.start) / bpPerPx
   const lastCheck = createStopTokenChecker(stopToken)
 
+  const adapterBySource = await getAdaptersForPerSourceRendering(
+    pluginManager,
+    renderProps,
+  )
+
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
     () =>
-      renderToAbstractCanvas(width, height, renderProps, ctx => {
-        const groups = groupBy(features, f => f.get('source'))
+      renderToAbstractCanvas(width, height, renderProps, async ctx => {
         let feats: Feature[] = []
-        for (const source of sources) {
-          const { reducedFeatures } = drawLine(ctx, {
-            ...renderProps,
-            features: groups[source.name] || [],
-            staticColor: source.color || 'blue',
-            colorCallback: () => '', // unused when staticColor is set
-            lastCheck,
-          })
-          feats = feats.concat(reducedFeatures)
-        }
+
+        await forEachSourceFeatures(
+          adapterBySource,
+          sources,
+          region,
+          renderProps,
+          (source, features) => {
+            const { reducedFeatures } = drawLine(ctx, {
+              ...renderProps,
+              features,
+              staticColor: source.color || 'blue',
+              colorCallback: () => '', // unused when staticColor is set
+              lastCheck,
+            })
+            feats = feats.concat(reducedFeatures)
+          },
+        )
+
         return { reducedFeatures: feats }
       }),
   )

--- a/plugins/wiggle/src/MultiRowLineRenderer/makeImageData.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/makeImageData.ts
@@ -5,13 +5,6 @@ export async function makeImageData(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const { renderMultiWiggle } = await import('../multiRendererHelper.ts')
-  return renderMultiWiggle(
-    pluginManager,
-    renderProps,
-    async (props, features) => {
-      const { renderMultiRowLine } = await import('./renderMultiRowLine.ts')
-      return renderMultiRowLine(props, features)
-    },
-  )
+  const { renderMultiRowLine } = await import('./renderMultiRowLine.ts')
+  return renderMultiRowLine(renderProps, pluginManager)
 }

--- a/plugins/wiggle/src/MultiRowLineRenderer/renderMultiRowLine.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/renderMultiRowLine.ts
@@ -4,10 +4,7 @@ import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawLine } from '../drawLine.ts'
-import {
-  forEachSourceFeatures,
-  getAdaptersForPerSourceRendering,
-} from '../multiRendererHelper.ts'
+import { forEachSourceFeatures } from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
@@ -32,11 +29,6 @@ export async function renderMultiRowLine(
   const rowHeight = height / sources.length
   const lastCheck = createStopTokenChecker(stopToken)
 
-  const adapterBySource = await getAdaptersForPerSourceRendering(
-    pluginManager,
-    renderProps,
-  )
-
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
@@ -45,29 +37,23 @@ export async function renderMultiRowLine(
         let feats: Feature[] = []
         ctx.save()
 
-        await forEachSourceFeatures(
-          adapterBySource,
-          sources,
-          region,
-          renderProps,
-          (source, features) => {
-            const { reducedFeatures } = drawLine(ctx, {
-              ...renderProps,
-              features,
-              height: rowHeight,
-              staticColor: source.color || 'blue',
-              colorCallback: () => '', // unused when staticColor is set
-              lastCheck,
-            })
-            ctx.strokeStyle = 'rgba(200,200,200,0.8)'
-            ctx.beginPath()
-            ctx.moveTo(0, rowHeight)
-            ctx.lineTo(width, rowHeight)
-            ctx.stroke()
-            ctx.translate(0, rowHeight)
-            feats = feats.concat(reducedFeatures)
-          },
-        )
+        await forEachSourceFeatures(pluginManager, renderProps, (source, features) => {
+          const { reducedFeatures } = drawLine(ctx, {
+            ...renderProps,
+            features,
+            height: rowHeight,
+            staticColor: source.color || 'blue',
+            colorCallback: () => '', // unused when staticColor is set
+            lastCheck,
+          })
+          ctx.strokeStyle = 'rgba(200,200,200,0.8)'
+          ctx.beginPath()
+          ctx.moveTo(0, rowHeight)
+          ctx.lineTo(width, rowHeight)
+          ctx.stroke()
+          ctx.translate(0, rowHeight)
+          feats = feats.concat(reducedFeatures)
+        })
 
         ctx.restore()
         return { reducedFeatures: feats }

--- a/plugins/wiggle/src/MultiRowLineRenderer/renderMultiRowLine.ts
+++ b/plugins/wiggle/src/MultiRowLineRenderer/renderMultiRowLine.ts
@@ -1,21 +1,22 @@
-import {
-  groupBy,
-  renderToAbstractCanvas,
-  updateStatus,
-} from '@jbrowse/core/util'
+import { renderToAbstractCanvas, updateStatus } from '@jbrowse/core/util'
 import { rpcResult } from '@jbrowse/core/util/librpc'
 import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill'
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawLine } from '../drawLine.ts'
+import {
+  forEachSourceFeatures,
+  getAdaptersForPerSourceRendering,
+} from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
+import type PluginManager from '@jbrowse/core/PluginManager'
 import type { Feature } from '@jbrowse/core/util'
 
 export async function renderMultiRowLine(
   renderProps: MultiRenderArgsDeserialized,
-  features: Feature[],
+  pluginManager: PluginManager,
 ) {
   const {
     sources,
@@ -31,31 +32,43 @@ export async function renderMultiRowLine(
   const rowHeight = height / sources.length
   const lastCheck = createStopTokenChecker(stopToken)
 
+  const adapterBySource = await getAdaptersForPerSourceRendering(
+    pluginManager,
+    renderProps,
+  )
+
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
     () =>
-      renderToAbstractCanvas(width, height, renderProps, ctx => {
-        const groups = groupBy(features, f => f.get('source'))
+      renderToAbstractCanvas(width, height, renderProps, async ctx => {
         let feats: Feature[] = []
         ctx.save()
-        for (const source of sources) {
-          const { reducedFeatures } = drawLine(ctx, {
-            ...renderProps,
-            features: groups[source.name] || [],
-            height: rowHeight,
-            staticColor: source.color || 'blue',
-            colorCallback: () => '', // unused when staticColor is set
-            lastCheck,
-          })
-          ctx.strokeStyle = 'rgba(200,200,200,0.8)'
-          ctx.beginPath()
-          ctx.moveTo(0, rowHeight)
-          ctx.lineTo(width, rowHeight)
-          ctx.stroke()
-          ctx.translate(0, rowHeight)
-          feats = feats.concat(reducedFeatures)
-        }
+
+        await forEachSourceFeatures(
+          adapterBySource,
+          sources,
+          region,
+          renderProps,
+          (source, features) => {
+            const { reducedFeatures } = drawLine(ctx, {
+              ...renderProps,
+              features,
+              height: rowHeight,
+              staticColor: source.color || 'blue',
+              colorCallback: () => '', // unused when staticColor is set
+              lastCheck,
+            })
+            ctx.strokeStyle = 'rgba(200,200,200,0.8)'
+            ctx.beginPath()
+            ctx.moveTo(0, rowHeight)
+            ctx.lineTo(width, rowHeight)
+            ctx.stroke()
+            ctx.translate(0, rowHeight)
+            feats = feats.concat(reducedFeatures)
+          },
+        )
+
         ctx.restore()
         return { reducedFeatures: feats }
       }),

--- a/plugins/wiggle/src/MultiRowXYPlotRenderer/makeImageData.ts
+++ b/plugins/wiggle/src/MultiRowXYPlotRenderer/makeImageData.ts
@@ -5,13 +5,6 @@ export async function makeImageData(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const { renderMultiWiggle } = await import('../multiRendererHelper.ts')
-  return renderMultiWiggle(
-    pluginManager,
-    renderProps,
-    async (props, features) => {
-      const { renderMultiRowXYPlot } = await import('./renderMultiRowXYPlot.ts')
-      return renderMultiRowXYPlot(props, features)
-    },
-  )
+  const { renderMultiRowXYPlot } = await import('./renderMultiRowXYPlot.ts')
+  return renderMultiRowXYPlot(renderProps, pluginManager)
 }

--- a/plugins/wiggle/src/MultiRowXYPlotRenderer/renderMultiRowXYPlot.ts
+++ b/plugins/wiggle/src/MultiRowXYPlotRenderer/renderMultiRowXYPlot.ts
@@ -7,10 +7,7 @@ import { rpcResult } from '@jbrowse/core/util/librpc'
 import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill'
 
 import { drawXY } from '../drawXY.ts'
-import {
-  forEachSourceFeatures,
-  getAdaptersForPerSourceRendering,
-} from '../multiRendererHelper.ts'
+import { forEachSourceFeatures } from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
@@ -36,11 +33,6 @@ export async function renderMultiRowXYPlot(
 
   const lastCheck = createStopTokenChecker(stopToken)
 
-  const adapterBySource = await getAdaptersForPerSourceRendering(
-    pluginManager,
-    renderProps,
-  )
-
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
@@ -49,28 +41,22 @@ export async function renderMultiRowXYPlot(
         let allReducedFeatures: Feature[] = []
         ctx.save()
 
-        await forEachSourceFeatures(
-          adapterBySource,
-          sources,
-          region,
-          renderProps,
-          (source, features) => {
-            const { reducedFeatures: reduced } = drawXY(ctx, {
-              ...renderProps,
-              features,
-              height: rowHeight,
-              colorCallback: () => source.color || 'blue',
-              lastCheck,
-            })
-            allReducedFeatures = allReducedFeatures.concat(reduced)
-            ctx.strokeStyle = 'rgba(200,200,200,0.8)'
-            ctx.beginPath()
-            ctx.moveTo(0, rowHeight)
-            ctx.lineTo(width, rowHeight)
-            ctx.stroke()
-            ctx.translate(0, rowHeight)
-          },
-        )
+        await forEachSourceFeatures(pluginManager, renderProps, (source, features) => {
+          const { reducedFeatures: reduced } = drawXY(ctx, {
+            ...renderProps,
+            features,
+            height: rowHeight,
+            colorCallback: () => source.color || 'blue',
+            lastCheck,
+          })
+          allReducedFeatures = allReducedFeatures.concat(reduced)
+          ctx.strokeStyle = 'rgba(200,200,200,0.8)'
+          ctx.beginPath()
+          ctx.moveTo(0, rowHeight)
+          ctx.lineTo(width, rowHeight)
+          ctx.stroke()
+          ctx.translate(0, rowHeight)
+        })
 
         ctx.restore()
         return { reducedFeatures: allReducedFeatures }

--- a/plugins/wiggle/src/MultiXYPlotRenderer/makeImageData.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/makeImageData.ts
@@ -5,13 +5,6 @@ export async function makeImageData(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const { renderMultiWiggle } = await import('../multiRendererHelper.ts')
-  return renderMultiWiggle(
-    pluginManager,
-    renderProps,
-    async (props, features) => {
-      const { renderMultiXYPlot } = await import('./renderMultiXYPlot.ts')
-      return renderMultiXYPlot(props, features)
-    },
-  )
+  const { renderMultiXYPlot } = await import('./renderMultiXYPlot.ts')
+  return renderMultiXYPlot(renderProps, pluginManager)
 }

--- a/plugins/wiggle/src/MultiXYPlotRenderer/renderMultiXYPlot.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/renderMultiXYPlot.ts
@@ -1,21 +1,22 @@
-import {
-  groupBy,
-  renderToAbstractCanvas,
-  updateStatus,
-} from '@jbrowse/core/util'
+import { renderToAbstractCanvas, updateStatus } from '@jbrowse/core/util'
 import { rpcResult } from '@jbrowse/core/util/librpc'
 import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill'
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawXY } from '../drawXY.ts'
+import {
+  forEachSourceFeatures,
+  getAdaptersForPerSourceRendering,
+} from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
+import type PluginManager from '@jbrowse/core/PluginManager'
 import type { Feature } from '@jbrowse/core/util'
 
 export async function renderMultiXYPlot(
   renderProps: MultiRenderArgsDeserialized,
-  features: Feature[],
+  pluginManager: PluginManager,
 ) {
   const {
     sources,
@@ -30,22 +31,35 @@ export async function renderMultiXYPlot(
   const width = (region.end - region.start) / bpPerPx
 
   const lastCheck = createStopTokenChecker(stopToken)
+
+  const adapterBySource = await getAdaptersForPerSourceRendering(
+    pluginManager,
+    renderProps,
+  )
+
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
     statusCallback,
     () =>
-      renderToAbstractCanvas(width, height, renderProps, ctx => {
-        const groups = groupBy(features, f => f.get('source'))
+      renderToAbstractCanvas(width, height, renderProps, async ctx => {
         let allReducedFeatures: Feature[] = []
-        for (const source of sources) {
-          const { reducedFeatures: reduced } = drawXY(ctx, {
-            ...renderProps,
-            features: groups[source.name] || [],
-            colorCallback: () => source.color || 'blue',
-            lastCheck,
-          })
-          allReducedFeatures = allReducedFeatures.concat(reduced)
-        }
+
+        await forEachSourceFeatures(
+          adapterBySource,
+          sources,
+          region,
+          renderProps,
+          (source, features) => {
+            const { reducedFeatures: reduced } = drawXY(ctx, {
+              ...renderProps,
+              features,
+              colorCallback: () => source.color || 'blue',
+              lastCheck,
+            })
+            allReducedFeatures = allReducedFeatures.concat(reduced)
+          },
+        )
+
         return {
           reducedFeatures: allReducedFeatures,
         }

--- a/plugins/wiggle/src/MultiXYPlotRenderer/renderMultiXYPlot.ts
+++ b/plugins/wiggle/src/MultiXYPlotRenderer/renderMultiXYPlot.ts
@@ -4,10 +4,7 @@ import { collectTransferables } from '@jbrowse/core/util/offscreenCanvasPonyfill
 import { createStopTokenChecker } from '@jbrowse/core/util/stopToken'
 
 import { drawXY } from '../drawXY.ts'
-import {
-  forEachSourceFeatures,
-  getAdaptersForPerSourceRendering,
-} from '../multiRendererHelper.ts'
+import { forEachSourceFeatures } from '../multiRendererHelper.ts'
 import { serializeWiggleFeature } from '../util.ts'
 
 import type { MultiRenderArgsDeserialized } from '../types.ts'
@@ -18,24 +15,13 @@ export async function renderMultiXYPlot(
   renderProps: MultiRenderArgsDeserialized,
   pluginManager: PluginManager,
 ) {
-  const {
-    sources,
-    height,
-    regions,
-    bpPerPx,
-    stopToken,
-    statusCallback = () => {},
-  } = renderProps
+  const { height, regions, bpPerPx, stopToken, statusCallback = () => {} } =
+    renderProps
 
   const region = regions[0]!
   const width = (region.end - region.start) / bpPerPx
 
   const lastCheck = createStopTokenChecker(stopToken)
-
-  const adapterBySource = await getAdaptersForPerSourceRendering(
-    pluginManager,
-    renderProps,
-  )
 
   const { reducedFeatures, ...rest } = await updateStatus(
     'Rendering plot',
@@ -44,21 +30,15 @@ export async function renderMultiXYPlot(
       renderToAbstractCanvas(width, height, renderProps, async ctx => {
         let allReducedFeatures: Feature[] = []
 
-        await forEachSourceFeatures(
-          adapterBySource,
-          sources,
-          region,
-          renderProps,
-          (source, features) => {
-            const { reducedFeatures: reduced } = drawXY(ctx, {
-              ...renderProps,
-              features,
-              colorCallback: () => source.color || 'blue',
-              lastCheck,
-            })
-            allReducedFeatures = allReducedFeatures.concat(reduced)
-          },
-        )
+        await forEachSourceFeatures(pluginManager, renderProps, (source, features) => {
+          const { reducedFeatures: reduced } = drawXY(ctx, {
+            ...renderProps,
+            features,
+            colorCallback: () => source.color || 'blue',
+            lastCheck,
+          })
+          allReducedFeatures = allReducedFeatures.concat(reduced)
+        })
 
         return {
           reducedFeatures: allReducedFeatures,

--- a/plugins/wiggle/src/multiRendererHelper.ts
+++ b/plugins/wiggle/src/multiRendererHelper.ts
@@ -2,34 +2,66 @@ import { getAdapter } from '@jbrowse/core/data_adapters/dataAdapterCache'
 import { firstValueFrom } from 'rxjs'
 import { toArray } from 'rxjs/operators'
 
+import type { Source } from './util.ts'
 import type { MultiRenderArgsDeserialized } from './types.ts'
 import type PluginManager from '@jbrowse/core/PluginManager'
 import type { BaseFeatureDataAdapter } from '@jbrowse/core/data_adapters/BaseAdapter'
-import type { RenderReturn } from '@jbrowse/core/pluggableElementTypes/renderers/RendererType'
-import type { Feature } from '@jbrowse/core/util'
+import type { Feature, Region } from '@jbrowse/core/util'
 
-type RenderFeaturesFn = (
-  props: MultiRenderArgsDeserialized,
-  features: Feature[],
-) => Promise<RenderReturn>
+interface AdapterEntry {
+  dataAdapter: BaseFeatureDataAdapter
+  source: string
+  name: string
+}
 
-export async function renderMultiWiggle(
+export interface PerSourceFeatureCallback {
+  (source: Source, features: Feature[]): void
+}
+
+/**
+ * Gets sub-adapters from MultiWiggleAdapter and provides a way to iterate
+ * over sources, fetching features one source at a time.
+ * This reduces peak memory by only loading one source's features at a time.
+ */
+export async function getAdaptersForPerSourceRendering(
   pluginManager: PluginManager,
   renderProps: MultiRenderArgsDeserialized,
-  renderFeatures: RenderFeaturesFn,
 ) {
-  const { sessionId, adapterConfig, regions } = renderProps
+  const { sessionId, adapterConfig } = renderProps
   const { dataAdapter } = await getAdapter(
     pluginManager,
     sessionId,
     adapterConfig,
   )
-  const region = regions[0]!
 
-  const features = await firstValueFrom(
-    (dataAdapter as BaseFeatureDataAdapter)
-      .getFeatures(region, renderProps)
-      .pipe(toArray()),
-  )
-  return renderFeatures(renderProps, features)
+  const adapters: AdapterEntry[] = await (
+    dataAdapter as BaseFeatureDataAdapter & {
+      getAdapters(): Promise<AdapterEntry[]>
+    }
+  ).getAdapters()
+
+  return new Map(adapters.map(a => [a.source, a.dataAdapter]))
+}
+
+/**
+ * Iterates over sources, fetching and processing features one source at a time.
+ * This reduces peak memory usage from O(all sources) to O(largest single source).
+ */
+export async function forEachSourceFeatures(
+  adapterBySource: Map<string, BaseFeatureDataAdapter>,
+  sources: Source[],
+  region: Region,
+  opts: Record<string, unknown>,
+  callback: PerSourceFeatureCallback,
+) {
+  for (const source of sources) {
+    const subAdapter = adapterBySource.get(source.name)
+    if (subAdapter) {
+      const features = await firstValueFrom(
+        subAdapter.getFeatures(region, opts).pipe(toArray()),
+      )
+      callback(source, features)
+      // features array goes out of scope here, can be GC'd before next source
+    }
+  }
 }


### PR DESCRIPTION
The current multi-wiggle rendering can result in large memory usage because it loads everything into memory and then renders it all at once

This PR changes it to render one by one

This could be slightly slower (might be worth benchmarking) but it will likely improve app stability

The MAFViewer recently changed to use a more 'streaming' style approach like this, and it reduced peak memory usage by 1/2 which was significantly since the large MAF files are quite memory intensive