### PR TITLE
Split large range requests to avoid origin limits on overly large range requests on e.g. deep-coverage BAM

### DIFF
--- a/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.test.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'jest-fetch-mock'
 
 import {
+  MAX_FETCH_CHUNKS,
   RemoteFileWithRangeCache,
   clearCache,
 } from './RemoteFileWithRangeCache.ts'
@@ -58,6 +59,49 @@ async function fetchRange(
     headers: { range: `bytes=${start}-${end}` },
   })
   return new Uint8Array(await res.arrayBuffer())
+}
+
+// Deterministic bytes (position mod 256) generated on the fly, so large
+// "files" can be served without allocating them up front.
+function genSlice(start: number, end: number) {
+  const out = new Uint8Array(end - start + 1)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = (start + i) % 256
+  }
+  return out
+}
+
+// Returns the first index where the result deviates from the deterministic
+// pattern (start+i) mod 256, or -1 if it matches. Avoids allocating a second
+// large array and jest's toEqual serialization, which OOMs on big buffers.
+function firstMismatch(result: Uint8Array, start: number) {
+  for (let i = 0; i < result.length; i++) {
+    if (result[i] !== (start + i) % 256) {
+      return i
+    }
+  }
+  return -1
+}
+
+function createLargeMockFetch(fileSize: number) {
+  const calls: { start: number; end: number }[] = []
+  const mockFetch = async (
+    _url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const range = new Headers(init?.headers).get('range')
+    if (range) {
+      const m = /bytes=(\d+)-(\d+)/.exec(range)
+      if (m) {
+        const start = Number(m[1])
+        const end = Math.min(Number(m[2]), fileSize - 1)
+        calls.push({ start, end })
+        return new Response(genSlice(start, end), { status: 206 })
+      }
+    }
+    return new Response('', { status: 200 })
+  }
+  return { calls, mockFetch }
 }
 
 afterEach(() => {
@@ -367,6 +411,77 @@ describe('RemoteFileWithRangeCache', () => {
     // Both chunks were in one coalesced run — only one HTTP request
     expect(calls).toHaveLength(1)
     expect(calls[0]!.start).toBe(CHUNK)
+  })
+
+  // Regression: a deep-coverage BAM locus makes @gmod/bam request a single
+  // ~100MB byte span. Coalescing it into one HTTP range request makes origins
+  // like Google Cloud Storage reject it (HTTP 500). The run is split into
+  // requests of at most MAX_FETCH_CHUNKS chunks so no single request is huge.
+  test('caps request size: a cold range larger than MAX_FETCH_CHUNKS splits into bounded requests', async () => {
+    const totalChunks = MAX_FETCH_CHUNKS * 2 + 3
+    const fileSize = totalChunks * CHUNK
+    const { calls, mockFetch } = createLargeMockFetch(fileSize)
+    const file = new RemoteFileWithRangeCache('http://example.com/big.bin', {
+      fetch: mockFetch,
+    })
+
+    const res = await file.fetch('http://example.com/big.bin', {
+      headers: { range: `bytes=0-${fileSize - 1}` },
+    })
+    const result = new Uint8Array(await res.arrayBuffer())
+
+    // All bytes returned, reassembled identically
+    expect(result).toHaveLength(fileSize)
+    expect(firstMismatch(result, 0)).toBe(-1)
+
+    // One contiguous run split into ceil(totalChunks / MAX_FETCH_CHUNKS) requests
+    expect(calls).toHaveLength(Math.ceil(totalChunks / MAX_FETCH_CHUNKS))
+
+    // No single request exceeds the cap
+    const maxBytes = MAX_FETCH_CHUNKS * CHUNK
+    for (const c of calls) {
+      expect(c.end - c.start + 1).toBeLessThanOrEqual(maxBytes)
+    }
+
+    // Requests are contiguous and cover the whole range with no gaps/overlap
+    const sorted = [...calls].sort((a, b) => a.start - b.start)
+    expect(sorted[0]!.start).toBe(0)
+    expect(sorted.at(-1)!.end).toBe(fileSize - 1)
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i]!.start).toBe(sorted[i - 1]!.end + 1)
+    }
+  })
+
+  test('request size cap applies per-run when gaps are already cached', async () => {
+    const totalChunks = MAX_FETCH_CHUNKS + 5
+    const fileSize = totalChunks * CHUNK
+    const { calls, mockFetch } = createLargeMockFetch(fileSize)
+    const file = new RemoteFileWithRangeCache('http://example.com/big.bin', {
+      fetch: mockFetch,
+    })
+
+    // Prime the very first chunk so the remaining cold run starts at chunk 1
+    await file.fetch('http://example.com/big.bin', {
+      headers: { range: `bytes=0-${CHUNK - 1}` },
+    })
+    expect(calls).toHaveLength(1)
+
+    // Request the whole file: chunks 1..totalChunks-1 form one cold run of
+    // (totalChunks - 1) chunks, split into bounded sub-requests
+    const res = await file.fetch('http://example.com/big.bin', {
+      headers: { range: `bytes=0-${fileSize - 1}` },
+    })
+    const result = new Uint8Array(await res.arrayBuffer())
+    expect(result).toHaveLength(fileSize)
+    expect(firstMismatch(result, 0)).toBe(-1)
+
+    const coldRunChunks = totalChunks - 1
+    const newCalls = calls.slice(1)
+    expect(newCalls).toHaveLength(Math.ceil(coldRunChunks / MAX_FETCH_CHUNKS))
+    const maxBytes = MAX_FETCH_CHUNKS * CHUNK
+    for (const c of newCalls) {
+      expect(c.end - c.start + 1).toBeLessThanOrEqual(maxBytes)
+    }
   })
 
   test('different URLs do not share cache', async () => {

--- a/packages/core/src/util/io/RemoteFileWithRangeCache.ts
+++ b/packages/core/src/util/io/RemoteFileWithRangeCache.ts
@@ -4,6 +4,14 @@ const MAX_CACHE_ENTRIES = 2000
 const CHUNK_SIZE = 256 * 1024
 const MAX_CONCURRENT = 20
 
+// Cap the size of any single HTTP range request. A contiguous run of uncached
+// chunks would otherwise be coalesced into one request, which can be large
+// enough for an origin to reject (e.g. Google Cloud Storage returns HTTP 500
+// for very large ranges, common over deep-coverage BAM loci). Splitting into
+// bounded requests fetches the same bytes and parallelizes via limitConcurrency.
+// 128 * 256KB = 32MB per request.
+export const MAX_FETCH_CHUNKS = 128
+
 let cache = new Map<string, Uint8Array>()
 let activeCount = 0
 const queue: (() => void)[] = []
@@ -143,17 +151,28 @@ export class RemoteFileWithRangeCache extends RemoteFile {
       }
     }
 
-    // Fetch each contiguous run as a single HTTP range request
+    // Split each contiguous run into sub-requests of at most MAX_FETCH_CHUNKS
+    // chunks so no single HTTP range request grows unbounded (see MAX_FETCH_CHUNKS).
+    // Offsets are relative to startChunk.
+    const fetches: { start: number; end: number }[] = []
+    for (const run of runs) {
+      for (let s = run.start; s <= run.end; s += MAX_FETCH_CHUNKS) {
+        fetches.push({
+          start: s,
+          end: Math.min(s + MAX_FETCH_CHUNKS - 1, run.end),
+        })
+      }
+    }
+
+    // Fetch each bounded sub-request as a single HTTP range request
     await Promise.all(
-      runs.map(run =>
+      fetches.map(req =>
         limitConcurrency(async () => {
-          const runStartChunk = startChunk + run.start
-          const runEndChunk = startChunk + run.end
-          const rangeStart = runStartChunk * CHUNK_SIZE
-          const rangeEnd = (runEndChunk + 1) * CHUNK_SIZE - 1
+          const rangeStart = (startChunk + req.start) * CHUNK_SIZE
+          const rangeEnd = (startChunk + req.end + 1) * CHUNK_SIZE - 1
           const data = await this.fetchRange(url, rangeStart, rangeEnd, signal)
-          for (let i = run.start; i <= run.end; i++) {
-            const offset = (i - run.start) * CHUNK_SIZE
+          for (let i = req.start; i <= req.end; i++) {
+            const offset = (i - req.start) * CHUNK_SIZE
             putCached(
               cacheKey(url, startChunk + i),
               data.subarray(offset, offset + CHUNK_SIZE),


### PR DESCRIPTION

A contiguous run of uncached chunks was coalesced into one HTTP range request. Over deep-coverage BAM loci this produced ~100MB single requests that some origins (e.g. Google Cloud Storage) reject with HTTP 500. Cap each request at MAX_FETCH_CHUNKS (8MB); the same bytes are fetched, now in parallel via the existing concurrency limiter.

Notably, this is not because of 'overmerging chunks' in bam-js, it is because there are actually just very large 'chunks' in the bam file itself

claude code reasoning when asked whether this should be added in bam-js itself (which does not have the 'transport layer' [the fetching], it just says what chunks to fetch and sometimes merges chunks to produce less requests, but this is not related to over merging)

```
 I checked, and the answer is no, it shouldn't move into the chunk-merging code, but
  the reasoning is worth laying out because it confirms the fix is in the right place.

  What the merge code actually does

  The merging logic in bam-js (optimizeChunks in src/util.ts — what you're calling canMergeBlocks)
  already has a size cap, and has since 2019 (v1.0.29):

  if (
    chunkMinBlock - lastMaxBlock < 65000 &&      // adjacent chunks, small gap
    chunkMaxBlock - lastMinBlock < 5000000       // combined span stays under 5MB
  ) { /* merge */ }

  So this code only ever combines small adjacent chunks, and it refuses to combine them past 5 MB. It
  is structurally incapable of producing a 100 MB request. The published 7.2.4 that current JBrowse
  ships has this cap.

  So where does Mike's 104 MB request come from?

  Logically it cannot be a merge result — every merge step checks the span stays under 5 MB, so any
  merged chunk is < 5 MB by construction. That leaves only one possibility: it's a single, un-merged
  chunk that is natively ~104 MB.

  That's exactly what deep targeted sequencing produces. The index (BAI) groups reads into bins; the
  smallest bin covers ~16 kb. If 5M reads pile into one 16 kb window, they're stored back-to-back and
  the index records that as one chunk spanning ~100 MB. optimizeChunks receives it already that big —
  there's nothing to merge, so the merge cap never even looks at it. It hands that one fat chunk
  straight through, and the code reads its whole byte span in a single request.

  Why splitting belongs at the transport layer, not in the merge code

  To fix it inside the merge code you'd have to add splitting logic — chop one oversized chunk into
  several smaller reads and then reassemble the bytes before decompressing. But that's not a "which
  chunks go together" decision (what the merge code is for); it's a "how do I physically fetch this
  byte range" decision. Reassembling pieces of a byte range is precisely what the download/cache layer
  already does.

  That's the clean separation the fix respects:
  - bam-js decides what bytes are needed (the logical chunks) — unchanged.
  - The download layer decides how to fetch them (in pieces if large) — this is where my change lives.

  bam-js asks for "bytes 523M–628M" exactly as before; the download layer quietly fetches that in 32
  MB pieces and hands back the complete result. bam-js decompresses it identically, completely unaware
  anything was split. No new reassembly logic in bam-js, no risk of splitting a compressed block in
  the wrong spot.

  Bonus: it's more general where it is

  A bam-js-only fix would only help BAM. The same "one giant native chunk" situation exists for CRAM,
  tabix-indexed VCF/GFF/BED, and BigWig — they all funnel through this same download layer, so they
  all get the protection for free.

  Bottom line

  The merge code is the right place for merging decisions and already caps itself sensibly. Mike's
  oversized request isn't a merging problem — it's a single naturally-huge chunk, and breaking a large
  byte fetch into smaller ones is a transport job. The fix is correctly placed. The only thing I'd
  add is that it's worth confirming Mike upgrades past whatever shipped in 3.2.0, but since this is a
  single-chunk issue rather than a merge issue, the download-layer cap is what actually closes it.


```