### PR TITLE
fix(core): prune layout rectangle map on discardRange to reduce memory retention

### DIFF
--- a/packages/core/src/util/layouts/GranularRectLayout.test.ts
+++ b/packages/core/src/util/layouts/GranularRectLayout.test.ts
@@ -94,6 +94,8 @@ test('discards regions', () => {
   l.discardRange(0, 220000)
   // @ts-expect-error
   expect(l.bitmap[0].intervals.length).toBe(0)
+  // @ts-expect-error — rectangle map should not retain discarded features
+  expect(l.rectangles.size).toBe(0)
 })
 
 // see issue #486

--- a/packages/core/src/util/layouts/GranularRectLayout.ts
+++ b/packages/core/src/util/layouts/GranularRectLayout.ts
@@ -494,6 +494,27 @@ export default class GranularRectLayout<T> implements BaseLayout<T> {
     for (const row of bitmap) {
       row.discardRange(pLeft, pRight)
     }
+    // Drop layout entries for features fully inside the discarded span so we
+    // release references to feature data (alignments, etc.). Rows alone do not
+    // clear this.rectangles. Only fully contained rects: partial overlaps still
+    // have bitmap intervals trimmed by LayoutRow and must keep this entry until
+    // a later discard. See #4844 / #4860.
+    for (const [id, rect] of this.rectangles) {
+      if (rect.l >= pLeft && rect.r <= pRight) {
+        this.rectangles.delete(id)
+      }
+    }
+    this.recomputeTotalHeight()
+  }
+
+  private recomputeTotalHeight() {
+    let max = 0
+    for (const rect of this.rectangles.values()) {
+      if (rect.top !== null) {
+        max = Math.max(max, rect.top + rect.h)
+      }
+    }
+    this.pTotalHeight = max
   }
 
   hasSeen(id: string) {

--- a/packages/core/src/util/layouts/PileupLayout.ts
+++ b/packages/core/src/util/layouts/PileupLayout.ts
@@ -258,6 +258,12 @@ export default class PileupLayout<T> implements BaseLayout<T> {
       this.rowMaxEnd[rowIdx] = maxEnd
     }
 
+    for (const [id, rect] of this.rectangles) {
+      if (rect.l >= left && rect.r <= right) {
+        this.rectangles.delete(id)
+      }
+    }
+
     // Reset hint when discarding
     this.lastLeft = -Infinity
     this.lastRow = 0


### PR DESCRIPTION
## Summary

`discardRange` already cleared per-row interval data, but `GranularRectLayout` and `PileupLayout` kept entries in the `rectangles` map. Those entries hold references to feature payloads (e.g. alignments), so memory could stay retained after panning away from a region.

This PR removes rectangle entries that lie **fully inside** the discarded genomic span, and recomputes total height for `GranularRectLayout`. Partially overlapping features are left in the map so bitmap trimming and serialization stay consistent (see comments in code).

## Testing

```bash
pnpm exec jest --selectProjects default --testMatch="**/GranularRectLayout.test.ts"
pnpm exec jest --selectProjects default --testMatch="**/PileupLayout.test.ts"
```

## Related

Addresses memory retention discussed in https://github.com/GMOD/jbrowse-components/issues/4844 (complements worker-side freeing from #4860).
