### PR TITLE
Add featureHeight, noSpacing, softClipping options to jb2export

### DIFF
--- a/products/jbrowse-img/README.md
+++ b/products/jbrowse-img/README.md
@@ -99,11 +99,38 @@ jb2export --fasta data/volvox/volvox.fa \
   --loc ctgA:609..968
 ```
 
-You can see that instead of adding extra dash dash --flags, it is a colon based
-syntax that follows a track definition.
+Instead of extra `--flags`, track modifiers use a colon-based syntax that
+follows the track file argument. Full list of available modifiers:
 
-The color and sort are specific to pileup, and height can apply to any track.
-More options may be described here soon
+**All tracks**
+
+| Modifier     | Example      | Description                        |
+| ------------ | ------------ | ---------------------------------- |
+| `height:N`   | `height:400` | Track height in pixels             |
+| `force:true` | `force:true` | Render even if region is too large |
+
+**Alignment tracks (BAM/CRAM)**
+
+| Modifier                         | Example                                          | Description                                                                      |
+| -------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `color:type` or `color:type:tag` | `color:strand`, `color:tag:XS`                   | Color scheme                                                                     |
+| `sort:type` or `sort:type:tag`   | `sort:strand`, `sort:tag:RG`                     | Sort reads                                                                       |
+| `featureHeight:preset\|N`        | `featureHeight:super-compact`, `featureHeight:4` | Per-read height. Presets: `normal` (7px), `compact` (2px), `super-compact` (1px) |
+| `noSpacing:true\|false`          | `noSpacing:true`                                 | Remove gap between reads                                                         |
+| `softClipping:true\|false`       | `softClipping:true`                              | Show soft-clipped bases                                                          |
+| `snpcov`                         | `snpcov`                                         | Render only the SNP/coverage subtrack                                            |
+
+**BigWig tracks**
+
+| Modifier                 | Example                | Description                                              |
+| ------------------------ | ---------------------- | -------------------------------------------------------- |
+| `autoscale:mode`         | `autoscale:localsd`    | Autoscale mode (`local`, `global`, `localsd`)            |
+| `minmax:min:max`         | `minmax:0:100`         | Manual score range                                       |
+| `scaletype:type`         | `scaletype:log`        | Scale type (`linear` or `log`)                           |
+| `fill:true\|false`       | `fill:false`           | Fill under curve                                         |
+| `crosshatch:true\|false` | `crosshatch:true`      | Draw crosshatches                                        |
+| `resolution:value`       | `resolution:superfine` | BigWig resolution (`fine`, `superfine`, or a multiplier) |
+| `color:colorname`        | `color:purple`         | Fill color                                               |
 
 ### Force render a large region
 

--- a/products/jbrowse-img/src/parseArgv.test.ts
+++ b/products/jbrowse-img/src/parseArgv.test.ts
@@ -27,3 +27,13 @@ test('parse', () => {
     ['noRasterize', []],
   ])
 })
+
+test('featureHeight options are parsed as track options', () => {
+  const args =
+    '--bam alignment.bam color:tag:XS featureHeight:super-compact --out out.svg'
+
+  expect(parseArgv(args.split(' '))).toEqual([
+    ['bam', ['alignment.bam', 'color:tag:XS', 'featureHeight:super-compact']],
+    ['out', ['out.svg']],
+  ])
+})

--- a/products/jbrowse-img/src/renderRegion.tsx
+++ b/products/jbrowse-img/src/renderRegion.tsx
@@ -398,6 +398,48 @@ function process(
       }
     }
 
+    // apply feature height to pileup (supports normal/compact/super-compact or a number)
+    else if (opt.startsWith('featureHeight:')) {
+      const [, val] = opt.split(':')
+      if (val) {
+        const pileup = display.PileupDisplay ?? display
+        if (val === 'normal') {
+          pileup.setFeatureHeight(7)
+          pileup.setNoSpacing(false)
+        } else if (val === 'compact') {
+          pileup.setFeatureHeight(2)
+          pileup.setNoSpacing(true)
+        } else if (val === 'super-compact') {
+          pileup.setFeatureHeight(1)
+          pileup.setNoSpacing(true)
+        } else {
+          const n = +val
+          if (isNaN(n)) {
+            throw new Error(
+              `Invalid featureHeight "${val}". Use normal, compact, super-compact, or a number.`,
+            )
+          }
+          pileup.setFeatureHeight(n)
+        }
+      }
+    }
+
+    // remove spacing between pileup features
+    else if (opt.startsWith('noSpacing:')) {
+      const [, val = 'true'] = opt.split(':')
+      const pileup = display.PileupDisplay ?? display
+      pileup.setNoSpacing(booleanize(val))
+    }
+
+    // show soft clipping on pileup
+    else if (opt.startsWith('softClipping:')) {
+      const [, val = 'true'] = opt.split(':')
+      const pileup = display.PileupDisplay ?? display
+      if (booleanize(val) !== pileup.showSoftClipping) {
+        pileup.toggleSoftClipping()
+      }
+    }
+
     // force track to render even if maxbpperpx limit hit...
     else if (opt.startsWith('force:')) {
       const [, force] = opt.split(':')


### PR DESCRIPTION
Couple extra options for jb2image, fixes #5555 (good number)

- featureHeight:normal|compact|super-compact|N
- noSpacing:true|false as a standalone modifier. the featureHeight auto-toggles this for compact/supercompact
- softClipping:true|false to show soft-clipped bases
- Validation error for non-numeric, non-preset featureHeight values
- Document all track modifiers in README