### PR TITLE
Export fetchResults from linear-genome-view

### DIFF
--- a/plugins/linear-genome-view/src/index.ts
+++ b/plugins/linear-genome-view/src/index.ts
@@ -114,6 +114,7 @@ export {
   RefNameAutocomplete,
   SearchBox,
 } from './LinearGenomeView/index.ts'
+export { fetchResults } from './searchUtils.ts'
 export type {
   BpOffset,
   ExportSvgOptions,


### PR DESCRIPTION
Hi,

I'm part of @bbimber's group. As part of responding to #5290, I'm updating our jbrowse-components version to v4.1.3. We have a component [here](https://github.com/BimberLab/DiscvrLabKeyModules/blob/d125afeb1e5b8dc1b83cd02065f6464f7781b57e/jbrowse/src/client/JBrowse/Search/components/StandaloneSearchComponent.tsx#L3) that relies on a deep import from the linear-genome-view plugin like so:

`import { fetchResults } from '@jbrowse/plugin-linear-genome-view/esm/LinearGenomeView/components/util';`

As I understand it, with the move to ESM, this sort of import is no longer possible. Would it make sense to export fetchResults, and potentially other members of `searchUtils.ts`?