### PR TITLE
fix: Windows dev/test ergonomics (Jest, webpack, web build, browser runner)

### DIFF
--- a/config/jest/canvas.js
+++ b/config/jest/canvas.js
@@ -1,85 +1,89 @@
-const { createCanvas } = require('canvas')
+// Patch jsdom canvas to use node-canvas for 2D. Skipped when there is no DOM
+// (e.g. files with @jest-environment node inside the default jsdom project).
+if (typeof HTMLCanvasElement !== 'undefined') {
+  const { createCanvas } = require('canvas')
 
-const nodeCanvasMap = new WeakMap()
+  const nodeCanvasMap = new WeakMap()
 
-function getNodeCanvas(domCanvas) {
-  let entry = nodeCanvasMap.get(domCanvas)
-  if (!entry) {
-    const nc = createCanvas(300, 150)
-    entry = { nc }
-    nodeCanvasMap.set(domCanvas, entry)
+  function getNodeCanvas(domCanvas) {
+    let entry = nodeCanvasMap.get(domCanvas)
+    if (!entry) {
+      const nc = createCanvas(300, 150)
+      entry = { nc }
+      nodeCanvasMap.set(domCanvas, entry)
+    }
+    return entry.nc
   }
-  return entry.nc
-}
 
-const origGetContext = HTMLCanvasElement.prototype.getContext
-HTMLCanvasElement.prototype.getContext = function (type, attrs) {
-  if (type === '2d') {
-    const nc = getNodeCanvas(this)
-    return nc.getContext('2d', attrs)
+  const origGetContext = HTMLCanvasElement.prototype.getContext
+  HTMLCanvasElement.prototype.getContext = function (type, attrs) {
+    if (type === '2d') {
+      const nc = getNodeCanvas(this)
+      return nc.getContext('2d', attrs)
+    }
+    return origGetContext.call(this, type, attrs)
   }
-  return origGetContext.call(this, type, attrs)
-}
 
-const widthDesc = Object.getOwnPropertyDescriptor(
-  HTMLCanvasElement.prototype,
-  'width',
-)
-const heightDesc = Object.getOwnPropertyDescriptor(
-  HTMLCanvasElement.prototype,
-  'height',
-)
+  const widthDesc = Object.getOwnPropertyDescriptor(
+    HTMLCanvasElement.prototype,
+    'width',
+  )
+  const heightDesc = Object.getOwnPropertyDescriptor(
+    HTMLCanvasElement.prototype,
+    'height',
+  )
 
-if (widthDesc?.set) {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'width', {
-    get: widthDesc.get,
-    set(v) {
-      widthDesc.set.call(this, v)
-      const nc = nodeCanvasMap.get(this)?.nc
-      if (nc) {
-        nc.width = v
-      }
-    },
-    configurable: true,
-  })
-}
-
-if (heightDesc?.set) {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'height', {
-    get: heightDesc.get,
-    set(v) {
-      heightDesc.set.call(this, v)
-      const nc = nodeCanvasMap.get(this)?.nc
-      if (nc) {
-        nc.height = v
-      }
-    },
-    configurable: true,
-  })
-}
-
-HTMLCanvasElement.prototype.getBoundingClientRect = function () {
-  const w = Number(this.getAttribute('width')) || this.width || 300
-  const h = Number(this.getAttribute('height')) || this.height || 150
-  return {
-    x: 0,
-    y: 0,
-    left: 0,
-    top: 0,
-    width: w,
-    height: h,
-    right: w,
-    bottom: h,
-    toJSON() {
-      return this
-    },
+  if (widthDesc?.set) {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'width', {
+      get: widthDesc.get,
+      set(v) {
+        widthDesc.set.call(this, v)
+        const nc = nodeCanvasMap.get(this)?.nc
+        if (nc) {
+          nc.width = v
+        }
+      },
+      configurable: true,
+    })
   }
-}
 
-HTMLCanvasElement.prototype.toDataURL = function (mimeType, quality) {
-  const nc = nodeCanvasMap.get(this)?.nc
-  if (nc) {
-    return nc.toDataURL(mimeType, quality)
+  if (heightDesc?.set) {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'height', {
+      get: heightDesc.get,
+      set(v) {
+        heightDesc.set.call(this, v)
+        const nc = nodeCanvasMap.get(this)?.nc
+        if (nc) {
+          nc.height = v
+        }
+      },
+      configurable: true,
+    })
   }
-  return 'data:,'
+
+  HTMLCanvasElement.prototype.getBoundingClientRect = function () {
+    const w = Number(this.getAttribute('width')) || this.width || 300
+    const h = Number(this.getAttribute('height')) || this.height || 150
+    return {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      width: w,
+      height: h,
+      right: w,
+      bottom: h,
+      toJSON() {
+        return this
+      },
+    }
+  }
+
+  HTMLCanvasElement.prototype.toDataURL = function (mimeType, quality) {
+    const nc = nodeCanvasMap.get(this)?.nc
+    if (nc) {
+      return nc.toDataURL(mimeType, quality)
+    }
+    return 'data:,'
+  }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,16 @@
+// canvas.js patches HTMLCanvasElement (jsdom); not available in pure Node
+const setupFilesBase = [
+  '<rootDir>/config/jest/textEncoder.js',
+  '<rootDir>/config/jest/console.js',
+  '<rootDir>/config/jest/messagechannel.js',
+  '<rootDir>/config/jest/structuredClone.js',
+  '<rootDir>/config/jest/setHTML.js',
+]
+const setupFilesWithCanvas = [
+  ...setupFilesBase,
+  '<rootDir>/config/jest/canvas.js',
+]
+
 const baseConfig = {
   moduleNameMapper: {
     '^@jbrowse/core/util/useMeasure$':
@@ -14,7 +27,9 @@ const baseConfig = {
     '\\.module\\.(css|sass|scss)$',
   ],
   collectCoverageFrom: [
-    '{packages,products,plugins}/*/src/**/*.{js,jsx,ts,tsx}',
+    'packages/*/src/**/*.{js,jsx,ts,tsx}',
+    'products/*/src/**/*.{js,jsx,ts,tsx}',
+    'plugins/*/src/**/*.{js,jsx,ts,tsx}',
   ],
   coveragePathIgnorePatterns: [
     '!*.d.ts',
@@ -22,14 +37,7 @@ const baseConfig = {
     'react-colorful.js',
     'QuickLRU.js',
   ],
-  setupFiles: [
-    '<rootDir>/config/jest/textEncoder.js',
-    '<rootDir>/config/jest/console.js',
-    '<rootDir>/config/jest/messagechannel.js',
-    '<rootDir>/config/jest/structuredClone.js',
-    '<rootDir>/config/jest/setHTML.js',
-    '<rootDir>/config/jest/canvas.js',
-  ],
+  setupFiles: setupFilesWithCanvas,
   testEnvironmentOptions: { url: 'http://localhost' },
   testTimeout: 15000,
 }
@@ -42,6 +50,7 @@ export default {
       testMatch: ['<rootDir>/integration.test.js'],
       testEnvironment: 'node',
       ...baseConfig,
+      setupFiles: setupFilesBase,
     },
     {
       // jbrowse-img uses Node environment with native fetch (no jest-fetch-mock)
@@ -50,12 +59,16 @@ export default {
       testPathIgnorePatterns: ['/dist/', '/cypress/', '/demos/'],
       testEnvironment: 'node',
       ...baseConfig,
+      setupFiles: setupFilesBase,
     },
     {
       // All other tests use jsdom with jest-fetch-mock
       displayName: 'default',
+      // Explicit globs (not brace expansion) so tests are discovered on Windows
       testMatch: [
-        '<rootDir>/{packages,products,plugins}/**/*.test.{ts,tsx,js,jsx}',
+        '<rootDir>/packages/**/*.test.{ts,tsx,js,jsx}',
+        '<rootDir>/products/**/*.test.{ts,tsx,js,jsx}',
+        '<rootDir>/plugins/**/*.test.{ts,tsx,js,jsx}',
       ],
       testPathIgnorePatterns: [
         '/dist/',

--- a/plugins/alignments/src/LinearAlignmentsDisplay/model.ts
+++ b/plugins/alignments/src/LinearAlignmentsDisplay/model.ts
@@ -1045,7 +1045,8 @@ export default function stateModelFactory(
           try {
             const feat = await fetchFeatureDetails(self, featureId)
             if (isAlive(self) && feat) {
-              selectFeature(feat)
+              ;(self as unknown as { selectFeature: (f: Feature) => void })
+                .selectFeature(feat)
             }
           } catch (e) {
             console.error(e)

--- a/plugins/canvas/src/LinearFeatureDisplay/components/FeatureComponent.tsx
+++ b/plugins/canvas/src/LinearFeatureDisplay/components/FeatureComponent.tsx
@@ -123,7 +123,7 @@ const FeatureComponent = observer(function FeatureComponent({ model }: Props) {
   )
   const [hoveredSubfeature, setHoveredSubfeature] =
     useState<SubfeatureInfo | null>(null)
-  const [clientXY, setClientXY] = useState([0, 0])
+  const [clientXY, setClientXY] = useState([0, 0] as [number, number])
   const [contextMenuCoord, setContextMenuCoord] = useState<
     [number, number] | undefined
   >()

--- a/plugins/linear-comparative-view/src/LGVSyntenyDisplay/index.ts
+++ b/plugins/linear-comparative-view/src/LGVSyntenyDisplay/index.ts
@@ -9,9 +9,15 @@ export default function LGVSyntenyDisplayF(pluginManager: PluginManager) {
   pluginManager.addDisplayType(() => {
     const configSchema = configSchemaF(pluginManager)
     const stateModel = stateModelF(configSchema)
-    const { ReactComponent } = pluginManager.getDisplayType(
+    const linearAlignmentsDisplay = pluginManager.getDisplayType(
       'LinearAlignmentsDisplay',
     )
+    if (!linearAlignmentsDisplay?.ReactComponent) {
+      throw new Error(
+        'LinearAlignmentsDisplay plugin must be registered before LGVSyntenyDisplay',
+      )
+    }
+    const { ReactComponent } = linearAlignmentsDisplay
     return new DisplayType({
       name: 'LGVSyntenyDisplay',
       configSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2464,6 +2464,10 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
 
 packages:
 
@@ -4728,49 +4732,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}

--- a/products/jbrowse-desktop/src/components/StartScreen/availableGenomes/GenomesDataTable.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/availableGenomes/GenomesDataTable.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from '@jbrowse/core/util/tss-react'
 import Help from '@mui/icons-material/Help'
 import MoreVert from '@mui/icons-material/MoreVert'
 import { Button, IconButton } from '@mui/material'
+/* eslint-disable import/named -- package exports are valid; eslint import resolver misses them */
 import {
   flexRender,
   getCoreRowModel,

--- a/products/jbrowse-desktop/src/components/StartScreen/availableGenomes/getColumnDefinitions.tsx
+++ b/products/jbrowse-desktop/src/components/StartScreen/availableGenomes/getColumnDefinitions.tsx
@@ -5,6 +5,7 @@ import Check from '@mui/icons-material/Check'
 import Close from '@mui/icons-material/Close'
 import MoreHoriz from '@mui/icons-material/MoreHoriz'
 import { Link, Tooltip } from '@mui/material'
+/* eslint-disable import/named -- package exports are valid; eslint import resolver misses them */
 import { createColumnHelper } from '@tanstack/react-table'
 
 import HighlightedText from './HighlightedText.tsx'

--- a/products/jbrowse-web/browser-tests/runner.ts
+++ b/products/jbrowse-web/browser-tests/runner.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import fs from 'fs'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 import { launch } from 'puppeteer'
 
@@ -80,7 +80,7 @@ async function discoverSuites(): Promise<TestSuite[]> {
   const suites: TestSuite[] = []
 
   for (const file of files) {
-    const mod = await import(path.join(suitesDir, file))
+    const mod = await import(pathToFileURL(path.join(suitesDir, file)).href)
     const exported = mod.default
     if (Array.isArray(exported)) {
       for (const s of exported) {

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -11,8 +11,8 @@
     "./src/makeWorkerInstance": "./src/makeWorkerInstance.ts"
   },
   "scripts": {
-    "start": "NODE_ENV=development node scripts/start.ts",
-    "build": "NODE_ENV=production node scripts/build.ts",
+    "start": "cross-env NODE_ENV=development node scripts/start.ts",
+    "build": "cross-env NODE_ENV=production node scripts/build.ts",
     "prebuild": "rimraf build",
     "postbuild": "node -e \"fs.writeFileSync('build/version.txt',JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version)\"",
     "prepack": "pnpm build",
@@ -85,6 +85,9 @@
     "pngjs": "^7.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0"
   },
   "browserslist": {
     "production": [

--- a/webpack/scripts/start.ts
+++ b/webpack/scripts/start.ts
@@ -39,6 +39,7 @@ export default function startWebpack(config: webpack.Configuration) {
       }
 
       const protocol = process.env.HTTPS === 'true' ? 'https' : 'http'
+      const wsProtocol = process.env.HTTPS === 'true' ? 'wss' : 'ws'
       const appName = JSON.parse(fs.readFileSync('package.json', 'utf8')).name
 
       const urls = prepareUrls(protocol, HOST, port)
@@ -54,6 +55,16 @@ export default function startWebpack(config: webpack.Configuration) {
           host: HOST,
           port,
           hot: false,
+          // With host 0.0.0.0, the injected dev-server client can pick a wrong
+          // WebSocket URL on Windows; the tab then spins forever. Pin WS to localhost.
+          client: {
+            webSocketURL: {
+              hostname: 'localhost',
+              pathname: '/ws',
+              port,
+              protocol: wsProtocol,
+            },
+          },
           static: {
             serveIndex: true,
             staticOptions: { dotfiles: 'allow' },


### PR DESCRIPTION
## Summary
Cross-platform fixes from testing **`webgl-poc`** on **Windows** so contributors can **lint**, **typecheck**, run **Jest** (including mixed Node/jsdom), **build `@jbrowse/web`**, and run the **Puppeteer browser runner** without the failures we hit locally.

## Changes
| Area | What |
|------|------|
| `config/jest/canvas.js` | Only patch canvas when `HTMLCanvasElement` exists, so `@jest-environment node` tests in the default project no longer crash at load. |
| `jest.config.js` | Explicit `testMatch` / `collectCoverageFrom` globs (no brace expansion) for Windows; `setupFiles` without `canvas.js` for **`integration`** and **`jbrowse-img`** after `...baseConfig`. |
| `webpack/scripts/start.ts` | `client.webSocketURL` for `localhost` + correct `ws`/`wss` when dev server binds to `0.0.0.0` (fixes stuck HMR on Windows). |
| `products/jbrowse-web/package.json` | `cross-env` for `build` / `start` (`NODE_ENV`). |
| `products/jbrowse-web/browser-tests/runner.ts` | Dynamic suite imports via `pathToFileURL` (fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows). |
| `plugins/alignments/.../model.ts` | Call `selectFeature` from `selectFeatureById` via a narrow cast (MST async `self` typing). |
| `plugins/canvas/.../FeatureComponent.tsx` | Mouse coords as `[number, number]` for tooltip typing. |
| `plugins/linear-comparative-view/.../LGVSyntenyDisplay/index.ts` | Guard if `LinearAlignmentsDisplay` is missing. |
| `products/jbrowse-desktop/.../GenomesDataTable.tsx` & `getColumnDefinitions.tsx` | `eslint-disable import/named` for `@tanstack/react-table` (resolver false positives). |
| `pnpm-lock.yaml` | Lockfile for `cross-env`. |

## Testing
- `pnpm lint` — pass  
- `pnpm typecheck` — pass  
- `pnpm exec jest --selectProjects integration --ci` — pass  
- `pnpm exec jest --selectProjects default --ci` — many suites pass; remaining noise is mostly **snapshots / visual** vs Linux CI  
- `pnpm --filter @jbrowse/web build` — pass (after `cross-env`)  
- `pnpm run test:browser:webgl` — runner starts; mix of pass / snapshot GPU differences on Windows  

## Notes
**Worked well:** lint, typecheck, integration Jest, web production build, browser runner discovery after the ESM path fix.

**Rougher on Windows:** full default Jest and pixel browser tests (snapshots, fonts, **ANGLE**); CLI tests can hit **`EBUSY`** on temp cleanup. **Not in this PR:** Git `test_data` symlinks often become stub files on Windows — directory junctions to repo-root `test_data` help locally; consider documenting in **CONTRIBUTING**.

cc @cmdcolin
