### PR TITLE
Fix inconsistent sanitization causing broken trix index file paths on desktop

### DIFF
--- a/packages/text-indexing-core/src/types/common.test.ts
+++ b/packages/text-indexing-core/src/types/common.test.ts
@@ -1,4 +1,9 @@
-import { guessAdapterFromFileName, isURL, makeLocation } from './common.ts'
+import {
+  guessAdapterFromFileName,
+  isURL,
+  makeLocation,
+  sanitizeForFilename,
+} from './common.ts'
 
 const supportedIndexingAdapters = new Set([
   'Gff3TabixAdapter',
@@ -11,6 +16,22 @@ const supportedIndexingAdapters = new Set([
 function isSupportedIndexingAdapter(type?: string) {
   return supportedIndexingAdapters.has(type || '')
 }
+
+describe('sanitizeForFilename', () => {
+  it('replaces forward slash with underscore', () => {
+    expect(sanitizeForFilename('test_a/b-index')).toBe('test_a_b-index')
+  })
+  it('replaces all Windows-invalid characters', () => {
+    expect(sanitizeForFilename('a\\b/c:d*e?f"g<h>i|j')).toBe(
+      'a_b_c_d_e_f_g_h_i_j',
+    )
+  })
+  it('leaves safe characters unchanged', () => {
+    expect(sanitizeForFilename('track-name_1234.index')).toBe(
+      'track-name_1234.index',
+    )
+  })
+})
 
 describe('utils for text indexing', () => {
   const local = './volvox.sort.gff3.gz'

--- a/packages/text-indexing-core/src/types/common.test.ts
+++ b/packages/text-indexing-core/src/types/common.test.ts
@@ -22,7 +22,7 @@ describe('sanitizeForFilename', () => {
     expect(sanitizeForFilename('test_a/b-index')).toBe('test_a_b-index')
   })
   it('replaces all Windows-invalid characters', () => {
-    expect(sanitizeForFilename('a\\b/c:d*e?f"g<h>i|j')).toBe(
+    expect(sanitizeForFilename(String.raw`a\b/c:d*e?f"g<h>i|j`)).toBe(
       'a_b_c_d_e_f_g_h_i_j',
     )
   })

--- a/packages/text-indexing-core/src/types/common.ts
+++ b/packages/text-indexing-core/src/types/common.ts
@@ -222,7 +222,7 @@ export function sanitizeForFilename(name: string) {
 /**
  * Generates metadata of index given a filename (trackId or assembly)
  */
-export async function generateMeta({
+export function generateMeta({
   configs,
   attributesToIndex,
   outDir,

--- a/packages/text-indexing/package.json
+++ b/packages/text-indexing/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "@jbrowse/core": "workspace:^",
     "@jbrowse/text-indexing-core": "workspace:^",
-    "ixixx": "^3.0.3",
-    "sanitize-filename": "^1.6.4"
+    "ixixx": "^3.0.3"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/text-indexing/src/TextIndexing.ts
+++ b/packages/text-indexing/src/TextIndexing.ts
@@ -132,7 +132,7 @@ async function aggregateIndex({
   }
   if (!assemblyNames) {
     throw new Error(
-      'No assemblies passed. Assmeblies required for aggregate indexes',
+      'No assemblies passed. Assemblies required for aggregate indexes',
     )
   }
   for (const asm of assemblyNames) {
@@ -186,7 +186,7 @@ async function indexDriver({
   statusCallback('Indexing files.')
   await runIxIxx(readable, outDir, name)
   checkStopToken(stopToken)
-  await generateMeta({
+  generateMeta({
     configs: tracks,
     attributesToIndex,
     outDir,

--- a/packages/text-indexing/src/TextIndexing.ts
+++ b/packages/text-indexing/src/TextIndexing.ts
@@ -233,8 +233,7 @@ async function* indexFiles({
           statusCallback(`${progressBytes}/${myTotalBytes}`)
         },
       })
-    }
-    if (type === 'Gff3TabixAdapter') {
+    } else if (type === 'Gff3TabixAdapter') {
       yield* indexGff3({
         config: track,
         attributesToIndex,

--- a/packages/text-indexing/src/util.test.ts
+++ b/packages/text-indexing/src/util.test.ts
@@ -1,0 +1,72 @@
+import path from 'path'
+
+import { createTextSearchConf } from './util.ts'
+
+describe('createTextSearchConf', () => {
+  const outDir = '/some/dir'
+  const trixBase = path.join(outDir, 'trix')
+
+  it('generates correct file paths for a simple name', () => {
+    const conf = createTextSearchConf(
+      'volvox-index',
+      ['volvox'],
+      ['volvox'],
+      outDir,
+    )
+    expect(conf.ixFilePath).toEqual({
+      localPath: path.join(trixBase, 'volvox-index.ix'),
+      locationType: 'LocalPathLocation',
+    })
+    expect(conf.ixxFilePath).toEqual({
+      localPath: path.join(trixBase, 'volvox-index.ixx'),
+      locationType: 'LocalPathLocation',
+    })
+    expect(conf.metaFilePath).toEqual({
+      localPath: path.join(trixBase, 'volvox-index_meta.json'),
+      locationType: 'LocalPathLocation',
+    })
+  })
+
+  it('replaces slashes in name with underscores (original bug: track named "test A/B")', () => {
+    // The trackId for a track named "test A/B" would contain a slash.
+    // Previously createTextSearchConf used sanitize-filename which stripped
+    // slashes, while runIxIxx used sanitizeForFilename which replaced with _.
+    // This caused ENOENT when looking up the index file.
+    const conf = createTextSearchConf(
+      'test_a/b-1234-index',
+      ['test_a/b-1234'],
+      ['volvox'],
+      outDir,
+    )
+    expect(conf.ixFilePath).toEqual({
+      localPath: path.join(trixBase, 'test_a_b-1234-index.ix'),
+      locationType: 'LocalPathLocation',
+    })
+    expect(conf.ixxFilePath).toEqual({
+      localPath: path.join(trixBase, 'test_a_b-1234-index.ixx'),
+      locationType: 'LocalPathLocation',
+    })
+    expect(conf.metaFilePath).toEqual({
+      localPath: path.join(trixBase, 'test_a_b-1234-index_meta.json'),
+      locationType: 'LocalPathLocation',
+    })
+  })
+
+  it('replaces all Windows-invalid characters with underscores', () => {
+    const conf = createTextSearchConf(
+      'track\\:*?"<>|name-index',
+      [],
+      [],
+      outDir,
+    )
+    expect(conf.ixFilePath).toEqual({
+      localPath: path.join(trixBase, 'track________name-index.ix'),
+      locationType: 'LocalPathLocation',
+    })
+  })
+
+  it('textSearchAdapterId retains the original unsanitized name', () => {
+    const conf = createTextSearchConf('test_a/b-index', [], [], outDir)
+    expect(conf.textSearchAdapterId).toBe('test_a/b-index')
+  })
+})

--- a/packages/text-indexing/src/util.test.ts
+++ b/packages/text-indexing/src/util.test.ts
@@ -54,7 +54,7 @@ describe('createTextSearchConf', () => {
 
   it('replaces all Windows-invalid characters with underscores', () => {
     const conf = createTextSearchConf(
-      'track\\:*?"<>|name-index',
+      String.raw`track\:*?"<>|name-index`,
       [],
       [],
       outDir,

--- a/packages/text-indexing/src/util.ts
+++ b/packages/text-indexing/src/util.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import { isSupportedIndexingAdapter } from '@jbrowse/core/util'
-import sanitize from 'sanitize-filename'
+import { sanitizeForFilename } from '@jbrowse/text-indexing-core'
 
 import type {
   LocalPathLocation,
@@ -102,7 +102,7 @@ export function createTextSearchConf(
   locationPath: string,
 ) {
   const base = path.join(locationPath, 'trix')
-  const n = sanitize(name)
+  const n = sanitizeForFilename(name)
   return {
     type: 'TrixTextSearchAdapter',
     textSearchAdapterId: name,
@@ -115,7 +115,7 @@ export function createTextSearchConf(
       locationType: 'LocalPathLocation' as const,
     },
     metaFilePath: {
-      localPath: path.join(base, `${n}.json`),
+      localPath: path.join(base, `${n}_meta.json`),
       locationType: 'LocalPathLocation' as const,
     },
     tracks: trackIds,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,9 +557,6 @@ importers:
       react-dom:
         specifier: '>=18.0.0'
         version: 19.2.4(react@19.2.4)
-      sanitize-filename:
-        specifier: ^1.6.4
-        version: 1.6.4
 
   packages/text-indexing-core: {}
 

--- a/products/jbrowse-cli/src/commands/text-index/config-utils.ts
+++ b/products/jbrowse-cli/src/commands/text-index/config-utils.ts
@@ -1,7 +1,11 @@
 import fs from 'fs'
 import path from 'path'
 
+import { sanitizeForFilename } from '@jbrowse/text-indexing-core'
+
 import { supported } from '../../types/common.ts'
+
+export { sanitizeForFilename as sanitizeNameForPath }
 
 import type { Config, Track } from '../../base.ts'
 
@@ -15,14 +19,6 @@ export function parseCommaSeparatedString(value?: string): string[] {
       .map(s => s.trim())
       .filter(Boolean) ?? []
   )
-}
-
-/**
- * Sanitizes a name for use in file paths by replacing invalid characters
- * Replaces characters that are problematic in file paths: / \ : * ? " < > |
- */
-export function sanitizeNameForPath(name: string): string {
-  return name.replace(/[/\\:*?"<>|]/g, '_')
 }
 
 /**

--- a/products/jbrowse-cli/src/commands/text-index/config-utils.ts
+++ b/products/jbrowse-cli/src/commands/text-index/config-utils.ts
@@ -1,11 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { sanitizeForFilename } from '@jbrowse/text-indexing-core'
-
 import { supported } from '../../types/common.ts'
-
-export { sanitizeForFilename as sanitizeNameForPath }
 
 import type { Config, Track } from '../../base.ts'
 
@@ -161,3 +157,5 @@ export function getTrackConfigs(
       return true
     })
 }
+
+export { sanitizeForFilename as sanitizeNameForPath } from '@jbrowse/text-indexing-core'

--- a/products/jbrowse-cli/src/commands/text-index/indexing-utils.ts
+++ b/products/jbrowse-cli/src/commands/text-index/indexing-utils.ts
@@ -162,7 +162,7 @@ export async function indexDriver({
     quiet,
   })
 
-  await generateMeta({
+  generateMeta({
     configs: trackConfigs,
     attributesToIndex: attributes,
     outDir: outLocation,


### PR DESCRIPTION
Two different sanitizers were used when writing vs looking up trix index files - sanitize-filename strips slashes while sanitizeForFilename replaces them with underscores, causing ENOENT for tracks with slashes in their name. Consolidate on sanitizeForFilename throughout.

Fixes https://github.com/GMOD/jbrowse-components/issues/5539