### PR TITLE
Make each sequence panel in feature details use an independent mobx-state-tree instance

### DIFF
--- a/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.test.tsx
+++ b/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.test.tsx
@@ -7,6 +7,10 @@ import { SequenceFeatureDetailsF } from './model.ts'
 import DLGAP3 from './test_data/DLGAP3.ts'
 import NCDN from './test_data/NCDN.ts'
 
+afterEach(() => {
+  localStorage.clear()
+})
+
 const f = {
   start: 1200,
   end: 1500,

--- a/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
+++ b/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/SequenceFeatureDetails.tsx
@@ -5,6 +5,10 @@ import { observer } from 'mobx-react'
 
 import SequenceFeatureMenu from './dialogs/SequenceFeatureMenu.tsx'
 import SequenceTypeSelector from './dialogs/SequenceTypeSelector.tsx'
+import {
+  createSequenceFeatureDetailsModel,
+  destroySequenceFeatureDetailsModel,
+} from './model.ts'
 import { ErrorMessage, LoadingEllipses } from '../../ui/index.ts'
 import { SimpleFeature, getSession } from '../../util/index.ts'
 import { useFeatureSequence } from '../../util/useFeatureSequence.ts'
@@ -25,7 +29,15 @@ const SequenceFeatureDetails = observer(function SequenceFeatureDetails({
   model: BaseFeatureWidgetModel
   feature: SimpleFeatureSerialized
 }) {
-  const { sequenceFeatureDetails } = model
+  const [sequenceFeatureDetails] = useState(() =>
+    createSequenceFeatureDetailsModel(),
+  )
+  useEffect(() => {
+    return () => {
+      destroySequenceFeatureDetailsModel(sequenceFeatureDetails)
+    }
+  }, [sequenceFeatureDetails])
+
   const { upDownBp } = sequenceFeatureDetails
   const seqPanelRef = useRef<HTMLDivElement>(null)
 
@@ -68,6 +80,7 @@ const SequenceFeatureDetails = observer(function SequenceFeatureDetails({
           <Suspense fallback={<LoadingEllipses />}>
             <SequenceDialog
               model={model}
+              sequenceFeatureDetails={sequenceFeatureDetails}
               feature={feature}
               handleClose={() => {
                 setOpenInDialog(false)

--- a/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
+++ b/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/dialogs/SequenceDialog.tsx
@@ -16,6 +16,7 @@ import { useFeatureSequence } from '../../../util/useFeatureSequence.ts'
 import SequencePanel from '../SequencePanel.tsx'
 
 import type { BaseFeatureWidgetModel } from '../../stateModelFactory.ts'
+import type { SequenceFeatureDetailsModel } from '../model.ts'
 
 const useStyles = makeStyles()({
   dialogContent: {
@@ -26,13 +27,14 @@ const useStyles = makeStyles()({
 const SequenceDialog = observer(function SequenceDialog({
   handleClose,
   model,
+  sequenceFeatureDetails,
   feature,
 }: {
   handleClose: () => void
   feature: SimpleFeatureSerialized
   model: BaseFeatureWidgetModel
+  sequenceFeatureDetails: SequenceFeatureDetailsModel
 }) {
-  const { sequenceFeatureDetails } = model
   const { upDownBp } = sequenceFeatureDetails
   const { classes } = useStyles()
   const seqPanelRef = useRef<HTMLDivElement>(null)

--- a/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/model.ts
+++ b/packages/core/src/BaseFeatureWidget/SequenceFeatureDetails/model.ts
@@ -1,4 +1,4 @@
-import { addDisposer, types } from '@jbrowse/mobx-state-tree'
+import { addDisposer, destroy, types } from '@jbrowse/mobx-state-tree'
 import { autorun } from 'mobx'
 
 import {
@@ -150,7 +150,7 @@ export function SequenceFeatureDetailsF() {
       },
     }))
     .actions(self => ({
-      afterAttach() {
+      afterCreate() {
         addDisposer(
           self,
           autorun(
@@ -179,6 +179,16 @@ export function SequenceFeatureDetailsF() {
         )
       },
     }))
+}
+
+export function createSequenceFeatureDetailsModel() {
+  return SequenceFeatureDetailsF().create({})
+}
+
+export function destroySequenceFeatureDetailsModel(
+  model: SequenceFeatureDetailsModel,
+) {
+  destroy(model)
 }
 
 export type SequenceFeatureDetailsStateModel = ReturnType<


### PR DESCRIPTION
Multiple sequence panels can show up when clicking e.g. a gene feature, but each of them on current main share a MST model. This makes them all independent

Fixes https://github.com/GMOD/jbrowse-components/issues/4688

