### PR TITLE
Add PNG export option to the 'Export SVG' dialog

### DIFF
--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/components/ExportSvgDialog.tsx
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/components/ExportSvgDialog.tsx
@@ -11,17 +11,19 @@ import {
   FormControlLabel,
   MenuItem,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material'
 
 import type { ExportSvgOptions } from '../types.ts'
 import type { TextFieldProps } from '@mui/material'
 
-function LoadingMessage() {
+function LoadingMessage({ format }: { format: string }) {
   return (
     <div>
       <CircularProgress size={20} style={{ marginRight: 20 }} />
-      <Typography display="inline">Creating SVG</Typography>
+      <Typography display="inline">Creating {format.toUpperCase()}</Typography>
     </div>
   )
 }
@@ -50,6 +52,7 @@ export default function ExportSvgDialog({
   const [showGridlines, setShowGridlines] = useSvgLocal('gridlines', false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
+  const [format, setFormat] = useSvgLocal<'svg' | 'png'>('format', 'svg')
   const [filename, setFilename] = useSvgLocal('file', 'jbrowse.svg')
   const [trackLabels, setTrackLabels] = useSvgLocal('tracklabels', 'offset')
   const [themeName, setThemeName] = useSvgLocal(
@@ -57,20 +60,40 @@ export default function ExportSvgDialog({
     session.themeName || 'default',
   )
   return (
-    <Dialog open onClose={handleClose} title="Export SVG">
+    <Dialog open onClose={handleClose} title="Export image">
       <DialogContent>
         {error ? (
           <ErrorMessage error={error} />
         ) : loading ? (
-          <LoadingMessage />
+          <LoadingMessage format={format} />
         ) : null}
-        <TextField2
-          helperText="filename"
-          value={filename}
-          onChange={event => {
-            setFilename(event.target.value)
-          }}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <TextField
+            helperText="filename"
+            value={filename}
+            onChange={event => {
+              setFilename(event.target.value)
+            }}
+          />
+          <ToggleButtonGroup
+            value={format}
+            exclusive
+            onChange={(_event, value: 'svg' | 'png' | null) => {
+              if (value) {
+                setFormat(value)
+                if (filename.endsWith('.svg') && value === 'png') {
+                  setFilename(filename.replace(/\.svg$/, '.png'))
+                } else if (filename.endsWith('.png') && value === 'svg') {
+                  setFilename(filename.replace(/\.png$/, '.svg'))
+                }
+              }
+            }}
+            size="small"
+          >
+            <ToggleButton value="svg">SVG</ToggleButton>
+            <ToggleButton value="png">PNG</ToggleButton>
+          </ToggleButtonGroup>
+        </div>
         <TextField2
           select
           label="Track label positioning"
@@ -159,6 +182,7 @@ export default function ExportSvgDialog({
             try {
               await model.exportSvg({
                 rasterizeLayers,
+                format,
                 filename,
                 trackLabels,
                 themeName,

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/model.ts
@@ -122,10 +122,43 @@ export default function stateModelFactory(pluginManager: PluginManager) {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { saveAs } = await import('file-saver-es')
 
-        saveAs(
-          new Blob([html], { type: 'image/svg+xml' }),
-          opts.filename || 'image.svg',
-        )
+        if (opts.format === 'png') {
+          const img = new Image()
+          const svgBlob = new Blob([html], { type: 'image/svg+xml' })
+          const url = URL.createObjectURL(svgBlob)
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => {
+              const canvas = document.createElement('canvas')
+              canvas.width = img.width
+              canvas.height = img.height
+              const ctx = canvas.getContext('2d')!
+              ctx.drawImage(img, 0, 0)
+              URL.revokeObjectURL(url)
+              canvas.toBlob(blob => {
+                if (blob) {
+                  saveAs(blob, opts.filename || 'image.png')
+                  resolve()
+                } else {
+                  reject(
+                    new Error(
+                      `Failed to create PNG. The image may be too large (${img.width}x${img.height}). Try reducing the view size or use SVG format.`,
+                    ),
+                  )
+                }
+              }, 'image/png')
+            }
+            img.onerror = () => {
+              URL.revokeObjectURL(url)
+              reject(new Error('Failed to load SVG for PNG conversion'))
+            }
+            img.src = url
+          })
+        } else {
+          saveAs(
+            new Blob([html], { type: 'image/svg+xml' }),
+            opts.filename || 'image.svg',
+          )
+        }
       },
     }))
     .views(self => ({

--- a/plugins/breakpoint-split-view/src/BreakpointSplitView/types.ts
+++ b/plugins/breakpoint-split-view/src/BreakpointSplitView/types.ts
@@ -1,5 +1,6 @@
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
+  format?: 'svg' | 'png'
   filename?: string
   Wrapper?: React.FC<{ children: React.ReactNode }>
   fontSize?: number

--- a/plugins/circular-view/src/CircularView/model.ts
+++ b/plugins/circular-view/src/CircularView/model.ts
@@ -38,6 +38,7 @@ export interface CircularViewInit {
 }
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
+  format?: 'svg' | 'png'
   filename?: string
   Wrapper?: React.FC<{ children: React.ReactNode }>
   themeName?: string
@@ -668,10 +669,44 @@ function stateModelFactory(pluginManager: PluginManager) {
         const html = await renderToSvg(self as CircularViewModel, opts)
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { saveAs } = await import('file-saver-es')
-        saveAs(
-          new Blob([html], { type: 'image/svg+xml' }),
-          opts.filename || 'image.svg',
-        )
+
+        if (opts.format === 'png') {
+          const img = new Image()
+          const svgBlob = new Blob([html], { type: 'image/svg+xml' })
+          const url = URL.createObjectURL(svgBlob)
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => {
+              const canvas = document.createElement('canvas')
+              canvas.width = img.width
+              canvas.height = img.height
+              const ctx = canvas.getContext('2d')!
+              ctx.drawImage(img, 0, 0)
+              URL.revokeObjectURL(url)
+              canvas.toBlob(blob => {
+                if (blob) {
+                  saveAs(blob, opts.filename || 'image.png')
+                  resolve()
+                } else {
+                  reject(
+                    new Error(
+                      `Failed to create PNG. The image may be too large (${img.width}x${img.height}). Try reducing the view size or use SVG format.`,
+                    ),
+                  )
+                }
+              }, 'image/png')
+            }
+            img.onerror = () => {
+              URL.revokeObjectURL(url)
+              reject(new Error('Failed to load SVG for PNG conversion'))
+            }
+            img.src = url
+          })
+        } else {
+          saveAs(
+            new Blob([html], { type: 'image/svg+xml' }),
+            opts.filename || 'image.svg',
+          )
+        }
       },
     }))
     .actions(self => ({

--- a/plugins/dotplot-view/src/DotplotView/components/ExportSvgDialog.tsx
+++ b/plugins/dotplot-view/src/DotplotView/components/ExportSvgDialog.tsx
@@ -11,17 +11,19 @@ import {
   FormControlLabel,
   MenuItem,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material'
 
 import type { ExportSvgOptions } from '../model.ts'
 import type { TextFieldProps } from '@mui/material'
 
-function LoadingMessage() {
+function LoadingMessage({ format }: { format: string }) {
   return (
     <div>
       <CircularProgress size={20} style={{ marginRight: 20 }} />
-      <Typography display="inline">Creating SVG</Typography>
+      <Typography display="inline">Creating {format.toUpperCase()}</Typography>
     </div>
   )
 }
@@ -49,26 +51,47 @@ export default function ExportSvgDialog({
   const [rasterizeLayers, setRasterizeLayers] = useState(offscreenCanvas)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
+  const [format, setFormat] = useSvgLocal<'svg' | 'png'>('format', 'svg')
   const [filename, setFilename] = useSvgLocal('file', 'jbrowse.svg')
   const [themeName, setThemeName] = useSvgLocal(
     'theme',
     session.themeName || 'default',
   )
   return (
-    <Dialog open onClose={handleClose} title="Export SVG">
+    <Dialog open onClose={handleClose} title="Export image">
       <DialogContent>
         {error ? (
           <ErrorMessage error={error} />
         ) : loading ? (
-          <LoadingMessage />
+          <LoadingMessage format={format} />
         ) : null}
-        <TextField2
-          helperText="filename"
-          value={filename}
-          onChange={event => {
-            setFilename(event.target.value)
-          }}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <TextField
+            helperText="filename"
+            value={filename}
+            onChange={event => {
+              setFilename(event.target.value)
+            }}
+          />
+          <ToggleButtonGroup
+            value={format}
+            exclusive
+            onChange={(_event, value: 'svg' | 'png' | null) => {
+              if (value) {
+                setFormat(value)
+                if (filename.endsWith('.svg') && value === 'png') {
+                  setFilename(filename.replace(/\.svg$/, '.png'))
+                } else if (filename.endsWith('.png') && value === 'svg') {
+                  setFilename(filename.replace(/\.png$/, '.svg'))
+                }
+              }
+            }}
+            size="small"
+          >
+            <ToggleButton value="svg">SVG</ToggleButton>
+            <ToggleButton value="png">PNG</ToggleButton>
+          </ToggleButtonGroup>
+        </div>
         {session.allThemes ? (
           <TextField2
             select
@@ -127,6 +150,7 @@ export default function ExportSvgDialog({
             try {
               await model.exportSvg({
                 rasterizeLayers,
+                format,
                 filename,
                 themeName,
               })

--- a/plugins/dotplot-view/src/DotplotView/model.ts
+++ b/plugins/dotplot-view/src/DotplotView/model.ts
@@ -58,6 +58,7 @@ const defaultFontSize = 15
 
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
+  format?: 'svg' | 'png'
   filename?: string
   Wrapper?: React.FC<{ children: React.ReactNode }>
   themeName?: string
@@ -684,10 +685,44 @@ export default function stateModelFactory(pm: PluginManager) {
         const html = await renderToSvg(self as DotplotViewModel, opts)
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { saveAs } = await import('file-saver-es')
-        saveAs(
-          new Blob([html], { type: 'image/svg+xml' }),
-          opts.filename || 'image.svg',
-        )
+
+        if (opts.format === 'png') {
+          const img = new Image()
+          const svgBlob = new Blob([html], { type: 'image/svg+xml' })
+          const url = URL.createObjectURL(svgBlob)
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => {
+              const canvas = document.createElement('canvas')
+              canvas.width = img.width
+              canvas.height = img.height
+              const ctx = canvas.getContext('2d')!
+              ctx.drawImage(img, 0, 0)
+              URL.revokeObjectURL(url)
+              canvas.toBlob(blob => {
+                if (blob) {
+                  saveAs(blob, opts.filename || 'image.png')
+                  resolve()
+                } else {
+                  reject(
+                    new Error(
+                      `Failed to create PNG. The image may be too large (${img.width}x${img.height}). Try reducing the view size or use SVG format.`,
+                    ),
+                  )
+                }
+              }, 'image/png')
+            }
+            img.onerror = () => {
+              URL.revokeObjectURL(url)
+              reject(new Error('Failed to load SVG for PNG conversion'))
+            }
+            img.src = url
+          })
+        } else {
+          saveAs(
+            new Blob([html], { type: 'image/svg+xml' }),
+            opts.filename || 'image.svg',
+          )
+        }
       },
       // if any of our assemblies are temporary assemblies
       beforeDestroy() {

--- a/plugins/linear-comparative-view/src/LinearSyntenyView/types.ts
+++ b/plugins/linear-comparative-view/src/LinearSyntenyView/types.ts
@@ -21,6 +21,7 @@ export interface LinearSyntenyViewInit {
 
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
+  format?: 'svg' | 'png'
   scale?: number
   filename?: string
   Wrapper?: React.FC<{ children: React.ReactNode }>

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/ExportSvgDialog.tsx
@@ -11,17 +11,19 @@ import {
   FormControlLabel,
   MenuItem,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material'
 
 import type { ExportSvgOptions } from '../types.ts'
 import type { TextFieldProps } from '@mui/material'
 
-function LoadingMessage() {
+function LoadingMessage({ format }: { format: string }) {
   return (
     <div>
       <CircularProgress size={20} style={{ marginRight: 20 }} />
-      <Typography display="inline">Creating SVG</Typography>
+      <Typography display="inline">Creating {format.toUpperCase()}</Typography>
     </div>
   )
 }
@@ -51,6 +53,7 @@ export default function ExportSvgDialog({
   const [showGridlines, setShowGridlines] = useSvgLocal('gridlines', false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
+  const [format, setFormat] = useSvgLocal<'svg' | 'png'>('format', 'svg')
   const [filename, setFilename] = useSvgLocal('file', 'jbrowse.svg')
   const [trackLabels, setTrackLabels] = useSvgLocal('tracklabels', 'offset')
   const [themeName, setThemeName] = useSvgLocal(
@@ -58,20 +61,40 @@ export default function ExportSvgDialog({
     session.themeName || 'default',
   )
   return (
-    <Dialog open onClose={handleClose} title="Export SVG">
+    <Dialog open onClose={handleClose} title="Export image">
       <DialogContent>
         {error ? (
           <ErrorMessage error={error} />
         ) : loading ? (
-          <LoadingMessage />
+          <LoadingMessage format={format} />
         ) : null}
-        <TextField2
-          helperText="filename"
-          value={filename}
-          onChange={event => {
-            setFilename(event.target.value)
-          }}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <TextField
+            helperText="filename"
+            value={filename}
+            onChange={event => {
+              setFilename(event.target.value)
+            }}
+          />
+          <ToggleButtonGroup
+            value={format}
+            exclusive
+            onChange={(_event, value: 'svg' | 'png' | null) => {
+              if (value) {
+                setFormat(value)
+                if (filename.endsWith('.svg') && value === 'png') {
+                  setFilename(filename.replace(/\.svg$/, '.png'))
+                } else if (filename.endsWith('.png') && value === 'svg') {
+                  setFilename(filename.replace(/\.png$/, '.svg'))
+                }
+              }
+            }}
+            size="small"
+          >
+            <ToggleButton value="svg">SVG</ToggleButton>
+            <ToggleButton value="png">PNG</ToggleButton>
+          </ToggleButtonGroup>
+        </div>
         <TextField2
           select
           label="Track label positioning"
@@ -159,6 +182,7 @@ export default function ExportSvgDialog({
             try {
               await model.exportSvg({
                 rasterizeLayers,
+                format,
                 filename,
                 trackLabels,
                 themeName,

--- a/plugins/linear-genome-view/src/LinearGenomeView/model.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/model.ts
@@ -1190,10 +1190,43 @@ export function stateModelFactory(pluginManager: PluginManager) {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { saveAs } = await import('file-saver-es')
 
-        saveAs(
-          new Blob([html], { type: 'image/svg+xml' }),
-          opts.filename || 'image.svg',
-        )
+        if (opts.format === 'png') {
+          const img = new Image()
+          const svgBlob = new Blob([html], { type: 'image/svg+xml' })
+          const url = URL.createObjectURL(svgBlob)
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => {
+              const canvas = document.createElement('canvas')
+              canvas.width = img.width
+              canvas.height = img.height
+              const ctx = canvas.getContext('2d')!
+              ctx.drawImage(img, 0, 0)
+              URL.revokeObjectURL(url)
+              canvas.toBlob(blob => {
+                if (blob) {
+                  saveAs(blob, opts.filename || 'image.png')
+                  resolve()
+                } else {
+                  reject(
+                    new Error(
+                      `Failed to create PNG. The image may be too large (${img.width}x${img.height}). Try reducing the view size or use SVG format.`,
+                    ),
+                  )
+                }
+              }, 'image/png')
+            }
+            img.onerror = () => {
+              URL.revokeObjectURL(url)
+              reject(new Error('Failed to load SVG for PNG conversion'))
+            }
+            img.src = url
+          })
+        } else {
+          saveAs(
+            new Blob([html], { type: 'image/svg+xml' }),
+            opts.filename || 'image.svg',
+          )
+        }
       },
     }))
     .actions(self => {

--- a/plugins/linear-genome-view/src/LinearGenomeView/types.ts
+++ b/plugins/linear-genome-view/src/LinearGenomeView/types.ts
@@ -11,6 +11,7 @@ export interface BpOffset {
 }
 export interface ExportSvgOptions {
   rasterizeLayers?: boolean
+  format?: 'svg' | 'png'
   filename?: string
   Wrapper?: React.FC<{ children: React.ReactNode }>
   fontSize?: number


### PR DESCRIPTION
This renders the png to a canvas, and then saves the canvas as png

Sometimes the image will be too large, but hopefully this helps some users

The dialog box still says Export SVG...maybe can be retitled but not done yet

Helps to fix part of #5461