### PR TITLE
Create github actions based publishing workflow using NPM trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: 10
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm publish -r --access public --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build and pack but do not publish)'
+        type: boolean
+        default: true
 
 jobs:
   publish:
@@ -25,4 +31,4 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm publish -r --access public --no-git-checks
+      - run: pnpm publish -r --access public --no-git-checks ${{ inputs.dry_run == true && '--dry-run' || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,22 +295,50 @@ particular notes include
 2. The use of tsconfig.build.json to generate types in the final release
 3. The use of referring to the src directory at development time
 
-## What to do if a release fails
+## Releasing
 
-### Option A. It already published to NPM
+Releases are done from the `main` branch. The release script handles versioning,
+changelog, blog post, and pushing the tag. npm publishing then happens
+automatically via the `publish` GitHub Actions workflow when the tag is pushed.
 
-You should probably run another patch release
+### Prerequisites (one-time setup)
 
-Note: You must make miniscule source code change or the changelog code will
-fail, so rename a random variable somewhere, commit, and re-run the release
+- `gh` CLI installed and authenticated
+- npm trusted publishing registered for all packages:
+  ```
+  scripts/register-trusted-publishing.sh
+  ```
 
-### Option B. It hasn't published to NPM
+### Running a release
 
-You can cancel the release script
+```
+scripts/release.sh patch   # or minor / major
+```
 
-If it already pushed the tag, then revert the automated commits it made, and
-then delete the tag and push the tag delete (e.g. git tag -d v1.2.3 && git push
-origin :refs/tags/v1.2.3)
+Before running, create a blog post draft at
+`website/release_announcement_drafts/vX.Y.Z.md` — the script will fail if it
+is missing.
 
-If it already made a release draft, delete it, and then re-run the release
-script
+The script will:
+
+- Run lint and tests
+- Compute the new version from the semver level argument
+- Generate the changelog from merged PRs
+- Create the blog post from the draft
+- Bump all package versions
+- Commit, tag, and push
+
+GitHub Actions then picks up the tag and publishes all packages to npm.
+
+### If a release fails
+
+**The tag has not been pushed yet** — fix the issue and re-run the script.
+
+**The tag was pushed but the publish workflow failed** — re-run the publish
+workflow from the Actions tab in GitHub.
+
+**Any other failure** — run a new patch release. If packages were partially
+published to npm, avoid deleting the tag and trying to re-use it, as that
+causes more problems. Just do a fresh release instead. Note that the changelog
+script requires at least one PR merged since the last release, so make a
+trivial commit if needed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,6 @@ export default defineConfig(
       'products/**/webpack.config.js',
       'products/**/webpack.config.mjs',
       '**/.storybook',
-      '**/output-version.js',
       '**/umd_plugin.js',
 
       'products/jbrowse-desktop/test/e2e.ts',

--- a/products/jbrowse-cli/output-version.js
+++ b/products/jbrowse-cli/output-version.js
@@ -1,9 +1,0 @@
-// used to output a version.js file to the src folder
-// this avoids bundlers having to know how to import ../../package.json or similar for downstream consumers
-import fs from 'fs'
-
-console.log(
-  `export const version = '${
-    JSON.parse(fs.readFileSync('package.json')).version
-  }'`,
-)

--- a/products/jbrowse-cli/package.json
+++ b/products/jbrowse-cli/package.json
@@ -32,7 +32,6 @@
     "prebuild": "pnpm clean",
     "build": "tsc && webpack -c webpack.config.mjs",
     "clean": "rimraf bundle",
-    "prepublishOnly": "node output-version.js > src/version.ts && git add -A src && git commit -m '[skip ci] Bump version.ts'",
     "prepack": "pnpm clean && pnpm build && pnpm generate-readme",
     "generate-readme": "./generate_readme.sh > README.md"
   },

--- a/products/jbrowse-react-app/output-version.js
+++ b/products/jbrowse-react-app/output-version.js
@@ -1,9 +1,0 @@
-// used to output a version.js file to the src folder
-// this avoids bundlers having to know how to import ../../package.json or similar for downstream consumers
-import fs from 'fs'
-
-console.log(
-  `export const version = '${
-    JSON.parse(fs.readFileSync('package.json')).version
-  }'`,
-)

--- a/products/jbrowse-react-app/package.json
+++ b/products/jbrowse-react-app/package.json
@@ -33,7 +33,6 @@
   ],
   "scripts": {
     "build": "pnpm run /^build:/",
-    "prepublishOnly": "node output-version.js > src/version.ts && git add -A src && git commit -m '[skip ci] Bump version.ts'",
     "build:esm": "tsc --build tsconfig.build.esm.json",
     "build:webpack": "webpack -c webpack.config.mjs",
     "clean": "rimraf esm *.tsbuildinfo",

--- a/products/jbrowse-react-circular-genome-view/output-version.js
+++ b/products/jbrowse-react-circular-genome-view/output-version.js
@@ -1,9 +1,0 @@
-// used to output a version.js file to the src folder
-// this avoids bundlers having to know how to import ../../package.json or similar for downstream consumers
-import fs from 'fs'
-
-console.log(
-  `export const version = '${
-    JSON.parse(fs.readFileSync('package.json')).version
-  }'`,
-)

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "prebuild": "pnpm clean",
     "build": "pnpm run /^build:/",
-    "prepublishOnly": "node output-version.js > src/version.ts && git add -A src && git commit -m '[skip ci] Bump version.ts'",
     "prepack": "pnpm build",
     "build:esm": "tsc -p tsconfig.build.esm.json",
     "build:webpack": "webpack -c webpack.config.mjs",

--- a/products/jbrowse-react-linear-genome-view/output-version.js
+++ b/products/jbrowse-react-linear-genome-view/output-version.js
@@ -1,9 +1,0 @@
-// used to output a version.js file to the src folder
-// this avoids bundlers having to know how to import ../../package.json or similar for downstream consumers
-import fs from 'fs'
-
-console.log(
-  `export const version = '${
-    JSON.parse(fs.readFileSync('package.json')).version
-  }'`,
-)

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -33,7 +33,6 @@
   ],
   "scripts": {
     "build": "pnpm run /^build:/",
-    "prepublishOnly": "node output-version.js > src/version.ts && git add -A src && git commit -m '[skip ci] Bump version.ts'",
     "build:esm": "tsc --build tsconfig.build.esm.json",
     "build:webpack": "webpack -c webpack.config.mjs",
     "clean": "rimraf esm *.tsbuildinfo",

--- a/scripts/register-trusted-publishing.sh
+++ b/scripts/register-trusted-publishing.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Registers npm trusted publishing for all public packages in this monorepo.
+# Requires: npm >= 11.10.0, 2FA enabled on npmjs.com
+# Run once - first package will prompt for 2FA, then you get a 5-minute window
+
+set -euo pipefail
+
+REPO="GMOD/jbrowse-components"
+WORKFLOW_FILE="publish.yml"
+
+node -e "
+const fs = require('fs');
+const path = require('path');
+for (const ws of ['packages', 'products', 'plugins']) {
+  if (!fs.existsSync(ws)) continue;
+  for (const dir of fs.readdirSync(ws)) {
+    const pkgPath = path.join(ws, dir, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    if (pkg.name && pkg.private !== true) console.log(pkg.name);
+  }
+}
+" | while read -r pkg; do
+  if npm trust list "$pkg" --json 2>/dev/null | grep -q '"id"'; then
+    echo "SKIP $pkg (already has trusted publisher)"
+    continue
+  fi
+  echo "Registering: $pkg -> $REPO (.github/workflows/$WORKFLOW_FILE)"
+  npm trust github "$pkg" --file "$WORKFLOW_FILE" --repo "$REPO" -y
+  sleep 2
+done
+
+echo "Done!"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,8 @@ set -o pipefail
 SEMVER_LEVEL="${1:-patch}"
 [[ "$SEMVER_LEVEL" =~ ^(patch|minor|major)$ ]] || { echo "Invalid semver level '$SEMVER_LEVEL'. Use patch, minor, or major." && exit 1; }
 
+trap 'rm -f tmp.json tmp_changelog.md' EXIT
+
 # Pre-flight checks
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 [[ "$BRANCH" != "main" ]] && { echo "Current branch is not main, please switch to main branch" && exit 1; }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,13 +6,12 @@
 set -e
 set -o pipefail
 
-[[ -n "$1" ]] && SEMVER_LEVEL="$1" || SEMVER_LEVEL="patch"
+SEMVER_LEVEL="${1:-patch}"
+[[ "$SEMVER_LEVEL" =~ ^(patch|minor|major)$ ]] || { echo "Invalid semver level '$SEMVER_LEVEL'. Use patch, minor, or major." && exit 1; }
 
 # Pre-flight checks
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 [[ "$BRANCH" != "main" ]] && { echo "Current branch is not main, please switch to main branch" && exit 1; }
-NPMUSER=$(pnpm whoami)
-[[ -n "$NPMUSER" ]] || { echo "No NPM user detected, please run 'pnpm login'" && exit 1; }
 git fetch origin main
 MAINUPDATED=$(git rev-list --left-only --count origin/main...main)
 [[ "$MAINUPDATED" != 0 ]] && { echo "main is not up to date with origin/main. Please pull and try again" && exit 1; }
@@ -26,7 +25,7 @@ pnpm test
 
 # Calculate new version
 PREVIOUS_VERSION=$(node --print "require('./plugins/alignments/package.json').version")
-VERSION=4.1.15
+VERSION=$(node --print "const [maj,min,pat] = '$PREVIOUS_VERSION'.split('.').map(Number); '$SEMVER_LEVEL'==='major' ? (maj+1)+'.0.0' : '$SEMVER_LEVEL'==='minor' ? maj+'.'+(min+1)+'.0' : maj+'.'+min+'.'+(pat+1)")
 RELEASE_TAG=v$VERSION
 
 # Check for blog post draft
@@ -73,17 +72,16 @@ for (const ws of ['packages', 'products', 'plugins']) {
 }
 "
 
-# Commit, tag, publish
+# Generate version.ts for packages that export it
+for pkg in products/jbrowse-cli products/jbrowse-react-app products/jbrowse-react-circular-genome-view products/jbrowse-react-linear-genome-view; do
+  echo "export const version = '$VERSION'" > $pkg/src/version.ts
+done
+
+# Commit, tag, push (publishing is handled by GitHub Actions)
 pnpm format
 git add .
 git commit --message "$RELEASE_TAG"
 git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
-if ! pnpm publish -r --access public --no-git-checks; then
-  echo "Publish failed. The commit and tag have been created locally but not pushed."
-  echo "To retry: pnpm publish -r --access public --no-git-checks && git push && git push --tags"
-  echo "To abort: git reset --hard HEAD~1 && git tag -d $RELEASE_TAG"
-  exit 1
-fi
 git push && git push --tags
 
 echo "✓ Released $RELEASE_TAG"


### PR DESCRIPTION
Currently publishing jbrowse is sort of laborious. It requires

- booting up an AWS EC2 instance to run publishing workflow [1]
- running scripts/release.sh
- wait for 30+ minutes while build occurs
- then checking that the draft release tag has all the binaries added to it (not always a guarantee....the apple , and hit publish

This PR gets rid of the first two steps, and as side benefits...

1) Makes this procedure easier for anyone on our team to use...just push a new git tag

2) This procedure uses 'trusted publishing' which ensures that the binaries on NPM exactly match the source code on github, which gives the packages a nice green checkbox. This idea was recently added and tested for data parsing libraries e.g. @gmod/bam https://www.npmjs.com/package/@gmod/bam#provenance


[1] may not be strictly necessary to use EC2 but it was found early on in the project that any network instability or even slowness from home network could compromise the whole publishing workflow with very complex errors, so publishing from cloud instance is better than from home internet...