### PR TITLE
Automatically show source code listing in storybook files

### DIFF
--- a/products/jbrowse-react-app/.storybook/manager.js
+++ b/products/jbrowse-react-app/.storybook/manager.js
@@ -3,4 +3,5 @@ import { themes } from 'storybook/theming'
 
 addons.setConfig({
   theme: themes.light,
+  showPanel: false,
 })

--- a/products/jbrowse-react-app/.storybook/preview.js
+++ b/products/jbrowse-react-app/.storybook/preview.js
@@ -1,3 +1,46 @@
+const GITHUB_BASE =
+  'https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/'
+
+export const decorators = [
+  (Story, { parameters, viewMode }) => {
+    const sourceCode = parameters.docs?.source?.code
+    const storyFile = parameters.storyFile
+    return (
+      <div>
+        <Story />
+        {sourceCode && viewMode === 'story' && (
+          <>
+            {storyFile && (
+              <a
+                href={`${GITHUB_BASE}${storyFile}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ display: 'inline-block', margin: '1em 0 0' }}
+              >
+                Source code on GitHub
+              </a>
+            )}
+            <pre
+              style={{
+                overflow: 'auto',
+                background: '#f6f8fa',
+                border: '1px solid #d0d7de',
+                borderRadius: 6,
+                padding: '1em',
+                margin: '0.5em 0 0',
+                fontSize: '0.85em',
+                lineHeight: 1.5,
+              }}
+            >
+              <code>{sourceCode}</code>
+            </pre>
+          </>
+        )}
+      </div>
+    )
+  },
+]
+
 export const parameters = {
   options: {
     storySort: {

--- a/products/jbrowse-react-app/stories/GettingStarted.mdx
+++ b/products/jbrowse-react-app/stories/GettingStarted.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { BasicExample } from './JBrowseReactApp.stories'
 
 <Meta title="Getting Started" />
@@ -15,6 +15,8 @@ all the bells and whistles) in any React application.
 This is an example of using the @jbrowse/react-app2 as a component:
 
 <Story of={BasicExample} />
+
+<Source of={BasicExample} />
 
 You can test out the various features of the component, and open tracks and
 interact with it as you would in your app. You can also click on the code button

--- a/products/jbrowse-react-app/stories/ImportConfigJson.mdx
+++ b/products/jbrowse-react-app/stories/ImportConfigJson.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   WithImportConfigJson,
   WithFetchConfigJson,
@@ -19,6 +19,10 @@ the app but must implement some things themselves
 
 <Story of={WithImportConfigJson} />
 
+<Source of={WithImportConfigJson} />
+
 ## Example 2. Using 'fetch' to get the config.json
 
 <Story of={WithFetchConfigJson} />
+
+<Source of={WithFetchConfigJson} />

--- a/products/jbrowse-react-app/stories/JBrowseReactApp.stories.tsx
+++ b/products/jbrowse-react-app/stories/JBrowseReactApp.stories.tsx
@@ -1,4 +1,4 @@
-export {
+import {
   BasicExample,
   DarkTheme,
   HumanDemo,
@@ -9,4 +9,45 @@ export {
   WithWebWorker,
 } from './examples/index.ts'
 
+import BasicExampleSource from '!!./raw-source-loader.cjs!./examples/BasicExample.tsx'
+import DarkThemeSource from '!!./raw-source-loader.cjs!./examples/DarkTheme.tsx'
+import HumanDemoSource from '!!./raw-source-loader.cjs!./examples/HumanDemo.tsx'
+import SyntenyExampleSource from '!!./raw-source-loader.cjs!./examples/SyntenyExample.tsx'
+import WithFetchConfigJsonSource from '!!./raw-source-loader.cjs!./examples/WithFetchConfigJson.tsx'
+import WithImportConfigJsonSource from '!!./raw-source-loader.cjs!./examples/WithImportConfigJson.tsx'
+import WithLaunchLinearGenomeViewSource from '!!./raw-source-loader.cjs!./examples/WithLaunchLinearGenomeView.tsx'
+import WithWebWorkerSource from '!!./raw-source-loader.cjs!./examples/WithWebWorker.tsx'
+
+const sourceMap = [
+  [BasicExample, BasicExampleSource],
+  [DarkTheme, DarkThemeSource],
+  [HumanDemo, HumanDemoSource],
+  [SyntenyExample, SyntenyExampleSource],
+  [WithFetchConfigJson, WithFetchConfigJsonSource],
+  [WithImportConfigJson, WithImportConfigJsonSource],
+  [WithLaunchLinearGenomeView, WithLaunchLinearGenomeViewSource],
+  [WithWebWorker, WithWebWorkerSource],
+] as const
+
+for (const [story, sourceCode] of sourceMap) {
+  const fileName = `${story.name}.tsx`
+  Object.assign(story, {
+    parameters: {
+      storyFile: fileName,
+      docs: { source: { code: sourceCode, language: 'tsx' } },
+    },
+  })
+}
+
 export default { title: 'Source code for examples' }
+
+export {
+  BasicExample,
+  DarkTheme,
+  HumanDemo,
+  SyntenyExample,
+  WithFetchConfigJson,
+  WithImportConfigJson,
+  WithLaunchLinearGenomeView,
+  WithWebWorker,
+} from './examples/index.ts'

--- a/products/jbrowse-react-app/stories/UsingWebWorker.mdx
+++ b/products/jbrowse-react-app/stories/UsingWebWorker.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { WithWebWorker } from './JBrowseReactApp.stories'
 
 <Meta title="Using WebWorker RPC" />
@@ -17,6 +17,8 @@ alignments datasets like BAM / CRAM.
 ## Example
 
 <Story of={WithWebWorker} />
+
+<Source of={WithWebWorker} />
 
 ## Note 1
 

--- a/products/jbrowse-react-app/stories/examples/BasicExample.tsx
+++ b/products/jbrowse-react-app/stories/examples/BasicExample.tsx
@@ -81,9 +81,6 @@ export const BasicExample = () => {
 
   return (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/BasicExample.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/examples/DarkTheme.tsx
+++ b/products/jbrowse-react-app/stories/examples/DarkTheme.tsx
@@ -88,9 +88,6 @@ export const DarkTheme = () => {
 
   return (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/BasicExample.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/examples/HumanDemo.tsx
+++ b/products/jbrowse-react-app/stories/examples/HumanDemo.tsx
@@ -131,9 +131,6 @@ export const HumanDemo = () => {
 
   return (
     <>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/HumanDemo.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={viewState} />
     </>
   )

--- a/products/jbrowse-react-app/stories/examples/SyntenyExample.tsx
+++ b/products/jbrowse-react-app/stories/examples/SyntenyExample.tsx
@@ -29,9 +29,6 @@ export const SyntenyExample = () => {
 
   return (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/SyntenyExample.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/examples/WithFetchConfigJson.tsx
+++ b/products/jbrowse-react-app/stories/examples/WithFetchConfigJson.tsx
@@ -29,9 +29,6 @@ export const WithFetchConfigJson = () => {
 
   return !state ? null : (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/WithFetchConfigJson.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/examples/WithImportConfigJson.tsx
+++ b/products/jbrowse-react-app/stories/examples/WithImportConfigJson.tsx
@@ -15,9 +15,6 @@ export const WithImportConfigJson = () => {
 
   return (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/WithImportConfigJson.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/examples/WithLaunchLinearGenomeView.tsx
+++ b/products/jbrowse-react-app/stories/examples/WithLaunchLinearGenomeView.tsx
@@ -137,9 +137,6 @@ export const WithLaunchLinearGenomeView = () => {
 
   return (
     <>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/WithLaunchLinearGenomeView.tsx">
-        Source code
-      </a>
       {error ? <div style={{ color: 'red' }}>{`${error}`}</div> : null}
       <JBrowseApp viewState={viewState} />
     </>

--- a/products/jbrowse-react-app/stories/examples/WithWebWorker.tsx
+++ b/products/jbrowse-react-app/stories/examples/WithWebWorker.tsx
@@ -34,9 +34,6 @@ export const WithWebWorker = () => {
 
   return (
     <div>
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-app/stories/examples/WithWebWorker.tsx">
-        Source code
-      </a>
       <JBrowseApp viewState={state} />
     </div>
   )

--- a/products/jbrowse-react-app/stories/raw-source-loader.cjs
+++ b/products/jbrowse-react-app/stories/raw-source-loader.cjs
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+  return `export default ${JSON.stringify(source)}`
+}

--- a/products/jbrowse-react-app/stories/raw.d.ts
+++ b/products/jbrowse-react-app/stories/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '!!*' {
+  const content: string
+  export default content
+}

--- a/products/jbrowse-react-circular-genome-view/.storybook/manager.js
+++ b/products/jbrowse-react-circular-genome-view/.storybook/manager.js
@@ -3,4 +3,5 @@ import { themes } from 'storybook/theming'
 
 addons.setConfig({
   theme: themes.light,
+  showPanel: false,
 })

--- a/products/jbrowse-react-circular-genome-view/.storybook/preview.js
+++ b/products/jbrowse-react-circular-genome-view/.storybook/preview.js
@@ -1,5 +1,5 @@
 const GITHUB_BASE =
-  'https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/'
+  'https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-circular-genome-view/stories/examples/'
 
 export const decorators = [
   (Story, { parameters, viewMode }) => {
@@ -44,13 +44,7 @@ export const decorators = [
 export const parameters = {
   options: {
     storySort: {
-      order: [
-        'Getting Started',
-        'Default Sessions',
-        'Linear View',
-        'Nextstrain View',
-        'Next.js Usage',
-      ],
+      order: ['Getting Started'],
       locales: '',
     },
   },

--- a/products/jbrowse-react-circular-genome-view/stories/GettingStarted.mdx
+++ b/products/jbrowse-react-circular-genome-view/stories/GettingStarted.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { Volvox, ShowTrack } from './JBrowseCircularGenomeView.stories'
 
 <Meta title="Getting Started" />
@@ -16,6 +16,8 @@ demonstration of how the component looks and works.
 This is an example of what a story looks like:
 
 <Story of={Volvox} />
+
+<Source of={Volvox} />
 
 You can test out the various features of the component, and open tracks and
 interact with it as you would in your app. You can also click on the code button
@@ -68,6 +70,8 @@ The CGV component only accepts a single assembly object instead of an array:
 You can call "showTrack" on the object returned by createViewState
 
 <Story of={ShowTrack} />
+
+<Source of={ShowTrack} />
 
 ## Additional resources
 

--- a/products/jbrowse-react-circular-genome-view/stories/JBrowseCircularGenomeView.stories.tsx
+++ b/products/jbrowse-react-circular-genome-view/stories/JBrowseCircularGenomeView.stories.tsx
@@ -1,7 +1,25 @@
-export { Human, ShowTrack, Volvox } from './examples/index.ts'
+import { Human, ShowTrack, Volvox } from './examples/index.ts'
 
-const JBrowseCircularGenomeViewStories = {
-  title: 'Circular Genome View',
+import HumanSource from '!!./raw-source-loader.cjs!./examples/Human.tsx'
+import ShowTrackSource from '!!./raw-source-loader.cjs!./examples/ShowTrack.tsx'
+import VolvoxSource from '!!./raw-source-loader.cjs!./examples/Volvox.tsx'
+
+const sourceMap = [
+  [Human, HumanSource],
+  [ShowTrack, ShowTrackSource],
+  [Volvox, VolvoxSource],
+] as const
+
+for (const [story, sourceCode] of sourceMap) {
+  const fileName = `${story.name}.tsx`
+  Object.assign(story, {
+    parameters: {
+      storyFile: fileName,
+      docs: { source: { code: sourceCode, language: 'tsx' } },
+    },
+  })
 }
 
-export default JBrowseCircularGenomeViewStories
+export default { title: 'Circular Genome View' }
+
+export { Human, ShowTrack, Volvox } from './examples/index.ts'

--- a/products/jbrowse-react-circular-genome-view/stories/examples/Human.tsx
+++ b/products/jbrowse-react-circular-genome-view/stories/examples/Human.tsx
@@ -89,9 +89,6 @@ export const Human = () => {
   return (
     <div>
       <JBrowseCircularGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-circular-genome-view/stories/examples/Human.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-circular-genome-view/stories/examples/ShowTrack.tsx
+++ b/products/jbrowse-react-circular-genome-view/stories/examples/ShowTrack.tsx
@@ -91,9 +91,6 @@ export const ShowTrack = () => {
   return (
     <div>
       <JBrowseCircularGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-circular-genome-view/stories/examples/ShowTrack.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-circular-genome-view/stories/examples/Volvox.tsx
+++ b/products/jbrowse-react-circular-genome-view/stories/examples/Volvox.tsx
@@ -102,9 +102,6 @@ export const Volvox = () => {
   return (
     <div>
       <JBrowseCircularGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-circular-genome-view/stories/examples/Volvox.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-circular-genome-view/stories/raw-source-loader.cjs
+++ b/products/jbrowse-react-circular-genome-view/stories/raw-source-loader.cjs
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+  return `export default ${JSON.stringify(source)}`
+}

--- a/products/jbrowse-react-circular-genome-view/stories/raw.d.ts
+++ b/products/jbrowse-react-circular-genome-view/stories/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '!!*' {
+  const content: string
+  export default content
+}

--- a/products/jbrowse-react-linear-genome-view/.storybook/manager.js
+++ b/products/jbrowse-react-linear-genome-view/.storybook/manager.js
@@ -3,4 +3,5 @@ import { themes } from 'storybook/theming'
 
 addons.setConfig({
   theme: themes.light,
+  showPanel: false,
 })

--- a/products/jbrowse-react-linear-genome-view/stories/DefaultSessions.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/DefaultSessions.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { DefaultSession } from './JBrowseLinearGenomeView.stories'
 
 <Meta title="Default Sessions" />
@@ -13,6 +13,8 @@ Here is an example LGV with a long reads alignment track loaded in the
 `defaultSession`:
 
 <Story of={DefaultSession} />
+
+<Source of={DefaultSession} />
 
 ## Creating a default session
 

--- a/products/jbrowse-react-linear-genome-view/stories/ErrorHandling.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/ErrorHandling.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { WithErrorHandler } from './JBrowseLinearGenomeView.stories'
 
 <Meta title="Error handling" />
@@ -16,3 +16,5 @@ The example below will have a red box complaining about the BadTrack track type
 not validating
 
 <Story of={WithErrorHandler} />
+
+<Source of={WithErrorHandler} />

--- a/products/jbrowse-react-linear-genome-view/stories/GettingStarted.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/GettingStarted.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   OneLinearGenomeView,
   UsingLocObject,
@@ -20,6 +20,8 @@ React application.
 This is an example of using the @jbrowse/react-linear-genome-view2 component
 
 <Story of={OneLinearGenomeView} />
+
+<Source of={OneLinearGenomeView} />
 
 You can test out the various features of the component, and open tracks and
 interact with it as you would in your app. You can also click on the code button
@@ -84,6 +86,8 @@ Example
 
 <Story of={UsingLocObject} />
 
+<Source of={UsingLocObject} />
+
 ## Disabling the ability to add tracks
 
 By default users can add tracks, but you can add the `disableAddTracks` flag to
@@ -104,6 +108,8 @@ Example
 
 <Story of={DisableAddTrack} />
 
+<Source of={DisableAddTrack} />
+
 ## Opening up tracks by default
 
 You can use the `showTrack` function on the object returned by `createViewState`
@@ -111,6 +117,8 @@ to show a track with a given trackId. This can be easier than using the
 defaultSession.
 
 <Story of={WithShowTrack} />
+
+<Source of={WithShowTrack} />
 
 ## An overview of the LGV API
 

--- a/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/JBrowseLinearGenomeView.stories.tsx
@@ -1,4 +1,4 @@
-export {
+import {
   DefaultSession,
   DisableAddTrack,
   ExternalNavigateLocstring,
@@ -31,4 +31,115 @@ export {
   WithWebWorker,
 } from './examples/index.ts'
 
+import DefaultSessionSource from '!!./raw-source-loader.cjs!./examples/DefaultSession.tsx'
+import DisableAddTrackSource from '!!./raw-source-loader.cjs!./examples/DisableAddTrack.tsx'
+import ExternalNavigateLocstringSource from '!!./raw-source-loader.cjs!./examples/ExternalNavigateLocstring.tsx'
+import ExternalNavigateObjectSource from '!!./raw-source-loader.cjs!./examples/ExternalNavigateObject.tsx'
+import HorizontallyFlippedSource from '!!./raw-source-loader.cjs!./examples/HorizontallyFlipped.tsx'
+import HumanExomeExampleSource from '!!./raw-source-loader.cjs!./examples/HumanExomeExample.tsx'
+import NextstrainExampleSource from '!!./raw-source-loader.cjs!./examples/NextstrainExample.tsx'
+import OneLinearGenomeViewSource from '!!./raw-source-loader.cjs!./examples/OneLinearGenomeView.tsx'
+import ShadowDOMOneLinearGenomeViewSource from '!!./raw-source-loader.cjs!./examples/ShadowDOMOneLinearGenomeView.tsx'
+import UsingLocObjectSource from '!!./raw-source-loader.cjs!./examples/UsingLocObject.tsx'
+import WithAggregateTextSearchingSource from '!!./raw-source-loader.cjs!./examples/WithAggregateTextSearching.tsx'
+import WithCustomThemeSource from '!!./raw-source-loader.cjs!./examples/WithCustomTheme.tsx'
+import WithDarkThemeSource from '!!./raw-source-loader.cjs!./examples/WithDarkTheme.tsx'
+import WithDisableZoomAndSideScrollSource from '!!./raw-source-loader.cjs!./examples/WithDisableZoomAndSideScroll.tsx'
+import WithErrorHandlerSource from '!!./raw-source-loader.cjs!./examples/WithErrorHandler.tsx'
+import WithExternalPluginSource from '!!./raw-source-loader.cjs!./examples/WithExternalPlugin.tsx'
+import WithInitSource from '!!./raw-source-loader.cjs!./examples/WithInit.tsx'
+import WithInlinePluginsSource from '!!./raw-source-loader.cjs!./examples/WithInlinePlugins.tsx'
+import WithInternetAccountsSource from '!!./raw-source-loader.cjs!./examples/WithInternetAccounts.tsx'
+import WithObserveVisibleFeaturesSource from '!!./raw-source-loader.cjs!./examples/WithObserveVisibleFeatures.tsx'
+import WithObserveVisibleRegionsSource from '!!./raw-source-loader.cjs!./examples/WithObserveVisibleRegions.tsx'
+import WithOutsideStylingSource from '!!./raw-source-loader.cjs!./examples/WithOutsideStyling.tsx'
+import WithPerTrackTextSearchingSource from '!!./raw-source-loader.cjs!./examples/WithPerTrackTextSearching.tsx'
+import WithReact18Source from '!!./raw-source-loader.cjs!./examples/WithReact18.tsx'
+import WithShowTrackSource from '!!./raw-source-loader.cjs!./examples/WithShowTrack.tsx'
+import WithTwoLinearGenomeViewsSource from '!!./raw-source-loader.cjs!./examples/WithTwoLinearGenomeViews.tsx'
+import WithWebWorkerSource from '!!./raw-source-loader.cjs!./examples/WithWebWorker.tsx'
+
+const storyFileOverrides: Record<string, string> = {
+  HorizontallyFlippedViaButton: 'HorizontallyFlipped.tsx',
+  HorizontallyFlippedViaDisplayedRegions: 'HorizontallyFlipped.tsx',
+  HorizontallyFlippedViaLocstring: 'HorizontallyFlipped.tsx',
+}
+
+const sourceMap = [
+  [DefaultSession, DefaultSessionSource],
+  [DisableAddTrack, DisableAddTrackSource],
+  [ExternalNavigateLocstring, ExternalNavigateLocstringSource],
+  [ExternalNavigateObject, ExternalNavigateObjectSource],
+  [HorizontallyFlippedViaButton, HorizontallyFlippedSource],
+  [HorizontallyFlippedViaDisplayedRegions, HorizontallyFlippedSource],
+  [HorizontallyFlippedViaLocstring, HorizontallyFlippedSource],
+  [HumanExomeExample, HumanExomeExampleSource],
+  [NextstrainExample, NextstrainExampleSource],
+  [OneLinearGenomeView, OneLinearGenomeViewSource],
+  [ShadowDOMOneLinearGenomeView, ShadowDOMOneLinearGenomeViewSource],
+  [UsingLocObject, UsingLocObjectSource],
+  [WithAggregateTextSearching, WithAggregateTextSearchingSource],
+  [WithCustomTheme, WithCustomThemeSource],
+  [WithDarkTheme, WithDarkThemeSource],
+  [WithDisableZoomAndSideScroll, WithDisableZoomAndSideScrollSource],
+  [WithErrorHandler, WithErrorHandlerSource],
+  [WithExternalPlugin, WithExternalPluginSource],
+  [WithInit, WithInitSource],
+  [WithInlinePlugins, WithInlinePluginsSource],
+  [WithInternetAccounts, WithInternetAccountsSource],
+  [WithObserveVisibleFeatures, WithObserveVisibleFeaturesSource],
+  [WithObserveVisibleRegions, WithObserveVisibleRegionsSource],
+  [WithOutsideStyling, WithOutsideStylingSource],
+  [WithPerTrackTextSearching, WithPerTrackTextSearchingSource],
+  [WithReact18, WithReact18Source],
+  [WithShowTrack, WithShowTrackSource],
+  [WithTwoLinearGenomeViews, WithTwoLinearGenomeViewsSource],
+  [WithWebWorker, WithWebWorkerSource],
+] as const
+
+for (const [story, sourceCode] of sourceMap) {
+  const fileName = storyFileOverrides[story.name] ?? `${story.name}.tsx`
+  Object.assign(story, {
+    parameters: {
+      storyFile: fileName,
+      docs: { source: { code: sourceCode, language: 'tsx' } },
+    },
+  })
+}
+
+export {
+  ShadowDOMOneLinearGenomeView,
+  UsingLocObject,
+  WithAggregateTextSearching,
+  WithCustomTheme,
+  WithDarkTheme,
+  WithDisableZoomAndSideScroll,
+  WithErrorHandler,
+  WithExternalPlugin,
+  WithInit,
+  WithInlinePlugins,
+  WithInternetAccounts,
+  WithObserveVisibleFeatures,
+  WithObserveVisibleRegions,
+  WithOutsideStyling,
+  WithPerTrackTextSearching,
+  WithReact18,
+  WithShowTrack,
+  WithTwoLinearGenomeViews,
+  WithWebWorker,
+}
+
 export default { title: 'Source code for examples' }
+
+export {
+  DefaultSession,
+  DisableAddTrack,
+  ExternalNavigateLocstring,
+  ExternalNavigateObject,
+  HorizontallyFlippedViaButton,
+  HorizontallyFlippedViaDisplayedRegions,
+  HorizontallyFlippedViaLocstring,
+  HumanExomeExample,
+  NextstrainExample,
+  OneLinearGenomeView,
+} from './examples/index.ts'

--- a/products/jbrowse-react-linear-genome-view/stories/NextstrainDemo.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/NextstrainDemo.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { NextstrainExample } from './JBrowseLinearGenomeView.stories'
 
 <Meta title="Nextstrain SARS-CoV-2 demo" />
@@ -11,6 +11,8 @@ color config to color gene's similar to the Nextstrain website, and also
 displays "Entropy score" to show diversity
 
 <Story of={NextstrainExample} />
+
+<Source of={NextstrainExample} />
 
 ### Source
 

--- a/products/jbrowse-react-linear-genome-view/stories/ShadowDOM.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/ShadowDOM.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   ShadowDOMOneLinearGenomeView,
   UsingLocObject,
@@ -14,3 +14,5 @@ This is an example of using the @jbrowse/react-linear-genome-view2 component in
 a ShadowDOM context.
 
 <Story of={ShadowDOMOneLinearGenomeView} />
+
+<Source of={ShadowDOMOneLinearGenomeView} />

--- a/products/jbrowse-react-linear-genome-view/stories/TextSearching.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/TextSearching.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   WithAggregateTextSearching,
   WithPerTrackTextSearching,
@@ -16,11 +16,15 @@ just be a single entry but could be multiple)
 
 <Story of={WithAggregateTextSearching} />
 
+<Source of={WithAggregateTextSearching} />
+
 ## Per-track search index
 
 Per-track search indexes contain information for a single track.
 
 <Story of={WithPerTrackTextSearching} />
+
+<Source of={WithPerTrackTextSearching} />
 
 # Preparing indexes
 

--- a/products/jbrowse-react-linear-genome-view/stories/Theming.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/Theming.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   WithDarkTheme,
   WithCustomTheme,
@@ -17,9 +17,13 @@ See [here](https://jbrowse.org/jb2/docs/config_guides/theme/) for more info
 
 <Story of={WithCustomTheme} />
 
+<Source of={WithCustomTheme} />
+
 ## Dark theme
 
 Basic effort was made to make JBrowse dark mode compatible. This can be toggled
 via the 'mode':'dark' in the theme palette
 
 <Story of={WithDarkTheme} />
+
+<Source of={WithDarkTheme} />

--- a/products/jbrowse-react-linear-genome-view/stories/UsingInternetAccounts.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/UsingInternetAccounts.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { WithInternetAccounts } from './JBrowseLinearGenomeView.stories'
 
 <Meta title="Using InternetAccounts" />
@@ -35,6 +35,8 @@ Then any file location in your tracks that specifies an `internetAccountId` of
 "manualGoogleEntry" will use the specified InternetAccount.
 
 <Story of={WithInternetAccounts} />
+
+<Source of={WithInternetAccounts} />
 
 The above example lets the user manually enter a token already retrieved
 elsewhere. An "Authorization" header is then set on any request to that resource

--- a/products/jbrowse-react-linear-genome-view/stories/UsingPlugins.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/UsingPlugins.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import {
   WithInlinePlugins,
   WithExternalPlugin,
@@ -24,11 +24,15 @@ console.log's the region that was selected
 
 <Story of={WithInlinePlugins} />
 
+<Source of={WithInlinePlugins} />
+
 ## Plugins loaded from external URL
 
 This example loads a plugin from an external URL
 
 <Story of={WithExternalPlugin} />
+
+<Source of={WithExternalPlugin} />
 
 ## Plugins loaded from NPM
 

--- a/products/jbrowse-react-linear-genome-view/stories/UsingWebWorker.mdx
+++ b/products/jbrowse-react-linear-genome-view/stories/UsingWebWorker.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Source } from '@storybook/addon-docs/blocks'
 import { WithWebWorker } from './JBrowseLinearGenomeView.stories'
 
 <Meta title="Using WebWorker RPC" />
@@ -18,6 +18,8 @@ alignments datasets like BAM / CRAM.
 ## Example
 
 <Story of={WithWebWorker} />
+
+<Source of={WithWebWorker} />
 
 ## Note 1
 

--- a/products/jbrowse-react-linear-genome-view/stories/examples/DefaultSession.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/DefaultSession.tsx
@@ -47,9 +47,6 @@ export const DefaultSession = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/DefaultSession.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/DisableAddTrack.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/DisableAddTrack.tsx
@@ -13,9 +13,6 @@ export const DisableAddTrack = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/DisableAddTrack.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateLocstring.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateLocstring.tsx
@@ -67,9 +67,6 @@ export const ExternalNavigateLocstring = () => {
       </select>
       {error ? <ErrorMessage error={error} /> : null}
       <JBrowseLinearGenomeView viewState={viewState} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateLocstring.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateObject.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateObject.tsx
@@ -77,9 +77,6 @@ export const ExternalNavigateObject = () => {
       </select>
       {error ? <ErrorMessage error={error} /> : null}
       <JBrowseLinearGenomeView viewState={viewState} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/ExternalNavigateObject.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/HorizontallyFlipped.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/HorizontallyFlipped.tsx
@@ -26,9 +26,6 @@ export const HorizontallyFlippedViaLocstring = () => {
         the horizontally flipped orientation.
       </p>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/HorizontallyFlipped.tsx">
-        Source code
-      </a>
     </div>
   )
 }
@@ -72,9 +69,6 @@ export const HorizontallyFlippedViaButton = () => {
       </p>
       <FlipButton state={state} />
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/HorizontallyFlipped.tsx">
-        Source code
-      </a>
     </div>
   )
 }
@@ -113,9 +107,6 @@ export const HorizontallyFlippedViaDisplayedRegions = () => {
         start in the horizontally flipped orientation.
       </p>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/HorizontallyFlipped.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/HumanExomeExample.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/HumanExomeExample.tsx
@@ -100,9 +100,6 @@ export const HumanExomeExample = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/HumanExomeExample.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/NextstrainExample.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/NextstrainExample.tsx
@@ -26,9 +26,6 @@ export const NextstrainExample = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/NextstrainExample.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/OneLinearGenomeView.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/OneLinearGenomeView.tsx
@@ -19,9 +19,6 @@ export const OneLinearGenomeView = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/OneLinearGenomeView.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/ShadowDOMOneLinearGenomeView.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/ShadowDOMOneLinearGenomeView.tsx
@@ -115,9 +115,6 @@ export const ShadowDOMOneLinearGenomeView = () => {
     <div>
       {/* @ts-expect-error */}
       <jbrowse-linear-view />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/ShadowDOMOneLinearGenomeView.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/UsingLocObject.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/UsingLocObject.tsx
@@ -18,9 +18,6 @@ export const UsingLocObject = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/UsingLocObject.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithAggregateTextSearching.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithAggregateTextSearching.tsx
@@ -101,9 +101,6 @@ export const WithAggregateTextSearching = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithAggregateTextSearching.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithCustomTheme.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithCustomTheme.tsx
@@ -36,9 +36,6 @@ export const WithCustomTheme = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithCustomTheme.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithDarkTheme.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithDarkTheme.tsx
@@ -25,9 +25,6 @@ export const WithDarkTheme = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithDarkTheme.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithDisableZoomAndSideScroll.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithDisableZoomAndSideScroll.tsx
@@ -43,9 +43,6 @@ export const WithDisableZoomAndSideScroll = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithDisableZoomAndSideScroll.tsx">
-        Source code
-      </a>
       (Note: This is a basic demo that was added for a user request and may not
       be a complete solution)
     </div>

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithErrorHandler.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithErrorHandler.tsx
@@ -37,9 +37,6 @@ export const WithErrorHandler = () => {
       ) : (
         'Loading...'
       )}
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithErrorHandler.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithExternalPlugin.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithExternalPlugin.tsx
@@ -92,9 +92,6 @@ export const WithExternalPlugin = () => {
       ) : (
         <JBrowseLinearGenomeView viewState={viewState} />
       )}
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithExternalPlugin.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithInit.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithInit.tsx
@@ -106,9 +106,6 @@ export const WithInit = () => {
   return (
     <div>
       <ViewWithErrorHandling state={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithInit.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithInlinePlugins.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithInlinePlugins.tsx
@@ -70,9 +70,6 @@ export const WithInlinePlugins = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithInlinePlugins.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithInternetAccounts.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithInternetAccounts.tsx
@@ -38,9 +38,6 @@ export const WithInternetAccounts = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithInternetAccounts.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleFeatures.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleFeatures.tsx
@@ -83,9 +83,6 @@ export const WithObserveVisibleFeatures = () => {
     <div>
       <JBrowseLinearGenomeView viewState={state} />
       <VisibleFeatures session={state.session} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleFeatures.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleRegions.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleRegions.tsx
@@ -38,9 +38,6 @@ export const WithObserveVisibleRegions = () => {
     <div>
       <JBrowseLinearGenomeView viewState={state} />
       <VisibleRegions viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithObserveVisibleRegions.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithOutsideStyling.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithOutsideStyling.tsx
@@ -22,9 +22,6 @@ export const WithOutsideStyling = () => {
         component, is fine here.
       </p>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithOutsideStyling.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithPerTrackTextSearching.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithPerTrackTextSearching.tsx
@@ -60,9 +60,6 @@ export const WithPerTrackTextSearching = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithPerTrackTextSearching.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithReact18.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithReact18.tsx
@@ -20,9 +20,6 @@ export const WithReact18 = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithReact18.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithShowTrack.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithShowTrack.tsx
@@ -17,9 +17,6 @@ export const WithShowTrack = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithShowTrack.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithTwoLinearGenomeViews.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithTwoLinearGenomeViews.tsx
@@ -19,9 +19,6 @@ export const WithTwoLinearGenomeViews = () => {
     <div>
       <JBrowseLinearGenomeView viewState={state1} />
       <JBrowseLinearGenomeView viewState={state2} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithTwoLinearGenomeViews.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/examples/WithWebWorker.tsx
+++ b/products/jbrowse-react-linear-genome-view/stories/examples/WithWebWorker.tsx
@@ -24,9 +24,6 @@ export const WithWebWorker = () => {
   return (
     <div>
       <JBrowseLinearGenomeView viewState={state} />
-      <a href="https://github.com/GMOD/jbrowse-components/blob/main/products/jbrowse-react-linear-genome-view/stories/examples/WithWebWorker.tsx">
-        Source code
-      </a>
     </div>
   )
 }

--- a/products/jbrowse-react-linear-genome-view/stories/raw-source-loader.cjs
+++ b/products/jbrowse-react-linear-genome-view/stories/raw-source-loader.cjs
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+  return `export default ${JSON.stringify(source)}`
+}

--- a/products/jbrowse-react-linear-genome-view/stories/raw.d.ts
+++ b/products/jbrowse-react-linear-genome-view/stories/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '!!*' {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
currently, our storybook files manually hardcode links to github to help illustrate the source code but this automatically adds a source code listing below the file. uses a custom 'loader' which isn't ideal but it works

an alternative exists where storybook itself has this functionality for mdx files but i want it to work on our individual examples