### PR TITLE
Fix alignments tracks not being able to vertically scroll since v4.1.4

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/components/LoadingOverlay.tsx
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/components/LoadingOverlay.tsx
@@ -56,7 +56,10 @@ export default function LoadingOverlay({
   const { classes } = useStyles()
   const isLoading = !!statusMessage
   return (
-    <div className={classes.container} style={height ? { height } : undefined}>
+    <div
+      className={classes.container}
+      style={height ? { minHeight: height } : undefined}
+    >
       {children}
       <span
         className={cx(classes.overlay, isLoading && classes.visible)}


### PR DESCRIPTION
We added a 'loading bar' that covers the full display height in fe26ca97e0d1, but it accidentally made the container "limited" to the display height. This fixes it

Fixes #5511