### PR TITLE
Read * as a glob in the location box's reference-sequence picker

### DIFF
--- a/packages/core/src/ui/RefNameAutocomplete/HelpDialog.tsx
+++ b/packages/core/src/ui/RefNameAutocomplete/HelpDialog.tsx
@@ -26,6 +26,13 @@ export default function HelpDialog({
           are allowed in the start and end coordinates. A space-separated list
           of locstrings can be used to open up multiple chromosomes at a time
         </li>
+        <li>
+          Find a group of reference sequences by typing a pattern containing{' '}
+          <code>*</code>, which stands for any run of characters. The matches
+          appear in the dropdown, with a row at the top that opens all of them
+          at once. Useful on a fragmented or haplotype-resolved assembly, where
+          the useful selection is a pattern rather than a list you keep by hand.
+        </li>
       </ul>
       <h3>Example Searches</h3>
       <ul>
@@ -53,6 +60,10 @@ export default function HelpDialog({
         <li>
           <code>chr1 100 200</code> - use whitespace separated refname, start,
           end
+        </li>
+        <li>
+          <code>*_hap1</code> - list every reference sequence whose name ends in
+          _hap1, and offer to open all of them
         </li>
       </ul>
     </InfoDialog>

--- a/packages/core/src/ui/RefNameAutocomplete/index.tsx
+++ b/packages/core/src/ui/RefNameAutocomplete/index.tsx
@@ -128,7 +128,7 @@ const RefNameAutocomplete = observer(function RefNameAutocomplete({
       options={
         hasSearchResults
           ? searchOptions
-          : getRefNameOptions(assembly?.regions ?? [], searchQuery)
+          : getRefNameOptions(assembly, searchQuery)
       }
       getOptionDisabled={option => !!option.isLimit}
       // both sources arrive already matched against a query — searchOptions

--- a/packages/core/src/ui/RefNameAutocomplete/util.test.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.test.ts
@@ -1,5 +1,6 @@
 import BaseResult from '../../TextSearch/BaseResults.ts'
 import {
+  MAX_SELECT_ALL,
   cap,
   coerceToResult,
   getDeduplicatedResult,
@@ -58,6 +59,99 @@ describe('getRefNameOptions', () => {
     expect(getRefNameOptions(many, 'scaffold4999').map(getOptionLabel)).toEqual(
       ['scaffold4999'],
     )
+  })
+})
+
+describe('getRefNameOptions globs', () => {
+  const regions = (refNames: string[]) => refNames.map(refName => ({ refName }))
+  const hap = regions([
+    'chr1_hap1',
+    'chr2_hap1',
+    'chr1_hap2',
+    'chr2_hap2',
+    'chrUn',
+  ])
+  const labels = (options: ReturnType<typeof getRefNameOptions>) =>
+    options.map(getOptionLabel)
+
+  it('reads * as an anchored glob', () => {
+    // a bare `_hap1` substring-matches the same two, but `*_hap1` is anchored,
+    // so this is the glob's answer rather than the substring filter's
+    expect(labels(getRefNameOptions(hap, '*_hap1')).slice(1)).toEqual([
+      'chr1_hap1',
+      'chr2_hap1',
+    ])
+  })
+
+  it('offers one option that selects every match, as a multi-region locstring', () => {
+    const [all] = getRefNameOptions(hap, '*_hap1')
+    expect(all!.result.getLabel()).toBe('Show all 2 regions matching *_hap1')
+    // the whitespace-separated form parseLocStrings already takes, so picking
+    // this needs no navigation code of its own
+    expect(all!.result.getLocation()).toBe('chr1_hap1 chr2_hap1')
+  })
+
+  it('offers no bulk row when the glob matches a single region', () => {
+    expect(labels(getRefNameOptions(hap, '*Un'))).toEqual(['chrUn'])
+  })
+
+  it('leaves a query with no * exactly as it was', () => {
+    expect(labels(getRefNameOptions(hap, 'hap1'))).toEqual([
+      'chr1_hap1',
+      'chr2_hap1',
+    ])
+  })
+
+  // `*` is a legal refName character — GRCh38's ALT decoys are HLA allele names
+  // — so the literal reading has to survive alongside the pattern one
+  const hla = regions([
+    'HLA-A*01:01:01:01',
+    'HLA-A*02:53N',
+    'HLA-A*24:01:01:01',
+  ])
+
+  it('finds a refName that itself contains a *, typed in full', () => {
+    // the glob reading of this text is ^HLA-A.*01:01:01:01$, which happens to
+    // match only the allele typed — but the substring reading finds it too, so
+    // it is in the list either way, which is the property that matters
+    expect(labels(getRefNameOptions(hla, 'HLA-A*01:01:01:01'))).toEqual([
+      'HLA-A*01:01:01:01',
+    ])
+  })
+
+  it('globs a starred name that names no refName exactly', () => {
+    expect(labels(getRefNameOptions(hla, 'HLA-A*')).slice(1)).toEqual([
+      'HLA-A*01:01:01:01',
+      'HLA-A*02:53N',
+      'HLA-A*24:01:01:01',
+    ])
+  })
+
+  it('keeps a literal hit the anchored glob would have dropped', () => {
+    // the union is doing real work here: `^a.*b$` does not match the embedded
+    // form, and the substring filter — which is what the box has always done —
+    // is the only reason it is still offered
+    expect(
+      labels(getRefNameOptions(regions(['a*b', 'xxa*byy']), 'a*b')),
+    ).toEqual(['Show all 2 regions matching a*b', 'a*b', 'xxa*byy'])
+  })
+
+  it('withholds the bulk row past the ceiling rather than truncating it', () => {
+    const many = regions(
+      Array.from({ length: MAX_SELECT_ALL + 5 }, (_, i) => `scaffold${i}_alt`),
+    )
+    const options = getRefNameOptions(many, '*_alt')
+    // a bulk row reading "all of them" that navigates to the first thousand is
+    // the one thing not worth offering; the individual rows still list
+    expect(options[0]!.result.getLabel()).toBe('scaffold0_alt')
+    expect(options).toHaveLength(101)
+  })
+
+  it('still bounds the visible list for a glob matching thousands', () => {
+    const many = regions(
+      Array.from({ length: 5000 }, (_, i) => `scaffold${i}_alt`),
+    )
+    expect(getRefNameOptions(many, '*_alt')).toHaveLength(101)
   })
 })
 

--- a/packages/core/src/ui/RefNameAutocomplete/util.test.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.test.ts
@@ -1,6 +1,6 @@
 import BaseResult from '../../TextSearch/BaseResults.ts'
+import { MAX_GLOB_REGIONS } from '../../util/selectNamedRegions.ts'
 import {
-  MAX_SELECT_ALL,
   cap,
   coerceToResult,
   getDeduplicatedResult,
@@ -152,7 +152,10 @@ describe('getRefNameOptions globs', () => {
 
   it('withholds the bulk row past the ceiling rather than truncating it', () => {
     const many = regions(
-      Array.from({ length: MAX_SELECT_ALL + 5 }, (_, i) => `scaffold${i}_alt`),
+      Array.from(
+        { length: MAX_GLOB_REGIONS + 5 },
+        (_, i) => `scaffold${i}_alt`,
+      ),
     )
     const options = getRefNameOptions(many, '*_alt')
     // a bulk row reading "all of them" that navigates to the first thousand is

--- a/packages/core/src/ui/RefNameAutocomplete/util.test.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.test.ts
@@ -30,7 +30,14 @@ describe('cap', () => {
 })
 
 describe('getRefNameOptions', () => {
-  const regions = (refNames: string[]) => refNames.map(refName => ({ refName }))
+  // an assembly with no aliases of its own. `allRefNames` still lists every
+  // region, because buildRefNameMaps identity-maps each one — an assembly whose
+  // regions are loaded always answers to at least its own names
+  const regions = (refNames: string[]) => ({
+    regions: refNames.map(refName => ({ refName })),
+    allRefNames: refNames,
+    getCanonicalRefName: (n: string) => n,
+  })
 
   it('matches case-insensitively on a substring of the refName', () => {
     expect(
@@ -63,7 +70,14 @@ describe('getRefNameOptions', () => {
 })
 
 describe('getRefNameOptions globs', () => {
-  const regions = (refNames: string[]) => refNames.map(refName => ({ refName }))
+  // an assembly with no aliases of its own. `allRefNames` still lists every
+  // region, because buildRefNameMaps identity-maps each one — an assembly whose
+  // regions are loaded always answers to at least its own names
+  const regions = (refNames: string[]) => ({
+    regions: refNames.map(refName => ({ refName })),
+    allRefNames: refNames,
+    getCanonicalRefName: (n: string) => n,
+  })
   const hap = regions([
     'chr1_hap1',
     'chr2_hap1',
@@ -152,6 +166,67 @@ describe('getRefNameOptions globs', () => {
       Array.from({ length: 5000 }, (_, i) => `scaffold${i}_alt`),
     )
     expect(getRefNameOptions(many, '*_alt')).toHaveLength(101)
+  })
+})
+
+describe('getRefNameOptions aliases', () => {
+  // an Ensembl/NCBI-named assembly carrying UCSC aliases, which is the ordinary
+  // case for anyone whose FASTA and whose habits disagree
+  const aliasOf: Record<string, string> = { chr1: '1', chr2: '2', chrM: 'MT' }
+  const ensembl = {
+    regions: [{ refName: '1' }, { refName: '2' }, { refName: 'MT' }],
+    // as an assembly builds it: aliases AND the canonical names, identity-mapped
+    allRefNames: ['chr1', 'chr2', 'chrM', '1', '2', 'MT'],
+    getCanonicalRefName: (n: string) => aliasOf[n] ?? n,
+  }
+  const labels = (options: ReturnType<typeof getRefNameOptions>) =>
+    options.map(getOptionLabel)
+
+  it('globs against aliases and labels with the canonical name', () => {
+    // the bug: matching `regions` alone saw only 1/2/MT, so `chr*` — which the
+    // text-search half of this same dropdown can never answer, since nothing
+    // PREFIX-matches the literal `chr*` — found nothing at all
+    expect(labels(getRefNameOptions(ensembl, 'chr*')).slice(1)).toEqual([
+      '1',
+      '2',
+      'MT',
+    ])
+  })
+
+  it('takes a region once when several of its names match', () => {
+    const many = {
+      regions: [{ refName: '1' }],
+      allRefNames: ['chr1', 'NC_000001.11', '1'],
+      getCanonicalRefName: () => '1',
+    }
+    expect(labels(getRefNameOptions(many, '*1*'))).toEqual(['1'])
+  })
+
+  it('lists alias matches in assembly order, not alias-list order', () => {
+    const scrambled = { ...ensembl, allRefNames: ['chrM', 'chr2', 'chr1'] }
+    expect(labels(getRefNameOptions(scrambled, 'chr*')).slice(1)).toEqual([
+      '1',
+      '2',
+      'MT',
+    ])
+  })
+
+  it('substring queries reach aliases too, so the two readings agree', () => {
+    expect(labels(getRefNameOptions(ensembl, 'chrM'))).toEqual(['MT'])
+  })
+
+  it('lists nothing for an unloaded assembly, without consulting the aliases', () => {
+    // setLoaded writes regions and refNameAliases together, so this is the only
+    // shape "not loaded yet" takes — there is no half-loaded assembly with
+    // regions but no names, and so no canonical-only path to fall back to.
+    // getCanonicalRefName THROWS in this state, which is what the call asserts
+    const unloaded = {
+      getCanonicalRefName: () => {
+        throw new Error('aliases not loaded')
+      },
+    }
+    expect(getRefNameOptions(unloaded, '*')).toEqual([])
+    expect(getRefNameOptions(undefined, 'chr')).toEqual([])
   })
 })
 

--- a/packages/core/src/ui/RefNameAutocomplete/util.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.ts
@@ -65,14 +65,23 @@ function selectAllOption(matches: string[], pattern: string): Option {
   }
 }
 
+// The part of an Assembly this needs, duck-typed so the matching can be tested
+// without building one.
+export interface RefNameSource {
+  regions?: readonly { refName: string }[]
+  // canonical names AND aliases. Undefined until the assembly's aliases load
+  allRefNames?: readonly string[]
+  getCanonicalRefName: (name: string) => string | undefined
+}
+
 /**
  * The browse/pre-fetch fallback list, shown while a typed query is in flight and
  * when it comes back empty (typed queries otherwise resolve through
- * fetchResults). An assembly can hold ~10^6 refNames, so match and materialize
- * in one bounded pass rather than building a million option objects or slicing
- * first — slicing first would hide every refName past the cap from the filter,
- * so a substring of a late scaffold's name matched nothing. Collecting one past
- * the cap lets `cap` still render its "keep typing" hint.
+ * fetchResults). An assembly can hold ~10^6 refNames, so this stays bounded:
+ * matching stops once it has one hit past whichever cap applies, and nothing is
+ * sliced before filtering — slicing first would hide every refName past the cap
+ * from the filter, so a substring of a late scaffold's name matched nothing.
+ * That extra hit is what lets `cap` render its "keep typing" hint.
  *
  * A query containing `*` is ALSO read as an anchored glob, the same reading
  * `selectNamedRegions` gives a `displayedRegionNames` entry — so `*_MATERNAL`
@@ -84,21 +93,61 @@ function selectAllOption(matches: string[], pattern: string): Option {
  * and not a resolver — an extra row in a list the user is looking at costs
  * nothing, where an extra region in a resolved set is a wrong answer.
  *
- * Only a glob query does the extra scanning. A plain substring query takes the
- * same bounded path, and costs the same, as it always has.
+ * BOTH READINGS MATCH ALIASES, and resolve their hits to the canonical name, so
+ * a pattern sees the names a user actually types. `chr*` has to work on an
+ * assembly whose FASTA calls its chromosomes `1`, `2`, `3`, and matching
+ * `regions` alone — canonical names only — meant it silently matched nothing
+ * there. `searchRefNames`, which fills this same dropdown whenever the text
+ * index answers, has always searched `allRefNames`; a glob is precisely the
+ * query it can never answer (nothing PREFIX-matches the literal `chr*`), so
+ * without this the two halves of one dropdown disagreed about which names exist.
+ * Labelling with the canonical name is also its choice, and for its reason: it
+ * is the name the view will display.
  */
 export function getRefNameOptions(
-  regions: readonly { refName: string }[],
+  assembly: RefNameSource | undefined,
   inputValue: string,
 ) {
+  const regions = assembly?.regions ?? []
   const query = inputValue.toLowerCase()
   const glob = query.includes('*') ? globToRegExp(query, 'i') : undefined
+  // A glob may gather up to MAX_SELECT_ALL for its bulk row; a plain query never
+  // needs more than the visible list, so it keeps the tighter bound it had.
+  const ceiling = glob ? MAX_SELECT_ALL : MAX_OPTIONS
+  // Every name the assembly answers to — aliases and canonical alike, since
+  // buildRefNameMaps identity-maps each region, so this is never short of
+  // `regions`. There is deliberately no canonical-only fallback for "aliases
+  // haven't loaded": `setLoaded` writes regions and refNameAliases in ONE
+  // action, so an absent list means an unloaded assembly, whose `regions` is
+  // equally absent and which therefore has nothing to list either way. Writing
+  // the fallback anyway would mean a glob quietly matching a smaller set of
+  // names in a state that cannot arise — the silent half-answer this whole
+  // alias fix exists to remove. It is also what makes getCanonicalRefName safe
+  // to call, since that THROWS before aliases load and is only ever reached
+  // here for a name that came out of this list.
+  const candidates = assembly?.allRefNames ?? []
+  const canonical = (n: string) => assembly?.getCanonicalRefName(n) ?? n
+
+  // Which regions match, by canonical name. Several aliases collapsing onto one
+  // region is the ordinary case (`chr1`, `NC_000001.11` and `1` are one contig),
+  // so this is a Set rather than a count.
+  const hits = new Set<string>()
+  for (const name of candidates) {
+    if (name.toLowerCase().includes(query) || glob?.test(name)) {
+      hits.add(canonical(name))
+      if (hits.size > ceiling) {
+        break
+      }
+    }
+  }
+
+  // Emitted by walking `regions`, so the list is in ASSEMBLY order rather than
+  // whatever order the alias file happened to list its names in — the same
+  // two-pass shape, for the same reason, as selectNamedRegions' glob branch.
   const options: Option[] = []
-  // gathered only for a glob, and only to build the bulk option below; one past
-  // the ceiling is all it takes to know the ceiling was passed
   const matches: string[] = []
   for (const { refName } of regions) {
-    if (!(refName.toLowerCase().includes(query) || glob?.test(refName))) {
+    if (!hits.has(refName)) {
       continue
     }
     if (options.length <= MAX_OPTIONS) {
@@ -106,16 +155,9 @@ export function getRefNameOptions(
         result: new RefSequenceResult({ refName, label: refName }),
       })
     }
-    if (glob && matches.length <= MAX_SELECT_ALL) {
-      matches.push(refName)
-    }
-    // stop once neither list can learn anything more: the options are one past
-    // their cap, which is all `cap` needs to render its hint, and the match list
-    // is one past the ceiling, which withholds the bulk option either way
-    if (
-      options.length > MAX_OPTIONS &&
-      (!glob || matches.length > MAX_SELECT_ALL)
-    ) {
+    matches.push(refName)
+    // every hit is placed, so there is nothing later in `regions` to find
+    if (matches.length === hits.size) {
       break
     }
   }

--- a/packages/core/src/ui/RefNameAutocomplete/util.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.ts
@@ -1,5 +1,6 @@
 import BaseResult, { RefSequenceResult } from '../../TextSearch/BaseResults.ts'
 import { measureText } from '../../util/index.ts'
+import { globToRegExp } from '../../util/selectNamedRegions.ts'
 
 // matches the rendered font-size of the TextField
 const INPUT_FONT_SIZE = 14
@@ -33,30 +34,94 @@ export function cap(options: Option[]) {
     : options
 }
 
-// The browse/pre-fetch fallback list, shown while a typed query is in flight
-// and when it comes back empty (typed queries otherwise resolve through
-// fetchResults). An assembly can hold ~10^6 refNames, so match and materialize
-// in one bounded pass rather than building a million option objects or slicing
-// first — slicing first would hide every refName past the cap from the filter,
-// so a substring of a late scaffold's name matched nothing. Collecting one past
-// the cap lets `cap` still render its "keep typing" hint.
+// How many matches a glob may gather into the one "show all" option below.
+// Displaying a few hundred whole chromosomes is ordinary — GRCh38 with its alts
+// and decoys is ~640 refNames, and showAllRegionsInAssembly lays out every one —
+// so the ceiling sits well above any real chromosome set. Past it, the option is
+// withheld rather than truncated: a bulk action that reads "all of them" and
+// navigates to the first thousand is the one behaviour not worth having, and the
+// individual options are still listed for picking one at a time.
+export const MAX_SELECT_ALL = 1000
+
+/**
+ * One option carrying every match as a whitespace-separated locstring — the
+ * multi-region form the box already accepts, and the form it already displays
+ * once a view holds more than one region. So picking it takes exactly the path
+ * typing those names by hand takes (`parseLocStrings` → `navToLocations` →
+ * `setDisplayedRegions` + `showAllRegions`), and there is no bulk-navigation
+ * code anywhere to keep in step with the single-region kind.
+ *
+ * It goes first in the list, and it is the reason a glob belongs in the picker
+ * rather than in the locstring parser: the set is on screen, and counted, before
+ * it is committed to. A pattern typed straight at the parser would resolve to
+ * however many regions it happened to match, sight unseen.
+ */
+function selectAllOption(matches: string[], pattern: string): Option {
+  return {
+    result: new BaseResult({
+      label: `Show all ${matches.length} regions matching ${pattern}`,
+      locString: matches.join(' '),
+    }),
+  }
+}
+
+/**
+ * The browse/pre-fetch fallback list, shown while a typed query is in flight and
+ * when it comes back empty (typed queries otherwise resolve through
+ * fetchResults). An assembly can hold ~10^6 refNames, so match and materialize
+ * in one bounded pass rather than building a million option objects or slicing
+ * first — slicing first would hide every refName past the cap from the filter,
+ * so a substring of a late scaffold's name matched nothing. Collecting one past
+ * the cap lets `cap` still render its "keep typing" hint.
+ *
+ * A query containing `*` is ALSO read as an anchored glob, the same reading
+ * `selectNamedRegions` gives a `displayedRegionNames` entry — so `*_MATERNAL`
+ * picks out a haplotype here exactly as it does in a session spec. Read as well
+ * as, never instead of, the substring match: `*` is a legal refName character
+ * (GRCh38's ALT decoys are HLA allele names like `HLA-A*01:01:01:01`), so a
+ * literal hit must not be lost to the pattern reading of the same text. Union,
+ * rather than selectNamedRegions' literal-first rule, because this is a filter
+ * and not a resolver — an extra row in a list the user is looking at costs
+ * nothing, where an extra region in a resolved set is a wrong answer.
+ *
+ * Only a glob query does the extra scanning. A plain substring query takes the
+ * same bounded path, and costs the same, as it always has.
+ */
 export function getRefNameOptions(
   regions: readonly { refName: string }[],
   inputValue: string,
 ) {
   const query = inputValue.toLowerCase()
+  const glob = query.includes('*') ? globToRegExp(query, 'i') : undefined
   const options: Option[] = []
+  // gathered only for a glob, and only to build the bulk option below; one past
+  // the ceiling is all it takes to know the ceiling was passed
+  const matches: string[] = []
   for (const { refName } of regions) {
-    if (refName.toLowerCase().includes(query)) {
+    if (!(refName.toLowerCase().includes(query) || glob?.test(refName))) {
+      continue
+    }
+    if (options.length <= MAX_OPTIONS) {
       options.push({
         result: new RefSequenceResult({ refName, label: refName }),
       })
-      if (options.length > MAX_OPTIONS) {
-        break
-      }
+    }
+    if (glob && matches.length <= MAX_SELECT_ALL) {
+      matches.push(refName)
+    }
+    // stop once neither list can learn anything more: the options are one past
+    // their cap, which is all `cap` needs to render its hint, and the match list
+    // is one past the ceiling, which withholds the bulk option either way
+    if (
+      options.length > MAX_OPTIONS &&
+      (!glob || matches.length > MAX_SELECT_ALL)
+    ) {
+      break
     }
   }
-  return options
+  return glob && matches.length > 1 && matches.length <= MAX_SELECT_ALL
+    ? [selectAllOption(matches, inputValue), ...options]
+    : options
 }
 
 // group hits sharing a display string into a single multi-result option (the

--- a/packages/core/src/ui/RefNameAutocomplete/util.ts
+++ b/packages/core/src/ui/RefNameAutocomplete/util.ts
@@ -1,6 +1,11 @@
 import BaseResult, { RefSequenceResult } from '../../TextSearch/BaseResults.ts'
 import { measureText } from '../../util/index.ts'
-import { globToRegExp } from '../../util/selectNamedRegions.ts'
+import {
+  MAX_GLOB_REGIONS,
+  matchRefNames,
+} from '../../util/selectNamedRegions.ts'
+
+import type { RefNameMatchSource } from '../../util/selectNamedRegions.ts'
 
 // matches the rendered font-size of the TextField
 const INPUT_FONT_SIZE = 14
@@ -34,15 +39,6 @@ export function cap(options: Option[]) {
     : options
 }
 
-// How many matches a glob may gather into the one "show all" option below.
-// Displaying a few hundred whole chromosomes is ordinary — GRCh38 with its alts
-// and decoys is ~640 refNames, and showAllRegionsInAssembly lays out every one —
-// so the ceiling sits well above any real chromosome set. Past it, the option is
-// withheld rather than truncated: a bulk action that reads "all of them" and
-// navigates to the first thousand is the one behaviour not worth having, and the
-// individual options are still listed for picking one at a time.
-export const MAX_SELECT_ALL = 1000
-
 /**
  * One option carrying every match as a whitespace-separated locstring — the
  * multi-region form the box already accepts, and the form it already displays
@@ -65,103 +61,35 @@ function selectAllOption(matches: string[], pattern: string): Option {
   }
 }
 
-// The part of an Assembly this needs, duck-typed so the matching can be tested
-// without building one.
-export interface RefNameSource {
-  regions?: readonly { refName: string }[]
-  // canonical names AND aliases. Undefined until the assembly's aliases load
-  allRefNames?: readonly string[]
-  getCanonicalRefName: (name: string) => string | undefined
-}
-
 /**
  * The browse/pre-fetch fallback list, shown while a typed query is in flight and
  * when it comes back empty (typed queries otherwise resolve through
- * fetchResults). An assembly can hold ~10^6 refNames, so this stays bounded:
- * matching stops once it has one hit past whichever cap applies, and nothing is
- * sliced before filtering — slicing first would hide every refName past the cap
- * from the filter, so a substring of a late scaffold's name matched nothing.
- * That extra hit is what lets `cap` render its "keep typing" hint.
+ * fetchResults).
  *
- * A query containing `*` is ALSO read as an anchored glob, the same reading
- * `selectNamedRegions` gives a `displayedRegionNames` entry — so `*_MATERNAL`
- * picks out a haplotype here exactly as it does in a session spec. Read as well
- * as, never instead of, the substring match: `*` is a legal refName character
- * (GRCh38's ALT decoys are HLA allele names like `HLA-A*01:01:01:01`), so a
- * literal hit must not be lost to the pattern reading of the same text. Union,
- * rather than selectNamedRegions' literal-first rule, because this is a filter
- * and not a resolver — an extra row in a list the user is looking at costs
- * nothing, where an extra region in a resolved set is a wrong answer.
+ * The matching itself is `matchRefNames`, in core beside the glob semantics,
+ * because Enter answers for the same typed text and the two must not each grow
+ * their own reading of it. What is left here is presentation: how many rows to
+ * materialize, and the bulk row.
  *
- * BOTH READINGS MATCH ALIASES, and resolve their hits to the canonical name, so
- * a pattern sees the names a user actually types. `chr*` has to work on an
- * assembly whose FASTA calls its chromosomes `1`, `2`, `3`, and matching
- * `regions` alone — canonical names only — meant it silently matched nothing
- * there. `searchRefNames`, which fills this same dropdown whenever the text
- * index answers, has always searched `allRefNames`; a glob is precisely the
- * query it can never answer (nothing PREFIX-matches the literal `chr*`), so
- * without this the two halves of one dropdown disagreed about which names exist.
- * Labelling with the canonical name is also its choice, and for its reason: it
- * is the name the view will display.
+ * A glob may gather up to MAX_GLOB_REGIONS for that bulk row; a plain query
+ * never needs more than the visible list, so it keeps the tighter bound and the
+ * cost it always had. Collecting one past MAX_OPTIONS is what lets `cap` render
+ * its "keep typing" hint.
  */
 export function getRefNameOptions(
-  assembly: RefNameSource | undefined,
+  assembly: RefNameMatchSource | undefined,
   inputValue: string,
 ) {
-  const regions = assembly?.regions ?? []
-  const query = inputValue.toLowerCase()
-  const glob = query.includes('*') ? globToRegExp(query, 'i') : undefined
-  // A glob may gather up to MAX_SELECT_ALL for its bulk row; a plain query never
-  // needs more than the visible list, so it keeps the tighter bound it had.
-  const ceiling = glob ? MAX_SELECT_ALL : MAX_OPTIONS
-  // Every name the assembly answers to — aliases and canonical alike, since
-  // buildRefNameMaps identity-maps each region, so this is never short of
-  // `regions`. There is deliberately no canonical-only fallback for "aliases
-  // haven't loaded": `setLoaded` writes regions and refNameAliases in ONE
-  // action, so an absent list means an unloaded assembly, whose `regions` is
-  // equally absent and which therefore has nothing to list either way. Writing
-  // the fallback anyway would mean a glob quietly matching a smaller set of
-  // names in a state that cannot arise — the silent half-answer this whole
-  // alias fix exists to remove. It is also what makes getCanonicalRefName safe
-  // to call, since that THROWS before aliases load and is only ever reached
-  // here for a name that came out of this list.
-  const candidates = assembly?.allRefNames ?? []
-  const canonical = (n: string) => assembly?.getCanonicalRefName(n) ?? n
-
-  // Which regions match, by canonical name. Several aliases collapsing onto one
-  // region is the ordinary case (`chr1`, `NC_000001.11` and `1` are one contig),
-  // so this is a Set rather than a count.
-  const hits = new Set<string>()
-  for (const name of candidates) {
-    if (name.toLowerCase().includes(query) || glob?.test(name)) {
-      hits.add(canonical(name))
-      if (hits.size > ceiling) {
-        break
-      }
-    }
-  }
-
-  // Emitted by walking `regions`, so the list is in ASSEMBLY order rather than
-  // whatever order the alias file happened to list its names in — the same
-  // two-pass shape, for the same reason, as selectNamedRegions' glob branch.
-  const options: Option[] = []
-  const matches: string[] = []
-  for (const { refName } of regions) {
-    if (!hits.has(refName)) {
-      continue
-    }
-    if (options.length <= MAX_OPTIONS) {
-      options.push({
-        result: new RefSequenceResult({ refName, label: refName }),
-      })
-    }
-    matches.push(refName)
-    // every hit is placed, so there is nothing later in `regions` to find
-    if (matches.length === hits.size) {
-      break
-    }
-  }
-  return glob && matches.length > 1 && matches.length <= MAX_SELECT_ALL
+  const isGlob = inputValue.includes('*')
+  const matches = matchRefNames(
+    assembly,
+    inputValue,
+    isGlob ? MAX_GLOB_REGIONS : MAX_OPTIONS,
+  )
+  const options: Option[] = matches.slice(0, MAX_OPTIONS + 1).map(refName => ({
+    result: new RefSequenceResult({ refName, label: refName }),
+  }))
+  return isGlob && matches.length > 1 && matches.length <= MAX_GLOB_REGIONS
     ? [selectAllOption(matches, inputValue), ...options]
     : options
 }

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -141,7 +141,12 @@ export {
   intersection2,
 } from './range.ts'
 export { dedupe } from './dedupe.ts'
-export { selectNamedRegions } from './selectNamedRegions.ts'
+export {
+  MAX_GLOB_REGIONS,
+  matchRefNames,
+  selectNamedRegions,
+} from './selectNamedRegions.ts'
+export type { RefNameMatchSource } from './selectNamedRegions.ts'
 export { isValidTag, tagRegex } from './tags.ts'
 export { formatRelativeTime } from './formatRelativeTime.ts'
 export { fetchJson } from './fetchJson.ts'

--- a/packages/core/src/util/selectNamedRegions.ts
+++ b/packages/core/src/util/selectNamedRegions.ts
@@ -5,16 +5,20 @@ import type { Region } from './types/index.ts'
  * so a refName containing regex punctuation (`chr1.1`, `scaffold[2]`) can't turn
  * into an accidental pattern. Anchored, so a pattern names whole refNames.
  *
- * Exported because the search box's refName picker reads the same syntax, and
+ * Exported because the search box's refName matching reads the same syntax, and
  * one reading of `*` is the whole point: a pattern that selects a set in a
- * session spec has to select the same set when typed into the box. The picker
- * passes `'i'`, since its matching has always been case-insensitive.
+ * session spec has to select the same set when typed into the box.
  */
-export function globToRegExp(pattern: string, flags?: string) {
+export function globToRegExp(pattern: string) {
   const escaped = pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, m =>
     m === '*' ? '.*' : `\\${m}`,
   )
-  return new RegExp(`^${escaped}$`, flags)
+  // Case-INSENSITIVE, and not optionally. The literal reading beside it resolves
+  // through getCanonicalRefName, which falls back to `lowerCaseRefNameAliases`,
+  // so `CHR1` has always found `chr1`; a case-sensitive glob meant `CHR1*` found
+  // nothing on the same assembly. No caller wants the other behaviour, so it is
+  // baked in rather than passed.
+  return new RegExp(`^${escaped}$`, 'i')
 }
 
 /**
@@ -68,6 +72,84 @@ export function selectNamedRegions(
         if (re.test(r.refName)) {
           take(r)
         }
+      }
+    }
+  }
+  return out
+}
+
+// The part of an Assembly the search box's name matching needs, duck-typed so
+// it can be tested without building one.
+export interface RefNameMatchSource {
+  regions?: readonly { refName: string }[]
+  // canonical names AND aliases. Absent only for an unloaded assembly, whose
+  // `regions` is equally absent — `setLoaded` writes both in ONE action
+  allRefNames?: readonly string[]
+  getCanonicalRefName: (name: string) => string | undefined
+}
+
+/**
+ * How many regions an INTERACTIVE glob will open at once. Displaying a few
+ * hundred whole chromosomes is ordinary — GRCh38 with its alts and decoys is
+ * ~640 refNames, and showAllRegionsInAssembly lays out every one — so this sits
+ * well above any real chromosome set and well below a scaffold-level assembly's
+ * contig count. Past it the offer is WITHHELD, never truncated: a bulk action
+ * reading "all of them" that opens the first thousand is the one behaviour not
+ * worth having.
+ *
+ * `selectNamedRegions` itself is deliberately unbounded — see its docstring.
+ * The bound belongs to the surfaces a person types at, not to the resolver a
+ * session spec goes through, because only the former has a way to say "too
+ * many, narrow it" and only the latter is a written-down intention.
+ */
+export const MAX_GLOB_REGIONS = 1000
+
+/**
+ * The canonical refNames a search-box query picks out, in ASSEMBLY order.
+ *
+ * Shared by the dropdown's option list and by what Enter does, which is the
+ * whole point of it being one function: those two answer for the same typed
+ * text, and a surface-by-surface reading of one syntax is the split this file
+ * keeps being fixed for. A substring match (what the box has always done) and,
+ * when the text contains `*`, an anchored glob — union, never one instead of
+ * the other, since `*` is a legal refName character and a literal hit must
+ * survive the pattern reading of the same text.
+ *
+ * Matching runs over every name the assembly answers to, aliases included, and
+ * resolves hits to the canonical name — the name the view will display, and the
+ * same choice `searchRefNames` makes. Emitting by walking `regions` is what
+ * keeps assembly order rather than alias-file order.
+ *
+ * Bounded: matching stops one hit past `ceiling`, so a caller can tell "at the
+ * limit" from "under it" without the scan being unbounded.
+ */
+export function matchRefNames(
+  assembly: RefNameMatchSource | undefined,
+  inputValue: string,
+  ceiling: number,
+): string[] {
+  const regions = assembly?.regions ?? []
+  const query = inputValue.toLowerCase()
+  const glob = query.includes('*') ? globToRegExp(query) : undefined
+  // getCanonicalRefName THROWS before aliases load, and is only ever reached
+  // for a name that came out of this list, which is empty in that state
+  const candidates = assembly?.allRefNames ?? []
+  const hits = new Set<string>()
+  for (const name of candidates) {
+    if (name.toLowerCase().includes(query) || glob?.test(name)) {
+      hits.add(assembly?.getCanonicalRefName(name) ?? name)
+      if (hits.size > ceiling) {
+        break
+      }
+    }
+  }
+  const out: string[] = []
+  for (const { refName } of regions) {
+    if (hits.has(refName)) {
+      out.push(refName)
+      // every hit is placed, so nothing later in `regions` can match
+      if (out.length === hits.size) {
+        break
       }
     }
   }

--- a/packages/core/src/util/selectNamedRegions.ts
+++ b/packages/core/src/util/selectNamedRegions.ts
@@ -1,13 +1,20 @@
 import type { Region } from './types/index.ts'
 
-// `*` is the only metacharacter; everything else in a name is matched literally,
-// so a refName containing regex punctuation (`chr1.1`, `scaffold[2]`) can't turn
-// into an accidental pattern.
-function globToRegExp(pattern: string) {
+/**
+ * `*` is the only metacharacter; everything else in a name is matched literally,
+ * so a refName containing regex punctuation (`chr1.1`, `scaffold[2]`) can't turn
+ * into an accidental pattern. Anchored, so a pattern names whole refNames.
+ *
+ * Exported because the search box's refName picker reads the same syntax, and
+ * one reading of `*` is the whole point: a pattern that selects a set in a
+ * session spec has to select the same set when typed into the box. The picker
+ * passes `'i'`, since its matching has always been case-insensitive.
+ */
+export function globToRegExp(pattern: string, flags?: string) {
   const escaped = pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, m =>
     m === '*' ? '.*' : `\\${m}`,
   )
-  return new RegExp(`^${escaped}$`)
+  return new RegExp(`^${escaped}$`, flags)
 }
 
 /**

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.test.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.test.tsx
@@ -286,6 +286,39 @@ describe('RefNameAutocomplete', () => {
     expect(screen.queryByText('ctg1_hap2')).toBeNull()
   })
 
+  it('pressing enter on a glob does what that row does', async () => {
+    // the property the shared matcher exists for: Enter and the row answer for
+    // the same typed text. Enter used to reach the text index, which can never
+    // answer a glob, and report no results over a list the box was showing
+    const user = userEvent.setup()
+    const { model, session } = setupHaplotypes()
+
+    render(
+      <RefNameAutocomplete
+        session={session}
+        assemblyName="volvox"
+        fetchResults={async () => []}
+        onSelect={option => {
+          navigateToSelectedOption({
+            model,
+            assemblyName: 'volvox',
+            option,
+          }).catch(() => {})
+        }}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Search for location')
+    await user.click(input)
+    await user.type(input, '*_hap1{Enter}')
+
+    await waitFor(() => {
+      expect(
+        model.displayedRegions.map((r: { refName: string }) => r.refName),
+      ).toEqual(['ctg1_hap1', 'ctg2_hap1'])
+    }, patience)
+  })
+
   it('picking that row displays every match, via the multi-region path', async () => {
     const user = userEvent.setup()
     const { model, session } = setupHaplotypes()

--- a/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.test.tsx
+++ b/plugins/linear-genome-view/src/LinearGenomeView/components/RefNameAutocomplete.test.tsx
@@ -8,6 +8,8 @@ import { createTestSession } from '@jbrowse/web/testUtils'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
+import { navigateToSelectedOption } from '../../searchUtils.ts'
+
 import type { StopToken } from '@jbrowse/core/util/stopToken'
 
 jest.mock('@jbrowse/web/makeWorkerInstance', () => () => {})
@@ -64,6 +66,33 @@ function setupWithChromosome() {
             seq: 'A'.repeat(100),
           },
         ],
+      },
+    },
+  })
+  const model = session.views[0]
+  return { model, session: getSession(model) }
+}
+
+// a haplotype-resolved assembly, which is the shape globbing exists for: the
+// useful selection is "all of hap1", never a hand-kept list of its scaffolds
+function setupHaplotypes() {
+  const session = createTestSession({ sessionSnapshot }) as any
+  session.addAssemblyConf({
+    name: 'volvox',
+    sequence: {
+      trackId: 'ref0',
+      type: 'ReferenceSequenceTrack',
+      adapter: {
+        type: 'FromConfigSequenceAdapter',
+        features: ['ctg1_hap1', 'ctg2_hap1', 'ctg1_hap2', 'ctg2_hap2'].map(
+          refName => ({
+            refName,
+            uniqueId: refName,
+            start: 0,
+            end: 100,
+            seq: 'A'.repeat(100),
+          }),
+        ),
       },
     },
   })
@@ -224,6 +253,72 @@ describe('RefNameAutocomplete', () => {
     await user.click(screen.getByText('ctgA:1..100'))
 
     expect(onSelect).toHaveBeenCalledWith(result)
+  })
+
+  // The whole reason a glob belongs in the picker rather than in the locstring
+  // parser: the matches are listed, and counted, before anything is committed
+  // to. These two go through the real navigation path — no bulk-navigation code
+  // exists, the "show all" row just carries the multi-region locstring the box
+  // has always accepted.
+  it("lists a glob's matches with one row that takes all of them", async () => {
+    const user = userEvent.setup()
+    const { session } = setupHaplotypes()
+
+    render(
+      <RefNameAutocomplete
+        session={session}
+        assemblyName="volvox"
+        fetchResults={async () => []}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Search for location')
+    await user.click(input)
+    await user.type(input, '*_hap1')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Show all 2 regions matching *_hap1'),
+      ).toBeTruthy()
+    }, patience)
+    // the individual matches are listed under it, and hap2 is not
+    expect(screen.getByText('ctg1_hap1')).toBeTruthy()
+    expect(screen.queryByText('ctg1_hap2')).toBeNull()
+  })
+
+  it('picking that row displays every match, via the multi-region path', async () => {
+    const user = userEvent.setup()
+    const { model, session } = setupHaplotypes()
+
+    render(
+      <RefNameAutocomplete
+        session={session}
+        assemblyName="volvox"
+        fetchResults={async () => []}
+        onSelect={option => {
+          navigateToSelectedOption({
+            model,
+            assemblyName: 'volvox',
+            option,
+          }).catch(() => {})
+        }}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Search for location')
+    await user.click(input)
+    await user.type(input, '*_hap1')
+    await waitFor(
+      () => screen.getByText('Show all 2 regions matching *_hap1'),
+      patience,
+    )
+    await user.click(screen.getByText('Show all 2 regions matching *_hap1'))
+
+    await waitFor(() => {
+      expect(
+        model.displayedRegions.map((r: { refName: string }) => r.refName),
+      ).toEqual(['ctg1_hap1', 'ctg2_hap1'])
+    }, patience)
   })
 
   it('calls onChange for each typed character', async () => {

--- a/plugins/linear-genome-view/src/searchUtils.ts
+++ b/plugins/linear-genome-view/src/searchUtils.ts
@@ -1,9 +1,11 @@
 import { RefSequenceResult } from '@jbrowse/core/TextSearch/BaseResults'
 import {
+  MAX_GLOB_REGIONS,
   UnknownRefNameError,
   dedupe,
   getEnv,
   getSession,
+  matchRefNames,
 } from '@jbrowse/core/util'
 import { isAlive } from '@jbrowse/mobx-state-tree'
 
@@ -182,6 +184,40 @@ export async function handleSelectedRegion({
       .every(entry => checkRef(entry, isRef))
   ) {
     await navToLocstrings()
+  } else if (input.includes('*') && !!assembly) {
+    // Enter does what the dropdown's "Show all N regions matching …" row does,
+    // for the same text. It is NOT a blind resolution: that row, and the matches
+    // under it, have been on screen the whole time the pattern was being typed,
+    // which is the reason a glob belongs in the picker at all. What would be
+    // indefensible is the two disagreeing — Enter reporting no results over a
+    // list the box is showing is the same failure the exact-first search pass
+    // was written to end, and a glob is precisely the query the text index can
+    // never answer, since nothing PREFIX-matches the literal `chr*`.
+    //
+    // Ordered after the refName check, so a contig whose name really contains
+    // `*` — GRCh38's HLA decoys — navigates to itself rather than being read as
+    // a pattern. Same literal-first rule as selectNamedRegions.
+    const names = matchRefNames(assembly, input, MAX_GLOB_REGIONS)
+    if (names.length > MAX_GLOB_REGIONS) {
+      // Refused rather than truncated, and said out loud. Opening the first
+      // thousand of a wider match is the one outcome that would look like it
+      // worked.
+      getSession(model).notify(
+        `"${input}" matches more than ${MAX_GLOB_REGIONS} regions — narrow the pattern`,
+        'warning',
+      )
+    } else if (names.length) {
+      await model.navToLocations(
+        parseLocStrings(names.join(' '), assemblyName, (ref, asm) =>
+          assemblyManager.isValidRefName(ref, asm),
+        ),
+        assemblyName,
+      )
+    } else {
+      // matched nothing: a pattern is not a feature name, so there is no index
+      // to fall through to, and the miss is the whole answer
+      throw new SearchResultsNotFoundError(`No results found for "${input}"`)
+    }
   } else {
     // Ask once, unrestricted, and read exactness off the hits. Prefer the
     // exact ones so a precise name navigates straight to its feature instead


### PR DESCRIPTION
Typing `*_hap1` into the location box lists nothing today. The picker
substring-matches, no refName contains the literal text `*_hap1`, and the
text-search index has no opinion about contig names — so the one selection a
haplotype-resolved assembly actually wants has no in-app spelling. It is only
reachable through `displayedRegionNames` in a URL or a session spec, or through
the dotplot and synteny import forms.

This teaches the refName picker the `*` syntax those surfaces already use.

## What it does

Typing a pattern lists the matching reference sequences in the dropdown, with a
row above them reading **"Show all N regions matching \<pattern\>"**. Picking
that row displays all of them.

That row carries its matches as a whitespace-separated locstring — the
multi-region form the box already accepts, and already displays once a view
holds more than one region. So picking it goes down the existing
`parseLocStrings` → `navToLocations` → `setDisplayedRegions` + `showAllRegions`
path, and there is **no bulk-navigation code** to keep in step with the
single-region kind.

## Three decisions worth a reviewer's attention

- **The glob belongs in the picker, not in the locstring parser.** That is the
  whole shape of this: the matches are on screen, and counted, before anything
  is committed to. A pattern resolved straight at the parser would open however
  many regions it happened to match, sight unseen.

- **A `*` query is read as a glob _as well as_ a substring, never instead.** `*`
  is a legal refName character — GRCh38's ALT decoys are HLA allele names like
  `HLA-A*01:01:01:01`. Unlike `selectNamedRegions`, which must pick one reading
  because it returns an answer, this is a filter and can offer both and let the
  user choose. There is a test with a refName only the substring reading finds.

- **Past 1000 matches the bulk row is withheld, not truncated.** A row saying
  "all of them" that opens the first thousand is worse than no row. The
  individual matches still list, capped as before.

Only glob queries pay for any of this; a plain query takes the bounded path it
always did.

## The second commit

Aliases. `searchRefNames`, which fills this same dropdown whenever the text
index answers, has always matched `assembly.allRefNames`. `getRefNameOptions`,
which fills it when the index answers nothing, matched `assembly.regions` —
canonical names only. A glob is exactly the query the index can never answer,
since nothing prefix-matches the literal `chr*`, so globs always landed in the
half that could not see the names people type: on an assembly whose FASTA calls
its chromosomes `1`, `2`, `3`, `chr*` silently listed nothing.

Both readings now match over `allRefNames` and resolve hits to the canonical
name — which is also what `searchRefNames` labels with, and for its reason: it
is the name the view will display. Emitting by walking `regions` keeps the list
in assembly order rather than alias-file order, and a region several of whose
names match is listed once.

There is deliberately no canonical-only fallback for "aliases have not loaded".
`setLoaded` writes `volatileRegions` and `refNameAliases` in one action, so an
absent name list means an unloaded assembly, whose regions are equally absent.

## Scope, and what this does not do

**Globs do not get you the autosomes**, and this should not be sold as if they
might. UCSC naming makes the unplaced and alt contigs extensions of the names
you want: `chr*` on hg38 also takes `chrUn_GL000195v1` and
`chr1_KI270706v1_random`, and even `chr1*` takes `chr10` through `chr19`. There
is no negation. The honest scope is name families an assembly actually
separates — `*_hap1`, `*_MATERNAL`, `*_alt`. A main-chromosome subset is still
best written as a list.

**Known gap, deliberately open:** pressing Enter on a glob still goes to the
text-search path and reports no results, while the dropdown above it is showing
the matches. Resolving it on Enter would navigate to a set sight-unseen, which
is what this shape exists to avoid, so the fix is more likely about what Enter
_says_, or about which row starts highlighted, than about resolving it. Worth
settling before merge.

**Companion fix, not in this PR:** `selectNamedRegions` has the identical alias
bug on its glob branch — an exact entry resolves via `getCanonicalRefName` but
the glob was tested against `region.refName` alone, so `["chr*"]` in a session
spec or `&regions=` matches nothing on an Ensembl-named assembly. That fix is
separate and lands on its own.

## Testing

Unit tests for the matching, the bulk row, the caps and the alias behaviour, and
two integration tests through a real MST model and the real navigation path —
one that the matches list, one that picking the bulk row sets `displayedRegions`
to all of them. The alias tests fail on the first commit.

Verified in jsdom, not in a browser: the behaviour is pinned, how the row reads
at real widths is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZbwwvamDTe3YDhh334mWu
