### PR TITLE
Use @gmod/cram v12's getTag and next-segment fields

### DIFF
--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@gmod/bam": "^8.5.0",
     "@gmod/bgzf-filehandle": "^6.4.0",
-    "@gmod/cram": "^11.4.1",
+    "@gmod/cram": "^12.0.0",
     "@jbrowse/alignments-core": "workspace:^",
     "@jbrowse/cigar-utils": "workspace:^",
     "@jbrowse/core": "workspace:^",

--- a/plugins/alignments/src/CramAdapter/CramAdapter.ts
+++ b/plugins/alignments/src/CramAdapter/CramAdapter.ts
@@ -33,10 +33,13 @@ function shouldFilterRecord(
   }
   // Multiple tag filters are AND-ed: reject the read if any one rejects it.
   const failsTag = tagFilters?.some(tf => {
+    // getTag rather than record.tags[...]: this runs per record of the query, and
+    // the object form decodes every tag on the read to answer for the one being
+    // filtered on.
     const tagValue =
       tf.tag === 'RG'
         ? samHeader.readGroups[record.readGroupId]
-        : record.tags[tf.tag]
+        : record.getTag(tf.tag)
     return filterTagValue(tagValue, tf.value)
   })
   if (failsTag) {

--- a/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
+++ b/plugins/alignments/src/CramAdapter/CramSlightlyLazyFeature.ts
@@ -68,21 +68,21 @@ export default class CramSlightlyLazyFeature implements MismatchFeature {
   }
 
   get next_ref() {
-    return this.record.mate
-      ? this.adapter.refIdToName(this.record.mate.sequenceId)
+    return this.record.hasNextPosition()
+      ? this.adapter.refIdToName(this.record.nextSequenceId)
       : undefined
   }
 
   get next_segment_position() {
-    return this.record.mate
-      ? `${this.adapter.refIdToName(this.record.mate.sequenceId)}:${
-          this.record.mate.start + 1
+    return this.record.hasNextPosition()
+      ? `${this.adapter.refIdToName(this.record.nextSequenceId)}:${
+          this.record.nextStart + 1
         }`
       : undefined
   }
 
   get next_pos() {
-    return this.record.mate ? this.record.mate.start : undefined
+    return this.record.hasNextPosition() ? this.record.nextStart : undefined
   }
 
   // Read group lives outside the CRAM tag block, so it is spliced in to match
@@ -92,6 +92,30 @@ export default class CramSlightlyLazyFeature implements MismatchFeature {
   get tags() {
     const RG = this.adapter.samHeader?.readGroups[this.record.readGroupId]
     return RG === undefined ? this.record.tags : { ...this.record.tags, RG }
+  }
+
+  /**
+   * One tag, without building the object `tags` above would.
+   *
+   * `extractFeatureTagValue` duck-types this method and only falls back to
+   * `get('tags')` without it, which is the full decode — so before CRAM records
+   * grew a `getTag`, every read on the colorBy.tag / sortTag / hasSA paths paid
+   * for every unrelated tag on the read to answer for one. `@gmod/cram` measures
+   * the targeted read at 3.8-7.8x the object's.
+   *
+   * The `RG` arm mirrors `tags` above rather than deferring to the record: the
+   * spread there lets the header's read group win over any `RG` the tag block
+   * carries, so this has to check the header first and only fall through when it
+   * has nothing.
+   */
+  getTag(tagName: string) {
+    if (tagName === 'RG') {
+      const RG = this.adapter.samHeader?.readGroups[this.record.readGroupId]
+      if (RG !== undefined) {
+        return RG
+      }
+    }
+    return this.record.getTag(tagName)
   }
 
   get seq() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,8 +729,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       '@gmod/cram':
-        specifier: ^11.4.1
-        version: 11.4.1
+        specifier: ^12.0.0
+        version: 12.0.0
       '@jbrowse/alignments-core':
         specifier: workspace:^
         version: link:../../packages/alignments-core
@@ -4295,8 +4295,8 @@ packages:
   '@gmod/bgzf-filehandle@6.4.0':
     resolution: {integrity: sha512-PrID2FLkIqPZWSuHwYnc4A4riG4qJ6jOg+c4UXnfNio+hejZrKctUn7A3+BPMJ8i8W+S0fZOmCfKgreFHzFuBg==}
 
-  '@gmod/cram@11.4.1':
-    resolution: {integrity: sha512-1W67sJ9Ri+QSOqHeO/wXhirE36zGFlDuswoeSjDMtozsZe3xjGNv0bSrMoNZEVs4Ev6HN2/JS0gxBwYH7jAPPw==}
+  '@gmod/cram@12.0.0':
+    resolution: {integrity: sha512-s24Ea9PgIsnpJC9X8yY7LcgD25ob5gH8pXrckFf5AvGMZbsnKyP8880/2jLX46EYHpA7jTDfzdogQPoCunf/xw==}
 
   '@gmod/faidx@3.0.1':
     resolution: {integrity: sha512-VvAPjPbZ1wGKQKFnyfaZJnhSiowon6eLQlgRuukmZb4InwVv8yAEzlCTvRyCl2Nlqjw6VN7W+jyHEVgWAD0uNQ==}
@@ -12239,7 +12239,7 @@ snapshots:
       generic-filehandle2: 2.3.0
       pako-esm2: 2.0.2
 
-  '@gmod/cram@11.4.1':
+  '@gmod/cram@12.0.0':
     dependencies:
       '@gmod/shared-read-cache': 1.5.1
       '@jbrowse/quick-lru': 7.3.5


### PR DESCRIPTION
Adopts `@gmod/cram` v12, which lands two things this adapter wanted.

## `CramSlightlyLazyFeature` gains `getTag`

`extractFeatureTagValue` duck-types a `getTag` and only falls back to
`get('tags')` without one. Its own comment says why that fallback hurts:

> `get('tags')` runs the full decode — a Record allocation plus every unrelated
> tag on the read (NM/AS/ms/de/…, often ~10) — to answer one, and this is on the
> adapter hot path, called per read for colorBy.tag, sortTag and the `hasSA`
> group predicate.

BAM records have always had `getTag`; CRAM records did not, so **every CRAM read
on those three paths took the slow route**. Upstream measures the targeted read at
3.8–7.8x the object's, and `CramAdapter.shouldFilterRecord` — which runs per
record of the query — now uses it too.

The `RG` arm mirrors the `tags` getter rather than deferring to the record: the
spread there lets the header's read group win over any `RG` in the tag block, so
`getTag` checks the header first and only falls through when it has none.
Deferring straight to `record.getTag` would have silently changed `RG` filtering.

## `record.mate` is gone

Replaced by `nextSequenceId` / `nextStart` / `hasNextPosition()` — SAM's
`RNEXT`/`PNEXT` naming, which is what this file already exposed those fields as
(`next_ref`, `next_pos`, `next_segment_position`), so the three getters become
near-passthroughs.

`hasNextPosition()` is deliberately not "has a mate": a paired read whose mate the
file does not locate returns `false`, which is the same condition the old
`record.mate &&` guard tested. Upstream keeps a three-state `nextSequenceId`
(`-2` unknown, `-1` unplaced, `>=0` placed) precisely so pair orientation stays
consistent between both halves of such a pair.

## Verification

Against the real published v12, not a stub:

- `typecheck` clean (typescript7)
- `lint` clean (`oxlint --type-aware --deny-warnings`)
- `check-format` clean (oxfmt)
- **alignments suite: 141 files, 1459 tests, 5 snapshots — all pass**

The snapshots are the meaningful part: `CramAdapter.test.ts` snapshots
`feature.toJSON()`, and that snapshot pins `next_ref` / `next_pos` /
`next_segment_position` / `tags`. All four rewritten accessors are therefore
checked against v12's real output rather than by inspection.

## About CI on this PR

**`main` is currently red on five jobs, and this branch inherits all of them.**
As of `31462575533` (the bgzf worker pool merge, #5612), main fails:

| job | cause |
| --- | --- |
| Generated files up to date | `pnpm autogen --check` drift in `website/docs/models/*.md` — MAF, MultiRowFeature, MultiSampleVariant, MultiLinearWiggle, MultiSampleVariantBase |
| Test | image-snapshot failures in `AlignmentArcs.test.tsx` / `AlignmentLinked.test.tsx` (long-read arcs and linked reads) |
| Validate docs | screenshot specs, over-length figure captions |
| Shaders | — |
| Test embedded components | — |

None of that is CRAM. I confirmed the autogen drift is pre-existing by running
`pnpm autogen --check` on pristine `origin/main`, which fails identically — the
regenerated diff touches only those five wiggle/variant model docs and no CRAM
file. I deliberately did **not** fold `pnpm autogen` output into this PR, since it
would bundle unrelated generated-file churn with a CRAM change and collide with
whoever fixes that drift properly.

The pre-push hook was skipped with its own documented `SKIP_DOCS_CHECK=1` for the
same reason.

**So please judge this PR by whether its failure set matches main's**, not by
green/red. If a job fails here that passes on main, that one is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
