### PR TITLE
fix(app-core): fix duplication in submenu items

### DIFF
--- a/packages/app-core/src/menus.test.ts
+++ b/packages/app-core/src/menus.test.ts
@@ -272,6 +272,39 @@ describe('item contributions', () => {
     expect(menus[0]!.menuItems()).not.toBe(definitions[0]!.menuItems)
   })
 
+  // a menuItem contribution can pre-populate its own subMenu (appendToMenu with
+  // a literal subMenu array) and a later contribution can target that same
+  // path (appendToSubMenu) to add to it. Repeated opens must not compound: the
+  // second contribution used to push into the first contribution's own,
+  // never-cloned subMenu array, so every open left one more copy behind.
+  it('does not accumulate items in a pre-populated sub-menu across opens', () => {
+    const menus = run(base, [
+      {
+        type: 'addItem',
+        menuPath: ['File'],
+        menuItem: {
+          label: 'SubMenu',
+          subMenu: [item('Item in sub-menu')],
+        } as unknown as MenuItem,
+      },
+      {
+        type: 'addItem',
+        menuPath: ['File', 'SubMenu'],
+        menuItem: item('Second item in sub-menu'),
+      },
+    ])
+    const expected = {
+      label: 'SubMenu',
+      subMenu: [
+        { label: 'Item in sub-menu' },
+        { label: 'Second item in sub-menu' },
+      ],
+    }
+    expect(menus[0]!.menuItems()).toContainEqual(expected)
+    expect(menus[0]!.menuItems()).toContainEqual(expected)
+    expect(menus[0]!.menuItems()).toContainEqual(expected)
+  })
+
   // menus() replays the whole action log on every re-render, and a menu can be
   // opened any number of times; neither may accumulate
   it('is stable across replays and repeated opens', () => {

--- a/packages/app-core/src/menus.ts
+++ b/packages/app-core/src/menus.ts
@@ -74,11 +74,20 @@ const reported = new WeakSet<AddItemAction>()
 // model's own literal or a thunk's internals; leaf items (with their
 // onClick/icon) are shared by ref
 function cloneMenuItems(items: MenuItem[]): MenuItem[] {
-  return items.map(item =>
-    'subMenu' in item
-      ? { ...item, subMenu: cloneMenuItems(item.subMenu) }
-      : item,
-  )
+  return items.map(cloneMenuItem)
+}
+
+// an item contribution's own menuItem needs the same protection as `base`: if
+// it already carries a subMenu (a plugin pre-populating one in the same call
+// that declares it), a later action targeting that path resolves this exact
+// array and pushes into it. Without cloning, that push lands on the action's
+// permanent menuItem object, so the next open's resolveSubMenu finds it
+// already containing last open's addition and appends another — one more
+// copy of the item every time the menu opens, forever.
+function cloneMenuItem(item: MenuItem): MenuItem {
+  return 'subMenu' in item
+    ? { ...item, subMenu: cloneMenuItems(item.subMenu) }
+    : item
 }
 
 function materialize(menuItems: MenuItemsGetter) {
@@ -124,7 +133,7 @@ function applyItemActions(items: MenuItem[], actions: AddItemAction[]) {
   for (const action of actions) {
     try {
       const target = resolveSubMenu(items, action.menuPath)
-      insertAt(target, action.menuItem, action.position)
+      insertAt(target, cloneMenuItem(action.menuItem), action.position)
     } catch (error) {
       if (!reported.has(action)) {
         reported.add(action)


### PR DESCRIPTION
Before this fix:

<img width="406" height="350" alt="image" src="https://github.com/user-attachments/assets/fa3be295-ab46-4958-8ddb-ad433d389575" />

After:

<img width="383" height="289" alt="image" src="https://github.com/user-attachments/assets/75d700b6-ede3-4c03-ba74-8a7a70b58b2f" />

Code used to create these menu items:


```ts
pluginManager.rootModel.appendToMenu('Help', {
  label: 'SubMenu',
  type: 'subMenu',
  subMenu: [
    {
      label: 'Item in sub-menu',
      icon: HelpIcon,
      onClick: (session: SessionWithWidgets) => {
        const widget = session.addWidget('HelpWidget', 'helpWidget')
        session.showWidget(widget)
      },
    },
  ],
})
pluginManager.rootModel.appendToSubMenu(['Help', 'SubMenu'], {
  label: 'Second item in sub-menu',
  icon: HelpIcon,
  onClick: (session: SessionWithWidgets) => {
    const widget = session.addWidget('HelpWidget', 'helpWidget')
    session.showWidget(widget)
  },
})
```