### PR TITLE
Add more re-exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -147,6 +147,7 @@
     "build": "pnpm build:esm"
   },
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/serialize": "^1.3.3",
     "@emotion/utils": "^1.4.2",
@@ -179,6 +180,7 @@
     "mobx": "^6.15.0",
     "mobx-react": "^9.2.1",
     "react-draggable": "^4.5.0",
+    "react-is": "^19.1.0",
     "rxjs": "^7.8.2",
     "source-map-js": "^1.2.1"
   },

--- a/packages/core/src/ReExports/list.ts
+++ b/packages/core/src/ReExports/list.ts
@@ -286,4 +286,13 @@ export default [
   '@jbrowse/core/util/rxjs',
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail',
   '@jbrowse/core/data_adapters/BaseAdapter',
+  '@jbrowse/core/jexl',
+
+  '@floating-ui/react',
+  'react-is',
+
+  '@emotion/cache',
+  '@emotion/react',
+  '@emotion/serialize',
+  '@emotion/utils',
 ]

--- a/packages/core/src/ReExports/modules.ts
+++ b/packages/core/src/ReExports/modules.ts
@@ -1,5 +1,11 @@
 import * as React from 'react'
+import * as ReactIs from 'react-is'
 
+import * as emotionCache from '@emotion/cache'
+import * as emotionReact from '@emotion/react'
+import * as emotionSerialize from '@emotion/serialize'
+import * as emotionUtils from '@emotion/utils'
+import * as floatingUiReact from '@floating-ui/react'
 import * as mst from '@jbrowse/mobx-state-tree'
 import { alpha, createTheme, useTheme } from '@mui/material'
 import * as MUIStyles from '@mui/material/styles'
@@ -47,6 +53,7 @@ import * as rxjs from '../util/rxjs.ts'
 import * as trackUtils from '../util/tracks.ts'
 import { cx, keyframes, makeStyles } from '../util/tss-react/index.ts'
 import * as mstTypes from '../util/types/mst.ts'
+import jexl from '../util/jexl.ts'
 
 const libs = {
   mobx,
@@ -158,6 +165,15 @@ const libs = {
 
   '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail': BaseFeatureDetail,
   '@jbrowse/core/data_adapters/BaseAdapter': BaseAdapterExports,
+  '@jbrowse/core/jexl': jexl,
+
+  '@floating-ui/react': floatingUiReact,
+  'react-is': ReactIs,
+
+  '@emotion/cache': emotionCache,
+  '@emotion/react': emotionReact,
+  '@emotion/serialize': emotionSerialize,
+  '@emotion/utils': emotionUtils,
 }
 
 const libsList = Object.keys(libs)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@emotion/cache':
+        specifier: ^11.14.0
+        version: 11.14.0
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.10)(react@19.2.4)
@@ -476,6 +479,9 @@ importers:
       react-draggable:
         specifier: ^4.5.0
         version: 4.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-is:
+        specifier: ^19.1.0
+        version: 19.2.4
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -4713,41 +4719,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}


### PR DESCRIPTION
Potential fix towards https://github.com/GMOD/jbrowse-plugin-template/issues/54

I'm not super excited about exporting such 'internal' packages but it is potentially bad/breaking behavior to even have plugins building and bundling their own versions