### PR TITLE
fix(jbrowse-web): a plugin install left every relative config uri 404ing

### DIFF
--- a/products/jbrowse-web/src/SessionLoader.ts
+++ b/products/jbrowse-web/src/SessionLoader.ts
@@ -5,6 +5,7 @@ import { destroy, getSnapshot, isAlive, types } from '@jbrowse/mobx-state-tree'
 import { autorun } from 'mobx'
 
 import { createPluginManager } from './createPluginManager.ts'
+import { resolveConfigPath } from './resolveConfigPath.ts'
 import {
   buildLgvInit,
   fetchRemoteConfig,
@@ -272,7 +273,7 @@ const SessionLoader = types
      * #getter
      */
     get resolvedConfigPath() {
-      return self.configPath || window.__jbrowseConfigPath || 'config.json'
+      return resolveConfigPath(self.configPath)
     },
   }))
   .views(self => ({

--- a/products/jbrowse-web/src/resolveConfigPath.ts
+++ b/products/jbrowse-web/src/resolveConfigPath.ts
@@ -1,0 +1,18 @@
+// Where a jbrowse-web page's config lives, resolved one way for everyone: the
+// explicit ?config= param, else the build-time global, else config.json.
+//
+// Two callers, and they have to agree. SessionLoader resolves it to fetch the
+// config, and fetchRemoteConfig stamps the resulting URL onto every relative
+// uri in it (addRelativeUris) so "volvox.2bit" in data/config.json means
+// data/volvox.2bit. The plugin-reload path then has to re-stamp against the
+// same URL, because the snapshot it hands the replacement app has had those
+// keys stripped on the way out. A second, drifting copy of this resolution
+// would give the replacement a different base than the original fetch used,
+// which is silent: the tracks just 404.
+export function resolveConfigPath(configPath?: string) {
+  return configPath || window.__jbrowseConfigPath || 'config.json'
+}
+
+export function configBaseUri(configPath: string) {
+  return new URL(configPath, window.location.href)
+}

--- a/products/jbrowse-web/src/rootModel/persistence.ts
+++ b/products/jbrowse-web/src/rootModel/persistence.ts
@@ -3,7 +3,9 @@ import { sessionLastUsed } from '@jbrowse/web-core'
 import { autorun } from 'mobx'
 
 import { openSessionDB } from '../openSessionDB.ts'
+import { configBaseUri, resolveConfigPath } from '../resolveConfigPath.ts'
 import { deleteSessionRows, upsertSessionRows } from '../sessionDbOps.ts'
+import { addRelativeUris } from '../util.ts'
 
 import type { SessionDBHandle } from '../sessionDbOps.ts'
 import type { Session, SessionMetadata } from '../types.ts'
@@ -219,6 +221,28 @@ function setupUnloadFlush(self: WebRootModel) {
   })
 }
 
+// The config the replacement app boots from when a plugin is installed.
+//
+// getSnapshot(jbrowse) runs jbrowseModel's snapshotProcessor, whose
+// postProcessor calls stripBaseUris. That is right for the flow it was written
+// for — JBrowse.tsx POSTs onSnapshot(jbrowse) straight to /updateConfig, and an
+// admin's config.json must not grow synthetic keys — and wrong here, because
+// this snapshot is not being serialized out, it is being booted from. Stripped
+// of its baseUris, every relative uri in it resolves against the page instead
+// of the config's directory, so each such track 404s after any plugin install.
+//
+// Re-stamp against the config's own URL, which is what fetchRemoteConfig did to
+// it in the first place. addRelativeUris only fills a baseUri that is absent, so
+// anything carrying its own (a track added from elsewhere) keeps it.
+function configSnapshotForReload(self: WebRootModel) {
+  const snap = structuredClone(getSnapshot(self.jbrowse)) as Record<
+    string,
+    unknown
+  >
+  addRelativeUris(snap, configBaseUri(resolveConfigPath(self.configPath)))
+  return snap
+}
+
 // Mirrors the current session into sessionStorage on every change so a tab
 // reload restores it. Also triggers reloadPluginManager when pluginsUpdated
 // flips — the snapshot must be written FIRST so the new plugin manager can
@@ -248,7 +272,7 @@ export function setupSessionStorageAutosave(self: WebRootModel) {
             if (self.pluginsUpdated && !reloadRequested) {
               reloadRequested = true
               self.reloadPluginManagerCallback(
-                structuredClone(getSnapshot(self.jbrowse)),
+                configSnapshotForReload(self),
                 structuredClone(sessionSnap),
               )
             }

--- a/products/jbrowse-web/src/rootModel/reloadConfigBaseUri.test.ts
+++ b/products/jbrowse-web/src/rootModel/reloadConfigBaseUri.test.ts
@@ -1,0 +1,103 @@
+import PluginManager from '@jbrowse/core/PluginManager'
+import { destroy, isAlive } from '@jbrowse/mobx-state-tree'
+
+import corePlugins from '../corePlugins.ts'
+import sessionModelFactory from '../sessionModel/index.ts'
+import rootModelFactory from './rootModel.ts'
+
+jest.mock('../makeWorkerInstance', () => () => {})
+
+type Root = ReturnType<ReturnType<typeof rootModelFactory>['create']>
+
+const roots: Root[] = []
+
+// fetchRemoteConfig() stamps a baseUri beside every uri in the config it
+// fetched (addRelativeUris), because a config at data/config.json naming
+// "volvox.2bit" means data/volvox.2bit, not /volvox.2bit. Everything
+// downstream resolves through it (resolveUriLocation in core/util/io).
+const BASE = 'http://localhost/data/config.json'
+
+function makeRoot() {
+  const pluginManager = new PluginManager(corePlugins.map(P => new P()))
+  pluginManager.createPluggableElements()
+  pluginManager.configure()
+  const root = rootModelFactory({ pluginManager, sessionModelFactory }).create({
+    configPath: 'data/config.json',
+    jbrowse: {
+      configuration: { rpc: { defaultDriver: 'MainThreadRpcDriver' } },
+      assemblies: [
+        {
+          name: 'volvox',
+          sequence: {
+            type: 'ReferenceSequenceTrack',
+            trackId: 'volvox_refseq',
+            adapter: {
+              type: 'TwoBitAdapter',
+              twoBitLocation: {
+                uri: 'volvox.2bit',
+                baseUri: BASE,
+                locationType: 'UriLocation',
+              },
+            },
+          },
+        },
+      ],
+    },
+  })
+  root.setSession({ name: 'testSession' })
+  roots.push(root)
+  return root
+}
+
+function findTwoBit(o: unknown): Record<string, unknown> | undefined {
+  if (typeof o === 'object' && o !== null) {
+    const rec = o as Record<string, unknown>
+    if (typeof rec.uri === 'string' && rec.uri.includes('2bit')) {
+      return rec
+    }
+    for (const v of Object.values(rec)) {
+      const hit = findTwoBit(v)
+      if (hit) {
+        return hit
+      }
+    }
+  }
+  return undefined
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    if (isAlive(root)) {
+      destroy(root)
+    }
+  }
+  roots.length = 0
+  sessionStorage.clear()
+  localStorage.clear()
+})
+
+// Installing/updating/removing a plugin flips pluginsUpdated, which makes the
+// autosave autorun hand a config snapshot to reloadPluginManagerCallback for
+// the replacement app to boot from. That snapshot goes through jbrowseModel's
+// snapshotProcessor, whose postProcessor runs stripBaseUris — written for the
+// admin "Save config" flow (JBrowse.tsx POSTs onSnapshot(jbrowse) straight to
+// /updateConfig, so it must not carry synthetic keys). The reload gets caught
+// by it too, and the replacement boots on a config whose relative uris now
+// resolve against the page instead of the config's directory: every such track
+// 404s after any plugin install.
+test('the plugin reload hands over a config whose relative uris still resolve', async () => {
+  const root = makeRoot()
+  const configs: Record<string, unknown>[] = []
+  root.setReloadPluginManagerCallback(config => {
+    configs.push(config)
+  })
+
+  root.setPluginsUpdated()
+  // the autosave autorun is debounced 400ms
+  await new Promise(r => setTimeout(r, 800))
+
+  expect(configs).toHaveLength(1)
+  expect(findTwoBit(configs[0])).toEqual(
+    expect.objectContaining({ uri: 'volvox.2bit', baseUri: BASE }),
+  )
+})

--- a/products/jbrowse-web/src/sessionLoaderHelpers.ts
+++ b/products/jbrowse-web/src/sessionLoaderHelpers.ts
@@ -8,6 +8,7 @@ import { indexedDBAvailable } from '@jbrowse/core/util'
 import { openLocation } from '@jbrowse/core/util/io'
 
 import { openSessionDB } from './openSessionDB.ts'
+import { configBaseUri } from './resolveConfigPath.ts'
 import { addRelativeUris } from './util.ts'
 
 import type { Snap } from './types.ts'
@@ -74,7 +75,7 @@ export async function fetchRemoteConfig(configPath: string) {
     locationType: 'UriLocation',
   }).readFile('utf8')
   const config = JSON.parse(text)
-  const configUri = new URL(configPath, window.location.href)
+  const configUri = configBaseUri(configPath)
   addRelativeUris(config, configUri)
   return { config, configUri }
 }


### PR DESCRIPTION
Installing, updating or removing a plugin left every relative uri in the config 404ing.

### The chain

`fetchRemoteConfig` stamps a `baseUri` beside each `uri` in the config it fetched (`addRelativeUris`), so `"volvox.2bit"` in `data/config.json` resolves to `data/volvox.2bit`. Everything downstream resolves through it (`resolveUriLocation` in `core/util/io`).

A plugin change flips `pluginsUpdated`, and the autosave autorun hands `getSnapshot(jbrowse)` to `reloadPluginManagerCallback` for the replacement app to boot from. That goes through `jbrowseModel`'s `snapshotProcessor`, whose `postProcessor` runs `stripBaseUris`.

That postProcessor is right for the flow it was written for — `JBrowse.tsx` POSTs `onSnapshot(jbrowse)` straight to `/updateConfig`, and an admin's `config.json` must not grow synthetic keys. It is wrong for the reload, which is not serializing the config out but booting from it. Stripped, the replacement resolved every relative uri against the page instead of the config's directory.

The failure is silent past the failed request, and only appears after an install — so it reads as the plugin having broken the tracks.

### The fix

Re-stamp at the producer rather than loosening the postProcessor, since the postProcessor is load-bearing for admin mode. `resolveConfigPath` is now shared with `SessionLoader` so the replacement cannot resolve against a different base than the original fetch used — a drifting second copy of that resolution would be silent in exactly the same way. `addRelativeUris` only fills an absent `baseUri`, so a location carrying its own keeps it.

### Test

`reloadConfigBaseUri.test.ts` drives the real `pluginsUpdated` path and asserts the config handed to the callback still carries its `baseUri`. On `main` it fails with the `baseUri` gone and everything else intact.

This was found with a puppeteer probe, not jest — the jest suites mock `fetch`, so uri resolution is never exercised there. In a real browser the reload produced `HTTP 404 fetching volvox.2bit` where the pre-reload load was clean.

### Note

The branch carries a separate `chore(docs)` commit regenerating the model tables, stale on `main` since 2eeaf1023d. Unrelated to the fix; separated so it can be read past.

`scripts/check-docs.ts` also fails on `main` (`packages/app-core/CLAUDE.md:220` references `DockviewRightHeaderActions`, a component ADR-068 deliberately deleted — the prose is correct and the checker is over-eager). Left alone rather than papered over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
