### PR TITLE
Fix cli text-indexing on remote files

### DIFF
--- a/packages/text-indexing-core/src/types/common.test.ts
+++ b/packages/text-indexing-core/src/types/common.test.ts
@@ -126,12 +126,13 @@ describe('getLocalOrRemoteStream', () => {
       onUpdate: () => {},
     })
     expect(stream).toBeInstanceOf(Readable)
-    const chunks: Buffer[] = []
+    const chunks: Uint8Array[] = []
     await new Promise<void>((resolve, reject) => {
-      stream.on('data', chunk => chunks.push(chunk as Buffer))
+      stream.on('data', chunk => chunks.push(chunk as Uint8Array))
       stream.on('end', resolve)
       stream.on('error', reject)
     })
-    expect(Buffer.concat(chunks).length).toBeGreaterThan(0)
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0)
+    expect(totalLength).toBeGreaterThan(0)
   })
 })

--- a/packages/text-indexing-core/src/types/common.test.ts
+++ b/packages/text-indexing-core/src/types/common.test.ts
@@ -1,9 +1,31 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from 'fs'
+import http from 'http'
+import path from 'path'
+import { Readable } from 'stream'
+
 import {
+  getLocalOrRemoteStream,
   guessAdapterFromFileName,
   isURL,
   makeLocation,
   sanitizeForFilename,
 } from './common.ts'
+
+const testDataDir = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'products',
+  'jbrowse-cli',
+  'test',
+  'data',
+)
 
 const supportedIndexingAdapters = new Set([
   'Gff3TabixAdapter',
@@ -66,5 +88,50 @@ describe('utils for text indexing', () => {
     expect(() => {
       guessAdapterFromFileName(unsupported)
     }).toThrow(`Unsupported file type ${unsupported}`)
+  })
+})
+
+describe('getLocalOrRemoteStream', () => {
+  let server: http.Server
+  let serverPort: number
+
+  beforeAll(done => {
+    server = http.createServer((req, res) => {
+      const filePath = path.join(testDataDir, 'volvox.sort.gff3.gz')
+      const stat = fs.statSync(filePath)
+      res.writeHead(200, {
+        'Content-Type': 'application/gzip',
+        'Content-Length': stat.size,
+      })
+      fs.createReadStream(filePath).pipe(res)
+    })
+    server.listen(0, () => {
+      const addr = server.address()
+      if (addr && typeof addr === 'object') {
+        serverPort = addr.port
+      }
+      done()
+    })
+  })
+
+  afterAll(done => {
+    server.close(done)
+  })
+
+  it('returns a readable node stream from a web ReadableStream (webstream regression)', async () => {
+    const stream = await getLocalOrRemoteStream({
+      file: `http://localhost:${serverPort}/volvox.sort.gff3.gz`,
+      out: testDataDir,
+      onStart: () => {},
+      onUpdate: () => {},
+    })
+    expect(stream).toBeInstanceOf(Readable)
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', chunk => chunks.push(chunk as Buffer))
+      stream.on('end', resolve)
+      stream.on('error', reject)
+    })
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(0)
   })
 })

--- a/packages/text-indexing-core/src/types/common.ts
+++ b/packages/text-indexing-core/src/types/common.ts
@@ -5,6 +5,8 @@ import { Readable } from 'stream'
 import { fileURLToPath } from 'url'
 import { createGunzip } from 'zlib'
 
+import type { ReadableStream } from 'node:stream/web'
+
 import type { LocalPathLocation, Track, UriLocation } from '../util.ts'
 
 export function isURL(fileName: string) {
@@ -57,9 +59,7 @@ export async function getLocalOrRemoteStream({
     }
 
     const nodeStream =
-      body instanceof Readable
-        ? body
-        : Readable.fromWeb(body as import('node:stream/web').ReadableStream)
+      body instanceof Readable ? body : Readable.fromWeb(body as ReadableStream)
     nodeStream.on('data', chunk => {
       receivedBytes += chunk.length
       onUpdate(receivedBytes)

--- a/packages/text-indexing-core/src/types/common.ts
+++ b/packages/text-indexing-core/src/types/common.ts
@@ -59,17 +59,7 @@ export async function getLocalOrRemoteStream({
     const nodeStream =
       body instanceof Readable
         ? body
-        : new Readable({
-            async read() {
-              const reader = body.getReader()
-              let result = await reader.read()
-              while (!result.done) {
-                this.push(result.value)
-                result = await reader.read()
-              }
-              this.push(null)
-            },
-          })
+        : Readable.fromWeb(body as import('node:stream/web').ReadableStream)
     nodeStream.on('data', chunk => {
       receivedBytes += chunk.length
       onUpdate(receivedBytes)


### PR DESCRIPTION
We changed our code to use 'native fetch' rather than fetch polyfills but we accidentally accessed the stream that read it twice, which resulted in "ReadableStream is locked"

This replaces a custom workaround with Readable.fromWeb() (https://nodejs.org/docs/latest-v18.x/api/stream.html#streamreadablefromwebreadablestream-options) which holds a single reader for the stream's lifetime

Fixes #5571