### PR TITLE
Fix docs URL for packages exported by jbrequire

### DIFF
--- a/website/docs/developer_guides/no_build_plugin.md
+++ b/website/docs/developer_guides/no_build_plugin.md
@@ -108,7 +108,7 @@ export default class MyPlugin {
 
 Since no-build plugins have no build step, use `jbrequire` to access packages
 exported by JBrowse core. See the
-[full list](https://github.com/GMOD/jbrowse-components/blob/main/packages/core/ReExports/list.ts).
+[full list](https://github.com/GMOD/jbrowse-components/blob/main/packages/core/src/ReExports/list.ts).
 
 ```typescript
 const { types } = pluginManager.jbrequire('@jbrowse/mobx-state-tree')


### PR DESCRIPTION
Hi, I noticed a broken link in the docs, and thought I would offer the fix.