### PR TITLE
Use Element setHTML if available

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -199,15 +199,8 @@ jobs:
         run: node --experimental-strip-types browser-tests/runner.ts
         working-directory: products/jbrowse-web
         continue-on-error: true
-      - name: Run auth browser tests with Puppeteer
-        id: auth-browser-tests
-        run: node --experimental-strip-types browser-tests/runner.ts --auth
-        working-directory: products/jbrowse-web
-        continue-on-error: true
       - name: Upload snapshot diffs to S3
-        if:
-          steps.browser-tests.outcome == 'failure' ||
-          steps.auth-browser-tests.outcome == 'failure'
+        if: steps.browser-tests.outcome == 'failure'
         run: |
           SNAPSHOTS_DIR="products/jbrowse-web/browser-tests/__snapshots__"
           S3_PATH="s3://jbrowse.org/demos/imagediff/${{ github.run_id }}"
@@ -229,9 +222,7 @@ jobs:
             echo "No snapshot diff files found"
           fi
       - name: Fail if browser tests failed
-        if:
-          steps.browser-tests.outcome == 'failure' ||
-          steps.auth-browser-tests.outcome == 'failure'
+        if: steps.browser-tests.outcome == 'failure'
         run: exit 1
 
       - name: Upload packed artifacts for component tests

--- a/config/jest/console.js
+++ b/config/jest/console.js
@@ -1,7 +1,7 @@
 const originalError = console.error
 const originalWarn = console.warn
 
-jest.spyOn(console, 'error').mockImplementation((...args) => {
+console.error = (...args) => {
   const r = String(args)
   if (
     r.includes('volvox.2bit_404') ||
@@ -15,13 +15,13 @@ jest.spyOn(console, 'error').mockImplementation((...args) => {
   }
 
   originalError.call(console, ...args)
-})
+}
 
-jest.spyOn(console, 'warn').mockImplementation((...args) => {
+console.warn = (...args) => {
   const r = String(args)
   if (r.includes('The `anchorEl` prop provided to the component is invalid')) {
     return undefined
   }
 
   originalWarn.call(console, ...args)
-})
+}

--- a/config/jest/setHTML.js
+++ b/config/jest/setHTML.js
@@ -1,0 +1,10 @@
+// Polyfill setHTML so that SanitizedHTML renders content synchronously in
+// tests instead of going through the lazy-loaded DOMPurify/Suspense path
+// which produces empty snapshots
+const dompurify = require('dompurify')
+
+if (typeof Element !== 'undefined' && !Element.prototype.setHTML) {
+  Element.prototype.setHTML = function (html) {
+    this.innerHTML = dompurify.sanitize(html)
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,6 @@ const baseConfig = {
   moduleNameMapper: {
     '^@jbrowse/core/util/useMeasure$':
       '<rootDir>/packages/__mocks__/@jbrowse/core/util/useMeasure.ts',
-    '^@jbrowse/core/ui/SanitizedHTML$':
-      '<rootDir>/packages/__mocks__/@jbrowse/core/ui/SanitizedHTML.tsx',
     '^@jbrowse/text-indexing-core$':
       '<rootDir>/packages/text-indexing-core/src/index.ts',
   },
@@ -29,6 +27,7 @@ const baseConfig = {
     '<rootDir>/config/jest/console.js',
     '<rootDir>/config/jest/messagechannel.js',
     '<rootDir>/config/jest/structuredClone.js',
+    '<rootDir>/config/jest/setHTML.js',
   ],
   testEnvironmentOptions: { url: 'http://localhost' },
   testTimeout: 15000,

--- a/packages/__mocks__/@jbrowse/core/ui/SanitizedHTML.tsx
+++ b/packages/__mocks__/@jbrowse/core/ui/SanitizedHTML.tsx
@@ -1,3 +1,0 @@
-export default function SanitizedHTML({ html }: { html: string }) {
-  return html
-}

--- a/packages/app-core/src/ui/App/ViewHeader.tsx
+++ b/packages/app-core/src/ui/App/ViewHeader.tsx
@@ -54,7 +54,11 @@ const ViewHeader = observer(function ViewHeader({
   // scroll the view into view when first mounted. note: this effect will run
   // only once, because of the empty array second param
   useEffect(() => {
-    if (typeof jest === 'undefined' && window.self === window.top) {
+    if (
+      typeof jest === 'undefined' &&
+      !navigator.webdriver &&
+      window.self === window.top
+    ) {
       scrollRef.current?.scrollIntoView({ block: 'center' })
     }
   }, [])

--- a/packages/core/src/ui/DOMPurifySanitizedHTML.tsx
+++ b/packages/core/src/ui/DOMPurifySanitizedHTML.tsx
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useRef } from 'react'
+
+import dompurify from 'dompurify'
+
+export default function DOMPurifySanitizedHTML({
+  value,
+  className,
+}: {
+  value: string
+  className?: string
+}) {
+  const spanRef = useRef<HTMLSpanElement>(null)
+
+  useLayoutEffect(() => {
+    const el = spanRef.current
+    if (el) {
+      for (const a of el.querySelectorAll('a')) {
+        a.setAttribute('rel', 'noopener noreferrer')
+        a.setAttribute('target', '_blank')
+      }
+    }
+  }, [value])
+
+  return (
+    <span
+      ref={spanRef}
+      className={className}
+      dangerouslySetInnerHTML={{ __html: dompurify.sanitize(value) }}
+    />
+  )
+}

--- a/packages/core/src/ui/SanitizedHTML.test.tsx
+++ b/packages/core/src/ui/SanitizedHTML.test.tsx
@@ -1,19 +1,92 @@
 import '@testing-library/jest-dom'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 
 import Sanitize from './SanitizedHTML.tsx'
 
-test('test basic escaping with bold', () => {
-  const { getByText } = render(<Sanitize html="<b>Test</b" />)
-  expect(getByText('Test')).toBeInTheDocument()
+test('test basic escaping with bold', async () => {
+  const { getByText } = render(<Sanitize html="<b>Test</b>" />)
+  await waitFor(() => {
+    expect(getByText('Test')).toBeInTheDocument()
+  })
 })
 
-test('test escaping', () => {
-  const { getByText } = render(<Sanitize html="<bb>Test</b" />)
-  expect(getByText('<bb>Test</b')).toBeInTheDocument()
+test('test escaping', async () => {
+  const { getByText } = render(<Sanitize html="<bb>Test</bb>" />)
+  await waitFor(() => {
+    expect(getByText('<bb>Test</bb>')).toBeInTheDocument()
+  })
 })
 
-test('test <TRA>', () => {
+test('test <TRA>', async () => {
   const { getByText } = render(<Sanitize html="<TRA><DEL><INS><DEL:ME>" />)
-  expect(getByText('<TRA><DEL><INS><DEL:ME>')).toBeInTheDocument()
+  await waitFor(() => {
+    expect(getByText('<TRA><DEL><INS><DEL:ME>')).toBeInTheDocument()
+  })
+})
+
+test('uses setHTML if available', () => {
+  const setHTMLMock = jest.fn(function (this: HTMLElement, html: string) {
+    this.innerHTML = html
+  })
+  // @ts-ignore
+  const oldSetHTML = Element.prototype.setHTML
+  // @ts-ignore
+  Element.prototype.setHTML = setHTMLMock
+
+  try {
+    const { getByText } = render(<Sanitize html="<p>Using setHTML</p>" />)
+    expect(getByText('Using setHTML')).toBeInTheDocument()
+    expect(setHTMLMock).toHaveBeenCalledWith('<p>Using setHTML</p>')
+  } finally {
+    // @ts-ignore
+    Element.prototype.setHTML = oldSetHTML
+  }
+})
+
+test('adds rel and target to links when using setHTML', () => {
+  const setHTMLMock = jest.fn(function (this: HTMLElement, html: string) {
+    this.innerHTML = html
+  })
+  // @ts-ignore
+  const oldSetHTML = Element.prototype.setHTML
+  // @ts-ignore
+  Element.prototype.setHTML = setHTMLMock
+
+  try {
+    const { getByRole } = render(
+      <Sanitize html='<a href="https://google.com">Google</a>' />,
+    )
+    const link = getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://google.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  } finally {
+    // @ts-ignore
+    Element.prototype.setHTML = oldSetHTML
+  }
+})
+
+test('falls back to dompurify if setHTML is unavailable', async () => {
+  // Ensure setHTML is NOT present
+  // @ts-ignore
+  const oldSetHTML = Element.prototype.setHTML
+  // @ts-ignore
+  delete Element.prototype.setHTML
+
+  try {
+    const { getByText, getByRole } = render(
+      <Sanitize html='<a href="https://google.com">Google</a>' />,
+    )
+    await waitFor(() => {
+      expect(getByRole('link')).toBeInTheDocument()
+    })
+    const link = getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://google.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(getByText('Google')).toBeInTheDocument()
+  } finally {
+    // @ts-ignore
+    Element.prototype.setHTML = oldSetHTML
+  }
 })

--- a/packages/core/src/ui/SanitizedHTML.tsx
+++ b/packages/core/src/ui/SanitizedHTML.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from 'react'
+import { Suspense, lazy, useLayoutEffect, useRef } from 'react'
 
-import dompurify from 'dompurify'
 import escapeHTML from 'escape-html'
 
 import { linkify } from '../util/index.ts'
@@ -44,7 +43,9 @@ const htmlTags = [
   'ul',
 ]
 
-let added = false
+const DOMPurifySanitizedHTML = lazy(
+  () => import('./DOMPurifySanitizedHTML.tsx'),
+)
 
 // adapted from is-html
 // https://github.com/sindresorhus/is-html/blob/master/index.js
@@ -56,12 +57,26 @@ function isHTML(str: string) {
   return full.test(str)
 }
 
-// note this is mocked during testing, see
-// packages/__mocks__/@jbrowse/core/ui/SanitizedHTML something about dompurify
-// behavior causes errors during tests, was seen in
-// products/jbrowse-web/src/tests/Connection.test.tsx test (can delete mock to
-// see)
-//
+function SetHTML({ value, className }: { value: string; className?: string }) {
+  const spanRef = useRef<HTMLSpanElement>(null)
+  useLayoutEffect(() => {
+    const el = spanRef.current
+    if (el) {
+      try {
+        // @ts-expect-error
+        el.setHTML(value)
+        for (const a of el.querySelectorAll('a')) {
+          a.setAttribute('rel', 'noopener noreferrer')
+          a.setAttribute('target', '_blank')
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }, [value])
+  return <span ref={spanRef} className={className} />
+}
+
 export default function SanitizedHTML({
   html: pre,
   className,
@@ -69,30 +84,17 @@ export default function SanitizedHTML({
   className?: string
   html: unknown
 }) {
-  // try to add links to the text first
   const html = linkify(`${pre}`)
   const value = isHTML(html) ? html : escapeHTML(html)
-  useEffect(() => {
-    if (!added) {
-      added = true
-      // see https://github.com/cure53/DOMPurify/issues/317
-      // only have to add this once, and can't do it globally because dompurify
-      // not yet initialized at global scope
-      dompurify.addHook('afterSanitizeAttributes', node => {
-        if (node.tagName === 'A') {
-          node.setAttribute('rel', 'noopener noreferrer')
-          node.setAttribute('target', '_blank')
-        }
-      })
-    }
-  }, [])
+
+  // @ts-expect-error
+  if (typeof Element !== 'undefined' && Element.prototype.setHTML) {
+    return <SetHTML value={value} className={className} />
+  }
 
   return (
-    <span
-      className={className}
-      dangerouslySetInnerHTML={{
-        __html: dompurify.sanitize(value),
-      }}
-    />
+    <Suspense fallback={<span className={className} />}>
+      <DOMPurifySanitizedHTML value={value} className={className} />
+    </Suspense>
   )
 }

--- a/plugins/alignments/src/AlignmentsFeatureDetail/index.test.tsx
+++ b/plugins/alignments/src/AlignmentsFeatureDetail/index.test.tsx
@@ -8,7 +8,7 @@ import { render } from '@testing-library/react'
 import ReactComponent from './AlignmentsFeatureDetail.tsx'
 import { stateModelFactory } from './stateModelFactory.ts'
 
-test('open up a widget', () => {
+test('open up a widget', async () => {
   const pluginManager = new PluginManager([])
 
   const Session = types.model({
@@ -40,11 +40,11 @@ test('open up a widget', () => {
     refName: 'ctgA',
     type: 'match',
   })
-  const { container, getByText } = render(
+  const { container, findByText } = render(
     <ThemeProvider theme={createJBrowseTheme()}>
       <ReactComponent model={session.widget} />,
     </ThemeProvider>,
   )
+  expect(await findByText('ctgA:3..102 (+)')).toBeTruthy()
   expect(container).toMatchSnapshot()
-  expect(getByText('ctgA:3..102 (+)')).toBeTruthy()
 })

--- a/plugins/alignments/src/LinearPileupDisplay/components/GroupByDialog.test.tsx
+++ b/plugins/alignments/src/LinearPileupDisplay/components/GroupByDialog.test.tsx
@@ -94,10 +94,10 @@ describe('GroupByDialog', () => {
     await user.click(screen.getByRole('option', { name: optionName }))
   }
 
-  test('renders dialog with initial state', () => {
+  test('renders dialog with initial state', async () => {
     renderDialog()
 
-    expect(screen.getByText('Group by')).toBeInTheDocument()
+    expect(await screen.findByText('Group by')).toBeInTheDocument()
     expect(screen.getByLabelText('Group by...')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()

--- a/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
+++ b/plugins/config/src/ConfigurationEditorWidget/components/__snapshots__/ConfigurationEditor.test.tsx.snap
@@ -21,7 +21,9 @@ exports[`renders all the different types of built-in slots 1`] = `
           <p
             class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
           >
-            Configuration
+            <span>
+              Configuration
+            </span>
           </p>
         </span>
         <span
@@ -760,7 +762,9 @@ exports[`renders with defaults of the PileupTrack schema 1`] = `
           <p
             class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
           >
-            Configuration
+            <span>
+              Configuration
+            </span>
           </p>
         </span>
         <span
@@ -1898,7 +1902,9 @@ exports[`renders with just the required model elements 1`] = `
           <p
             class="MuiTypography-root MuiTypography-body1 css-1xfjy4j-MuiTypography-root"
           >
-            Configuration
+            <span>
+              Configuration
+            </span>
           </p>
         </span>
         <span

--- a/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
+++ b/plugins/data-management/src/AssemblyManager/AssemblyManager.test.tsx
@@ -34,8 +34,8 @@ const mockRootModel = {
   },
 }
 
-test('renders successfully', () => {
-  const { getByText } = render(
+test('renders successfully', async () => {
+  const { findByText } = render(
     <AssemblyManager
       // @ts-expect-error
       session={mockRootModel.session}
@@ -43,7 +43,7 @@ test('renders successfully', () => {
       onClose={() => {}}
     />,
   )
-  expect(getByText('Assembly manager')).toBeTruthy()
+  expect(await findByText('Assembly manager')).toBeTruthy()
 })
 
 test('opens up the Add Assembly Form when clicked', async () => {

--- a/products/jbrowse-web/browser-tests/runner.ts
+++ b/products/jbrowse-web/browser-tests/runner.ts
@@ -27,7 +27,7 @@ const volvoxDataPath = path.resolve(__dirname, '../test_data/volvox')
 const PORT = 3333
 const OAUTH_PORT = 3030
 const BASICAUTH_PORT = 3040
-const runAuthTests = args.includes('--auth')
+const runAuthTests = !args.includes('--no-auth')
 
 // Helpers
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
This is a new web standard called 'setHTML' that allows safe html sanitization that can replace our use of npm packages like dompurify and prevents XSS

This PR uses setHTML if available and dompurify as a fallback. It lazily loads dompurify so it can be a small bundle size improvement
