### PR TITLE
fix(alignments): pileup soft-clip layout cap and sort order (#3471, #4671)

### DIFF
--- a/plugins/alignments/src/PileupRenderer/layoutFeature.test.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeature.test.ts
@@ -1,0 +1,82 @@
+import { PileupLayout } from '@jbrowse/core/util/layouts'
+
+import { layoutFeature } from './layoutFeature.ts'
+
+import type { Feature } from '@jbrowse/core/util'
+import type { Mismatch } from '../shared/types.ts'
+
+function makeFeature(
+  start: number,
+  end: number,
+  mismatches: Mismatch[],
+): Feature {
+  return {
+    id: () => 'r1',
+    get(name: string) {
+      if (name === 'start') {
+        return start
+      }
+      if (name === 'end') {
+        return end
+      }
+      if (name === 'mismatches') {
+        return mismatches
+      }
+      return undefined
+    },
+  } as Feature
+}
+
+test('soft clip layout expansion is capped by maxClippingSize', () => {
+  const layout = new PileupLayout({
+    featureHeight: 7,
+    spacing: 0,
+    maxHeight: 1200,
+  })
+  const feature = makeFeature(100_000, 100_100, [
+    { type: 'softclip', start: 0, cliplen: 50_000 },
+    { type: 'softclip', start: 99, cliplen: 40_000 },
+  ])
+
+  layoutFeature({
+    feature,
+    layout,
+    showSoftClip: true,
+    heightPx: 7,
+    displayMode: 'normal',
+    maxClippingSize: 10_000,
+  })
+
+  const tuple = layout.getRectangles().get('r1')
+  expect(tuple).toBeDefined()
+  const [left, , right] = tuple!
+  expect(left).toBe(90_000)
+  expect(right).toBe(110_100)
+})
+
+test('soft clip sums per side then applies cap', () => {
+  const layout = new PileupLayout({
+    featureHeight: 7,
+    spacing: 0,
+    maxHeight: 1200,
+  })
+  const feature = makeFeature(1000, 1100, [
+    { type: 'softclip', start: 0, cliplen: 3000 },
+    { type: 'softclip', start: 0, cliplen: 4000 },
+  ])
+
+  layoutFeature({
+    feature,
+    layout,
+    showSoftClip: true,
+    heightPx: 7,
+    displayMode: 'normal',
+    maxClippingSize: 5000,
+  })
+
+  const tuple = layout.getRectangles().get('r1')
+  expect(tuple).toBeDefined()
+  const [left, , right] = tuple!
+  expect(left).toBe(-4000)
+  expect(right).toBe(1100)
+})

--- a/plugins/alignments/src/PileupRenderer/layoutFeature.test.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeature.test.ts
@@ -1,17 +1,18 @@
 import { PileupLayout } from '@jbrowse/core/util/layouts'
 
-import { layoutFeature } from './layoutFeature.ts'
+import { getPileupLayoutSpan, layoutFeature } from './layoutFeature.ts'
 
-import type { Feature } from '@jbrowse/core/util'
 import type { Mismatch } from '../shared/types.ts'
+import type { Feature } from '@jbrowse/core/util'
 
 function makeFeature(
+  id: string,
   start: number,
   end: number,
   mismatches: Mismatch[],
 ): Feature {
   return {
-    id: () => 'r1',
+    id: () => id,
     get(name: string) {
       if (name === 'start') {
         return start
@@ -33,7 +34,7 @@ test('soft clip layout expansion is capped by maxClippingSize', () => {
     spacing: 0,
     maxHeight: 1200,
   })
-  const feature = makeFeature(100_000, 100_100, [
+  const feature = makeFeature('r1', 100_000, 100_100, [
     { type: 'softclip', start: 0, cliplen: 50_000 },
     { type: 'softclip', start: 99, cliplen: 40_000 },
   ])
@@ -60,7 +61,7 @@ test('soft clip sums per side then applies cap', () => {
     spacing: 0,
     maxHeight: 1200,
   })
-  const feature = makeFeature(1000, 1100, [
+  const feature = makeFeature('r1', 1000, 1100, [
     { type: 'softclip', start: 0, cliplen: 3000 },
     { type: 'softclip', start: 0, cliplen: 4000 },
   ])
@@ -79,4 +80,15 @@ test('soft clip sums per side then applies cap', () => {
   const [left, , right] = tuple!
   expect(left).toBe(-4000)
   expect(right).toBe(1100)
+})
+
+test('getPileupLayoutSpan left edge can be left of a read with lower genomic start (#4671)', () => {
+  const laterStart = makeFeature('a', 5000, 5100, [
+    { type: 'softclip', start: 0, cliplen: 6000 },
+  ])
+  const earlierStart = makeFeature('b', 1000, 2000, [])
+  const { s: sa } = getPileupLayoutSpan(laterStart, true, 10_000)
+  const { s: sb } = getPileupLayoutSpan(earlierStart, true, 10_000)
+  expect(laterStart.get('start')).toBeGreaterThan(earlierStart.get('start'))
+  expect(sa).toBeLessThan(sb)
 })

--- a/plugins/alignments/src/PileupRenderer/layoutFeature.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeature.ts
@@ -3,32 +3,22 @@ import type { Mismatch } from '../shared/types.ts'
 import type { Feature } from '@jbrowse/core/util'
 import type { BaseLayout } from '@jbrowse/core/util/layouts'
 
-export function layoutFeature({
-  feature,
-  layout,
-  showSoftClip,
-  heightPx,
-  displayMode,
-  maxClippingSize,
-}: {
-  feature: Feature
-  layout: BaseLayout<Feature>
-  showSoftClip?: boolean
-  heightPx: number
-  displayMode: string
-  /** Caps soft-clip expansion for layout; matches PileupRenderer region expansion (#3471). */
-  maxClippingSize: number
-}): LayoutFeature | null {
-  // Cache start/end to avoid multiple get() calls
+/**
+ * Genomic interval used for pileup collision detection. When soft clipping is
+ * on, left/right edges follow mismatch clips (capped by maxClippingSize).
+ * Must match the order used when laying out features — see layoutFeats sort
+ * (#4671).
+ */
+export function getPileupLayoutSpan(
+  feature: Feature,
+  showSoftClip: boolean,
+  maxClippingSize: number,
+): { s: number; e: number } {
   const featureStart = feature.get('start')
   const featureEnd = feature.get('end')
-
   let s = featureStart
   let e = featureEnd
 
-  // Expand the start and end of feature when softclipping enabled, capped by
-  // maxClippingSize per side (same bound as getExpandedRegion) so layout
-  // intervals cannot exceed what the block fetch accounts for.
   if (showSoftClip) {
     const mismatches = feature.get('mismatches') as Mismatch[] | undefined
     if (mismatches) {
@@ -48,6 +38,30 @@ export function layoutFeature({
       e += Math.min(rightExtra, maxClippingSize)
     }
   }
+  return { s, e }
+}
+
+export function layoutFeature({
+  feature,
+  layout,
+  showSoftClip,
+  heightPx,
+  displayMode,
+  maxClippingSize,
+}: {
+  feature: Feature
+  layout: BaseLayout<Feature>
+  showSoftClip?: boolean
+  heightPx: number
+  displayMode: string
+  /** Caps soft-clip expansion for layout; matches PileupRenderer region expansion (#3471). */
+  maxClippingSize: number
+}): LayoutFeature | null {
+  const { s, e } = getPileupLayoutSpan(
+    feature,
+    !!showSoftClip,
+    maxClippingSize,
+  )
 
   if (displayMode === 'compact') {
     heightPx /= 3

--- a/plugins/alignments/src/PileupRenderer/layoutFeature.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeature.ts
@@ -9,12 +9,15 @@ export function layoutFeature({
   showSoftClip,
   heightPx,
   displayMode,
+  maxClippingSize,
 }: {
   feature: Feature
   layout: BaseLayout<Feature>
   showSoftClip?: boolean
   heightPx: number
   displayMode: string
+  /** Caps soft-clip expansion for layout; matches PileupRenderer region expansion (#3471). */
+  maxClippingSize: number
 }): LayoutFeature | null {
   // Cache start/end to avoid multiple get() calls
   const featureStart = feature.get('start')
@@ -23,20 +26,26 @@ export function layoutFeature({
   let s = featureStart
   let e = featureEnd
 
-  // Expand the start and end of feature when softclipping enabled
+  // Expand the start and end of feature when softclipping enabled, capped by
+  // maxClippingSize per side (same bound as getExpandedRegion) so layout
+  // intervals cannot exceed what the block fetch accounts for.
   if (showSoftClip) {
     const mismatches = feature.get('mismatches') as Mismatch[] | undefined
     if (mismatches) {
+      let leftExtra = 0
+      let rightExtra = 0
       for (const mismatch of mismatches) {
         if (mismatch.type === 'softclip') {
           const cliplen = mismatch.cliplen
           if (mismatch.start === 0) {
-            s -= cliplen
+            leftExtra += cliplen
           } else {
-            e += cliplen
+            rightExtra += cliplen
           }
         }
       }
+      s -= Math.min(leftExtra, maxClippingSize)
+      e += Math.min(rightExtra, maxClippingSize)
     }
   }
 

--- a/plugins/alignments/src/PileupRenderer/layoutFeatures.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeatures.ts
@@ -1,6 +1,6 @@
 import { readConfObject } from '@jbrowse/core/configuration'
 
-import { layoutFeature } from './layoutFeature.ts'
+import { getPileupLayoutSpan, layoutFeature } from './layoutFeature.ts'
 import { sortFeature } from './sortUtil.ts'
 
 import type { LayoutFeature, PreProcessedRenderArgs } from './types.ts'
@@ -16,11 +16,19 @@ export function layoutFeats(props: PreProcessedRenderArgs) {
   const displayMode = readConfObject(config, 'displayMode')
   const maxClippingSize = readConfObject(config, 'maxClippingSize') as number
 
-  // Sort features by start position for PileupLayout's built-in hint optimization,
-  // but only when not using explicit sorting (which has its own order)
+  // Sort by layout left edge (expanded when soft clipping) so iteration order
+  // matches PileupLayout's row-hint optimization (#4671). Plain start order
+  // disagrees with collision intervals when clips extend reads leftward.
   const featureArr = hasSortedBy
     ? [...featureMap.values()]
-    : [...featureMap.values()].sort((a, b) => a.get('start') - b.get('start'))
+    : [...featureMap.values()].sort((a, b) => {
+        const { s: as } = getPileupLayoutSpan(a, !!showSoftClip, maxClippingSize)
+        const { s: bs } = getPileupLayoutSpan(b, !!showSoftClip, maxClippingSize)
+        if (as !== bs) {
+          return as - bs
+        }
+        return a.get('start') - b.get('start')
+      })
 
   const layoutRecords: LayoutFeature[] = []
 

--- a/plugins/alignments/src/PileupRenderer/layoutFeatures.ts
+++ b/plugins/alignments/src/PileupRenderer/layoutFeatures.ts
@@ -14,6 +14,7 @@ export function layoutFeats(props: PreProcessedRenderArgs) {
 
   const heightPx = readConfObject(config, 'height')
   const displayMode = readConfObject(config, 'displayMode')
+  const maxClippingSize = readConfObject(config, 'maxClippingSize') as number
 
   // Sort features by start position for PileupLayout's built-in hint optimization,
   // but only when not using explicit sorting (which has its own order)
@@ -30,6 +31,7 @@ export function layoutFeats(props: PreProcessedRenderArgs) {
       showSoftClip,
       heightPx,
       displayMode,
+      maxClippingSize,
     })
 
     if (result) {


### PR DESCRIPTION
## Summary

### #3471 — cap layout span

Pileup layout expanded soft-clipped reads using the full `mismatches` clip lengths, while feature fetching only expands the visible block by `maxClippingSize` (`PileupRenderer.getExpandedRegion`). That mismatch could make layout intervals far wider than the data region and stress the pileup layout.

**Change:** cap **left** and **right** soft-clip expansion **per side** to `maxClippingSize`, summing clips on each side first then applying the cap. Shared helper: `getPileupLayoutSpan`.

### #4671 — sort order vs layout interval

`PileupLayout` assumes features are processed in left-to-right order of the **collision interval**. Sorting only by genomic `start` disagrees with expanded left coordinates when soft clipping is on, which breaks row hints and can produce poor vertical spacing.

**Change:** when not using `sortedBy`, sort by layout left edge `s` from `getPileupLayoutSpan` (tie-break: genomic `start`).

## Testing

```bash
pnpm exec jest --selectProjects default --testMatch="**/layoutFeature.test.ts"
```

## Related

- https://github.com/GMOD/jbrowse-components/issues/3471
- https://github.com/GMOD/jbrowse-components/issues/4671
