### PR TITLE
Free renderer resources on block teardown (DataCloneError prevents freeResources from ever running)

### DIFF
--- a/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
+++ b/plugins/linear-genome-view/src/BaseLinearDisplay/models/serverSideRenderedBlock.ts
@@ -259,9 +259,16 @@ const blockState = types
             if (self.renderArgs && self.cachedDisplay) {
               const { rpcManager } = getSession(self)
               const { rendererType } = self.cachedDisplay
+              // renderArgs carries a statusCallback function, which
+              // structuredClone cannot handle. Cloning it whole threw
+              // DataCloneError on every block teardown -- and because the clone
+              // is an argument, it threw *before* freeResourcesInClient ran, so
+              // the renderer's layout ranges were never discarded. freeResources
+              // only needs the regions and the layout id, never the callback.
+              const { statusCallback, ...cloneableArgs } = self.renderArgs
               await rendererType.freeResourcesInClient(
                 rpcManager,
-                structuredClone(self.renderArgs),
+                structuredClone(cloneableArgs),
               )
             }
           } catch (e) {


### PR DESCRIPTION
> **Note on provenance:** this issue was found and the fix recommended by Claude (Anthropic's coding agent) while I was debugging a layout-accumulation problem in a plugin of my own. I have reviewed and verified it. Flagging that up front so you can weigh it accordingly.

**This is not a logging issue.** It surfaces as a console error, but the console error is a symptom — the real effect is that renderer resources are never released, which has memory and performance implications for every renderer built on `BoxRendererType`.

## Symptom

Every time a block is destroyed, `blockState.beforeDestroy` logs:

```
Error while destroying block DataCloneError: Failed to execute 'structuredClone' on 'Window': message => {
```

Reproducible on stock `jbrowse-web` with no plugins: load volvox, zoom out and back in — it appears 34 times.

## Cause

`beforeDestroy` clones `renderArgs` to hand to `freeResourcesInClient`:

```ts
await rendererType.freeResourcesInClient(
  rpcManager,
  structuredClone(self.renderArgs),
)
```

But `renderArgs` is built in `renderBlockData` and carries a function:

```ts
renderArgs: {
  statusCallback: (message: string) => { ... },
  ...
}
```

`structuredClone` cannot serialize a function, so it throws.

## Why this matters beyond the console

The clone is evaluated as an **argument**, so it throws *before* `freeResourcesInClient` is ever invoked, and the surrounding `try/catch` downgrades that to a `console.error`. The net effect is that **`freeResources` has never run**.

`BoxRendererType.freeResources` exists solely to do:

```ts
session.layout.discardRange(region.refName, region.start, region.end)
```

So that discard is not happening for any renderer. The `LayoutSession` held in the worker accumulates rectangles for every region ever visited and never releases them — the layout is only rebuilt when `bpPerPx` changes, so it survives panning indefinitely. `GranularRectLayout` additionally tracks `pTotalHeight` as a monotonic high-water mark that `discardRange` does not lower, so a layout that is never discarded can only grow.

I noticed this because I hit the downstream consequence directly: in a custom renderer, lane heights derived from `sublayout.getTotalHeight()` grew when panning into feature-dense sequence and would not shrink on the way back. That is the same accumulation, just made visible.

The severity is presumably modest for a casual session and worse for long-lived ones over dense data, but I have not tried to quantify it — I am reporting the mechanism, not a benchmark.

## Fix

`freeResources` only reads `args.regions` and the layout id; it never touches `statusCallback`. Drop the callback before cloning.

## Verification

- Stock volvox zoom-out/zoom-in run: **34 `DataCloneError`s → 0**, no other console errors.
- `eslint` on the changed file: clean.
- `jest plugins/linear-genome-view/src/BaseLinearDisplay`: **116 passed / 116**, 9 suites.

Happy to add a regression test if you would like one, and equally happy to close this if you would rather fix it differently — the diagnosis is the useful part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
