### PR TITLE
fix(jbrowse-web): Error when reloading with `reloadPluginManagerCallback`

### DIFF
--- a/products/jbrowse-web/src/components/disposeLoader.test.ts
+++ b/products/jbrowse-web/src/components/disposeLoader.test.ts
@@ -32,5 +32,7 @@ test('a superseded loader is destroyed on detach', async () => {
   const loader = await makeActivatedLoader()
   loader.setSuperseded()
   disposeLoader(loader)
+  // destroy() is deferred a microtask past this call (see disposeLoader.ts)
+  await Promise.resolve()
   expect(isAlive(loader)).toBe(false)
 })

--- a/products/jbrowse-web/src/components/disposeLoader.ts
+++ b/products/jbrowse-web/src/components/disposeLoader.ts
@@ -16,6 +16,18 @@ import type { SessionLoaderModel } from '../SessionLoader.ts'
 export function disposeLoader(loader: SessionLoaderModel) {
   loader.deactivate()
   if (loader.superseded) {
-    destroy(loader)
+    // Deferred a tick: this cleanup runs inside React's passive-effect
+    // flush, synchronously followed — same flush, same call stack — by its
+    // dev-mode component-render logging, which reads `loader` again as
+    // Renderer's/SessionTriaged's "previous props". Destroying synchronously
+    // here made every property on it (configPath, sessionQuery, ...) log a
+    // "you are trying to read or write to an object that is no longer part
+    // of a state tree" MST warning. A microtask runs only once that
+    // synchronous flush has fully unwound, so this still frees the node
+    // well before the next paint, just after the dev-mode read that would
+    // otherwise hit a dead one.
+    queueMicrotask(() => {
+      destroy(loader)
+    })
   }
 }


### PR DESCRIPTION
I was seeing a page crash and various console warnings in Apollo, and this small addition of moving the destroy to a microtask fixes it.