### PR TITLE
Fix potential fetch beyond end of file resulting in HTTP 416

### DIFF
--- a/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
@@ -1,0 +1,219 @@
+import fetchMock from 'jest-fetch-mock'
+
+import {
+  RemoteFileWithRangeCache,
+  clearCache,
+} from './RemoteFileWithRangeCache.ts'
+
+// Disable jest-fetch-mock so our custom mock fetch functions work
+fetchMock.disableMocks()
+
+const CHUNK = 256 * 1024
+
+// Deterministic 1MB "file" where each byte equals its position mod 256
+const FILE_SIZE = 2 * 1024 * 1024
+const fileData = new Uint8Array(FILE_SIZE)
+for (let i = 0; i < FILE_SIZE; i++) {
+  fileData[i] = i % 256
+}
+
+function slice(start: number, end: number) {
+  return fileData.slice(start, end + 1)
+}
+
+// Mock fetch that serves range requests from fileData and tracks calls
+function createMockFetch() {
+  const calls: { start: number; end: number }[] = []
+  const mockFetch = async (
+    _url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const range = new Headers(init?.headers).get('range')
+    if (range) {
+      const m = /bytes=(\d+)-(\d+)/.exec(range)
+      if (m) {
+        const start = Number(m[1])
+        const end = Math.min(Number(m[2]), FILE_SIZE - 1)
+        calls.push({ start, end })
+        return new Response(slice(start, end), { status: 206 })
+      }
+    }
+    return new Response('', { status: 200 })
+  }
+  return { calls, mockFetch }
+}
+
+function makeFile(mockFetch: typeof globalThis.fetch) {
+  return new RemoteFileWithRangeCache('http://example.com/data.bin', {
+    fetch: mockFetch,
+  })
+}
+
+async function fetchRange(
+  file: RemoteFileWithRangeCache,
+  start: number,
+  end: number,
+) {
+  const res = await file.fetch('http://example.com/data.bin', {
+    headers: { range: `bytes=${start}-${end}` },
+  })
+  return new Uint8Array(await res.arrayBuffer())
+}
+
+afterEach(() => {
+  clearCache()
+})
+
+describe('RemoteFileWithRangeCache', () => {
+  test('returns correct bytes for a small range within one chunk', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    const result = await fetchRange(file, 100, 199)
+    expect(result).toEqual(slice(100, 199))
+    expect(calls).toHaveLength(1)
+  })
+
+  test('returns correct bytes spanning two chunks', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    const start = CHUNK - 10
+    const end = CHUNK + 10
+    const result = await fetchRange(file, start, end)
+    expect(result).toEqual(slice(start, end))
+    expect(calls).toHaveLength(1)
+  })
+
+  test('second request for same range hits cache with no new fetches', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    await fetchRange(file, 0, 99)
+    expect(calls).toHaveLength(1)
+    const result = await fetchRange(file, 0, 99)
+    expect(result).toEqual(slice(0, 99))
+    expect(calls).toHaveLength(1)
+  })
+
+  test('overlapping request reuses cached chunks', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+
+    // Fetch first chunk
+    await fetchRange(file, 0, CHUNK - 1)
+    expect(calls).toHaveLength(1)
+
+    // Fetch range spanning first and second chunk — only second chunk fetched
+    const start = CHUNK - 50
+    const end = CHUNK + 50
+    const result = await fetchRange(file, start, end)
+    expect(result).toEqual(slice(start, end))
+    expect(calls).toHaveLength(2)
+    // Second fetch should only be for chunk 1, not chunk 0
+    expect(calls[1]!.start).toBe(CHUNK)
+  })
+
+  test('large range spanning many chunks makes a single fetch', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    const start = 0
+    const end = CHUNK * 5 - 1
+    const result = await fetchRange(file, start, end)
+    expect(result).toEqual(slice(start, end))
+    expect(calls).toHaveLength(1)
+  })
+
+  test('gap detection fetches only missing middle chunks', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+
+    // Prime chunk 0 and chunk 3
+    await fetchRange(file, 0, CHUNK - 1)
+    await fetchRange(file, CHUNK * 3, CHUNK * 4 - 1)
+    expect(calls).toHaveLength(2)
+
+    // Now request chunks 0-3: only chunks 1-2 should be fetched
+    const result = await fetchRange(file, 0, CHUNK * 4 - 1)
+    expect(result).toEqual(slice(0, CHUNK * 4 - 1))
+    expect(calls).toHaveLength(3)
+    expect(calls[2]!.start).toBe(CHUNK)
+    expect(calls[2]!.end).toBe(CHUNK * 3 - 1)
+  })
+
+  test('non-range request passes through without caching', async () => {
+    const { mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    const res = await file.fetch('http://example.com/data.bin')
+    expect(res.status).toBe(200)
+  })
+
+  test('clearCache causes subsequent requests to re-fetch', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    await fetchRange(file, 0, 99)
+    expect(calls).toHaveLength(1)
+
+    clearCache()
+
+    await fetchRange(file, 0, 99)
+    expect(calls).toHaveLength(2)
+  })
+
+  test('unaligned range within a chunk returns exact bytes', async () => {
+    const { mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+    const start = 1000
+    const end = 2000
+    const result = await fetchRange(file, start, end)
+    expect(result).toEqual(slice(start, end))
+    expect(result).toHaveLength(1001)
+  })
+
+  test('fetch error propagates with status', async () => {
+    const mockFetch = async () => new Response('', { status: 404 })
+    const file = makeFile(mockFetch)
+    await expect(fetchRange(file, 0, 99)).rejects.toThrow('HTTP 404')
+    await expect(fetchRange(file, 0, 99)).rejects.toHaveProperty('status', 404)
+  })
+
+  test('HTTP 416 range not satisfiable returns empty buffer', async () => {
+    // Simulates a BAM file where the chunk-aligned range start is past EOF
+    const mockFetch = async () => new Response('', { status: 416 })
+    const file = makeFile(mockFetch)
+    const result = await fetchRange(file, 0, 99)
+    expect(result).toHaveLength(0)
+  })
+
+  test('multiple disjoint gaps produce separate fetches', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+
+    // Prime chunks 0 and 2, leaving 1 and 3 as separate gaps
+    await fetchRange(file, 0, CHUNK - 1)
+    await fetchRange(file, CHUNK * 2, CHUNK * 3 - 1)
+    expect(calls).toHaveLength(2)
+
+    // Request chunks 0-3: should fetch chunk 1 and chunk 3 separately
+    const result = await fetchRange(file, 0, CHUNK * 4 - 1)
+    expect(result).toEqual(slice(0, CHUNK * 4 - 1))
+    expect(calls).toHaveLength(4)
+    expect(calls[2]!.start).toBe(CHUNK)
+    expect(calls[2]!.end).toBe(CHUNK * 2 - 1)
+    expect(calls[3]!.start).toBe(CHUNK * 3)
+    expect(calls[3]!.end).toBe(CHUNK * 4 - 1)
+  })
+
+  test('different URLs do not share cache', async () => {
+    const { calls, mockFetch } = createMockFetch()
+    const file = makeFile(mockFetch)
+
+    await fetchRange(file, 0, 99)
+    expect(calls).toHaveLength(1)
+
+    // Same range but different URL should trigger a new fetch
+    const res = await file.fetch('http://example.com/other.bin', {
+      headers: { range: 'bytes=0-99' },
+    })
+    const result = new Uint8Array(await res.arrayBuffer())
+    expect(result).toEqual(slice(0, 99))
+    expect(calls).toHaveLength(2)
+  })
+})

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
@@ -278,6 +278,97 @@ describe('RemoteFileWithRangeCache', () => {
     expect(calls).toHaveLength(2)
   })
 
+  test('stat() returns file size from Content-Range header', async () => {
+    const mockFetch = async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const range = new Headers(init?.headers).get('range')
+      if (range) {
+        const m = /bytes=(\d+)-(\d+)/.exec(range)
+        if (m) {
+          const start = Number(m[1])
+          const end = Math.min(Number(m[2]), FILE_SIZE - 1)
+          return new Response(slice(start, end), {
+            status: 206,
+            headers: {
+              'content-range': `bytes ${start}-${end}/${FILE_SIZE}`,
+            },
+          })
+        }
+      }
+      return new Response('', { status: 200 })
+    }
+    const file = new RemoteFileWithRangeCache('http://example.com/data.bin', {
+      fetch: mockFetch,
+    })
+    const stat = await file.stat()
+    expect(stat.size).toBe(FILE_SIZE)
+  })
+
+  test('stat() does not throw when Content-Range is not exposed (CORS)', async () => {
+    const { mockFetch } = createMockFetch() // no Content-Range headers
+    const file = makeFile(mockFetch)
+    // Falls back to parent stat() — should not crash
+    await expect(file.stat()).resolves.toBeDefined()
+  })
+
+  // Cold cache: the over-read request is the FIRST request, so no short chunk
+  // is cached yet. The coalesced fetch covers both a valid and past-EOF chunk
+  // in one HTTP request — the server clips the response, and the past-EOF
+  // chunk is cached as empty. No 416.
+  test('cold-cache over-read handles partial server response gracefully', async () => {
+    const smallFileSize = CHUNK + 210_000
+    const smallFile = new Uint8Array(smallFileSize)
+    for (let i = 0; i < smallFileSize; i++) {
+      smallFile[i] = i % 256
+    }
+
+    const calls: { start: number; end: number }[] = []
+    const mockFetch = async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const range = new Headers(init?.headers).get('range')
+      if (range) {
+        const m = /bytes=(\d+)-(\d+)/.exec(range)
+        if (m) {
+          const reqStart = Number(m[1])
+          const reqEnd = Number(m[2])
+          calls.push({ start: reqStart, end: reqEnd })
+          if (reqStart >= smallFileSize) {
+            return new Response('', { status: 416 })
+          }
+          const end = Math.min(reqEnd, smallFileSize - 1)
+          return new Response(smallFile.slice(reqStart, end + 1), {
+            status: 206,
+          })
+        }
+      }
+      return new Response('', { status: 200 })
+    }
+
+    const file = new RemoteFileWithRangeCache('http://example.com/small.bin', {
+      fetch: mockFetch,
+    })
+
+    // Single request spanning chunks 1 and 2, with no prior cached chunks.
+    // Chunk 1 has data, chunk 2 is past EOF.
+    const overreadStart = CHUNK + 200_000
+    const overreadEnd = overreadStart + 65_535
+    const res = await file.fetch('http://example.com/small.bin', {
+      headers: { range: `bytes=${overreadStart}-${overreadEnd}` },
+    })
+    const result = new Uint8Array(await res.arrayBuffer())
+
+    // Returns only the bytes that exist
+    expect(result).toEqual(smallFile.slice(overreadStart, smallFileSize))
+
+    // Both chunks were in one coalesced run — only one HTTP request
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.start).toBe(CHUNK)
+  })
+
   test('different URLs do not share cache', async () => {
     const { calls, mockFetch } = createMockFetch()
     const file = makeFile(mockFetch)

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
@@ -201,6 +201,83 @@ describe('RemoteFileWithRangeCache', () => {
     expect(calls[3]!.end).toBe(CHUNK * 4 - 1)
   })
 
+  // Regression test: @gmod/bam and @gmod/tabix compute
+  // fetchedSize() = maxv.blockPosition + (1<<16) - minv.blockPosition to
+  // guarantee they read the complete final bgzf block. When the file ends
+  // near a 256 KiB chunk boundary, this over-read crosses into a chunk whose
+  // start is past EOF — the server would return 416 for that chunk.
+  //
+  // Fix: once a cached chunk is shorter than CHUNK_SIZE, the file ended
+  // within it. Any chunk beyond it starts past EOF and is skipped without a
+  // network request.
+  test('skips chunk past EOF when previous chunk was short (bam/tabix over-read pattern)', async () => {
+    // File ends 210 000 bytes into chunk 1 (chunks are 256 KiB = 262 144 bytes).
+    const smallFileSize = CHUNK + 210_000 // 472 144 bytes
+    const smallFile = new Uint8Array(smallFileSize)
+    for (let i = 0; i < smallFileSize; i++) {
+      smallFile[i] = i % 256
+    }
+
+    const calls: { start: number; end: number }[] = []
+    const mockFetch = async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const range = new Headers(init?.headers).get('range')
+      if (range) {
+        const m = /bytes=(\d+)-(\d+)/.exec(range)
+        if (m) {
+          const reqStart = Number(m[1])
+          const reqEnd = Number(m[2])
+          calls.push({ start: reqStart, end: reqEnd })
+          if (reqStart >= smallFileSize) {
+            // Should never reach here — the fix prevents this request
+            return new Response('', { status: 416 })
+          }
+          const end = Math.min(reqEnd, smallFileSize - 1)
+          return new Response(smallFile.slice(reqStart, end + 1), {
+            status: 206,
+          })
+        }
+      }
+      return new Response('', { status: 200 })
+    }
+
+    const file = new RemoteFileWithRangeCache('http://example.com/small.bin', {
+      fetch: mockFetch,
+    })
+
+    // Prime chunk 0 (full) and chunk 1 (short — server clips to smallFileSize)
+    await file.fetch('http://example.com/small.bin', {
+      headers: { range: `bytes=0-${CHUNK - 1}` },
+    })
+    await file.fetch('http://example.com/small.bin', {
+      headers: { range: `bytes=${CHUNK}-${2 * CHUNK - 1}` },
+    })
+    expect(calls).toHaveLength(2)
+    // Chunk 1 server response was shorter than CHUNK bytes
+
+    // Over-read pattern: start near end of chunk 1, length = 1<<16,
+    // which crosses into chunk 2 (starts at 2*CHUNK = 524 288 > smallFileSize)
+    const overreadStart = CHUNK + 200_000 // 462 144 — within chunk 1, within file
+    const overreadEnd = overreadStart + 65_535 // 527 679 — lands in chunk 2
+    expect(Math.floor(overreadEnd / CHUNK)).toBe(2) // confirm chunk 2 is involved
+
+    const res = await file.fetch('http://example.com/small.bin', {
+      headers: { range: `bytes=${overreadStart}-${overreadEnd}` },
+    })
+    const result = new Uint8Array(await res.arrayBuffer())
+
+    // Only the bytes that actually exist are returned
+    expect(result).toEqual(smallFile.slice(overreadStart, smallFileSize))
+
+    // Chunk 2 (starts at 2*CHUNK, past EOF) must NOT have been requested
+    const chunk2Requests = calls.filter(c => c.start >= 2 * CHUNK)
+    expect(chunk2Requests).toHaveLength(0)
+    // Total fetches: 2 priming + 0 new (chunk 1 already cached, chunk 2 skipped)
+    expect(calls).toHaveLength(2)
+  })
+
   test('different URLs do not share cache', async () => {
     const { calls, mockFetch } = createMockFetch()
     const file = makeFile(mockFetch)

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.ts
@@ -116,7 +116,21 @@ export class RemoteFileWithRangeCache extends RemoteFile {
   ) {
     const startChunk = Math.floor(start / CHUNK_SIZE)
     const endChunk = Math.floor((start + length - 1) / CHUNK_SIZE)
-    const chunkCount = endChunk - startChunk + 1
+
+    // Pre-pass: if any already-cached chunk in [startChunk, endChunk) is
+    // shorter than CHUNK_SIZE, the file ended within it. Chunks beyond that
+    // point start past EOF — skip fetching them. This prevents @gmod/bam and
+    // @gmod/tabix's fetchedSize() over-read of (1<<16) bytes past the last
+    // bgzf block from triggering a 416 when the over-read crosses a chunk boundary.
+    let effectiveEndChunk = endChunk
+    for (let i = startChunk; i < endChunk; i++) {
+      const c = getCached(cacheKey(url, i))
+      if (c !== undefined && c.length < CHUNK_SIZE) {
+        effectiveEndChunk = i
+        break
+      }
+    }
+    const chunkCount = effectiveEndChunk - startChunk + 1
 
     // Find contiguous runs of missing (uncached) chunks
     const runs: { start: number; end: number }[] = []
@@ -156,7 +170,10 @@ export class RemoteFileWithRangeCache extends RemoteFile {
     const result = new Uint8Array(length)
     let written = 0
     for (let i = 0; i < chunkCount; i++) {
-      const chunk = getCached(cacheKey(url, startChunk + i)) ?? new Uint8Array(0)
+      // Every chunk in [startChunk, effectiveEndChunk] is guaranteed cached
+      // here: either it was already present (skipped by the runs loop) or it
+      // was just fetched and putCached'd above.
+      const chunk = getCached(cacheKey(url, startChunk + i))!
       const sourceStart = i === 0 ? offsetInFirstChunk : 0
       const available = chunk.length - sourceStart
       const needed = length - written

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.ts
@@ -68,14 +68,12 @@ export class RemoteFileWithRangeCache extends RemoteFile {
 
   async stat() {
     if (!this.cachedStat) {
-      // Trigger a range fetch which will populate cachedStat from Content-Range
       await this.getCachedRange(this.url, 0, 1)
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!this.cachedStat) {
-        throw new Error(`unable to determine size of file at ${this.url}`)
-      }
     }
-    return this.cachedStat
+    // Content-Range may not be exposed (CORS) — return size 0 rather than
+    // throwing so callers degrade gracefully.
+
+    return this.cachedStat ?? { size: 0 }
   }
 
   private async fetchRange(

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.ts
@@ -64,6 +64,20 @@ function cacheKey(url: string, chunkIndex: number) {
 }
 
 export class RemoteFileWithRangeCache extends RemoteFile {
+  private cachedStat?: { size: number }
+
+  async stat() {
+    if (!this.cachedStat) {
+      // Trigger a range fetch which will populate cachedStat from Content-Range
+      await this.getCachedRange(this.url, 0, 1)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!this.cachedStat) {
+        throw new Error(`unable to determine size of file at ${this.url}`)
+      }
+    }
+    return this.cachedStat
+  }
+
   private async fetchRange(
     url: string,
     start: number,
@@ -74,10 +88,22 @@ export class RemoteFileWithRangeCache extends RemoteFile {
       signal: signal ?? undefined,
       headers: { range: `bytes=${start}-${end}` },
     })
+    if (res.status === 416) {
+      // Range Not Satisfiable: requested range starts past end of file
+      return new Uint8Array(0)
+    }
     if (!res.ok) {
-      const errorMessage = `HTTP ${res.status} fetching ${url} bytes ${start}-${end}`
       const hint = ' (should be 206 for range requests)'
-      throw new Error(`${errorMessage}${res.status === 200 ? hint : ''}`)
+      const msg = `HTTP ${res.status} fetching ${url} bytes ${start}-${end}${res.status === 200 ? hint : ''}`
+      throw Object.assign(new Error(msg), { status: res.status })
+    }
+    // Parse total file size from Content-Range (e.g. "bytes 0-255/12345")
+    if (!this.cachedStat) {
+      const contentRange = res.headers.get('content-range')
+      const match = contentRange ? /\/(\d+)$/.exec(contentRange) : null
+      if (match) {
+        this.cachedStat = { size: parseInt(match[1]!, 10) }
+      }
     }
     return new Uint8Array(await res.arrayBuffer())
   }
@@ -92,33 +118,45 @@ export class RemoteFileWithRangeCache extends RemoteFile {
     const endChunk = Math.floor((start + length - 1) / CHUNK_SIZE)
     const chunkCount = endChunk - startChunk + 1
 
-    const chunks = await Promise.all(
-      Array.from({ length: chunkCount }, (_, i) => {
-        const idx = startChunk + i
-        const key = cacheKey(url, idx)
-        const existing = getCached(key)
-        if (existing) {
-          return Promise.resolve(existing)
+    // Find contiguous runs of missing (uncached) chunks
+    const runs: { start: number; end: number }[] = []
+    for (let i = 0; i < chunkCount; i++) {
+      if (!getCached(cacheKey(url, startChunk + i))) {
+        const lastRun = runs[runs.length - 1]
+        if (lastRun && lastRun.end === i - 1) {
+          lastRun.end = i
+        } else {
+          runs.push({ start: i, end: i })
         }
-        return limitConcurrency(async () => {
-          const alreadyCached = getCached(key)
-          if (alreadyCached) {
-            return alreadyCached
+      }
+    }
+
+    // Fetch each contiguous run as a single HTTP range request
+    await Promise.all(
+      runs.map(run =>
+        limitConcurrency(async () => {
+          const runStartChunk = startChunk + run.start
+          const runEndChunk = startChunk + run.end
+          const rangeStart = runStartChunk * CHUNK_SIZE
+          const rangeEnd = (runEndChunk + 1) * CHUNK_SIZE - 1
+          const data = await this.fetchRange(url, rangeStart, rangeEnd, signal)
+          for (let i = run.start; i <= run.end; i++) {
+            const offset = (i - run.start) * CHUNK_SIZE
+            putCached(
+              cacheKey(url, startChunk + i),
+              data.subarray(offset, offset + CHUNK_SIZE),
+            )
           }
-          const chunkStart = idx * CHUNK_SIZE
-          const chunkEnd = chunkStart + CHUNK_SIZE - 1
-          const data = await this.fetchRange(url, chunkStart, chunkEnd, signal)
-          putCached(key, data)
-          return data
-        })
-      }),
+        }),
+      ),
     )
 
+    // Assemble result from cached chunks
     const offsetInFirstChunk = start - startChunk * CHUNK_SIZE
     const result = new Uint8Array(length)
     let written = 0
-    for (const [i, chunk_] of chunks.entries()) {
-      const chunk = chunk_
+    for (let i = 0; i < chunkCount; i++) {
+      const chunk = getCached(cacheKey(url, startChunk + i)) ?? new Uint8Array(0)
       const sourceStart = i === 0 ? offsetInFirstChunk : 0
       const available = chunk.length - sourceStart
       const needed = length - written

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.ts
@@ -45,7 +45,7 @@ function limitConcurrency<T>(fn: () => Promise<T>) {
         },
         (err: unknown) => {
           activeCount--
-          reject(err as Error)
+          reject(err instanceof Error ? err : new Error(String(err)))
           runNext()
         },
       )
@@ -137,7 +137,7 @@ export class RemoteFileWithRangeCache extends RemoteFile {
     for (let i = 0; i < chunkCount; i++) {
       if (!getCached(cacheKey(url, startChunk + i))) {
         const lastRun = runs[runs.length - 1]
-        if (lastRun && lastRun.end === i - 1) {
+        if (lastRun?.end === i - 1) {
           lastRun.end = i
         } else {
           runs.push({ start: i, end: i })


### PR DESCRIPTION
Follow up to https://github.com/GMOD/jbrowse-components/issues/5490

This unfortunately didn't fully fix it and had a similar problem, but this now has a method that 'stops fetching' if it receives a chunk that is smaller than the requested size, which prevents fetching beyond the end of the file

Adds testing for this scenario to help avoid regressions